### PR TITLE
#1654 - move download management to content service from core

### DIFF
--- a/ng2-components/ng2-activiti-analytics/src/components/analytics-report-parameters.component.spec.ts
+++ b/ng2-components/ng2-activiti-analytics/src/components/analytics-report-parameters.component.spec.ts
@@ -530,7 +530,6 @@ describe('AnalyticsReportParametersComponent', () => {
 
             it('Should show a dialog to allowing report export', async(() => {
                 component.submit(values);
-                spyOn(component, 'generateDownloadElement').and.stub();
                 fixture.detectChanges();
                 let exportButton: HTMLButtonElement = <HTMLButtonElement>element.querySelector('#export-button');
                 expect(exportButton).toBeDefined();

--- a/ng2-components/ng2-activiti-analytics/src/components/analytics-report-parameters.component.ts
+++ b/ng2-components/ng2-activiti-analytics/src/components/analytics-report-parameters.component.ts
@@ -29,7 +29,7 @@ import {
 } from '@angular/core';
 import { FormGroup, FormBuilder, FormControl } from '@angular/forms';
 import * as moment from 'moment';
-import { AlfrescoTranslationService, LogService } from 'ng2-alfresco-core';
+import { AlfrescoTranslationService, LogService, ContentService } from 'ng2-alfresco-core';
 import { AnalyticsService } from '../services/analytics.service';
 import {
     ReportParametersModel,
@@ -106,7 +106,8 @@ export class AnalyticsReportParametersComponent implements OnInit, OnChanges, On
     constructor(private translateService: AlfrescoTranslationService,
                 private analyticsService: AnalyticsService,
                 private formBuilder: FormBuilder,
-                private logService: LogService) {
+                private logService: LogService,
+                private contentService: ContentService) {
         if (translateService) {
             translateService.addTranslationFolder('ng2-activiti-analytics', 'node_modules/ng2-activiti-analytics/src');
         }
@@ -357,17 +358,8 @@ export class AnalyticsReportParametersComponent implements OnInit, OnChanges, On
         this.analyticsService.exportReportToCsv(this.reportId, paramQuery).subscribe(
             (data: any) => {
                 let blob: Blob = new Blob([data], { type: 'text/csv' });
-                let downloadUrl = window.URL.createObjectURL(blob);
-                this.generateDownloadElement(downloadUrl, paramQuery);
+                this.contentService.downloadBlob(blob, paramQuery.reportName + '.csv');
             });
-    }
-
-    generateDownloadElement(downloadUrl: string, paramQuery: ReportQuery) {
-        let downloadElement = window.document.createElement('a');
-        downloadElement.setAttribute('id', 'export-download');
-        downloadElement.setAttribute('href', downloadUrl);
-        downloadElement.setAttribute('download', paramQuery.reportName);
-        downloadElement.click();
     }
 
     doSave(paramQuery: ReportQuery) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behaviour?** (You can also link to an open issue here)

Firefox and Safari are not able to export reports. 
Component is not using the centralized system for download.

**What is the new behaviour?**
Moved the download management to ContentService of core.
Safari and firefox are able to download reports.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
