### PR TITLE
Remove deprecated use of getAlfrescoApi() #1094

### DIFF
--- a/ng2-components/ng2-activiti-form/src/components/activiti-form.component.spec.ts
+++ b/ng2-components/ng2-activiti-form/src/components/activiti-form.component.spec.ts
@@ -41,7 +41,7 @@ describe('ActivitiForm', () => {
         window['componentHandler'] = componentHandler;
 
         formService = new FormService(null, null);
-        nodeService = new NodeService(null);
+        nodeService = new NodeService(null, null);
         formComponent = new ActivitiForm(formService, visibilityService, null, nodeService);
     });
 

--- a/ng2-components/ng2-activiti-form/src/components/widgets/attach/attach.widget.spec.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/attach/attach.widget.spec.ts
@@ -30,7 +30,7 @@ describe('AttachWidget', () => {
     let dialogPolyfill: any;
 
     beforeEach(() => {
-        contentService = new ActivitiAlfrescoContentService(null);
+        contentService = new ActivitiAlfrescoContentService(null, null);
         widget = new AttachWidget(contentService);
 
         dialogPolyfill = {

--- a/ng2-components/ng2-activiti-form/src/services/activiti-alfresco.service.ts
+++ b/ng2-components/ng2-activiti-form/src/services/activiti-alfresco.service.ts
@@ -17,9 +17,10 @@
 
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Rx';
-import { AlfrescoAuthenticationService } from 'ng2-alfresco-core';
+import { AlfrescoAuthenticationService, AlfrescoApiService } from 'ng2-alfresco-core';
 import { ExternalContent } from '../components/widgets/core/external-content';
 import { ExternalContentLink } from '../components/widgets/core/external-content-link';
+import { AlfrescoApi } from  'alfresco-js-api';
 
 @Injectable()
 export class ActivitiAlfrescoContentService {
@@ -27,7 +28,7 @@ export class ActivitiAlfrescoContentService {
     static UNKNOWN_ERROR_MESSAGE: string = 'Unknown error';
     static GENERIC_ERROR_MESSAGE: string = 'Server error';
 
-    constructor(private authService: AlfrescoAuthenticationService) {
+    constructor(private authService: AlfrescoAuthenticationService, private apiService: AlfrescoApiService) {
     }
 
     /**
@@ -38,7 +39,7 @@ export class ActivitiAlfrescoContentService {
      * @returns {null}
      */
     getAlfrescoNodes(accountId: string, folderId: string): Observable<[ExternalContent]> {
-        let apiService: any = this.authService.getAlfrescoApi();
+        let apiService: AlfrescoApi = this.apiService.getInstance();
         let accountShortId = accountId.replace('alfresco-', '');
         return Observable.fromPromise(apiService.activiti.alfrescoApi.getContentInFolder(accountShortId, folderId))
             .map(this.toJsonArray)
@@ -54,7 +55,7 @@ export class ActivitiAlfrescoContentService {
      * @returns {null}
      */
     linkAlfrescoNode(accountId: string, node: ExternalContent, siteId: string): Observable<ExternalContentLink> {
-        let apiService: any = this.authService.getAlfrescoApi();
+        let apiService: AlfrescoApi = this.apiService.getInstance();
         return Observable.fromPromise(apiService.activiti.contentApi.createTemporaryRelatedContent({
             link: true,
             name: node.title,

--- a/ng2-components/ng2-activiti-form/src/services/node.service.ts
+++ b/ng2-components/ng2-activiti-form/src/services/node.service.ts
@@ -16,14 +16,14 @@
  */
 
 import { Injectable } from '@angular/core';
-import { AlfrescoAuthenticationService } from 'ng2-alfresco-core';
+import { AlfrescoAuthenticationService, AlfrescoApiService } from 'ng2-alfresco-core';
 import { Observable } from 'rxjs/Rx';
 import { NodeMetadata } from '../models/node-metadata.model';
 
 @Injectable()
 export class NodeService {
 
-    constructor(private authService: AlfrescoAuthenticationService) {
+    constructor(private authService: AlfrescoAuthenticationService, private apiService: AlfrescoApiService) {
     }
 
     /**
@@ -32,7 +32,7 @@ export class NodeService {
      * @returns NodeMetadata
      */
     public getNodeMetadata(nodeId: string): Observable<NodeMetadata> {
-        return Observable.fromPromise(this.authService.getAlfrescoApi().nodes.getNodeInfo(nodeId)).map(this.cleanMetadataFromSemicolon);
+        return Observable.fromPromise(this.apiService.getInstance().nodes.getNodeInfo(nodeId)).map(this.cleanMetadataFromSemicolon);
     }
 
     /**
@@ -71,7 +71,7 @@ export class NodeService {
         };
 
         // TODO: requires update to alfresco-js-api typings
-        let apiService: any = this.authService.getAlfrescoApi();
+        let apiService: any = this.apiService.getInstance();
         return Observable.fromPromise(apiService.nodes.addNode('-root-', body, {}));
     }
 

--- a/ng2-components/ng2-activiti-processlist/src/components/activiti-filters.component.spec.ts
+++ b/ng2-components/ng2-activiti-processlist/src/components/activiti-filters.component.spec.ts
@@ -43,7 +43,7 @@ describe('ActivitiFilters', () => {
     });
 
     beforeEach(() => {
-        activitiService = new ActivitiProcessService(null);
+        activitiService = new ActivitiProcessService(null, null);
         filterList = new ActivitiProcessFilters(null, activitiService);
     });
 

--- a/ng2-components/ng2-activiti-processlist/src/services/activiti-process.service.spec.ts
+++ b/ng2-components/ng2-activiti-processlist/src/services/activiti-process.service.spec.ts
@@ -43,6 +43,7 @@ describe('ActivitiProcessService', () => {
     let service: ActivitiProcessService;
     let authenticationService: AlfrescoAuthenticationService;
     let injector: ReflectiveInjector;
+    let apiService: AlfrescoApiService;
     let alfrescoApi: AlfrescoApi;
 
     beforeEach(() => {
@@ -54,7 +55,8 @@ describe('ActivitiProcessService', () => {
         ]);
         service = injector.get(ActivitiProcessService);
         authenticationService = injector.get(AlfrescoAuthenticationService);
-        alfrescoApi = authenticationService.getAlfrescoApi();
+        apiService = injector.get(AlfrescoApiService);
+        alfrescoApi = apiService.getInstance();
     });
 
     describe('process instances', () => {

--- a/ng2-components/ng2-activiti-processlist/src/services/activiti-process.service.ts
+++ b/ng2-components/ng2-activiti-processlist/src/services/activiti-process.service.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { AlfrescoAuthenticationService } from 'ng2-alfresco-core';
+import { AlfrescoApiService, AlfrescoAuthenticationService } from 'ng2-alfresco-core';
 import { ProcessInstance, ProcessDefinitionRepresentation } from '../models/index';
 import { ProcessFilterRequestRepresentation } from '../models/process-instance-filter.model';
 import {
@@ -33,7 +33,7 @@ declare var moment: any;
 @Injectable()
 export class ActivitiProcessService {
 
-    constructor(public authService: AlfrescoAuthenticationService) {
+    constructor(public authService: AlfrescoAuthenticationService, public apiService: AlfrescoApiService) {
     }
 
     /**
@@ -41,13 +41,13 @@ export class ActivitiProcessService {
      * @returns {Observable<any>}
      */
     getDeployedApplications(name: string): Observable<AppDefinitionRepresentationModel> {
-        return Observable.fromPromise(this.authService.getAlfrescoApi().activiti.appsApi.getAppDefinitions())
+        return Observable.fromPromise(this.apiService.getInstance().activiti.appsApi.getAppDefinitions())
             .map((response: any) => response.data.find((p: AppDefinitionRepresentationModel) => p.name === name))
             .catch(this.handleError);
     }
 
     getProcessInstances(requestNode: ProcessFilterRequestRepresentation): Observable<ProcessInstance[]> {
-        return Observable.fromPromise(this.authService.getAlfrescoApi().activiti.processApi.getProcessInstances(requestNode))
+        return Observable.fromPromise(this.apiService.getInstance().activiti.processApi.getProcessInstances(requestNode))
             .map((res: any) => {
                 if (requestNode.processDefinitionKey) {
                     return res.data.filter(p => p.processDefinitionKey === requestNode.processDefinitionKey);
@@ -155,7 +155,7 @@ export class ActivitiProcessService {
     }
 
     getProcess(id: string): Observable<ProcessInstance> {
-        return Observable.fromPromise(this.authService.getAlfrescoApi().activiti.processApi.getProcessInstance(id))
+        return Observable.fromPromise(this.apiService.getInstance().activiti.processApi.getProcessInstance(id))
             .catch(this.handleError);
     }
 
@@ -166,7 +166,7 @@ export class ActivitiProcessService {
         } : {
             processInstanceId: id
         };
-        return Observable.fromPromise(this.authService.getAlfrescoApi().activiti.taskApi.listTasks(taskOpts))
+        return Observable.fromPromise(this.apiService.getInstance().activiti.taskApi.listTasks(taskOpts))
             .map(this.extractData)
             .map(tasks => tasks.map((task: any) => {
                 task.created =  moment(task.created, 'YYYY-MM-DD').format();
@@ -181,7 +181,7 @@ export class ActivitiProcessService {
      * @returns {<Comment[]>}
      */
     getProcessInstanceComments(id: string): Observable<Comment[]> {
-        return Observable.fromPromise(this.authService.getAlfrescoApi().activiti.commentsApi.getProcessInstanceComments(id))
+        return Observable.fromPromise(this.apiService.getInstance().activiti.commentsApi.getProcessInstanceComments(id))
             .map(res => res)
             .map((response: any) => {
                 let comments: Comment[] = [];
@@ -206,7 +206,7 @@ export class ActivitiProcessService {
      */
     addProcessInstanceComment(id: string, message: string): Observable<Comment> {
         return Observable.fromPromise(
-            this.authService.getAlfrescoApi().activiti.commentsApi.addProcessInstanceComment({message: message}, id)
+            this.apiService.getInstance().activiti.commentsApi.addProcessInstanceComment({message: message}, id)
             )
             .map((response: Comment) => {
                 return new Comment(response.id, response.message, response.created, response.createdBy);
@@ -222,7 +222,7 @@ export class ActivitiProcessService {
             latest: true
         };
         return Observable.fromPromise(
-            this.authService.getAlfrescoApi().activiti.processApi.getProcessDefinitions(opts)
+            this.apiService.getInstance().activiti.processApi.getProcessDefinitions(opts)
             )
             .map(this.extractData)
             .map(processDefs => processDefs.map((pd) => new ProcessDefinitionRepresentation(pd)))
@@ -238,7 +238,7 @@ export class ActivitiProcessService {
             startRequest.values = startFormValues;
         }
         return Observable.fromPromise(
-            this.authService.getAlfrescoApi().activiti.processApi.startNewProcessInstance(startRequest)
+            this.apiService.getInstance().activiti.processApi.startNewProcessInstance(startRequest)
             )
             .map((pd) => new ProcessInstance(pd))
             .catch(this.handleError);
@@ -246,17 +246,17 @@ export class ActivitiProcessService {
 
     cancelProcess(processInstanceId: string): Observable<void> {
         return Observable.fromPromise(
-            this.authService.getAlfrescoApi().activiti.processApi.deleteProcessInstance(processInstanceId)
+            this.apiService.getInstance().activiti.processApi.deleteProcessInstance(processInstanceId)
             )
             .catch(this.handleError);
     }
 
     private callApiGetUserProcessInstanceFilters(filterOpts) {
-        return this.authService.getAlfrescoApi().activiti.userFiltersApi.getUserProcessInstanceFilters(filterOpts);
+        return this.apiService.getInstance().activiti.userFiltersApi.getUserProcessInstanceFilters(filterOpts);
     }
 
     private callApiAddFilter(filter: FilterRepresentationModel) {
-        return this.authService.getAlfrescoApi().activiti.userFiltersApi.createUserProcessInstanceFilter(filter);
+        return this.apiService.getInstance().activiti.userFiltersApi.createUserProcessInstanceFilter(filter);
     }
 
     private extractData(res: any) {

--- a/ng2-components/ng2-activiti-tasklist/src/components/activiti-filters.component.spec.ts
+++ b/ng2-components/ng2-activiti-tasklist/src/components/activiti-filters.component.spec.ts
@@ -42,7 +42,7 @@ describe('ActivitiFilters', () => {
     });
 
     beforeEach(() => {
-        let activitiService = new ActivitiTaskListService(null);
+        let activitiService = new ActivitiTaskListService(null, null);
         filterList = new ActivitiFilters(null, null, activitiService);
     });
 

--- a/ng2-components/ng2-activiti-tasklist/src/services/activiti-tasklist.service.ts
+++ b/ng2-components/ng2-activiti-tasklist/src/services/activiti-tasklist.service.ts
@@ -16,7 +16,7 @@
  */
 
 import {Injectable} from '@angular/core';
-import {AlfrescoAuthenticationService} from 'ng2-alfresco-core';
+import {AlfrescoAuthenticationService, AlfrescoApiService} from 'ng2-alfresco-core';
 import {Observable} from 'rxjs/Rx';
 import {FilterRepresentationModel} from '../models/filter.model';
 import {TaskQueryRequestRepresentationModel} from '../models/filter.model';
@@ -27,7 +27,7 @@ import {TaskDetailsModel} from '../models/task-details.model';
 @Injectable()
 export class ActivitiTaskListService {
 
-    constructor(public authService: AlfrescoAuthenticationService) {
+    constructor(public authService: AlfrescoAuthenticationService, private apiService: AlfrescoApiService) {
     }
 
     /**
@@ -35,7 +35,7 @@ export class ActivitiTaskListService {
      * @returns {Observable<any>}
      */
     getDeployedApplications(name?: string): Observable<any> {
-        return Observable.fromPromise(this.authService.getAlfrescoApi().activiti.appsApi.getAppDefinitions())
+        return Observable.fromPromise(this.apiService.getInstance().activiti.appsApi.getAppDefinitions())
             .map((response: any) => {
                 if (name) {
                     return response.data.find(p => p.name === name);
@@ -233,47 +233,47 @@ export class ActivitiTaskListService {
     }
 
     private callApiTasksFiltered(requestNode: TaskQueryRequestRepresentationModel) {
-        return this.authService.getAlfrescoApi().activiti.taskApi.listTasks(requestNode);
+        return this.apiService.getInstance().activiti.taskApi.listTasks(requestNode);
     }
 
     private callApiTaskFilters(appId?: string) {
         if (appId) {
-            return this.authService.getAlfrescoApi().activiti.userFiltersApi.getUserTaskFilters({appId: appId});
+            return this.apiService.getInstance().activiti.userFiltersApi.getUserTaskFilters({appId: appId});
         } else {
-            return this.authService.getAlfrescoApi().activiti.userFiltersApi.getUserTaskFilters();
+            return this.apiService.getInstance().activiti.userFiltersApi.getUserTaskFilters();
         }
     }
 
     private callApiTaskDetails(id: string) {
-        return this.authService.getAlfrescoApi().activiti.taskApi.getTask(id);
+        return this.apiService.getInstance().activiti.taskApi.getTask(id);
     }
 
     private callApiTaskComments(id: string) {
-        return this.authService.getAlfrescoApi().activiti.taskApi.getTaskComments(id);
+        return this.apiService.getInstance().activiti.taskApi.getTaskComments(id);
     }
 
     private callApiAddTaskComment(id: string, message: string) {
-        return this.authService.getAlfrescoApi().activiti.taskApi.addTaskComment({message: message}, id);
+        return this.apiService.getInstance().activiti.taskApi.addTaskComment({message: message}, id);
     }
 
     private callApiAddTask(task: TaskDetailsModel) {
-        return this.authService.getAlfrescoApi().activiti.taskApi.addSubtask(task.parentTaskId, task);
+        return this.apiService.getInstance().activiti.taskApi.addSubtask(task.parentTaskId, task);
     }
 
     private callApiAddFilter(filter: FilterRepresentationModel) {
-        return this.authService.getAlfrescoApi().activiti.userFiltersApi.createUserTaskFilter(filter);
+        return this.apiService.getInstance().activiti.userFiltersApi.createUserTaskFilter(filter);
     }
 
     private callApiTaskChecklist(id: string) {
-        return this.authService.getAlfrescoApi().activiti.taskApi.getChecklist(id);
+        return this.apiService.getInstance().activiti.taskApi.getChecklist(id);
     }
 
     private callApiCompleteTask(id: string) {
-        return this.authService.getAlfrescoApi().activiti.taskApi.completeTask(id);
+        return this.apiService.getInstance().activiti.taskApi.completeTask(id);
     }
 
     private callApiCreateTask(task: TaskDetailsModel) {
-        return this.authService.getAlfrescoApi().activiti.taskApi.createNewTask(task);
+        return this.apiService.getInstance().activiti.taskApi.createNewTask(task);
     }
 
     private handleError(error: any) {

--- a/ng2-components/ng2-alfresco-core/src/services/AlfrescoAuthentication.service.spec.ts
+++ b/ng2-components/ng2-alfresco-core/src/services/AlfrescoAuthentication.service.spec.ts
@@ -88,7 +88,7 @@ describe('AlfrescoAuthentication', () => {
             authService.login('fake-username', 'fake-password').subscribe(() => {
                 expect(authService.isLoggedIn()).toBe(true);
                 expect(authService.getTicketBpm()).toBeNull();
-                expect(authService.getAlfrescoApi().bpmAuth.isLoggedIn()).toBeFalsy();
+                expect(authService.alfrescoApi.bpmAuth.isLoggedIn()).toBeFalsy();
                 done();
             });
 
@@ -187,7 +187,7 @@ describe('AlfrescoAuthentication', () => {
             authService.login('fake-username', 'fake-password').subscribe(() => {
                 expect(authService.isLoggedIn()).toBe(true);
                 expect(authService.getTicketEcm()).toBeNull();
-                expect(authService.getAlfrescoApi().ecmAuth.isLoggedIn()).toBeFalsy();
+                expect(authService.alfrescoApi.ecmAuth.isLoggedIn()).toBeFalsy();
                 done();
             });
 
@@ -258,19 +258,19 @@ describe('AlfrescoAuthentication', () => {
         it('should host ecm url change be reflected in the api configuration', () => {
             settingsService.ecmHost = '127.99.99.99';
 
-            expect(authService.getAlfrescoApi().config.hostEcm).toBe('127.99.99.99');
+            expect(authService.alfrescoApi.config.hostEcm).toBe('127.99.99.99');
         });
 
         it('should host bpm url change be reflected in the api configuration', () => {
             settingsService.bpmHost = '127.99.99.99';
 
-            expect(authService.getAlfrescoApi().config.hostBpm).toBe('127.99.99.99');
+            expect(authService.alfrescoApi.config.hostBpm).toBe('127.99.99.99');
         });
 
         it('should host bpm provider change be reflected in the api configuration', () => {
             settingsService.setProviders('ECM');
 
-            expect(authService.getAlfrescoApi().config.provider).toBe('ECM');
+            expect(authService.alfrescoApi.config.provider).toBe('ECM');
         });
 
     });

--- a/ng2-components/ng2-alfresco-core/src/services/AlfrescoAuthentication.service.ts
+++ b/ng2-components/ng2-alfresco-core/src/services/AlfrescoAuthentication.service.ts
@@ -221,8 +221,4 @@ export class AlfrescoAuthenticationService {
         console.error('Error when logging in', error);
         return Observable.throw(error || 'Server error');
     }
-
-    getAlfrescoApi(): any {
-        return this.alfrescoApi;
-    }
 }

--- a/ng2-components/ng2-alfresco-core/src/services/AlfrescoContent.service.ts
+++ b/ng2-components/ng2-alfresco-core/src/services/AlfrescoContent.service.ts
@@ -18,11 +18,12 @@
 import { Injectable } from '@angular/core';
 
 import { AlfrescoAuthenticationService } from './AlfrescoAuthentication.service';
+import { AlfrescoApiService } from './AlfrescoApi.service';
 
 @Injectable()
 export class AlfrescoContentService {
 
-    constructor(private authService: AlfrescoAuthenticationService) {
+    constructor(public authService: AlfrescoAuthenticationService, public apiService: AlfrescoApiService) {
     }
 
     /**
@@ -31,7 +32,7 @@ export class AlfrescoContentService {
      * @returns {string} URL address.
      */
     getDocumentThumbnailUrl(document: any): string {
-        return this.authService.getAlfrescoApi().content.getDocumentThumbnailUrl(document.entry.id);
+        return this.apiService.getInstance().content.getDocumentThumbnailUrl(document.entry.id);
     }
 
     /**
@@ -40,6 +41,6 @@ export class AlfrescoContentService {
      * @returns {string} URL address.
      */
     getContentUrl(document: any): string {
-        return this.authService.getAlfrescoApi().content.getContentUrl(document.entry.id);
+        return this.apiService.getInstance().content.getContentUrl(document.entry.id);
     }
 }

--- a/ng2-components/ng2-alfresco-documentlist/src/assets/document-list.service.mock.ts
+++ b/ng2-components/ng2-alfresco-documentlist/src/assets/document-list.service.mock.ts
@@ -22,7 +22,8 @@ import { DocumentListService } from './../services/document-list.service';
 import {
     AlfrescoSettingsService,
     AlfrescoAuthenticationService,
-    AlfrescoContentService
+    AlfrescoContentService,
+    AlfrescoApiService
 } from 'ng2-alfresco-core';
 
 export class DocumentListServiceMock extends DocumentListService {
@@ -34,9 +35,10 @@ export class DocumentListServiceMock extends DocumentListService {
     constructor(
         settings?: AlfrescoSettingsService,
         authService?: AlfrescoAuthenticationService,
-        contentService?: AlfrescoContentService
+        contentService?: AlfrescoContentService,
+        apiService?: AlfrescoApiService
     ) {
-        super(authService, contentService);
+        super(authService, contentService, apiService);
     }
 
     getFolder(folder: string) {

--- a/ng2-components/ng2-alfresco-documentlist/src/services/document-actions.service.spec.ts
+++ b/ng2-components/ng2-alfresco-documentlist/src/services/document-actions.service.spec.ts
@@ -30,7 +30,7 @@ describe('DocumentActionsService', () => {
 
     beforeEach(() => {
         documentListService = new DocumentListServiceMock();
-        contentService = new AlfrescoContentService(null);
+        contentService = new AlfrescoContentService(null, null);
         service = new DocumentActionsService(documentListService, contentService);
     });
 

--- a/ng2-components/ng2-alfresco-documentlist/src/services/document-list.service.ts
+++ b/ng2-components/ng2-alfresco-documentlist/src/services/document-list.service.ts
@@ -18,10 +18,11 @@
 import { Injectable } from '@angular/core';
 import { Response } from '@angular/http';
 import { Observable } from 'rxjs/Rx';
-import { AlfrescoApi, NodePaging, MinimalNodeEntity } from 'alfresco-js-api';
+import { NodePaging, MinimalNodeEntity } from 'alfresco-js-api';
 import {
     AlfrescoAuthenticationService,
-    AlfrescoContentService
+    AlfrescoContentService,
+    AlfrescoApiService
 } from 'ng2-alfresco-core';
 
 @Injectable()
@@ -58,11 +59,7 @@ export class DocumentListService {
         'application/vnd.apple.numbers': 'ft_ic_spreadsheet.svg'
     };
 
-    constructor(private authService: AlfrescoAuthenticationService, private contentService: AlfrescoContentService) {
-    }
-
-    private getAlfrescoApi(): AlfrescoApi {
-        return this.authService.getAlfrescoApi();
+    constructor(private authService: AlfrescoAuthenticationService, private contentService: AlfrescoContentService, private apiService: AlfrescoApiService) {
     }
 
     private getNodesPromise(folder: string, opts?: any): Promise<NodePaging> {
@@ -81,11 +78,11 @@ export class DocumentListService {
             }
         }
 
-        return this.getAlfrescoApi().nodes.getNodeChildren(nodeId, params);
+        return this.apiService.getInstance().nodes.getNodeChildren(nodeId, params);
     }
 
     deleteNode(nodeId: string): Observable<any> {
-        return Observable.fromPromise(this.getAlfrescoApi().nodes.deleteNode(nodeId));
+        return Observable.fromPromise(this.apiService.getInstance().nodes.deleteNode(nodeId));
     }
 
     /**

--- a/ng2-components/ng2-alfresco-search/src/services/alfresco-search.service.spec.ts
+++ b/ng2-components/ng2-alfresco-search/src/services/alfresco-search.service.spec.ts
@@ -25,7 +25,7 @@ declare let jasmine: any;
 describe('AlfrescoSearchService', () => {
 
     let service: AlfrescoSearchService;
-    let authenticationService: AlfrescoAuthenticationService;
+    let apiService: AlfrescoApiService;
     let injector: ReflectiveInjector;
 
     beforeEach(() => {
@@ -36,8 +36,8 @@ describe('AlfrescoSearchService', () => {
             AlfrescoAuthenticationService
         ]);
         service = injector.get(AlfrescoSearchService);
-        authenticationService = injector.get(AlfrescoAuthenticationService);
-        spyOn(authenticationService, 'getAlfrescoApi').and.returnValue(fakeApi);
+        apiService = injector.get(AlfrescoApiService);
+        spyOn(apiService, 'getInstance').and.returnValue(fakeApi);
     });
 
     it('should call search API with no additional options', (done) => {

--- a/ng2-components/ng2-alfresco-search/src/services/alfresco-search.service.ts
+++ b/ng2-components/ng2-alfresco-search/src/services/alfresco-search.service.ts
@@ -17,7 +17,7 @@
 
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Rx';
-import { AlfrescoAuthenticationService } from 'ng2-alfresco-core';
+import { AlfrescoAuthenticationService, AlfrescoApiService } from 'ng2-alfresco-core';
 
 /**
  * Internal service used by Document List component.
@@ -25,7 +25,7 @@ import { AlfrescoAuthenticationService } from 'ng2-alfresco-core';
 @Injectable()
 export class AlfrescoSearchService {
 
-    constructor(private authService: AlfrescoAuthenticationService) {
+    constructor(public authService: AlfrescoAuthenticationService, private apiService: AlfrescoApiService) {
     }
 
     /**
@@ -42,7 +42,7 @@ export class AlfrescoSearchService {
     }
 
     private getQueryNodesPromise(term: string, opts: SearchOptions) {
-        return this.authService.getAlfrescoApi().core.queriesApi.findNodes(term, opts);
+        return this.apiService.getInstance().core.queriesApi.findNodes(term, opts);
     }
 
     private handleError(error: any): Observable<any> {

--- a/ng2-components/ng2-alfresco-webscript/src/webscript.component.ts
+++ b/ng2-components/ng2-alfresco-webscript/src/webscript.component.ts
@@ -16,7 +16,7 @@
  */
 
 import { Component, Input, Output, EventEmitter } from '@angular/core';
-import { AlfrescoAuthenticationService } from 'ng2-alfresco-core';
+import { AlfrescoAuthenticationService, AlfrescoApiService } from 'ng2-alfresco-core';
 import { ObjectDataTableAdapter } from 'ng2-alfresco-datatable';
 
 /**
@@ -83,7 +83,7 @@ export class WebscriptComponent {
      * Constructor
      * @param authService
      */
-    constructor(private authService: AlfrescoAuthenticationService) {
+    constructor(private authService: AlfrescoAuthenticationService, private apiService: AlfrescoApiService) {
 
     }
 
@@ -93,7 +93,7 @@ export class WebscriptComponent {
         }
 
         return new Promise((resolve, reject) => {
-            this.authService.getAlfrescoApi().webScript.executeWebScript('GET', this.scriptPath, this.scriptArgs, this.contextRoot, this.servicePath).then((webScriptdata) => {
+            this.apiService.getInstance().webScript.executeWebScript('GET', this.scriptPath, this.scriptArgs, this.contextRoot, this.servicePath).then((webScriptdata) => {
 
                 this.data = webScriptdata;
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
[x] Tests for the changes have been added (for bug fixes / features)
[x] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**

Remove deprecated use of getAlfrescoApi

**Does this PR introduce a breaking change?** (check one with "x")
```
[x] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
remove getAlfrescoApi from auth #1094