### PR TITLE
#159 improved error reporting for document-list

### DIFF
--- a/demo-shell-ng2/app/components/files/files.component.css
+++ b/demo-shell-ng2/app/components/files/files.component.css
@@ -7,3 +7,11 @@
         margin: 0;
     }
 }
+
+.error-message {
+    text-align: left;
+}
+
+.error-message--text {
+    color: #d50000;
+}

--- a/demo-shell-ng2/app/components/files/files.component.html
+++ b/demo-shell-ng2/app/components/files/files.component.html
@@ -7,11 +7,18 @@
             [currentFolderPath]="currentPath"
             [target]="documentList">
         </alfresco-document-list-breadcrumb>
+        <div *ngIf="errorMessage" class="error-message">
+            <button (click)="resetError()" class="mdl-button mdl-js-button mdl-button--icon">
+                <i class="material-icons">highlight_off</i>
+            </button>
+            <span class="error-message--text">{{errorMessage}}</span>
+        </div>
         <alfresco-document-list
                 #documentList
                 [currentFolderPath]="currentPath"
                 [contextMenuActions]="true"
                 [contentActions]="true"
+                (error)="onNavigationError($event)"
                 (preview)="showFile($event)"
                 (folderChange)="onFolderChanged($event)">
             <!--
@@ -116,6 +123,9 @@
         </li>
         <li>
             <button (click)="documentList.currentFolderPath = '/'">Go to root</button>
+        </li>
+        <li>
+            <button (click)="documentList.currentFolderPath = '!@£$%^&*()'">Go to the wrong path</button>
         </li>
         <li>
             <button (click)="fileDialog.toggleShowDialog()">Show/Hide File Dialog</button>

--- a/demo-shell-ng2/app/components/files/files.component.ts
+++ b/demo-shell-ng2/app/components/files/files.component.ts
@@ -38,6 +38,7 @@ declare let __moduleName: string;
 export class FilesComponent implements OnInit {
     currentPath: string = '/Sites/swsdp/documentLibrary';
 
+    errorMessage: string = null;
     fileNodeId: any;
     fileShowed: boolean = false;
     multipleFileUpload: boolean = false;
@@ -118,6 +119,16 @@ export class FilesComponent implements OnInit {
 
     viewActivitiForm(event?: any) {
         this.router.navigate(['/activiti/tasksnode', event.value.entry.id]);
+    }
+
+    onNavigationError(err: any) {
+        if (err) {
+            this.errorMessage = err.message || 'Navigation error';
+        }
+    }
+
+    resetError() {
+        this.errorMessage = null;
     }
 
     private setupBpmActions(actions: any[]) {

--- a/ng2-components/ng2-alfresco-documentlist/src/components/breadcrumb/breadcrumb.component.spec.ts
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/breadcrumb/breadcrumb.component.spec.ts
@@ -85,15 +85,18 @@ describe('DocumentListBreadcrumb', () => {
         component.onRoutePathClick(node, null);
     });
 
-    it('should update document list on click', () => {
+    it('should update document list on click', (done) => {
         let documentList = new DocumentList(null, null, null);
-        spyOn(documentList, 'displayFolderContent').and.stub();
+        spyOn(documentList, 'displayFolderContent').and.returnValue(Promise.resolve());
 
         let node = <PathNode> { name: 'name', path: '/path' };
         component.target = documentList;
 
         component.onRoutePathClick(node, null);
-        expect(documentList.currentFolderPath).toBe(node.path);
+        setTimeout(() => {
+            expect(documentList.currentFolderPath).toBe(node.path);
+            done();
+        }, 0);
     });
 
     it('should do nothing for same path', () => {

--- a/ng2-components/ng2-alfresco-documentlist/src/data/share-datatable-adapter.spec.ts
+++ b/ng2-components/ng2-alfresco-documentlist/src/data/share-datatable-adapter.spec.ts
@@ -322,7 +322,7 @@ describe('ShareDataTableAdapter', () => {
         expect(value).toBeNull();
     });
 
-    it('should log load error', () => {
+    it('should log load error', (done) => {
         let error = 'My Error';
         documentListService.getFolderReject = true;
         documentListService.getFolderRejectError = error;
@@ -331,10 +331,10 @@ describe('ShareDataTableAdapter', () => {
         spyOn(documentListService, 'getFolder').and.callThrough();
 
         let adapter = new ShareDataTableAdapter(documentListService, null, null);
-        adapter.loadPath('/some/path');
-
-        expect(documentListService.getFolder).toHaveBeenCalled();
-        expect(console.error).toHaveBeenCalledWith(error);
+        adapter.loadPath('/some/path').catch(err => {
+            expect(err).toBe(error);
+            done();
+        });
     });
 
     it('should generate file icon path based on mime type', () => {

--- a/ng2-components/ng2-alfresco-documentlist/src/data/share-datatable-adapter.ts
+++ b/ng2-components/ng2-alfresco-documentlist/src/data/share-datatable-adapter.ts
@@ -203,21 +203,29 @@ export class ShareDataTableAdapter implements DataTableAdapter, PaginationProvid
         this.setSorting(sorting);
     }
 
-    loadPath(path: string) {
-        if (path && this.documentListService) {
-            this.currentPath = path;
-            this.documentListService
-                .getFolder(path, {
-                    maxItems: this._maxItems,
-                    skipCount: this._skipCount,
-                    rootPath: this.rootPath
-                })
-                .subscribe(val => {
-                    this.loadPage(<NodePaging>val);
-                    this.dataLoaded.emit(null);
-                },
-                error => console.error(error));
-        }
+    loadPath(path: string): Promise<any> {
+        return new Promise((resolve, reject) => {
+            if (path && this.documentListService) {
+                this.documentListService
+                    .getFolder(path, {
+                        maxItems: this._maxItems,
+                        skipCount: this._skipCount,
+                        rootPath: this.rootPath
+                    })
+                    .subscribe(val => {
+                        this.currentPath = path;
+                        this.loadPage(<NodePaging>val);
+                        this.dataLoaded.emit(null);
+                        resolve(true);
+                    },
+                    error => {
+                        reject(error);
+                    });
+            } else {
+                resolve(false);
+            }
+        });
+
     }
 
     setFilter(filter: RowFilter) {


### PR DESCRIPTION
- expose ‘error’ event
- change path only on successful navigation
- extend demo shell with error handling and reporting
- additional unit tests for document-list