### PR TITLE
fix horizontal scrollbar issue for Safari

### DIFF
--- a/ng2-components/ng2-activiti-form/src/components/widgets/dynamic-table/dynamic-table.widget.css
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/dynamic-table/dynamic-table.widget.css
@@ -2,6 +2,10 @@
     padding: 8px;
 }
 
+.dynamic-table-widget__buttons {
+    margin-top: 10px;
+}
+
 .dynamic-table-widget__row-selected,
 .dynamic-table-widget__row-selected:hover {
     background-color: #eef !important;

--- a/ng2-components/ng2-activiti-form/src/components/widgets/dynamic-table/dynamic-table.widget.html
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/dynamic-table/dynamic-table.widget.html
@@ -26,7 +26,7 @@
             </table>
          </div>
 
-        <div>
+        <div class="dynamic-table-widget__buttons">
             <button class="mdl-button mdl-js-button mdl-button--icon"
                     [disabled]="!hasSelection()"
                     (click)="moveSelectionUp()">


### PR DESCRIPTION
adding top margin helps solving issue with horizontal scrollbar issue
for Safari when mouse is attached or system scrollbars visibility set
to ‘always’ (macOS)

fixes #986