### PR TITLE
[ADF-716] Task header - Provide a way to customise the properties

### DIFF
--- a/ng2-components/ng2-activiti-tasklist/README.md
+++ b/ng2-components/ng2-activiti-tasklist/README.md
@@ -408,6 +408,7 @@ The purpose of the component is populate the local variable called `properties` 
 | --- | --- | --- | --- |
 | taskDetails | [TaskDetailsModel](#taskdetailsmodel) | | (**required**) The task details related to the task. |
 | formName | string | | The name of the form. |
+| propertyNames | string [] | ['status', 'due_date', 'category', 'created_by', 'created', 'id', 'description', 'form_name'] | Array of property names to be shown as part of task header |
 
 ### Events
 

--- a/ng2-components/ng2-activiti-tasklist/src/components/activiti-task-header.component.spec.ts
+++ b/ng2-components/ng2-activiti-tasklist/src/components/activiti-task-header.component.spec.ts
@@ -124,4 +124,60 @@ describe('ActivitiTaskHeader', () => {
         expect(valueEl.nativeElement.innerText).toBe('No form');
     });
 
+    it('should display all properties if no property name is provided', () => {
+        component.ngOnChanges({});
+        fixture.detectChanges();
+        let valueEl = fixture.debugElement.query(By.css('[data-automation-id="header-status"] .adf-header__value'));
+        expect(valueEl.nativeElement.innerText).not.toBeNull();
+
+        valueEl = fixture.debugElement.query(By.css('[data-automation-id="header-dueDate"] .adf-header__value'));
+        expect(valueEl.nativeElement.innerText).not.toBeNull();
+
+        valueEl = fixture.debugElement.query(By.css('[data-automation-id="header-category"] .adf-header__value'));
+        expect(valueEl.nativeElement.innerText).not.toBeNull();
+
+        valueEl = fixture.debugElement.query(By.css('[data-automation-id="header-assignee"] .adf-header__value'));
+        expect(valueEl.nativeElement.innerText).not.toBeNull();
+
+        valueEl = fixture.debugElement.query(By.css('[data-automation-id="header-created"] .adf-header__value'));
+        expect(valueEl.nativeElement.innerText).not.toBeNull();
+
+        valueEl = fixture.debugElement.query(By.css('[data-automation-id="header-id"] .adf-header__value'));
+        expect(valueEl.nativeElement.innerText).not.toBeNull();
+
+        valueEl = fixture.debugElement.query(By.css('[data-automation-id="header-description"] .adf-header__value'));
+        expect(valueEl.nativeElement.innerText).not.toBeNull();
+
+        valueEl = fixture.debugElement.query(By.css('[data-automation-id="header-formName"] .adf-header__value'));
+        expect(valueEl.nativeElement.innerText).not.toBeNull();
+    });
+
+    it('should display only provided properties', () => {
+        component.propertyNames = ['status'];
+        component.ngOnChanges({});
+        fixture.detectChanges();
+        let valueEl = fixture.debugElement.query(By.css('[data-automation-id="header-status"] .adf-header__value'));
+        expect(valueEl.nativeElement.innerText).not.toBeNull();
+
+        valueEl = fixture.debugElement.query(By.css('[data-automation-id="header-dueDate"]'));
+        expect(valueEl).toBeNull();
+
+        valueEl = fixture.debugElement.query(By.css('[data-automation-id="header-category"]'));
+        expect(valueEl).toBeNull();
+
+        valueEl = fixture.debugElement.query(By.css('[data-automation-id="header-assignee"]'));
+        expect(valueEl).toBeNull();
+
+        valueEl = fixture.debugElement.query(By.css('[data-automation-id="header-created"]'));
+        expect(valueEl).toBeNull();
+
+        valueEl = fixture.debugElement.query(By.css('[data-automation-id="header-id"]'));
+        expect(valueEl).toBeNull();
+
+        valueEl = fixture.debugElement.query(By.css('[data-automation-id="header-description"]'));
+        expect(valueEl).toBeNull();
+
+        valueEl = fixture.debugElement.query(By.css('[data-automation-id="header-formName"]'));
+        expect(valueEl).toBeNull();
+    });
 });

