### PR TITLE
[ADF-180] Adding tabindices to viewer control elements

### DIFF
--- a/ng2-components/ng2-alfresco-viewer/src/components/pdfViewer.component.html
+++ b/ng2-components/ng2-alfresco-viewer/src/components/pdfViewer.component.html
@@ -14,7 +14,7 @@
 
 <!-- Pagination toolbar start -->
 <div *ngIf="showToolbar" id="viewer-toolbar-pagination" class="viewer-toolbar-pagination mdl-cell--hide-tablet mdl-cell--hide-phone">
-    <div id="viewer-previous-page-button" aria-label="arrow left" class="button-page left" (click)="previousPage()">
+    <div id="viewer-previous-page-button" aria-label="arrow left" class="button-page left" (click)="previousPage()" tabindex="0">
         <i class="icon material-icons">keyboard_arrow_left</i>
     </div>
 
@@ -24,7 +24,7 @@
         <div id="viewer-total-pages"  class="left viewer-total-pages">/ {{totalPages}}</div>
     </div>
 
-    <div id="viewer-next-page-button" aria-label="arrow right" class="button-page left"  (click)="nextPage()" >
+    <div id="viewer-next-page-button" aria-label="arrow right" class="button-page left"  (click)="nextPage()" tabindex="0">
         <i class="icon material-icons" >keyboard_arrow_right</i>
     </div>
 </div>
@@ -32,13 +32,13 @@
 
 <!-- Command toolbar start -->
 <div *ngIf="showToolbar"  id="viewer-toolbar-command" class="viewer-toolbar-command">
-    <div id="viewer-scale-page-button" aria-label="zoom out map" class="button-page left" (click)="pageFit()">
+    <div id="viewer-scale-page-button" aria-label="zoom out map" class="button-page left" (click)="pageFit()" tabindex="0">
         <i class="icon material-icons">zoom_out_map</i>
     </div>
-    <div id="viewer-zoom-in-button" aria-label="zoom in" class="button-page left" (click)="zoomIn()">
+    <div id="viewer-zoom-in-button" aria-label="zoom in" class="button-page left" (click)="zoomIn()" tabindex="0">
         <i class="icon material-icons">zoom_in</i>
     </div>
-    <div id="viewer-zoom-out-button" aria-label="zoom out" class="button-page left" (click)="zoomOut()">
+    <div id="viewer-zoom-out-button" aria-label="zoom out" class="button-page left" (click)="zoomOut()" tabindex="0">
         <i class="icon material-icons">zoom_out</i>
     </div>
 </div>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behaviour?** (You can also link to an open issue here)
When using a screen reader user can NOT tab into any of the elements/buttons within the previewer e.g. close button, maximise, minimise etc.


**What is the new behaviour?**
When using a screen reader user can tab into any of the elements/buttons within the previewer e.g. close button, maximise, minimise etc.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
