### PR TITLE
[ADF-673] - text widget value is not updated when the mask is not app…

### DIFF
--- a/ng2-components/ng2-activiti-form/src/components/widgets/text/text-mask.component.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/text/text-mask.component.ts
@@ -70,6 +70,8 @@ export class InputMaskDirective implements OnChanges, ControlValueAccessor {
         if (this.inputMask && this.inputMask.mask) {
             this.maskValue(this.el.nativeElement.value, this.el.nativeElement.selectionStart,
                 this.inputMask.mask, this.inputMask.isReversed, event.keyCode);
+        } else {
+            this._onChange(this.el.nativeElement.value);
         }
     }
 

--- a/ng2-components/ng2-activiti-form/src/components/widgets/text/text.widget.spec.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/text/text.widget.spec.ts
@@ -65,6 +65,36 @@ describe('TextWidget', () => {
             TestBed.resetTestingModule();
         });
 
+        describe('and no mask is configured on text element', () => {
+
+            let inputElement: HTMLInputElement;
+
+            beforeEach(() => {
+                textWidget.field = new FormFieldModel(new FormModel({ taskId: 'fake-task-id' }), {
+                    id: 'text-id',
+                    name: 'text-name',
+                    value: '',
+                    type: FormFieldTypes.TEXT,
+                    readOnly: false
+                });
+
+                fixture.detectChanges();
+                inputElement = <HTMLInputElement>element.querySelector('#text-id');
+            });
+
+            it('should raise ngModelChange event', async(() => {
+                inputElement.value = 'TEXT';
+                expect(textWidget.field.value).toBe('');
+                inputElement.dispatchEvent(new Event('input'));
+                fixture.whenStable().then(() => {
+                    fixture.detectChanges();
+                    expect(textWidget.field).not.toBeNull();
+                    expect(textWidget.field.value).not.toBeNull();
+                    expect(textWidget.field.value).toBe('TEXT');
+                });
+            }));
+        });
+
         describe('and mask is configured on text element', () => {
 
             let inputElement: HTMLInputElement;


### PR DESCRIPTION
…lied

**Please check if the PR fulfills these requirements**
```
[ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behaviour?** (You can also link to an open issue here)

NgModelChange event is not triggered when the field does not have an input mask

**What is the new behaviour?**
change event is now triggered for every text widget.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
