### PR TITLE
[ADF-640] reload document list on folder upload

### DIFF
--- a/demo-shell-ng2/app/components/files/files.component.ts
+++ b/demo-shell-ng2/app/components/files/files.component.ts
@@ -20,7 +20,7 @@ import { ActivatedRoute, Params, Router } from '@angular/router';
 import { AlfrescoAuthenticationService, LogService, NotificationService } from 'ng2-alfresco-core';
 import { DocumentActionsService, DocumentListComponent, ContentActionHandler, DocumentActionModel, FolderActionModel } from 'ng2-alfresco-documentlist';
 import { FormService } from 'ng2-activiti-form';
-import { UploadButtonComponent, UploadDragAreaComponent } from 'ng2-alfresco-upload';
+import { UploadService, UploadButtonComponent, UploadDragAreaComponent, FolderCreatedEvent } from 'ng2-alfresco-upload';
 
 @Component({
     selector: 'files-component',
@@ -72,6 +72,7 @@ export class FilesComponent implements OnInit, AfterViewInit {
                 private changeDetector: ChangeDetectorRef,
                 private router: Router,
                 private notificationService: NotificationService,
+                private uploadService: UploadService,
                 @Optional() private route: ActivatedRoute) {
         documentActions.setHandler('my-handler', this.myDocumentActionHandler.bind(this));
     }
@@ -120,6 +121,8 @@ export class FilesComponent implements OnInit, AfterViewInit {
         } else {
             this.logService.warn('You are not logged in to BPM');
         }
+
+        this.uploadService.folderCreated.subscribe(value => this.onFolderCreated(value));
     }
 
     ngAfterViewInit() {
@@ -168,6 +171,14 @@ export class FilesComponent implements OnInit, AfterViewInit {
         return function (obj: any, target?: any) {
             window.alert(`Starting BPM process: ${processDefinition.id}`);
         }.bind(this);
+    }
+
+    onFolderCreated(event: FolderCreatedEvent) {
+        console.log('FOLDER CREATED');
+        console.log(event);
+        if (event && event.parentId === this.documentList.currentFolderId) {
+            this.documentList.reload();
+        }
     }
 
     onPermissionsFailed(event: any) {

--- a/ng2-components/ng2-alfresco-upload/README.md
+++ b/ng2-components/ng2-alfresco-upload/README.md
@@ -307,6 +307,16 @@ This component should be used in combination with upload button or drag & drop a
 <file-uploading-dialog></file-uploading-dialog>
 ```
 
+### UploadService service
+
+Provides access to various APIs related to file upload features.
+
+#### Events
+
+| Name | Type | Description |
+| --- | --- | --- |
+| folderCreated | FolderCreatedEvent | Raised when dropped folder gets created |
+
 ## Build from sources
 
 Alternatively you can build component from sources with the following commands:

--- a/ng2-components/ng2-alfresco-upload/index.ts
+++ b/ng2-components/ng2-alfresco-upload/index.ts
@@ -49,6 +49,7 @@ export * from './src/directives/file-draggable.directive';
 export * from './src/components/file-uploading-list.component';
 export * from './src/models/file.model';
 export * from './src/models/permissions.model';
+export * from './src/events/folder-created.event';
 
 export const UPLOAD_DIRECTIVES: any[] = [
     FileDraggableDirective,

--- a/ng2-components/ng2-alfresco-upload/src/events/folder-created.event.ts
+++ b/ng2-components/ng2-alfresco-upload/src/events/folder-created.event.ts
@@ -1,0 +1,27 @@
+/*!
+ * @license
+ * Copyright 2016 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MinimalNodeEntity } from 'alfresco-js-api';
+
+export interface FolderCreatedEvent {
+
+    name: string;
+    relativePath?: string;
+    parentId?: string;
+    node?: MinimalNodeEntity;
+
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

- extend UploadService with 'folderCreated' event to be able reacting on folder uploads globally
- extend Demo Shell to reload document list on UploadService events (folderCreated)

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
