### PR TITLE
disable add button when no valid ID is provided #1591

### DIFF
--- a/ng2-components/ng2-alfresco-tag/src/components/tag-actions.component.html
+++ b/ng2-components/ng2-alfresco-tag/src/components/tag-actions.component.html
@@ -13,7 +13,7 @@
             <input class="mdl-textfield__input tag-input" type="text" id="new-tag-text" (keypress)="cleanErrorMsg()" [(ngModel)]="newTagName"/>
             <label class="mdl-textfield__label" for="new-tag-text" > {{'TAG.LABEL.NEWTAG' | translate }}</label>
             <span class="mdl-textfield__error">{{errorMsg}}</span>
-            <button id="add-tag" class="mdl-button mdl-js-button mdl-button--raised button" (click)="addTag()">
+            <button id="add-tag" class="mdl-button mdl-js-button mdl-button--raised button" (click)="addTag()" [disabled]="disableAddTag">
                 {{'TAG.BUTTON.ADD' | translate }}
             </button>
         </div>
@@ -33,7 +33,7 @@
             <input class="mdl-textfield__input tag-input" type="text" id="new-tag-text" (keypress)="cleanErrorMsg()" [(ngModel)]="newTagName"/>
             <label class="mdl-textfield__label" for="new-tag-text" > {{'TAG.LABEL.NEWTAG' | translate }}</label>
             <span  *ngIf="errorMsg" class="mdl-textfield__error">{{errorMsg}}</span>
-            <button id="add-tag" class="mdl-button mdl-js-button mdl-button--raised button" (click)="addTag()">
+            <button id="add-tag" class="mdl-button mdl-js-button mdl-button--raised button" (click)="addTag()" [disabled]="disableAddTag">
                 {{'TAG.BUTTON.ADD' | translate }}
             </button>
         </div>

--- a/ng2-components/ng2-alfresco-tag/src/components/tag-actions.component.spec.ts
+++ b/ng2-components/ng2-alfresco-tag/src/components/tag-actions.component.spec.ts
@@ -172,5 +172,48 @@ describe('Test ng2-alfresco-tag Tag actions list', () => {
                 status: 200
             });
         });
+
+        it('Add tag should be disabled by default', (done) => {
+            component.nodeId = 'fake-node-id';
+            component.newTagName = 'fake-tag-name';
+
+            let addButton: any = element.querySelector('#add-tag');
+            expect(addButton.disabled).toEqual(true);
+            done();
+        });
+
+        it('Add tag should be disabled if the node id is not a correct node', (done) => {
+            component.nodeId = 'fake-node-id';
+            component.newTagName = 'fake-tag-name';
+
+            component.resultsEmitter.subscribe(() => {
+                let addButton: any = element.querySelector('#add-tag');
+                expect(addButton.disabled).toEqual(true);
+                done();
+            });
+
+            component.ngOnChanges();
+
+            jasmine.Ajax.requests.mostRecent().respondWith({
+                status: 404
+            });
+        });
+
+        it('Add tag should be enable if the node id is a correct node', (done) => {
+            component.nodeId = 'fake-node-id';
+            component.newTagName = 'fake-tag-name';
+
+            component.resultsEmitter.subscribe(() => {
+                let addButton: any = element.querySelector('#add-tag');
+                expect(addButton.disabled).toEqual(false);
+                done();
+            });
+
+            component.ngOnChanges();
+
+            jasmine.Ajax.requests.mostRecent().respondWith({
+                status: 200
+            });
+        });
     });
 });

--- a/ng2-components/ng2-alfresco-tag/src/components/tag-actions.component.spec.ts
+++ b/ng2-components/ng2-alfresco-tag/src/components/tag-actions.component.spec.ts
@@ -146,12 +146,25 @@ describe('Test ng2-alfresco-tag Tag actions list', () => {
                 done();
             });
 
