### PR TITLE
Add missing polyfill for Firefox (date picker)

### DIFF
--- a/demo-shell-ng2/index.html
+++ b/demo-shell-ng2/index.html
@@ -10,11 +10,13 @@
     <!-- 1. Load libraries -->
     <!-- Polyfill(s) for Safari (pre-10.x) -->
     <script src=js/Intl.min.js></script>
+    
+    <!-- IE/FF -->
+    <script src=js/element.scrollintoviewifneeded-polyfill.js></script>
 
     <!--[if IE]>
     <script src=js/shim.min.js></script>
     <script src=//cdnjs.cloudflare.com/ajax/libs/dom4/1.8.3/dom4.js></script>
-    <script src=js/element.scrollintoviewifneeded-polyfill.js></script>
     <script src=js/classlist-polyfill.js></script>
     <script src=js/web-animations.min.js></script>
     <script src=js/typedarray.js></script>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)
Year picker not working for FF


**What is the new behavior?**
Added missing polyfill for FF, refs #1403


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
