### PR TITLE
[ADF- 556] Analytics Service - Add a new method to get the report details by name

### DIFF
--- a/ng2-components/ng2-activiti-analytics/src/assets/analytics.service.mock.ts
+++ b/ng2-components/ng2-activiti-analytics/src/assets/analytics.service.mock.ts
@@ -1,0 +1,28 @@
+/*!
+ * @license
+ * Copyright 2016 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export let fakeReportList = [
+    {
+        id: '1',
+        name: 'Fake Report 1'
+    },
+    {
+        id: '2',
+        name: 'Fake Report 2'
+    }
+];
+

--- a/ng2-components/ng2-activiti-analytics/src/services/analytics.service.spec.ts
+++ b/ng2-components/ng2-activiti-analytics/src/services/analytics.service.spec.ts
@@ -1,0 +1,91 @@
+/*!
+ * @license
+ * Copyright 2016 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ReflectiveInjector } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { async } from '@angular/core/testing';
+import { CoreModule, AlfrescoApiService, LogService } from 'ng2-alfresco-core';
+import { ReportParametersModel, ParameterValueModel } from '../models/report.model';
+import { AnalyticsService } from './analytics.service';
+import { fakeReportList } from '../assets/analytics.service.mock';
+
+declare let jasmine: any;
+
+describe('Activiti Analytics Service', () => {
+
+    let service: AnalyticsService;
+    let apiService: AlfrescoApiService;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [
+                CoreModule.forRoot()
+            ],
+            providers: [
+                AnalyticsService
+            ]
+        });
+        service = TestBed.get(AnalyticsService);
+        apiService = TestBed.get(AlfrescoApiService);
+    });
+
+    beforeEach(() => {
+        jasmine.Ajax.install();
+    });
+
+    afterEach(() => {
+        jasmine.Ajax.uninstall();
+    });
+
+    describe('Content tests', () => {
+
+        it('should return the report list by appId', (done) => {
+            service.getReportList('1').subscribe(
+                (reportList) => {
+                    expect(reportList).toBeDefined();
+                    expect(reportList.length).toEqual(2);
+                    expect(reportList[0].name).toEqual('Fake Report 1');
+                    expect(reportList[1].name).toEqual('Fake Report 2');
+                    done();
+                }
+            );
+
+            jasmine.Ajax.requests.mostRecent().respondWith({
+                'status': 200,
+                contentType: 'application/json',
+                responseText: JSON.stringify(fakeReportList)
+            });
+        });
+
+        it('should return the report by report name', (done) => {
+            service.getReportByName('Fake Report 2').subscribe(
+                (report) => {
+                    expect(report).toBeDefined();
+                    expect(report).not.toBeNull();
+                    expect(report.id).toEqual(2);
+                    done();
+                }
+            );
+
+            jasmine.Ajax.requests.mostRecent().respondWith({
+                'status': 200,
+                contentType: 'application/json',
+                responseText: JSON.stringify(fakeReportList)
+            });
+        });
+    });
+});

--- a/ng2-components/ng2-activiti-analytics/src/services/analytics.service.ts
+++ b/ng2-components/ng2-activiti-analytics/src/services/analytics.service.ts
@@ -55,6 +55,18 @@ export class AnalyticsService {
             }).catch(err => this.handleError(err));
     }
 
+    /**
+      * Retrive Report by name
+      * @param reportName - string - The name of report
+      * @returns {Observable<any>}
+      */
+     getReportByName(reportName: string): Observable<any> {
+         return Observable.fromPromise(this.apiService.getInstance().activiti.reportApi.getReportList())
+             .map((response: any) => {
+                 return response.find(report => report.name === reportName);
+             }).catch(err => this.handleError(err));
+     }
+
     private isReportValid(appId: string, report: ReportParametersModel) {
         let isValid: boolean = true;
         if (appId && appId !== '0' && report.name.includes('Process definition overview')) {

--- a/ng2-components/ng2-activiti-analytics/src/services/analytics.service.ts
+++ b/ng2-components/ng2-activiti-analytics/src/services/analytics.service.ts
@@ -56,16 +56,16 @@ export class AnalyticsService {
     }
 
     /**
-      * Retrive Report by name
-      * @param reportName - string - The name of report
-      * @returns {Observable<any>}
-      */
-     getReportByName(reportName: string): Observable<any> {
-         return Observable.fromPromise(this.apiService.getInstance().activiti.reportApi.getReportList())
-             .map((response: any) => {
-                 return response.find(report => report.name === reportName);
-             }).catch(err => this.handleError(err));
-     }
+     * Retrive Report by name
+     * @param reportName - string - The name of report
+     * @returns {Observable<any>}
+     */
+    getReportByName(reportName: string): Observable<any> {
+        return Observable.fromPromise(this.apiService.getInstance().activiti.reportApi.getReportList())
+            .map((response: any) => {
+                return response.find(report => report.name === reportName);
+            }).catch(err => this.handleError(err));
+    }
 
     private isReportValid(appId: string, report: ReportParametersModel) {
         let isValid: boolean = true;


### PR DESCRIPTION
Fix for Issue#DW-47: Create a service that returns report details for a given report name as part of ng2-activiti-analytics component. There is no spec file for this service thats why skipped Unit Testcase.

https://issues.alfresco.com/jira/browse/DW-47