### PR TITLE
use original error message for CORS/offline state in login

### DIFF
--- a/ng2-components/ng2-alfresco-login/src/components/alfresco-login.component.spec.ts
+++ b/ng2-components/ng2-alfresco-login/src/components/alfresco-login.component.spec.ts
@@ -294,7 +294,7 @@ describe('AlfrescoLogin', () => {
         expect(component.error).toBe(true);
         expect(component.success).toBe(false);
         expect(element.querySelector('#login-error')).toBeDefined();
-        expect(element.querySelector('#login-error').innerText).toEqual('LOGIN.MESSAGES.LOGIN-ERROR-CORS');
+        expect(element.querySelector('#login-error').innerText).toEqual('ERROR: the network is offline, Origin is not allowed by Access-Control-Allow-Origin');
     });
 
     it('should return CSRF error when server CSRF error occurs', () => {

--- a/ng2-components/ng2-alfresco-login/src/components/alfresco-login.component.ts
+++ b/ng2-components/ng2-alfresco-login/src/components/alfresco-login.component.ts
@@ -179,9 +179,8 @@ export class AlfrescoLoginComponent implements OnInit {
      * Check and display the right error message in the UI
      */
     private displayErrorMessage(err: any): void {
-        if (err.error && err.error.crossDomain && err.error.message.indexOf('the network is offline, Origin is not allowed by' +
-                ' Access-Control-Allow-Origin') !== -1) {
-            this.errorMsg = 'LOGIN.MESSAGES.LOGIN-ERROR-CORS';
+        if (err.error && err.error.crossDomain && err.error.message.indexOf('Access-Control-Allow-Origin') !== -1) {
+            this.errorMsg = err.error.message;
             return;
         }
 


### PR DESCRIPTION
refs #1728 

- show original message for CORS/offline problems

![screen shot 2017-03-30 at 11 40 10](https://cloud.githubusercontent.com/assets/503991/24500591/f0053242-153d-11e7-924b-810de5f878b1.png)
