### PR TITLE
[ADF-957] removed double call to load form

### DIFF
--- a/ng2-components/ng2-activiti-form/src/components/activiti-form.component.spec.ts
+++ b/ng2-components/ng2-activiti-form/src/components/activiti-form.component.spec.ts
@@ -60,12 +60,6 @@ describe('ActivitiForm', () => {
         expect(formComponent.setupMaterialComponents()).toBeFalsy();
     });
 
-    it('should start loading form on init', () => {
-        spyOn(formComponent, 'loadForm').and.stub();
-        formComponent.ngOnInit();
-        expect(formComponent.loadForm).toHaveBeenCalled();
-    });
-
     it('should check form', () => {
         expect(formComponent.hasForm()).toBeFalsy();
         formComponent.form = new FormModel();
@@ -732,8 +726,8 @@ describe('ActivitiForm', () => {
         spyOn(formComponent, 'loadFormFromActiviti').and.stub();
 
         const nodeId = '<id>';
-        formComponent.nodeId = nodeId;
-        formComponent.ngOnInit();
+        let change = new SimpleChange(null, nodeId, false);
+        formComponent.ngOnChanges({'nodeId' : change});
 
         expect(nodeService.getNodeMetadata).toHaveBeenCalledWith(nodeId);
         expect(formComponent.loadFormFromActiviti).toHaveBeenCalled();

--- a/ng2-components/ng2-activiti-form/src/components/activiti-form.component.ts
+++ b/ng2-components/ng2-activiti-form/src/components/activiti-form.component.ts
@@ -169,12 +169,6 @@ export class ActivitiForm implements OnInit, AfterViewChecked, OnChanges {
         this.formService.formContentClicked.subscribe((content: ContentLinkModel) => {
             this.formContentClicked.emit(content);
         });
-
-        if (this.nodeId) {
-            this.loadFormForEcmNode();
-        } else {
-            this.loadForm();
-        }
     }
 
     ngAfterViewChecked() {
@@ -202,7 +196,7 @@ export class ActivitiForm implements OnInit, AfterViewChecked, OnChanges {
 
         let nodeId = changes['nodeId'];
         if (nodeId && nodeId.currentValue) {
-            this.loadFormForEcmNode();
+            this.loadFormForEcmNode(nodeId.currentValue);
             return;
         }
 
@@ -439,8 +433,8 @@ export class ActivitiForm implements OnInit, AfterViewChecked, OnChanges {
         this.onFormDataRefreshed(this.form);
     }
 
-    private loadFormForEcmNode(): void {
-        this.nodeService.getNodeMetadata(this.nodeId).subscribe(data => {
+    private loadFormForEcmNode(nodeId: string): void {
+        this.nodeService.getNodeMetadata(nodeId).subscribe(data => {
                 this.data = data.metadata;
                 this.loadFormFromActiviti(data.nodeType);
             },

--- a/ng2-components/ng2-activiti-form/src/components/adf-form-list.component.spec.ts
+++ b/ng2-components/ng2-activiti-form/src/components/adf-form-list.component.spec.ts
@@ -70,7 +70,7 @@ describe('TaskAttachmentList', () => {
 
     }));
 
-    fit('should show the forms as a list', async(() => {
+    it('should show the forms as a list', async(() => {
         spyOn(service, 'getForms').and.returnValue(Observable.of([
             { name: 'FakeName-1', lastUpdatedByFullName: 'FakeUser-1', lastUpdated: '2017-01-02' },
             { name: 'FakeName-2', lastUpdatedByFullName: 'FakeUser-2', lastUpdated: '2017-01-03' }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
The form is loaded twice and causing double call to all the rest dropdown.


**What is the new behaviour?**
The form is loaded onChanges only.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