-            let addButton: any = element.querySelector('#add-tag');
-            addButton.click();
+            component.resultsEmitter.subscribe(() => {
+                fixture.detectChanges();
+
+                let addButton: any = element.querySelector('#add-tag');
+                addButton.click();
+
+                jasmine.Ajax.requests.mostRecent().respondWith({
+                    status: 200
+                });
+            });
+
+            component.ngOnChanges();
 
             jasmine.Ajax.requests.mostRecent().respondWith({
-                status: 200
+                status: 200,
+                contentType: 'json',
+                responseText: dataTag
             });
+
         });
 
         it('The input box should be cleared after add tag', (done) => {
@@ -165,11 +178,23 @@ describe('Test ng2-alfresco-tag Tag actions list', () => {
                 done();
             });
 
-            let addButton: any = element.querySelector('#add-tag');
-            addButton.click();
+            component.resultsEmitter.subscribe(() => {
+                fixture.detectChanges();
+
+                let addButton: any = element.querySelector('#add-tag');
+                addButton.click();
+
+                jasmine.Ajax.requests.mostRecent().respondWith({
+                    status: 200
+                });
+            });
+
+            component.ngOnChanges();
 
             jasmine.Ajax.requests.mostRecent().respondWith({
-                status: 200
+                status: 200,
+                contentType: 'json',
+                responseText: dataTag
             });
         });
 
@@ -204,6 +229,8 @@ describe('Test ng2-alfresco-tag Tag actions list', () => {
             component.newTagName = 'fake-tag-name';
 
             component.resultsEmitter.subscribe(() => {
+                fixture.detectChanges();
+
                 let addButton: any = element.querySelector('#add-tag');
                 expect(addButton.disabled).toEqual(false);
                 done();
@@ -212,7 +239,9 @@ describe('Test ng2-alfresco-tag Tag actions list', () => {
             component.ngOnChanges();
 
             jasmine.Ajax.requests.mostRecent().respondWith({
-                status: 200
+                status: 200,
+                contentType: 'json',
+                responseText: dataTag
             });
         });
     });

--- a/ng2-components/ng2-alfresco-tag/src/components/tag-actions.component.ts
+++ b/ng2-components/ng2-alfresco-tag/src/components/tag-actions.component.ts
@@ -67,12 +67,12 @@ export class TagActionsComponent {
     refreshTag() {
         this.tagService.getTagsByNodeId(this.nodeId).subscribe((data) => {
             this.tagsEntries = data.list.entries;
-            this.resultsEmitter.emit(this.tagsEntries);
             this.disableAddTag = false;
+            this.resultsEmitter.emit(this.tagsEntries);
         }, () => {
             this.tagsEntries = null;
-            this.resultsEmitter.emit();
             this.disableAddTag = true;
+            this.resultsEmitter.emit(this.tagsEntries);
         });
     }
 

--- a/ng2-components/ng2-alfresco-tag/src/components/tag-actions.component.ts
+++ b/ng2-components/ng2-alfresco-tag/src/components/tag-actions.component.ts
@@ -52,6 +52,8 @@ export class TagActionsComponent {
 
     errorMsg: string;
 
+    disableAddTag: boolean = true;
+
     constructor(private tagService: TagService, private translateService: AlfrescoTranslationService) {
         if (translateService) {
             translateService.addTranslationFolder('ng2-alfresco-tag', 'node_modules/ng2-alfresco-tag/src');
@@ -66,6 +68,11 @@ export class TagActionsComponent {
         this.tagService.getTagsByNodeId(this.nodeId).subscribe((data) => {
             this.tagsEntries = data.list.entries;
             this.resultsEmitter.emit(this.tagsEntries);
+            this.disableAddTag = false;
+        }, () => {
+            this.tagsEntries = null;
+            this.resultsEmitter.emit();
+            this.disableAddTag = true;
         });
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[x ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
[ x] Tests for the changes have been added (for bug fixes / features)
[x ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behaviour?** (You can also link to an open issue here)


**What is the new behaviour?**
disable add button when no valid nodeid is provided



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
