### PR TITLE
[ADF-524] Datatable loading state

### DIFF
--- a/ng2-components/ng2-alfresco-datatable/README.md
+++ b/ng2-components/ng2-alfresco-datatable/README.md
@@ -195,9 +195,9 @@ You can add a template that will be showed when there are no result in your data
     
         <no-content-template>
             <!--Add your custom empty template here-->
-            <template>
+            <ng-template>
                 <h1>Sorry, no content</h1>
-            </template>
+            </ng-template>
         </no-content-template>
         
 </alfresco-datatable>
@@ -239,7 +239,7 @@ You can add a template that will be showed during the loading of your data:
     }
 ```
 
-Note: the ```html <loading-content-template> ``` and ```html <no-content-template> ``` can be used together
+Note: the `<loading-content-template>` and `<no-content-template>` can be used together
 
 #### Column Templates
 

--- a/ng2-components/ng2-alfresco-datatable/README.md
+++ b/ng2-components/ng2-alfresco-datatable/README.md
@@ -123,6 +123,7 @@ export class DataTableDemo {
 | fallbackThumbnail | string |  | Fallback image for row ehre thubnail is missing|
 | contextMenu | boolean | false | Toggles custom context menu for the component |
 | allowDropFiles | boolean | false | Toggle file drop support for rows (see **ng2-alfresco-core/UploadDirective** for more details) |
+| loading | boolean | false | Flag that indicate if the datable is in loading state and need to show the loading template. Read the documentation above to know how to configure a loading template  |
 
 ### DataColumn Properties
 
@@ -176,7 +177,9 @@ onRowClick(event) {
 
 ![](docs/assets/datatable-dom-events.png)
 
-### Advanced usage
+### Empty content template
+
+You can add a template that will be showed when there are no result in your datatable:
 
 ```html
 <alfresco-datatable
