### PR TITLE
[ADF-696] Entire accordion group header should be clickable

### DIFF
--- a/ng2-components/ng2-alfresco-core/README.md
+++ b/ng2-components/ng2-alfresco-core/README.md
@@ -355,6 +355,7 @@ export class MyComponent implements OnInit {
 | `heading` | {string} | optional | The header title. |
 | `isSelected` | {boolean} | optional | Define if the accordion group is selected or not. |
 | `headingIcon` | {string} | optional | The material design icon. |
+| `hasAccordionIcon` | {boolean} | optional | Define if the accordion (expand) icon needs to be shown or not, the default value is true |
 
 
 ## Authentication Service

--- a/ng2-components/ng2-alfresco-core/src/components/collapsable/accordion-group.component.html
+++ b/ng2-components/ng2-alfresco-core/src/components/collapsable/accordion-group.component.html
@@ -1,11 +1,9 @@
 <div class="adf-panel adf-panel-default" [ngClass]="{'adf-panel-open': isOpen}">
     <div class="adf-panel-heading" [ngClass]="{'adf-panel-heading-selected': isSelected}" (click)="onHeadingClick()">
-        <div>
-            <div id="heading-icon" *ngIf="hasHeadingIcon()" class="adf-panel-heading-icon">
-                <i class="material-icons">{{headingIcon}}</i>
-            </div>
-            <div id="heading-text" class="adf-panel-heading-text">{{heading}}</div>
+        <div id="heading-icon" *ngIf="hasHeadingIcon()" class="adf-panel-heading-icon">
+            <i class="material-icons">{{headingIcon}}</i>
         </div>
+        <div id="heading-text" class="adf-panel-heading-text">{{heading}}</div>        
         <div id="accordion-button" *ngIf="hasAccordionIcon" class="adf-panel-heading-toggle" (click)="toggleOpen($event)">
             <i class="material-icons">{{getAccordionIcon()}}</i>
         </div>

--- a/ng2-components/ng2-alfresco-core/src/components/collapsable/accordion-group.component.html
+++ b/ng2-components/ng2-alfresco-core/src/components/collapsable/accordion-group.component.html
@@ -1,12 +1,12 @@
 <div class="adf-panel adf-panel-default" [ngClass]="{'adf-panel-open': isOpen}">
-    <div class="adf-panel-heading" [ngClass]="{'adf-panel-heading-selected': isSelected}">
-        <div (click)="onHeadingClick()">
+    <div class="adf-panel-heading" [ngClass]="{'adf-panel-heading-selected': isSelected}" (click)="onHeadingClick()">
+        <div>
             <div id="heading-icon" *ngIf="hasHeadingIcon()" class="adf-panel-heading-icon">
                 <i class="material-icons">{{headingIcon}}</i>
             </div>
             <div id="heading-text" class="adf-panel-heading-text">{{heading}}</div>
         </div>
-        <div id="accordion-button" *ngIf="!isGroupContentEmpty()" class="adf-panel-heading-toggle" (click)="toggleOpen($event)">
+        <div id="accordion-button" *ngIf="hasAccordionIcon" class="adf-panel-heading-toggle" (click)="toggleOpen($event)">
             <i class="material-icons">{{getAccordionIcon()}}</i>
         </div>
     </div>

--- a/ng2-components/ng2-alfresco-core/src/components/collapsable/accordion-group.component.spec.ts
+++ b/ng2-components/ng2-alfresco-core/src/components/collapsable/accordion-group.component.spec.ts
@@ -75,17 +75,6 @@ describe('AccordionGroupComponent', () => {
         });
     });
 
-    it('should hide expand icon by default', () => {
-        component.heading = 'Fake Header';
-        component.headingIcon = 'fake-icon';
-        component.contentWrapper.nativeElement.innerHTML = '';
-        fixture.whenStable().then(() => {
-            fixture.detectChanges();
-            let headerIcon = element.querySelector('#accordion-button');
-            expect(headerIcon).toBeNull();
-        });
-    });
-
     it('should show expand icon by default', () => {
         component.heading = 'Fake Header';
         component.headingIcon = 'fake-icon';
@@ -94,6 +83,18 @@ describe('AccordionGroupComponent', () => {
             fixture.detectChanges();
             let headerIcon = element.querySelector('#accordion-button');
             expect(headerIcon).toBeDefined();
+        });
+    });
+
+    it('should hide expand icon', () => {
+        component.heading = 'Fake Header';
+        component.headingIcon = 'fake-icon';
+        component.hasAccordionIcon = false;
+        component.contentWrapper.nativeElement.innerHTML = '<a>Test</a>';
+        fixture.whenStable().then(() => {
+            fixture.detectChanges();
+            let headerIcon = element.querySelector('#accordion-button');
+            expect(headerIcon).toBeNull();
         });
     });
 

--- a/ng2-components/ng2-alfresco-core/src/components/collapsable/accordion-group.component.ts
+++ b/ng2-components/ng2-alfresco-core/src/components/collapsable/accordion-group.component.ts
@@ -88,5 +88,4 @@ export class AccordionGroupComponent implements OnDestroy {
     onHeadingClick() {
         this.headingClick.emit(this.heading);
     }
-    
 }

--- a/ng2-components/ng2-alfresco-core/src/components/collapsable/accordion-group.component.ts
+++ b/ng2-components/ng2-alfresco-core/src/components/collapsable/accordion-group.component.ts
@@ -37,6 +37,9 @@ export class AccordionGroupComponent implements OnDestroy {
     @Input()
     headingIcon: string;
 
+    @Input()
+    hasAccordionIcon: boolean = true;
+
     @Output()
     headingClick: EventEmitter<any> = new EventEmitter<any>();
 
@@ -85,8 +88,5 @@ export class AccordionGroupComponent implements OnDestroy {
     onHeadingClick() {
         this.headingClick.emit(this.heading);
     }
-
-    isGroupContentEmpty() {
-        return this.contentWrapper.nativeElement.innerHTML.trim().length === 0;
-    }
+    
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
[x] Tests for the changes have been added (for bug fixes / features)
[x] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behaviour?** (You can also link to an open issue here)

https://issues.alfresco.com/jira/browse/ADF-696

Entire group header is not clickable
Accordion (expand) icon hiding logic doesn't work properly.


**What is the new behaviour?**

Entire group header will be clickable
Added input show/hide accordion icon

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
