### PR TITLE
[ADF-939] Make the login component responsive again (now the height)

### DIFF
--- a/demo-shell-ng2/app/components/login/login-demo.component.css
+++ b/demo-shell-ng2/app/components/login/login-demo.component.css
@@ -16,8 +16,8 @@
 }
 
 .toggle {
-    width: 120px;
-    margin: 20px;
+    width: 190px;
+    margin: 5px;
     padding: 5px;
 }
 

--- a/demo-shell-ng2/app/components/login/login-demo.component.html
+++ b/demo-shell-ng2/app/components/login/login-demo.component.html
@@ -21,6 +21,12 @@
             <span class="mdl-switch__label">CSRF</span>
         </label>
     </p>
+    <p class="toggle">
+        <label for="switch4" class="mdl-switch mdl-js-switch mdl-js-ripple-effect">
+            <input type="checkbox" id="switch4" class="mdl-switch__input" [checked]="showFooter" (click)="showFooter = !showFooter">
+            <span class="mdl-switch__label">Login footer</span>
+        </label>
+    </p>
 </div>
 
 <!--SETTING BUTTON-->
@@ -34,6 +40,8 @@
                 [providers]="providers"
                 [fieldsValidation]="customValidation"
                 [disableCsrf]="disableCsrf"
+                [showLoginActions]="showFooter"
+                [showRememberMe]="showFooter"
                 (onSuccess)="onLogin($event)"
                 (onError)="onError($event)">
     <div class="mobile-settings">
@@ -55,6 +63,12 @@
             <label for="switch3-mobile" class="mdl-switch mdl-js-switch mdl-js-ripple-effect">
                 <input type="checkbox" id="switch3-mobile" class="mdl-switch__input" [checked]="!disableCsrf" (click)="toggleCSRF()">
                 <span class="mdl-switch__label">CSRF</span>
+            </label>
+        </p>
+        <p>
+            <label for="switch4-mobile" class="mdl-switch mdl-js-switch mdl-js-ripple-effect">
+                <input type="checkbox" id="switch4-mobile" class="mdl-switch__input" [checked]="showFooter" (click)="showFooter = !showFooter">
+                <span class="mdl-switch__label">Login footer</span>
             </label>
         </p>
     </div>

--- a/demo-shell-ng2/app/components/login/login-demo.component.ts
+++ b/demo-shell-ng2/app/components/login/login-demo.component.ts
@@ -36,6 +36,7 @@ export class LoginDemoComponent implements OnInit {
     disableCsrf: boolean = false;
     isECM: boolean = true;
     isBPM: boolean = false;
+    showFooter: boolean = true;
     customMinLenght: number = 2;
 
     constructor(private router: Router,

--- a/ng2-components/ng2-alfresco-login/src/components/alfresco-login.component.css
+++ b/ng2-components/ng2-alfresco-login/src/components/alfresco-login.component.css
@@ -42,7 +42,6 @@
     box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.24), 0 0 2px 0 rgba(0, 0, 0, 0.12);
     width: 450px;
     min-width: 350px;
-    min-height: 450px;
     padding: 21px 64px 34px 64px;
     box-sizing: border-box;
 }

--- a/ng2-components/ng2-alfresco-login/src/components/alfresco-login.component.html
+++ b/ng2-components/ng2-alfresco-login/src/components/alfresco-login.component.html
@@ -85,7 +85,7 @@
                     <md-checkbox class="rememberme-cb" [checked]="rememberMe" (change)="rememberMe = !rememberMe">{{ 'LOGIN.LABEL.REMEMBER' | translate }}</md-checkbox>
                 </div>
             </div>
-            <div class="mdl-card__actions mdl-card--border mdl-card__link">
+            <div *ngIf="footerTemplate || showLoginActions" class="mdl-card__actions mdl-card--border mdl-card__link">
 
                 <!--FOOTER TEMPLATE-->
                 <ng-template *ngIf="footerTemplate"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Login component didn't shrink when the loginActions or the footerTemplate are disabled.


**What is the new behaviour?**
Now the login box consumes only that much space, which is absolutely needed.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