--- a/ng2-components/ng2-activiti-tasklist/src/components/activiti-task-header.component.ts
+++ b/ng2-components/ng2-activiti-tasklist/src/components/activiti-task-header.component.ts
@@ -33,6 +33,9 @@ export class ActivitiTaskHeader implements OnChanges {
     @Input()
     taskDetails: TaskDetailsModel;
 
+    @Input()
+    propertyNames: string [] = ['status', 'due_date', 'category', 'created_by', 'created', 'id', 'description', 'form_name'];
+
     @Output()
     claim: EventEmitter<any> = new EventEmitter<any>();
 
@@ -52,23 +55,42 @@ export class ActivitiTaskHeader implements OnChanges {
 
     refreshData() {
         if (this.taskDetails) {
-            this.properties = [
-                new CardViewModel({label: 'Status:', value: this.getTaskStatus(), key: 'status'}),
-                new CardViewModel({label: 'Due Date:', value: this.taskDetails.dueDate, format: 'MMM DD YYYY', key: 'dueDate', default: 'No date'}),
-                new CardViewModel({label: 'Category:', value: this.taskDetails.category, key: 'category', default: 'No category'}),
-                new CardViewModel(
-                    {
-                        label: 'Created By:',
-                        value: this.taskDetails.getFullName(),
-                        key: 'assignee',
-                        default: 'No assignee'
-                    }),
-                new CardViewModel({label: 'Created:', value: this.taskDetails.created, format: 'MMM DD YYYY', key: 'created'}),
-                new CardViewModel({label: 'Id:', value: this.taskDetails.id, key: 'id'}),
-                new CardViewModel({label: 'Description:', value: this.taskDetails.description, key: 'description', default: 'No description'}),
-                new CardViewModel({label: 'Form name:', value: this.formName, key: 'formName', default: 'No form'})
-            ];
+            this.propertyNames.forEach( propertyName => {
+                let property: CardViewModel = this.createProperty(propertyName);
+                if (this.properties) {
+                    this.properties.push(property);
+                } else {
+                    this.properties = [property];
+                }
+            });
         }
+    }
+
+    private createProperty(propertyName: string): CardViewModel {
+        let property: CardViewModel;
+        if (propertyName === 'status') {
+            property = new CardViewModel({label: 'Status:', value: this.getTaskStatus(), key: 'status'});
+        } else if (propertyName === 'due_date') {
+            property = new CardViewModel({label: 'Due Date:', value: this.taskDetails.dueDate, format: 'MMM DD YYYY', key: 'dueDate', default: 'No date'});
+        } else if (propertyName === 'category') {
+            property = new CardViewModel({label: 'Category:', value: this.taskDetails.category, key: 'category', default: 'No category'});
+        } else if (propertyName === 'created_by') {
+            property = new CardViewModel({
+                    label: 'Created By:',
+                    value: this.taskDetails.getFullName(),
+                    key: 'assignee',
+                    default: 'No assignee'
+                });
+        } else if (propertyName === 'created') {
+            property = new CardViewModel({label: 'Created:', value: this.taskDetails.created, format: 'MMM DD YYYY', key: 'created'});
+        } else if (propertyName === 'id') {
+            property = new CardViewModel({label: 'Id:', value: this.taskDetails.id, key: 'id'});
+        } else if (propertyName === 'description') {
+            property = new CardViewModel({label: 'Description:', value: this.taskDetails.description, key: 'description', default: 'No description'});
+        } else if (propertyName === 'form_name') {
+            property = new CardViewModel({label: 'Form name:', value: this.formName, key: 'formName', default: 'No form'});
+        }
+        return property;
     }
 
     public hasAssignee(): boolean {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
[x] Tests for the changes have been added (for bug fixes / features)
[x] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behaviour?** (You can also link to an open issue here)

There is no way to customise the properties displayed as part of task header.

**What is the new behaviour?**

Added a new input to pass the array of property names to be displayed.

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[x] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
