### PR TITLE
#1102 add link ng2-component dependecy during the build in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ before_script:
         (cd ng2-components/ng2-activiti-diagrams; npm link ng2-alfresco-core; if [ ! -d "dist" ]; then npm install; fi; npm link);
     fi
   - cd ng2-components/$MODULE;
+  - npm run travis;
   - npm install;
 script: npm run test
 # Send coverage data to Coveralls


### PR DESCRIPTION
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 
 Check also that your commit messages follow our commit message format guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format
 -->

**Type of contribution:** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code formatting 
[ ] Code Refactoring
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```
**This PR adds the following feature:** 
<!-- you can ignore this line in the case of a bugfix -->

**Current behavior:** 

**New behavior:**

**This PR fixes the following issue:** 
<!-- link to the open issue, ignore this if there are no issues open -->
#1102 Travis build must link the dependency alfresco-ng2-components-* package

**This PR introduces a breaking change:** (check one with "x")
```
- [ ] Yes
- [x] No
```

<!-- Please describe the reason to introduce a breaking change, and what exactly breaks -->


**More information:**


