### PR TITLE
Added permission check on documentlist action menu

### DIFF
--- a/demo-shell-ng2/app/components/files/files.component.html
+++ b/demo-shell-ng2/app/components/files/files.component.html
@@ -20,7 +20,8 @@
                 [allowDropFiles]="true"
                 (error)="onNavigationError($event)"
                 (success)="resetError()"
-                (preview)="showFile($event)">
+                (preview)="showFile($event)"
+                (permissionError)="onPermissionsFailed($event)">
             <data-columns>
                 <data-column key="$thumbnail" type="image" [sortable]="false"></data-column>
                 <data-column

--- a/demo-shell-ng2/app/components/setting/setting.component.html
+++ b/demo-shell-ng2/app/components/setting/setting.component.html
@@ -27,7 +27,7 @@
                 </div>
                 <nav class="mdl-navigation">
                     <i class="icon material-icons icon-margin">link</i>
-                    <div class="mdl-textfield mdl-js-textfield adf-setting-input-paddingg">
+                    <div class="mdl-textfield mdl-js-textfield adf-setting-input-padding">
                         <input class="mdl-textfield__input"
                                type="text"
                                (change)="onChangeBPMHost($event)"

--- a/ng2-components/ng2-alfresco-documentlist/README.md
+++ b/ng2-components/ng2-alfresco-documentlist/README.md
@@ -783,6 +783,7 @@ DocumentList emits the following events:
 | `nodeDblClick` | emitted when user double-clicks list node |
 | `folderChange` | emitted once current display folder has changed |
 | `preview` | emitted when user acts upon files with either single or double click (depends on `navigation-mode`), recommended for Viewer components integration  |
+| `permissionError` | emitted when user is attempting to create a folder via action menu but it doesn't have the permission to do it |
 
 ## Advanced usage and customization
 

--- a/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.html
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.html
@@ -1,6 +1,7 @@
 <alfresco-document-menu-action
     *ngIf="creationMenuActions"
     [folderId]="currentFolderId"
+    [allowableOperations]="allowableOperations"
     (success)="onActionMenuSuccess($event)"
     (error)="onActionMenuError($event)">
 </alfresco-document-menu-action>

--- a/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.html
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.html
@@ -2,7 +2,8 @@
     *ngIf="creationMenuActions"
     [folderId]="currentFolderId"
     (success)="onActionMenuSuccess($event)"
-    (error)="onActionMenuError($event)">
+    (error)="onActionMenuError($event)"
+    (permissionErrorEvent)="onPermissionError($event)">
 </alfresco-document-menu-action>
 <alfresco-datatable
     [data]="data"

--- a/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.html
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.html
@@ -1,7 +1,6 @@
 <alfresco-document-menu-action
     *ngIf="creationMenuActions"
     [folderId]="currentFolderId"
-    [allowableOperations]="allowableOperations"
     (success)="onActionMenuSuccess($event)"
     (error)="onActionMenuError($event)">
 </alfresco-document-menu-action>

--- a/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.ts
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.ts
@@ -139,6 +139,9 @@ export class DocumentListComponent implements OnInit, OnChanges, AfterContentIni
     @Output()
     error: EventEmitter<any> = new EventEmitter();
 
+    @Output()
+    permissionError: EventEmitter<any> = new EventEmitter();
+
     @ViewChild(DataTableComponent)
     dataTable: DataTableComponent;
 
@@ -147,7 +150,6 @@ export class DocumentListComponent implements OnInit, OnChanges, AfterContentIni
     emptyFolderTemplate: TemplateRef<any>;
     contextActionHandler: Subject<any> = new Subject();
     data: ShareDataTableAdapter;
-    allowableOperations: string[];
 
     constructor(private documentListService: DocumentListService,
                 private ngZone: NgZone,
@@ -495,5 +497,9 @@ export class DocumentListComponent implements OnInit, OnChanges, AfterContentIni
     onPrevPage(event: Pagination): void {
         this.skipCount = event.skipCount;
         this.reload();
+    }
+
+    onPermissionError(event) {
+        this.permissionError.emit(event);
     }
 }

