### PR TITLE
[ADF-780] Process service - getProcessFilterByName wrong behaviour

### DIFF
--- a/ng2-components/ng2-activiti-processlist/src/services/activiti-process.service.ts
+++ b/ng2-components/ng2-activiti-processlist/src/services/activiti-process.service.ts
@@ -96,13 +96,14 @@ export class ActivitiProcessService {
 
     /**
      * Retrieve the process filter by name
-     * @param processName - string - The name of the filter
+     * @param filterName - string - The name of the filter
+     * @param appId - string - optional - The id of app
      * @returns {Observable<FilterProcessRepresentationModel>}
      */
-    getProcessFilterByName(processName: string, appId?: string): Observable<FilterProcessRepresentationModel> {
+    getProcessFilterByName(filterName: string, appId?: string): Observable<FilterProcessRepresentationModel> {
         return Observable.fromPromise(this.callApiProcessFilters(appId))
             .map((response: any) => {
-                return response.data.find(filter => filter.name === processName);
+                return response.data.find(filter => filter.name === filterName);
             }).catch(err => this.handleError(err));
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behaviour?** (You can also link to an open issue here)

getProcessFilterByName api in activiti-process.service does not return filter for the given filter name and appId. It always returns a default filter irrespective of the appId. 

https://issues.alfresco.com/jira/browse/ADF-780

**What is the new behaviour?**

Now getProcessFilterByName feches filter for the given filter name and appId.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
