### PR TITLE
[DW-43] Task Service - Fix the input type from string to number

### DIFF
--- a/ng2-components/ng2-activiti-tasklist/src/assets/tasklist-service.mock.ts
+++ b/ng2-components/ng2-activiti-tasklist/src/assets/tasklist-service.mock.ts
@@ -25,12 +25,12 @@ export var fakeFilters = {
     data: [
         new AppDefinitionRepresentationModel(
             {
-                id: '1', name: 'FakeInvolvedTasks', recent: false, icon: 'glyphicon-align-left',
+                id: 1, name: 'FakeInvolvedTasks', recent: false, icon: 'glyphicon-align-left',
                 filter: { sort: 'created-desc', name: '', state: 'open', assignment: 'fake-involved' }
             }
         ),
         {
-            id: '2', name: 'FakeMyTasks', recent: false, icon: 'glyphicon-align-left',
+            id: 2, name: 'FakeMyTasks', recent: false, icon: 'glyphicon-align-left',
             filter: { sort: 'created-desc', name: '', state: 'open', assignment: 'fake-assignee' }
         }
     ]

--- a/ng2-components/ng2-activiti-tasklist/src/services/activiti-tasklist.service.spec.ts
+++ b/ng2-components/ng2-activiti-tasklist/src/services/activiti-tasklist.service.spec.ts
@@ -103,13 +103,13 @@ describe('Activiti TaskList Service', () => {
 
         it('should return the task filter by id', (done) => {
             service.getTaskFilterById(2).subscribe(
-                (res: FilterRepresentationModel) => {
-                    expect(res).toBeDefined();
-                    expect(res.id).toEqual(2);
-                    expect(res.name).toEqual('FakeMyTasks');
-                    expect(res.filter.sort).toEqual('created-desc');
-                    expect(res.filter.state).toEqual('open');
-                    expect(res.filter.assignment).toEqual('fake-assignee');
+                (taskFilter: FilterRepresentationModel) => {
+                    expect(taskFilter).toBeDefined();
+                    expect(taskFilter.id).toEqual(2);
+                    expect(taskFilter.name).toEqual('FakeMyTasks');
+                    expect(taskFilter.filter.sort).toEqual('created-desc');
+                    expect(taskFilter.filter.state).toEqual('open');
+                    expect(taskFilter.filter.assignment).toEqual('fake-assignee');
                     done();
                 }
             );

--- a/ng2-components/ng2-activiti-tasklist/src/services/activiti-tasklist.service.spec.ts
+++ b/ng2-components/ng2-activiti-tasklist/src/services/activiti-tasklist.service.spec.ts
@@ -102,10 +102,10 @@ describe('Activiti TaskList Service', () => {
         });
 
         it('should return the task filter by id', (done) => {
-            service.getTaskFilterById('2').subscribe(
+            service.getTaskFilterById(2).subscribe(
                 (res: FilterRepresentationModel) => {
                     expect(res).toBeDefined();
-                    expect(res.id).toEqual('2');
+                    expect(res.id).toEqual(2);
                     expect(res.name).toEqual('FakeMyTasks');
                     expect(res.filter.sort).toEqual('created-desc');
                     expect(res.filter.state).toEqual('open');

--- a/ng2-components/ng2-activiti-tasklist/src/services/activiti-tasklist.service.spec.ts
+++ b/ng2-components/ng2-activiti-tasklist/src/services/activiti-tasklist.service.spec.ts
@@ -125,7 +125,7 @@ describe('Activiti TaskList Service', () => {
             service.getTaskFilterByName('FakeMyTasks').subscribe(
                 (res: FilterRepresentationModel) => {
                     expect(res).toBeDefined();
-                    expect(res.id).toEqual('2');
+                    expect(res.id).toEqual(2);
                     expect(res.name).toEqual('FakeMyTasks');
                     expect(res.filter.sort).toEqual('created-desc');
                     expect(res.filter.state).toEqual('open');

--- a/ng2-components/ng2-activiti-tasklist/src/services/activiti-tasklist.service.ts
+++ b/ng2-components/ng2-activiti-tasklist/src/services/activiti-tasklist.service.ts
@@ -67,13 +67,14 @@ export class ActivitiTaskListService {
 
     /**
      * Retrieve the Tasks filter by id
-     * @param taskId - string - The id of the filter
+     * @param filterId - number - The id of the filter
+     * @param appId - string - optional - The id of app
      * @returns {Observable<FilterRepresentationModel>}
      */
-    getTaskFilterById(taskId: string, appId?: string): Observable<FilterRepresentationModel> {
+    getTaskFilterById(filterId: number, appId?: string): Observable<FilterRepresentationModel> {
         return Observable.fromPromise(this.callApiTaskFilters(appId))
             .map((response: any) => {
-                return response.data.find(filter => filter.id.toString() === taskId);
+                return response.data.find(filter => filter.id === filterId);
             }).catch(err => this.handleError(err));
     }
 

--- a/ng2-components/ng2-activiti-tasklist/src/services/activiti-tasklist.service.ts
+++ b/ng2-components/ng2-activiti-tasklist/src/services/activiti-tasklist.service.ts
@@ -73,7 +73,7 @@ export class ActivitiTaskListService {
     getTaskFilterById(taskId: string, appId?: string): Observable<FilterRepresentationModel> {
         return Observable.fromPromise(this.callApiTaskFilters(appId))
             .map((response: any) => {
-                return response.data.find(filter => filter.id === taskId);
+                return response.data.find(filter => filter.id.toString() === taskId);
             }).catch(err => this.handleError(err));
     }
 


### PR DESCRIPTION
Fix for Issue #DW-43: Incompatible comparison between string and integer variables in getTaskFilterById service

https://issues.alfresco.com/jira/browse/DW-43