### PR TITLE
exclude various folders from live reload

### DIFF
--- a/demo-shell-ng2/config/webpack.common.js
+++ b/demo-shell-ng2/config/webpack.common.js
@@ -18,8 +18,8 @@ let options = {
 let alfrescoLibs = glob.sync(pattern, options);
 // console.dir(alfrescoLibs);
 
-// Uncomment if you need all node_modules folders for Alfresco components
-// let alfrescoLibsModules = alfrescoLibs.map(p => path.join(p, 'node_modules'));
+let alfrescoLibsModules = alfrescoLibs.map(p => path.join(p, 'node_modules'));
+let alfrescoLibsSources = alfrescoLibs.map(p => path.join(p, 'src'));
 
 module.exports = {
     entry: {
@@ -109,6 +109,11 @@ module.exports = {
         new webpack.ProvidePlugin({
             'dialogPolyfill': 'dialog-polyfill/dialog-polyfill'
         }),
+
+        new webpack.WatchIgnorePlugin([
+            ...alfrescoLibsModules,
+            ...alfrescoLibsSources
+        ]),
 
         new CopyWebpackPlugin([
             { from: 'versions.json' }

--- a/demo-shell-ng2/package.json
+++ b/demo-shell-ng2/package.json
@@ -127,10 +127,6 @@
     "webpack": "^1.13.0",
     "webpack-dev-server": "^1.14.1",
     "webpack-merge": "^0.14.0",
-    "source-map-loader": "^0.1.5",
-    "script-loader": "^0.7.0",
-    "copy-webpack-plugin": "^4.0.1",
-    "glob": "^7.1.1",
     "wsrv": "^0.1.6"
   },
   "license-check-config": {


### PR DESCRIPTION
- exclude node_modules within every symlinked component library
- exclude source folders from watching (as needs getting bundles instead)