### PR TITLE
bug fixes for thumbnails and Safari download

### DIFF
--- a/ng2-components/ng2-activiti-form/src/components/activiti-content.component.ts
+++ b/ng2-components/ng2-activiti-form/src/components/activiti-content.component.ts
@@ -33,7 +33,7 @@ export class ActivitiContent implements OnChanges {
     id: string;
 
     @Input()
-    showDocumentContent: boolean = false;
+    showDocumentContent: boolean = true;
 
     @Output()
     contentClick = new EventEmitter();

--- a/ng2-components/ng2-activiti-form/src/components/widgets/display-value/display-value.widget.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/display-value/display-value.widget.ts
@@ -48,7 +48,7 @@ export class DisplayValueWidget extends WidgetComponent implements OnInit {
 
     // upload/attach
     hasFile: boolean = false;
-    showDocumentContent: boolean = false;
+    showDocumentContent: boolean = true;
 
     constructor(private formService: FormService,
                 private visibilityService: WidgetVisibilityService,
@@ -61,7 +61,9 @@ export class DisplayValueWidget extends WidgetComponent implements OnInit {
             this.value = this.field.value;
             this.visibilityService.refreshEntityVisibility(this.field);
             if (this.field.params) {
-                this.showDocumentContent = !!this.field.params['showDocumentContent'];
+                if (this.field.params['showDocumentContent'] !== undefined) {
+                    this.showDocumentContent = !!this.field.params['showDocumentContent'];
+                }
                 let originalField = this.field.params['field'];
                 if (originalField && originalField.type) {
                     this.fieldType = originalField.type;

--- a/ng2-components/ng2-alfresco-core/src/services/content.service.ts
+++ b/ng2-components/ng2-alfresco-core/src/services/content.service.ts
@@ -32,17 +32,13 @@ export class ContentService {
             return function (data, format, fileName) {
                 let blob = null;
 
-                if (format === 'blob') {
-                    blob = data;
-                }
-
-                if (format === 'data') {
-                    blob = new Blob([data], {type: 'octet/stream'});
+                if (format === 'blob' || format === 'data') {
+                    blob = new Blob([data], { type: 'octet/stream' });
                 }
 
                 if (format === 'object' || format === 'json') {
                     let json = JSON.stringify(data);
-                    blob = new Blob([json], {type: 'octet/stream'});
+                    blob = new Blob([json], { type: 'octet/stream' });
                 }
 
                 if (blob) {


### PR DESCRIPTION
- set ‘show thumbnail’ to true by default
- add support for safe downloads in Safari (upcoming 10.1 and TP)