### PR TITLE
[ADF-643] upload enhancements

### DIFF
--- a/demo-shell-ng2/app/components/files/files.component.html
+++ b/demo-shell-ng2/app/components/files/files.component.html
@@ -101,16 +101,6 @@
                 <!-- folder actions -->
                 <content-action
                         target="folder"
-                        title="{{'DOCUMENT_LIST.ACTIONS.FOLDER.SYSTEM_1' | translate}}"
-                        handler="system1">
-                </content-action>
-                <content-action
-                        target="folder"
-                        title="{{'DOCUMENT_LIST.ACTIONS.FOLDER.CUSTOM' | translate}}"
-                        (execute)="myFolderAction1($event)">
-                </content-action>
-                <content-action
-                        target="folder"
                         permission="delete"
                         [disableWithNoPermission]="true"
                         title="{{'DOCUMENT_LIST.ACTIONS.FOLDER.DELETE' | translate}}"
@@ -125,26 +115,11 @@
                 </content-action>
                 <content-action
                         target="document"
-                        title="{{'DOCUMENT_LIST.ACTIONS.DOCUMENT.SYSTEM_2' | translate}}"
-                        handler="system2">
-                </content-action>
-                <content-action
-                        target="document"
-                        title="{{'DOCUMENT_LIST.ACTIONS.DOCUMENT.CUSTOM' | translate}}"
-                        (execute)="myCustomAction1($event)">
-                </content-action>
-                <content-action
-                        target="document"
                         permission="delete"
                         [disableWithNoPermission]="true"
                         (permissionEvent)="onPermissionsFailed($event)"
                         title="{{'DOCUMENT_LIST.ACTIONS.DOCUMENT.DELETE' | translate}}"
                         handler="delete">
-                </content-action>
-                <content-action
-                        target="folder"
-                        title="Activiti: View Form"
-                        (execute)="viewActivitiForm($event)">
                 </content-action>
             </content-actions>
         </alfresco-document-list>

--- a/demo-shell-ng2/app/components/files/files.component.html
+++ b/demo-shell-ng2/app/components/files/files.component.html
@@ -49,7 +49,7 @@
                 (error)="onNavigationError($event)"
                 (success)="resetError()"
                 (preview)="showFile($event)"
-                (permissionError)="onPermissionsFailed($event)">
+                (permissionError)="handlePermissionError($event)">
             <data-columns>
                 <data-column key="$thumbnail" type="image" [sortable]="false"></data-column>
                 <data-column
@@ -104,7 +104,7 @@
                         permission="delete"
                         [disableWithNoPermission]="true"
                         title="{{'DOCUMENT_LIST.ACTIONS.FOLDER.DELETE' | translate}}"
-                        (permissionEvent)="onPermissionsFailed($event)"
+                        (permissionEvent)="handlePermissionError($event)"
                         handler="delete">
                 </content-action>
                 <!-- document actions -->
@@ -117,7 +117,7 @@
                         target="document"
                         permission="delete"
                         [disableWithNoPermission]="true"
-                        (permissionEvent)="onPermissionsFailed($event)"
+                        (permissionEvent)="handlePermissionError($event)"
                         title="{{'DOCUMENT_LIST.ACTIONS.DOCUMENT.DELETE' | translate}}"
                         handler="delete">
                 </content-action>
@@ -169,7 +169,7 @@
             [uploadFolders]="folderUpload"
             [versioning]="versioning"
             [disableWithNoPermission]="disableWithNoPermission"
-            (permissionEvent)="onUploadPermissionFailed($event)">
+            (permissionEvent)="handlePermissionError($event)">
         </alfresco-upload-button>
     </div>
     <div *ngIf="acceptedFilesTypeShow">
@@ -183,7 +183,7 @@
             [uploadFolders]="folderUpload"
             [versioning]="versioning"
             [disableWithNoPermission]="disableWithNoPermission"
-            (permissionEvent)="onUploadPermissionFailed($event)">
+            (permissionEvent)="handlePermissionError($event)">
         </alfresco-upload-button>
     </div>
     <section>

--- a/demo-shell-ng2/app/components/files/files.component.html
+++ b/demo-shell-ng2/app/components/files/files.component.html
@@ -46,7 +46,6 @@
                 [contextMenuActions]="true"
                 [contentActions]="true"
                 [allowDropFiles]="true"
-                [sorting]="['name', 'desc']"
                 (error)="onNavigationError($event)"
                 (success)="resetError()"
                 (preview)="showFile($event)"

--- a/demo-shell-ng2/app/components/files/files.component.ts
+++ b/demo-shell-ng2/app/components/files/files.component.ts
@@ -21,7 +21,7 @@ import { MdDialog } from '@angular/material';
 import { AlfrescoAuthenticationService, AlfrescoContentService, FolderCreatedEvent, LogService, NotificationService } from 'ng2-alfresco-core';
 import { DocumentActionsService, DocumentListComponent, ContentActionHandler, DocumentActionModel, FolderActionModel } from 'ng2-alfresco-documentlist';
 import { FormService } from 'ng2-activiti-form';
-import { UploadService, UploadButtonComponent, UploadDragAreaComponent } from 'ng2-alfresco-upload';
+import { UploadService, UploadButtonComponent, UploadDragAreaComponent, FileUploadCompleteEvent } from 'ng2-alfresco-upload';
 
 import { CreateFolderDialog } from '../../dialogs/create-folder.dialog';
 
@@ -38,7 +38,7 @@ export class FilesComponent implements OnInit, AfterViewInit {
     fileNodeId: any;
     fileShowed: boolean = false;
 
-    useCustomToolbar = false;
+    useCustomToolbar = true;
 
     @Input()
     multipleFileUpload: boolean = false;
@@ -129,6 +129,7 @@ export class FilesComponent implements OnInit, AfterViewInit {
             this.logService.warn('You are not logged in to BPM');
         }
 
+        this.uploadService.fileUploadComplete.debounceTime(300).subscribe(value => this.onFileUploadComplete(value));
         this.contentService.folderCreated.subscribe(value => this.onFolderCreated(value));
     }
 