--- a/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.ts
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.ts
@@ -22,7 +22,14 @@ import {
 import { Subject } from 'rxjs/Rx';
 import { MinimalNodeEntity, MinimalNodeEntryEntity, NodePaging, Pagination } from 'alfresco-js-api';
 import { AlfrescoTranslationService, DataColumnListComponent } from 'ng2-alfresco-core';
-import { DataRowEvent, DataTableComponent, ObjectDataColumn, DataCellEvent, DataRowActionEvent, DataColumn } from 'ng2-alfresco-datatable';
+import {
+    DataRowEvent,
+    DataTableComponent,
+    ObjectDataColumn,
+    DataCellEvent,
+    DataRowActionEvent,
+    DataColumn
+} from 'ng2-alfresco-datatable';
 import { DocumentListService } from './../services/document-list.service';
 import { ContentActionModel } from './../models/content-action.model';
 import { ShareDataTableAdapter, ShareDataRow, RowFilter, ImageResolver } from './../data/share-datatable-adapter';
@@ -140,6 +147,7 @@ export class DocumentListComponent implements OnInit, OnChanges, AfterContentIni
     emptyFolderTemplate: TemplateRef<any>;
     contextActionHandler: Subject<any> = new Subject();
     data: ShareDataTableAdapter;
+    allowableOperations: string[];
 
     constructor(private documentListService: DocumentListService,
                 private ngZone: NgZone,
@@ -320,6 +328,7 @@ export class DocumentListComponent implements OnInit, OnChanges, AfterContentIni
 
     loadFolder() {
         let nodeId = this.folderNode ? this.folderNode.id : this.currentFolderId;
+        this.getAllowableOperations(this.folderNode);
         if (nodeId) {
             this.loadFolderNodesByFolderNodeId(nodeId, this.pageSize, this.skipCount).catch(err => this.error.emit(err));
         }
@@ -328,11 +337,12 @@ export class DocumentListComponent implements OnInit, OnChanges, AfterContentIni
     // gets folder node and its content
     loadFolderByNodeId(nodeId: string) {
         this.documentListService.getFolderNode(nodeId).then(node => {
-                this.folderNode = node;
-                this.currentFolderId = node.id;
-                this.skipCount = 0;
-                this.loadFolderNodesByFolderNodeId(node.id, this.pageSize, this.skipCount).catch(err => this.error.emit(err));
-            })
+            this.getAllowableOperations(node);
+            this.folderNode = node;
+            this.currentFolderId = node.id;
+            this.skipCount = 0;
+            this.loadFolderNodesByFolderNodeId(node.id, this.pageSize, this.skipCount).catch(err => this.error.emit(err));
+        })
             .catch(err => this.error.emit(err));
     }
 
@@ -487,5 +497,9 @@ export class DocumentListComponent implements OnInit, OnChanges, AfterContentIni
     onPrevPage(event: Pagination): void {
         this.skipCount = event.skipCount;
         this.reload();
+    }
+
+    getAllowableOperations(node: any) {
+        this.allowableOperations = node ? node.allowableOperations : null;
     }
 }

