### PR TITLE
#1652 - Save and Export should appear on saved reports

### DIFF
--- a/ng2-components/ng2-activiti-analytics/src/components/analytics-report-parameters.component.html
+++ b/ng2-components/ng2-activiti-analytics/src/components/analytics-report-parameters.component.html
@@ -23,7 +23,7 @@
                             <button id="delete-button" (click)="deleteReport(reportId)" mdTooltip="{{'ANALYTICS.MESSAGES.ICON-DELETE' | translate}}" class="mdl-button mdl-js-button">
                                 <i class="material-icons">delete</i>
                             </button>
-                            <span *ngIf="isFormValid()">
+                            <span [hidden]="!isFormValid()">
                                 <button id="export-button" (click)="showDialog('Export')" mdTooltip="{{'ANALYTICS.MESSAGES.ICON-EXPORT-CSV' | translate}}" class="mdl-button mdl-js-button">
                                      <i class="material-icons">file_download</i>
                                 </button>

--- a/ng2-components/ng2-activiti-analytics/src/components/analytics-report-parameters.component.html
+++ b/ng2-components/ng2-activiti-analytics/src/components/analytics-report-parameters.component.html
@@ -23,7 +23,7 @@
                             <button id="delete-button" (click)="deleteReport(reportId)" mdTooltip="{{'ANALYTICS.MESSAGES.ICON-DELETE' | translate}}" class="mdl-button mdl-js-button">
                                 <i class="material-icons">delete</i>
                             </button>
-                            <span [hidden]="!isFormValid()">
+                            <span *ngIf="isFormValid()">
                                 <button id="export-button" (click)="showDialog('Export')" mdTooltip="{{'ANALYTICS.MESSAGES.ICON-EXPORT-CSV' | translate}}" class="mdl-button mdl-js-button">
                                      <i class="material-icons">file_download</i>
                                 </button>

--- a/ng2-components/ng2-activiti-analytics/src/components/analytics-report-parameters.component.spec.ts
+++ b/ng2-components/ng2-activiti-analytics/src/components/analytics-report-parameters.component.spec.ts
@@ -428,6 +428,7 @@ describe('AnalyticsReportParametersComponent', () => {
         });
 
         describe('When the form is rendered correctly', () => {
+            let validForm: boolean = true;
             let values: any = {
                 dateRange: {
                     startDate: '2016-09-01', endDate: '2016-10-05'
@@ -468,10 +469,16 @@ describe('AnalyticsReportParametersComponent', () => {
                 fixture.whenStable().then(() => {
                     component.toggleParameters();
                     component.reportId = '1';
-                    spyOn(component, 'isFormValid').and.returnValue(true);
+                    spyOn(component, 'isFormValid').and.callFake(() => {
+                        return validForm;
+                    });
                     fixture.detectChanges();
                 });
             }));
+
+            afterEach(() => {
+                validForm = true;
+            });
 
             it('Should be able to change the report title', async(() => {
                 let title: HTMLElement = element.querySelector('h4');
@@ -567,6 +574,52 @@ describe('AnalyticsReportParametersComponent', () => {
                     contentType: 'json'
                 });
             }));
+
+            it('Should hide export button if the form is not valid', async(() => {
+                let exportButton: HTMLButtonElement = <HTMLButtonElement>element.querySelector('#export-button');
+                expect(exportButton).toBeDefined();
+                expect(exportButton).not.toBeNull();
+                validForm = false;
+                fixture.detectChanges();
+                fixture.whenStable().then(() => {
+                    fixture.detectChanges();
+                    exportButton = <HTMLButtonElement>element.querySelector('#export-button');
+                    expect(exportButton).toBeNull();
+                });
+            }));
+
+            it('Should hide save button if the form is not valid', async(() => {
+                let saveButton: HTMLButtonElement = <HTMLButtonElement>element.querySelector('#save-button');
+                expect(saveButton).toBeDefined();
+                expect(saveButton).not.toBeNull();
+                validForm = false;
+                fixture.detectChanges();
+                fixture.whenStable().then(() => {
+                    fixture.detectChanges();
+                    saveButton = <HTMLButtonElement>element.querySelector('#save-button');
+                    expect(saveButton).toBeNull();
+                });
+            }));
+
+            it('Should show export and save button when the form became valid', async(() => {
+                validForm = false;
+                fixture.detectChanges();
+                let saveButton: HTMLButtonElement = <HTMLButtonElement>element.querySelector('#save-button');
+                let exportButton: HTMLButtonElement = <HTMLButtonElement>element.querySelector('#export-button');
+                expect(saveButton).toBeNull();
+                expect(exportButton).toBeNull();
+                validForm = true;
+                fixture.whenStable().then(() => {
+                    fixture.detectChanges();
+                    saveButton = <HTMLButtonElement>element.querySelector('#save-button');
+                    exportButton = <HTMLButtonElement>element.querySelector('#export-button');
+                    expect(saveButton).not.toBeNull();
+                    expect(saveButton).toBeDefined();
+                    expect(exportButton).not.toBeNull();
+                    expect(exportButton).toBeDefined();
+                });
+            }));
         });
+
     });
 });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behaviour?** (You can also link to an open issue here)

On saved reports the save and export button are not showed without touching the form

**What is the new behaviour?**
On saved reports the save and export button are now showed without touching the form


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[X] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
