### PR TITLE
[ADF-967] evaluate "hostname" and "port" for string settings

### DIFF
--- a/demo-shell-ng2/app.config-dev.json
+++ b/demo-shell-ng2/app.config-dev.json
@@ -1,6 +1,6 @@
 {
-    "ecmHost": "http://localhost:3000/ecm",
-    "bpmHost": "http://localhost:3000/bpm",
+    "ecmHost": "http://{hostname}:{port}/ecm",
+    "bpmHost": "http://{hostname}:{port}/bpm",
     "application": {
         "name": "Alfresco"
     }

--- a/demo-shell-ng2/app.config-prod.json
+++ b/demo-shell-ng2/app.config-prod.json
@@ -1,6 +1,6 @@
 {
-    "ecmHost": "http://localhost:3000/ecm",
-    "bpmHost": "http://localhost:3000/bpm",
+    "ecmHost": "http://{hostname}:{port}/ecm",
+    "bpmHost": "http://{hostname}:{port}/bpm",
     "application": {
         "name": "Alfresco"
     }

--- a/demo-shell-ng2/app.config-prod.json
+++ b/demo-shell-ng2/app.config-prod.json
@@ -1,6 +1,6 @@
 {
-    "ecmHost": "http://{hostname}:{port}/ecm",
-    "bpmHost": "http://{hostname}:{port}/bpm",
+    "ecmHost": "http://{hostname}",
+    "bpmHost": "http://{hostname}",
     "application": {
         "name": "Alfresco"
     }

--- a/ng2-components/ng2-activiti-analytics/src/components/analytics-report-list.component.spec.ts
+++ b/ng2-components/ng2-activiti-analytics/src/components/analytics-report-list.component.spec.ts
@@ -90,7 +90,7 @@ describe('AnalyticsReportListComponent', () => {
         });
 
         it('should return the default reports when the report list is empty', (done) => {
-            jasmine.Ajax.stubRequest('http://localhost:3000/bpm/activiti-app/app/rest/reporting/reports').andReturn({
+            jasmine.Ajax.stubRequest('http://localhost:9876/bpm/activiti-app/app/rest/reporting/reports').andReturn({
                 status: 200,
                 contentType: 'json',
                 responseText: []
@@ -98,13 +98,13 @@ describe('AnalyticsReportListComponent', () => {
 
             fixture.detectChanges();
 
-            jasmine.Ajax.stubRequest('http://localhost:3000/bpm/activiti-app/app/rest/reporting/default-reports').andReturn({
+            jasmine.Ajax.stubRequest('http://localhost:9876/bpm/activiti-app/app/rest/reporting/default-reports').andReturn({
                 status: 200,
                 contentType: 'json',
                 responseText: []
             });
 
-            jasmine.Ajax.stubRequest('http://localhost:3000/bpm/activiti-app/app/rest/reporting/reports').andReturn({
+            jasmine.Ajax.stubRequest('http://localhost:9876/bpm/activiti-app/app/rest/reporting/reports').andReturn({
                 status: 200,
                 contentType: 'json',
                 responseText: reportList

--- a/ng2-components/ng2-activiti-analytics/src/components/analytics-report-parameters.component.spec.ts
+++ b/ng2-components/ng2-activiti-analytics/src/components/analytics-report-parameters.component.spec.ts
@@ -295,13 +295,13 @@ describe('AnalyticsReportParametersComponent', () => {
                 done();
             });
 
-            jasmine.Ajax.stubRequest('http://localhost:3000/bpm/activiti-app/app/rest/reporting/report-params/1').andReturn({
+            jasmine.Ajax.stubRequest('http://localhost:9876/bpm/activiti-app/app/rest/reporting/report-params/1').andReturn({
                 status: 200,
                 contentType: 'json',
                 responseText: analyticParamsMock.reportDefParamProcessDef
             });
 
-            jasmine.Ajax.stubRequest('http://localhost:3000/bpm/activiti-app/app/rest/reporting/process-definitions').andReturn({
+            jasmine.Ajax.stubRequest('http://localhost:9876/bpm/activiti-app/app/rest/reporting/process-definitions').andReturn({
                 status: 200,
                 contentType: 'json',
                 responseText: analyticParamsMock.reportDefParamProcessDefOptionsNoApp
@@ -326,7 +326,7 @@ describe('AnalyticsReportParametersComponent', () => {
                 done();
             });
 
-            jasmine.Ajax.stubRequest('http://localhost:3000/bpm/activiti-app/app/rest/reporting/report-params/1').andReturn({
+            jasmine.Ajax.stubRequest('http://localhost:9876/bpm/activiti-app/app/rest/reporting/report-params/1').andReturn({
                 status: 200,
                 contentType: 'json',
                 responseText: analyticParamsMock.reportDefParamProcessDef
@@ -334,7 +334,7 @@ describe('AnalyticsReportParametersComponent', () => {
 
             let appId = '1';
 
-            jasmine.Ajax.stubRequest('http://localhost:3000/bpm/activiti-app/api/enterprise/process-definitions?appDefinitionId=' + appId).andReturn({
+            jasmine.Ajax.stubRequest('http://localhost:9876/bpm/activiti-app/api/enterprise/process-definitions?appDefinitionId=' + appId).andReturn({
                 status: 200,
                 contentType: 'json',
                 responseText: analyticParamsMock.reportDefParamProcessDefOptionsApp
@@ -392,13 +392,13 @@ describe('AnalyticsReportParametersComponent', () => {
                 done();
             });
 
-            jasmine.Ajax.stubRequest('http://localhost:3000/bpm/activiti-app/app/rest/reporting/report-params/1').andReturn({
+            jasmine.Ajax.stubRequest('http://localhost:9876/bpm/activiti-app/app/rest/reporting/report-params/1').andReturn({
                 status: 200,
                 contentType: 'json',
                 responseText: analyticParamsMock.reportDefParamProcessDef
             });
 
-            jasmine.Ajax.stubRequest('http://localhost:3000/bpm/activiti-app/app/rest/reporting/process-definitions').andReturn({
+            jasmine.Ajax.stubRequest('http://localhost:9876/bpm/activiti-app/app/rest/reporting/process-definitions').andReturn({
                 status: 404,
                 contentType: 'json',
                 responseText: []

--- a/ng2-components/ng2-activiti-form/src/services/form.service.spec.ts
+++ b/ng2-components/ng2-activiti-form/src/services/form.service.spec.ts
@@ -526,7 +526,7 @@ describe('Form service', () => {
 
             function stubCreateForm() {
                 jasmine.Ajax.stubRequest(
-                    'http://localhost:3000/bpm/activiti-app/api/enterprise/models'
+                    'http://localhost:9876/bpm/activiti-app/api/enterprise/models'
                 ).andReturn({
                     status: 200,
                     statusText: 'HTTP/1.1 200 OK',
@@ -537,7 +537,7 @@ describe('Form service', () => {
 
             function stubGetEcmModel() {
                 jasmine.Ajax.stubRequest(
-                    'http://localhost:3000/ecm/alfresco/api/-default-/private/alfresco/versions/1/cmm/activitiFormsModel/types'
+                    'http://localhost:9876/ecm/alfresco/api/-default-/private/alfresco/versions/1/cmm/activitiFormsModel/types'
                 ).andReturn({
                     status: 200,
                     statusText: 'HTTP/1.1 200 OK',
@@ -558,7 +558,7 @@ describe('Form service', () => {
 
             function stubAddFieldsToAForm() {
                 jasmine.Ajax.stubRequest(
-                    'http://localhost:3000/bpm/activiti-app/api/enterprise/editor/form-models/' + formId
+                    'http://localhost:9876/bpm/activiti-app/api/enterprise/editor/form-models/' + formId
                 ).andReturn({
                     status: 200,
                     statusText: 'HTTP/1.1 200 OK',

--- a/ng2-components/ng2-alfresco-core/README.md
+++ b/ng2-components/ng2-alfresco-core/README.md
@@ -354,6 +354,27 @@ if (process.env.ENV === 'production') {
 })
 ```
 
+### Variable substitution in configuration strings
+
+The `AppConfigService` also supports a limited set of variable substitutions to greatly simplify certain scenarios. 
+
+```json
+{
+    "ecmHost": "http://{hostname}:{port}/ecm",
+    "bpmHost": "http://{hostname}:{port}/bpm",
+    "application": {
+        "name": "Alfresco"
+    }
+}
+```
+
+The supported variables are:
+
+| Variable name | Runtime value |
+| --- | --- |
+| hostname | `location.hostname` |
+| port | `location.port` |
+
 ## Notification Service
 
 The Notification Service is implemented on top of the Angular 2 Material Design snackbar.

--- a/ng2-components/ng2-alfresco-core/src/services/alfresco-content.service.spec.ts
+++ b/ng2-components/ng2-alfresco-core/src/services/alfresco-content.service.spec.ts
@@ -83,7 +83,7 @@ describe('AlfrescoContentService', () => {
 
     it('should return a valid content URL', (done) => {
         authService.login('fake-username', 'fake-password').subscribe(() => {
-            expect(contentService.getContentUrl(node)).toBe('http://localhost:3000/ecm/alfresco/api/' +
+            expect(contentService.getContentUrl(node)).toBe('http://localhost:9876/ecm/alfresco/api/' +
                 '-default-/public/alfresco/versions/1/nodes/fake-node-id/content?attachment=false&alf_ticket=fake-post-ticket');
             done();
         });
@@ -98,7 +98,7 @@ describe('AlfrescoContentService', () => {
     it('should return a valid thumbnail URL', (done) => {
         authService.login('fake-username', 'fake-password').subscribe(() => {
             expect(contentService.getDocumentThumbnailUrl(node))
-                .toBe('http://localhost:3000/ecm/alfresco/api/-default-/public/alfresco' +
+                .toBe('http://localhost:9876/ecm/alfresco/api/-default-/public/alfresco' +
                     '/versions/1/nodes/fake-node-id/renditions/doclib/content?attachment=false&alf_ticket=fake-post-ticket');
             done();
         });

--- a/ng2-components/ng2-alfresco-core/src/services/app-config.service.ts
+++ b/ng2-components/ng2-alfresco-core/src/services/app-config.service.ts
@@ -42,7 +42,6 @@ export class AppConfigService {
             map.set('port', location.port);
             result = this.formatString(result, map);
         }
-        console.log(result);
         return <T> result;
     }
 
@@ -67,7 +66,6 @@ export class AppConfigService {
         let result = str;
 
         map.forEach((value, key) => {
-            console.log(`${key}:${value}`);
             const expr = new RegExp('{' + key + '}', 'gm');
             result = result.replace(expr, value);
         });

--- a/ng2-components/ng2-alfresco-core/src/services/app-config.service.ts
+++ b/ng2-components/ng2-alfresco-core/src/services/app-config.service.ts
@@ -23,8 +23,8 @@ import { ObjectUtils } from '../utils/object-utils';
 export class AppConfigService {
 
     private config: any = {
-        'ecmHost': 'http://localhost:3000/ecm',
-        'bpmHost': 'http://localhost:3000/bpm',
+        'ecmHost': 'http://{hostname}:{port}/ecm',
+        'bpmHost': 'http://{hostname}:{port}/bpm',
         'application': {
             'name': 'Alfresco'
         }
@@ -35,7 +35,15 @@ export class AppConfigService {
     constructor(private http: Http) {}
 
     get<T>(key: string): T {
-        return <T> ObjectUtils.getValue(this.config, key);
+        let result: any = ObjectUtils.getValue(this.config, key);
+        if (typeof result === 'string') {
+            const map = new Map<string, string>();
+            map.set('hostname', location.hostname);
+            map.set('port', location.port);
+            result = this.formatString(result, map);
+        }
+        console.log(result);
+        return <T> result;
     }
 
     load(resource: string = 'app.config.json'): Promise<any> {
@@ -53,6 +61,18 @@ export class AppConfigService {
                 }
             );
         });
+    }
+
+    private formatString(str: string, map: Map<string, string>): string {
+        let result = str;
+
+        map.forEach((value, key) => {
+            console.log(`${key}:${value}`);
+            const expr = new RegExp('{' + key + '}', 'gm');
+            result = result.replace(expr, value);
+        });
+
+        return result;
     }
 }
 

--- a/ng2-components/ng2-alfresco-core/src/services/renditions.service.spec.ts
+++ b/ng2-components/ng2-alfresco-core/src/services/renditions.service.spec.ts
@@ -71,7 +71,7 @@ describe('RenditionsService', () => {
     it('Create redition service should call the server with the ID passed and the asked encoding', (done) => {
         service.createRendition('fake-node-id', 'pdf').subscribe((res) => {
             expect(jasmine.Ajax.requests.mostRecent().method).toBe('POST');
-            expect(jasmine.Ajax.requests.mostRecent().url).toBe('http://localhost:3000/ecm/alfresco/api/-default-/public/alfresco/versions/1/nodes/fake-node-id/renditions');
+            expect(jasmine.Ajax.requests.mostRecent().url).toBe('http://localhost:9876/ecm/alfresco/api/-default-/public/alfresco/versions/1/nodes/fake-node-id/renditions');
             done();
         });
 
@@ -88,7 +88,7 @@ describe('RenditionsService', () => {
             service.convert('fake-node-id', 'pdf', 1000);
 
             expect(jasmine.Ajax.requests.mostRecent().method).toBe('POST');
-            expect(jasmine.Ajax.requests.mostRecent().url).toBe('http://localhost:3000/ecm/alfresco/api/-default-/public/alfresco/versions/1/nodes/fake-node-id/renditions');
+            expect(jasmine.Ajax.requests.mostRecent().url).toBe('http://localhost:9876/ecm/alfresco/api/-default-/public/alfresco/versions/1/nodes/fake-node-id/renditions');
             done();
         });
     });

--- a/ng2-components/ng2-alfresco-tag/src/components/tag-actions.component.spec.ts
+++ b/ng2-components/ng2-alfresco-tag/src/components/tag-actions.component.spec.ts
@@ -118,7 +118,7 @@ describe('Test ng2-alfresco-tag Tag actions list', () => {
                 deleteButton.click();
 
                 expect(jasmine.Ajax.requests.at(1).url)
-                    .toBe('http://localhost:3000/ecm/alfresco/api/-default-/public/alfresco/versions/1/nodes/fake-node-id/tags/0ee933fa-57fc-4587-8a77-b787e814f1d2');
+                    .toBe('http://localhost:9876/ecm/alfresco/api/-default-/public/alfresco/versions/1/nodes/fake-node-id/tags/0ee933fa-57fc-4587-8a77-b787e814f1d2');
                 expect(jasmine.Ajax.requests.at(1).method).toBe('DELETE');
 
                 jasmine.Ajax.requests.mostRecent().respondWith({

--- a/ng2-components/ng2-alfresco-tag/src/components/tag-node-list.component.spec.ts
+++ b/ng2-components/ng2-alfresco-tag/src/components/tag-node-list.component.spec.ts
@@ -117,7 +117,7 @@ describe('Test ng2-alfresco-tag Tag relative node list', () => {
                 deleteButton.click();
 
                 expect(jasmine.Ajax.requests.mostRecent().url).
-                toBe('http://localhost:3000/ecm/alfresco/api/-default-/public/alfresco/versions/1/nodes/fake-node-id/tags/0ee933fa-57fc-4587-8a77-b787e814f1d2');
+                toBe('http://localhost:9876/ecm/alfresco/api/-default-/public/alfresco/versions/1/nodes/fake-node-id/tags/0ee933fa-57fc-4587-8a77-b787e814f1d2');
                 expect(jasmine.Ajax.requests.mostRecent().method).toBe('DELETE');
 
                 jasmine.Ajax.requests.mostRecent().respondWith({

--- a/ng2-components/ng2-alfresco-tag/src/services/tag.service.spec.ts
+++ b/ng2-components/ng2-alfresco-tag/src/services/tag.service.spec.ts
@@ -54,7 +54,7 @@ describe('Tag service', () => {
             service.removeTag('fake-node-id', 'fake-tag').subscribe(() => {
                 expect(jasmine.Ajax.requests.mostRecent().method).toBe('DELETE');
                 expect(jasmine.Ajax.requests.mostRecent().url)
-                    .toBe('http://localhost:3000/ecm/alfresco/api/-default-/public/alfresco/versions/1/nodes/fake-node-id/tags/fake-tag');
+                    .toBe('http://localhost:9876/ecm/alfresco/api/-default-/public/alfresco/versions/1/nodes/fake-node-id/tags/fake-tag');
                 done();
             });
 
@@ -67,7 +67,7 @@ describe('Tag service', () => {
             service.addTag('fake-node-id', 'fake-tag').subscribe(() => {
                 expect(jasmine.Ajax.requests.mostRecent().method).toBe('POST');
                 expect(jasmine.Ajax.requests.mostRecent().url)
-                    .toBe('http://localhost:3000/ecm/alfresco/api/-default-/public/alfresco/versions/1/nodes/fake-node-id/tags');
+                    .toBe('http://localhost:9876/ecm/alfresco/api/-default-/public/alfresco/versions/1/nodes/fake-node-id/tags');
                 done();
             });
 
@@ -80,7 +80,7 @@ describe('Tag service', () => {
             service.getAllTheTags().subscribe(() => {
                 expect(jasmine.Ajax.requests.mostRecent().method).toBe('GET');
                 expect(jasmine.Ajax.requests.mostRecent().url)
-                    .toBe('http://localhost:3000/ecm/alfresco/api/-default-/public/alfresco/versions/1/tags');
+                    .toBe('http://localhost:9876/ecm/alfresco/api/-default-/public/alfresco/versions/1/tags');
                 done();
             });
 
@@ -93,7 +93,7 @@ describe('Tag service', () => {
             service.getTagsByNodeId('fake-node-id').subscribe(() => {
                 expect(jasmine.Ajax.requests.mostRecent().method).toBe('GET');
                 expect(jasmine.Ajax.requests.mostRecent().url)
-                    .toBe('http://localhost:3000/ecm/alfresco/api/-default-/public/alfresco/versions/1/nodes/fake-node-id/tags');
+                    .toBe('http://localhost:9876/ecm/alfresco/api/-default-/public/alfresco/versions/1/nodes/fake-node-id/tags');
                 done();
             });
 

--- a/ng2-components/ng2-alfresco-upload/src/services/upload.service.spec.ts
+++ b/ng2-components/ng2-alfresco-upload/src/services/upload.service.spec.ts
@@ -85,7 +85,7 @@ describe('UploadService', () => {
         service.uploadFilesInTheQueue(emitter);
 
         let request = jasmine.Ajax.requests.mostRecent();
-        expect(request.url).toBe('http://localhost:3000/ecm/alfresco/api/-default-/public/alfresco/versions/1/nodes/-root-/children?autoRename=true');
+        expect(request.url).toBe('http://localhost:9876/ecm/alfresco/api/-default-/public/alfresco/versions/1/nodes/-root-/children?autoRename=true');
         expect(request.method).toBe('POST');
 
         jasmine.Ajax.requests.mostRecent().respondWith({
@@ -109,7 +109,7 @@ describe('UploadService', () => {
         service.addToQueue(fileFake);
         service.uploadFilesInTheQueue(emitter);
         expect(jasmine.Ajax.requests.mostRecent().url)
-            .toBe('http://localhost:3000/ecm/alfresco/api/-default-/public/alfresco/versions/1/nodes/-root-/children?autoRename=true');
+            .toBe('http://localhost:9876/ecm/alfresco/api/-default-/public/alfresco/versions/1/nodes/-root-/children?autoRename=true');
 
         jasmine.Ajax.requests.mostRecent().respondWith({
             'status': 404,
@@ -159,7 +159,7 @@ describe('UploadService', () => {
         service.uploadFilesInTheQueue(emitter);
 
         let request = jasmine.Ajax.requests.mostRecent();
-        expect(request.url).toBe('http://localhost:3000/ecm/alfresco/api/-default-/public/alfresco/versions/1/nodes/123/children?autoRename=true');
+        expect(request.url).toBe('http://localhost:9876/ecm/alfresco/api/-default-/public/alfresco/versions/1/nodes/123/children?autoRename=true');
         expect(request.method).toBe('POST');
 
         jasmine.Ajax.requests.mostRecent().respondWith({

--- a/ng2-components/ng2-alfresco-webscript/src/webscript.component.spec.ts
+++ b/ng2-components/ng2-alfresco-webscript/src/webscript.component.spec.ts
@@ -87,7 +87,7 @@ describe('Test ng2-alfresco-webscript', () => {
 
             component.ngOnChanges(null).then(() => {
                 fixture.detectChanges();
-                expect(jasmine.Ajax.requests.mostRecent().url).toBe('http://localhost:3000/ecm/alfresco/service/sample/folder/Company%20Home');
+                expect(jasmine.Ajax.requests.mostRecent().url).toBe('http://localhost:9876/ecm/alfresco/service/sample/folder/Company%20Home');
                 done();
             });
 


### PR DESCRIPTION
Provides ability for AppConfigService to evaluate "hostname" and "port" variables within string values