### PR TITLE
Fix typos in component properties

### DIFF
--- a/ng2-components/ng2-alfresco-datatable/README.md
+++ b/ng2-components/ng2-alfresco-datatable/README.md
@@ -177,7 +177,7 @@ platformBrowserDynamic().bootstrapModule(AppModule);
 | `data` | DataTableAdapter | instance of **ObjectDataTableAdapter** | data source |
 | `multiselect` | boolean | false | Toggles multiple row selection, renders checkboxes at the beginning of each row |
 | `actions` | boolean | false | Toggles data actions column |
-| `fallbackThubnail` | string |  | Fallback image for row ehre thubnail is missing|
+| `fallbackThumbnail` | string |  | Fallback image for row ehre thubnail is missing|
 
 ### Events
 

--- a/ng2-components/ng2-alfresco-documentlist/README.md
+++ b/ng2-components/ng2-alfresco-documentlist/README.md
@@ -178,7 +178,7 @@ The properties currentFolderId, folderNode and node are the entry initialization
 | `navigate` | boolean | true | Toggles navigation to folder content or file preview |
 | `navigationMode` | string (click\|dblclick) | dblclick | User interaction for folder navigation or file preview |
 | `thumbnails` | boolean | false | Show document thumbnails rather than icons |
-| `fallbackThubnail` | string |  | Fallback image for row ehre thubnail is missing|
+| `fallbackThumbnail` | string |  | Path to fallback image to use if the row thumbnail is missing |
 | `multiselect` | boolean | false | Toggles multiselect mode |
 | `contentActions` | boolean | false | Toggles content actions for each row |
 | `contextMenuActions` | boolean | false | Toggles context menus for each row |

--- a/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.html
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.html
@@ -8,7 +8,7 @@
     [data]="data"
     [actions]="contentActions"
     [multiselect]="multiselect"
-    [fallbackThumbnail]="fallbackThubnail"
+    [fallbackThumbnail]="fallbackThumbnail"
     (showRowContextMenu)="onShowRowContextMenu($event)"
     (showRowActionsMenu)="onShowRowActionsMenu($event)"
     (executeRowAction)="onExecuteRowAction($event)"

--- a/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.ts
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.ts
@@ -54,7 +54,7 @@ export class DocumentListComponent implements OnInit, OnChanges, AfterContentIni
     baseComponentPath = module.id.replace('/components/document-list.component.js', '');
 
     @Input()
-    fallbackThubnail: string = this.baseComponentPath + '/assets/images/ft_ic_miscellaneous.svg';
+    fallbackThumbnail: string = this.baseComponentPath + '/assets/images/ft_ic_miscellaneous.svg';
 
     @Input()
     navigate: boolean = true;

