### PR TITLE
[ADF-1070] fix issue with user preferences and page reload

### DIFF
--- a/ng2-components/ng2-alfresco-core/src/services/user-preferences.service.spec.ts
+++ b/ng2-components/ng2-alfresco-core/src/services/user-preferences.service.spec.ts
@@ -61,6 +61,7 @@ describe('UserPreferencesService', () => {
     });
 
     it('should format property key for default prefix', () => {
+        preferences.setStoragePrefix(null);
         expect(preferences.getPropertyKey('propertyA')).toBe('GUEST__propertyA');
     });
 

--- a/ng2-components/ng2-alfresco-core/src/services/user-preferences.service.ts
+++ b/ng2-components/ng2-alfresco-core/src/services/user-preferences.service.ts
@@ -26,14 +26,12 @@ export class UserPreferencesService {
         paginationSize: 25
     };
 
-    private _storagePrefix: string = 'GUEST';
-
     getStoragePrefix(): string {
-        return this._storagePrefix;
+        return this.storage.getItem('USER_PROFILE') || 'GUEST';
     }
 
     setStoragePrefix(value: string) {
-        this._storagePrefix = value || 'GUEST';
+        this.storage.setItem('USER_PROFILE', value || 'GUEST');
     }
 
     constructor(


### PR DESCRIPTION
- the settings prefix is now stored in the local storage as 'USER_PROFILE' value to allow restoring back on page redirects or reloads