### PR TITLE
[ADF-733] Start Process - appId not mandatory

### DIFF
--- a/ng2-components/ng2-activiti-processlist/src/components/activiti-start-process.component.spec.ts
+++ b/ng2-components/ng2-activiti-processlist/src/components/activiti-start-process.component.spec.ts
@@ -78,12 +78,20 @@ describe('ActivitiStartProcessInstance', () => {
 
     describe('process definitions list', () => {
 
-        it('should call service to fetch process definitions', () => {
+        it('should call service to fetch process definitions with appId', () => {
             let change = new SimpleChange(null, '123', true);
             component.ngOnChanges({'appId': change});
             fixture.detectChanges();
 
-            expect(getDefinitionsSpy).toHaveBeenCalled();
+            expect(getDefinitionsSpy).toHaveBeenCalledWith('123');
+        });
+
+        it('should call service to fetch process definitions without appId', () => {
+            let change = new SimpleChange(null, null, true);
+            component.ngOnChanges({'appId': change});
+            fixture.detectChanges();
+
+            expect(getDefinitionsSpy).toHaveBeenCalledWith(null);
         });
 
         it('should call service to fetch process definitions with appId when provided', () => {
@@ -165,11 +173,6 @@ describe('ActivitiStartProcessInstance', () => {
         it('should reload processes when appId input changed to null', () => {
             component.ngOnChanges({appId: nullChange});
             expect(getDefinitionsSpy).toHaveBeenCalledWith(null);
-        });
-
-        it('should not reload processes when changes do not include appId input', () => {
-            component.ngOnChanges({});
-            expect(getDefinitionsSpy).not.toHaveBeenCalled();
         });
 
     });

--- a/ng2-components/ng2-activiti-processlist/src/components/activiti-start-process.component.ts
+++ b/ng2-components/ng2-activiti-processlist/src/components/activiti-start-process.component.ts
@@ -65,14 +65,12 @@ export class ActivitiStartProcessInstance implements OnChanges {
     }
 
     ngOnChanges(changes: SimpleChanges) {
-        let appId = changes['appId'];
-        if (appId && (appId.currentValue || appId.currentValue === null)) {
-            this.load(appId.currentValue);
-            return;
-        }
+        let appIdChange = changes['appId'];
+        let appId = appIdChange ? appIdChange.currentValue : null;
+        this.load(appId);
     }
 
-    public load(appId: string) {
+    public load(appId?: string) {
         this.resetSelectedProcessDefinition();
         this.resetErrorMessage();
         this.activitiProcess.getProcessDefinitions(appId).subscribe(


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
The loadProcess is not called when the appId is null
https://issues.alfresco.com/jira/browse/ADF-733

**What is the new behaviour?**
The loadProcess should be called when the appId is null


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
