### PR TITLE
[ADF-689] Fix alfresco-document-menu-action styling (z-index)

### DIFF
--- a/ng2-components/ng2-alfresco-documentlist/src/components/document-menu-action.component.css
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/document-menu-action.component.css
@@ -15,5 +15,5 @@
     position: relative;
     -webkit-transition: height .35s cubic-bezier(0.4,0.0,1,1),border-color .4s;
     transition: height .35s cubic-bezier(0.4,0.0,1,1),border-color .4s;
-    z-index: 5;
+    z-index: 1;
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
As described in [ADF-689]: "Upload list dialogue is rendered behind Document List toolbar"


**What is the new behaviour?**
Upload list dialogue is rendered in front of Document List toolbar


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
