### PR TITLE
[ADF-528] activiti-start-process should accept list of process variable in input

### DIFF
--- a/ng2-components/ng2-activiti-processlist/README.md
+++ b/ng2-components/ng2-activiti-processlist/README.md
@@ -267,13 +267,13 @@ The AccordionComponent is exposed by the alfresco-core.
 
 ![how-create-accordion-menu](docs/assets/how-to-create-accordion-menu.png)
 
-### Start Process Button component
+### Start Process component
 
 Displays a button which in turn displays a dialog when clicked, allowing the user
 to specify some basic details needed to start a new process instance.
 
 ```html
-<activiti-start-process-instance></activiti-start-process-instance>
+<activiti-start-process appId="YOUR_APP_ID" ></activiti-start-process>
 ```
 
 #### Options
@@ -281,18 +281,24 @@ to specify some basic details needed to start a new process instance.
 
 | Name | Description |
 | --- | --- |
-| `appId` | Limit the list of processes which can be started to those contained in the specified app |
+| `appId` |  (required): Limit the list of processes which can be started to those contained in the specified app |
+| `variables` | Variables in input to the process [RestVariable]**](https://github.com/Alfresco/alfresco-js-api/tree/master/src/alfresco-activiti-rest-api/docs/RestVariable.md)|
+
 
 #### Events
 
-No events are emitted by this component
+| Name | Description |
+| --- | --- |
+| `start` | The event is emitted when the process start |
+| `error` | The event is emitted when the start process fail |
+
 
 ### Process Details component
 
 This component displays detailed information on a specified process instance
 
 ```html
-<activiti-process-instance-details processInstanceId="123"></activiti-process-instance-details>
+<activiti-process-instance-details processInstanceId="YOUR_PROCESS_INSTANCE_ID"></activiti-process-instance-details>
 ```
 
 #### Options
@@ -337,7 +343,7 @@ This is a sub-component of the process details component, which renders some gen
 Lists both the active and completed tasks associated with a particular process instance
 
 ```html
-<activiti-process-instance-tasks processInstanceId="123" showRefreshButton="true"></activiti-process-instance-tasks>
+<activiti-process-instance-tasks processInstanceId="YOUR_PROCESS_INSTANCE_ID" showRefreshButton="true"></activiti-process-instance-tasks>
 ```
 
 #### Options
@@ -359,7 +365,7 @@ Lists both the active and completed tasks associated with a particular process i
 Displays comments associated with a particular process instances and allows the user to add new comments
 
 ```html
-<activiti-process-instance-comments processInstanceId="123"></activiti-process-instance-comments>
+<activiti-process-instance-comments processInstanceId="YOUR_PROCESS_INSTANCE_ID"></activiti-process-instance-comments>
 ```
 
 #### Options

--- a/ng2-components/ng2-activiti-processlist/src/components/activiti-start-process.component.spec.ts
+++ b/ng2-components/ng2-activiti-processlist/src/components/activiti-start-process.component.spec.ts
@@ -26,6 +26,7 @@ import { TranslationMock } from './../assets/translation.service.mock';
 import { newProcess, fakeProcessDefs, fakeProcessDefWithForm, taskFormMock } from './../assets/activiti-start-process.component.mock';
 import { ActivitiStartProcessInstance } from './activiti-start-process.component';
 import { ActivitiProcessService } from '../services/activiti-process.service';
+import { RestVariable } from 'alfresco-js-api';
 
 describe('ActivitiStartProcessInstance', () => {
 
@@ -201,7 +202,24 @@ describe('ActivitiStartProcessInstance', () => {
             component.onProcessDefChange('my:process1');
             component.startProcess();
             fixture.whenStable().then(() => {
-                expect(startProcessSpy).toHaveBeenCalledWith('my:process1', 'My new process', undefined, undefined);
+                expect(startProcessSpy).toHaveBeenCalledWith('my:process1', 'My new process', undefined, undefined, undefined);
+            });
+        }));
+
+        it('should call service to start process with the variables setted', async(() => {
+            let inputProcessVariable = [];
+
+            let variable: any = {};
+            variable.name = 'nodeId';
+            variable.value ='id';
+
+            inputProcessVariable.push(variable);
+
+            component.variables = inputProcessVariable;
+            component.onProcessDefChange('my:process1');
+            component.startProcess();
+            fixture.whenStable().then(() => {
+                expect(startProcessSpy).toHaveBeenCalledWith('my:process1', 'My new process', undefined, undefined, inputProcessVariable);
             });
         }));
 
@@ -214,8 +232,8 @@ describe('ActivitiStartProcessInstance', () => {
             });
         }));
 
