### PR TITLE
Clean the login storage ticket info before to login

### DIFF
--- a/ng2-components/ng2-alfresco-core/src/services/AlfrescoAuthentication.service.ts
+++ b/ng2-components/ng2-alfresco-core/src/services/AlfrescoAuthentication.service.ts
@@ -140,6 +140,7 @@ export class AlfrescoAuthenticationService {
     public removeTicket(): void {
         this.storage.removeItem('ticket-ECM');
         this.storage.removeItem('ticket-BPM');
+        this.alfrescoApi.setTicket(undefined, undefined);
     }
 
     /**


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
1. Login to Activiti only
 2. Go to Login, switch off Activiti and enable ECM checkbox
 3. Login again
 4. Now isolated storage has 2 tickets, one for old activiti and one for new ecm

**What is the new behavior?**
Login must cleanup everything on each Login

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**: