### PR TITLE
[ADF-621] show drop effect on folders only

### DIFF
--- a/ng2-components/ng2-alfresco-datatable/src/components/datatable/datatable.component.html
+++ b/ng2-components/ng2-alfresco-datatable/src/components/datatable/datatable.component.html
@@ -32,7 +32,7 @@
     <tr *ngFor="let row of data.getRows(); let idx = index" tabindex="0"
         class="alfresco-datatable__row"
         [class.alfresco-datatable__row--selected]="selectedRow === row"
-        [adf-upload]="allowDropFiles" [adf-upload-data]="row">
+        [adf-upload]="allowDropFiles && rowAllowsDrop(row)" [adf-upload-data]="row">
 
         <!-- Actions (left) -->
         <td *ngIf="actions && actionsPosition === 'left'" class="alfresco-datatable__actions-cell">

--- a/ng2-components/ng2-alfresco-datatable/src/components/datatable/datatable.component.ts
+++ b/ng2-components/ng2-alfresco-datatable/src/components/datatable/datatable.component.ts
@@ -266,9 +266,6 @@ export class DataTableComponent implements AfterContentInit, OnChanges {
     }
 
     rowAllowsDrop(row: DataRow): boolean {
-        if (row.hasValue('allowDrop')) {
-            return row.getValue('allowDrop') === true;
-        }
-        return true;
+        return row.isDropTarget === true;
     }
 }

--- a/ng2-components/ng2-alfresco-datatable/src/components/datatable/datatable.component.ts
+++ b/ng2-components/ng2-alfresco-datatable/src/components/datatable/datatable.component.ts
@@ -264,4 +264,11 @@ export class DataTableComponent implements AfterContentInit, OnChanges {
             this.executeRowAction.emit(new DataRowActionEvent(row, action));
         }
     }
+
+    rowAllowsDrop(row: DataRow): boolean {
+        if (row.hasValue('allowDrop')) {
+            return row.getValue('allowDrop') === true;
+        }
+        return true;
+    }
 }

--- a/ng2-components/ng2-alfresco-datatable/src/data/datatable-adapter.ts
+++ b/ng2-components/ng2-alfresco-datatable/src/data/datatable-adapter.ts
@@ -32,6 +32,7 @@ export interface DataTableAdapter {
 
 export interface DataRow {
     isSelected: boolean;
+    isDropTarget?: boolean;
     hasValue(key: string): boolean;
     getValue(key: string): any;
 }

--- a/ng2-components/ng2-alfresco-datatable/src/data/object-datatable-adapter.ts
+++ b/ng2-components/ng2-alfresco-datatable/src/data/object-datatable-adapter.ts
@@ -209,7 +209,7 @@ export class ObjectDataRow implements DataRow {
     }
 
     hasValue(key: string): boolean {
-        return this.getValue(key) ? true : false;
+        return this.getValue(key) !== undefined;
     }
 }
 

--- a/ng2-components/ng2-alfresco-documentlist/src/data/share-datatable-adapter.ts
+++ b/ng2-components/ng2-alfresco-documentlist/src/data/share-datatable-adapter.ts
@@ -243,6 +243,10 @@ export class ShareDataRow implements DataRow {
         if (!obj) {
             throw new Error(ShareDataRow.ERR_OBJECT_NOT_FOUND);
         }
+
+        if (obj.entry) {
+            this.cache['allowDrop'] = obj.entry.isFolder;
+        }
     }
 
     cacheValue(key: string, value: any): any {
@@ -258,7 +262,7 @@ export class ShareDataRow implements DataRow {
     }
 
     hasValue(key: string): boolean {
-        return this.getValue(key) ? true : false;
+        return this.getValue(key) !== undefined;
     }
 }
 

--- a/ng2-components/ng2-alfresco-documentlist/src/data/share-datatable-adapter.ts
+++ b/ng2-components/ng2-alfresco-documentlist/src/data/share-datatable-adapter.ts
@@ -234,6 +234,7 @@ export class ShareDataRow implements DataRow {
 
     cache: { [key: string]: any } = {};
     isSelected: boolean = false;
+    readonly isDropTarget;
 
     get node(): NodeMinimalEntry {
         return this.obj;
@@ -244,9 +245,7 @@ export class ShareDataRow implements DataRow {
             throw new Error(ShareDataRow.ERR_OBJECT_NOT_FOUND);
         }
 
-        if (obj.entry) {
-            this.cache['allowDrop'] = obj.entry.isFolder;
-        }
+        this.isDropTarget = obj.entry && obj.entry.isFolder;
     }
 
     cacheValue(key: string, value: any): any {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no API changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

- fix `hasValue` API for data rows (avoid 'false' value to be evaluated as missing value)
- support for evaluating drop support for rows
- document list enables upload zones for folders only

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
