### PR TITLE
[ADF - 334] Added prefix to amount widget

### DIFF
--- a/ng2-components/ng2-activiti-form/index.ts
+++ b/ng2-components/ng2-activiti-form/index.ts
@@ -16,7 +16,7 @@
  */
 
 import { NgModule, ModuleWithProviders } from '@angular/core';
-import { MdCheckboxModule, MdTabsModule, MdCardModule, MdButtonModule, MdIconModule, MdSlideToggleModule } from '@angular/material';
+import { MdCheckboxModule, MdTabsModule, MdCardModule, MdButtonModule, MdIconModule, MdSlideToggleModule, MdInputModule } from '@angular/material';
 import { CoreModule } from 'ng2-alfresco-core';
 
 import { ActivitiForm } from './src/components/activiti-form.component';
@@ -71,7 +71,8 @@ export const ACTIVITI_FORM_PROVIDERS: any[] = [
         MdCardModule,
         MdButtonModule,
         MdIconModule,
-        MdSlideToggleModule
+        MdSlideToggleModule,
+        MdInputModule
     ],
     declarations: [
         ...ACTIVITI_FORM_DIRECTIVES,
@@ -90,7 +91,8 @@ export const ACTIVITI_FORM_PROVIDERS: any[] = [
         MdCardModule,
         MdButtonModule,
         MdIconModule,
-        MdSlideToggleModule
+        MdSlideToggleModule,
+        MdInputModule
     ]
 })
 export class ActivitiFormModule {

--- a/ng2-components/ng2-activiti-form/src/components/activiti-start-form.component.spec.ts
+++ b/ng2-components/ng2-activiti-form/src/components/activiti-start-form.component.spec.ts
@@ -30,6 +30,7 @@ import { EcmModelService } from './../services/ecm-model.service';
 import { WidgetVisibilityService } from './../services/widget-visibility.service';
 import { AlfrescoTranslationService, CoreModule } from 'ng2-alfresco-core';
 import { TranslationMock } from './../assets/translation.service.mock';
+import { MdInputModule } from '@angular/material';
 
 describe('ActivitiStartForm', () => {
 
@@ -46,6 +47,7 @@ describe('ActivitiStartForm', () => {
         TestBed.configureTestingModule({
             imports: [
                 MdTabsModule,
+                MdInputModule,
                 CoreModule.forRoot()],
             declarations: [
                 ActivitiStartForm,

--- a/ng2-components/ng2-activiti-form/src/components/widgets/amount/amount.widget.css
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/amount/amount.widget.css
@@ -25,13 +25,32 @@
     width: 100%;
 }
 
-.cutomize-spacing {
+.amount-widget__input .mat-focused {
+    transition: none;
+}
+
+.amount-widget__error_message {
+    color: #d50000;
+    position: absolute;
+    font-size: 12px;
+    margin-top: 3px;
+    display: block;
     padding-top: 3px;
 }
 
 md-input-container >>> .mat-input-wrapper {
     margin-top: 0px;
     padding-top: 4px;
+}
+
+md-input-container >>> .mat-input-ripple {
+    transition: none;
+    visibility: hidden;
+}
+
+md-input-container.mat-focused >>> .mat-input-underline .mat-input-ripple {
+    visibility: hidden;
+    transition: none;
 }
 
 .amount-widget__invalid .mdl-textfield__input {
@@ -44,8 +63,4 @@ md-input-container >>> .mat-input-wrapper {
 
 .amount-widget__invalid .mdl-textfield__label:after {
     background-color: #d50000;
-}
-
-.amount-widget__invalid .mdl-textfield__error {
-    visibility: visible !important;
 }

--- a/ng2-components/ng2-activiti-form/src/components/widgets/amount/amount.widget.css
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/amount/amount.widget.css
@@ -2,6 +2,37 @@
     width: 100%;
 }
 
+.amount-widget__container {
+    position: relative;
+    font-size: 16px;
+    display: inline-block;
+    box-sizing: border-box;
+    width: 300px;
+    max-width: 100%;
+    margin: 0;
+    padding: 20px 0;
+}
+
+.adf-amount-widget {
+    vertical-align: baseline !important;
+}
+
+.adf-amount-widget__prefix-spacing {
+    padding-right: 5px;
+}
+
+:host() .amount-widget__input {
+    width: 100%;
+}
+
+.cutomize-spacing {
+    padding-top: 3px;
+}
+
+md-input-container >>> .mat-input-wrapper {
+    margin-top: 0px;
+    padding-top: 4px;
+}
 
 .amount-widget__invalid .mdl-textfield__input {
     border-color: #d50000;

--- a/ng2-components/ng2-activiti-form/src/components/widgets/amount/amount.widget.html
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/amount/amount.widget.html
@@ -3,7 +3,7 @@
     <div>
         <label>{{field.name}} <span *ngIf="isRequired()">*</span></label>
     </div>
-    <md-input-container floatPlaceholder="never" color="" class="amount-widget__input">
+    <md-input-container floatPlaceholder="never" class="amount-widget__input">
         <span mdPrefix class="adf-amount-widget__prefix-spacing"> {{currency }}</span>
         <input mdInput
                 class="adf-amount-widget"
@@ -14,8 +14,8 @@
                 [(ngModel)]="field.value"
                 (ngModelChange)="checkVisibility(field)"
                 [disabled]="field.readOnly"
-                placeholder="{{field.placeholder}}"
-                hideRequiredMarker="true">
-    <span *ngIf="field.validationSummary" class="mdl-textfield__error cutomize-spacing">{{field.validationSummary}}</span>
+                placeholder="{{field.placeholder}}">
+        <span *ngIf="field.validationSummary" class="amount-widget__error_message">{{field.validationSummary}}</span>
     </md-input-container>
 </div>
+

--- a/ng2-components/ng2-activiti-form/src/components/widgets/amount/amount.widget.html
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/amount/amount.widget.html
@@ -1,14 +1,21 @@
-<div class="mdl-textfield mdl-js-textfield amount-widget {{field.className}}"
+<div class="amount-widget__container amount-widget {{field.className}}"
      [class.amount-widget__invalid]="!field.isValid">
-    <label [attr.for]="field.id">{{field.name}}, {{currency}}<span *ngIf="isRequired()">*</span></label>
-    <input class="mdl-textfield__input"
-           type="text"
-           [attr.id]="field.id"
-           [attr.required]="isRequired()"
-           [value]="field.value"
-           [(ngModel)]="field.value"
-           (ngModelChange)="checkVisibility(field)"
-           [disabled]="field.readOnly"
-           placeholder="{{field.placeholder}}">
-    <span *ngIf="field.validationSummary" class="mdl-textfield__error">{{field.validationSummary}}</span>
+    <div>
+        <label>{{field.name}} <span *ngIf="isRequired()">*</span></label>
+    </div>
+    <md-input-container floatPlaceholder="never" color="" class="amount-widget__input">
+        <span mdPrefix class="adf-amount-widget__prefix-spacing"> {{currency }}</span>
+        <input mdInput
+                class="adf-amount-widget"
+                type="text"
+                [attr.id]="field.id"
+                [attr.required]="isRequired()"
+                [value]="field.value"
+                [(ngModel)]="field.value"
+                (ngModelChange)="checkVisibility(field)"
+                [disabled]="field.readOnly"
+                placeholder="{{field.placeholder}}"
+                hideRequiredMarker="true">
+    <span *ngIf="field.validationSummary" class="mdl-textfield__error cutomize-spacing">{{field.validationSummary}}</span>
+    </md-input-container>
 </div>

--- a/ng2-components/ng2-activiti-form/src/components/widgets/amount/amount.widget.spec.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/amount/amount.widget.spec.ts
@@ -22,6 +22,7 @@ import { CoreModule } from 'ng2-alfresco-core';
 import { FormService } from './../../../services/form.service';
 import { EcmModelService } from './../../../services/ecm-model.service';
 import { ActivitiAlfrescoContentService } from '../../../services/activiti-alfresco.service';
+import { MdInputModule } from '@angular/material';
 
 describe('AmountWidget', () => {
 
@@ -31,7 +32,8 @@ describe('AmountWidget', () => {
     beforeEach(async(() => {
         TestBed.configureTestingModule({
             imports: [
-                CoreModule.forRoot()
+                CoreModule.forRoot(),
+                MdInputModule
             ],
             declarations: [
                 AmountWidget

--- a/ng2-components/ng2-activiti-form/src/components/widgets/container/container.widget.spec.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/container/container.widget.spec.ts
@@ -25,7 +25,7 @@ import { MASK_DIRECTIVE } from '../index';
 import { FormFieldComponent } from './../../form-field/form-field.component';
 import { ActivitiContent } from './../../activiti-content.component';
 import { fakeFormJson } from '../../../services/assets/widget-visibility.service.mock';
-import { MdTabsModule } from '@angular/material';
+import { MdTabsModule, MdInputModule } from '@angular/material';
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { CoreModule } from 'ng2-alfresco-core';
 import { FormService } from './../../../services/form.service';
@@ -45,7 +45,8 @@ describe('ContainerWidget', () => {
         TestBed.configureTestingModule({
             imports: [
                 CoreModule.forRoot(),
-                MdTabsModule
+                MdTabsModule,
+                MdInputModule
             ],
             declarations: [FormFieldComponent, ActivitiContent, WIDGET_DIRECTIVES, MASK_DIRECTIVE],
             providers: [

--- a/ng2-components/ng2-activiti-form/src/components/widgets/tabs/tabs.widget.spec.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/tabs/tabs.widget.spec.ts
@@ -26,7 +26,7 @@ import { MASK_DIRECTIVE } from '../index';
 import { FormFieldComponent } from './../../form-field/form-field.component';
 import { ActivitiContent } from './../../activiti-content.component';
 import { CoreModule } from 'ng2-alfresco-core';
-import { MdTabsModule } from '@angular/material';
+import { MdTabsModule, MdInputModule } from '@angular/material';
 
 describe('TabsWidget', () => {
 
@@ -105,7 +105,7 @@ describe('TabsWidget', () => {
 
         beforeEach(async(() => {
             TestBed.configureTestingModule({
-                imports: [CoreModule, MdTabsModule],
+                imports: [CoreModule, MdTabsModule, MdInputModule],
                 declarations: [FormFieldComponent, ActivitiContent, WIDGET_DIRECTIVES, MASK_DIRECTIVE]
             }).compileComponents().then(() => {
                 fixture = TestBed.createComponent(TabsWidget);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [X] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
amount widget uses material design ligth spec. The currency symbol is next to the label.

**What is the new behaviour?**
Migrated amount widget from mdl to new material design input
The currency symbol is put as prefix.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
