### PR TITLE
[ADF-740] Add button for process attachment list

### DIFF
--- a/demo-shell-ng2/app/components/activiti/activiti-demo.component.html
+++ b/demo-shell-ng2/app/components/activiti/activiti-demo.component.html
@@ -88,7 +88,7 @@
                             <div *ngIf="isCreateTaskAttachVisible()">
                                 <adf-create-task-attachment *ngIf="currentTaskId"
                                                             [taskId]="currentTaskId"
-                                                            (success)="onCreateTaskSuccess  ()">
+                                                            (success)="onCreateTaskSuccess()">
                                 </adf-create-task-attachment>
                             </div>
                         </div>
@@ -155,10 +155,22 @@
                             </activiti-process-instance-details>
                             <hr>
                             <h5>Attachments</h5>
+                            <div class="action-header">
+                                <button class="mdl-button mdl-js-button" (click)="toggleCreateProcessAttach()">
+                                    Attach Document
+                                    <i class="material-icons">add</i>
+                                </button>
+                            </div>
                             <adf-process-attachment-list *ngIf="currentProcessInstanceId"
                                                       [processInstanceId]="currentProcessInstanceId"
                                                       (attachmentClick)="onAttachmentClick($event)">
                             </adf-process-attachment-list>
+                            <div *ngIf="isCreateProcessAttachVisible()">
+                                <adf-create-process-attachment *ngIf="currentProcessInstanceId"
+                                                            [processInstanceId]="currentProcessInstanceId"
+                                                            (contentCreated)="onContentCreated()">
+                                </adf-create-process-attachment>
+                            </div>
                         </div>
                         <div class="mdl-cell mdl-cell--10-col task-column mdl-shadow--2dp" *ngIf="isStartProcessMode()">
                             <activiti-start-process [appId]="appId" (start)="onStartProcessInstance($event)"></activiti-start-process>

--- a/demo-shell-ng2/app/components/activiti/activiti-demo.component.html
+++ b/demo-shell-ng2/app/components/activiti/activiti-demo.component.html
@@ -156,7 +156,7 @@
                             <hr>
                             <h5>Attachments</h5>
                             <div class="action-header">
-                                <button class="mdl-button mdl-js-button" (click)="toggleCreateProcessAttach()">
+                                <button id="show_process_attach" class="mdl-button mdl-js-button" (click)="toggleCreateProcessAttach()">
                                     Attach Document
                                     <i class="material-icons">add</i>
                                 </button>