--- a/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.ts
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.ts
@@ -328,7 +328,6 @@ export class DocumentListComponent implements OnInit, OnChanges, AfterContentIni
 
     loadFolder() {
         let nodeId = this.folderNode ? this.folderNode.id : this.currentFolderId;
-        this.getAllowableOperations(this.folderNode);
         if (nodeId) {
             this.loadFolderNodesByFolderNodeId(nodeId, this.pageSize, this.skipCount).catch(err => this.error.emit(err));
         }
@@ -337,7 +336,6 @@ export class DocumentListComponent implements OnInit, OnChanges, AfterContentIni
     // gets folder node and its content
     loadFolderByNodeId(nodeId: string) {
         this.documentListService.getFolderNode(nodeId).then(node => {
-            this.getAllowableOperations(node);
             this.folderNode = node;
             this.currentFolderId = node.id;
             this.skipCount = 0;
@@ -497,9 +495,5 @@ export class DocumentListComponent implements OnInit, OnChanges, AfterContentIni
     onPrevPage(event: Pagination): void {
         this.skipCount = event.skipCount;
         this.reload();
-    }
-
-    getAllowableOperations(node: any) {
-        this.allowableOperations = node ? node.allowableOperations : null;
     }
 }

--- a/ng2-components/ng2-alfresco-documentlist/src/components/document-menu-action.component.html
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/document-menu-action.component.html
@@ -1,5 +1,5 @@
 <div class="container">
-    <button id="folder-create-button" md-button [mdMenuTriggerFor]="menu" [attr.disabled]="!hasCreatePermission()">
+    <button id="folder-create-button" md-button [mdMenuTriggerFor]="menu" [disabled]="isButtonDisabled()">
         <md-icon>add</md-icon>
         <span>{{ 'ALFRESCO_DOCUMENT_LIST.BUTTON.ACTION_CREATE' | translate }}</span>
     </button>

--- a/ng2-components/ng2-alfresco-documentlist/src/components/document-menu-action.component.html
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/document-menu-action.component.html
@@ -1,5 +1,5 @@
 <div class="container">
-    <button md-button [mdMenuTriggerFor]="menu" [disabled]="!hasCreatePermission()">
+    <button id="folder-create-button" md-button [mdMenuTriggerFor]="menu" [disabled]="!hasCreatePermission()">
         <md-icon>add</md-icon>
         <span>{{ 'ALFRESCO_DOCUMENT_LIST.BUTTON.ACTION_CREATE' | translate }}</span>
     </button>

--- a/ng2-components/ng2-alfresco-documentlist/src/components/document-menu-action.component.html
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/document-menu-action.component.html
@@ -1,5 +1,5 @@
 <div class="container">
-    <button id="folder-create-button" md-button [mdMenuTriggerFor]="menu" [disabled]="!hasCreatePermission()">
+    <button id="folder-create-button" md-button [mdMenuTriggerFor]="menu" [attr.disabled]="!hasCreatePermission()">
         <md-icon>add</md-icon>
         <span>{{ 'ALFRESCO_DOCUMENT_LIST.BUTTON.ACTION_CREATE' | translate }}</span>
     </button>

--- a/ng2-components/ng2-alfresco-documentlist/src/components/document-menu-action.component.html
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/document-menu-action.component.html
@@ -1,5 +1,5 @@
 <div class="container">
-    <button md-button [mdMenuTriggerFor]="menu">
+    <button md-button [mdMenuTriggerFor]="menu" [disabled]="!hasPermission(createPermission)">
         <md-icon>add</md-icon>
         <span>{{ 'ALFRESCO_DOCUMENT_LIST.BUTTON.ACTION_CREATE' | translate }}</span>
     </button>

--- a/ng2-components/ng2-alfresco-documentlist/src/components/document-menu-action.component.html
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/document-menu-action.component.html
@@ -1,5 +1,5 @@
 <div class="container">
-    <button md-button [mdMenuTriggerFor]="menu" [disabled]="!hasPermission(createPermission)">
+    <button md-button [mdMenuTriggerFor]="menu" [disabled]="!hasCreatePermission()">
         <md-icon>add</md-icon>
         <span>{{ 'ALFRESCO_DOCUMENT_LIST.BUTTON.ACTION_CREATE' | translate }}</span>
     </button>

--- a/ng2-components/ng2-alfresco-documentlist/src/components/document-menu-action.component.spec.ts
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/document-menu-action.component.spec.ts
@@ -47,6 +47,23 @@ let exampleFolderWithCreate = {
     }
 };
 
+let exampleFolderWithPermissions = {
+    'entry': {
+        'aspectNames': ['cm:auditable'],
+        'allowableOperations': ['check'],
+        'createdAt': '2017-04-03T11:34:35.708+0000',
+        'isFolder': true,
+        'isFile': false,
+        'createdByUser': { 'id': 'admin', 'displayName': 'Administrator' },
+        'modifiedAt': '2017-04-03T11:34:35.708+0000',
+        'modifiedByUser': { 'id': 'admin', 'displayName': 'Administrator' },
+        'name': 'test-folder2',
+        'id': 'c0284dc3-841d-48b2-955c-bcb2218e2b03',
+        'nodeType': 'cm:folder',
+        'parentId': '1ee81bf8-52d6-4cfc-a924-1efbc79306bf'
+    }
+};
+
 let exampleFolderWithNoOperations = {
     'entry': {
         'aspectNames': ['cm:auditable'],
@@ -106,12 +123,8 @@ describe('Document menu action', () => {
 
     describe('Folder creation', () => {
 
-        beforeEach(() => {
-            component.disableWithNoPermission = false;
-        });
-
         it('should createFolder fire a success event if the folder has been created', (done) => {
-
+            component.allowableOperations = ['create'];
             component.showDialog();
 
             component.createFolder('test-folder');
@@ -123,26 +136,12 @@ describe('Document menu action', () => {
             jasmine.Ajax.requests.mostRecent().respondWith({
                 status: 200,
                 contentType: 'application/json',
-                responseText: JSON.stringify({
-                    'entry': {
-                        'aspectNames': ['cm:auditable'],
-                        'createdAt': '2017-04-03T11:34:35.708+0000',
-                        'isFolder': true,
-                        'isFile': false,
-                        'createdByUser': { 'id': 'admin', 'displayName': 'Administrator' },
-                        'modifiedAt': '2017-04-03T11:34:35.708+0000',
-                        'modifiedByUser': { 'id': 'admin', 'displayName': 'Administrator' },
-                        'name': 'test-folder2',
-                        'id': 'c0284dc3-841d-48b2-955c-bcb2218e2b03',
-                        'nodeType': 'cm:folder',
-                        'parentId': '1ee81bf8-52d6-4cfc-a924-1efbc79306bf'
-                    }
-                })
+                responseText: JSON.stringify(exampleFolderWithCreate)
             });
         });
 
         it('should createFolder fire an error event if the folder has not been created', (done) => {
-
+            component.allowableOperations = ['create'];
             component.showDialog();
 
             component.createFolder('test-folder');
@@ -157,6 +156,7 @@ describe('Document menu action', () => {
         });
 
         it('should createFolder fire an error when folder already exists', (done) => {
+            component.allowableOperations = ['create'];
             component.showDialog();
 
             component.createFolder('test-folder');
@@ -204,7 +204,25 @@ describe('Document menu action', () => {
                 contentType: 'application/json',
                 responseText: JSON.stringify(exampleFolderWithNoOperations)
             });
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+                fixture.detectChanges();
+                let createButton: HTMLButtonElement = <HTMLButtonElement> element.querySelector('#folder-create-button');
+                expect(createButton).toBeDefined();
+                expect(createButton.disabled).toBeTruthy();
+            });
+        }));
 
+        it('should disable the create button if folder does not have create permission', async(() => {
+            let change = new SimpleChange('folder-id', 'new-folder-id');
+            component.ngOnChanges({ 'folderId': change });
+
+            jasmine.Ajax.requests.mostRecent().respondWith({
+                status: 200,
+                contentType: 'application/json',
+                responseText: JSON.stringify(exampleFolderWithPermissions)
+            });
+            fixture.detectChanges();
             fixture.whenStable().then(() => {
                 fixture.detectChanges();
                 let createButton: HTMLButtonElement = <HTMLButtonElement> element.querySelector('#folder-create-button');

--- a/ng2-components/ng2-alfresco-documentlist/src/components/document-menu-action.component.ts
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/document-menu-action.component.ts
@@ -154,17 +154,14 @@ export class DocumentMenuActionComponent implements OnChanges {
     }
 
     isButtonDisabled(): boolean {
-        let disbled = !this.hasCreatePermission() && this.disableWithNoPermission ? true : undefined;
-        return disbled;
+        return !this.hasCreatePermission() && this.disableWithNoPermission ? true : undefined;
     }
 
     hasPermission(permission: string): boolean {
-        let hasPermission: boolean = true;
+        let hasPermission: boolean = false;
         if (this.allowableOperations) {
             let permFound = this.allowableOperations.find(element => element === permission);
             hasPermission = permFound ? true : false;
-        } else {
-            hasPermission = false;
         }
         return hasPermission;
     }

--- a/ng2-components/ng2-alfresco-documentlist/src/components/document-menu-action.component.ts
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/document-menu-action.component.ts
@@ -101,7 +101,11 @@ export class DocumentMenuActionComponent implements OnChanges {
                     }
                 );
         } else {
-            this.permissionErrorEvent.emit(new PermissionModel({type: 'folder', action: 'create', permission: this.allowableOperations}));
+            this.permissionErrorEvent.emit(new PermissionModel({
+                type: 'folder',
+                action: 'create',
+                permission: 'create'
+            }));
         }
     }
 
@@ -149,12 +153,17 @@ export class DocumentMenuActionComponent implements OnChanges {
         return this.folderName === '' ? true : false;
     }
 
+    isButtonDisabled(): boolean {
+        let disbled = !this.hasCreatePermission() && this.disableWithNoPermission ? true : undefined;
+        return disbled;
+    }
+
     hasPermission(permission: string): boolean {
         let hasPermission: boolean = true;
         if (this.allowableOperations) {
             let permFound = this.allowableOperations.find(element => element === permission);
-            hasPermission = !permFound && this.disableWithNoPermission ? false : true;
-        } else if (this.disableWithNoPermission) {
+            hasPermission = permFound ? true : false;
+        } else {
             hasPermission = false;
         }
         return hasPermission;

--- a/ng2-components/ng2-alfresco-documentlist/src/components/document-menu-action.component.ts
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/document-menu-action.component.ts
@@ -21,6 +21,7 @@ import { MinimalNodeEntity } from 'alfresco-js-api';
 
 import { DocumentListService } from './../services/document-list.service';
 import { ContentActionModel } from './../models/content-action.model';
+import { PermissionModel } from '../models/permissions.model';
 
 declare let dialogPolyfill: any;
 
@@ -79,7 +80,7 @@ export class DocumentMenuActionComponent implements OnChanges {
 
     public createFolder(name: string) {
         this.cancel();
-        if (this.hasPermission('create')) {
+        if (this.hasCreatePermission()) {
             this.documentListService.createFolder(name, this.folderId)
                 .subscribe(
                     (res: MinimalNodeEntity) => {
@@ -100,7 +101,7 @@ export class DocumentMenuActionComponent implements OnChanges {
                     }
                 );
         } else {
-            this.permissionErrorEvent.emit();
+            this.permissionErrorEvent.emit(new PermissionModel({type: 'folder', action: 'create', permission: this.allowableOperations}));
         }
     }
 

--- a/ng2-components/ng2-alfresco-documentlist/src/services/document-list.service.ts
+++ b/ng2-components/ng2-alfresco-documentlist/src/services/document-list.service.ts
@@ -115,6 +115,7 @@ export class DocumentListService {
     getFolder(folder: string, opts?: any) {
         return Observable.fromPromise(this.getNodesPromise(folder, opts))
             .map(res => <NodePaging> res)
+            .do(res => console.log(res))
             .catch(err => this.handleError(err));
     }
 

--- a/ng2-components/ng2-alfresco-documentlist/src/services/document-list.service.ts
+++ b/ng2-components/ng2-alfresco-documentlist/src/services/document-list.service.ts
@@ -115,7 +115,6 @@ export class DocumentListService {
     getFolder(folder: string, opts?: any) {
         return Observable.fromPromise(this.getNodesPromise(folder, opts))
             .map(res => <NodePaging> res)
-            .do(res => console.log(res))
             .catch(err => this.handleError(err));
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behaviour?** (You can also link to an open issue here)
On create menu of document list no permission is checked when user try to create a folder

**What is the new behaviour?**
Permission are checked for the user who attempt to create a folder 


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
