### PR TITLE
[ADF-784] Fix current page number issue in the viewer

### DIFF
--- a/ng2-components/ng2-alfresco-viewer/src/components/pdfViewer.component.ts
+++ b/ng2-components/ng2-alfresco-viewer/src/components/pdfViewer.component.ts
@@ -161,7 +161,7 @@ export class PdfViewerComponent {
                 heigthContainer = documentContainer.clientHeight;
             }
 
-            let currentPage = this.pdfViewer._pages[this.pdfViewer._currentPageNumber];
+            let currentPage = this.pdfViewer._pages[this.pdfViewer._currentPageNumber - 1];
 
             let padding = 20;
             let pageWidthScale = (widthContainer - padding) / currentPage.width * currentPage.scale;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behaviour?** (You can also link to an open issue here)
Pdf viewing (overlay mode independent)
Zoom and Fullscreen buttons are not working correctly in the viewer if the pdf contains only 1 page. A javascript error was thrown which stopped the further execution.


**What is the new behaviour?**
Buttons are working properly either with one-page or multipage pdf documents in the viewer.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
