### PR TITLE
user-info improvements

### DIFF
--- a/demo-shell-ng2/wsrv-config.json
+++ b/demo-shell-ng2/wsrv-config.json
@@ -6,6 +6,7 @@
         "node_modules/ng2-alfresco-login/dist/**/*.{html,css,js}",
         "node_modules/ng2-alfresco-search/dist/**/*.{html,css,js}",
         "node_modules/ng2-alfresco-upload/dist/**/*.{html,css,js}",
+        "node_modules/ng2-alfresco-userinfo/dist/**/*.{html,css,js}",
         "node_modules/ng2-alfresco-viewer/dist/**/*.{html,css,js}",
         "node_modules/ng2-alfresco-webscript/dist/**/*.{html,css,js}",
         "node_modules/ng2-activiti-form/dist/**/*.{html,css,js}",

--- a/ng2-components/ng2-alfresco-documentlist/README.md
+++ b/ng2-components/ng2-alfresco-documentlist/README.md
@@ -114,7 +114,6 @@ import { NgModule, Component, ViewChild } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { CoreModule } from 'ng2-alfresco-core';
-import { DataTableModule }  from 'ng2-alfresco-datatable';
 import { DocumentListModule, DocumentList } from 'ng2-alfresco-documentlist';
 import { AlfrescoSettingsService, AlfrescoAuthenticationService } from 'ng2-alfresco-core';
 
