### PR TITLE
attach widget improvements

### DIFF
--- a/ng2-components/ng2-activiti-form/src/components/widgets/upload/upload.widget.css
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/upload/upload.widget.css
@@ -1,5 +1,6 @@
 .upload-widget {
-    width:100%
+    width:100%;
+    word-break: break-all;
 }
 
 .upload-widget__icon {
@@ -13,7 +14,7 @@
 
 .upload-widget__reset {
     float: left;
-    margin-top: 4px;
+    margin-top: -2px;
 }
 
 .upload-widget__invalid .upload-widget__label {

--- a/ng2-components/ng2-activiti-form/src/components/widgets/upload/upload.widget.html
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/upload/upload.widget.html
@@ -10,7 +10,10 @@
                [attr.id]="field.id"
                class="upload-widget__file"
                (change)="onFileChanged($event)">
-        <button *ngIf="hasFile" (click)="reset(file);" class="upload-widget__reset">X</button>
+        <button *ngIf="hasFile" (click)="reset(file);"
+                class="mdl-button mdl-js-button mdl-button--icon upload-widget__reset">
+            <i class="material-icons">highlight_off</i>
+        </button>
     </div>
     <span *ngIf="field.validationSummary" class="mdl-textfield__error">{{field.validationSummary}}</span>
 </div>


### PR DESCRIPTION
- material remove button (same look cross browser)
- word wrapping for long file names

closes #748

**Short name:**
<img width="169" alt="screen shot 2016-11-04 at 11 57 20" src="https://cloud.githubusercontent.com/assets/503991/20004850/86ac427e-a286-11e6-906b-be26c9cdf6ec.png">

**Long name:**
<img width="760" alt="screen shot 2016-11-04 at 11 57 31" src="https://cloud.githubusercontent.com/assets/503991/20004856/8c9ede6c-a286-11e6-9413-a657d36a4505.png">