@@ -178,6 +179,13 @@ export class FilesComponent implements OnInit, AfterViewInit {
         return function (obj: any, target?: any) {
             window.alert(`Starting BPM process: ${processDefinition.id}`);
         }.bind(this);
+    }
+
+    onFileUploadComplete(event: FileUploadCompleteEvent) {
+        if (event && event.file.options.parentId === this.documentList.currentFolderId) {
+            console.log('Reloading on File upload complete');
+            this.documentList.reload();
+        }
     }
 
     onFolderCreated(event: FolderCreatedEvent) {

--- a/demo-shell-ng2/app/components/files/files.component.ts
+++ b/demo-shell-ng2/app/components/files/files.component.ts
@@ -16,9 +16,9 @@
  */
 
 import { Component, Input, OnInit, Optional, ViewChild, ChangeDetectorRef } from '@angular/core';
-import { ActivatedRoute, Params, Router } from '@angular/router';
+import { ActivatedRoute, Params } from '@angular/router';
 import { MdDialog } from '@angular/material';
-import { AlfrescoAuthenticationService, AlfrescoContentService, FolderCreatedEvent, LogService, NotificationService } from 'ng2-alfresco-core';
+import { AlfrescoContentService, FolderCreatedEvent, NotificationService } from 'ng2-alfresco-core';
 import { DocumentListComponent } from 'ng2-alfresco-documentlist';
 import { UploadService, FileUploadCompleteEvent } from 'ng2-alfresco-upload';
 
@@ -63,10 +63,7 @@ export class FilesComponent implements OnInit {
     @ViewChild(DocumentListComponent)
     documentList: DocumentListComponent;
 
-    constructor(private authService: AlfrescoAuthenticationService,
-                private logService: LogService,
-                private changeDetector: ChangeDetectorRef,
-                private router: Router,
+    constructor(private changeDetector: ChangeDetectorRef,
                 private notificationService: NotificationService,
                 private uploadService: UploadService,
                 private contentService: AlfrescoContentService,
@@ -128,20 +125,11 @@ export class FilesComponent implements OnInit {
         }
     }
 
-    onPermissionsFailed(event: any) {
-        this.notificationService.openSnackMessage(`you don't have the ${event.permission} permission to ${event.action} the ${event.type} `, 4000);
-    }
-
-    onUploadPermissionFailed(event: any) {
-        this.notificationService.openSnackMessage(`you don't have the ${event.permission} permission to ${event.action} the ${event.type} `, 4000);
-    }
-
-    reload(event: any) {
-        if (event && event.value && event.value.entry && event.value.entry.parentId) {
-            if (this.documentList.currentFolderId === event.value.entry.parentId) {
-                this.documentList.reload();
-            }
-        }
+    handlePermissionError(event: any) {
+        this.notificationService.openSnackMessage(
+            `You don't have the ${event.permission} permission to ${event.action} the ${event.type} `,
+            4000
+        );
     }
 
     onCreateFolderClicked(event: Event) {
@@ -149,12 +137,8 @@ export class FilesComponent implements OnInit {
         dialogRef.afterClosed().subscribe(folderName => {
             if (folderName) {
                 this.contentService.createFolder('', folderName, this.documentList.currentFolderId).subscribe(
-                    node => {
-                        console.log(node);
-                    },
-                    err => {
-                        console.log(err);
-                    }
+                    node => console.log(node),
+                    err => console.log(err)
                 );
             }
         });

--- a/demo-shell-ng2/app/components/files/files.component.ts
+++ b/demo-shell-ng2/app/components/files/files.component.ts
@@ -112,7 +112,6 @@ export class FilesComponent implements OnInit {
 
     onFileUploadComplete(event: FileUploadCompleteEvent) {
         if (event && event.file.options.parentId === this.documentList.currentFolderId) {
-            console.log('Reloading on File upload complete');
             this.documentList.reload();
         }
     }

--- a/ng2-components/ng2-alfresco-core/src/directives/upload.directive.spec.ts
+++ b/ng2-components/ng2-alfresco-core/src/directives/upload.directive.spec.ts
@@ -17,6 +17,7 @@
 
 import { ElementRef } from '@angular/core';
 import { UploadDirective } from './upload.directive';
+import { FileInfo } from './../utils/file-utils';
 
 describe('UploadDirective', () => {
 
@@ -106,30 +107,35 @@ describe('UploadDirective', () => {
         expect(event.preventDefault).not.toHaveBeenCalled();
     });
 
-    it('should raise upload-files event on files drop', () => {
+    it('should raise upload-files event on files drop', (done) => {
         directive.enabled = true;
-        let files = [<File> {}];
         let event = jasmine.createSpyObj('event', ['preventDefault', 'stopPropagation']);
         spyOn(directive, 'getDataTransfer').and.returnValue({});
-        spyOn(directive, 'getFilesDropped').and.returnValue(files);
-        spyOn(nativeElement, 'dispatchEvent').and.stub();
+        spyOn(directive, 'getFilesDropped').and.returnValue(Promise.resolve([
+            <FileInfo> {},
+            <FileInfo> {}
+        ]));
+        spyOn(nativeElement, 'dispatchEvent').and.callFake(_ => {
+            done();
+        });
         directive.onDrop(event);
-        expect(nativeElement.dispatchEvent).toHaveBeenCalled();
     });
 
-    it('should provide dropped files in upload-files event', () => {
+    it('should provide dropped files in upload-files event', (done) => {
         directive.enabled = true;
-        let files = [<File> {}];
+        let files = [
+            <FileInfo> {}
+        ];
         let event = jasmine.createSpyObj('event', ['preventDefault', 'stopPropagation']);
         spyOn(directive, 'getDataTransfer').and.returnValue({});
-        spyOn(directive, 'getFilesDropped').and.returnValue(files);
+        spyOn(directive, 'getFilesDropped').and.returnValue(Promise.resolve(files));
 
         spyOn(nativeElement, 'dispatchEvent').and.callFake(e => {
             expect(e.detail.files.length).toBe(1);
             expect(e.detail.files[0]).toBe(files[0]);
+            done();
         });
         directive.onDrop(event);
-        expect(nativeElement.dispatchEvent).toHaveBeenCalled();
     });
 
 });

--- a/ng2-components/ng2-alfresco-core/src/directives/upload.directive.ts
+++ b/ng2-components/ng2-alfresco-core/src/directives/upload.directive.ts
@@ -213,8 +213,15 @@ export class UploadDirective implements OnInit, OnDestroy {
                     }
                 } else {
                     // safari or FF
-                    let files = dataTransfer.files;
-                    iterations.push(Promise.resolve(this.getFilesSelected(files)));
+                    let files = FileUtils
+                        .toFileArray(dataTransfer.files)
+                        .map(file => <FileInfo> {
+                            entry: null,
+                            file: file,
+                            relativeFolder: '/'
+                        });
+
+                    iterations.push(Promise.resolve(files));
                 }
             }
 
@@ -225,27 +232,13 @@ export class UploadDirective implements OnInit, OnDestroy {
     }
 
     /**
-     * Extract files from the FileList object used to hold files that user selected by means of File Dialog.
-     * @param fileList List of selected files
-     */
-    protected getFilesSelected(fileList: FileList): File[] {
-        let result: File[] = [];
-        if (fileList && fileList.length > 0) {
-            for (let i = 0; i < fileList.length; i++) {
-                result.push(fileList[i]);
-            }
-        }
-        return result;
-    }
-
-    /**
      * Invoked when user selects files or folders by means of File Dialog
      * @param e DOM event
      */
     protected onSelectFiles(e: Event) {
         if (this.isClickMode()) {
             const input = (<HTMLInputElement>e.currentTarget);
-            const files = this.getFilesSelected(input.files);
+            const files = FileUtils.toFileArray(input.files);
             this.onUploadFiles(files.map(file => <FileInfo> {
                 entry: null,
                 file: file,

--- a/ng2-components/ng2-alfresco-core/src/directives/upload.directive.ts
+++ b/ng2-components/ng2-alfresco-core/src/directives/upload.directive.ts
@@ -246,9 +246,9 @@ export class UploadDirective implements OnInit, OnDestroy {
         if (this.isClickMode()) {
             const input = (<HTMLInputElement>e.currentTarget);
             const files = this.getFilesSelected(input.files);
-            this.onUploadFiles(files.map(f => <FileInfo> {
+            this.onUploadFiles(files.map(file => <FileInfo> {
                 entry: null,
-                file: f,
+                file: file,
                 relativeFolder: '/'
             }));
         }

--- a/ng2-components/ng2-alfresco-core/src/directives/upload.directive.ts
+++ b/ng2-components/ng2-alfresco-core/src/directives/upload.directive.ts
@@ -16,6 +16,7 @@
  */
 
 import { Directive, Input, HostListener, ElementRef, Renderer, OnInit, NgZone, OnDestroy } from '@angular/core';
+import { FileUtils, FileInfo } from '../utils/file-utils';
 
 @Directive({
     selector: '[adf-upload]'
@@ -129,14 +130,16 @@ export class UploadDirective implements OnInit, OnDestroy {
 
             const dataTranfer = this.getDataTransfer(event);
             if (dataTranfer) {
-                const files = this.getFilesDropped(dataTranfer);
-                this.onUploadFiles(files);
+                this.getFilesDropped(dataTranfer).then(files => {
+                    this.onUploadFiles(files);
+                });
+
             }
         }
         return false;
     }
 
-    onUploadFiles(files: File[]) {
+    onUploadFiles(files: FileInfo[]) {
         if (this.enabled && files.length > 0) {
             let e = new CustomEvent('upload-files', {
                 detail: {
@@ -177,27 +180,55 @@ export class UploadDirective implements OnInit, OnDestroy {
      * Extract files from the DataTransfer object used to hold the data that is being dragged during a drag and drop operation.
      * @param dataTransfer DataTransfer object
      */
-    protected getFilesDropped(dataTransfer: DataTransfer): File[] {
-        const result: File[] = [];
+    protected getFilesDropped(dataTransfer: DataTransfer): Promise<FileInfo[]> {
+        return new Promise(resolve => {
+            const iterations = [];
 
-        if (dataTransfer) {
-            const items: FileList = dataTransfer.files;
-
-            if (items && items.length > 0) {
-                for (let i = 0; i < items.length; i++) {
-                result.push(items[i]);
+            if (dataTransfer) {
+                const items = dataTransfer.items;
+                if (items) {
+                    for (let i = 0; i < items.length; i++) {
+                        if (typeof items[i].webkitGetAsEntry !== 'undefined') {
+                            let item = items[i].webkitGetAsEntry();
+                            if (item) {
+                                if (item.isFile) {
+                                    iterations.push(Promise.resolve(<FileInfo> {
+                                        entry: item,
+                                        file: items[i].getAsFile(),
+                                        relativeFolder: '/'
+                                    }));
+                                } else if (item.isDirectory) {
+                                    iterations.push(new Promise(resolveFolder => {
+                                        FileUtils.flattern(item).then(files => resolveFolder(files));
+                                    }));
+                                }
+                            }
+                        } else {
+                            iterations.push(Promise.resolve(<FileInfo>{
+                                entry: null,
+                                file: items[i].getAsFile(),
+                                relativeFolder: '/'
+                            }));
+                        }
+                    }
+                } else {
+                    // safari or FF
+                    let files = dataTransfer.files;
+                    iterations.push(Promise.resolve(this.getFilesSelected(files)));
                 }
             }
-        }
 
-        return result;
+            Promise.all(iterations).then(result => {
+                resolve(result.reduce((a, b) => a.concat(b), []));
+            });
+        });
     }
 
     /**
      * Extract files from the FileList object used to hold files that user selected by means of File Dialog.
      * @param fileList List of selected files
      */
-    protected getFilesSelected(fileList: FileList) {
+    protected getFilesSelected(fileList: FileList): File[] {
         let result: File[] = [];
         if (fileList && fileList.length > 0) {
             for (let i = 0; i < fileList.length; i++) {
@@ -215,7 +246,11 @@ export class UploadDirective implements OnInit, OnDestroy {
         if (this.isClickMode()) {
             const input = (<HTMLInputElement>e.currentTarget);
             const files = this.getFilesSelected(input.files);
-            this.onUploadFiles(files);
+            this.onUploadFiles(files.map(f => <FileInfo> {
+                entry: null,
+                file: f,
+                relativeFolder: '/'
+            }));
         }
     }
 }

--- a/ng2-components/ng2-alfresco-core/src/utils/file-utils.ts
+++ b/ng2-components/ng2-alfresco-core/src/utils/file-utils.ts
@@ -1,0 +1,61 @@
+/*!
+ * @license
+ * Copyright 2016 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface FileInfo {
+    entry?: WebKitFileEntry;
+    file?: File;
+    relativeFolder?: string;
+}
+
+export class FileUtils {
+
+    static flattern(folder: any): Promise<FileInfo[]> {
+        let reader = folder.createReader();
+        let files: FileInfo[] = [];
+        return new Promise(resolve => {
+            let iterations = [];
+            (function traverse() {
+                reader.readEntries((entries) => {
+                    if (!entries.length) {
+                        Promise.all(iterations).then(result => resolve(files));
+                    } else {
+                        iterations.push(Promise.all(entries.map(entry => {
+                            if (entry.isFile) {
+                                return new Promise(resolveFile => {
+                                    entry.file(function (f: File) {
+                                        files.push({
+                                            entry: entry,
+                                            file: f,
+                                            relativeFolder: entry.fullPath.replace(/\/[^\/]*$/, '')
+                                        });
+                                        resolveFile();
+                                    });
+                                });
+                            } else {
+                                return FileUtils.flattern(entry).then(result => {
+                                    files.push(...result);
+                                });
+                            }
+                        })));
+                        // Try calling traverse() again for the same dir, according to spec
+                        traverse();
+                    }
+                });
+            })();
+        });
+    }
+}

--- a/ng2-components/ng2-alfresco-core/src/utils/file-utils.ts
+++ b/ng2-components/ng2-alfresco-core/src/utils/file-utils.ts
@@ -58,4 +58,16 @@ export class FileUtils {
             })();
         });
     }
+
+    static toFileArray(fileList: FileList): File[] {
+        let result = [];
+
+        if (fileList && fileList.length > 0) {
+            for (let i = 0; i < fileList.length; i++) {
+                result.push(fileList[i]);
+            }
+        }
+
+        return result;
+    }
 }

--- a/ng2-components/ng2-alfresco-core/src/utils/index.ts
+++ b/ng2-components/ng2-alfresco-core/src/utils/index.ts
@@ -16,3 +16,4 @@
  */
 
 export * from './object-utils';
+export * from './file-utils';

--- a/ng2-components/ng2-alfresco-upload/README.md
+++ b/ng2-components/ng2-alfresco-upload/README.md
@@ -128,6 +128,7 @@ Follow the 3 steps below:
 | `multipleFiles` | *boolean* | false | Allow/disallow multiple files |
 | `acceptedFilesType` | *string* | * |  array of allowed file extensions , example: ".jpg,.gif,.png,.svg" |
 | **(deprecated)** `currentFolderPath` | *string* | '/Sites/swsdp/documentLibrary' | define the path where the files are uploaded. **Deprecated in 1.6.0: use rootFolderId instead.** |
+| `rootFolderId` | *string* | '-root-' | The ID of the root folder node. |
 | `versioning` | *boolean* | false   |  Versioning false is the default uploader behaviour and it rename using an integer suffix if there is a name clash. Versioning true to indicate that a major version should be created |
 | `staticTitle` | *string* | 'FILE_UPLOAD.BUTTON.UPLOAD_FILE' or 'FILE_UPLOAD.BUTTON.UPLOAD_FOLDER' string in the JSON text file | define the text of the upload button |
 | `disableWithNoPermission` | *boolean* | false |  If the value is true and the user doesn't have the permission to delete the node the button will be disabled |
@@ -210,7 +211,7 @@ export class AppComponent {
 | --- | --- | --- | --- |
 | `enabled` | *boolean* | true | Toggle component enabled state |
 | **(deprecated)** `showNotificationBar` | *boolean* | true |  Hide/show notification bar. **Deprecated in 1.6.0: use UploadService events and NotificationService api instead.** |
-| `rootFolderId` | *string* | '-root-' | The ID of the root folder node.
+| `rootFolderId` | *string* | '-root-' | The ID of the root folder node. |
 | **(deprecated)** `currentFolderPath` | *string* | '/' | define the path where the files are uploaded. **Deprecated in 1.6.0: use rootFolderId instead.** |
 | `versioning` | *boolean* | false |  Versioning false is the default uploader behaviour and it rename using an integer suffix if there is a name clash. Versioning true to indicate that a major version should be created  | 
 

--- a/ng2-components/ng2-alfresco-upload/README.md
+++ b/ng2-components/ng2-alfresco-upload/README.md
@@ -102,68 +102,14 @@ Follow the 3 steps below:
 
 ```html
 <alfresco-upload-button 
-    [showNotificationBar]="true"
+    [rootFolderId]="-my-"
     [uploadFolders]="true"
     [multipleFiles]="false"
     [acceptedFilesType]=".jpg,.gif,.png,.svg"
-    [currentFolderPath]="/Sites/swsdp/documentLibrary"
     [versioning]="false"
     (onSuccess)="customMethod($event)">
 </alfresco-upload-button>
 <file-uploading-dialog></file-uploading-dialog>
-```
-
-Example of an App that declares upload button component :
-
-```ts
-import { NgModule, Component } from '@angular/core';
-import { BrowserModule } from '@angular/platform-browser';
-import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
-import { CoreModule, AlfrescoSettingsService, AlfrescoAuthenticationService } from 'ng2-alfresco-core';
-import { UploadModule } from 'ng2-alfresco-upload';
-
-@Component({
-    selector: 'alfresco-app-demo',
-    template: `
-        <alfresco-upload-button 
-            [showNotificationBar]="true"
-            [uploadFolders]="false"
-            [multipleFiles]="false"
-            [acceptedFilesType]="'.jpg,.gif,.png,.svg'"
-            (onSuccess)="onSuccess($event)">
-        </alfresco-upload-button>
-        <file-uploading-dialog></file-uploading-dialog>
-    `
-})
-export class MyDemoApp {
-
-    constructor(private authService: AlfrescoAuthenticationService, 
-                private settingsService: AlfrescoSettingsService) {
-        settingsService.ecmHost = 'http://localhost:8080';
-
-        this.authService.login('admin', 'admin').subscribe(
-            ticket => console.log(ticket),
-            error => console.log(error)
-        );
-    }
-
-    public onSuccess(event: Object): void {
-        console.log('File uploaded');
-    }
-}
-
-@NgModule({
-    imports: [
-        BrowserModule,
-        CoreModule.forRoot(),
-        UploadModule.forRoot()
-    ],
-    declarations: [ MyDemoApp ],
-    bootstrap:    [ MyDemoApp ]
-})
-export class AppModule { }
-
-platformBrowserDynamic().bootstrapModule(AppModule);
 ```
 
 ### Events
@@ -177,11 +123,11 @@ platformBrowserDynamic().bootstrapModule(AppModule);
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | `disabled` | *boolean* | false | Toggle component disabled state |
-| `showNotificationBar` | *boolean* | true | Hide/show notification bar |
+| **(deprecated)** `showNotificationBar` | *boolean* | true | Hide/show notification bar. **Deprecated in 1.6.0: use UploadService events and NotificationService api instead.** |
 | `uploadFolders` | *boolean* | false | Allow/disallow upload folders (only for chrome) |
 | `multipleFiles` | *boolean* | false | Allow/disallow multiple files |
 | `acceptedFilesType` | *string* | * |  array of allowed file extensions , example: ".jpg,.gif,.png,.svg" |
-| `currentFolderPath` | *string* | '/Sites/swsdp/documentLibrary' | define the path where the files are uploaded |
+| **(deprecated)** `currentFolderPath` | *string* | '/Sites/swsdp/documentLibrary' | define the path where the files are uploaded. **Deprecated in 1.6.0: use rootFolderId instead.** |
 | `versioning` | *boolean* | false   |  Versioning false is the default uploader behaviour and it rename using an integer suffix if there is a name clash. Versioning true to indicate that a major version should be created |
 | `staticTitle` | *string* | 'FILE_UPLOAD.BUTTON.UPLOAD_FILE' or 'FILE_UPLOAD.BUTTON.UPLOAD_FOLDER' string in the JSON text file | define the text of the upload button |
 | `disableWithNoPermission` | *boolean* | false |  If the value is true and the user doesn't have the permission to delete the node the button will be disabled |
@@ -199,7 +145,9 @@ You can subscribe to this event from your component and use the NotificationServ
     [rootFolderId]="currentFolderId"
     (permissionEvent)="onUploadPermissionFailed($event)">
 </alfresco-upload-button>
+```
 
+```ts
 export class MyComponent {
 
     onUploadPermissionFailed(event: any) {
@@ -232,61 +180,22 @@ The UploadButtonComponent provides the property disableWithNoPermission that can
 This component, provide a drag and drop are to upload files to alfresco.
 
 ```html
-<alfresco-upload-drag-area 
-    (onSuccess)="customMethod($event)">
+<alfresco-upload-drag-area (onSuccess)="customMethod($event)">
+    <div style="width: 200px; height: 100px; border: 1px solid #888888">
+        DRAG HERE
+    </div>
 </alfresco-upload-drag-area>
 <file-uploading-dialog></file-uploading-dialog>
 ```
 
-Example of an App that declares upload drag and drop component:
-
 ```ts
-import { NgModule, Component } from '@angular/core';
-import { BrowserModule } from '@angular/platform-browser';
-import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
-import { CoreModule, AlfrescoSettingsService, AlfrescoAuthenticationService } from 'ng2-alfresco-core';
-import { UploadModule } from 'ng2-alfresco-upload';
-
-@Component({
-    selector: 'alfresco-app-demo',
-    template: `
-        <alfresco-upload-drag-area (onSuccess)="customMethod($event)" >
-            <div style="width: 200px; height: 100px; border: 1px solid #888888">
-                DRAG HERE
-            </div>
-        </alfresco-upload-drag-area>
-        <file-uploading-dialog></file-uploading-dialog>
-    `
-})
-export class MyDemoApp {
-
-    constructor(private authService: AlfrescoAuthenticationService, 
-                private settingsService: AlfrescoSettingsService) {
-        settingsService.ecmHost = 'http://localhost:8080';
-
-        this.authService.login('admin', 'admin').subscribe(
-            ticket => console.log(ticket),
-            error => console.log(error)
-        );
-    }
+export class AppComponent {
 
     public onSuccess(event: Object): void {
         console.log('File uploaded');
     }
+
 }
-
-@NgModule({
-    imports: [
-        BrowserModule,
-        CoreModule.forRoot(),
-        UploadModule.forRoot()
-    ],
-    declarations: [ MyDemoApp ],
-    bootstrap:    [ MyDemoApp ]
-})
-export class AppModule { }
-
-platformBrowserDynamic().bootstrapModule(AppModule);
 ```
 
 ### Events
@@ -300,9 +209,9 @@ platformBrowserDynamic().bootstrapModule(AppModule);
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | `enabled` | *boolean* | true | Toggle component enabled state |
-| `showNotificationBar` | *boolean* | true |  Hide/show notification bar |
+| **(deprecated)** `showNotificationBar` | *boolean* | true |  Hide/show notification bar. **Deprecated in 1.6.0: use UploadService events and NotificationService api instead.** |
 | `rootFolderId` | *string* | '-root-' | The ID of the root folder node.
-| `currentFolderPath` | *string* | '/' | define the path where the files are uploaded |
+| **(deprecated)** `currentFolderPath` | *string* | '/' | define the path where the files are uploaded. **Deprecated in 1.6.0: use rootFolderId instead.** |
 | `versioning` | *boolean* | false |  Versioning false is the default uploader behaviour and it rename using an integer suffix if there is a name clash. Versioning true to indicate that a major version should be created  | 
 
 ## FileUploadingDialogComponent

--- a/ng2-components/ng2-alfresco-upload/src/components/file-uploading-dialog.component.ts
+++ b/ng2-components/ng2-alfresco-upload/src/components/file-uploading-dialog.component.ts
@@ -67,7 +67,6 @@ export class FileUploadingDialogComponent implements OnInit, OnDestroy {
         });
 
         this.uploadService.fileUpload.subscribe(e => {
-            console.log(e);
             this.cd.detectChanges();
         });
     }

--- a/ng2-components/ng2-alfresco-upload/src/components/upload-button.component.spec.ts
+++ b/ng2-components/ng2-alfresco-upload/src/components/upload-button.component.spec.ts
@@ -186,7 +186,7 @@ describe('UploadButtonComponent', () => {
         fixture.detectChanges();
 
         component.onFilesAdded(fakeEvent);
-        expect(uploadService.uploadFilesInTheQueue).toHaveBeenCalledWith('-root-', '/root-fake-/sites-fake/folder-fake', null);
+        expect(uploadService.uploadFilesInTheQueue).toHaveBeenCalledWith(null);
     });
 
     it('should call uploadFile with a custom root folder', () => {
@@ -202,7 +202,7 @@ describe('UploadButtonComponent', () => {
         fixture.detectChanges();
 
         component.onFilesAdded(fakeEvent);
-        expect(uploadService.uploadFilesInTheQueue).toHaveBeenCalledWith('-my-', '/root-fake-/sites-fake/folder-fake', null);
+        expect(uploadService.uploadFilesInTheQueue).toHaveBeenCalledWith(null);
     });
 
     it('should create a folder and emit an File uploaded event', (done) => {
@@ -225,21 +225,6 @@ describe('UploadButtonComponent', () => {
                 value: 'File uploaded'
             });
         });
-        component.onDirectoryAdded(fakeEvent);
-    });
-
-    it('should emit an onError event when the folder already exist', (done) => {
-        component.rootFolderId = '-my-';
-        spyOn(contentService, 'createFolder').and.returnValue(Observable.throw(new Error('')));
-        spyOn(component, 'getFolderNode').and.returnValue(Observable.of(fakeFolderNodeWithPermission));
-
-        component.ngOnChanges({ rootFolderId: new SimpleChange(null, component.rootFolderId, true) });
-
-        component.onError.subscribe(e => {
-            expect(e.value).toEqual('Error');
-            done();
-        });
-
         component.onDirectoryAdded(fakeEvent);
     });
 

--- a/ng2-components/ng2-alfresco-upload/src/components/upload-button.component.ts
+++ b/ng2-components/ng2-alfresco-upload/src/components/upload-button.component.ts
@@ -23,8 +23,6 @@ import { UploadService } from '../services/upload.service';
 import { FileModel } from '../models/file.model';
 import { PermissionModel } from '../models/permissions.model';
 
-const ERROR_FOLDER_ALREADY_EXIST = 409;
-
 @Component({
     selector: 'alfresco-upload-button',
     templateUrl: './upload-button.component.html',
@@ -37,6 +35,12 @@ export class UploadButtonComponent implements OnInit, OnChanges {
     @Input()
     disabled: boolean = false;
 
+    /**
+     * @deprecated Deprecated in 1.6.0, you can use UploadService events and NotificationService api instead.
+     *
+     * @type {boolean}
+     * @memberof UploadButtonComponent
+     */
     @Input()
     showNotificationBar: boolean = true;
 
@@ -55,6 +59,12 @@ export class UploadButtonComponent implements OnInit, OnChanges {
     @Input()
     staticTitle: string;
 
+    /**
+     * @deprecated Deprecated in 1.6.0, this property is not used for couple of releases already.
+     *
+     * @type {string}
+     * @memberof UploadDragAreaComponent
+     */
     @Input()
     currentFolderPath: string = '/';
 
@@ -122,16 +132,11 @@ export class UploadButtonComponent implements OnInit, OnChanges {
         return !this.hasPermission && this.disableWithNoPermission ? true : undefined;
     }
 
-    /**
-     * Method called when files are dropped in the drag area.
-     *
-     * @param {File[]} files - files dropped in the drag area.
-     */
     onFilesAdded($event: any): void {
         let files: File[] = this.getFiles($event.currentTarget.files);
 
         if (this.hasPermission) {
-            this.uploadFiles(this.currentFolderPath, files);
+            this.uploadFiles(files);
         } else {
             this.permissionEvent.emit(new PermissionModel({type: 'content', action: 'upload', permission: 'create'}));
         }
@@ -139,38 +144,10 @@ export class UploadButtonComponent implements OnInit, OnChanges {
         $event.target.value = '';
     }
 
-    /**
-     * Method called when a folder is dropped in the drag area.
-     *
-     * @param {File[]} files - files of a folder dropped in the drag area.
-     */
     onDirectoryAdded($event: any): void {
-        let files: File[] = this.getFiles($event.currentTarget.files);
         if (this.hasPermission) {
-            let hashMapDir = this.convertIntoHashMap(files);
-
-            hashMapDir.forEach((filesDir, directoryPath) => {
-                let directoryName = this.getDirectoryName(directoryPath);
-                let absolutePath = this.currentFolderPath + this.getDirectoryPath(directoryPath);
-
-                this.contentService.createFolder(absolutePath, directoryName, this.rootFolderId)
-                    .subscribe(
-                        _ => {
-                            let relativeDir = this.currentFolderPath + '/' + directoryPath;
-                            this.uploadFiles(relativeDir, filesDir);
-                        },
-                        error => {
-                            let errorMessagePlaceholder = this.getErrorMessage(error.response);
-                            if (errorMessagePlaceholder) {
-                                this.onError.emit({value: errorMessagePlaceholder});
-                                let errorMessage = this.formatString(errorMessagePlaceholder, [directoryName]);
-                                if (errorMessage) {
-                                    this.showErrorNotificationBar(errorMessage);
-                                }
-                            }
-                        }
-                    );
-            });
+            let files: File[] = this.getFiles($event.currentTarget.files);
+            this.uploadFiles(files);
         } else {
             this.permissionEvent.emit(new PermissionModel({type: 'content', action: 'upload', permission: 'create'}));
         }
@@ -180,35 +157,22 @@ export class UploadButtonComponent implements OnInit, OnChanges {
 
     /**
      * Upload a list of file in the specified path
-     * @param path
      * @param files
+     * @param path
      */
-    uploadFiles(path: string, files: File[]): void {
-        if (files.length) {
-            const latestFilesAdded = files.map(f => new FileModel(f, { newVersion: this.versioning }));
+    uploadFiles(files: File[]): void {
+        if (files.length > 0) {
+            const latestFilesAdded = files.map(f => new FileModel(f, {
+                newVersion: this.versioning,
+                parentId: this.rootFolderId,
+                path: f.webkitRelativePath.replace(/\/[^\/]*$/, '')
+            }));
             this.uploadService.addToQueue(...latestFilesAdded);
-            this.uploadService.uploadFilesInTheQueue(this.rootFolderId, path, this.onSuccess);
+            this.uploadService.uploadFilesInTheQueue(this.onSuccess);
             if (this.showNotificationBar) {
                 this.showUndoNotificationBar(latestFilesAdded);
             }
         }
-    }
-
-    /**
-     * It converts the array given as input into a map. The map is a key values pairs, where the key is the directory name and the value are
-     * all the files that the directory contains.
-     * @param files - array of files
-     * @returns {Map}
-     */
-    private convertIntoHashMap(files: File[]): Map<string, File[]> {
-        let directoryMap = new Map<string, File[]>();
-        for (let file of files) {
-            let directory = this.getDirectoryPath(file.webkitRelativePath);
-            let filesSomeDir = directoryMap.get(directory) || [];
-            filesSomeDir.push(file);
-            directoryMap.set(directory, filesSomeDir);
-        }
-        return directoryMap;
     }
 
     private getFiles(fileList: FileList): File[] {
@@ -224,35 +188,6 @@ export class UploadButtonComponent implements OnInit, OnChanges {
     }
 
     /**
-     * Split the directory path given as input and cut the last directory name
-     * @param directory
-     * @returns {string}
-     */
-    private getDirectoryPath(directory: string): string {
-        let relativeDirPath = '';
-        let dirPath = directory.split('/');
-        if (dirPath.length > 1) {
-            dirPath.pop();
-            relativeDirPath = '/' + dirPath.join('/');
-        }
-        return relativeDirPath;
-    }
-
-    /**
-     * Split a directory path passed in input and return the first directory name
-     * @param directory
-     * @returns {string}
-     */
-    private getDirectoryName(directory: string): string {
-        let dirPath = directory.split('/');
-        if (dirPath.length > 1) {
-            return dirPath.pop();
-        } else {
-            return dirPath[0];
-        }
-    }
-
-    /**
      * Show undo notification bar.
      *
      * @param {FileModel[]} latestFilesAdded - files in the upload queue enriched with status flag and xhr object.
@@ -265,43 +200,6 @@ export class UploadButtonComponent implements OnInit, OnChanges {
         this.notificationService.openSnackMessageAction(messageTranslate.value, actionTranslate.value, 3000).onAction().subscribe(() => {
             this.uploadService.cancelUpload(...latestFilesAdded);
         });
-    }
-
-    /**
-     * Retrive the error message using the error status code
-     * @param response - object that contain the HTTP response
-     * @returns {string}
-     */
-    private getErrorMessage(response: any): string {
-        if (response && response.body && response.body.error.statusCode === ERROR_FOLDER_ALREADY_EXIST) {
-            let errorMessage: any;
-            errorMessage = this.translateService.get('FILE_UPLOAD.MESSAGES.FOLDER_ALREADY_EXIST');
-            return errorMessage.value;
-        }
-        return 'Error';
-    }
-
-    /**
-     * Show the error inside Notification bar
-     * @param Error message
-     * @private
-     */
-    private showErrorNotificationBar(errorMessage: string): void {
-        this.notificationService.openSnackMessage(errorMessage, 3000);
-    }
-
-    /**
-     * Replace a placeholder {0} in a message with the input keys
-     * @param message - the message that conains the placeholder
-     * @param keys - array of value
-     * @returns {string} - The message without placeholder
-     */
-    private formatString(message: string, keys: any []): string {
-        let i = keys.length;
-        while (i--) {
-            message = message.replace(new RegExp('\\{' + i + '\\}', 'gm'), keys[i]);
-        }
-        return message;
     }
 
     checkPermission() {

--- a/ng2-components/ng2-alfresco-upload/src/components/upload-button.component.ts
+++ b/ng2-components/ng2-alfresco-upload/src/components/upload-button.component.ts
@@ -17,7 +17,7 @@
 
 import { Component, ElementRef, Input, Output, EventEmitter, OnInit, OnChanges, SimpleChanges } from '@angular/core';
 import { Observable, Subject } from 'rxjs/Rx';
-import { AlfrescoApiService, AlfrescoContentService, AlfrescoTranslationService, LogService, NotificationService, AlfrescoSettingsService } from 'ng2-alfresco-core';
+import { AlfrescoApiService, AlfrescoContentService, AlfrescoTranslationService, LogService, NotificationService, AlfrescoSettingsService, FileUtils } from 'ng2-alfresco-core';
 import { MinimalNodeEntryEntity } from 'alfresco-js-api';
 import { UploadService } from '../services/upload.service';
 import { FileModel } from '../models/file.model';
@@ -131,7 +131,7 @@ export class UploadButtonComponent implements OnInit, OnChanges {
     }
 
     onFilesAdded($event: any): void {
-        let files: File[] = this.getFiles($event.currentTarget.files);
+        let files: File[] = FileUtils.toFileArray($event.currentTarget.files);
 
         if (this.hasPermission) {
             this.uploadFiles(files);
@@ -144,7 +144,7 @@ export class UploadButtonComponent implements OnInit, OnChanges {
 
     onDirectoryAdded($event: any): void {
         if (this.hasPermission) {
-            let files: File[] = this.getFiles($event.currentTarget.files);
+            let files: File[] = FileUtils.toFileArray($event.currentTarget.files);
             this.uploadFiles(files);
         } else {
             this.permissionEvent.emit(new PermissionModel({type: 'content', action: 'upload', permission: 'create'}));
@@ -160,10 +160,10 @@ export class UploadButtonComponent implements OnInit, OnChanges {
      */
     uploadFiles(files: File[]): void {
         if (files.length > 0) {
-            const latestFilesAdded = files.map(f => new FileModel(f, {
+            const latestFilesAdded = files.map(file => new FileModel(f, {
                 newVersion: this.versioning,
                 parentId: this.rootFolderId,
-                path: (f.webkitRelativePath || '').replace(/\/[^\/]*$/, '')
+                path: (file.webkitRelativePath || '').replace(/\/[^\/]*$/, '')
             }));
             this.uploadService.addToQueue(...latestFilesAdded);
             this.uploadService.uploadFilesInTheQueue(this.onSuccess);
@@ -171,18 +171,6 @@ export class UploadButtonComponent implements OnInit, OnChanges {
                 this.showUndoNotificationBar(latestFilesAdded);
             }
         }
-    }
-
-    private getFiles(fileList: FileList): File[] {
-        const result: File[] = [];
-
-        if (fileList && fileList.length > 0) {
-            for (let i = 0; i < fileList.length; i++) {
-                result.push(fileList[i]);
-            }
-        }
-
-        return result;
     }
 
     /**

--- a/ng2-components/ng2-alfresco-upload/src/components/upload-button.component.ts
+++ b/ng2-components/ng2-alfresco-upload/src/components/upload-button.component.ts
@@ -228,13 +228,9 @@ export class UploadButtonComponent implements OnInit, OnChanges {
     }
 
     private hasCreatePermission(node: any): boolean {
-        if (this.hasPermissions(node)) {
+        if (node && node.allowableOperations) {
             return node.allowableOperations.find(permision => permision === 'create') ? true : false;
         }
         return false;
-    }
-
-    private hasPermissions(node: any): boolean {
-        return node && node.allowableOperations ? true : false;
     }
 }

--- a/ng2-components/ng2-alfresco-upload/src/components/upload-button.component.ts
+++ b/ng2-components/ng2-alfresco-upload/src/components/upload-button.component.ts
@@ -163,7 +163,7 @@ export class UploadButtonComponent implements OnInit, OnChanges {
             const latestFilesAdded = files.map(f => new FileModel(f, {
                 newVersion: this.versioning,
                 parentId: this.rootFolderId,
-                path: f.webkitRelativePath.replace(/\/[^\/]*$/, '')
+                path: (f.webkitRelativePath || '').replace(/\/[^\/]*$/, '')
             }));
             this.uploadService.addToQueue(...latestFilesAdded);
             this.uploadService.uploadFilesInTheQueue(this.onSuccess);

--- a/ng2-components/ng2-alfresco-upload/src/components/upload-button.component.ts
+++ b/ng2-components/ng2-alfresco-upload/src/components/upload-button.component.ts
@@ -160,7 +160,7 @@ export class UploadButtonComponent implements OnInit, OnChanges {
      */
     uploadFiles(files: File[]): void {
         if (files.length > 0) {
-            const latestFilesAdded = files.map(file => new FileModel(f, {
+            const latestFilesAdded = files.map(file => new FileModel(file, {
                 newVersion: this.versioning,
                 parentId: this.rootFolderId,
                 path: (file.webkitRelativePath || '').replace(/\/[^\/]*$/, '')

--- a/ng2-components/ng2-alfresco-upload/src/components/upload-button.component.ts
+++ b/ng2-components/ng2-alfresco-upload/src/components/upload-button.component.ts
@@ -30,8 +30,6 @@ import { PermissionModel } from '../models/permissions.model';
 })
 export class UploadButtonComponent implements OnInit, OnChanges {
 
-    private static DEFAULT_ROOT_ID: string = '-root-';
-
     @Input()
     disabled: boolean = false;
 
@@ -69,7 +67,7 @@ export class UploadButtonComponent implements OnInit, OnChanges {
     currentFolderPath: string = '/';
 
     @Input()
-    rootFolderId: string = UploadButtonComponent.DEFAULT_ROOT_ID;
+    rootFolderId: string = '-root-';
 
     @Input()
     disableWithNoPermission: boolean = false;
@@ -211,6 +209,7 @@ export class UploadButtonComponent implements OnInit, OnChanges {
         }
     }
 
+    // TODO: move to AlfrescoContentService
     getFolderNode(nodeId: string): Observable<MinimalNodeEntryEntity> {
         let opts: any = {
             includeSource: true,

--- a/ng2-components/ng2-alfresco-upload/src/components/upload-drag-area.component.spec.ts
+++ b/ng2-components/ng2-alfresco-upload/src/components/upload-drag-area.component.spec.ts
@@ -67,21 +67,22 @@ describe('UploadDragAreaComponent', () => {
         TestBed.resetTestingModule();
     });
 
-    it('should upload the list of files dropped', () => {
+    it('should upload the list of files dropped', (done) => {
         component.currentFolderPath = '/root-fake-/sites-fake/folder-fake';
         component.onSuccess = null;
         component.showNotificationBar = false;
-        uploadService.addToQueue = jasmine.createSpy('addToQueue');
         uploadService.uploadFilesInTheQueue = jasmine.createSpy('uploadFilesInTheQueue');
 
         fixture.detectChanges();
         const file = <File> {name: 'fake-name-1', size: 10, webkitRelativePath: 'fake-folder1/fake-name-1.json'};
-        let fileFake = new FileModel(file);
-        let filesList = [fileFake];
+        let filesList = [file];
+
+        spyOn(uploadService, 'addToQueue').and.callFake((f: FileModel) => {
+            expect(f.file).toBe(file);
+            done();
+        });
 
         component.onFilesDropped(filesList);
-        expect(uploadService.addToQueue).toHaveBeenCalledWith(fileFake);
-        expect(uploadService.uploadFilesInTheQueue).toHaveBeenCalledWith(null);
     });
 
     it('should show the loading messages in the notification bar when the files are dropped', () => {
@@ -92,7 +93,7 @@ describe('UploadDragAreaComponent', () => {
         component.showUndoNotificationBar = jasmine.createSpy('_showUndoNotificationBar');
 
         fixture.detectChanges();
-        let fileFake = new FileModel(<File> {name: 'fake-name-1', size: 10, webkitRelativePath: 'fake-folder1/fake-name-1.json'});
+        let fileFake = <File> {name: 'fake-name-1', size: 10, webkitRelativePath: 'fake-folder1/fake-name-1.json'};
         let filesList = [fileFake];
 
         component.onFilesDropped(filesList);

--- a/ng2-components/ng2-alfresco-upload/src/components/upload-drag-area.component.spec.ts
+++ b/ng2-components/ng2-alfresco-upload/src/components/upload-drag-area.component.spec.ts
@@ -81,7 +81,7 @@ describe('UploadDragAreaComponent', () => {
 
         component.onFilesDropped(filesList);
         expect(uploadService.addToQueue).toHaveBeenCalledWith(fileFake);
-        expect(uploadService.uploadFilesInTheQueue).toHaveBeenCalledWith('-root-', '/root-fake-/sites-fake/folder-fake', null);
+        expect(uploadService.uploadFilesInTheQueue).toHaveBeenCalledWith(null);
     });
 
     it('should show the loading messages in the notification bar when the files are dropped', () => {
@@ -96,7 +96,7 @@ describe('UploadDragAreaComponent', () => {
         let filesList = [fileFake];
 
         component.onFilesDropped(filesList);
-        expect(uploadService.uploadFilesInTheQueue).toHaveBeenCalledWith('-root-', '/root-fake-/sites-fake/folder-fake', null);
+        expect(uploadService.uploadFilesInTheQueue).toHaveBeenCalledWith(null);
         expect(component.showUndoNotificationBar).toHaveBeenCalled();
     });
 
@@ -119,8 +119,7 @@ describe('UploadDragAreaComponent', () => {
         };
 
         component.onFilesEntityDropped(itemEntity);
-        expect(uploadService.uploadFilesInTheQueue)
-            .toHaveBeenCalledWith('-root-', '/root-fake-/sites-fake/document-library-fake/folder-fake/', null);
+        expect(uploadService.uploadFilesInTheQueue).toHaveBeenCalledWith(null);
     });
 
     it('should upload a file with a custom root folder ID when dropped', () => {
@@ -143,7 +142,6 @@ describe('UploadDragAreaComponent', () => {
         };
 
         component.onFilesEntityDropped(itemEntity);
-        expect(uploadService.uploadFilesInTheQueue)
-            .toHaveBeenCalledWith('-my-', '/root-fake-/sites-fake/document-library-fake/folder-fake/', null);
+        expect(uploadService.uploadFilesInTheQueue).toHaveBeenCalledWith(null);
     });
 });

--- a/ng2-components/ng2-alfresco-upload/src/components/upload-drag-area.component.ts
+++ b/ng2-components/ng2-alfresco-upload/src/components/upload-drag-area.component.ts
@@ -79,12 +79,12 @@ export class UploadDragAreaComponent {
                 if (e.detail.data && e.detail.data.obj.entry.isFolder) {
                     parentId = e.detail.data.obj.entry.id || this.rootFolderId;
                 }
-                const fileModels = files.map(f => new FileModel(f.file, {
+                const fileModels = files.map(fileInfo => new FileModel(fileInfo.file, {
                     newVersion: this.versioning,
-                    path: f.relativeFolder,
+                    path: fileInfo.relativeFolder,
                     parentId: parentId
                 }));
-                this.onFilesDropped(fileModels);
+                this.uploadFiles(fileModels);
             }
         }
     }
@@ -94,9 +94,14 @@ export class UploadDragAreaComponent {
      *
      * @param {File[]} files - files dropped in the drag area.
      */
-    onFilesDropped(files: FileModel[]): void {
+    onFilesDropped(files: File[]): void {
         if (this.enabled && files.length) {
-            this.uploadService.addToQueue(...files);
+            const fileModels = files.map(file => new FileModel(file, {
+                newVersion: this.versioning,
+                path: '/',
+                parentId: this.rootFolderId
+            }));
+            this.uploadService.addToQueue(...fileModels);
             this.uploadService.uploadFilesInTheQueue(this.onSuccess);
             let latestFilesAdded = this.uploadService.getQueue();
             if (this.showNotificationBar) {
@@ -161,5 +166,16 @@ export class UploadDragAreaComponent {
         this.notificationService.openSnackMessageAction(messageTranslate.value, actionTranslate.value, 3000).onAction().subscribe(() => {
             this.uploadService.cancelUpload(...latestFilesAdded);
         });
+    }
+
+    private uploadFiles(files: FileModel[]): void {
+        if (this.enabled && files.length) {
+            this.uploadService.addToQueue(...files);
+            this.uploadService.uploadFilesInTheQueue(this.onSuccess);
+            let latestFilesAdded = this.uploadService.getQueue();
+            if (this.showNotificationBar) {
+                this.showUndoNotificationBar(latestFilesAdded);
+            }
+        }
     }
 }

--- a/ng2-components/ng2-alfresco-upload/src/components/upload-drag-area.component.ts
+++ b/ng2-components/ng2-alfresco-upload/src/components/upload-drag-area.component.ts
@@ -27,8 +27,6 @@ import { FileModel, FileUploadOptions } from '../models/file.model';
 })
 export class UploadDragAreaComponent {
 
-    private static DEFAULT_ROOT_ID: string = '-root-';
-
     @Input()
     enabled: boolean = true;
 
@@ -54,7 +52,7 @@ export class UploadDragAreaComponent {
     currentFolderPath: string = '/';
 
     @Input()
-    rootFolderId: string = UploadDragAreaComponent.DEFAULT_ROOT_ID;
+    rootFolderId: string = '-root-';
 
     @Output()
     onSuccess = new EventEmitter();
@@ -165,14 +163,5 @@ export class UploadDragAreaComponent {
         this.notificationService.openSnackMessageAction(messageTranslate.value, actionTranslate.value, 3000).onAction().subscribe(() => {
             this.uploadService.cancelUpload(...latestFilesAdded);
         });
-    }
-
-    /**
-     * Show the error inside Notification bar
-     * @param Error message
-     * @private
-     */
-    showErrorNotificationBar(errorMessage: string) {
-        this.notificationService.openSnackMessage(errorMessage, 3000);
     }
 }

--- a/ng2-components/ng2-alfresco-upload/src/components/upload-drag-area.component.ts
+++ b/ng2-components/ng2-alfresco-upload/src/components/upload-drag-area.component.ts
@@ -45,7 +45,7 @@ export class UploadDragAreaComponent {
     versioning: boolean = false;
 
     /**
-     * @deprecated Deprecated in 1.6.0, this property is not used for couple of releases already.
+     * @deprecated Deprecated in 1.6.0, this property is not used for couple of releases already. Use rootFolderId instead.
      *
      * @type {string}
      * @memberof UploadDragAreaComponent

--- a/ng2-components/ng2-alfresco-upload/src/components/upload-drag-area.component.ts
+++ b/ng2-components/ng2-alfresco-upload/src/components/upload-drag-area.component.ts
@@ -18,7 +18,7 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { AlfrescoTranslationService, NotificationService, FileUtils, FileInfo } from 'ng2-alfresco-core';
 import { UploadService } from '../services/upload.service';
-import { FileModel, FileUploadOptions } from '../models/file.model';
+import { FileModel } from '../models/file.model';
 
 @Component({
     selector: 'alfresco-upload-drag-area',
@@ -112,15 +112,14 @@ export class UploadDragAreaComponent {
     onFilesEntityDropped(item: any): void {
         if (this.enabled) {
             item.file((file: File) => {
-                const options: FileUploadOptions = {
+                const fileModel = new FileModel(file, {
                     newVersion: this.versioning,
                     parentId: this.rootFolderId,
                     path: item.fullPath.replace(item.name, '')
-                };
-                const fileModel = new FileModel(file, options);
+                });
                 this.uploadService.addToQueue(fileModel);
+                this.uploadService.uploadFilesInTheQueue(this.onSuccess);
             });
-            this.uploadService.uploadFilesInTheQueue(this.onSuccess);
         }
     }
 
@@ -132,12 +131,11 @@ export class UploadDragAreaComponent {
         if (this.enabled && folder.isDirectory) {
             FileUtils.flattern(folder).then(entries => {
                 let files = entries.map(entry => {
-                    const options: FileUploadOptions = {
+                    return new FileModel(entry.file, {
                         newVersion: this.versioning,
                         parentId: this.rootFolderId,
                         path: entry.relativeFolder
-                    };
-                    return new FileModel(entry.file, options);
+                    });
                 });
                 this.uploadService.addToQueue(...files);
                 /* @deprecated in 1.6.0 */

--- a/ng2-components/ng2-alfresco-upload/src/components/upload-drag-area.component.ts
+++ b/ng2-components/ng2-alfresco-upload/src/components/upload-drag-area.component.ts
@@ -16,11 +16,9 @@
  */
 
 import { Component, Input, Output, EventEmitter } from '@angular/core';
-import { AlfrescoTranslationService, AlfrescoContentService, LogService, NotificationService } from 'ng2-alfresco-core';
+import { AlfrescoTranslationService, NotificationService, FileUtils, FileInfo } from 'ng2-alfresco-core';
 import { UploadService } from '../services/upload.service';
-import { FileModel } from '../models/file.model';
-
-const ERROR_FOLDER_ALREADY_EXIST = 409;
+import { FileModel, FileUploadOptions } from '../models/file.model';
 
 @Component({
     selector: 'alfresco-upload-drag-area',
@@ -34,12 +32,24 @@ export class UploadDragAreaComponent {
     @Input()
     enabled: boolean = true;
 
+    /**
+     * @deprecated Deprecated in 1.6.0, you can use UploadService events and NotificationService api instead.
+     *
+     * @type {boolean}
+     * @memberof UploadButtonComponent
+     */
     @Input()
     showNotificationBar: boolean = true;
 
     @Input()
     versioning: boolean = false;
 
+    /**
+     * @deprecated Deprecated in 1.6.0, this property is not used for couple of releases already.
+     *
+     * @type {string}
+     * @memberof UploadDragAreaComponent
+     */
     @Input()
     currentFolderPath: string = '/';
 
@@ -51,9 +61,7 @@ export class UploadDragAreaComponent {
 
     constructor(private uploadService: UploadService,
                 private translateService: AlfrescoTranslationService,
-                private logService: LogService,
-                private notificationService: NotificationService,
-                private contentService: AlfrescoContentService) {
+                private notificationService: NotificationService) {
         if (translateService) {
             translateService.addTranslationFolder('ng2-alfresco-upload', 'assets/ng2-alfresco-upload');
         }
@@ -67,15 +75,18 @@ export class UploadDragAreaComponent {
         e.stopPropagation();
         e.preventDefault();
         if (this.enabled) {
-            let files: File[] = e.detail.files;
+            let files: FileInfo[] = e.detail.files;
             if (files && files.length > 0) {
-                const fileModels = files.map(f => new FileModel(f, { newVersion: this.versioning }));
-                if (e.detail.data.obj.entry.isFolder) {
-                    let id = e.detail.data.obj.entry.id;
-                    this.onFilesDropped(fileModels, id, '/');
-                } else {
-                    this.onFilesDropped(fileModels);
+                let parentId = this.rootFolderId;
+                if (e.detail.data && e.detail.data.obj.entry.isFolder) {
+                    parentId = e.detail.data.obj.entry.id || this.rootFolderId;
                 }
+                const fileModels = files.map(f => new FileModel(f.file, {
+                    newVersion: this.versioning,
+                    path: f.relativeFolder,
+                    parentId: parentId
+                }));
+                this.onFilesDropped(fileModels);
             }
         }
     }
@@ -85,10 +96,10 @@ export class UploadDragAreaComponent {
      *
      * @param {File[]} files - files dropped in the drag area.
      */
-    onFilesDropped(files: FileModel[], rootId?: string, directory?: string): void {
+    onFilesDropped(files: FileModel[]): void {
         if (this.enabled && files.length) {
             this.uploadService.addToQueue(...files);
-            this.uploadService.uploadFilesInTheQueue(rootId || this.rootFolderId, directory || this.currentFolderPath, this.onSuccess);
+            this.uploadService.uploadFilesInTheQueue(this.onSuccess);
             let latestFilesAdded = this.uploadService.getQueue();
             if (this.showNotificationBar) {
                 this.showUndoNotificationBar(latestFilesAdded);
@@ -103,12 +114,15 @@ export class UploadDragAreaComponent {
     onFilesEntityDropped(item: any): void {
         if (this.enabled) {
             item.file((file: File) => {
-                const fileModel = new FileModel(file, { newVersion: this.versioning });
+                const options: FileUploadOptions = {
+                    newVersion: this.versioning,
+                    parentId: this.rootFolderId,
+                    path: item.fullPath.replace(item.name, '')
+                };
+                const fileModel = new FileModel(file, options);
                 this.uploadService.addToQueue(fileModel);
-                let path = item.fullPath.replace(item.name, '');
-                let filePath = this.currentFolderPath + path;
-                this.uploadService.uploadFilesInTheQueue(this.rootFolderId, filePath, this.onSuccess);
             });
+            this.uploadService.uploadFilesInTheQueue(this.onSuccess);
         }
     }
 
@@ -118,52 +132,23 @@ export class UploadDragAreaComponent {
      */
     onFolderEntityDropped(folder: any): void {
         if (this.enabled && folder.isDirectory) {
-            let relativePath = folder.fullPath.replace(folder.name, '');
-            relativePath = this.currentFolderPath + relativePath;
-
-            this.contentService.createFolder(relativePath, folder.name, this.rootFolderId)
-                .subscribe(
-                    message => {
-                        this.onSuccess.emit({
-                            value: 'Created folder'
-                        });
-                        let dirReader = folder.createReader();
-                        dirReader.readEntries((entries: any) => {
-                            for (let i = 0; i < entries.length; i++) {
-                                this._traverseFileTree(entries[i]);
-                            }
-                            if (this.showNotificationBar) {
-                                let latestFilesAdded = this.uploadService.getQueue();
-                                this.showUndoNotificationBar(latestFilesAdded);
-                            }
-                        });
-                    },
-                    error => {
-                        let errorMessagePlaceholder = this.getErrorMessage(error.response);
-                        let errorMessage = this.formatString(errorMessagePlaceholder, [folder.name]);
-                        if (this.showNotificationBar) {
-                            this.showErrorNotificationBar(errorMessage);
-                        } else {
-                            this.logService.error(errorMessage);
-                        }
-
-                    }
-                );
-        }
-    }
-
-    /**
-     * Travers all the files and folders, and create it on the alfresco.
-     *
-     * @param {Object} item - can contains files or folders.
-     */
-    private _traverseFileTree(item: any): void {
-        if (item.isFile) {
-            this.onFilesEntityDropped(item);
-        } else {
-            if (item.isDirectory) {
-                this.onFolderEntityDropped(item);
-            }
+            FileUtils.flattern(folder).then(entries => {
+                let files = entries.map(entry => {
+                    const options: FileUploadOptions = {
+                        newVersion: this.versioning,
+                        parentId: this.rootFolderId,
+                        path: entry.relativeFolder
+                    };
+                    return new FileModel(entry.file, options);
+                });
+                this.uploadService.addToQueue(...files);
+                /* @deprecated in 1.6.0 */
+                if (this.showNotificationBar) {
+                    let latestFilesAdded = this.uploadService.getQueue();
+                    this.showUndoNotificationBar(latestFilesAdded);
+                }
+                this.uploadService.uploadFilesInTheQueue(this.onSuccess);
+            });
         }
     }
 
@@ -189,34 +174,5 @@ export class UploadDragAreaComponent {
      */
     showErrorNotificationBar(errorMessage: string) {
         this.notificationService.openSnackMessage(errorMessage, 3000);
-    }
-
-    /**
-     * Retrive the error message using the error status code
-     * @param response - object that contain the HTTP response
-     * @returns {string}
-     */
-    private getErrorMessage(response: any): string {
-        if (response.body.error.statusCode === ERROR_FOLDER_ALREADY_EXIST) {
-            let errorMessage: any;
-            errorMessage = this.translateService.get('FILE_UPLOAD.MESSAGES.FOLDER_ALREADY_EXIST');
-            return errorMessage.value;
-        }
-    }
-
-    /**
-     * Replace a placeholder {0} in a message with the input keys
-     * @param message - the message that conains the placeholder
-     * @param keys - array of value
-     * @returns {string} - The message without placeholder
-     */
-    private formatString(message: string, keys: any []) {
-        if (message) {
-            let i = keys.length;
-            while (i--) {
-                message = message.replace(new RegExp('\\{' + i + '\\}', 'gm'), keys[i]);
-            }
-        }
-        return message;
     }
 }

--- a/ng2-components/ng2-alfresco-upload/src/directives/file-draggable.directive.ts
+++ b/ng2-components/ng2-alfresco-upload/src/directives/file-draggable.directive.ts
@@ -16,6 +16,7 @@
  */
 
 import { Directive, EventEmitter, Input, Output, OnInit, OnDestroy, ElementRef, NgZone } from '@angular/core';
+import { FileUtils } from 'ng2-alfresco-core';
 
 @Directive({
     selector: '[file-draggable]'
@@ -28,7 +29,7 @@ export class FileDraggableDirective implements OnInit, OnDestroy {
     enabled: boolean = true;
 
     @Output()
-    onFilesDropped: EventEmitter<any> = new EventEmitter();
+    onFilesDropped: EventEmitter<File[]> = new EventEmitter<File[]>();
 
     @Output()
     onFilesEntityDropped: EventEmitter<any> = new EventEmitter();
@@ -80,13 +81,13 @@ export class FileDraggableDirective implements OnInit, OnDestroy {
                             }
                         }
                     } else {
-                        let files = event.dataTransfer.files;
+                        let files = FileUtils.toFileArray(event.dataTransfer.files);
                         this.onFilesDropped.emit(files);
                     }
                 }
             } else {
                 // safari or FF
-                let files = event.dataTransfer.files;
+                let files = FileUtils.toFileArray(event.dataTransfer.files);
                 this.onFilesDropped.emit(files);
             }
 

--- a/ng2-components/ng2-alfresco-upload/src/directives/file-draggable.directive.ts
+++ b/ng2-components/ng2-alfresco-upload/src/directives/file-draggable.directive.ts
@@ -73,7 +73,11 @@ export class FileDraggableDirective implements OnInit, OnDestroy {
                     if (typeof items[i].webkitGetAsEntry !== 'undefined') {
                         let item = items[i].webkitGetAsEntry();
                         if (item) {
-                            this.traverseFileTree(item);
+                            if (item.isFile) {
+                                this.onFilesEntityDropped.emit(item);
+                            } else if (item.isDirectory) {
+                                this.onFolderEntityDropped.emit(item);
+                            }
                         }
                     } else {
                         let files = event.dataTransfer.files;
@@ -87,22 +91,6 @@ export class FileDraggableDirective implements OnInit, OnDestroy {
             }
 
             this.element.classList.remove(this.cssClassName);
-        }
-    }
-
-    /**
-     * Travers all the files and folders, and emit an event for each file or directory.
-     *
-     * @param {Object} item - can contains files or folders.
-     */
-    private traverseFileTree(item: any): void {
-        if (item.isFile) {
-            let self = this;
-            self.onFilesEntityDropped.emit(item);
-        } else {
-            if (item.isDirectory) {
-                this.onFolderEntityDropped.emit(item);
-            }
         }
     }
 

--- a/ng2-components/ng2-alfresco-upload/src/models/file.model.ts
+++ b/ng2-components/ng2-alfresco-upload/src/models/file.model.ts
@@ -23,6 +23,8 @@ export interface FileUploadProgress {
 
 export interface FileUploadOptions {
     newVersion?: boolean;
+    parentId?: string;
+    path?: string;
 }
 
 export enum FileUploadStatus {

--- a/ng2-components/ng2-alfresco-upload/src/services/upload.service.spec.ts
+++ b/ng2-components/ng2-alfresco-upload/src/services/upload.service.spec.ts
@@ -19,7 +19,7 @@ import { EventEmitter } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { CoreModule } from 'ng2-alfresco-core';
 import { UploadService } from './upload.service';
-import { FileModel } from '../models/file.model';
+import { FileModel, FileUploadOptions } from '../models/file.model';
 
 declare let jasmine: any;
 
@@ -77,9 +77,12 @@ describe('UploadService', () => {
             expect(e.value).toBe('File uploaded');
             done();
         });
-        let fileFake = new FileModel(<File>{name: 'fake-name', size: 10});
+        let fileFake = new FileModel(
+            <File>{name: 'fake-name', size: 10},
+            <FileUploadOptions> { parentId: '-root-', path: 'fake-dir' }
+        );
         service.addToQueue(fileFake);
-        service.uploadFilesInTheQueue('-root-', 'fake-dir', emitter);
+        service.uploadFilesInTheQueue(emitter);
 
         let request = jasmine.Ajax.requests.mostRecent();
         expect(request.url).toBe('http://localhost:8080/alfresco/api/-default-/public/alfresco/versions/1/nodes/-root-/children?autoRename=true');
@@ -99,9 +102,12 @@ describe('UploadService', () => {
             expect(e.value).toBe('Error file uploaded');
             done();
         });
-        let fileFake = new FileModel(<File>{name: 'fake-name', size: 10});
+        let fileFake = new FileModel(
+            <File>{name: 'fake-name', size: 10},
+            <FileUploadOptions> { parentId: '-root-' }
+        );
         service.addToQueue(fileFake);
-        service.uploadFilesInTheQueue('-root-', '', emitter);
+        service.uploadFilesInTheQueue(emitter);
         expect(jasmine.Ajax.requests.mostRecent().url)
             .toBe('http://localhost:8080/alfresco/api/-default-/public/alfresco/versions/1/nodes/-root-/children?autoRename=true');
 
@@ -121,7 +127,7 @@ describe('UploadService', () => {
         });
         let fileFake = new FileModel(<File>{name: 'fake-name', size: 10});
         service.addToQueue(fileFake);
-        service.uploadFilesInTheQueue('-root-', '', emitter);
+        service.uploadFilesInTheQueue(emitter);
 
         let file = service.getQueue();
         service.cancelUpload(...file);
@@ -132,7 +138,7 @@ describe('UploadService', () => {
 
         const filesFake = new FileModel(<File>{name: 'fake-name', size: 10}, { newVersion: true });
         service.addToQueue(filesFake);
-        service.uploadFilesInTheQueue('-root-', '', emitter);
+        service.uploadFilesInTheQueue(emitter);
 
         expect(jasmine.Ajax.requests.mostRecent().url.endsWith('autoRename=true')).toBe(false);
         expect(jasmine.Ajax.requests.mostRecent().params.has('majorVersion')).toBe(true);
@@ -145,9 +151,12 @@ describe('UploadService', () => {
             expect(e.value).toBe('File uploaded');
             done();
         });
-        let filesFake = new FileModel(<File>{name: 'fake-name', size: 10});
+        let filesFake = new FileModel(
+            <File>{name: 'fake-name', size: 10},
+            <FileUploadOptions> { parentId: '123', path: 'fake-dir' }
+        );
         service.addToQueue(filesFake);
-        service.uploadFilesInTheQueue('123', 'fake-dir', emitter);
+        service.uploadFilesInTheQueue(emitter);
 
         let request = jasmine.Ajax.requests.mostRecent();
         expect(request.url).toBe('http://localhost:8080/alfresco/api/-default-/public/alfresco/versions/1/nodes/123/children?autoRename=true');


### PR DESCRIPTION
Numerous upload enhancements:

- limits concurrent downloads not to block UI
- flattens hierarchy on folder upload
- performs a single traversal of the entire folder hierarchy and ends with a complete file list
- allows now dropping folders on existing folders
- overall code improvements
- cleanup demo shell demo for the document list

Marked for deprecation:

- UploadButtonComponent.showNotificationBar
- UploadButtonComponent.currentFolderPath
- UploadDragAreaComponent.showNotificationBar
- UploadDragAreaComponent.currentFolderPath