### PR TITLE
#1091 - fix typeahead widget

### DIFF
--- a/ng2-components/ng2-activiti-form/src/components/widgets/typeahead/typeahead.widget.html
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/typeahead/typeahead.widget.html
@@ -1,6 +1,6 @@
 <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label typeahead-widget"
      [class.is-dirty]="value"
-     [class.typeahead-widget__invalid]="!field.isValid" id="typehead-div">
+     [class.typeahead-widget__invalid]="!field.isValid" id="typehead-div" *ngIf="field.isVisible">
     <input class="mdl-textfield__input"
            type="text"
            [attr.id]="field.id"
@@ -14,6 +14,7 @@
 <div class="typeahead-autocomplete mdl-shadow--2dp" *ngIf="options.length > 0 && popupVisible">
     <ul>
         <li *ngFor="let item of options"
+            [attr.id]="field.id +'-'+item.id"
             class="mdl-menu__item"
             (click)="onItemClick(item, $event)">
             {{item.name}}

--- a/ng2-components/ng2-activiti-form/src/components/widgets/typeahead/typeahead.widget.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/typeahead/typeahead.widget.ts
@@ -19,6 +19,7 @@ import { Component, OnInit } from '@angular/core';
 import { FormService } from './../../../services/form.service';
 import { WidgetComponent } from './../widget.component';
 import { FormFieldOption } from './../core/form-field-option';
+import { WidgetVisibilityService } from '../../../services/widget-visibility.service';
 
 @Component({
     moduleId: module.id,
@@ -33,15 +34,16 @@ export class TypeaheadWidget extends WidgetComponent implements OnInit {
     value: string;
     options: FormFieldOption[] = [];
 
-    constructor(private formService: FormService) {
+    constructor(private formService: FormService,
+                private visibilityService: WidgetVisibilityService) {
         super();
     }
 
     ngOnInit() {
-        if (this.field.form.processDefinitionId) {
-            this.getValuesByProcessDefinitionId();
-        } else {
+        if (this.field.form.taskId) {
             this.getValuesByTaskId();
+        } else {
+            this.getValuesByProcessDefinitionId();
         }
     }
 
@@ -113,7 +115,7 @@ export class TypeaheadWidget extends WidgetComponent implements OnInit {
     onBlur() {
         setTimeout(() => {
             this.flushValue();
-            this.checkVisibility(this.field);
+            this.checkVisibility();
         }, 200);
     }
 
@@ -141,7 +143,7 @@ export class TypeaheadWidget extends WidgetComponent implements OnInit {
         if (item) {
             this.field.value = item.id;
             this.value = item.name;
-            this.checkVisibility(this.field);
+            this.checkVisibility();
         }
         if (event) {
             event.preventDefault();
@@ -150,6 +152,10 @@ export class TypeaheadWidget extends WidgetComponent implements OnInit {
 
     handleError(error: any) {
         console.error(error);
+    }
+
+    checkVisibility() {
+        this.visibilityService.refreshVisibility(this.field.form);
     }
 
 }


### PR DESCRIPTION
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 
 Check also that your commit messages follow our commit message format guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format
 -->

**Type of contribution:** (check one with "x")
```
[ X ] Bugfix
[ ] Feature
[ ] Code formatting 
[ ] Code Refactoring
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```
**This PR adds the following feature:** 
<!-- you can ignore this line in the case of a bugfix -->

**Current behavior:** 
Typeahead widget is not working on start process form
**New behavior:**
Typeahead widget is correctly populated

**This PR fixes the following issue:** 
#1091 

**This PR introduces a breaking change:** (check one with "x")
- [ ] Yes
- [ X ] No

<!-- Please describe the reason to introduce a breaking change, and what exactly breaks -->


**More information:**


