### PR TITLE
IE fixes

### DIFF
--- a/demo-shell-ng2/index.html
+++ b/demo-shell-ng2/index.html
@@ -22,10 +22,13 @@
     <!-- Polyfill(s) for Safari (pre-10.x) -->
     <script src="node_modules/intl/dist/Intl.min.js"></script>
     <script src="node_modules/intl/locale-data/jsonp/en.js"></script>
-    <script src="node_modules/moment/min/moment.min.js"></script>
 
     <!-- Polyfill(s) for older browsers -->
     <script src="node_modules/core-js/client/shim.min.js"></script>
+
+    <!-- Polyfill(s) for dialogs -->
+    <script src="node_modules/dialog-polyfill/dialog-polyfill.js"></script>
+    <link rel="stylesheet" type="text/css" href="node_modules/dialog-polyfill/dialog-polyfill.css" />
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
     <script src="node_modules/reflect-metadata/Reflect.js"></script>
@@ -37,12 +40,10 @@
     <script src="node_modules/pdfjs-dist/build/pdf.worker.js"></script>
     <script src="node_modules/pdfjs-dist/web/pdf_viewer.js"></script>
     <script src="node_modules/chart.js/dist/Chart.bundle.min.js"></script>
+    <script src="node_modules/moment/min/moment.min.js"></script>
     <script src="node_modules/md-date-time-picker/dist/js/mdDateTimePicker.min.js"></script>
     <script src="node_modules/md-date-time-picker/dist/js/draggabilly.pkgd.min.js"></script>
 
-    <!-- Polyfill(s) for dialogs -->
-    <script src="node_modules/dialog-polyfill/dialog-polyfill.js"></script>
-    <link rel="stylesheet" type="text/css" href="node_modules/dialog-polyfill/dialog-polyfill.css" />
 
     <!-- 2. Configure SystemJS -->
     <script src="systemjs.config.js"></script>

--- a/demo-shell-ng2/index.html
+++ b/demo-shell-ng2/index.html
@@ -22,13 +22,10 @@
     <!-- Polyfill(s) for Safari (pre-10.x) -->
     <script src="node_modules/intl/dist/Intl.min.js"></script>
     <script src="node_modules/intl/locale-data/jsonp/en.js"></script>
+    <script src="node_modules/moment/min/moment.min.js"></script>
 
     <!-- Polyfill(s) for older browsers -->
     <script src="node_modules/core-js/client/shim.min.js"></script>
-
-    <!-- Polyfill(s) for dialogs -->
-    <script src="node_modules/dialog-polyfill/dialog-polyfill.js"></script>
-    <link rel="stylesheet" type="text/css" href="node_modules/dialog-polyfill/dialog-polyfill.css" />
 
     <script src="node_modules/zone.js/dist/zone.js"></script>
     <script src="node_modules/reflect-metadata/Reflect.js"></script>
@@ -40,10 +37,12 @@
     <script src="node_modules/pdfjs-dist/build/pdf.worker.js"></script>
     <script src="node_modules/pdfjs-dist/web/pdf_viewer.js"></script>
     <script src="node_modules/chart.js/dist/Chart.bundle.min.js"></script>
-    <script src="node_modules/moment/min/moment.min.js"></script>
     <script src="node_modules/md-date-time-picker/dist/js/mdDateTimePicker.min.js"></script>
     <script src="node_modules/md-date-time-picker/dist/js/draggabilly.pkgd.min.js"></script>
 
+    <!-- Polyfill(s) for dialogs -->
+    <script src="node_modules/dialog-polyfill/dialog-polyfill.js"></script>
+    <link rel="stylesheet" type="text/css" href="node_modules/dialog-polyfill/dialog-polyfill.css" />
 
     <!-- 2. Configure SystemJS -->
     <script src="systemjs.config.js"></script>

--- a/demo-shell-ng2/package.json
+++ b/demo-shell-ng2/package.json
@@ -6,11 +6,13 @@
   "scripts": {
     "clean": "npm install rimraf && rimraf dist node_modules typings",
     "build": "npm run tslint && npm run tsc && npm run licensecheck",
-    "start": "npm run build && concurrently \"npm run tsc:w\" \"npm run serve\" ",
+    "start": "npm run build && npm run serve",
+    "start:dev": "npm run build && concurrently \"npm run tsc:w\" \"npm run serve:dev\" ",
     "aws": "node app.js",
     "tsc": "tsc",
     "tsc:w": "tsc -w",
-    "serve": "wsrv -O http://localhost:3000 -s -l -p 3000 -a 0.0.0.0 -x ./server/versions.js",
+    "serve": "wsrv -O http://localhost:3000 -s -p 3000 -a 0.0.0.0 -x ./server/versions.js",
+    "serve:dev": "wsrv -O http://localhost:3000 -s -l -p 3000 -a 0.0.0.0 -x ./server/versions.js",
     "tslint": "tslint -c tslint.json *.ts && tslint -c tslint.json 'app/{,**/}**.ts'",
     "licensecheck": "license-check"
   },

--- a/ng2-components/ng2-alfresco-core/src/services/AlfrescoTranslation.service.ts
+++ b/ng2-components/ng2-alfresco-core/src/services/AlfrescoTranslation.service.ts
@@ -25,8 +25,7 @@ export class AlfrescoTranslationService {
     userLang: string = 'en' ;
 
     constructor(private translate: TranslateService) {
-        this.userLang = navigator.language.split('-')[0]; // use navigator lang if available
-        this.userLang = /(fr|en)/gi.test(this.userLang) ? this.userLang : 'en';
+        this.userLang = translate.getBrowserLang() || 'en';
         translate.setDefaultLang(this.userLang);
     }
 


### PR DESCRIPTION
- `npm start` now runs demo shell without TS watchers and live reload
(public/testing mode)
- new `npm run start:dev` script to run ‘development’ mode with
watchers and live reload
- Switch to ng2-translate language detection (that takes into account
various cases)

refs #932
refs #931