### PR TITLE
#589 ability to prevent default outcome behaviour

### DIFF
--- a/ng2-components/ng2-activiti-form/README.md
+++ b/ng2-components/ng2-activiti-form/README.md
@@ -106,8 +106,9 @@ The recommended set of properties can be found in the following table:
 | formLoaded | Invoked when form is loaded or reloaded. |
 | formSaved | Invoked when form is submitted with `Save` or custom outcomes.  |
 | formCompleted | Invoked when form is submitted with `Complete` outcome.  |
+| executeOutcome | Invoked when any outcome is executed, default behaviour can be prevented via `event.preventDefault()` |
 
-All `form*` events recieve an instance of the `FormModel` as event argument for ease of development:
+All `form*` events receive an instance of the `FormModel` as event argument for ease of development:
 
 **MyView.component.html**
 ```html
@@ -123,6 +124,56 @@ onFormSaved(form: FormModel) {
     console.log(form);
 }
 ```
+
+#### Controlling outcome execution behaviour
+
+If absolutely needed it is possible taking full control over form outcome execution by means of `executeOutcome` event. 
+This event is fired upon each outcome execution, both system and custom ones.
+
+You can prevent default behaviour by calling `event.preventDefault()`. 
+This allows for example having custom form validation scenarios and/or additional validation summary presentation.
+
+Alternatively you may want just running additional code on outcome execution without suppressing default one.
+
+**MyView.component.html**
+```html
+<activiti-form 
+    [taskId]="selectedTask?.id"
+    executeOutcome="validateForm($event)">
+</activiti-form>
+```
+
+**MyView.component.ts**
+```ts
+import { FormOutcomeEvent } from 'ng2-activiti-form';
+
+export class MyView {
+
+    validateForm(event: FormOutcomeEvent) {
+        let outcome = event.outcome;
+        
+        // you can also get additional properties of outcomes 
+        // if you defined them within outcome definition
+        
+        if (outcome) {
+            let form = outcome.form;
+            if (form) {
+                // check/update the form here
+                event.preventDefault();
+            }
+        }
+    }
+    
+}
+```
+
+There are two additional functions that can be of a great value when controlling outcomes:
+
+- `saveTaskForm()` - saves current form
+- `completeTaskForm(outcome?: string)` - save and complete form with a given outcome name
+
+**Please note that if `event.preventDefault()` is not called then default outcome behaviour 
+will also be executed after your custom code.**
 
 ## Build from sources
 

--- a/ng2-components/ng2-activiti-form/src/components/activiti-form.component.ts
+++ b/ng2-components/ng2-activiti-form/src/components/activiti-form.component.ts
@@ -26,7 +26,7 @@ import {
 import { MATERIAL_DESIGN_DIRECTIVES } from 'ng2-alfresco-core';
 
 import { FormService } from './../services/form.service';
-import { FormModel, FormOutcomeModel, FormValues, FormFieldModel } from './widgets/core/index';
+import { FormModel, FormOutcomeModel, FormValues, FormFieldModel, FormOutcomeEvent } from './widgets/core/index';
 
 import { TabsWidget } from './widgets/tabs/tabs.widget';
 import { ContainerWidget } from './widgets/container/container.widget';
@@ -116,6 +116,9 @@ export class ActivitiForm implements OnInit, AfterViewChecked, OnChanges {
     @Output()
     formLoaded: EventEmitter<FormModel> = new EventEmitter<FormModel>();
 
+    @Output()
+    executeOutcome: EventEmitter<FormOutcomeEvent> = new EventEmitter<FormOutcomeEvent>();
+
     form: FormModel;
 
     debugMode: boolean = false;
@@ -185,6 +188,13 @@ export class ActivitiForm implements OnInit, AfterViewChecked, OnChanges {
      */
     onOutcomeClicked(outcome: FormOutcomeModel): boolean {
         if (!this.readOnly && outcome && this.form) {
+
+            let args = new FormOutcomeEvent(outcome);
+            this.executeOutcome.emit(args);
+            if (args.defaultPrevented) {
+                return false;
+            }
+
             if (outcome.isSystem) {
                 if (outcome.id === ActivitiForm.SAVE_OUTCOME_ID) {
                     this.saveTaskForm();
@@ -340,6 +350,8 @@ export class ActivitiForm implements OnInit, AfterViewChecked, OnChanges {
     }
 
     checkVisibility(field: FormFieldModel) {
-        this.visibilityService.updateVisibilityForForm(field.form);
+        if (field && field.form) {
+            this.visibilityService.updateVisibilityForForm(field.form);
+        }
     }
 }

--- a/ng2-components/ng2-activiti-form/src/components/widgets/core/form-outcome-event.model.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/core/form-outcome-event.model.ts
@@ -15,15 +15,27 @@
  * limitations under the License.
  */
 
-export * from './form-field-metadata';
-export * from './form-values';
-export * from './form-field-types';
-export * from './form-field-option';
-export * from './form-widget.model';
-export * from './form-field.model';
-export * from './form.model';
-export * from './container-column.model';
-export * from './container.model';
-export * from './tab.model';
-export * from './form-outcome.model';
-export * from './form-outcome-event.model';
+import { FormOutcomeModel } from './form-outcome.model';
+
+export class FormOutcomeEvent {
+
+    private _outcome: FormOutcomeModel;
+    private _defaultPrevented: boolean = false;
+
+    get outcome(): FormOutcomeModel {
+        return this._outcome;
+    }
+
+    get defaultPrevented() {
+        return this._defaultPrevented;
+    }
+
+    constructor(outcome: FormOutcomeModel) {
+        this._outcome = outcome;
+    }
+
+    preventDefault() {
+        this._defaultPrevented = true;
+    }
+
+}


### PR DESCRIPTION
- ability to prevent default outcome behaviour (i.e. custom validation)
- new ‘executeOutcome’ event for DocumentList
- unit tests
- readme updates