### PR TITLE
[DW-47] - Analytics Service - Add a new method to get the report details by name

### DIFF
--- a/ng2-components/ng2-activiti-analytics/src/services/analytics.service.ts
+++ b/ng2-components/ng2-activiti-analytics/src/services/analytics.service.ts
@@ -55,6 +55,18 @@ export class AnalyticsService {
             }).catch(err => this.handleError(err));
     }
 
+    /**
+      * Retrive Report by name
+      * @param reportName - string - The name of report
+      * @returns {Observable<any>}
+      */
+     getReportByName(reportName: string): Observable<any> {
+         return Observable.fromPromise(this.apiService.getInstance().activiti.reportApi.getReportList())
+             .map((response: any) => {
+                 return response.find(report => report.name === reportName);
+             }).catch(err => this.handleError(err));
+     }
+
     private isReportValid(appId: string, report: ReportParametersModel) {
         let isValid: boolean = true;
         if (appId && appId !== '0' && report.name.includes('Process definition overview')) {


### PR DESCRIPTION
Fix for Issue#DW-47: Create a service that returns report details for a given report name as part of ng2-activiti-analytics component. There is no spec file for this service thats why skipped Unit Testcase.

https://issues.alfresco.com/jira/browse/DW-47