@@ -133,7 +132,8 @@ class DocumentListDemo {
     @ViewChild(DocumentList)
     documentList: DocumentList;
 
-    constructor(private authService: AlfrescoAuthenticationService, private settingsService: AlfrescoSettingsService) {
+    constructor(private authService: AlfrescoAuthenticationService, 
+                private settingsService: AlfrescoSettingsService) {
         settingsService.ecmHost = 'http://localhost:8080';
 
         this.authService.login('admin', 'admin').subscribe(
@@ -151,7 +151,6 @@ class DocumentListDemo {
     imports: [
         BrowserModule,
         CoreModule.forRoot(),
-        DataTableModule,
         DocumentListModule.forRoot()
     ],
     declarations: [DocumentListDemo],
@@ -169,24 +168,25 @@ platformBrowserDynamic().bootstrapModule(AppModule);
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| `navigate` | boolean | true | Toggles navigation to folder content or file preview |
-| `navigationMode` | string (click\|dblclick) | dblclick | User interaction for folder navigation or file preview |
-| `thumbnails` | boolean | false | Show document thumbnails rather than icons |
-| `fallbackThubnail` | string |  | Fallback image for row ehre thubnail is missing|
-| `multiselect` | boolean | false | Toggles multiselect mode |
-| `contentActions` | boolean | false | Toggles content actions for each row |
-| `contextMenuActions` | boolean | false | Toggles context menus for each row |
-| `rowFilter` | `RowFilter` | | Custom row filter, [see more](#custom-row-filter).
-| `imageResolver` | `ImageResolver` | | Custom image resolver, [see more](#custom-image-resolver).
+| rootPath | string | -root- | Root node path, i.e. `-root-`, `-shared-`, `-my-`, etc. |
+| navigate | boolean | true | Toggles navigation to folder content or file preview |
+| navigationMode | string (click\|dblclick) | dblclick | User interaction for folder navigation or file preview |
+| thumbnails | boolean | false | Show document thumbnails rather than icons |
+| fallbackThubnail | string |  | Fallback image for row ehre thubnail is missing|
+| multiselect | boolean | false | Toggles multiselect mode |
+| contentActions | boolean | false | Toggles content actions for each row |
+| contextMenuActions | boolean | false | Toggles context menus for each row |
+| rowFilter | RowFilter | | Custom row filter, [see more](#custom-row-filter).
+| imageResolver | ImageResolver | | Custom image resolver, [see more](#custom-image-resolver).
 
 ### Events
 
 | Name | Description |
 | --- | --- |
-| `nodeClick` | Emitted when user clicks the node |
-| `nodeDblClick` | Emitted when user double-clicks the node |
-| `folderChange` | Emitted upon display folder changed |
-| `preview` | Emitted when document preview is requested either with single or double click |
+| nodeClick | Emitted when user clicks the node |
+| nodeDblClick | Emitted when user double-clicks the node |
+| folderChange | Emitted upon display folder changed |
+| preview | Emitted when document preview is requested either with single or double click |
 
 
 _For a complete example source code please refer to 
@@ -278,13 +278,13 @@ HTML attributes:
 
 | Name | Type | Default | Description
 | --- | --- | --- | --- |
-| `title` | string | | Column title |
-| `sr-title` | string | | Screen reader title, used only when `title` is empty |
-| `key` | string | | Column source key, example: `createdByUser.displayName` |
-| `sortable` | boolean | false | Toggle sorting ability via column header clicks |
-| `class`| string | | CSS class list, example: `full-width ellipsis-cell` |
-| `type` | string | text | Column type, text\|date\|number |
-| `format` | string | | Value format pattern |
+| title | string | | Column title |
+| sr-title | string | | Screen reader title, used only when `title` is empty |
+| key | string | | Column source key, example: `createdByUser.displayName` |
+| sortable | boolean | false | Toggle sorting ability via column header clicks |
+| class | string | | CSS class list, example: `full-width ellipsis-cell` |
+| type | string | text | Column type, text\|date\|number |
+| format | string | | Value format pattern |
 
 For `date` column type the [DatePipe](https://angular.io/docs/ts/latest/api/common/DatePipe-class.html) formatting is used.
 For a full list of available `format` values please refer to [DatePipe](https://angular.io/docs/ts/latest/api/common/DatePipe-class.html) documentation.
@@ -414,24 +414,12 @@ into context menu items like shown below:
 Enabling context menu is very simple:
 
 ```ts
-import {
-    CONTEXT_MENU_DIRECTIVES,
-    CONTEXT_MENU_PROVIDERS
-} from 'ng2-alfresco-core';
-
-import {
-    DOCUMENT_LIST_DIRECTIVES,
-    DOCUMENT_LIST_PROVIDERS
-} from 'ng2-alfresco-documentlist';
-
 @Component({
     selector: 'my-view',
     template: `
         <alfresco-document-list>...</alfresco-document-list>
         <context-menu-holder></context-menu-holder>
-    `,
-    directives: [DOCUMENT_LIST_DIRECTIVES, CONTEXT_MENU_DIRECTIVES],
-    providers: [DOCUMENT_LIST_PROVIDERS, CONTEXT_MENU_PROVIDERS]
+    `
 })
 export class MyView {
 }
@@ -691,9 +679,7 @@ You register custom handler called `my-handler` that will be executing `myDocume
 function each time upon being invoked.
 
 ```ts
-import {
-    DocumentActionsService
-} from 'ng2-alfresco-documentlist';
+import { DocumentActionsService } from 'ng2-alfresco-documentlist';
 
 export class MyView {
 
@@ -745,7 +731,7 @@ npm run build
 ### Build the files and keep watching for changes
 
 ```sh
-$ npm run build:w
+npm run build:w
 ```
 
 ## Running unit tests

--- a/ng2-components/ng2-alfresco-documentlist/README.md
+++ b/ng2-components/ng2-alfresco-documentlist/README.md
@@ -168,25 +168,25 @@ platformBrowserDynamic().bootstrapModule(AppModule);
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| rootPath | string | -root- | Root node path, i.e. `-root-`, `-shared-`, `-my-`, etc. |
-| navigate | boolean | true | Toggles navigation to folder content or file preview |
-| navigationMode | string (click\|dblclick) | dblclick | User interaction for folder navigation or file preview |
-| thumbnails | boolean | false | Show document thumbnails rather than icons |
-| fallbackThubnail | string |  | Fallback image for row ehre thubnail is missing|
-| multiselect | boolean | false | Toggles multiselect mode |
-| contentActions | boolean | false | Toggles content actions for each row |
-| contextMenuActions | boolean | false | Toggles context menus for each row |
-| rowFilter | RowFilter | | Custom row filter, [see more](#custom-row-filter).
-| imageResolver | ImageResolver | | Custom image resolver, [see more](#custom-image-resolver).
+| `rootPath` | string | -root- | Root node path, i.e. `-root-`, `-shared-`, `-my-`, etc. |
+| `navigate` | boolean | true | Toggles navigation to folder content or file preview |
+| `navigationMode` | string (click\|dblclick) | dblclick | User interaction for folder navigation or file preview |
+| `thumbnails` | boolean | false | Show document thumbnails rather than icons |
+| `fallbackThubnail` | string |  | Fallback image for row ehre thubnail is missing|
+| `multiselect` | boolean | false | Toggles multiselect mode |
+| `contentActions` | boolean | false | Toggles content actions for each row |
+| `contextMenuActions` | boolean | false | Toggles context menus for each row |
+| `rowFilter` | `RowFilter` | | Custom row filter, [see more](#custom-row-filter).
+| `imageResolver` | `ImageResolver` | | Custom image resolver, [see more](#custom-image-resolver).
 
 ### Events
 
 | Name | Description |
 | --- | --- |
-| nodeClick | Emitted when user clicks the node |
-| nodeDblClick | Emitted when user double-clicks the node |
-| folderChange | Emitted upon display folder changed |
-| preview | Emitted when document preview is requested either with single or double click |
+| `nodeClick` | Emitted when user clicks the node |
+| `nodeDblClick` | Emitted when user double-clicks the node |
+| `folderChange` | Emitted upon display folder changed |
+| `preview` | Emitted when document preview is requested either with single or double click |
 
 
 _For a complete example source code please refer to 
@@ -278,13 +278,13 @@ HTML attributes:
 
 | Name | Type | Default | Description
 | --- | --- | --- | --- |
-| title | string | | Column title |
-| sr-title | string | | Screen reader title, used only when `title` is empty |
-| key | string | | Column source key, example: `createdByUser.displayName` |
-| sortable | boolean | false | Toggle sorting ability via column header clicks |
-| class | string | | CSS class list, example: `full-width ellipsis-cell` |
-| type | string | text | Column type, text\|date\|number |
-| format | string | | Value format pattern |
+| `title` | string | | Column title |
+| `sr-title` | string | | Screen reader title, used only when `title` is empty |
+| `key` | string | | Column source key, example: `createdByUser.displayName` |
+| `sortable` | boolean | false | Toggle sorting ability via column header clicks |
+| `class` | string | | CSS class list, example: `full-width ellipsis-cell` |
+| `type` | string | text | Column type, text\|date\|number |
+| `format` | string | | Value format pattern |
 
 For `date` column type the [DatePipe](https://angular.io/docs/ts/latest/api/common/DatePipe-class.html) formatting is used.
 For a full list of available `format` values please refer to [DatePipe](https://angular.io/docs/ts/latest/api/common/DatePipe-class.html) documentation.
@@ -452,10 +452,10 @@ DocumentList emits the following events:
 
 | Name | Description |
 | --- | --- |
-| nodeClick | emitted when user clicks a list node |
-| nodeDblClick | emitted when user double-clicks list node |
-| folderChange | emitted once current display folder has changed |
-| preview | emitted when user acts upon files with either single or double click (depends on `navigation-mode`), recommended for Viewer components integration  |
+| `nodeClick` | emitted when user clicks a list node |
+| `nodeDblClick` | emitted when user double-clicks list node |
+| `folderChange` | emitted once current display folder has changed |
+| `preview` | emitted when user acts upon files with either single or double click (depends on `navigation-mode`), recommended for Viewer components integration  |
 
 ## Advanced usage and customization
 

--- a/ng2-components/ng2-alfresco-documentlist/demo/src/main.ts
+++ b/ng2-components/ng2-alfresco-documentlist/demo/src/main.ts
@@ -19,7 +19,6 @@ import { NgModule, Component, OnInit, ViewChild } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { CoreModule } from 'ng2-alfresco-core';
-import { DataTableModule }  from 'ng2-alfresco-datatable';
 import { DocumentListModule, DocumentList } from 'ng2-alfresco-documentlist';
 
 import {
@@ -217,7 +216,6 @@ class DocumentListDemo implements OnInit {
     imports: [
         BrowserModule,
         CoreModule.forRoot(),
-        DataTableModule,
         DocumentListModule.forRoot()
     ],
     declarations: [ DocumentListDemo ],

--- a/ng2-components/ng2-alfresco-documentlist/index.ts
+++ b/ng2-components/ng2-alfresco-documentlist/index.ts
@@ -80,6 +80,7 @@ export const DOCUMENT_LIST_PROVIDERS: any[] = [
         ...DOCUMENT_LIST_PROVIDERS
     ],
     exports: [
+        DataTableModule,
         ...DOCUMENT_LIST_DIRECTIVES
     ]
 })

--- a/ng2-components/ng2-alfresco-documentlist/src/components/document-list.spec.ts
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/document-list.spec.ts
@@ -47,6 +47,14 @@ describe('DocumentList', () => {
         window['componentHandler'] = componentHandler;
     });
 
+    it('should update root path', () => {
+        let adapter = documentList.data;
+        expect(adapter.rootPath).toBe(adapter.DEFAULT_ROOT_PATH);
+
+        documentList.rootPath = '-shared-';
+        expect(adapter.rootPath).toBe('-shared-');
+    });
+
     it('should setup default columns', () => {
         spyOn(documentList, 'setupDefaultColumns').and.callThrough();
 

--- a/ng2-components/ng2-alfresco-documentlist/src/components/document-list.ts
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/document-list.ts
@@ -61,6 +61,13 @@ export class DocumentList implements OnInit, AfterContentInit {
         this.data.rootPath = value || this.data.DEFAULT_ROOT_PATH;
     }
 
+    get rootPath(): string {
+        if (this.data) {
+            return this.data.rootPath;
+        }
+        return null;
+    }
+
     @Input()
     fallbackThubnail: string = this.baseComponentPath + '/img/ft_ic_miscellaneous.svg';
 

--- a/ng2-components/ng2-alfresco-documentlist/src/components/document-list.ts
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/document-list.ts
@@ -57,6 +57,11 @@ export class DocumentList implements OnInit, AfterContentInit {
     baseComponentPath = module.id.replace('/components/document-list.js', '');
 
     @Input()
+    set rootPath(value: string) {
+        this.data.rootPath = value || this.data.DEFAULT_ROOT_PATH;
+    }
+
+    @Input()
     fallbackThubnail: string = this.baseComponentPath + '/img/ft_ic_miscellaneous.svg';
 
     @Input()

--- a/ng2-components/ng2-alfresco-documentlist/src/data/share-datatable-adapter.ts
+++ b/ng2-components/ng2-alfresco-documentlist/src/data/share-datatable-adapter.ts
@@ -31,6 +31,7 @@ export class ShareDataTableAdapter implements DataTableAdapter, PaginationProvid
     ERR_ROW_NOT_FOUND: string = 'Row not found';
     ERR_COL_NOT_FOUND: string = 'Column not found';
 
+    DEFAULT_ROOT_PATH: string = '-root-';
     DEFAULT_DATE_FORMAT: string = 'medium';
     DEFAULT_PAGE_SIZE: number = 20;
     MIN_PAGE_SIZE: number = 5;
@@ -52,6 +53,7 @@ export class ShareDataTableAdapter implements DataTableAdapter, PaginationProvid
 
     thumbnails: boolean = false;
     dataLoaded: DataLoadedEventEmitter;
+    rootPath: string = this.DEFAULT_ROOT_PATH;
 
     constructor(private documentListService: DocumentListService,
                 private basePath: string,
@@ -207,7 +209,8 @@ export class ShareDataTableAdapter implements DataTableAdapter, PaginationProvid
             this.documentListService
                 .getFolder(path, {
                     maxItems: this._maxItems,
-                    skipCount: this._skipCount
+                    skipCount: this._skipCount,
+                    rootPath: this.rootPath
                 })
                 .subscribe(val => {
                     this.loadPage(<NodePaging>val);

--- a/ng2-components/ng2-alfresco-documentlist/src/services/document-list.service.ts
+++ b/ng2-components/ng2-alfresco-documentlist/src/services/document-list.service.ts
@@ -63,7 +63,12 @@ export class DocumentListService {
     }
 
     private getNodesPromise(folder: string, opts?: any): Promise<NodePaging> {
-        let nodeId = '-root-';
+        let rootPath = '-root-';
+
+        if (opts && opts.rootPath) {
+            rootPath = opts.rootPath;
+        }
+
         let params: any = {
             relativePath: folder,
             include: ['path', 'properties']
@@ -78,7 +83,7 @@ export class DocumentListService {
             }
         }
 
-        return this.apiService.getInstance().nodes.getNodeChildren(nodeId, params);
+        return this.apiService.getInstance().nodes.getNodeChildren(rootPath, params);
     }
 
     deleteNode(nodeId: string): Observable<any> {

--- a/ng2-components/ng2-alfresco-userinfo/src/components/user-info.component.html
+++ b/ng2-components/ng2-alfresco-userinfo/src/components/user-info.component.html
@@ -1,83 +1,84 @@
 <div id="userinfo_container" *ngIf="isLoggedIn()">
-    <div *ngIf="ecmUser || bpmUser" class="button-profile" id="user-profile" data-automation-id="user-profile">
-        <img id="logged-user-img"
-             [src]="getUserAvatar()"
-             alt="user-info-profile-button"
-             (error)="onImageLoadingError($event)"
-             class="profile-image"/>
-    </div>
-    <div *ngIf="ecmUser || bpmUser" id="user-profile-lists" class="user-profile-list-mdl
-                mdl-menu mdl-js-menu mdl-js-ripple-effect"
-         [class.mdl-menu--bottom-left]="menuOpenType === 'left'? true : false"
-         [class.mdl-menu--bottom-right]="menuOpenType === 'right'? true : false"
-         for="user-profile" (click)="stopClosing($event)">
-        <div class="mdl-tabs mdl-js-tabs mdl-js-ripple-effect menu-container__items">
-            <div id="tab-bar-env" class="mdl-tabs__tab-bar" [hidden]="!(ecmUser && bpmUser)">
-                <a href="#ecm-panel" id="ecm-tab" class="mdl-tabs__tab is-active">ECM</a>
-                <a href="#bpm-panel" id="bpm-tab" class="mdl-tabs__tab">BPM</a>
-            </div>
-            <div class="mdl-tabs__panel" [class.is-active]="ecmUser?true:false" id="ecm-panel">
-                <div class="detail-user-profile-list-mdl mdl-list" *ngIf="ecmUser">
-                    <div class="demo-card-wide mdl-card">
-                        <div class="card-title__option mdl-card__title"
-                             id="ecm-background-image"
-                             [style.background-image]="'url(' + ( ecmBackgroundImage || baseComponentPath + '/../img/orangeBanner.png')+')'">
-                            <img class="profile-picture"
-                                 id="ecm-user-detail-image"
-                                 alt="ecm-profile-image"
-                                 (error)="onImageLoadingError($event)"
-                                 [src]="getEcmUserAvatar()"/>
-                            <h2 class="mdl-card__title-text" id="ecm-username">{{getUserNameHeaderFor('ECM')}}</h2>
-                        </div>
-                        <div class="mdl-card__supporting-text">
-                            <li class="mdl-list__item mdl-list__item--two-line">
-                                <span class="mdl-list__item-primary-content">
-                                  <span id="ecm-full-name" class="truncate-long-names">
-                                      {{ formatValue(ecmUser.firstName) }} {{ formatValue(ecmUser.lastName) }}
-                                  </span>
-                                  <span id="ecm-email" class="mdl-list__item-sub-title">{{ecmUser.email}}</span>
-                                </span>
-                                <span id="ecm-job-title" class="mdl-list__item-secondary-content custom-role-style">
-                                    <span
-                                        class="role-label-user">{{ 'USER_PROFILE.LABELS.ECM.JOB_TITLE' | translate }}</span>
-                                    {{ecmUser.jobTitle?ecmUser.jobTitle:'N/A'}}
-                                </span>
-                            </li>
+    <div *ngIf="ecmUser || bpmUser">
+        <div class="button-profile" id="user-profile" data-automation-id="user-profile">
+            <img id="logged-user-img"
+                [src]="getUserAvatar()"
+                alt="user-info-profile-button"
+                (error)="onImageLoadingError($event)"
+                class="profile-image"/>
+        </div>
+        <div mdl id="user-profile-lists" class="user-profile-list-mdl mdl-menu mdl-js-menu mdl-js-ripple-effect"
+            [class.mdl-menu--bottom-left]="menuOpenType === 'left'? true : false"
+            [class.mdl-menu--bottom-right]="menuOpenType === 'right'? true : false"
+            for="user-profile" (click)="stopClosing($event)">
+            <div class="mdl-tabs mdl-js-tabs mdl-js-ripple-effect menu-container__items">
+                <div id="tab-bar-env" class="mdl-tabs__tab-bar" [hidden]="!(ecmUser && bpmUser)">
+                    <a href="#ecm-panel" id="ecm-tab" class="mdl-tabs__tab is-active">ECM</a>
+                    <a href="#bpm-panel" id="bpm-tab" class="mdl-tabs__tab">BPM</a>
+                </div>
+                <div class="mdl-tabs__panel" [class.is-active]="ecmUser?true:false" id="ecm-panel">
+                    <div class="detail-user-profile-list-mdl mdl-list" *ngIf="ecmUser">
+                        <div class="demo-card-wide mdl-card">
+                            <div class="card-title__option mdl-card__title"
+                                id="ecm-background-image"
+                                [style.background-image]="'url(' + ( ecmBackgroundImage || baseComponentPath + '/../img/orangeBanner.png')+')'">
+                                <img class="profile-picture"
+                                    id="ecm-user-detail-image"
+                                    alt="ecm-profile-image"
+                                    (error)="onImageLoadingError($event)"
+                                    [src]="getEcmUserAvatar()"/>
+                                <h2 class="mdl-card__title-text" id="ecm-username">{{getUserNameHeaderFor('ECM')}}</h2>
+                            </div>
+                            <div class="mdl-card__supporting-text">
+                                <li class="mdl-list__item mdl-list__item--two-line">
+                                    <span class="mdl-list__item-primary-content">
+                                    <span id="ecm-full-name" class="truncate-long-names">
+                                        {{ formatValue(ecmUser.firstName) }} {{ formatValue(ecmUser.lastName) }}
+                                    </span>
+                                    <span id="ecm-email" class="mdl-list__item-sub-title">{{ecmUser.email}}</span>
+                                    </span>
+                                    <span id="ecm-job-title" class="mdl-list__item-secondary-content custom-role-style">
+                                        <span
+                                            class="role-label-user">{{ 'USER_PROFILE.LABELS.ECM.JOB_TITLE' | translate }}</span>
+                                        {{ecmUser.jobTitle?ecmUser.jobTitle:'N/A'}}
+                                    </span>
+                                </li>
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
-            <div class="mdl-tabs__panel" [class.is-active]="bpmUser && !ecmUser?true:false" id="bpm-panel">
-                <div class="detail-user-profile-list-mdl mdl-list" *ngIf="bpmUser">
-                    <div class="demo-card-wide mdl-card">
-                        <div class="card-title__option mdl-card__title"
-                             id="bpm-background-image"
-                             [style.background-image]="'url(' + (bpmBackgroundImage || baseComponentPath + '/../img/blueBanner.png')+')'">
-                            <img class="profile-picture"
-                                 id="bpm-user-detail-image"
-                                 alt="bpm-profile-image"
-                                 (error)="onImageLoadingError($event)"
-                                 [src]="getBpmUserAvatar()"/>
-                            <h2 class="mdl-card__title-text" id="bpm-username">{{getUserNameHeaderFor('BPM')}}</h2>
-                        </div>
-                        <div class="mdl-card__supporting-text">
-                            <li class="mdl-list__item mdl-list__item--two-line">
-                        <span class="mdl-list__item-primary-content">
-                          <span id="bpm-full-name" class="truncate-long-names">
-                              {{ formatValue(bpmUser.firstName) }} {{ formatValue(bpmUser.lastName) }}
-                          </span>
-                          <span id="bpm-email" class="mdl-list__item-sub-title">{{bpmUser.email}}</span>
-                        </span>
-                                <span id="bpm-tenant" class="mdl-list__item-secondary-content custom-role-style">
-                            <span class="role-label-user">{{ 'USER_PROFILE.LABELS.BPM.TENANT' | translate }}</span>
-                            {{bpmUser.tenantName}}
-                        </span>
-                            </li>
+                <div class="mdl-tabs__panel" [class.is-active]="bpmUser && !ecmUser?true:false" id="bpm-panel">
+                    <div class="detail-user-profile-list-mdl mdl-list" *ngIf="bpmUser">
+                        <div class="demo-card-wide mdl-card">
+                            <div class="card-title__option mdl-card__title"
+                                id="bpm-background-image"
+                                [style.background-image]="'url(' + (bpmBackgroundImage || baseComponentPath + '/../img/blueBanner.png')+')'">
+                                <img class="profile-picture"
+                                    id="bpm-user-detail-image"
+                                    alt="bpm-profile-image"
+                                    (error)="onImageLoadingError($event)"
+                                    [src]="getBpmUserAvatar()"/>
+                                <h2 class="mdl-card__title-text" id="bpm-username">{{getUserNameHeaderFor('BPM')}}</h2>
+                            </div>
+                            <div class="mdl-card__supporting-text">
+                                <li class="mdl-list__item mdl-list__item--two-line">
+                            <span class="mdl-list__item-primary-content">
+                            <span id="bpm-full-name" class="truncate-long-names">
+                                {{ formatValue(bpmUser.firstName) }} {{ formatValue(bpmUser.lastName) }}
+                            </span>
+                            <span id="bpm-email" class="mdl-list__item-sub-title">{{bpmUser.email}}</span>
+                            </span>
+                                    <span id="bpm-tenant" class="mdl-list__item-secondary-content custom-role-style">
+                                <span class="role-label-user">{{ 'USER_PROFILE.LABELS.BPM.TENANT' | translate }}</span>
+                                {{bpmUser.tenantName}}
+                            </span>
+                                </li>
+                            </div>
                         </div>
                     </div>
                 </div>
             </div>
         </div>
-    </div>
 
+    </div>
 </div>

--- a/ng2-components/ng2-alfresco-userinfo/src/components/user-info.component.ts
+++ b/ng2-components/ng2-alfresco-userinfo/src/components/user-info.component.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Component, OnInit, Input, AfterViewChecked } from '@angular/core';
+import { Component, OnInit, Input } from '@angular/core';
 import { EcmUserModel } from './../models/ecm-user.model';
 import { BpmUserModel } from './../models/bpm-user.model';
 import { EcmUserService } from './../services/ecm-user.service';
@@ -30,7 +30,7 @@ declare let componentHandler: any;
     styleUrls: ['./user-info.component.css'],
     templateUrl: './user-info.component.html'
 })
-export class UserInfoComponent implements AfterViewChecked, OnInit {
+export class UserInfoComponent implements OnInit {
 
     @Input()
     ecmBackgroundImage: string;
@@ -67,13 +67,6 @@ export class UserInfoComponent implements AfterViewChecked, OnInit {
         authService.loginSubject.subscribe((response) => {
             this.getUserInfo();
         });
-    }
-
-    ngAfterViewChecked() {
-        // workaround for MDL issues with dynamic components
-        if (componentHandler) {
-            componentHandler.upgradeAllRegistered();
-        }
     }
 
     ngOnInit() {


### PR DESCRIPTION
- setup live reloads for user-info (demo shell)
- optimise user-info template (single *ngIf, [mdl] directive for
‘user-profile-lists’ instead of CPU-hungry `ngAfterViewChecked`)