### PR TITLE
fix dynamic table validation

### DIFF
--- a/ng2-components/ng2-activiti-form/src/components/widgets/dynamic-table/dynamic-table.widget.model.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/dynamic-table/dynamic-table.widget.model.ts
@@ -16,7 +16,6 @@
  */
 
 import { FormWidgetModel } from './../core/form-widget.model';
-import { FormModel } from './../core/form.model';
 import { FormFieldModel } from './../core/form-field.model';
 import * as moment from 'moment';
 
@@ -50,19 +49,19 @@ export class DynamicTableModel extends FormWidgetModel {
         }
     }
 
-    constructor(form: FormModel, json?: any) {
-        super(form, json);
+    constructor(field: FormFieldModel) {
+        super(field.form, field.json);
+        this.field = field;
 
-        if (json) {
-            this.field = new FormFieldModel(form, json);
+        if (field.json) {
 
-            if (json.columnDefinitions) {
-                this.columns = json.columnDefinitions.map(obj => <DynamicTableColumn> obj);
+            if (field.json.columnDefinitions) {
+                this.columns = field.json.columnDefinitions.map(obj => <DynamicTableColumn> obj);
                 this.visibleColumns = this.columns.filter(col => col.visible);
             }
 
-            if (json.value) {
-                this.rows = json.value.map(obj => <DynamicTableRow> {selected: false, value: obj});
+            if (field.json.value) {
+                this.rows = field.json.value.map(obj => <DynamicTableRow> {selected: false, value: obj});
             }
         }
 

--- a/ng2-components/ng2-activiti-form/src/components/widgets/dynamic-table/dynamic-table.widget.spec.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/dynamic-table/dynamic-table.widget.spec.ts
@@ -18,7 +18,7 @@
 import { LogServiceMock } from 'ng2-alfresco-core';
 import { DynamicTableWidget } from './dynamic-table.widget';
 import { DynamicTableModel, DynamicTableRow, DynamicTableColumn } from './dynamic-table.widget.model';
-import { FormModel, FormFieldTypes } from './../core/index';
+import { FormModel, FormFieldTypes, FormFieldModel } from './../core/index';
 import { WidgetVisibilityService } from '../../../services/widget-visibility.service';
 
 describe('DynamicTableWidget', () => {
@@ -30,7 +30,8 @@ describe('DynamicTableWidget', () => {
 
     beforeEach(() => {
         logService = new LogServiceMock();
-        table = new DynamicTableModel(null);
+        const field = new FormFieldModel(new FormModel());
+        table = new DynamicTableModel(field);
         visibilityService = new WidgetVisibilityService(null, logService);
         widget = new DynamicTableWidget(null, visibilityService, logService);
         widget.content = table;
@@ -223,11 +224,12 @@ describe('DynamicTableWidget', () => {
 
     it('should take validation state from underlying field', () => {
         let form = new FormModel();
-        widget.content = new DynamicTableModel(form, {
+        let field = new FormFieldModel(form, {
             type: FormFieldTypes.DYNAMIC_TABLE,
             required: true,
             value: null
         });
+        widget.content = new DynamicTableModel(field);
 
         expect(widget.content.field.validate()).toBeFalsy();
         expect(widget.isValid()).toBe(widget.content.field.isValid);

--- a/ng2-components/ng2-activiti-form/src/components/widgets/dynamic-table/dynamic-table.widget.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/dynamic-table/dynamic-table.widget.ts
@@ -44,7 +44,7 @@ export class DynamicTableWidget extends WidgetComponent implements OnInit {
 
     ngOnInit() {
         if (this.field) {
-            this.content = new DynamicTableModel(this.field.form, this.field.json);
+            this.content = new DynamicTableModel(this.field);
             this.visibilityService.refreshVisibility(this.field.form);
         }
     }

--- a/ng2-components/ng2-activiti-form/src/components/widgets/dynamic-table/editors/date/date.editor.spec.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/dynamic-table/editors/date/date.editor.spec.ts
@@ -19,6 +19,7 @@ import { ElementRef } from '@angular/core';
 import { DateEditorComponent } from './date.editor';
 import { DynamicTableModel, DynamicTableRow, DynamicTableColumn } from './../../dynamic-table.widget.model';
 import * as moment from 'moment';
+import { FormFieldModel, FormModel } from '../../../index';
 
 describe('DateEditorComponent', () => {
 
@@ -36,7 +37,8 @@ describe('DateEditorComponent', () => {
 
         row = <DynamicTableRow> { value: { date: '1879-03-14T00:00:00.000Z' } };
         column = <DynamicTableColumn> { id: 'date', type: 'Date' };
-        table = new DynamicTableModel(null);
+        const field = new FormFieldModel(new FormModel());
+        table = new DynamicTableModel(field);
         table.rows.push(row);
         table.columns.push(column);
 

--- a/ng2-components/ng2-activiti-form/src/components/widgets/dynamic-table/editors/dropdown/dropdown.editor.spec.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/dynamic-table/editors/dropdown/dropdown.editor.spec.ts
@@ -51,8 +51,7 @@ describe('DropdownEditorComponent', () => {
         };
 
         form = new FormModel({ taskId: '<task-id>' });
-        table = new DynamicTableModel(form, null);
-        table.field = new FormFieldModel(form, { id: '<field-id>' });
+        table = new DynamicTableModel(new FormFieldModel(form, { id: '<field-id>' }));
         table.rows.push(row);
         table.columns.push(column);
 
@@ -150,8 +149,7 @@ describe('DropdownEditorComponent', () => {
     it('should handle REST error getting option with processDefinitionId', () => {
         column.optionType = 'rest';
         let procForm = new FormModel ({processDefinitionId: '<process-definition-id>'});
-        let procTable = new DynamicTableModel(procForm, null);
-        procTable.field = new FormFieldModel(form, { id: '<field-id>' });
+        let procTable = new DynamicTableModel(new FormFieldModel(procForm, { id: '<field-id>' }));
         component.table = procTable;
         const error = 'error';
 
@@ -219,8 +217,7 @@ describe('DropdownEditorComponent', () => {
                     ]
                 };
                 form = new FormModel({ taskId: '<task-id>' });
-                dynamicTable = new DynamicTableModel(form, null);
-                dynamicTable.field = new FormFieldModel(form, { id: '<field-id>' });
+                dynamicTable = new DynamicTableModel(new FormFieldModel(form, { id: '<field-id>' }));
                 dynamicTable.rows.push(row);
                 dynamicTable.columns.push(column);
                 dropDownEditorComponent.table = dynamicTable;
@@ -261,8 +258,7 @@ describe('DropdownEditorComponent', () => {
                     ]
                 };
                 form = new FormModel({ processDefinitionId: '<proc-id>' });
-                dynamicTable = new DynamicTableModel(form, null);
-                dynamicTable.field = new FormFieldModel(form, { id: '<field-id>' });
+                dynamicTable = new DynamicTableModel(new FormFieldModel(form, { id: '<field-id>' }));
                 dynamicTable.rows.push(row);
                 dynamicTable.columns.push(column);
                 dropDownEditorComponent.table = dynamicTable;

--- a/ng2-components/ng2-activiti-form/src/components/widgets/dynamic-table/editors/row.editor.spec.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/dynamic-table/editors/row.editor.spec.ts
@@ -17,6 +17,7 @@
 
 import { RowEditorComponent } from './row.editor';
 import { DynamicTableModel, DynamicTableRow, DynamicTableColumn, DynamicRowValidationSummary } from './../dynamic-table.widget.model';
+import { FormFieldModel, FormModel } from '../../index';
 
 describe('RowEditorComponent', () => {
 
@@ -24,7 +25,8 @@ describe('RowEditorComponent', () => {
 
     beforeEach(() => {
         component = new RowEditorComponent();
-        component.table = new DynamicTableModel(null);
+        const field = new FormFieldModel(new FormModel());
+        component.table = new DynamicTableModel(field);
         component.row =  <DynamicTableRow> {};
         component.column = <DynamicTableColumn> {};
     });


### PR DESCRIPTION
refs #1611 

- fix the problem with start/complete buttons disabled for valid required datatable 
- dynamic table widget no longer creates a copy of field model, but
uses original one, fixes the problem with validation and state
management
- update unit tests