### PR TITLE
[ADF-696] Entire accordion group header should be clickable

### DIFF
--- a/ng2-components/ng2-alfresco-core/src/components/collapsable/accordion-group.component.html
+++ b/ng2-components/ng2-alfresco-core/src/components/collapsable/accordion-group.component.html
@@ -1,10 +1,10 @@
 <div class="adf-panel adf-panel-default" [ngClass]="{'adf-panel-open': isOpen}">
-    <div class="adf-panel-heading" [ngClass]="{'adf-panel-heading-selected': isSelected}" (click)="onHeadingClick()">
+    <div class="adf-panel-heading" [ngClass]="{'adf-panel-heading-selected': isSelected}" (click)="toggleOpen($event)">
         <div id="heading-icon" *ngIf="hasHeadingIcon()" class="adf-panel-heading-icon">
             <i class="material-icons">{{headingIcon}}</i>
         </div>
-        <div id="heading-text" class="adf-panel-heading-text">{{heading}}</div>        
-        <div id="accordion-button" *ngIf="hasAccordionIcon" class="adf-panel-heading-toggle" (click)="toggleOpen($event)">
+        <div id="heading-text" class="adf-panel-heading-text">{{heading}}</div>
+        <div id="accordion-button" *ngIf="hasAccordionIcon" class="adf-panel-heading-toggle">
             <i class="material-icons">{{getAccordionIcon()}}</i>
         </div>
     </div>

--- a/ng2-components/ng2-alfresco-core/src/components/collapsable/accordion-group.component.spec.ts
+++ b/ng2-components/ng2-alfresco-core/src/components/collapsable/accordion-group.component.spec.ts
@@ -107,8 +107,8 @@ describe('AccordionGroupComponent', () => {
             expect(headName).toEqual(heading);
             done();
         });
-
-        component.onHeadingClick();
+        let header = element.querySelector('.adf-panel-heading');
+        header.click();
     });
 
 });

--- a/ng2-components/ng2-alfresco-core/src/components/collapsable/accordion-group.component.ts
+++ b/ng2-components/ng2-alfresco-core/src/components/collapsable/accordion-group.component.ts
@@ -79,13 +79,11 @@ export class AccordionGroupComponent implements OnDestroy {
     toggleOpen(event: MouseEvent): void {
         event.preventDefault();
         this.isOpen = !this.isOpen;
+        this.headingClick.emit(this.heading);
     }
 
     getAccordionIcon(): string {
         return this.isOpen ? 'expand_less' : 'expand_more';
     }
 
-    onHeadingClick() {
-        this.headingClick.emit(this.heading);
-    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
[x] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behaviour?** (You can also link to an open issue here)

With the previous implementation, only headingClick event was emitted on click of menu header and accordion was not toggled. 

**What is the new behaviour?**

Now a click anywhere on the group header toggles the state of accordion along with emitting headingClick event.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
