### PR TITLE
[ADF-811] upload service exposes created nodes

### DIFF
--- a/ng2-components/ng2-alfresco-upload/src/events/file.event.ts
+++ b/ng2-components/ng2-alfresco-upload/src/events/file.event.ts
@@ -29,7 +29,7 @@ export class FileUploadEvent {
 
 export class FileUploadCompleteEvent extends FileUploadEvent {
 
-    constructor(file: FileModel, public totalComplete: number = 0) {
+    constructor(file: FileModel, public totalComplete: number = 0, public data?: any) {
         super(file, FileUploadStatus.Complete);
     }
 

--- a/ng2-components/ng2-alfresco-upload/src/services/upload.service.ts
+++ b/ng2-components/ng2-alfresco-upload/src/services/upload.service.ts
@@ -152,7 +152,7 @@ export class UploadService {
             emitter.emit({ value: 'Error file uploaded' });
         })
         .on('success', data => {
-            this.onUploadComplete(file);
+            this.onUploadComplete(file, data);
             emitter.emit({ value: data });
         })
         .catch(err => {
@@ -199,7 +199,7 @@ export class UploadService {
         }
     }
 
-    private onUploadComplete(file: FileModel): void {
+    private onUploadComplete(file: FileModel, data: any): void {
         if (file) {
             file.status = FileUploadStatus.Complete;
             this.totalComplete++;
@@ -209,7 +209,7 @@ export class UploadService {
                 delete this.cache[file.id];
             }
 
-            const event = new FileUploadCompleteEvent(file, this.totalComplete);
+            const event = new FileUploadCompleteEvent(file, this.totalComplete, data);
             this.fileUpload.next(event);
             this.fileUploadComplete.next(event);
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behaviour?** (You can also link to an open issue here)

It is not possible to get created node upon file upload

**What is the new behaviour?**

Upload service now exposes created nodes upon successful upload

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