-        it('should throw start event error when process cannot be started', async(() => {
-            let errorSpy = spyOn(component.start, 'error');
+        it('should throw error event when process cannot be started', async(() => {
+            let errorSpy = spyOn(component.error, 'error');
             let error = { message: 'My error' };
             startProcessSpy = startProcessSpy.and.returnValue(Observable.throw(error));
             component.onProcessDefChange('my:process1');

--- a/ng2-components/ng2-activiti-processlist/src/components/activiti-start-process.component.ts
+++ b/ng2-components/ng2-activiti-processlist/src/components/activiti-start-process.component.ts
@@ -21,6 +21,7 @@ import { ActivitiStartForm } from 'ng2-activiti-form';
 import { ProcessInstance } from './../models/process-instance.model';
 import { ProcessDefinitionRepresentation } from './../models/process-definition.model';
 import { ActivitiProcessService } from './../services/activiti-process.service';
+import { RestVariable } from 'alfresco-js-api';
 
 declare let componentHandler: any;
 declare let dialogPolyfill: any;
@@ -36,10 +37,13 @@ export class ActivitiStartProcessInstance implements OnChanges {
     appId: string;
 
     @Input()
-    showStartButton: boolean = true;
+    variables: RestVariable;
 
     @Output()
     start: EventEmitter<ProcessInstance> = new EventEmitter<ProcessInstance>();
+
+    @Output()
+    error: EventEmitter<ProcessInstance> = new EventEmitter<ProcessInstance>();
 
     @ViewChild(ActivitiStartForm)
     startForm: ActivitiStartForm;
@@ -85,14 +89,14 @@ export class ActivitiStartProcessInstance implements OnChanges {
         if (this.currentProcessDef.id && this.name) {
             this.resetErrorMessage();
             let formValues = this.startForm ? this.startForm.form.values : undefined;
-            this.activitiProcess.startProcess(this.currentProcessDef.id, this.name, outcome, formValues).subscribe(
+            this.activitiProcess.startProcess(this.currentProcessDef.id, this.name, outcome, formValues, this.variables).subscribe(
                 (res) => {
                     this.name = '';
                     this.start.emit(res);
                 },
                 (err) => {
                     this.errorMessageId = 'START_PROCESS.ERROR.START';
-                    this.start.error(err);
+                    this.error.error(err);
                 }
             );
         }

--- a/ng2-components/ng2-activiti-processlist/src/services/activiti-process.service.ts
+++ b/ng2-components/ng2-activiti-processlist/src/services/activiti-process.service.ts
@@ -18,6 +18,7 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { AlfrescoApiService, LogService } from 'ng2-alfresco-core';
+import { RestVariable } from 'alfresco-js-api';
 import { ProcessInstance, ProcessDefinitionRepresentation } from '../models/index';
 import { ProcessFilterRequestRepresentation } from '../models/process-instance-filter.model';
 import { ProcessInstanceVariable } from './../models/process-instance-variable.model';
@@ -277,7 +278,7 @@ export class ActivitiProcessService {
             .catch(err => this.handleError(err));
     }
 
-    startProcess(processDefinitionId: string, name: string, outcome?: string, startFormValues?: any): Observable<ProcessInstance> {
+    startProcess(processDefinitionId: string, name: string, outcome?: string, startFormValues?: any, variables?: RestVariable): Observable<ProcessInstance> {
         let startRequest: any = {
             name: name,
             processDefinitionId: processDefinitionId
@@ -287,6 +288,9 @@ export class ActivitiProcessService {
         }
         if (startFormValues) {
             startRequest.values = startFormValues;
+        }
+        if (variables) {
+            startRequest.variables = variables;
         }
         return Observable.fromPromise(
             this.apiService.getInstance().activiti.processApi.startNewProcessInstance(startRequest)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[ x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
[ x] Tests for the changes have been added (for bug fixes / features)
[ x] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[ x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behaviour?** (You can also link to an open issue here)
activiti-start-process should accept list of process variable in input https://issues.alfresco.com/jira/browse/ADF-528


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
