### PR TITLE
[DW-45] Process Service - Fix the input type from string to number

### DIFF
--- a/ng2-components/ng2-activiti-processlist/src/assets/activiti-process.service.mock.ts
+++ b/ng2-components/ng2-activiti-processlist/src/assets/activiti-process.service.mock.ts
@@ -28,7 +28,7 @@ export var fakeFilters = {
     data: [new FilterProcessRepresentationModel({
         'name': 'Running',
         'appId': '22',
-        'id': '333',
+        'id': 333,
         'recent': true,
         'icon': 'glyphicon-random',
         'filter': {'sort': 'created-desc', 'name': '', 'state': 'running'}

--- a/ng2-components/ng2-activiti-processlist/src/services/activiti-process.service.spec.ts
+++ b/ng2-components/ng2-activiti-processlist/src/services/activiti-process.service.spec.ts
@@ -596,10 +596,10 @@ describe('ActivitiProcessService', () => {
             });
 
             it('should return the task filter by id', (done) => {
-                service.getProcessFilterById('333').subscribe(
+                service.getProcessFilterById(333).subscribe(
                     (res: FilterProcessRepresentationModel) => {
                         expect(res).toBeDefined();
-                        expect(res.id).toEqual('333');
+                        expect(res.id).toEqual(333);
                         expect(res.name).toEqual('Running');
                         expect(res.filter.sort).toEqual('created-desc');
                         expect(res.filter.state).toEqual('running');

--- a/ng2-components/ng2-activiti-processlist/src/services/activiti-process.service.spec.ts
+++ b/ng2-components/ng2-activiti-processlist/src/services/activiti-process.service.spec.ts
@@ -597,12 +597,12 @@ describe('ActivitiProcessService', () => {
 
             it('should return the task filter by id', (done) => {
                 service.getProcessFilterById(333).subscribe(
-                    (res: FilterProcessRepresentationModel) => {
-                        expect(res).toBeDefined();
-                        expect(res.id).toEqual(333);
-                        expect(res.name).toEqual('Running');
-                        expect(res.filter.sort).toEqual('created-desc');
-                        expect(res.filter.state).toEqual('running');
+                    (processFilter: FilterProcessRepresentationModel) => {
+                        expect(processFilter).toBeDefined();
+                        expect(processFilter.id).toEqual(333);
+                        expect(processFilter.name).toEqual('Running');
+                        expect(processFilter.filter.sort).toEqual('created-desc');
+                        expect(processFilter.filter.state).toEqual('running');
                         done();
                     }
                 );

--- a/ng2-components/ng2-activiti-processlist/src/services/activiti-process.service.spec.ts
+++ b/ng2-components/ng2-activiti-processlist/src/services/activiti-process.service.spec.ts
@@ -612,7 +612,7 @@ describe('ActivitiProcessService', () => {
                 service.getProcessFilterByName('Running').subscribe(
                     (res: FilterProcessRepresentationModel) => {
                         expect(res).toBeDefined();
-                        expect(res.id).toEqual('333');
+                        expect(res.id).toEqual(333);
                         expect(res.name).toEqual('Running');
                         expect(res.filter.sort).toEqual('created-desc');
                         expect(res.filter.state).toEqual('running');

--- a/ng2-components/ng2-activiti-processlist/src/services/activiti-process.service.ts
+++ b/ng2-components/ng2-activiti-processlist/src/services/activiti-process.service.ts
@@ -72,16 +72,17 @@ export class ActivitiProcessService {
 
     /**
      * Retrieve the process filter by id
-     * @param processId - string - The id of the filter
+     * @param filterId - number - The id of the filter
+     * @param appId - string - optional - The id of app
      * @returns {Observable<FilterProcessRepresentationModel>}
      */
-    getProcessFilterById(processId: string, appId?: string): Observable<FilterProcessRepresentationModel> {
+    getProcessFilterById(filterId: number, appId?: string): Observable<FilterProcessRepresentationModel> {
         let filterObj = {
             'appId': appId
         };
         return Observable.fromPromise(this.callApiGetUserProcessInstanceFilters(filterObj))
             .map((response: any) => {
-                return response.data.find(filter => filter.id.toString() === processId);
+                return response.data.find(filter => filter.id === filterId);
             }).catch(err => this.handleError(err));
     }
 

--- a/ng2-components/ng2-activiti-processlist/src/services/activiti-process.service.ts
+++ b/ng2-components/ng2-activiti-processlist/src/services/activiti-process.service.ts
@@ -76,7 +76,10 @@ export class ActivitiProcessService {
      * @returns {Observable<FilterProcessRepresentationModel>}
      */
     getProcessFilterById(processId: string, appId?: string): Observable<FilterProcessRepresentationModel> {
-        return Observable.fromPromise(this.callApiGetUserProcessInstanceFilters(appId))
+        let filterObj = {
+            'appId': appId
+        };
+        return Observable.fromPromise(this.callApiGetUserProcessInstanceFilters(filterObj))
             .map((response: any) => {
                 return response.data.find(filter => filter.id.toString() === processId);
             }).catch(err => this.handleError(err));

--- a/ng2-components/ng2-activiti-processlist/src/services/activiti-process.service.ts
+++ b/ng2-components/ng2-activiti-processlist/src/services/activiti-process.service.ts
@@ -78,7 +78,7 @@ export class ActivitiProcessService {
     getProcessFilterById(processId: string, appId?: string): Observable<FilterProcessRepresentationModel> {
         return Observable.fromPromise(this.callApiGetUserProcessInstanceFilters(appId))
             .map((response: any) => {
-                return response.data.find(filter => filter.id === processId);
+                return response.data.find(filter => filter.id.toString() === processId);
             }).catch(err => this.handleError(err));
     }
 

--- a/ng2-components/ng2-activiti-processlist/src/services/activiti-process.service.ts
+++ b/ng2-components/ng2-activiti-processlist/src/services/activiti-process.service.ts
@@ -77,10 +77,7 @@ export class ActivitiProcessService {
      * @returns {Observable<FilterProcessRepresentationModel>}
      */
     getProcessFilterById(filterId: number, appId?: string): Observable<FilterProcessRepresentationModel> {
-        let filterObj = {
-            'appId': appId
-        };
-        return Observable.fromPromise(this.callApiGetUserProcessInstanceFilters(filterObj))
+        return Observable.fromPromise(this.callApiProcessFilters(appId))
             .map((response: any) => {
                 return response.data.find(filter => filter.id === filterId);
             }).catch(err => this.handleError(err));


### PR DESCRIPTION
Fix for Issue#DW-45: getProcessFilterById service in activiti-process.service.ts (https://github.com/Alfresco/alfresco-ng2-components/blob/development/ng2-components/ng2-activiti-processlist/src/services/activiti-process.service.ts) has a comparison between two variables of different types. and parameter issue.

https://issues.alfresco.com/jira/browse/DW-45