### PR TITLE
Fix host configuration in demo-shell when no port is present

### DIFF
--- a/demo-shell-ng2/app/app.component.ts
+++ b/demo-shell-ng2/app/app.component.ts
@@ -29,8 +29,8 @@ declare var document: any;
 export class AppComponent {
     searchTerm: string = '';
 
-    ecmHost: string = `http://${window.location.hostname}:${window.location.port}/ecm`;
-    bpmHost: string = `http://${window.location.hostname}:${window.location.port}/bpm`;
+    ecmHost: string = `http://${window.location.hostname}` + (window.location.port ? `:${window.location.port}` : '') + `/ecm`;
+    bpmHost: string = `http://${window.location.hostname}` + (window.location.port ? `:${window.location.port}` : '') + `/bpm`;
 
     constructor(private authService: AlfrescoAuthenticationService,
                 private router: Router,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[x ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
[x ] Tests for the changes have been added (for bug fixes / features)
[x ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behaviour?** (You can also link to an open issue here)
When no port is present in the windows.location obj the setting index result with : that should not there


**What is the new behaviour?**
Fix host configuration in demo-shell when no port is present


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