--- a/ng2-components/ng2-alfresco-upload/README.md
+++ b/ng2-components/ng2-alfresco-upload/README.md
@@ -99,7 +99,7 @@ Follow the 3 steps below:
 
 
 ```html
-<alfresco-upload-button [showUdoNotificationBar]="true"
+<alfresco-upload-button [showNotificationBar]="true"
                         [uploadFolders]="true"
                         [multipleFiles]="false"
                         [acceptedFilesType]=".jpg,.gif,.png,.svg"
@@ -121,7 +121,7 @@ import { UploadModule } from 'ng2-alfresco-upload';
 
 @Component({
     selector: 'alfresco-app-demo',
-    template: `<alfresco-upload-button [showUdoNotificationBar]="true"
+    template: `<alfresco-upload-button [showNotificationBar]="true"
                                        [uploadFolders]="false"
                                        [multipleFiles]="false"
                                        [acceptedFilesType]="'.jpg,.gif,.png,.svg'"
@@ -171,7 +171,7 @@ Attribute     | Description
 
 Attribute     | Options     | Default      | Description | Mandatory
 ---           | ---         | ---          | ---         | ---
-`showUdoNotificationBar`         | *boolean*    |     true   |  Hide/show notification bar | 
+`showNotificationBar`         | *boolean*    |     true   |  Hide/show notification bar | 
 `uploadFolders`         | *boolean*    |     false   |  Allow/disallow upload folders (only for chrome) | 
 `multipleFiles`         | *boolean*    |     false   |  Allow/disallow multiple files | 
 `acceptedFilesType`         | *string*    |     *   |  array of allowed file extensions , example: ".jpg,.gif,.png,.svg" | 
@@ -251,7 +251,7 @@ Attribute     | Description
 
 Attribute     | Options     | Default      | Description | Mandatory
 ---           | ---         | ---          | ---         | ---
-`showUdoNotificationBar`         | *boolean*    |     true   |  Hide/show notification bar | 
+`showNotificationBar`         | *boolean*    |     true   |  Hide/show notification bar | 
 `currentFolderPath`         | *string*    |     '/Sites/swsdp/documentLibrary'   |  define the path where the files are uploaded | 
 `versioning`         | *boolean*    |     false   |  Versioning false is the default uploader behaviour and it rename using an integer suffix if there is a name clash. Versioning true to indicate that a major version should be created  | 
 

--- a/ng2-components/ng2-alfresco-upload/index.ts
+++ b/ng2-components/ng2-alfresco-upload/index.ts
@@ -31,7 +31,7 @@ import { UploadService } from './src/services/upload.service';
  * Components provided:
  *         - A button to upload files
  *           <alfresco-upload-button [showDialogUpload]="boolean"
- *                                   [showUdoNotificationBar]="boolean"
+ *                                   [showNotificationBar]="boolean"
  *                                   [uploadFolders]="boolean"
  *                                   [multipleFiles]="boolean"
  *                                   [acceptedFilesType]="string">

--- a/ng2-components/ng2-alfresco-upload/src/components/upload-button.component.ts
+++ b/ng2-components/ng2-alfresco-upload/src/components/upload-button.component.ts
@@ -26,7 +26,7 @@ declare let componentHandler: any;
 const ERROR_FOLDER_ALREADY_EXIST = 409;
 
 /**
- * <alfresco-upload-button [showUdoNotificationBar]="boolean"
+ * <alfresco-upload-button [showNotificationBar]="boolean"
  *                         [uploadFolders]="boolean"
  *                         [multipleFiles]="boolean"
  *                         [acceptedFilesType]="string"
@@ -35,7 +35,7 @@ const ERROR_FOLDER_ALREADY_EXIST = 409;
  *
  * This component, provide a set of buttons to upload files to alfresco.
  *
- * @InputParam {boolean} [true] showUdoNotificationBar - hide/show notification bar.
+ * @InputParam {boolean} [true] showNotificationBar - hide/show notification bar.
  * @InputParam {boolean} [false] versioning - true to indicate that a major version should be created
  * @InputParam {boolean} [false] uploadFolders - allow/disallow upload folders (only for chrome).
  * @InputParam {boolean} [false] multipleFiles - allow/disallow multiple files.
@@ -56,7 +56,7 @@ export class UploadButtonComponent {
     private static DEFAULT_ROOT_ID: string = '-root-';
 
     @Input()
-    showUdoNotificationBar: boolean = true;
+    showNotificationBar: boolean = true;
 
     @Input()
     uploadFolders: boolean = false;
@@ -157,7 +157,7 @@ export class UploadButtonComponent {
         if (files.length) {
             let latestFilesAdded = this.uploadService.addToQueue(files);
             this.uploadService.uploadFilesInTheQueue(this.rootFolderId, path, this.onSuccess);
-            if (this.showUdoNotificationBar) {
+            if (this.showNotificationBar) {
                 this._showUndoNotificationBar(latestFilesAdded);
             }
         }

--- a/ng2-components/ng2-alfresco-upload/src/components/upload-drag-area.component.spec.ts
+++ b/ng2-components/ng2-alfresco-upload/src/components/upload-drag-area.component.spec.ts
@@ -66,7 +66,7 @@ describe('UploadDragAreaComponent', () => {
     });
 
     it('should show an folder non supported error in console when the file type is empty', () => {
-        component.showUdoNotificationBar = false;
+        component.showNotificationBar = false;
         spyOn(logService, 'error');
 
         let fileFake = new File([''], 'folder-fake', {type: ''});
@@ -77,7 +77,7 @@ describe('UploadDragAreaComponent', () => {
 
     it('should show an folder non supported error in the notification bar when the file type is empty', () => {
         component.showErrorNotificationBar = jasmine.createSpy('_showErrorNotificationBar');
-        component.showUdoNotificationBar = true;
+        component.showNotificationBar = true;
 
         let fileFake = new File([''], 'folder-fake', {type: ''});
         component.onFilesDropped([fileFake]);
@@ -88,7 +88,7 @@ describe('UploadDragAreaComponent', () => {
     it('should upload the list of files dropped', () => {
         component.currentFolderPath = '/root-fake-/sites-fake/folder-fake';
         component.onSuccess = null;
-        component.showUdoNotificationBar = false;
+        component.showNotificationBar = false;
         uploadService.addToQueue = jasmine.createSpy('addToQueue');
         uploadService.uploadFilesInTheQueue = jasmine.createSpy('uploadFilesInTheQueue');
 
@@ -104,7 +104,7 @@ describe('UploadDragAreaComponent', () => {
     it('should show the loading messages in the notification bar when the files are dropped', () => {
         component.currentFolderPath = '/root-fake-/sites-fake/folder-fake';
         component.onSuccess = null;
-        component.showUdoNotificationBar = true;
+        component.showNotificationBar = true;
         uploadService.uploadFilesInTheQueue = jasmine.createSpy('uploadFilesInTheQueue');
         component.showUndoNotificationBar = jasmine.createSpy('_showUndoNotificationBar');
 
@@ -166,7 +166,7 @@ describe('UploadDragAreaComponent', () => {
 
     xit('should throws an exception and show it in the notification bar when the folder already exist', done => {
         component.currentFolderPath = '/root-fake-/sites-fake/folder-fake';
-        component.showUdoNotificationBar = true;
+        component.showNotificationBar = true;
 
         fixture.detectChanges();
         let fakeRest = {

--- a/ng2-components/ng2-alfresco-upload/src/components/upload-drag-area.component.ts
+++ b/ng2-components/ng2-alfresco-upload/src/components/upload-drag-area.component.ts
@@ -44,7 +44,7 @@ export class UploadDragAreaComponent {
     private static DEFAULT_ROOT_ID: string = '-root-';
 
     @Input()
-    showUdoNotificationBar: boolean = true;
+    showNotificationBar: boolean = true;
 
     @Input()
     versioning: boolean = false;
@@ -83,13 +83,13 @@ export class UploadDragAreaComponent {
                 this.uploadService.addToQueue(files);
                 this.uploadService.uploadFilesInTheQueue(this.rootFolderId, this.currentFolderPath, this.onSuccess);
                 let latestFilesAdded = this.uploadService.getQueue();
-                if (this.showUdoNotificationBar) {
+                if (this.showNotificationBar) {
                     this.showUndoNotificationBar(latestFilesAdded);
                 }
             } else {
                 let errorMessage: any;
                 errorMessage = this.translateService.get('FILE_UPLOAD.MESSAGES.FOLDER_NOT_SUPPORTED');
-                if (this.showUdoNotificationBar) {
+                if (this.showNotificationBar) {
                     this.showErrorNotificationBar(errorMessage.value);
                 } else {
                     this.logService.error(errorMessage.value);
@@ -143,7 +143,7 @@ export class UploadDragAreaComponent {
                             for (let i = 0; i < entries.length; i++) {
                                 this._traverseFileTree(entries[i]);
                             }
-                            if (this.showUdoNotificationBar) {
+                            if (this.showNotificationBar) {
                                 let latestFilesAdded = this.uploadService.getQueue();
                                 this.showUndoNotificationBar(latestFilesAdded);
                             }
@@ -152,7 +152,7 @@ export class UploadDragAreaComponent {
                     error => {
                         let errorMessagePlaceholder = this.getErrorMessage(error.response);
                         let errorMessage = this.formatString(errorMessagePlaceholder, [folder.name]);
-                        if (this.showUdoNotificationBar) {
+                        if (this.showNotificationBar) {
                             this.showErrorNotificationBar(errorMessage);
                         } else {
                             this.logService.error(errorMessage);


### PR DESCRIPTION
Refs #1559

**Breaking Changes**

- Input `UploadButtonComponent.showUdoNotificationBar` renamed to `showNotificationBar`
- Input `UploadDragAreaComponent.showUdoNotificationBar` renamed to `showNotificationBar`
- Input `DocumentListComponent.fallbackThubnail` renamed to `fallbackThumbnail`