--- a/demo-shell-ng2/app/components/activiti/activiti-demo.component.ts
+++ b/demo-shell-ng2/app/components/activiti/activiti-demo.component.ts
@@ -30,7 +30,8 @@ import {
     ActivitiProcessInstanceListComponent,
     ActivitiStartProcessInstance,
     FilterProcessRepresentationModel,
-    ProcessInstance
+    ProcessInstance,
+    ActivitiProcessAttachmentListComponent
 } from 'ng2-activiti-processlist';
 import { AnalyticsReportListComponent } from 'ng2-activiti-analytics';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -73,6 +74,9 @@ export class ActivitiDemoComponent implements AfterViewInit {
     @ViewChild(ActivitiProcessInstanceDetails)
     activitiprocessdetails: ActivitiProcessInstanceDetails;
 
+    @ViewChild(ActivitiProcessAttachmentListComponent)
+    processAttachList: ActivitiProcessAttachmentListComponent;
+
     @ViewChild(ActivitiStartProcessInstance)
     activitiStartProcess: ActivitiStartProcessInstance;
 
@@ -105,6 +109,7 @@ export class ActivitiDemoComponent implements AfterViewInit {
     blobFile: any;
     flag: boolean = true;
     createTaskAttach: boolean = false;
+    createProcessAttach: boolean = false;
 
     dataTasks: ObjectDataTableAdapter;
     dataProcesses: ObjectDataTableAdapter;
@@ -336,6 +341,11 @@ export class ActivitiDemoComponent implements AfterViewInit {
         this.toggleCreateTakAttach();
     }
 
+    onContentCreated() {
+        this.processAttachList.reload();
+        this.toggleCreateProcessAttach();
+    }
+
     toggleCreateTakAttach(): void {
         this.createTaskAttach = !this.createTaskAttach;
     }
@@ -344,4 +354,11 @@ export class ActivitiDemoComponent implements AfterViewInit {
         return this.createTaskAttach;
     }
 
+    toggleCreateProcessAttach(): void {
+        this.createProcessAttach = !this.createProcessAttach;
+    }
+
+    isCreateProcessAttachVisible(): boolean {
+        return this.createProcessAttach;
+    }
 }

--- a/ng2-components/ng2-activiti-processlist/src/components/activiti-create-process-attachment.component.css
+++ b/ng2-components/ng2-activiti-processlist/src/components/activiti-create-process-attachment.component.css
@@ -1,4 +1,4 @@
-.upload-attachment-container {
+.adf-upload-attachment-container {
     border: 1px solid rgb(224, 224, 224);
     background: #fff;
     text-align: left;
@@ -7,13 +7,13 @@
     text-align: center;
 }
 
-.drag-area {
+.adf-drag-area {
     border: 1px solid #eee;
     padding: 100px 10px;
     margin-bottom: 10px;
 }
 
-.upload-attachment-container button {
+.adf-upload-attachment-container button {
     color: rgb(253, 145, 0);
     opacity: 0.64;
 }

--- a/ng2-components/ng2-activiti-processlist/src/components/activiti-create-process-attachment.component.html
+++ b/ng2-components/ng2-activiti-processlist/src/components/activiti-create-process-attachment.component.html
@@ -1,14 +1,14 @@
-<div class="upload-attachment-container">
-    <div class="drag-area"
-    (upload-files)="onFileUpload($event)" 
+<div class="adf-upload-attachment-container">
+    <div class="adf-drag-area"
+    (upload-files)="onFileUpload($event)"
     mode="['click', 'drop']"
     [adf-upload]="true">
         Drop Files Here...
     </div>
     <button class="mdl-button mdl-js-button mdl-button--raised"
-    [adf-upload]="true" 
-    mode="['click']" 
-    [multiple]="true" 
+    [adf-upload]="true"
+    mode="['click']"
+    [multiple]="true"
     (upload-files)="onFileUpload($event)">
         Upload Attachment
     </button>

--- a/ng2-components/ng2-activiti-processlist/src/components/adf-create-process-attachment.component.css
+++ b/ng2-components/ng2-activiti-processlist/src/components/adf-create-process-attachment.component.css
@@ -1,0 +1,19 @@
+.upload-attachment-container {
+    border: 1px solid rgb(224, 224, 224);
+    background: #fff;
+    text-align: left;
+    border-top: none;
+    padding: 10px;
+    text-align: center;
+}
+
+.drag-area {
+    border: 1px solid #eee;
+    padding: 100px 10px;
+    margin-bottom: 10px;
+}
+
+.upload-attachment-container button {
+    color: rgb(253, 145, 0);
+    opacity: 0.64;
+}

--- a/ng2-components/ng2-activiti-processlist/src/components/adf-create-process-attachment.component.html
+++ b/ng2-components/ng2-activiti-processlist/src/components/adf-create-process-attachment.component.html
@@ -1,15 +1,17 @@
 <div class="upload-attachment-container">
     <div class="drag-area"
-    (upload-files)="onFileUpload($event)"
-    mode="['click', 'drop']"
-    [adf-upload]="true">
+         id="add_new_process_content_area"
+         (upload-files)="onFileUpload($event)"
+         mode="['click', 'drop']"
+         [adf-upload]="true">
         {{ 'DETAILS.BUTTON.DRAG-ATTACHMENT' | translate }}
     </div>
     <button class="mdl-button mdl-js-button mdl-button--raised"
-    [adf-upload]="true"
-    mode="['click']"
-    [multiple]="true"
-    (upload-files)="onFileUpload($event)">
+            id="add_new_process_content_button"
+            [adf-upload]="true"
+            mode="['click']"
+            [multiple]="true"
+            (upload-files)="onFileUpload($event)">
         {{ 'DETAILS.BUTTON.UPLOAD-ATTACHMENT' | translate }}
     </button>
 </div>

--- a/ng2-components/ng2-activiti-processlist/src/components/adf-create-process-attachment.component.html
+++ b/ng2-components/ng2-activiti-processlist/src/components/adf-create-process-attachment.component.html
@@ -1,0 +1,15 @@
+<div class="upload-attachment-container">
+    <div class="drag-area"
+    (upload-files)="onFileUpload($event)"
+    mode="['click', 'drop']"
+    [adf-upload]="true">
+        {{ 'DETAILS.BUTTON.DRAG-ATTACHMENT' | translate }}
+    </div>
+    <button class="mdl-button mdl-js-button mdl-button--raised"
+    [adf-upload]="true"
+    mode="['click']"
+    [multiple]="true"
+    (upload-files)="onFileUpload($event)">
+        {{ 'DETAILS.BUTTON.UPLOAD-ATTACHMENT' | translate }}
+    </button>
+</div>

--- a/ng2-components/ng2-activiti-processlist/src/components/adf-create-process-attachment.component.spec.ts
+++ b/ng2-components/ng2-activiti-processlist/src/components/adf-create-process-attachment.component.spec.ts
@@ -1,0 +1,101 @@
+/*!
+ * @license
+ * Copyright 2016 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { SimpleChange } from '@angular/core';
+import { ComponentFixture, TestBed, async } from '@angular/core/testing';
+import { Observable } from 'rxjs/Rx';
+
+import { AlfrescoTranslationService, CoreModule } from 'ng2-alfresco-core';
+import { ActivitiContentService } from 'ng2-activiti-form';
+
+import { ActivitiCreateTaskAttachmentComponent } from './adf-create-task-attachment.component';
+
+describe('Activiti Task Create Attachment', () => {
+
+    let componentHandler: any;
+    let service: ActivitiContentService;
+    let component: ActivitiCreateTaskAttachmentComponent;
+    let fixture: ComponentFixture<ActivitiCreateTaskAttachmentComponent>;
+    let createTaskRelatedContentSpy: jasmine.Spy;
+
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            imports: [
+                CoreModule.forRoot()
+            ],
+            declarations: [
+                ActivitiCreateTaskAttachmentComponent
+            ],
+            providers: [
+                { provide: AlfrescoTranslationService },
+                ActivitiContentService
+            ]
+        }).compileComponents();
+    }));
+
+    beforeEach(() => {
+
+        fixture = TestBed.createComponent(ActivitiCreateTaskAttachmentComponent);
+        component = fixture.componentInstance;
+        service = fixture.debugElement.injector.get(ActivitiContentService);
+
+        createTaskRelatedContentSpy = spyOn(service, 'createTaskRelatedContent').and.returnValue(Observable.of(
+            {
+              status: true
+            }));
+
+        componentHandler = jasmine.createSpyObj('componentHandler', [
+            'upgradeAllRegistered',
+            'upgradeElement'
+        ]);
+        window['componentHandler'] = componentHandler;
+    });
+
+    it('should not call createTaskRelatedContent service when taskId changed', () => {
+        let change = new SimpleChange(null, '123', true);
+        component.ngOnChanges({ 'taskId': change });
+        expect(createTaskRelatedContentSpy).not.toHaveBeenCalled();
+    });
+
+    it('should not call createTaskRelatedContent service when there is no file uploaded', () => {
+        let change = new SimpleChange(null, '123', true);
+        component.ngOnChanges({ 'taskId': change });
+        let customEvent = {
+            detail: {
+                files: [
+                ]
+            }
+        };
+        component.onFileUpload(customEvent);
+        expect(createTaskRelatedContentSpy).not.toHaveBeenCalled();
+    });
+
+    it('should call createTaskRelatedContent service when there is a file uploaded', () => {
+        let change = new SimpleChange(null, '123', true);
+        component.ngOnChanges({ 'taskId': change });
+        let file = new File([new Blob()], 'Test');
+        let customEvent = {
+            detail: {
+                files: [
+                    file
+                ]
+            }
+        };
+        component.onFileUpload(customEvent);
+        expect(createTaskRelatedContentSpy).toHaveBeenCalled();
+    });
+});

--- a/ng2-components/ng2-activiti-processlist/src/components/adf-create-process-attachment.component.spec.ts
+++ b/ng2-components/ng2-activiti-processlist/src/components/adf-create-process-attachment.component.spec.ts
@@ -22,14 +22,14 @@ import { Observable } from 'rxjs/Rx';
 import { AlfrescoTranslationService, CoreModule } from 'ng2-alfresco-core';
 import { ActivitiContentService } from 'ng2-activiti-form';
 
-import { ActivitiCreateTaskAttachmentComponent } from './adf-create-task-attachment.component';
+import { ActivitiCreateProcessAttachmentComponent } from './adf-create-process-attachment.component';
 
-describe('Activiti Task Create Attachment', () => {
+describe('Activiti Process Create Attachment', () => {
 
     let componentHandler: any;
     let service: ActivitiContentService;
-    let component: ActivitiCreateTaskAttachmentComponent;
-    let fixture: ComponentFixture<ActivitiCreateTaskAttachmentComponent>;
+    let component: ActivitiCreateProcessAttachmentComponent;
+    let fixture: ComponentFixture<ActivitiCreateProcessAttachmentComponent>;
     let createTaskRelatedContentSpy: jasmine.Spy;
 
     beforeEach(async(() => {
@@ -38,7 +38,7 @@ describe('Activiti Task Create Attachment', () => {
                 CoreModule.forRoot()
             ],
             declarations: [
-                ActivitiCreateTaskAttachmentComponent
+                ActivitiCreateProcessAttachmentComponent
             ],
             providers: [
                 { provide: AlfrescoTranslationService },
@@ -49,11 +49,11 @@ describe('Activiti Task Create Attachment', () => {
 
     beforeEach(() => {
 
-        fixture = TestBed.createComponent(ActivitiCreateTaskAttachmentComponent);
+        fixture = TestBed.createComponent(ActivitiCreateProcessAttachmentComponent);
         component = fixture.componentInstance;
         service = fixture.debugElement.injector.get(ActivitiContentService);
 
-        createTaskRelatedContentSpy = spyOn(service, 'createTaskRelatedContent').and.returnValue(Observable.of(
+        createTaskRelatedContentSpy = spyOn(service, 'createProcessRelatedContent').and.returnValue(Observable.of(
             {
               status: true
             }));

--- a/ng2-components/ng2-activiti-processlist/src/components/adf-create-process-attachment.component.ts
+++ b/ng2-components/ng2-activiti-processlist/src/components/adf-create-process-attachment.component.ts
@@ -24,16 +24,16 @@ import { ActivitiContentService } from 'ng2-activiti-form';
     styleUrls: ['./adf-create-process-attachment.component.css'],
     templateUrl: './adf-create-process-attachment.component.html'
 })
-export class ActivitiCreateTaskAttachmentComponent implements OnChanges {
+export class ActivitiCreateProcessAttachmentComponent implements OnChanges {
 
     @Input()
     processInstanceId: string;
 
     @Output()
-    error: EventEmitter<any> = new EventEmitter<any>();
+    creationError: EventEmitter<any> = new EventEmitter<any>();
 
     @Output()
-    success: EventEmitter<any> = new EventEmitter<any>();
+    contentCreated: EventEmitter<any> = new EventEmitter<any>();
 
     constructor(private translateService: AlfrescoTranslationService,
                 private activitiContentService: ActivitiContentService) {
@@ -44,8 +44,8 @@ export class ActivitiCreateTaskAttachmentComponent implements OnChanges {
     }
 
     ngOnChanges(changes: SimpleChanges) {
-        if (changes['taskId'] && changes['taskId'].currentValue) {
-            this.taskId = changes['taskId'].currentValue;
+        if (changes['processInstanceId'] && changes['processInstanceId'].currentValue) {
+            this.processInstanceId = changes['processInstanceId'].currentValue;
         }
     }
 
@@ -56,10 +56,10 @@ export class ActivitiCreateTaskAttachmentComponent implements OnChanges {
             let file: File = files[i];
             this.activitiContentService.createProcessRelatedContent(this.processInstanceId, file).subscribe(
                 (res) => {
-                    this.success.emit(res);
+                    this.contentCreated.emit(res);
                 },
                 (err) => {
-                    this.error.emit(err);
+                    this.creationError.emit(err);
                 }
             );
         }

--- a/ng2-components/ng2-activiti-processlist/src/components/adf-create-process-attachment.component.ts
+++ b/ng2-components/ng2-activiti-processlist/src/components/adf-create-process-attachment.component.ts
@@ -1,0 +1,67 @@
+/*!
+ * @license
+ * Copyright 2016 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, OnChanges, Input, SimpleChanges, Output, EventEmitter } from '@angular/core';
+import { AlfrescoTranslationService } from 'ng2-alfresco-core';
+import { ActivitiContentService } from 'ng2-activiti-form';
+
+@Component({
+    selector: 'adf-create-process-attachment',
+    styleUrls: ['./adf-create-process-attachment.component.css'],
+    templateUrl: './adf-create-process-attachment.component.html'
+})
+export class ActivitiCreateTaskAttachmentComponent implements OnChanges {
+
+    @Input()
+    processInstanceId: string;
+
+    @Output()
+    error: EventEmitter<any> = new EventEmitter<any>();
+
+    @Output()
+    success: EventEmitter<any> = new EventEmitter<any>();
+
+    constructor(private translateService: AlfrescoTranslationService,
+                private activitiContentService: ActivitiContentService) {
+
+        if (translateService) {
+            translateService.addTranslationFolder('ng2-activiti-processlist', 'node_modules/ng2-activiti-processlist/src');
+        }
+    }
+
+    ngOnChanges(changes: SimpleChanges) {
+        if (changes['taskId'] && changes['taskId'].currentValue) {
+            this.taskId = changes['taskId'].currentValue;
+        }
+    }
+
+    onFileUpload(event: any) {
+        let files: File[] = event.detail.files;
+
+        for (let i = 0; i < files.length; i++) {
+            let file: File = files[i];
+            this.activitiContentService.createProcessRelatedContent(this.processInstanceId, file).subscribe(
+                (res) => {
+                    this.success.emit(res);
+                },
+                (err) => {
+                    this.error.emit(err);
+                }
+            );
+        }
+    }
+}

--- a/ng2-components/ng2-activiti-processlist/src/components/adf-create-process-attachment.component.ts
+++ b/ng2-components/ng2-activiti-processlist/src/components/adf-create-process-attachment.component.ts
@@ -39,7 +39,7 @@ export class ActivitiCreateProcessAttachmentComponent implements OnChanges {
                 private activitiContentService: ActivitiContentService) {
 
         if (translateService) {
-            translateService.addTranslationFolder('ng2-activiti-processlist', 'node_modules/ng2-activiti-processlist/src');
+            translateService.addTranslationFolder('ng2-activiti-processlist', 'assets/ng2-activiti-processlist/src');
         }
     }
 

--- a/ng2-components/ng2-activiti-processlist/src/components/adf-process-attachment-list.component.ts
+++ b/ng2-components/ng2-activiti-processlist/src/components/adf-process-attachment-list.component.ts
@@ -59,6 +59,10 @@ export class ActivitiProcessAttachmentListComponent implements OnChanges {
         this.attachments = [];
     }
 
+    reload(): void {
+        this.loadAttachmentsByProcessInstanceId(this.processInstanceId);
+    }
+
     private loadAttachmentsByProcessInstanceId(processInstanceId: string) {
         if (processInstanceId) {
             this.reset();

--- a/ng2-components/ng2-activiti-processlist/src/components/index.ts
+++ b/ng2-components/ng2-activiti-processlist/src/components/index.ts
@@ -24,4 +24,4 @@ export * from './activiti-process-comments.component';
 export * from './activiti-process-instance-details.component';
 export * from './activiti-start-process.component';
 export * from './adf-process-attachment-list.component';
-export * from './activiti-create-process-attachment.component';
+export * from './adf-create-process-attachment.component';

--- a/ng2-components/ng2-activiti-processlist/src/i18n/en.json
+++ b/ng2-components/ng2-activiti-processlist/src/i18n/en.json
@@ -25,7 +25,9 @@
         },
         "BUTTON": {
             "CANCEL": "Cancel Process",
-            "SHOW_DIAGRAM": "Show Diagram"
+            "SHOW_DIAGRAM": "Show Diagram",
+            "DRAG-ATTACHMENT": "Drop Files Here...",
+            "UPLOAD-ATTACHMENT": "Upload Attachment"
         },
         "MESSAGES": {
             "NONE": "No process details found."


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behaviour?** (You can also link to an open issue here)
There is no button allowing users to upload content on process attachment list


**What is the new behaviour?**
Added a button which allows users to upload content on process attachment list


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
