### PR TITLE
[ADF-778] cancel window for upload dialog shows only on complete

### DIFF
--- a/ng2-components/ng2-alfresco-upload/src/components/file-uploading-dialog.component.html
+++ b/ng2-components/ng2-alfresco-upload/src/components/file-uploading-dialog.component.html
@@ -9,7 +9,7 @@
                 <i class="material-icons up" title="expand upload list">keyboard_arrow_up</i>
             </div>
 
-            <div *ngIf="canCloseDialogWindow" id="button-close-upload-list" class="close-button" (click)="toggleVisible()" (keyup.enter)="toggleVisible()" tabindex="0" title="close upload list">
+            <div *ngIf="showCloseButton" id="button-close-upload-list" class="close-button" (click)="toggleVisible()" (keyup.enter)="toggleVisible()" tabindex="0" title="close upload list">
                 <i class="material-icons">clear</i>
             </div>
         </div>

--- a/ng2-components/ng2-alfresco-upload/src/components/file-uploading-dialog.component.html
+++ b/ng2-components/ng2-alfresco-upload/src/components/file-uploading-dialog.component.html
@@ -9,7 +9,7 @@
                 <i class="material-icons up" title="expand upload list">keyboard_arrow_up</i>
             </div>
 
-            <div *ngIf="canCloseDialogWindow" class="close-button" (click)="toggleVisible()" (keyup.enter)="toggleVisible()" tabindex="0" title="close upload list">
+            <div *ngIf="canCloseDialogWindow" id="button-close-upload-list" class="close-button" (click)="toggleVisible()" (keyup.enter)="toggleVisible()" tabindex="0" title="close upload list">
                 <i class="material-icons">clear</i>
             </div>
         </div>

--- a/ng2-components/ng2-alfresco-upload/src/components/file-uploading-dialog.component.html
+++ b/ng2-components/ng2-alfresco-upload/src/components/file-uploading-dialog.component.html
@@ -9,7 +9,7 @@
                 <i class="material-icons up" title="expand upload list">keyboard_arrow_up</i>
             </div>
 
-            <div class="close-button" (click)="toggleVisible()" (keyup.enter)="toggleVisible()" tabindex="0" title="close upload list">
+            <div *ngIf="canCloseDialogWindow" class="close-button" (click)="toggleVisible()" (keyup.enter)="toggleVisible()" tabindex="0" title="close upload list">
                 <i class="material-icons">clear</i>
             </div>
         </div>

--- a/ng2-components/ng2-alfresco-upload/src/components/file-uploading-dialog.component.spec.ts
+++ b/ng2-components/ng2-alfresco-upload/src/components/file-uploading-dialog.component.spec.ts
@@ -123,7 +123,7 @@ describe('FileUploadingDialogComponent', () => {
         uploadService.fileUpload.next(new FileUploadCompleteEvent(file, 1, { status: FileUploadStatus.Complete }, 0));
     }));
 
