### PR TITLE
#1484 - clean search result when nothing is typed in the search input

### DIFF
--- a/ng2-components/ng2-activiti-tasklist/src/components/activiti-people-search.component.html
+++ b/ng2-components/ng2-activiti-tasklist/src/components/activiti-people-search.component.html
@@ -11,6 +11,6 @@
         </button>
     </li>
     <div *ngIf="userList?.length === 0" id="no-user-found">
-        No user found to involve
+        {{'PEOPLE.SEARCH.NO_USERS' | translate }}
     </div>
 </ul>

--- a/ng2-components/ng2-activiti-tasklist/src/components/activiti-people-search.component.spec.ts
+++ b/ng2-components/ng2-activiti-tasklist/src/components/activiti-people-search.component.spec.ts
@@ -83,7 +83,7 @@ describe('ActivitiPeopleSearch', () => {
         fixture.whenStable()
             .then(() => {
                 expect(element.querySelector('#no-user-found')).not.toBeNull();
-                expect(element.querySelector('#no-user-found').textContent).toContain('No user found to involve');
+                expect(element.querySelector('#no-user-found').textContent).toContain('PEOPLE.SEARCH.NO_USERS');
             });
     });
 

--- a/ng2-components/ng2-activiti-tasklist/src/components/activiti-people-search.component.ts
+++ b/ng2-components/ng2-activiti-tasklist/src/components/activiti-people-search.component.ts
@@ -58,9 +58,11 @@ export class ActivitiPeopleSearch implements OnInit, AfterViewInit {
         this.searchUser
             .valueChanges
             .debounceTime(200)
-            .subscribe((event) => {
-                if (event) {
+            .subscribe((event: string) => {
+                if (event && event.trim()) {
                     this.onSearch.emit(event);
+                } else {
+                    this.userList = [];
                 }
             });
     }
@@ -97,9 +99,5 @@ export class ActivitiPeopleSearch implements OnInit, AfterViewInit {
         let firstName = user.firstName && user.firstName !== 'null' ? user.firstName : 'N/A';
         let lastName = user.lastName && user.lastName !== 'null' ? user.lastName : 'N/A';
         return firstName + ' - ' + lastName;
-    }
-
-    cleanSearch() {
-        this.searchUser.reset();
     }
 }

--- a/ng2-components/ng2-activiti-tasklist/src/components/activiti-people.component.html
+++ b/ng2-components/ng2-activiti-tasklist/src/components/activiti-people.component.html
@@ -29,7 +29,7 @@
         </activiti-people-search>
     </div>
     <div class="mdl-dialog__actions">
-        <button type="button" id="close-people-dialog" (click)="activitipeoplesearch.cleanSearch();cancel()" class="mdl-button close">
+        <button type="button" id="close-people-dialog" (click)="closeDialog()" class="mdl-button close">
             {{'PEOPLE.DIALOG_CLOSE' | translate }}
         </button>
     </div>

--- a/ng2-components/ng2-activiti-tasklist/src/components/activiti-people.component.spec.ts
+++ b/ng2-components/ng2-activiti-tasklist/src/components/activiti-people.component.spec.ts
@@ -111,9 +111,23 @@ describe('ActivitiPeople', () => {
         it('should close dialog when clicked on cancel', () => {
             activitiPeopleComponent.showDialog();
             expect(element.querySelector('#addPeople')).not.toBeNull();
-            activitiPeopleComponent.cancel();
+            activitiPeopleComponent.closeDialog();
             let dialogWindow = <HTMLElement> element.querySelector('#add-people-dialog');
             expect(dialogWindow.getAttribute('open')).toBeNull();
+        });
+
+        it('should reset search input when the dialog is closed', () => {
+            let userInputSearch: HTMLInputElement;
+            activitiPeopleComponent.showDialog();
+            expect(element.querySelector('#addPeople')).not.toBeNull();
+            userInputSearch = <HTMLInputElement> element.querySelector('#userSearchText');
+            userInputSearch.value = 'fake-search-value';
+            activitiPeopleComponent.closeDialog();
+            activitiPeopleComponent.showDialog();
+            userInputSearch = <HTMLInputElement> element.querySelector('#userSearchText');
+
+            expect(userInputSearch).not.toBeNull();
+            expect(userInputSearch.value).toBeFalsy();
         });
     });
 

--- a/ng2-components/ng2-activiti-tasklist/src/components/activiti-people.component.ts
+++ b/ng2-components/ng2-activiti-tasklist/src/components/activiti-people.component.ts
@@ -48,6 +48,9 @@ export class ActivitiPeople {
     @ViewChild('dialog')
     dialog: any;
 
+    @ViewChild('activitipeoplesearch')
+    activitipeoplesearch: any;
+
     private peopleSearchObserver: Observer<User[]>;
     peopleSearch$: Observable<User[]>;
 
@@ -74,10 +77,11 @@ export class ActivitiPeople {
         }
     }
 
-    public cancel() {
+    public closeDialog() {
         if (this.dialog) {
             this.dialog.nativeElement.close();
             this.peopleSearchObserver.next([]);
+            this.activitipeoplesearch.searchUser.reset();
         }
     }
 

--- a/ng2-components/ng2-activiti-tasklist/src/i18n/en.json
+++ b/ng2-components/ng2-activiti-tasklist/src/i18n/en.json
@@ -78,6 +78,9 @@
         }
     },
     "PEOPLE": {
-        "DIALOG_CLOSE": "CLOSE"
+        "DIALOG_CLOSE": "CLOSE",
+        "SEARCH": {
+            "NO_USERS": "No user found to involve"
+        }
     }
 }

--- a/ng2-components/ng2-activiti-tasklist/src/i18n/it.json
+++ b/ng2-components/ng2-activiti-tasklist/src/i18n/it.json
@@ -34,6 +34,9 @@
         }
     },
     "PEOPLE": {
-        "DIALOG_CLOSE": "CHIUDI"
+        "DIALOG_CLOSE": "CHIUDI",
+        "SEARCH": {
+            "NO_USERS": "Nessun utente trovato"
+        }
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

Message not translated. Searching a white space shows all the results. Clean search doesn't hide the results.

**What is the new behavior?**
Message is translated. Searching a white space doesn't show anything. Clean search clean the results.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