@@ -188,13 +191,55 @@ onRowClick(event) {
     (executeRowAction)="onExecuteRowAction($event)"
     (rowClick)="onRowClick($event)"
     (rowDblClick)="onRowDblClick($event)">
-    <no-content-template>
-        <template>
-            <h1>Sorry, no content</h1>
-        </template>
-    </no-content-template>
+    
+    
+        <no-content-template>
+            <!--Add your custom empty template here-->
+            <template>
+                <h1>Sorry, no content</h1>
+            </template>
+        </no-content-template>
+        
 </alfresco-datatable>
 ```
+
+### Loading content template
+
+You can add a template that will be showed during the loading of your data:
+
+```html
+<alfresco-datatable
+    [data]="data"
+    [actions]="contentActions"
+    [multiselect]="multiselect"
+    [loading]=isLoading()"
+    (showRowContextMenu)="onShowRowContextMenu($event)"
+    (showRowActionsMenu)="onShowRowActionsMenu($event)"
+    (executeRowAction)="onExecuteRowAction($event)"
+    (rowClick)="onRowClick($event)"
+    (rowDblClick)="onRowDblClick($event)">
+    
+        <loading-content-template>
+            <ng-template>
+               <!--Add your custom loading template here-->
+                <md-progress-spinner
+                    class="adf-document-list-loading-margin"
+                    [color]="'primary'"
+                    [mode]="'indeterminate'">
+                </md-progress-spinner>
+            </ng-template>
+        </loading-content-template>
+        
+</alfresco-datatable>
+```
+
+```js
+    isLoading(): boolean {
+        //your custom logic to identify if you are in a loading state 
+    }
+```
+
+Note: the ```html <loading-content-template> ``` and ```html <no-content-template> ``` can be used together
 
 #### Column Templates
 

--- a/ng2-components/ng2-alfresco-datatable/index.ts
+++ b/ng2-components/ng2-alfresco-datatable/index.ts
@@ -26,7 +26,8 @@ export * from './src/components/datatable/data-cell.event';
 export * from './src/components/datatable/data-row-action.event';
 
 import { DataTableComponent } from './src/components/datatable/datatable.component';
-import { NoContentTemplateComponent } from './src/components/datatable/no-content-template.component';
+import { NoContentTemplateComponent } from './src/directives/no-content-template.component';
+import { LoadingContentTemplateComponent } from './src/directives/loading-template.component';
 import { PaginationComponent } from './src/components/pagination/pagination.component';
 import { DataTableCellComponent } from './src/components/datatable/datatable-cell.component';
 
@@ -34,6 +35,7 @@ export const ALFRESCO_DATATABLE_DIRECTIVES: [any] = [
     DataTableComponent,
     DataTableCellComponent,
     NoContentTemplateComponent,
+    LoadingContentTemplateComponent,
     PaginationComponent
 ];
 

--- a/ng2-components/ng2-alfresco-datatable/src/components/datatable/datatable.component.css
+++ b/ng2-components/ng2-alfresco-datatable/src/components/datatable/datatable.component.css
@@ -26,11 +26,20 @@
 
 /* Empty folder */
 
-:host .no-content-container {
+:host .adf-no-content-container {
     padding: 0 !important;
 }
 
-:host .no-content-container > img {
+:host .adf-no-content-container > img {
+    width: 100%;
+}
+/* Loading folder */
+
+:host .adf-loading-content-container {
+    padding: 0 !important;
+}
+
+:host .adf-loading-content-container > img {
     width: 100%;
 }
 

--- a/ng2-components/ng2-alfresco-datatable/src/components/datatable/datatable.component.html
+++ b/ng2-components/ng2-alfresco-datatable/src/components/datatable/datatable.component.html
@@ -38,7 +38,8 @@
 
         <!-- Actions (left) -->
         <td *ngIf="actions && actionsPosition === 'left'" class="alfresco-datatable__actions-cell">
-            <button [id]="'action_menu_' + idx" alfresco-mdl-button class="mdl-button--icon" [attr.data-automation-id]="actions_menu">
+            <button [id]="'action_menu_' + idx" alfresco-mdl-button class="mdl-button--icon"
+                    [attr.data-automation-id]="actions_menu">
                 <i class="material-icons">more_vert</i>
             </button>
             <ul alfresco-mdl-menu class="mdl-menu--bottom-left"
@@ -66,21 +67,23 @@
                     <div *ngSwitchCase="'image'" class="cell-value">
                         <i *ngIf="isIconValue(row, col)" class="material-icons icon-cell">{{asIconValue(row, col)}}</i>
                         <img *ngIf="!isIconValue(row, col)"
-                            class="image-cell"
-                            alt="{{ iconAltTextKey(data.getValue(row, col)) | translate }}"
-                            src="{{ data.getValue(row, col) }}"
-                            (error)="onImageLoadingError($event)">
+                             class="image-cell"
+                             alt="{{ iconAltTextKey(data.getValue(row, col)) | translate }}"
+                             src="{{ data.getValue(row, col) }}"
+                             (error)="onImageLoadingError($event)">
                     </div>
                     <div *ngSwitchCase="'icon'" class="cell-value">
                         <img class="image-cell"
-                            alt="{{ iconAltTextKey(data.getValue(row, col)) | translate }}"
-                            src="{{ data.getValue(row, col) }}"
-                            (error)="onImageLoadingError($event)">
+                             alt="{{ iconAltTextKey(data.getValue(row, col)) | translate }}"
+                             src="{{ data.getValue(row, col) }}"
+                             (error)="onImageLoadingError($event)">
                     </div>
-                    <div *ngSwitchCase="'date'" class="cell-value" [attr.data-automation-id]="'date_' + data.getValue(row, col)">
+                    <div *ngSwitchCase="'date'" class="cell-value"
+                         [attr.data-automation-id]="'date_' + data.getValue(row, col)">
                         <alfresco-datatable-cell [data]="data" [column]="col" [row]="row"></alfresco-datatable-cell>
                     </div>
-                    <div *ngSwitchCase="'text'" class="cell-value" [attr.data-automation-id]="'text_' + data.getValue(row, col)">
+                    <div *ngSwitchCase="'text'" class="cell-value"
+                         [attr.data-automation-id]="'text_' + data.getValue(row, col)">
                         <alfresco-datatable-cell [data]="data" [column]="col" [row]="row"></alfresco-datatable-cell>
                     </div>
                     <span *ngSwitchDefault class="cell-value">
@@ -98,7 +101,8 @@
 
         <!-- Actions (right) -->
         <td *ngIf="actions && actionsPosition === 'right'" class="alfresco-datatable__actions-cell">
-            <button [id]="'action_menu_' + idx" alfresco-mdl-button class="mdl-button--icon" [attr.data-automation-id]="actions_menu">
+            <button [id]="'action_menu_' + idx" alfresco-mdl-button class="mdl-button--icon"
+                    [attr.data-automation-id]="actions_menu">
                 <i class="material-icons">more_vert</i>
             </button>
             <ul alfresco-mdl-menu class="mdl-menu--bottom-right"
@@ -113,12 +117,21 @@
         </td>
 
     </tr>
-    <tr *ngIf="data.getRows().length === 0">
-        <td class="mdl-data-table__cell--non-numeric no-content-container"
+    <tr *ngIf="data.getRows().length === 0 && !loading">
+        <td class="mdl-data-table__cell--non-numeric adf-no-content-container"
             [attr.colspan]="1 + data.getColumns().length">
             <ng-template *ngIf="noContentTemplate"
-                      ngFor [ngForOf]="[data]"
-                      [ngForTemplate]="noContentTemplate">
+                         ngFor [ngForOf]="[data]"
+                         [ngForTemplate]="noContentTemplate">
+            </ng-template>
+        </td>
+    </tr>
+    <tr *ngIf="loading">
+        <td class="mdl-data-table__cell--non-numeric adf-loading-content-container"
+            [attr.colspan]="1 + data.getColumns().length">
+            <ng-template *ngIf="loadingTemplate"
+                         ngFor [ngForOf]="[data]"
+                         [ngForTemplate]="loadingTemplate">
             </ng-template>
         </td>
     </tr>

--- a/ng2-components/ng2-alfresco-datatable/src/components/datatable/datatable.component.ts
+++ b/ng2-components/ng2-alfresco-datatable/src/components/datatable/datatable.component.ts
@@ -15,20 +15,7 @@
  * limitations under the License.
  */
 
-import {
-    Component,
-    OnChanges,
-    SimpleChange,
-    SimpleChanges,
-    Input,
-    Output,
-    EventEmitter,
-    ElementRef,
-    TemplateRef,
-    AfterContentInit,
-    ContentChild,
-    Optional
-} from '@angular/core';
+import { Component, OnChanges, SimpleChange, SimpleChanges, Input, Output, EventEmitter, ElementRef, TemplateRef, AfterContentInit, ContentChild, Optional } from '@angular/core';
 import { DataTableAdapter, DataRow, DataColumn, DataSorting, DataRowEvent, ObjectDataTableAdapter, ObjectDataRow } from '../../data/index';
 import { DataCellEvent } from './data-cell.event';
 import { DataRowActionEvent } from './data-row-action.event';
@@ -94,7 +81,12 @@ export class DataTableComponent implements AfterContentInit, OnChanges {
     @Output()
     executeRowAction: EventEmitter<DataRowActionEvent> = new EventEmitter<DataRowActionEvent>();
 
-    noContentTemplate: TemplateRef<any>;
+    @Input()
+    loading: boolean = false;
+
+    public noContentTemplate: TemplateRef<any>;
+    public loadingTemplate: TemplateRef<any>;
+
     isSelectAllChecked: boolean = false;
 
     constructor(@Optional() private el: ElementRef) {

--- a/ng2-components/ng2-alfresco-datatable/src/directives/index.ts
+++ b/ng2-components/ng2-alfresco-datatable/src/directives/index.ts
@@ -15,5 +15,5 @@
  * limitations under the License.
  */
 
-export * from './datatable.component';
-export * from './datatable-cell.component';
+export * from './no-content-template.component';
+export * from './loading-template.component';

--- a/ng2-components/ng2-alfresco-datatable/src/directives/loading-template.component.spec.ts
+++ b/ng2-components/ng2-alfresco-datatable/src/directives/loading-template.component.spec.ts
@@ -1,0 +1,41 @@
+/*!
+ * @license
+ * Copyright 2016 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { LoadingContentTemplateComponent } from './loading-template.component';
+import { Injector } from '@angular/core';
+import { getTestBed, TestBed } from '@angular/core/testing';
+import { DataTableComponent } from '../components/datatable/datatable.component';
+
+describe('LoadingContentTemplateComponent', () => {
+    let injector: Injector;
+    let loadingContentTemplateComponent: LoadingContentTemplateComponent;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [
+                LoadingContentTemplateComponent,
+                DataTableComponent
+            ]
+        });
+        injector = getTestBed();
+        loadingContentTemplateComponent = injector.get(LoadingContentTemplateComponent);
+    });
+
+    it('is defined', () => {
+        expect(loadingContentTemplateComponent).toBeDefined();
+    });
+});

--- a/ng2-components/ng2-alfresco-datatable/src/directives/loading-template.component.ts
+++ b/ng2-components/ng2-alfresco-datatable/src/directives/loading-template.component.ts
@@ -15,27 +15,22 @@
  * limitations under the License.
  */
 
-import {
-    Directive,
-    ContentChild,
-    TemplateRef,
-    AfterContentInit
-} from '@angular/core';
-import { DataTableComponent } from './datatable.component';
+import { Directive, ContentChild, TemplateRef, AfterContentInit } from '@angular/core';
+import { DataTableComponent } from '../components/datatable/datatable.component';
 
 @Directive({
-    selector: 'no-content-template'
+    selector: 'loading-content-template'
 })
-export class NoContentTemplateComponent implements AfterContentInit {
+export class LoadingContentTemplateComponent implements AfterContentInit {
 
     @ContentChild(TemplateRef)
     template: any;
 
-    constructor(
-        private dataTable: DataTableComponent) {
+    constructor(private dataTable: DataTableComponent) {
     }
 
     ngAfterContentInit() {
-        this.dataTable.noContentTemplate = this.template;
+        this.dataTable.loadingTemplate = this.template;
     }
+
 }

--- a/ng2-components/ng2-alfresco-datatable/src/directives/no-content-template.component.spec.ts
+++ b/ng2-components/ng2-alfresco-datatable/src/directives/no-content-template.component.spec.ts
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-import { NoContentTemplateComponent } from '../datatable/no-content-template.component';
+import { NoContentTemplateComponent } from './no-content-template.component';
 import { Injector } from '@angular/core';
 import { getTestBed, TestBed } from '@angular/core/testing';
-import { DataTableComponent } from './datatable.component';
+import { DataTableComponent } from '../components/datatable/datatable.component';
 
 describe('NoContentTemplateComponent', () => {
     let injector: Injector;

--- a/ng2-components/ng2-alfresco-datatable/src/directives/no-content-template.component.ts
+++ b/ng2-components/ng2-alfresco-datatable/src/directives/no-content-template.component.ts
@@ -15,5 +15,21 @@
  * limitations under the License.
  */
 
-export * from './datatable.component';
-export * from './datatable-cell.component';
+import { Directive, ContentChild, TemplateRef, AfterContentInit } from '@angular/core';
+import { DataTableComponent } from '../components/datatable/datatable.component';
+
+@Directive({
+    selector: 'no-content-template'
+})
+export class NoContentTemplateComponent implements AfterContentInit {
+
+    @ContentChild(TemplateRef)
+    template: any;
+
+    constructor(private dataTable: DataTableComponent) {
+    }
+
+    ngAfterContentInit() {
+        this.dataTable.noContentTemplate = this.template;
+    }
+}

--- a/ng2-components/ng2-alfresco-documentlist/README.md
+++ b/ng2-components/ng2-alfresco-documentlist/README.md
@@ -689,6 +689,7 @@ DocumentList emits the following events:
 | folderChange | emitted once current display folder has changed |
 | preview | emitted when user acts upon files with either single or double click (depends on `navigation-mode`), recommended for Viewer components integration  |
 | permissionError | emitted when user is attempting to create a folder via action menu but it doesn't have the permission to do it |
+| ready | emitted when the documentList is ready and load all the elements|
 
 ## Advanced usage and customization
 

--- a/ng2-components/ng2-alfresco-documentlist/index.ts
+++ b/ng2-components/ng2-alfresco-documentlist/index.ts
@@ -16,7 +16,7 @@
  */
 
 import { NgModule, ModuleWithProviders } from '@angular/core';
-import { MdMenuModule, MdButtonModule, MdIconModule } from '@angular/material';
+import { MdMenuModule, MdButtonModule, MdIconModule, MdProgressSpinnerModule } from '@angular/material';
 import { CoreModule } from 'ng2-alfresco-core';
 import { DataTableModule } from 'ng2-alfresco-datatable';
 
@@ -79,7 +79,8 @@ export const DOCUMENT_LIST_PROVIDERS: any[] = [
         DataTableModule,
         MdMenuModule,
         MdButtonModule,
-        MdIconModule
+        MdIconModule,
+        MdProgressSpinnerModule
     ],
     declarations: [
         ...DOCUMENT_LIST_DIRECTIVES

--- a/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.css
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.css
@@ -42,3 +42,7 @@
     object-fit: contain;
     margin-top: 17px;
 }
+
+.adf-document-list-loading-margin {
+    margin: auto;
+}

--- a/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.html
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.html
@@ -16,6 +16,7 @@
     [contextMenu]="contextMenuActions"
     [rowStyle]="rowStyle"
     [rowStyleClass]="rowStyleClass"
+    [loading]="loading"
     (showRowContextMenu)="onShowRowContextMenu($event)"
     (showRowActionsMenu)="onShowRowActionsMenu($event)"
     (executeRowAction)="onExecuteRowAction($event)"
@@ -24,20 +25,31 @@
     <div *ngIf="!isEmptyTemplateDefined()">
         <no-content-template>
             <ng-template>
-                <div class="document-list_empty_template">
-                    <div class="document-list__this-space-is-empty">This folder is empty</div>
-                    <div class="document-list__drag-drop">Drag and Drop</div>
-                    <div class="document-list__any-files-here-to-add">any files here to add</div>
-                    <img [src]="emptyFolderImageUrl" class="document-list__empty_doc_lib">
-                </div>
+                <!--put your cutom template here-->
+                <md-progress-spinner
+                    class="adf-document-list-loading-margin"
+                    [color]="'primary'"
+                    [mode]="'indeterminate'">
+                </md-progress-spinner>
             </ng-template>
         </no-content-template>
     </div>
+    <div>
+        <loading-content-template>
+            <ng-template>
+                <md-progress-spinner id="adf-document-list-loading"
+                    class="adf-document-list-loading-margin"
+                    [color]="'primary'"
+                    [mode]="'indeterminate'">
+                </md-progress-spinner>
+            </ng-template>
+        </loading-content-template>
+    </div>
 </alfresco-datatable>
 <alfresco-pagination *ngIf="isPaginationEnabled()"
-    (changePageSize)="onChangePageSize($event)"
-    (nextPage)="onNextPage($event)"
-    (prevPage)="onPrevPage($event)"
-    [pagination]="pagination"
-    [supportedPageSizes]="[5, 10, 15, 20]">
+                     (changePageSize)="onChangePageSize($event)"
+                     (nextPage)="onNextPage($event)"
+                     (prevPage)="onPrevPage($event)"
+                     [pagination]="pagination"
+                     [supportedPageSizes]="[5, 10, 15, 20]">
 </alfresco-pagination>

--- a/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.spec.ts
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.spec.ts
@@ -28,6 +28,7 @@ import { ShareDataRow, RowFilter, ImageResolver } from './../data/share-datatabl
 import { DataTableModule } from 'ng2-alfresco-datatable';
 import { DocumentMenuActionComponent } from './document-menu-action.component';
 import { Observable } from 'rxjs/Rx';
+import { MdProgressSpinnerModule } from '@angular/material';
 
 declare let jasmine: any;
 
@@ -43,7 +44,7 @@ let fakeNodeAnswerWithEntries = {
         'entries': [{
             'entry': {
                 'isFile': true,
-                'createdByUser': { 'id': 'admin', 'displayName': 'Administrator' },
+                'createdByUser': {'id': 'admin', 'displayName': 'Administrator'},
                 'modifiedAt': '2017-05-24T15:08:55.640Z',
                 'nodeType': 'cm:content',
                 'content': {
@@ -60,13 +61,13 @@ let fakeNodeAnswerWithEntries = {
                     'elements': [{
                         'id': '94acfc73-7014-4475-9bd9-93a2162f0f8c',
                         'name': 'Company Home'
-                    }, { 'id': 'd124de26-6ba0-4f40-8d98-4907da2d337a', 'name': 'Guest Home' }]
+                    }, {'id': 'd124de26-6ba0-4f40-8d98-4907da2d337a', 'name': 'Guest Home'}]
                 },
                 'isFolder': false,
-                'modifiedByUser': { 'id': 'admin', 'displayName': 'Administrator' },
+                'modifiedByUser': {'id': 'admin', 'displayName': 'Administrator'},
                 'name': 'b_txt_file.rtf',
                 'id': '67b80f77-dbca-4f58-be6c-71b9dd61ea53',
-                'properties': { 'cm:versionLabel': '1.0', 'cm:versionType': 'MAJOR' },
+                'properties': {'cm:versionLabel': '1.0', 'cm:versionType': 'MAJOR'},
                 'allowableOperations': ['delete', 'update']
             }
         }]
@@ -100,7 +101,8 @@ describe('DocumentList', () => {
         TestBed.configureTestingModule({
             imports: [
                 CoreModule.forRoot(),
-                DataTableModule.forRoot()
+                DataTableModule.forRoot(),
+                MdProgressSpinnerModule
             ],
             declarations: [
                 DocumentListComponent,
@@ -108,7 +110,7 @@ describe('DocumentList', () => {
             ],
             providers: [
                 DocumentListService,
-                { provide: NgZone, useValue: zone }
+                {provide: NgZone, useValue: zone}
             ]
         }).compileComponents();
     }));
@@ -199,6 +201,19 @@ describe('DocumentList', () => {
 
     });
 
+    it('should show the loading state during the loading of new elements', (done) => {
+        documentList.ngAfterContentInit();
+        documentList.node = new NodePaging();
+
+        fixture.detectChanges();
+
+        fixture.whenStable().then(() => {
+            fixture.detectChanges();
+            expect(element.querySelector('#adf-document-list-loading')).toBeDefined();
+            done();
+        });
+    });
+
     it('should not execute action without node provided', () => {
         let action = new ContentActionModel();
         action.handler = function () {
@@ -248,7 +263,7 @@ describe('DocumentList', () => {
             documentMenu
         ];
 
-        let nodeFile = { entry: { isFile: true, name: 'xyz', allowableOperations: ['create', 'update'] } };
+        let nodeFile = {entry: {isFile: true, name: 'xyz', allowableOperations: ['create', 'update']}};
 
         let actions = documentList.getNodeActions(nodeFile);
         expect(actions.length).toBe(1);
@@ -269,7 +284,7 @@ describe('DocumentList', () => {
             documentMenu
         ];
 
-        let nodeFile = { entry: { isFolder: true, name: 'xyz', allowableOperations: ['create', 'update'] } };
+        let nodeFile = {entry: {isFolder: true, name: 'xyz', allowableOperations: ['create', 'update']}};
 
         let actions = documentList.getNodeActions(nodeFile);
         expect(actions.length).toBe(1);
@@ -290,7 +305,7 @@ describe('DocumentList', () => {
             documentMenu
         ];
 
-        let nodeFile = { entry: { isFile: true, name: 'xyz', allowableOperations: ['create', 'update'] } };
+        let nodeFile = {entry: {isFile: true, name: 'xyz', allowableOperations: ['create', 'update']}};
 
         let actions = documentList.getNodeActions(nodeFile);
         expect(actions.length).toBe(1);
@@ -310,7 +325,7 @@ describe('DocumentList', () => {
             documentMenu
         ];
 
-        let nodeFile = { entry: { isFolder: true, name: 'xyz', allowableOperations: ['create', 'update'] } };
+        let nodeFile = {entry: {isFolder: true, name: 'xyz', allowableOperations: ['create', 'update']}};
 
         let actions = documentList.getNodeActions(nodeFile);
         expect(actions.length).toBe(1);
@@ -330,7 +345,7 @@ describe('DocumentList', () => {
             documentMenu
         ];
 
-        let nodeFile = { entry: { isFile: true, name: 'xyz', allowableOperations: ['create', 'update', 'delete'] } };
+        let nodeFile = {entry: {isFile: true, name: 'xyz', allowableOperations: ['create', 'update', 'delete']}};
 
         let actions = documentList.getNodeActions(nodeFile);
         expect(actions.length).toBe(1);
@@ -350,7 +365,7 @@ describe('DocumentList', () => {
             documentMenu
         ];
 
-        let nodeFile = { entry: { isFolder: true, name: 'xyz', allowableOperations: ['create', 'update', 'delete'] } };
+        let nodeFile = {entry: {isFolder: true, name: 'xyz', allowableOperations: ['create', 'update', 'delete']}};
 
         let actions = documentList.getNodeActions(nodeFile);
         expect(actions.length).toBe(1);
@@ -369,7 +384,7 @@ describe('DocumentList', () => {
             documentMenu
         ];
 
-        let nodeFile = { entry: { isFile: true, name: 'xyz', allowableOperations: null } };
+        let nodeFile = {entry: {isFile: true, name: 'xyz', allowableOperations: null}};
 
         let actions = documentList.getNodeActions(nodeFile);
         expect(actions.length).toBe(1);
@@ -388,7 +403,7 @@ describe('DocumentList', () => {
             documentMenu
         ];
 
-        let nodeFile = { entry: { isFolder: true, name: 'xyz', allowableOperations: null } };
+        let nodeFile = {entry: {isFolder: true, name: 'xyz', allowableOperations: null}};
 
         let actions = documentList.getNodeActions(nodeFile);
         expect(actions.length).toBe(1);
@@ -692,7 +707,7 @@ describe('DocumentList', () => {
         });
 
         documentList.currentFolderId = 'wrong-id';
-        documentList.ngOnChanges({ currentFolderId: new SimpleChange(null, documentList.currentFolderId, true) });
+        documentList.ngOnChanges({currentFolderId: new SimpleChange(null, documentList.currentFolderId, true)});
     });
 
     it('should require dataTable to check empty template', () => {
@@ -784,11 +799,11 @@ describe('DocumentList', () => {
     it('should load folder by ID on init', () => {
         documentList.currentFolderId = '1d26e465-dea3-42f3-b415-faa8364b9692';
         spyOn(documentList, 'loadFolderNodesByFolderNodeId').and.returnValue(Promise.resolve());
-        documentList.ngOnChanges({ folderNode: new SimpleChange(null, documentList.currentFolderId, true) });
+        documentList.ngOnChanges({folderNode: new SimpleChange(null, documentList.currentFolderId, true)});
         expect(documentList.loadFolderNodesByFolderNodeId).toHaveBeenCalled();
     });
 
-    it('should load previous page if there are no other elements in multi page table', async(() => {
+    it('should load previous page if there are no other elements in multi page table', () => {
         documentList.currentFolderId = '1d26e465-dea3-42f3-b415-faa8364b9692';
         documentList.folderNode = new NodeMinimal();
         documentList.folderNode.id = '1d26e465-dea3-42f3-b415-faa8364b9692';
@@ -799,11 +814,12 @@ describe('DocumentList', () => {
 
         fixture.detectChanges();
 
-        fixture.whenStable().then(() => {
+        documentList.ready.subscribe(() => {
             fixture.detectChanges();
             let rowElement = element.querySelector('[data-automation-id="b_txt_file.rtf"]');
             expect(rowElement).toBeDefined();
             expect(rowElement).not.toBeNull();
+            done();
         });
 
         jasmine.Ajax.requests.at(0).respondWith({
@@ -817,5 +833,5 @@ describe('DocumentList', () => {
             contentType: 'application/json',
             responseText: JSON.stringify(fakeNodeAnswerWithEntries)
         });
-    }));
+    });
 });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[ x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
[ x] Tests for the changes have been added (for bug fixes / features)
[ x] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[X ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behaviour?** (You can also link to an open issue here)
When the datatbale is in a intermediate   state now it show the empty template


**What is the new behaviour?**
I have added in the datatable and in consequence in the  documentlist a loading state 


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
