### PR TITLE
[ADF-758] support for headless chrome

### DIFF
--- a/ng2-components/config/karma.conf-all.js
+++ b/ng2-components/config/karma.conf-all.js
@@ -68,12 +68,21 @@ module.exports = function (config) {
         browserDisconnectTolerance: 10,
         browserNoActivityTimeout: 3000000,
 
-        browsers: ['Chrome'],
+        browsers: ['Chrome_headless'],
 
         customLaunchers: {
             Chrome_travis_ci: {
                 base: 'Chrome',
                 flags: ['--no-sandbox']
+            },
+            Chrome_headless: {
+                base: 'Chrome',
+                flags: [
+                    '--no-sandbox',
+                    '--headless',
+                    '--disable-gpu',
+                    '--remote-debugging-port=9222'
+                ]
             }
         },
 


### PR DESCRIPTION
Provides support for running unit tests in Headless mode if a developer has Chrome 59 or later installed.