### PR TITLE
[ADF-971] Create task/process attachment should show the new button

### DIFF
--- a/demo-shell-ng2/app/components/activiti/activiti-process-attachments.component.css
+++ b/demo-shell-ng2/app/components/activiti/activiti-process-attachments.component.css
@@ -1,0 +1,3 @@
+adf-create-process-attachment >>> button {
+    float: right;
+}

--- a/demo-shell-ng2/app/components/activiti/activiti-process-attachments.component.html
+++ b/demo-shell-ng2/app/components/activiti/activiti-process-attachments.component.html
@@ -13,7 +13,7 @@
 
         <adf-create-process-attachment
             [processInstanceId]="processId"
-            (contentCreated)="onFileUploadComplete($event)">
+            (success)="onFileUploadComplete($event)">
         </adf-create-process-attachment>
 
     </div>

--- a/demo-shell-ng2/app/components/activiti/activiti-process-attachments.component.ts
+++ b/demo-shell-ng2/app/components/activiti/activiti-process-attachments.component.ts
@@ -22,6 +22,7 @@ import { UploadService } from 'ng2-alfresco-core';
 @Component({
     selector: 'activiti-process-attachments',
     templateUrl: './activiti-process-attachments.component.html',
+    styleUrls: ['./activiti-process-attachments.component.css'],
     providers: [
         { provide: UploadService, useClass: ProcessUploadService }
     ]

--- a/demo-shell-ng2/app/components/activiti/activiti-task-attachments.component.css
+++ b/demo-shell-ng2/app/components/activiti/activiti-task-attachments.component.css
@@ -1,0 +1,3 @@
+adf-create-task-attachment >>> button {
+    float: right;
+}

--- a/demo-shell-ng2/app/components/activiti/activiti-task-attachments.component.ts
+++ b/demo-shell-ng2/app/components/activiti/activiti-task-attachments.component.ts
@@ -22,6 +22,7 @@ import { UploadService } from 'ng2-alfresco-core';
 @Component({
     selector: 'activiti-task-attachments',
     templateUrl: './activiti-task-attachments.component.html',
+    styleUrls: ['./activiti-task-attachments.component.css'],
     providers: [
         { provide: UploadService, useClass: ProcessUploadService }
     ]

--- a/ng2-components/ng2-activiti-processlist/src/components/adf-create-process-attachment.component.css
+++ b/ng2-components/ng2-activiti-processlist/src/components/adf-create-process-attachment.component.css
@@ -1,19 +1,5 @@
-.upload-attachment-container {
-    border: 1px solid rgb(224, 224, 224);
-    background: #fff;
-    text-align: left;
-    border-top: none;
-    padding: 10px;
-    text-align: center;
-}
-
-.drag-area {
-    border: 1px solid #eee;
-    padding: 100px 10px;
-    margin-bottom: 10px;
-}
-
-.upload-attachment-container button {
-    color: rgb(253, 145, 0);
-    opacity: 0.64;
+.adf-create-attachment {
+    display: inline-block;
+    line-height: 0px;
+    vertical-align: middle;
 }

--- a/ng2-components/ng2-activiti-processlist/src/components/adf-create-process-attachment.component.html
+++ b/ng2-components/ng2-activiti-processlist/src/components/adf-create-process-attachment.component.html
@@ -1,17 +1,11 @@
-<div class="upload-attachment-container">
-    <div class="drag-area"
-         id="add_new_process_content_area"
-         (upload-files)="onFileUpload($event)"
-         mode="['click', 'drop']"
-         [adf-upload]="true">
-        {{ 'DETAILS.BUTTON.DRAG-ATTACHMENT' | translate }}
-    </div>
-    <button class="mdl-button mdl-js-button mdl-button--raised"
-            id="add_new_process_content_button"
-            [adf-upload]="true"
-            mode="['click']"
-            [multiple]="true"
-            (upload-files)="onFileUpload($event)">
-        {{ 'DETAILS.BUTTON.UPLOAD-ATTACHMENT' | translate }}
-    </button>
-</div>
+<button
+    md-button
+    md-raised-button
+    md-icon-button
+    class="adf-create-attachment"
+    [adf-upload]="true"
+    mode="['click']"
+    [multiple]="true"
+    (upload-files)="onFileUpload($event)">
+    <md-icon>add</md-icon>
+</button>

--- a/ng2-components/ng2-activiti-processlist/src/components/adf-create-process-attachment.component.html
+++ b/ng2-components/ng2-activiti-processlist/src/components/adf-create-process-attachment.component.html
@@ -1,4 +1,5 @@
 <button
+    id="add_new_process_content_button"
     md-button
     md-raised-button
     md-icon-button

--- a/ng2-components/ng2-activiti-processlist/src/components/adf-create-process-attachment.component.spec.ts
+++ b/ng2-components/ng2-activiti-processlist/src/components/adf-create-process-attachment.component.spec.ts
@@ -98,7 +98,7 @@ describe('Activiti Process Create Attachment', () => {
     });
 
     it('should emit content created event when the file is uploaded', async(() => {
-        component.contentCreated.subscribe((res) => {
+        component.success.subscribe((res) => {
             expect(res).toBeDefined();
             expect(res).not.toBeNull();
             expect(res.id).toBe(9999);
@@ -118,7 +118,7 @@ describe('Activiti Process Create Attachment', () => {
         expect(dragArea).toBeDefined();
         expect(dragArea).not.toBeNull();
 
-        component.contentCreated.subscribe((res) => {
+        component.success.subscribe((res) => {
             expect(res).toBeDefined();
             expect(res).not.toBeNull();
             expect(res.id).toBe(9999);
@@ -140,7 +140,7 @@ describe('Activiti Process Create Attachment', () => {
         expect(buttonUpload).toBeDefined();
         expect(buttonUpload).not.toBeNull();
 
-        component.contentCreated.subscribe((res) => {
+        component.success.subscribe((res) => {
             expect(res).toBeDefined();
             expect(res).not.toBeNull();
             expect(res.id).toBe(9999);

--- a/ng2-components/ng2-activiti-processlist/src/components/adf-create-process-attachment.component.spec.ts
+++ b/ng2-components/ng2-activiti-processlist/src/components/adf-create-process-attachment.component.spec.ts
@@ -113,28 +113,6 @@ describe('Activiti Process Create Attachment', () => {
         });
     }));
 
-    it('should allow user to drag&drop files', async(() => {
-        let dragArea: HTMLElement = <HTMLElement> element.querySelector('#add_new_process_content_area');
-        expect(dragArea).toBeDefined();
-        expect(dragArea).not.toBeNull();
-
-        component.success.subscribe((res) => {
-            expect(res).toBeDefined();
-            expect(res).not.toBeNull();
-            expect(res.id).toBe(9999);
-        });
-
-        let dropEvent = new CustomEvent('upload-files', customEvent);
-        dragArea.dispatchEvent(dropEvent);
-        fixture.detectChanges();
-
-        jasmine.Ajax.requests.mostRecent().respondWith({
-            'status': 200,
-            contentType: 'application/json',
-            responseText: JSON.stringify(fakeUploadResponse)
-        });
-    }));
-
     it('should allow user to upload files via button', async(() => {
         let buttonUpload: HTMLElement = <HTMLElement> element.querySelector('#add_new_process_content_button');
         expect(buttonUpload).toBeDefined();

--- a/ng2-components/ng2-activiti-processlist/src/components/adf-create-process-attachment.component.ts
+++ b/ng2-components/ng2-activiti-processlist/src/components/adf-create-process-attachment.component.ts
@@ -30,10 +30,10 @@ export class ActivitiCreateProcessAttachmentComponent implements OnChanges {
     processInstanceId: string;
 
     @Output()
-    creationError: EventEmitter<any> = new EventEmitter<any>();
+    error: EventEmitter<any> = new EventEmitter<any>();
 
     @Output()
-    contentCreated: EventEmitter<any> = new EventEmitter<any>();
+    success: EventEmitter<any> = new EventEmitter<any>();
 
     constructor(private translateService: AlfrescoTranslationService,
                 private activitiContentService: ActivitiContentService) {
@@ -59,10 +59,10 @@ export class ActivitiCreateProcessAttachmentComponent implements OnChanges {
             };
             this.activitiContentService.createProcessRelatedContent(this.processInstanceId, file, opts).subscribe(
                 (res) => {
-                    this.contentCreated.emit(res);
+                    this.success.emit(res);
                 },
                 (err) => {
-                    this.creationError.emit(err);
+                    this.error.emit(err);
                 });
         }
     }

--- a/ng2-components/ng2-activiti-tasklist/src/components/adf-create-task-attachment.component.css
+++ b/ng2-components/ng2-activiti-tasklist/src/components/adf-create-task-attachment.component.css
@@ -1,19 +1,5 @@
-.upload-attachment-container {
-    border: 1px solid rgb(224, 224, 224);
-    background: #fff;
-    text-align: left;
-    border-top: none;
-    padding: 10px;
-    text-align: center;
-}
-
-.drag-area {
-    border: 1px solid #eee;
-    padding: 100px 10px;
-    margin-bottom: 10px;
-}
-
-.upload-attachment-container button {
-    color: rgb(253, 145, 0);
-    opacity: 0.64;
+.adf-create-attachment {
+    display: inline-block;
+    line-height: 0px;
+    vertical-align: middle;
 }

--- a/ng2-components/ng2-activiti-tasklist/src/components/adf-create-task-attachment.component.html
+++ b/ng2-components/ng2-activiti-tasklist/src/components/adf-create-task-attachment.component.html
@@ -1,15 +1,11 @@
-<div class="upload-attachment-container">
-    <div class="drag-area"
-    (upload-files)="onFileUpload($event)"
-    mode="['click', 'drop']"
-    [adf-upload]="true">
-        {{ 'TASK_DETAILS.BUTTON.DRAG-ATTACHMENT' | translate }}
-    </div>
-    <button class="mdl-button mdl-js-button mdl-button--raised"
+<button
+    md-button
+    md-raised-button
+    md-icon-button
+    class="adf-create-attachment"
     [adf-upload]="true"
     mode="['click']"
     [multiple]="true"
     (upload-files)="onFileUpload($event)">
-        {{ 'TASK_DETAILS.BUTTON.UPLOAD-ATTACHMENT' | translate }}
-    </button>
-</div>
+    <md-icon>add</md-icon>
+</button>


### PR DESCRIPTION
Change the design button
Fix the Event with the name inside the Readme

**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
The create attachment shows the drag and drop area and the button (with a classic style) to upload a file


**What is the new behaviour?**
With the new design, the button is changed and we don't need the drag and drop area anymore.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
