### PR TITLE
#1303 - fix typeahead show for completed tasks

### DIFF
--- a/ng2-components/ng2-activiti-form/src/components/widgets/display-value/display-value.widget.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/display-value/display-value.widget.ts
@@ -179,6 +179,7 @@ export class DisplayValueWidget extends WidgetComponent implements OnInit {
                     } else {
                         this.value = this.field.value;
                     }
+                    this.visibilityService.refreshVisibility(this.field.form);
                 },
                 error => {
                     console.log(error);
@@ -191,20 +192,21 @@ export class DisplayValueWidget extends WidgetComponent implements OnInit {
         this.formService
             .getRestFieldValues(this.field.form.taskId, this.field.id)
             .subscribe(
-                (result: FormFieldOption[]) => {
-                    let options = result || [];
-                    let toSelect = options.find(item => item.id === this.field.value);
-                    this.field.options = options;
-                    if (toSelect) {
-                        this.value = toSelect.name;
-                    } else {
-                        this.value = this.field.value;
-                    }
-                },
-                error => {
-                    console.log(error);
+            (result: FormFieldOption[]) => {
+                let options = result || [];
+                let toSelect = options.find(item => item.id === this.field.value);
+                this.field.options = options;
+                if (toSelect) {
+                    this.value = toSelect.name;
+                } else {
                     this.value = this.field.value;
                 }
+                this.visibilityService.refreshVisibility(this.field.form);
+            },
+            error => {
+                console.log(error);
+                this.value = this.field.value;
+            }
             );
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

typeahead widget is not showed on completed form

**What is the new behavior?**
typeahead widget is showed on completed form


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