-    fit('should show the close button when the file upload is in error', async(() => {
+    it('should show the close button when the file upload is in error', async(() => {
         component.isDialogActive = true;
         fixture.detectChanges();
         fixture.whenStable().then(() => {
@@ -134,7 +134,7 @@ describe('FileUploadingDialogComponent', () => {
         uploadService.fileUpload.next(new FileUploadEvent(file, FileUploadStatus.Error));
     }));
 
-    fit('should show the close button when the file upload is cancelled', async(() => {
+    it('should show the close button when the file upload is cancelled', async(() => {
         component.isDialogActive = true;
         fixture.detectChanges();
         fixture.whenStable().then(() => {

--- a/ng2-components/ng2-alfresco-upload/src/components/file-uploading-dialog.component.spec.ts
+++ b/ng2-components/ng2-alfresco-upload/src/components/file-uploading-dialog.component.spec.ts
@@ -22,8 +22,8 @@ import { CoreModule } from 'ng2-alfresco-core';
 import { FileUploadingDialogComponent } from './file-uploading-dialog.component';
 import { FileUploadingListComponent } from './file-uploading-list.component';
 import { UploadService } from '../services/upload.service';
-import { FileModel } from '../models/file.model';
-import { FileUploadCompleteEvent } from '../events/file.event';
+import { FileModel, FileUploadStatus } from '../models/file.model';
+import { FileUploadCompleteEvent, FileUploadEvent } from '../events/file.event';
 
 describe('FileUploadingDialogComponent', () => {
 
@@ -110,4 +110,38 @@ describe('FileUploadingDialogComponent', () => {
 
         expect(element.querySelector('.minimize-button').getAttribute('class')).toEqual('minimize-button active');
     });
+
+    it('should show the close button when the file upload is completed', async(() => {
+        component.isDialogActive = true;
+        uploadService.addToQueue(new FileModel(<File> { name: 'file' }));
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+            let closeButton = element.querySelector('#button-close-upload-list');
+            expect(closeButton).not.toBeNull();
+        });
+
+        uploadService.fileUpload.next(new FileUploadCompleteEvent(file, 1, { status: FileUploadStatus.Complete }, 0));
+    }));
+
+    fit('should show the close button when the file upload is in error', async(() => {
+        component.isDialogActive = true;
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+            let closeButton = element.querySelector('#button-close-upload-list');
+            expect(closeButton).not.toBeNull();
+        });
+
+        uploadService.fileUpload.next(new FileUploadEvent(file, FileUploadStatus.Error));
+    }));
+
+    fit('should show the close button when the file upload is cancelled', async(() => {
+        component.isDialogActive = true;
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+            let closeButton = element.querySelector('#button-close-upload-list');
+            expect(closeButton).not.toBeNull();
+        });
+
+        uploadService.fileUpload.next(new FileUploadEvent(file, FileUploadStatus.Cancelled));
+    }));
 });

--- a/ng2-components/ng2-alfresco-upload/src/components/file-uploading-dialog.component.ts
+++ b/ng2-components/ng2-alfresco-upload/src/components/file-uploading-dialog.component.ts
@@ -39,7 +39,7 @@ export class FileUploadingDialogComponent implements OnInit, OnDestroy {
 
     private listSubscription: any;
     private counterSubscription: any;
-    private canCloseDialogWindow: boolean = false;
+    private showCloseButton: boolean = false;
 
     constructor(private cd: ChangeDetectorRef,
                 translateService: AlfrescoTranslationService,
@@ -57,7 +57,7 @@ export class FileUploadingDialogComponent implements OnInit, OnDestroy {
                 this.isDialogActive = true;
                 this.cd.detectChanges();
             }
-            this.canCloseDialogWindow = false;
+            this.showCloseButton = false;
         });
 
         this.counterSubscription = this.uploadService.fileUploadComplete.subscribe((event: FileUploadCompleteEvent) => {
@@ -68,7 +68,7 @@ export class FileUploadingDialogComponent implements OnInit, OnDestroy {
             this.cd.detectChanges();
         });
 
-        this.uploadService.fileUpload.subscribe(event => {
+        this.uploadService.fileUpload.subscribe((event: FileUploadCompleteEvent) => {
             if (event.status !== FileUploadStatus.Progress) {
                 this.isUploadProcessCompleted(event);
             }
@@ -100,14 +100,14 @@ export class FileUploadingDialogComponent implements OnInit, OnDestroy {
 
     private isUploadProcessCompleted(event: FileUploadCompleteEvent) {
         if (this.isAllFileUploadEnded(event) && this.isUploadStateCompleted(event.status)) {
-            this.showCloseButton();
+            this.showCloseDialogButton();
         } else if (event.status === FileUploadStatus.Error || event.status === FileUploadStatus.Cancelled) {
-            this.showCloseButton();
+            this.showCloseDialogButton();
         }
     }
 
-    private showCloseButton() {
-        this.canCloseDialogWindow = true;
+    private showCloseDialogButton() {
+        this.showCloseButton = true;
     }
 
     private isAllFileUploadEnded(event: FileUploadCompleteEvent) {

--- a/ng2-components/ng2-alfresco-upload/src/events/file.event.ts
+++ b/ng2-components/ng2-alfresco-upload/src/events/file.event.ts
@@ -29,7 +29,7 @@ export class FileUploadEvent {
 
 export class FileUploadCompleteEvent extends FileUploadEvent {
 
-    constructor(file: FileModel, public totalComplete: number = 0, public data?: any) {
+    constructor(file: FileModel, public totalComplete: number = 0, public data?: any, public totalAborted: number = 0) {
         super(file, FileUploadStatus.Complete);
     }
 

--- a/ng2-components/ng2-alfresco-upload/src/services/upload.service.spec.ts
+++ b/ng2-components/ng2-alfresco-upload/src/services/upload.service.spec.ts
@@ -48,15 +48,15 @@ describe('UploadService', () => {
     });
 
     it('should add an element in the queue and returns it', () => {
-        let filesFake = new FileModel(<File>{name: 'fake-name', size: 10});
+        let filesFake = new FileModel(<File>{ name: 'fake-name', size: 10 });
         service.addToQueue(filesFake);
         expect(service.getQueue().length).toEqual(1);
     });
 
     it('should add two elements in the queue and returns them', () => {
         let filesFake = [
-            new FileModel(<File>{name: 'fake-name', size: 10}),
-            new FileModel(<File>{name: 'fake-name2', size: 20})
+            new FileModel(<File>{ name: 'fake-name', size: 10 }),
+            new FileModel(<File>{ name: 'fake-name2', size: 20 })
         ];
         service.addToQueue(...filesFake);
         expect(service.getQueue().length).toEqual(2);
@@ -78,7 +78,7 @@ describe('UploadService', () => {
             done();
         });
         let fileFake = new FileModel(
-            <File>{name: 'fake-name', size: 10},
+            <File>{ name: 'fake-name', size: 10 },
             <FileUploadOptions> { parentId: '-root-', path: 'fake-dir' }
         );
         service.addToQueue(fileFake);
@@ -103,7 +103,7 @@ describe('UploadService', () => {
             done();
         });
         let fileFake = new FileModel(
-            <File>{name: 'fake-name', size: 10},
+            <File>{ name: 'fake-name', size: 10 },
             <FileUploadOptions> { parentId: '-root-' }
         );
         service.addToQueue(fileFake);
@@ -125,7 +125,7 @@ describe('UploadService', () => {
             expect(e.value).toEqual('File aborted');
             done();
         });
-        let fileFake = new FileModel(<File>{name: 'fake-name', size: 10});
+        let fileFake = new FileModel(<File>{ name: 'fake-name', size: 10 });
         service.addToQueue(fileFake);
         service.uploadFilesInTheQueue(emitter);
 
@@ -136,7 +136,7 @@ describe('UploadService', () => {
     it('If versioning is true autoRename should not be present and majorVersion should be a param', () => {
         let emitter = new EventEmitter();
 
-        const filesFake = new FileModel(<File>{name: 'fake-name', size: 10}, { newVersion: true });
+        const filesFake = new FileModel(<File>{ name: 'fake-name', size: 10 }, { newVersion: true });
         service.addToQueue(filesFake);
         service.uploadFilesInTheQueue(emitter);
 
@@ -152,7 +152,7 @@ describe('UploadService', () => {
             done();
         });
         let filesFake = new FileModel(
-            <File>{name: 'fake-name', size: 10},
+            <File>{ name: 'fake-name', size: 10 },
             <FileUploadOptions> { parentId: '123', path: 'fake-dir' }
         );
         service.addToQueue(filesFake);
@@ -167,5 +167,27 @@ describe('UploadService', () => {
             contentType: 'text/plain',
             responseText: 'File uploaded'
         });
+    });
+
+    it('should start downloading the next one if a file of the list is aborted', (done) => {
+        let emitter = new EventEmitter();
+
+        service.fileUploadAborted.subscribe(e => {
+            expect(e).not.toBeNull();
+        });
+
+        service.fileUploadCancelled.subscribe(e => {
+            expect(e).not.toBeNull();
+            done();
+        });
+
+        let fileFake1 = new FileModel(<File>{ name: 'fake-name1', size: 10 });
+        let fileFake2 = new FileModel(<File>{ name: 'fake-name2', size: 10 });
+        let filelist = [fileFake1, fileFake2];
+        service.addToQueue(...filelist);
+        service.uploadFilesInTheQueue(emitter);
+
+        let file = service.getQueue();
+        service.cancelUpload(...file);
     });
 });

--- a/ng2-components/ng2-alfresco-upload/src/services/upload.service.ts
+++ b/ng2-components/ng2-alfresco-upload/src/services/upload.service.ts
@@ -27,6 +27,7 @@ export class UploadService {
     private queue: FileModel[] = [];
     private cache: { [key: string]: any } = {};
     private totalComplete: number = 0;
+    private totalAborted: number = 0;
     private activeTask: Promise<any> = null;
 
     queueChanged: Subject<FileModel[]> = new Subject<FileModel[]>();
@@ -98,6 +99,8 @@ export class UploadService {
                     setTimeout(() => this.uploadFilesInTheQueue(emitter), 100);
                 };
 
+                promise.next = next;
+
                 promise.then(
                     () => next(),
                     () => next()
@@ -120,6 +123,12 @@ export class UploadService {
             this.fileUpload.next(event);
             this.fileUploadCancelled.next(event);
         });
+    }
+
+    clearQueue(){
+        this.queue = [];
+        this.totalComplete = 0;
+        this.totalAborted = 0;
     }
 
     private beginUpload(file: FileModel, /* @deprecated */emitter: EventEmitter<any>): any {
@@ -209,7 +218,7 @@ export class UploadService {
                 delete this.cache[file.id];
             }
 
-            const event = new FileUploadCompleteEvent(file, this.totalComplete, data);
+            const event = new FileUploadCompleteEvent(file, this.totalComplete, data, this.totalAborted);
             this.fileUpload.next(event);
             this.fileUploadComplete.next(event);
 
@@ -220,6 +229,7 @@ export class UploadService {
     private onUploadAborted(file: FileModel): void {
         if (file) {
             file.status = FileUploadStatus.Aborted;
+            this.totalAborted++;
 
             const promise = this.cache[file.id];
             if (promise) {
@@ -229,6 +239,7 @@ export class UploadService {
             const event = new FileUploadEvent(file, FileUploadStatus.Aborted);
             this.fileUpload.next(event);
             this.fileUploadAborted.next(event);
+            promise.next();
         }
     }
 }

--- a/ng2-components/ng2-alfresco-upload/src/services/upload.service.ts
+++ b/ng2-components/ng2-alfresco-upload/src/services/upload.service.ts
@@ -125,7 +125,7 @@ export class UploadService {
         });
     }
 
-    clearQueue(){
+    clearQueue() {
         this.queue = [];
         this.totalComplete = 0;
         this.totalAborted = 0;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
```
[ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
[ ] Tests for the changes have been added (for bug fixes / features)
[ ] Docs have been added / updated (for bug fixes / features)
```
<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] Documentation
[ ] Other... Please describe:
```

**What is the current behaviour?** (You can also link to an open issue here)
Close button is always showed for upload dialog.
Upload dialog list is never cleared.


**What is the new behaviour?**
Upload dialog close button is showed on : Complete, Error and cancel.
When user close the dialog the list is deleted.


**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ ] No
```

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
