### PR TITLE
[ADF-851] execute-outcome event for form service

### DIFF
--- a/ng2-components/ng2-activiti-form/README.md
+++ b/ng2-components/ng2-activiti-form/README.md
@@ -314,6 +314,7 @@ class MyComponent {
 | taskCompletedError | FormErrorEvent | Raised when a task is completed unsuccessfully  |
 | taskSaved | FormEvent | Raised when a task is saved successfully |
 | taskSavedError | FormErrorEvent | Raised when a task is saved unsuccessfully |
+| executeOutcome | FormOutcomeEvent | Raised when a form outcome is executed |
 
 ### Methods
 

--- a/ng2-components/ng2-activiti-form/src/components/activiti-form.component.spec.ts
+++ b/ng2-components/ng2-activiti-form/src/components/activiti-form.component.spec.ts
@@ -800,4 +800,18 @@ describe('ActivitiForm', () => {
         expect(formComponent.isOutcomeButtonEnabled(outcome)).toBeFalsy();
     });
 
+    it('should raise [executeOutcome] event for formService', (done) => {
+        formService.executeOutcome.subscribe(() => {
+            done();
+        });
+
+        let outcome = new FormOutcomeModel(new FormModel(), {
+            id: ActivitiForm.CUSTOM_OUTCOME_ID,
+            name: 'Custom'
+        });
+
+        formComponent.form = new FormModel();
+        formComponent.onOutcomeClicked(outcome);
+    });
+
 });

--- a/ng2-components/ng2-activiti-form/src/components/activiti-form.component.ts
+++ b/ng2-components/ng2-activiti-form/src/components/activiti-form.component.ts
@@ -211,9 +211,7 @@ export class ActivitiForm implements OnInit, AfterViewChecked, OnChanges {
     onOutcomeClicked(outcome: FormOutcomeModel): boolean {
         if (!this.readOnly && outcome && this.form) {
 
-            let args = new FormOutcomeEvent(outcome);
-            this.executeOutcome.emit(args);
-            if (args.defaultPrevented) {
+            if (!this.onExecuteOutcome(outcome)) {
                 return false;
             }
 
@@ -490,5 +488,21 @@ export class ActivitiForm implements OnInit, AfterViewChecked, OnChanges {
     protected onTaskCompletedError(form: FormModel, error: any) {
         this.handleError(error);
         this.formService.taskCompletedError.next(new FormErrorEvent(form, error));
+    }
+
+    protected onExecuteOutcome(outcome: FormOutcomeModel): boolean {
+        let args = new FormOutcomeEvent(outcome);
+
+        this.formService.executeOutcome.next(args);
+        if (args.defaultPrevented) {
+            return false;
+        }
+
+        this.executeOutcome.emit(args);
+        if (args.defaultPrevented) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/ng2-components/ng2-activiti-form/src/services/form.service.ts
+++ b/ng2-components/ng2-activiti-form/src/services/form.service.ts
@@ -18,7 +18,7 @@
 import { Injectable } from '@angular/core';
 import { Observable, Subject } from 'rxjs/Rx';
 import { AlfrescoApiService, LogService } from 'ng2-alfresco-core';
-import { FormValues } from './../components/widgets/core/index';
+import { FormValues, FormOutcomeEvent } from './../components/widgets/core/index';
 import { FormDefinitionModel } from '../models/form-definition.model';
 import { EcmModelService } from './ecm-model.service';
 import { GroupModel } from './../components/widgets/core/group.model';
@@ -39,6 +39,8 @@ export class FormService {
     taskSaved: Subject<FormEvent> = new Subject<FormEvent>();
     taskSavedError: Subject<FormErrorEvent> = new Subject<FormErrorEvent>();
     formContentClicked: Subject<ContentLinkModel> = new Subject<ContentLinkModel>();
+
+    executeOutcome: Subject<FormOutcomeEvent> = new Subject<FormOutcomeEvent>();
 
     constructor(private ecmModelService: EcmModelService,
                 private apiService: AlfrescoApiService,


### PR DESCRIPTION
- support for subscribing for form outcome execution events (`executeOutcome`)
- ability to cancel outcome execution events