### PR TITLE
#1495 - Added no process definition message on start process

### DIFF
--- a/ng2-components/ng2-activiti-processlist/src/components/activiti-start-process.component.html
+++ b/ng2-components/ng2-activiti-processlist/src/components/activiti-start-process.component.html
@@ -1,4 +1,4 @@
-<div class="mdl-card mdl-shadow--2dp">
+<div *ngIf="processDefinitions.length > 0 || errorMessageId" class="mdl-card mdl-shadow--2dp">
     <div class="mdl-card__supporting-text">
         <div class="mdl-card mdl-shadow--2dp error-message" *ngIf="errorMessageId">
             <div class="mdl-card__supporting-text">{{errorMessageId|translate}}</div>
@@ -23,5 +23,12 @@
     </div>
     <div class="mdl-card__actions mdl-card--border" *ngIf="!hasStartForm()">
         <button type="button" [disabled]="!validateForm()" (click)="startProcess()" class="mdl-button" data-automation-id="btn-start">{{'START_PROCESS.DIALOG.ACTION.START'|translate}}</button>
+    </div>
+</div>
+<div *ngIf="processDefinitions.length === 0 && !errorMessageId" class="mdl-card mdl-shadow--2dp">
+    <div class="mdl-card__supporting-text">
+        <div class="mdl-textfield mdl-js-textfield alf-mdl-selectfield">
+            <span id="no-process-message">{{'START_PROCESS.NO_PROCESS_DEFINITIONS' | translate}}</span>
+        </div>
     </div>
 </div>

--- a/ng2-components/ng2-activiti-processlist/src/components/activiti-start-process.component.spec.ts
+++ b/ng2-components/ng2-activiti-processlist/src/components/activiti-start-process.component.spec.ts
@@ -127,6 +127,19 @@ describe('ActivitiStartProcessInstance', () => {
             });
         }));
 
+        it('should show no process available message when no process definition is loaded', async(() => {
+            getDefinitionsSpy = getDefinitionsSpy.and.returnValue(Observable.of([]));
+            let change = new SimpleChange(null, '123');
+            component.ngOnChanges({ 'appId': change });
+            fixture.detectChanges();
+
+            fixture.whenStable().then(() => {
+                let noprocessElement: DebugElement = debugElement.query(By.css('#no-process-message'));
+                expect(noprocessElement).not.toBeNull('Expected no available process message to be present');
+                expect(noprocessElement.nativeElement.innerText.trim()).toBe('START_PROCESS.NO_PROCESS_DEFINITIONS');
+            });
+        }));
+
     });
 
     describe('input changes', () => {

--- a/ng2-components/ng2-activiti-processlist/src/i18n/en.json
+++ b/ng2-components/ng2-activiti-processlist/src/i18n/en.json
@@ -83,6 +83,7 @@
     },
     "START_PROCESS": {
         "BUTTON": "Start Process",
+        "NO_PROCESS_DEFINITIONS": "You cannot start a process as there are no process definitions available",
         "DIALOG": {
             "TITLE": "Start Process",
             "LABEL": {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behavior?** (You can also link to an open issue here)

If no process definition are available an empty dropdown is showed and no message appear

**What is the new behavior?**
If no process definition are available is showed a message 


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
