### PR TITLE
upload: new 'click' mode with file/folder dialog support

### DIFF
--- a/ng2-components/ng2-alfresco-core/README.md
+++ b/ng2-components/ng2-alfresco-core/README.md
@@ -89,6 +89,56 @@ It is possible controlling when upload behaviour is enabled/disabled by binding 
 <div [adf-upload]="isUploadEnabled()">...</div>
 ```
 
+You can decorate any element including buttons, for example:
+
+```html
+<button [adf-upload]="true" [multiple]="true" [accept]="'image/*'">
+    Upload photos
+</button>
+```
+
+### Modes
+
+Directive supports several modes:
+
+- **drop** mode, where decorated element acts like a drop zone for files (**default** mode)
+- **click** mode, where decorated element invokes File Dialog to select files or folders.
+
+It is also possible combining modes together. 
+
+```html
+<div [adf-upload]="true" mode="['click']">...</div>
+<div [adf-upload]="true" mode="['drop']">...</div>
+<div [adf-upload]="true" mode="['click', 'drop']">...</div>
+```
+
+#### Click mode
+
+For the click mode you can provide additional attributes for the File Dialog:
+
+- **directory**, enables directory selection
+- **multiple**, enables multiple file/folder selection
+- **accept**, filters the content accepted
+
+```html
+<div style="width: 50px; height: 50px; background-color: brown"
+     [adf-upload]="true"
+     [multiple]="true"
+     [accept]="'image/*'">
+</div>
+
+<div style="width: 50px; height: 50px; background-color: blueviolet"
+     [adf-upload]="true"
+     [multiple]="true"
+     [directory]="true">
+</div>
+```
+
+#### Drop mode
+
+For the moment upload directive supports only Files (single or multiple). 
+Support for Folders and `accept` filters is subject to implement.
+
 ### Events
 
 Once a single or multiple files are dropped on the decorated element the `upload-files` [CustomEvent](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent) is raised.

--- a/ng2-components/ng2-alfresco-core/src/directives/upload.directive.spec.ts
+++ b/ng2-components/ng2-alfresco-core/src/directives/upload.directive.spec.ts
@@ -27,7 +27,7 @@ describe('UploadDirective', () => {
         nativeElement = {
             dispatchEvent: () => {}
         };
-        directive = new UploadDirective(new ElementRef(nativeElement));
+        directive = new UploadDirective(new ElementRef(nativeElement), null);
     });
 
     it('should be enabled by default', () => {

--- a/ng2-components/ng2-alfresco-core/src/directives/upload.directive.ts
+++ b/ng2-components/ng2-alfresco-core/src/directives/upload.directive.ts
@@ -149,20 +149,14 @@ export class UploadDirective implements OnInit {
      * @param dataTransfer DataTransfer object
      */
     protected getFilesDropped(dataTransfer: DataTransfer): File[] {
-        let result: File[] = [];
+        const result: File[] = [];
 
         if (dataTransfer) {
-            let items: DataTransferItemList = dataTransfer.items;
+            const items: FileList = dataTransfer.files;
 
             if (items && items.length > 0) {
                 for (let i = 0; i < items.length; i++) {
-                    let item: DataTransferItem = items[i];
-                    if (item.type) {
-                        let file = item.getAsFile();
-                        if (file) {
-                            result.push(file);
-                        }
-                    }
+                result.push(items[i]);
                 }
             }
         }


### PR DESCRIPTION
refs #510 

- adds support for clicking to select files and/or folders (UploadDirective)
- allows decorating any elements with a click, drop or combined modes
- Safari compatibility for dropping files to folders
- readme updates

**what is not supported with this PR**:
- dropping external folders on folders to upload (will be a separate issue/pr)