### PR TITLE
generate JS sourcemap during the UMD build

### DIFF
--- a/ng2-components/ng2-activiti-analytics/gulpfile.ts
+++ b/ng2-components/ng2-activiti-analytics/gulpfile.ts
@@ -9,6 +9,7 @@ import * as Builder from 'systemjs-builder';
 var autoprefixer = require('autoprefixer');
 import * as cssnano from 'cssnano';
 import * as filter from 'gulp-filter';
+import * as sourcemaps from 'gulp-sourcemaps';
 
 var APP_SRC = `.`;
 var CSS_PROD_BUNDLE = 'main.css';
@@ -286,6 +287,7 @@ gulp.task('build.js.prod', () => {
     let result = gulp.src(src)
         .pipe(plugins.plumber())
         .pipe(plugins.inlineNg2Template(INLINE_OPTIONS))
+        .pipe(sourcemaps.init())
         .pipe(tsProject())
         .once('error', function (e: any) {
             this.once('finish', () => process.exit(1));
@@ -293,6 +295,7 @@ gulp.task('build.js.prod', () => {
 
     return result.js
         .pipe(plugins.template())
+        .pipe(sourcemaps.write())
         .pipe(gulp.dest('src'))
         .on('error', (e: any) => {
             console.log(e);

--- a/ng2-components/ng2-activiti-analytics/package.json
+++ b/ng2-components/ng2-activiti-analytics/package.json
@@ -83,6 +83,7 @@
     "gulp-plumber": "^1.1.0",
     "gulp-postcss": "^6.2.0",
     "gulp-replace": "^0.5.4",
+    "gulp-sourcemaps": "^1.9.1",
     "gulp-template": "^4.0.0",
     "gulp-typescript": "^3.1.3",
     "gulp-uglify": "^2.0.0",

--- a/ng2-components/ng2-activiti-diagrams/gulpfile.ts
+++ b/ng2-components/ng2-activiti-diagrams/gulpfile.ts
@@ -9,6 +9,7 @@ import * as Builder from 'systemjs-builder';
 var autoprefixer = require('autoprefixer');
 import * as cssnano from 'cssnano';
 import * as filter from 'gulp-filter';
+import * as sourcemaps from 'gulp-sourcemaps';
 
 var APP_SRC = `.`;
 var CSS_PROD_BUNDLE = 'main.css';
@@ -285,6 +286,7 @@ gulp.task('build.js.prod', () => {
     let result = gulp.src(src)
         .pipe(plugins.plumber())
         .pipe(plugins.inlineNg2Template(INLINE_OPTIONS))
+        .pipe(sourcemaps.init())
         .pipe(tsProject())
         .once('error', function (e: any) {
             this.once('finish', () => process.exit(1));
@@ -292,6 +294,7 @@ gulp.task('build.js.prod', () => {
 
     return result.js
         .pipe(plugins.template())
+        .pipe(sourcemaps.write())
         .pipe(gulp.dest('src'))
         .on('error', (e: any) => {
             console.log(e);

--- a/ng2-components/ng2-activiti-diagrams/package.json
+++ b/ng2-components/ng2-activiti-diagrams/package.json
@@ -76,6 +76,7 @@
     "gulp-plumber": "^1.1.0",
     "gulp-postcss": "^6.2.0",
     "gulp-replace": "^0.5.4",
+    "gulp-sourcemaps": "^1.9.1",
     "gulp-template": "^4.0.0",
     "gulp-typescript": "^3.1.3",
     "gulp-uglify": "^2.0.0",

--- a/ng2-components/ng2-activiti-form/gulpfile.ts
+++ b/ng2-components/ng2-activiti-form/gulpfile.ts
@@ -9,6 +9,7 @@ import * as Builder from 'systemjs-builder';
 var autoprefixer = require('autoprefixer');
 import * as cssnano from 'cssnano';
 import * as filter from 'gulp-filter';
+import * as sourcemaps from 'gulp-sourcemaps';
 
 var APP_SRC = `.`;
 var CSS_PROD_BUNDLE = 'main.css';
@@ -285,6 +286,7 @@ gulp.task('build.js.prod', () => {
     let result = gulp.src(src)
         .pipe(plugins.plumber())
         .pipe(plugins.inlineNg2Template(INLINE_OPTIONS))
+        .pipe(sourcemaps.init())
         .pipe(tsProject())
         .once('error', function (e: any) {
             this.once('finish', () => process.exit(1));
@@ -292,6 +294,7 @@ gulp.task('build.js.prod', () => {
 
     return result.js
         .pipe(plugins.template())
+        .pipe(sourcemaps.write())
         .pipe(gulp.dest('src'))
         .on('error', (e: any) => {
             console.log(e);

--- a/ng2-components/ng2-activiti-form/package.json
+++ b/ng2-components/ng2-activiti-form/package.json
@@ -83,6 +83,7 @@
     "gulp-plumber": "^1.1.0",
     "gulp-postcss": "^6.2.0",
     "gulp-replace": "^0.5.4",
+    "gulp-sourcemaps": "^1.9.1",
     "gulp-template": "^4.0.0",
     "gulp-typescript": "^3.1.3",
     "gulp-uglify": "^2.0.0",

--- a/ng2-components/ng2-activiti-processlist/gulpfile.ts
+++ b/ng2-components/ng2-activiti-processlist/gulpfile.ts
@@ -9,6 +9,7 @@ import * as Builder from 'systemjs-builder';
 var autoprefixer = require('autoprefixer');
 import * as cssnano from 'cssnano';
 import * as filter from 'gulp-filter';
+import * as sourcemaps from 'gulp-sourcemaps';
 
 var APP_SRC = `.`;
 var CSS_PROD_BUNDLE = 'main.css';
@@ -282,6 +283,7 @@ gulp.task('build.js.prod', () => {
     let result = gulp.src(src)
         .pipe(plugins.plumber())
         .pipe(plugins.inlineNg2Template(INLINE_OPTIONS))
+        .pipe(sourcemaps.init())
         .pipe(tsProject())
         .once('error', function (e: any) {
             this.once('finish', () => process.exit(1));
@@ -289,6 +291,7 @@ gulp.task('build.js.prod', () => {
 
     return result.js
         .pipe(plugins.template())
+        .pipe(sourcemaps.write())
         .pipe(gulp.dest('src'))
         .on('error', (e: any) => {
             console.log(e);

--- a/ng2-components/ng2-activiti-processlist/package.json
+++ b/ng2-components/ng2-activiti-processlist/package.json
@@ -83,6 +83,7 @@
     "gulp-plumber": "^1.1.0",
     "gulp-postcss": "^6.2.0",
     "gulp-replace": "^0.5.4",
+    "gulp-sourcemaps": "^1.9.1",
     "gulp-template": "^4.0.0",
     "gulp-typescript": "^3.1.3",
     "gulp-uglify": "^2.0.0",

--- a/ng2-components/ng2-activiti-tasklist/gulpfile.ts
+++ b/ng2-components/ng2-activiti-tasklist/gulpfile.ts
@@ -9,6 +9,7 @@ import * as Builder from 'systemjs-builder';
 var autoprefixer = require('autoprefixer');
 import * as cssnano from 'cssnano';
 import * as filter from 'gulp-filter';
+import * as sourcemaps from 'gulp-sourcemaps';
 
 var APP_SRC = `.`;
 var CSS_PROD_BUNDLE = 'main.css';
@@ -283,6 +284,7 @@ gulp.task('build.js.prod', () => {
     let result = gulp.src(src)
         .pipe(plugins.plumber())
         .pipe(plugins.inlineNg2Template(INLINE_OPTIONS))
+        .pipe(sourcemaps.init())
         .pipe(tsProject())
         .once('error', function (e: any) {
             this.once('finish', () => process.exit(1));
@@ -290,6 +292,7 @@ gulp.task('build.js.prod', () => {
 
     return result.js
         .pipe(plugins.template())
+        .pipe(sourcemaps.write())
         .pipe(gulp.dest('src'))
         .on('error', (e: any) => {
             console.log(e);

--- a/ng2-components/ng2-activiti-tasklist/package.json
+++ b/ng2-components/ng2-activiti-tasklist/package.json
@@ -88,6 +88,7 @@
     "gulp-plumber": "^1.1.0",
     "gulp-postcss": "^6.2.0",
     "gulp-replace": "^0.5.4",
+    "gulp-sourcemaps": "^1.9.1",
     "gulp-template": "^4.0.0",
     "gulp-typescript": "^3.1.3",
     "gulp-uglify": "^2.0.0",

--- a/ng2-components/ng2-alfresco-core/gulpfile.ts
+++ b/ng2-components/ng2-alfresco-core/gulpfile.ts
@@ -9,6 +9,7 @@ import * as Builder from 'systemjs-builder';
 var autoprefixer = require('autoprefixer');
 import * as cssnano from 'cssnano';
 import * as filter from 'gulp-filter';
+import * as sourcemaps from 'gulp-sourcemaps';
 
 var APP_SRC = `.`;
 var CSS_PROD_BUNDLE = 'main.css';
@@ -283,6 +284,7 @@ gulp.task('build.js.prod', () => {
     let result = gulp.src(src)
         .pipe(plugins.plumber())
         .pipe(plugins.inlineNg2Template(INLINE_OPTIONS))
+        .pipe(sourcemaps.init())
         .pipe(tsProject())
         .once('error', function (e: any) {
             this.once('finish', () => process.exit(1));
@@ -290,6 +292,7 @@ gulp.task('build.js.prod', () => {
 
     return result.js
         .pipe(plugins.template())
+        .pipe(sourcemaps.write())
         .pipe(gulp.dest('src'))
         .on('error', (e: any) => {
             console.log(e);

--- a/ng2-components/ng2-alfresco-core/package.json
+++ b/ng2-components/ng2-alfresco-core/package.json
@@ -94,6 +94,7 @@
     "gulp-plumber": "^1.1.0",
     "gulp-postcss": "^6.2.0",
     "gulp-replace": "^0.5.4",
+    "gulp-sourcemaps": "^1.9.1",
     "gulp-template": "^4.0.0",
     "gulp-typescript": "^3.1.3",
     "gulp-uglify": "^2.0.0",

--- a/ng2-components/ng2-alfresco-datatable/gulpfile.ts
+++ b/ng2-components/ng2-alfresco-datatable/gulpfile.ts
@@ -9,6 +9,7 @@ import * as Builder from 'systemjs-builder';
 var autoprefixer = require('autoprefixer');
 import * as cssnano from 'cssnano';
 import * as filter from 'gulp-filter';
+import * as sourcemaps from 'gulp-sourcemaps';
 
 var APP_SRC = `.`;
 var CSS_PROD_BUNDLE = 'main.css';
@@ -282,6 +283,7 @@ gulp.task('build.js.prod', () => {
     let result = gulp.src(src)
         .pipe(plugins.plumber())
         .pipe(plugins.inlineNg2Template(INLINE_OPTIONS))
+        .pipe(sourcemaps.init())
         .pipe(tsProject())
         .once('error', function (e: any) {
             this.once('finish', () => process.exit(1));
@@ -289,6 +291,7 @@ gulp.task('build.js.prod', () => {
 
     return result.js
         .pipe(plugins.template())
+        .pipe(sourcemaps.write())
         .pipe(gulp.dest('src'))
         .on('error', (e: any) => {
             console.log(e);

--- a/ng2-components/ng2-alfresco-datatable/package.json
+++ b/ng2-components/ng2-alfresco-datatable/package.json
@@ -80,6 +80,7 @@
     "gulp-plumber": "^1.1.0",
     "gulp-postcss": "^6.2.0",
     "gulp-replace": "^0.5.4",
+    "gulp-sourcemaps": "^1.9.1",
     "gulp-template": "^4.0.0",
     "gulp-typescript": "^3.1.3",
     "gulp-uglify": "^2.0.0",

--- a/ng2-components/ng2-alfresco-documentlist/gulpfile.ts
+++ b/ng2-components/ng2-alfresco-documentlist/gulpfile.ts
@@ -9,6 +9,7 @@ import * as Builder from 'systemjs-builder';
 var autoprefixer = require('autoprefixer');
 import * as cssnano from 'cssnano';
 import * as filter from 'gulp-filter';
+import * as sourcemaps from 'gulp-sourcemaps';
 
 var APP_SRC = `.`;
 var CSS_PROD_BUNDLE = 'main.css';
@@ -282,6 +283,7 @@ gulp.task('build.js.prod', () => {
     let result = gulp.src(src)
         .pipe(plugins.plumber())
         .pipe(plugins.inlineNg2Template(INLINE_OPTIONS))
+        .pipe(sourcemaps.init())
         .pipe(tsProject())
         .once('error', function (e: any) {
             this.once('finish', () => process.exit(1));
@@ -289,6 +291,7 @@ gulp.task('build.js.prod', () => {
 
     return result.js
         .pipe(plugins.template())
+        .pipe(sourcemaps.write())
         .pipe(gulp.dest('src'))
         .on('error', (e: any) => {
             console.log(e);

--- a/ng2-components/ng2-alfresco-documentlist/package.json
+++ b/ng2-components/ng2-alfresco-documentlist/package.json
@@ -89,6 +89,7 @@
     "gulp-plumber": "^1.1.0",
     "gulp-postcss": "^6.2.0",
     "gulp-replace": "^0.5.4",
+    "gulp-sourcemaps": "^1.9.1",
     "gulp-template": "^4.0.0",
     "gulp-typescript": "^3.1.3",
     "gulp-uglify": "^2.0.0",

--- a/ng2-components/ng2-alfresco-login/gulpfile.ts
+++ b/ng2-components/ng2-alfresco-login/gulpfile.ts
@@ -9,6 +9,7 @@ import * as Builder from 'systemjs-builder';
 var autoprefixer = require('autoprefixer');
 import * as cssnano from 'cssnano';
 import * as filter from 'gulp-filter';
+import * as sourcemaps from 'gulp-sourcemaps';
 
 var APP_SRC = `.`;
 var CSS_PROD_BUNDLE = 'main.css';
@@ -282,6 +283,7 @@ gulp.task('build.js.prod', () => {
     let result = gulp.src(src)
         .pipe(plugins.plumber())
         .pipe(plugins.inlineNg2Template(INLINE_OPTIONS))
+        .pipe(sourcemaps.init())
         .pipe(tsProject())
         .once('error', function (e: any) {
             this.once('finish', () => process.exit(1));
@@ -289,6 +291,7 @@ gulp.task('build.js.prod', () => {
 
     return result.js
         .pipe(plugins.template())
+        .pipe(sourcemaps.write())
         .pipe(gulp.dest('src'))
         .on('error', (e: any) => {
             console.log(e);

--- a/ng2-components/ng2-alfresco-login/package.json
+++ b/ng2-components/ng2-alfresco-login/package.json
@@ -91,6 +91,7 @@
     "gulp-plumber": "^1.1.0",
     "gulp-postcss": "^6.2.0",
     "gulp-replace": "^0.5.4",
+    "gulp-sourcemaps": "^1.9.1",
     "gulp-template": "^4.0.0",
     "gulp-typescript": "^3.1.3",
     "gulp-uglify": "^2.0.0",

--- a/ng2-components/ng2-alfresco-search/gulpfile.ts
+++ b/ng2-components/ng2-alfresco-search/gulpfile.ts
@@ -9,6 +9,7 @@ import * as Builder from 'systemjs-builder';
 var autoprefixer = require('autoprefixer');
 import * as cssnano from 'cssnano';
 import * as filter from 'gulp-filter';
+import * as sourcemaps from 'gulp-sourcemaps';
 
 var APP_SRC = `.`;
 var CSS_PROD_BUNDLE = 'main.css';
@@ -282,6 +283,7 @@ gulp.task('build.js.prod', () => {
     let result = gulp.src(src)
         .pipe(plugins.plumber())
         .pipe(plugins.inlineNg2Template(INLINE_OPTIONS))
+        .pipe(sourcemaps.init())
         .pipe(tsProject())
         .once('error', function (e: any) {
             this.once('finish', () => process.exit(1));
@@ -289,6 +291,7 @@ gulp.task('build.js.prod', () => {
 
     return result.js
         .pipe(plugins.template())
+        .pipe(sourcemaps.write())
         .pipe(gulp.dest('src'))
         .on('error', (e: any) => {
             console.log(e);

--- a/ng2-components/ng2-alfresco-search/package.json
+++ b/ng2-components/ng2-alfresco-search/package.json
@@ -88,6 +88,7 @@
     "gulp-plumber": "^1.1.0",
     "gulp-postcss": "^6.2.0",
     "gulp-replace": "^0.5.4",
+    "gulp-sourcemaps": "^1.9.1",
     "gulp-template": "^4.0.0",
     "gulp-typescript": "^3.1.3",
     "gulp-uglify": "^2.0.0",

--- a/ng2-components/ng2-alfresco-tag/gulpfile.ts
+++ b/ng2-components/ng2-alfresco-tag/gulpfile.ts
@@ -9,6 +9,7 @@ import * as Builder from 'systemjs-builder';
 var autoprefixer = require('autoprefixer');
 import * as cssnano from 'cssnano';
 import * as filter from 'gulp-filter';
+import * as sourcemaps from 'gulp-sourcemaps';
 
 var APP_SRC = `.`;
 var CSS_PROD_BUNDLE = 'main.css';
@@ -282,6 +283,7 @@ gulp.task('build.js.prod', () => {
     let result = gulp.src(src)
         .pipe(plugins.plumber())
         .pipe(plugins.inlineNg2Template(INLINE_OPTIONS))
+        .pipe(sourcemaps.init())
         .pipe(tsProject())
         .once('error', function (e: any) {
             this.once('finish', () => process.exit(1));
@@ -289,6 +291,7 @@ gulp.task('build.js.prod', () => {
 
     return result.js
         .pipe(plugins.template())
+        .pipe(sourcemaps.write())
         .pipe(gulp.dest('src'))
         .on('error', (e: any) => {
             console.log(e);

--- a/ng2-components/ng2-alfresco-tag/package.json
+++ b/ng2-components/ng2-alfresco-tag/package.json
@@ -68,6 +68,7 @@
     "gulp-plumber": "^1.1.0",
     "gulp-postcss": "^6.2.0",
     "gulp-replace": "^0.5.4",
+    "gulp-sourcemaps": "^1.9.1",
     "gulp-template": "^4.0.0",
     "gulp-typescript": "^3.1.3",
     "gulp-uglify": "^2.0.0",

--- a/ng2-components/ng2-alfresco-upload/gulpfile.ts
+++ b/ng2-components/ng2-alfresco-upload/gulpfile.ts
@@ -9,6 +9,7 @@ import * as Builder from 'systemjs-builder';
 var autoprefixer = require('autoprefixer');
 import * as cssnano from 'cssnano';
 import * as filter from 'gulp-filter';
+import * as sourcemaps from 'gulp-sourcemaps';
 
 var APP_SRC = `.`;
 var CSS_PROD_BUNDLE = 'main.css';
@@ -282,6 +283,7 @@ gulp.task('build.js.prod', () => {
     let result = gulp.src(src)
         .pipe(plugins.plumber())
         .pipe(plugins.inlineNg2Template(INLINE_OPTIONS))
+        .pipe(sourcemaps.init())
         .pipe(tsProject())
         .once('error', function (e: any) {
             this.once('finish', () => process.exit(1));
@@ -289,6 +291,7 @@ gulp.task('build.js.prod', () => {
 
     return result.js
         .pipe(plugins.template())
+        .pipe(sourcemaps.write())
         .pipe(gulp.dest('src'))
         .on('error', (e: any) => {
             console.log(e);

--- a/ng2-components/ng2-alfresco-upload/package.json
+++ b/ng2-components/ng2-alfresco-upload/package.json
@@ -89,6 +89,7 @@
     "gulp-plumber": "^1.1.0",
     "gulp-postcss": "^6.2.0",
     "gulp-replace": "^0.5.4",
+    "gulp-sourcemaps": "^1.9.1",
     "gulp-template": "^4.0.0",
     "gulp-typescript": "^3.1.3",
     "gulp-uglify": "^2.0.0",

--- a/ng2-components/ng2-alfresco-userinfo/gulpfile.ts
+++ b/ng2-components/ng2-alfresco-userinfo/gulpfile.ts
@@ -9,6 +9,7 @@ import * as Builder from 'systemjs-builder';
 var autoprefixer = require('autoprefixer');
 import * as cssnano from 'cssnano';
 import * as filter from 'gulp-filter';
+import * as sourcemaps from 'gulp-sourcemaps';
 
 var APP_SRC = `.`;
 var CSS_PROD_BUNDLE = 'main.css';
@@ -282,6 +283,7 @@ gulp.task('build.js.prod', () => {
     let result = gulp.src(src)
         .pipe(plugins.plumber())
         .pipe(plugins.inlineNg2Template(INLINE_OPTIONS))
+        .pipe(sourcemaps.init())
         .pipe(tsProject())
         .once('error', function (e: any) {
             this.once('finish', () => process.exit(1));
@@ -289,6 +291,7 @@ gulp.task('build.js.prod', () => {
 
     return result.js
         .pipe(plugins.template())
+        .pipe(sourcemaps.write())
         .pipe(gulp.dest('src'))
         .on('error', (e: any) => {
             console.log(e);

--- a/ng2-components/ng2-alfresco-userinfo/package.json
+++ b/ng2-components/ng2-alfresco-userinfo/package.json
@@ -67,6 +67,7 @@
     "gulp-plumber": "^1.1.0",
     "gulp-postcss": "^6.2.0",
     "gulp-replace": "^0.5.4",
+    "gulp-sourcemaps": "^1.9.1",
     "gulp-template": "^4.0.0",
     "gulp-typescript": "^3.1.3",
     "gulp-uglify": "^2.0.0",

--- a/ng2-components/ng2-alfresco-viewer/gulpfile.ts
+++ b/ng2-components/ng2-alfresco-viewer/gulpfile.ts
@@ -9,6 +9,7 @@ import * as Builder from 'systemjs-builder';
 var autoprefixer = require('autoprefixer');
 import * as cssnano from 'cssnano';
 import * as filter from 'gulp-filter';
+import * as sourcemaps from 'gulp-sourcemaps';
 
 var APP_SRC = `.`;
 var CSS_PROD_BUNDLE = 'main.css';
@@ -282,6 +283,7 @@ gulp.task('build.js.prod', () => {
     let result = gulp.src(src)
         .pipe(plugins.plumber())
         .pipe(plugins.inlineNg2Template(INLINE_OPTIONS))
+        .pipe(sourcemaps.init())
         .pipe(tsProject())
         .once('error', function (e: any) {
             this.once('finish', () => process.exit(1));
@@ -289,6 +291,7 @@ gulp.task('build.js.prod', () => {
 
     return result.js
         .pipe(plugins.template())
+        .pipe(sourcemaps.write())
         .pipe(gulp.dest('src'))
         .on('error', (e: any) => {
             console.log(e);

--- a/ng2-components/ng2-alfresco-viewer/package.json
+++ b/ng2-components/ng2-alfresco-viewer/package.json
@@ -83,6 +83,7 @@
     "gulp-plumber": "^1.1.0",
     "gulp-postcss": "^6.2.0",
     "gulp-replace": "^0.5.4",
+    "gulp-sourcemaps": "^1.9.1",
     "gulp-template": "^4.0.0",
     "gulp-typescript": "^3.1.3",
     "gulp-uglify": "^2.0.0",

--- a/ng2-components/ng2-alfresco-webscript/gulpfile.ts
+++ b/ng2-components/ng2-alfresco-webscript/gulpfile.ts
@@ -9,6 +9,7 @@ import * as Builder from 'systemjs-builder';
 var autoprefixer = require('autoprefixer');
 import * as cssnano from 'cssnano';
 import * as filter from 'gulp-filter';
+import * as sourcemaps from 'gulp-sourcemaps';
 
 var APP_SRC = `.`;
 var CSS_PROD_BUNDLE = 'main.css';
@@ -282,6 +283,7 @@ gulp.task('build.js.prod', () => {
     let result = gulp.src(src)
         .pipe(plugins.plumber())
         .pipe(plugins.inlineNg2Template(INLINE_OPTIONS))
+        .pipe(sourcemaps.init())
         .pipe(tsProject())
         .once('error', function (e: any) {
             this.once('finish', () => process.exit(1));
@@ -289,6 +291,7 @@ gulp.task('build.js.prod', () => {
 
     return result.js
         .pipe(plugins.template())
+        .pipe(sourcemaps.write())
         .pipe(gulp.dest('src'))
         .on('error', (e: any) => {
             console.log(e);

--- a/ng2-components/ng2-alfresco-webscript/package.json
+++ b/ng2-components/ng2-alfresco-webscript/package.json
@@ -68,6 +68,7 @@
     "gulp-plumber": "^1.1.0",
     "gulp-postcss": "^6.2.0",
     "gulp-replace": "^0.5.4",
+    "gulp-sourcemaps": "^1.9.1",
     "gulp-template": "^4.0.0",
     "gulp-typescript": "^3.1.3",
     "gulp-uglify": "^2.0.0",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
the UMD build rewrite the JS file in order to inject the template without regenerate the source map


**What is the new behavior?**
Generate the sourcemap JS during the UMD build


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**: