### PR TITLE
Populate context/action menus with BPM process names

### DIFF
--- a/ng2-components/ng2-activiti-form/src/services/form.service.ts
+++ b/ng2-components/ng2-activiti-form/src/services/form.service.ts
@@ -24,7 +24,17 @@ import { AlfrescoSettingsService } from 'ng2-alfresco-core';
 @Injectable()
 export class FormService {
 
-    constructor(private http: Http, private alfrescoSettingsService: AlfrescoSettingsService) {
+    constructor(private http: Http,
+                private alfrescoSettingsService: AlfrescoSettingsService) {
+    }
+
+    getProcessDefinitions(): Observable<any> {
+        let url = `${this.alfrescoSettingsService.bpmHost}/activiti-app/api/enterprise/process-definitions`;
+        let options = this.getRequestOptions();
+        return this.http
+            .get(url, options)
+            .map(this.toJsonArray)
+            .catch(this.handleError);
     }
 
     getTasks(): Observable<any> {

--- a/ng2-components/ng2-alfresco-documentlist/index.ts
+++ b/ng2-components/ng2-alfresco-documentlist/index.ts
@@ -41,6 +41,10 @@ export * from './src/services/folder-actions.service';
 export * from './src/services/document-actions.service';
 export * from './src/services/document-list.service';
 
+// models
+export * from './src/models/content-action.model';
+export * from './src/models/document-library.model';
+
 export const DOCUMENT_LIST_DIRECTIVES: [any] = [
     DocumentList,
     ContentColumn,


### PR DESCRIPTION
Extends demo shell with BPM integration example for Document List

- tries reaching Activiti for published apps/processes and populates context/action menus for document list with demo actions based on process definition names.
- displays process definition id upon action execution

<img width="689" alt="screen shot 2016-07-27 at 11 42 18" src="https://cloud.githubusercontent.com/assets/503991/17172963/e2b07d46-53ef-11e6-8369-ca295d94fc5b.png">

<img width="1428" alt="screen shot 2016-07-27 at 11 42 34" src="https://cloud.githubusercontent.com/assets/503991/17172966/e8c04e1e-53ef-11e6-9657-4e8f7aa5ebdd.png">

<img width="462" alt="screen shot 2016-07-27 at 11 42 54" src="https://cloud.githubusercontent.com/assets/503991/17172981/fe32cfa6-53ef-11e6-9173-b2f980ede189.png">

