### PR TITLE
Hide the process list when starting and after started new process

### DIFF
--- a/demo-shell-ng2/app/components/activiti/activiti-demo.component.html
+++ b/demo-shell-ng2/app/components/activiti/activiti-demo.component.html
@@ -68,7 +68,7 @@
                                                                (filterClick)="onProcessFilterClick($event)"
                                                                (onSuccess)="onSuccessProcessFilterList($event)"></activiti-process-instance-filters>
                         </div>
-                        <div class="mdl-cell mdl-cell--3-col task-column list-column  mdl-shadow--2dp">
+                        <div class="mdl-cell mdl-cell--3-col task-column list-column mdl-shadow--2dp" *ngIf="processFilter && !isStartProcessMode()">
                             <span><h5>Process List</h5></span>
                             <hr>
                             <activiti-process-instance-list *ngIf="processFilter?.hasFilter()" [appId]="processFilter.appId"
@@ -80,7 +80,9 @@
                                                             (rowClick)="onProcessRowClick($event)"
                                                             (onSuccess)="onSuccessProcessList($event)"></activiti-process-instance-list>
                         </div>
-                        <div class="mdl-cell mdl-cell--7-col task-column mdl-shadow--2dp" *ngIf="!isStartProcessMode()">
+                        <div class="mdl-cell task-column mdl-shadow--2dp" *ngIf="!isStartProcessMode()"
+                            [class.mdl-cell--7-col]="processFilter && !isStartProcessMode()"
+                            [class.mdl-cell--10-col]="!processFilter || isStartProcessMode()">
                             <span><h5>Process Details</h5></span>
                             <hr>
                             <activiti-process-instance-details
@@ -89,8 +91,8 @@
                                 (taskClick)="onProcessDetailsTaskClick($event)">
                             </activiti-process-instance-details>
                         </div>
-                        <div class="mdl-cell mdl-cell--7-col task-column" *ngIf="isStartProcessMode()">
-                            <span>Start Process</span>
+                        <div class="mdl-cell mdl-cell--10-col task-column mdl-shadow--2dp" *ngIf="isStartProcessMode()">
+                            <span><h5>Start Process</h5></span>
                             <hr>
                             <activiti-start-process [appId]="appId" (start)="onStartProcessInstance($event)"></activiti-start-process>
                         </div>

--- a/demo-shell-ng2/app/components/activiti/activiti-demo.component.ts
+++ b/demo-shell-ng2/app/components/activiti/activiti-demo.component.ts
@@ -166,6 +166,7 @@ export class ActivitiDemoComponent implements AfterViewInit {
     }
 
     onProcessFilterClick(event: FilterProcessRepresentationModel) {
+        this.currentProcessInstanceId = null;
         this.processFilter = event;
     }
 
@@ -190,13 +191,16 @@ export class ActivitiDemoComponent implements AfterViewInit {
     }
 
     navigateStartProcess() {
+        this.processFilter = null;
+        this.activitiprocessfilter.selectFilter(null);
         this.currentProcessInstanceId = currentProcessIdNew;
     }
 
     onStartProcessInstance(instance: ProcessInstance) {
         this.currentProcessInstanceId = instance.id;
         this.activitiStartProcess.reset();
-        this.activitiprocesslist.reload();
+        this.processFilter = null;
+        this.activitiprocessfilter.selectFilter(null);
     }
 
     isStartProcessMode() {


### PR DESCRIPTION
- Ensures that the newly-started process is *always* shown
- No need to reload the list any more as not shown
- Filter component shows no selected filter when starting process
- User can exit Start Process by clicking a filter again

Refs #1332, #1307