### PR TITLE
workaround for tooltips

### DIFF
--- a/ng2-components/ng2-activiti-analytics/src/components/analytics-generator.component.css
+++ b/ng2-components/ng2-activiti-analytics/src/components/analytics-generator.component.css
@@ -8,8 +8,8 @@
 }
 
 .report-icons {
-    margin: 20px 20px 20px 20px;
-    float: right;
+    margin: 20px 0;
+    float: left;
 }
 
 .full-width {

--- a/ng2-components/ng2-activiti-analytics/src/components/analytics-generator.component.html
+++ b/ng2-components/ng2-activiti-analytics/src/components/analytics-generator.component.html
@@ -1,10 +1,11 @@
 <div *ngIf="reports">
     <div class="report-icons">
-        <button mdTooltip="{{report.title}}" (click)="selectCurrent(idx)"
-                [class.mdl-button--accent]="isCurrent(idx)"
-                class="mdl-button mdl-js-button"
-                *ngFor="let report of reports; let idx = index">
-            <i class="material-icons">{{report.icon}}</i>
+        <button md-icon-button
+                *ngFor="let report of reports; let idx = index"
+                [mdTooltip]="report.title"
+                [color]="isCurrent(idx) ? 'primary' : null"
+                (click)="selectCurrent(idx)">
+            <md-icon>{{report.icon}}</md-icon>
         </button>
     </div>
     <div class="clear-both"> </div>


### PR DESCRIPTION
refs #1668 

- migrate buttons to angular/material
- move buttons to the left (workaround for tooltips)

<img width="919" alt="screen shot 2017-03-28 at 17 11 50" src="https://cloud.githubusercontent.com/assets/503991/24415617/f51613f6-13d9-11e7-8853-40c3707ae6d3.png">
