### PR TITLE
fix: Cannot save a dynamic table if certain property types are added

### DIFF
--- a/ng2-components/ng2-activiti-form/src/components/widgets/dynamic-table/editors/boolean/boolean.editor.spec.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/dynamic-table/editors/boolean/boolean.editor.spec.ts
@@ -29,7 +29,7 @@ describe('BooleanEditorComponent', () => {
     it('should update row value on change', () => {
         let row = <DynamicTableRow> { value: {} };
         let column = <DynamicTableColumn> { id: 'key' };
-        let event = { srcElement: { checked: true } };
+        let event = { target: { checked: true } };
 
         component.onValueChanged(row, column, event);
         expect(row.value[column.id]).toBeTruthy();

--- a/ng2-components/ng2-activiti-form/src/components/widgets/dynamic-table/editors/boolean/boolean.editor.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/dynamic-table/editors/boolean/boolean.editor.ts
@@ -28,7 +28,7 @@ import { DynamicTableRow, DynamicTableColumn } from './../../../core/index';
 export class BooleanEditorComponent extends CellEditorComponent {
 
     onValueChanged(row: DynamicTableRow, column: DynamicTableColumn, event: any) {
-        let value: boolean = (<HTMLInputElement>event.srcElement).checked;
+        let value: boolean = (<HTMLInputElement>event.target).checked;
         row.value[column.id] = value;
     }
 

--- a/ng2-components/ng2-activiti-form/src/components/widgets/dynamic-table/editors/dropdown/dropdown.editor.spec.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/dynamic-table/editors/dropdown/dropdown.editor.spec.ts
@@ -146,7 +146,7 @@ describe('DropdownEditorComponent', () => {
     });
 
     it('should update row on value change', () => {
-        let event = { srcElement: { value: 'two' } };
+        let event = { target: { value: 'two' } };
         component.onValueChanged(row, column, event);
         expect(row.value[column.id]).toBe(column.options[1]);
     });

--- a/ng2-components/ng2-activiti-form/src/components/widgets/dynamic-table/editors/dropdown/dropdown.editor.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/dynamic-table/editors/dropdown/dropdown.editor.ts
@@ -61,7 +61,7 @@ export class DropdownEditorComponent extends CellEditorComponent implements OnIn
     }
 
     onValueChanged(row: DynamicTableRow, column: DynamicTableColumn, event: any) {
-        let value: any = (<HTMLInputElement>event.srcElement).value;
+        let value: any = (<HTMLInputElement>event.target).value;
         value = column.options.find(opt => opt.name === value);
         row.value[column.id] = value;
     }

--- a/ng2-components/ng2-activiti-form/src/components/widgets/dynamic-table/editors/text/text.editor.spec.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/dynamic-table/editors/text/text.editor.spec.ts
@@ -31,7 +31,7 @@ describe('TextEditorComponent', () => {
         let column = <DynamicTableColumn> { id: 'key' };
 
         const value = '<value>';
-        let event = { srcElement: { value } };
+        let event = { target: { value } };
 
         editor.onValueChanged(row, column, event);
         expect(row.value[column.id]).toBe(value);

--- a/ng2-components/ng2-activiti-form/src/components/widgets/dynamic-table/editors/text/text.editor.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/dynamic-table/editors/text/text.editor.ts
@@ -28,7 +28,7 @@ import { DynamicTableRow, DynamicTableColumn } from './../../../core/index';
 export class TextEditorComponent extends CellEditorComponent {
 
     onValueChanged(row: DynamicTableRow, column: DynamicTableColumn, event: any) {
-        let value: any = (<HTMLInputElement>event.srcElement).value;
+        let value: any = (<HTMLInputElement>event.target).value;
         row.value[column.id] = value;
     }
 

--- a/ng2-components/ng2-alfresco-datatable/src/components/datatable/datatable.component.spec.ts
+++ b/ng2-components/ng2-alfresco-datatable/src/components/datatable/datatable.component.spec.ts
@@ -314,26 +314,26 @@ describe('DataTable', () => {
 
     it('should replace image source with fallback thumbnail on error', () => {
         let event = <any> {
-            srcElement: {
+            target: {
                 src: 'missing-image'
             }
         };
 
         dataTable.fallbackThumbnail = '<fallback>';
         dataTable.onImageLoadingError(event);
-        expect(event.srcElement.src).toBe(dataTable.fallbackThumbnail);
+        expect(event.target.src).toBe(dataTable.fallbackThumbnail);
     });
 
     it('should replace image source only when fallback available', () => {
         const originalSrc = 'missing-image';
         let event = <any> {
-            srcElement: {
+            target: {
                 src: originalSrc
             }
         };
 
         dataTable.fallbackThumbnail = null;
         dataTable.onImageLoadingError(event);
-        expect(event.srcElement.src).toBe(originalSrc);
+        expect(event.target.src).toBe(originalSrc);
     });
 });

--- a/ng2-components/ng2-alfresco-datatable/src/components/datatable/datatable.component.ts
+++ b/ng2-components/ng2-alfresco-datatable/src/components/datatable/datatable.component.ts
@@ -146,7 +146,7 @@ export class DataTableComponent implements OnInit, AfterViewChecked {
 
     onImageLoadingError(event: Event) {
         if (event && this.fallbackThumbnail) {
-            let element = <any> event.srcElement;
+            let element = <any> event.target;
             element.src = this.fallbackThumbnail;
         }
     }


### PR DESCRIPTION
- use cross browser `event.target` instead of IE-specific
`event.srcElement`

refs #960 