### PR TITLE
#1033 - fix demo shell for user info profile icon

### DIFF
--- a/demo-shell-ng2/app/app.component.css
+++ b/demo-shell-ng2/app/app.component.css
@@ -9,7 +9,7 @@
 }
 
 .user-profile {
-    margin-right: 50px;
+    margin-right: 10px;
 }
 
 .mdl-button-padding {

--- a/demo-shell-ng2/app/app.component.html
+++ b/demo-shell-ng2/app/app.component.html
@@ -4,10 +4,9 @@
         <header class="mdl-layout__header">
             <div class="mdl-button-padding mdl-layout__header-row">
 
-                <div *ngIf="isLoggedIn()">
-                    <ng2-alfresco-userinfo class="user-profile" [menuOpenType]="left">
-                    </ng2-alfresco-userinfo>
-                </div>
+
+                <ng2-alfresco-userinfo class="user-profile" [menuOpenType]="left">
+                </ng2-alfresco-userinfo>
 
 
                 <!-- Title -->
@@ -20,7 +19,8 @@
 
                 <!-- Navigation. We hide it in small screens. -->
                 <nav class="mdl-navigation mdl-layout--large-screen-only">
-                    <a class="mdl-navigation__link" data-automation-id="files" href="" routerLink="/files">DocumentList</a>
+                    <a class="mdl-navigation__link" data-automation-id="files" href=""
+                       routerLink="/files">DocumentList</a>
                     <a class="mdl-navigation__link" data-automation-id="datatable" href="" routerLink="/datatable">DataTable</a>
                     <a class="mdl-navigation__link" data-automation-id="uploader" href="" routerLink="/uploader">Uploader</a>
                     <a class="mdl-navigation__link" data-automation-id="activiti" href="" routerLink="/activiti">Activiti</a>
@@ -66,10 +66,12 @@
             <span class="mdl-layout-title">Components List</span>
             <nav class="mdl-navigation">
                 <a class="mdl-navigation__link" href="" routerLink="/files" (click)="hideDrawer()">DocumentList Demo</a>
-                <a class="mdl-navigation__link" href="" routerLink="/datatable" (click)="hideDrawer()">DataTable Demo</a>
+                <a class="mdl-navigation__link" href="" routerLink="/datatable" (click)="hideDrawer()">DataTable
+                    Demo</a>
                 <a class="mdl-navigation__link" href="" routerLink="/uploader" (click)="hideDrawer()">Uploader Demo</a>
                 <a class="mdl-navigation__link" href="" routerLink="/login" (click)="hideDrawer()">Login Demo</a>
-                <a class="mdl-navigation__link" href="" routerLink="/activiti" (click)="hideDrawer()">Activiti Components Demo</a>
+                <a class="mdl-navigation__link" href="" routerLink="/activiti" (click)="hideDrawer()">Activiti
+                    Components Demo</a>
                 <a class="mdl-navigation__link" href="" routerLink="/webscript" (click)="hideDrawer()">Webscript</a>
                 <a class="mdl-navigation__link" href="" routerLink="/tag" (click)="hideDrawer()">Tag</a>
                 <a class="mdl-navigation__link" href="" routerLink="/settings" (click)="hideDrawer()">Settings</a>


### PR DESCRIPTION
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 
 Check also that your commit messages follow our commit message format guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format
 -->

**Type of contribution:** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code formatting 
[ ] Code Refactoring
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```
**This PR adds the following feature:** 
<!-- you can ignore this line in the case of a bugfix -->

**Current behavior:** 
on firefox / safari and ie user info profile button is shifted up
**New behavior:**
on all browsers should be now centered

**This PR fixes the following issue:** 
#1033 

**This PR introduces a breaking change:** (check one with "x")
```
- [ ] Yes
- [x] No
```

<!-- Please describe the reason to introduce a breaking change, and what exactly breaks -->


**More information:**

