### PR TITLE
[ADF-495] disable debug button by default

### DIFF
--- a/demo-shell-ng2/app/components/activiti/activiti-demo.component.html
+++ b/demo-shell-ng2/app/components/activiti/activiti-demo.component.html
@@ -58,6 +58,7 @@
                     </div>
                     <div class="mdl-cell mdl-cell--7-col task-column mdl-shadow--2dp">
                         <activiti-task-details #activitidetails
+                            [debugMode]="true"
                             [taskId]="currentTaskId"
                             (formCompleted)="onFormCompleted($event)"
                             (formContentClicked)="onFormContentClick($event)"

--- a/ng2-components/ng2-activiti-form/src/components/activiti-form.component.ts
+++ b/ng2-components/ng2-activiti-form/src/components/activiti-form.component.ts
@@ -26,7 +26,6 @@ import { FormEvent, FormErrorEvent } from './../events/index';
 
 import { WidgetVisibilityService }  from './../services/widget-visibility.service';
 
-declare let dialogPolyfill: any;
 declare var componentHandler: any;
 
 /**
@@ -118,7 +117,7 @@ export class ActivitiForm implements OnInit, AfterViewChecked, OnChanges {
     showSaveButton: boolean = true;
 
     @Input()
-    showDebugButton: boolean = true;
+    showDebugButton: boolean = false;
 
     @Input()
     readOnly: boolean = false;

--- a/ng2-components/ng2-activiti-tasklist/src/components/activiti-task-details.component.html
+++ b/ng2-components/ng2-activiti-tasklist/src/components/activiti-task-details.component.html
@@ -46,6 +46,7 @@
     </div>
     <div *ngIf="isAssignedToMe()">
         <activiti-form *ngIf="hasFormKey()" #activitiForm
+            [showDebugButton]="debugMode"
             [taskId]="taskDetails.id"
             [showTitle]="showFormTitle"
             [showRefreshButton]="showFormRefreshButton"

--- a/ng2-components/ng2-activiti-tasklist/src/components/activiti-task-details.component.ts
+++ b/ng2-components/ng2-activiti-tasklist/src/components/activiti-task-details.component.ts
@@ -43,6 +43,9 @@ export class ActivitiTaskDetails implements OnInit, OnChanges {
     errorDialog: DebugElement;
 
     @Input()
+    debugMode: boolean = false;
+
+    @Input()
     taskId: string;
 
     @Input()


### PR DESCRIPTION
- debug button is now disabled by default for the Form and Task Details
- debug mode now enabled by the demo shell explicitly