### PR TITLE
[ADF-709] add autofocus when a new row is added on dynamic table widget

### DIFF
--- a/ng2-components/ng2-activiti-form/src/components/widgets/dynamic-table/dynamic-table.widget.html
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/dynamic-table/dynamic-table.widget.html
@@ -4,7 +4,7 @@
 
     <div *ngIf="!editMode">
         <div class="dynamic-table-widget__table-container">
-            <table class="mdl-data-table mdl-js-data-table dynamic-table-widget__table" id="dynamic-table-{{content.id}}">
+            <table class="mdl-data-table mdl-js-data-table dynamic-table-widget__table" id="dynamic-table-{{content.id}}" #dynamicTable>
                 <thead>
                     <tr>
                         <th *ngFor="let column of content.visibleColumns"
@@ -38,7 +38,8 @@
                 <i class="material-icons">arrow_downward</i>
             </button>
             <button class="mdl-button mdl-js-button mdl-button--icon"
-                    (click)="addNewRow()">
+                    id="{{content.id}}-add-row"
+                    (click)="addNewRow()" #addRowButton>
                 <i class="material-icons">add_circle_outline</i>
             </button>
             <button class="mdl-button mdl-js-button mdl-button--icon"

--- a/ng2-components/ng2-activiti-form/src/components/widgets/dynamic-table/dynamic-table.widget.html
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/dynamic-table/dynamic-table.widget.html
@@ -4,7 +4,7 @@
 
     <div *ngIf="!editMode">
         <div class="dynamic-table-widget__table-container">
-            <table class="mdl-data-table mdl-js-data-table dynamic-table-widget__table" id="dynamic-table-{{content.id}}" #dynamicTable>
+            <table class="mdl-data-table mdl-js-data-table dynamic-table-widget__table" id="dynamic-table-{{content.id}}">
                 <thead>
                     <tr>
                         <th *ngFor="let column of content.visibleColumns"
@@ -39,7 +39,7 @@
             </button>
             <button class="mdl-button mdl-js-button mdl-button--icon"
                     id="{{content.id}}-add-row"
-                    (click)="addNewRow()" #addRowButton>
+                    (click)="addNewRow()">
                 <i class="material-icons">add_circle_outline</i>
             </button>
             <button class="mdl-button mdl-js-button mdl-button--icon"

--- a/ng2-components/ng2-activiti-form/src/components/widgets/dynamic-table/dynamic-table.widget.spec.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/dynamic-table/dynamic-table.widget.spec.ts
@@ -86,7 +86,12 @@ describe('DynamicTableWidget', () => {
         const field = new FormFieldModel(new FormModel());
         table = new DynamicTableModel(field);
         visibilityService = new WidgetVisibilityService(null, logService);
-        widget = new DynamicTableWidget(null, visibilityService, logService);
+        let changeDetectorSpy = jasmine.createSpyObj('cd', ['detectChanges']);
+        let nativeElementSpy = jasmine.createSpyObj('nativeElement', ['querySelector']);
+        changeDetectorSpy.nativeElement = nativeElementSpy;
+        let elementRefSpy = jasmine.createSpyObj('elementRef', ['']);
+        elementRefSpy.nativeElement = nativeElementSpy;
+        widget = new DynamicTableWidget(elementRefSpy, visibilityService, logService, changeDetectorSpy);
         widget.content = table;
     });
 
@@ -334,16 +339,16 @@ describe('DynamicTableWidget', () => {
             window['componentHandler'] = componentHandler;
         }));
 
-        afterEach(() => {
-            fixture.destroy();
-            TestBed.resetTestingModule();
-        });
-
         beforeEach(() => {
             dynamicTableWidget.field = new FormFieldModel(new FormModel({ taskId: 'fake-task-id' }), fakeFormField);
             dynamicTableWidget.field.type = FormFieldTypes.DYNAMIC_TABLE;
 
             fixture.detectChanges();
+        });
+
+        afterEach(() => {
+            fixture.destroy();
+            TestBed.resetTestingModule();
         });
 
         it('should select a row when press space bar', async(() => {
@@ -361,6 +366,21 @@ describe('DynamicTableWidget', () => {
             fixture.whenStable().then(() => {
                 let selectedRow = element.querySelector('#fake-dynamic-table-row-0');
                 expect(selectedRow.className).toBe('dynamic-table-widget__row-selected');
+            });
+        }));
+
+        it('should focus on add button when a new row is saved', async(() => {
+            let addNewRowButton: HTMLButtonElement = <HTMLButtonElement> element.querySelector('#fake-dynamic-table-add-row');
+
+            expect(element.querySelector('#dynamic-table-fake-dynamic-table')).not.toBeNull();
+            expect(addNewRowButton).not.toBeNull();
+
+            dynamicTableWidget.addNewRow();
+            dynamicTableWidget.onSaveChanges();
+            fixture.detectChanges();
+
+            fixture.whenStable().then(() => {
+                expect(document.activeElement.id).toBe('fake-dynamic-table-add-row');
             });
         }));
     });

--- a/ng2-components/ng2-activiti-form/src/components/widgets/dynamic-table/dynamic-table.widget.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/dynamic-table/dynamic-table.widget.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Component, ElementRef, OnInit, Input } from '@angular/core';
+import { Component, ElementRef, OnInit, Input, ChangeDetectorRef } from '@angular/core';
 import { LogService } from 'ng2-alfresco-core';
 import { WidgetComponent } from './../widget.component';
 import { DynamicTableModel, DynamicTableRow, DynamicTableColumn } from './dynamic-table.widget.model';
@@ -46,7 +46,8 @@ export class DynamicTableWidget extends WidgetComponent implements OnInit {
 
     constructor(private elementRef: ElementRef,
                 private visibilityService: WidgetVisibilityService,
-                private logService: LogService) {
+                private logService: LogService,
+                private cd: ChangeDetectorRef) {
         super();
     }
 
@@ -55,6 +56,20 @@ export class DynamicTableWidget extends WidgetComponent implements OnInit {
             this.content = new DynamicTableModel(this.field);
             this.visibilityService.refreshVisibility(this.field.form);
         }
+    }
+
+    forceFocusOnAddButton() {
+        if (this.content) {
+            this.cd.detectChanges();
+            let buttonAddRow = <HTMLButtonElement>this.elementRef.nativeElement.querySelector('#' + this.content.id + '-add-row');
+            if (this.isDynamicTableReady(buttonAddRow)) {
+                buttonAddRow.focus();
+            }
+        }
+    }
+
+    private isDynamicTableReady(buttonAddRow) {
+        return this.field && !this.editMode && buttonAddRow;
     }
 
     isValid() {
@@ -159,11 +174,13 @@ export class DynamicTableWidget extends WidgetComponent implements OnInit {
             this.logService.error(this.ERROR_MODEL_NOT_FOUND);
         }
         this.editMode = false;
+        this.forceFocusOnAddButton();
     }
 
     onCancelChanges() {
         this.editMode = false;
         this.editRow = null;
+        this.forceFocusOnAddButton();
     }
 
     copyRow(row: DynamicTableRow): DynamicTableRow {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behaviour?** (You can also link to an open issue here)
The focus goes on the first element in the page after adding a new line on DynamicTableWidget


**What is the new behaviour?**
The add button is focused after adding a new line on DynamicTableWidget


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
