### PR TITLE
[ADF-694] Split the module runner ts-loader 

### DIFF
--- a/demo-shell-ng2/config/webpack.common.js
+++ b/demo-shell-ng2/config/webpack.common.js
@@ -62,15 +62,6 @@ module.exports = {
                 exclude: [ /public/, /resources/, /dist/]
             },
             {
-                test: /\.ts$/,
-                include: [helpers.root('app'), helpers.root('../ng2-components')],
-                loader: [
-                    'ts-loader',
-                    'angular2-template-loader'
-                ],
-                exclude: [ /node_modules/, /public/, /resources/, /dist/]
-            },
-            {
                 test: /\.html$/,
                 loader: 'html-loader',
                 exclude: [ /node_modules/, /public/, /resources/, /dist/]

--- a/demo-shell-ng2/config/webpack.dev.js
+++ b/demo-shell-ng2/config/webpack.dev.js
@@ -15,6 +15,20 @@ module.exports = webpackMerge(commonConfig, {
         chunkFilename: '[id].chunk.js'
     },
 
+    module: {
+        rules: [
+            {
+                test: /\.ts$/,
+                include: [helpers.root('app'), helpers.root('../ng2-components')],
+                loader: [
+                    'ts-loader',
+                    'angular2-template-loader'
+                ],
+                exclude: [ /node_modules/, /public/, /resources/, /dist/]
+            }
+        ]
+    },
+
     resolve: {
         alias: {
             "ng2-alfresco-core$": path.resolve(__dirname, '../../ng2-components/ng2-alfresco-core/index.ts'),

--- a/demo-shell-ng2/config/webpack.prod.js
+++ b/demo-shell-ng2/config/webpack.prod.js
@@ -41,6 +41,21 @@ module.exports = webpackMerge(commonConfig, {
         modules: [helpers.root('node_modules')]
     },
 
+    module: {
+        rules: [
+            {
+                test: /\.ts$/,
+                include: [helpers.root('app'), helpers.root('../ng2-components')],
+                use: ['ts-loader?' + JSON.stringify({
+                    "compilerOptions": {
+                        "paths": {}
+                    }
+                }), 'angular2-template-loader'],
+                exclude: [ /node_modules/, /public/, /resources/, /dist/]
+            }
+        ]
+    },
+
     plugins: [
         new CopyWebpackPlugin([
             ... alfrescoLibs.map(lib => {


### PR DESCRIPTION
…ay that the production runner will override the path during the build

**Please check if the PR fulfills these requirements**
```
[x ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
[x ] Tests for the changes have been added (for bug fixes / features)
[x ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behaviour?** (You can also link to an open issue here)
Demo shell npm run build doesn't work on development branch when the ng2-components are not builded


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
