### PR TITLE
[ADF-1047] preserve login providers between page reloads

### DIFF
--- a/ng2-components/ng2-alfresco-core/src/services/alfresco-api.service.ts
+++ b/ng2-components/ng2-alfresco-core/src/services/alfresco-api.service.ts
@@ -18,7 +18,6 @@
 import { Injectable } from '@angular/core';
 import { AlfrescoApi } from 'alfresco-js-api';
 import * as alfrescoApi from 'alfresco-js-api';
-import { AlfrescoSettingsService } from './alfresco-settings.service';
 import { AppConfigService } from './app-config.service';
 import { StorageService } from './storage.service';
 
@@ -26,42 +25,26 @@ import { StorageService } from './storage.service';
 export class AlfrescoApiService {
 
     private alfrescoApi: AlfrescoApi;
-    private provider: string;
-    private disableCsrf: boolean;
 
     public getInstance(): AlfrescoApi {
         return this.alfrescoApi;
     }
 
     constructor(private appConfig: AppConfigService,
-                private settingsService: AlfrescoSettingsService,
                 private storage: StorageService) {
 
-        this.provider = this.settingsService.getProviders();
-        this.disableCsrf = false;
-
-        this.init();
-
-        settingsService.csrfSubject.subscribe((disableCsrf) => {
-            this.disableCsrf = disableCsrf;
-            this.init();
-        });
-
-        settingsService.providerSubject.subscribe((provider) => {
-            this.provider = provider;
-            this.init();
-        });
+        this.reset();
     }
 
-    private init() {
+    reset() {
         this.alfrescoApi = <AlfrescoApi>new alfrescoApi({
-            provider: this.provider,
+            provider: this.storage.getItem('AUTH_TYPE'),
             ticketEcm: this.storage.getItem('ticket-ECM'),
             ticketBpm: this.storage.getItem('ticket-BPM'),
             hostEcm: this.appConfig.get<string>('ecmHost'),
             hostBpm: this.appConfig.get<string>('bpmHost'),
             contextRoot: 'alfresco',
-            disableCsrf: this.disableCsrf
+            disableCsrf: this.storage.getItem('DISABLE_CSRF') === 'true'
         });
     }
 }

--- a/ng2-components/ng2-alfresco-core/src/services/alfresco-authentication.service.spec.ts
+++ b/ng2-components/ng2-alfresco-core/src/services/alfresco-authentication.service.spec.ts
@@ -24,6 +24,7 @@ import { AppConfigModule } from './app-config.service';
 import { CookieService } from './cookie.service';
 import { LogService } from './log.service';
 import { StorageService } from './storage.service';
+import { UserPreferencesService } from './user-preferences.service';
 
 declare let jasmine: any;
 
@@ -31,6 +32,7 @@ describe('AlfrescoAuthenticationService', () => {
     let apiService: AlfrescoApiService;
     let authService: AlfrescoAuthenticationService;
     let settingsService: AlfrescoSettingsService;
+    let preferences: UserPreferencesService;
     let storage: StorageService;
     let cookie: CookieService;
 
@@ -44,6 +46,7 @@ describe('AlfrescoAuthenticationService', () => {
                 AlfrescoApiService,
                 AlfrescoAuthenticationService,
                 StorageService,
+                UserPreferencesService,
                 { provide: CookieService, useClass: CookieServiceMock },
                 LogService
             ]
@@ -54,6 +57,7 @@ describe('AlfrescoAuthenticationService', () => {
         apiService = TestBed.get(AlfrescoApiService);
         authService = TestBed.get(AlfrescoAuthenticationService);
         settingsService = TestBed.get(AlfrescoSettingsService);
+        preferences = TestBed.get(UserPreferencesService);
         cookie = TestBed.get(CookieService);
         storage = TestBed.get(StorageService);
         storage.clear();
@@ -68,10 +72,10 @@ describe('AlfrescoAuthenticationService', () => {
     describe('remembe me', () => {
 
         beforeEach(() => {
-            settingsService.setProviders('ECM');
+            preferences.authType = 'ECM';
         });
 
-        it('should save the remember me cookie as a session cookie after successful login', (done) => {
+        it('[ECM] should save the remember me cookie as a session cookie after successful login', (done) => {
             authService.login('fake-username', 'fake-password', false).subscribe(() => {
                 expect(cookie['ALFRESCO_REMEMBER_ME']).not.toBeUndefined();
                 expect(cookie['ALFRESCO_REMEMBER_ME'].expiration).toBeNull();
@@ -85,7 +89,7 @@ describe('AlfrescoAuthenticationService', () => {
             });
         });
 
-        it('should save the remember me cookie as a persistent cookie after successful login', (done) => {
+        it('[ECM] should save the remember me cookie as a persistent cookie after successful login', (done) => {
             authService.login('fake-username', 'fake-password', true).subscribe(() => {
                 expect(cookie['ALFRESCO_REMEMBER_ME']).not.toBeUndefined();
                 expect(cookie['ALFRESCO_REMEMBER_ME'].expiration).not.toBeNull();
@@ -99,7 +103,7 @@ describe('AlfrescoAuthenticationService', () => {
             });
         });
 
-        it('should not save the remember me cookie after failed login', (done) => {
+        it('[ECM] should not save the remember me cookie after failed login', (done) => {
             authService.login('fake-username', 'fake-password').subscribe(
                 (res) => {},
                 (err: any) => {
@@ -126,10 +130,10 @@ describe('AlfrescoAuthenticationService', () => {
     describe('when the setting is ECM', () => {
 
         beforeEach(() => {
-            settingsService.setProviders('ECM');
+            preferences.authType = 'ECM';
         });
 
-        it('should return an ECM ticket after the login done', (done) => {
+        it('[ECM] should return an ECM ticket after the login done', (done) => {
             authService.login('fake-username', 'fake-password').subscribe(() => {
                 expect(authService.isLoggedIn()).toBe(true);
                 expect(authService.getTicketEcm()).toEqual('fake-post-ticket');
@@ -144,7 +148,7 @@ describe('AlfrescoAuthenticationService', () => {
             });
         });
 
-        it('should save only ECM ticket on localStorage', (done) => {
+        it('[ECM] should save only ECM ticket on localStorage', (done) => {
             authService.login('fake-username', 'fake-password').subscribe(() => {
                 expect(authService.isLoggedIn()).toBe(true);
                 expect(authService.getTicketBpm()).toBeNull();
@@ -159,7 +163,7 @@ describe('AlfrescoAuthenticationService', () => {
             });
         });
 
-        xit('should return ticket undefined when the credentials are wrong', (done) => {
+        xit('[ECM] should return ticket undefined when the credentials are wrong', (done) => {
             authService.login('fake-wrong-username', 'fake-wrong-password').subscribe(
                 (res) => {
                 },
@@ -185,7 +189,7 @@ describe('AlfrescoAuthenticationService', () => {
             });
         });
 
-        it('should login in the ECM if no provider are defined calling the login', (done) => {
+        it('[ECM] should login in the ECM if no provider are defined calling the login', (done) => {
             authService.login('fake-username', 'fake-password').subscribe(() => {
                 done();
             });
@@ -197,7 +201,7 @@ describe('AlfrescoAuthenticationService', () => {
             });
         });
 
-        it('should return a ticket undefined after logout', (done) => {
+        it('[ECM] should return a ticket undefined after logout', (done) => {
             authService.login('fake-username', 'fake-password').subscribe(() => {
                 authService.logout().subscribe(() => {
                     expect(authService.isLoggedIn()).toBe(false);
@@ -218,7 +222,7 @@ describe('AlfrescoAuthenticationService', () => {
             });
         });
 
-        it('ticket should be deleted only after logout request is accepted', (done) => {
+        it('[ECM] ticket should be deleted only after logout request is accepted', (done) => {
 
             authService.login('fake-username', 'fake-password').subscribe(() => {
                 let logoutPromise = authService.logout();
@@ -244,7 +248,7 @@ describe('AlfrescoAuthenticationService', () => {
             });
         });
 
-        it('should return false if the user is not logged in', () => {
+        it('[ECM] should return false if the user is not logged in', () => {
             expect(authService.isLoggedIn()).toBe(false);
             expect(authService.isEcmLoggedIn()).toBe(false);
         });
@@ -253,10 +257,10 @@ describe('AlfrescoAuthenticationService', () => {
     describe('when the setting is BPM', () => {
 
         beforeEach(() => {
-            settingsService.setProviders('BPM');
+            preferences.authType = 'BPM';
         });
 
-        it('should return an BPM ticket after the login done', (done) => {
+        it('[BPM] should return an BPM ticket after the login done', (done) => {
             authService.login('fake-username', 'fake-password').subscribe(() => {
                 expect(authService.isLoggedIn()).toBe(true);
                 expect(authService.getTicketBpm()).toEqual('Basic ZmFrZS11c2VybmFtZTpmYWtlLXBhc3N3b3Jk');
@@ -269,7 +273,7 @@ describe('AlfrescoAuthenticationService', () => {
             });
         });
 
-        it('should save only BPM ticket on localStorage', (done) => {
+        it('[BPM] should save only BPM ticket on localStorage', (done) => {
             authService.login('fake-username', 'fake-password').subscribe(() => {
                 expect(authService.isLoggedIn()).toBe(true);
                 expect(authService.getTicketEcm()).toBeNull();
@@ -284,7 +288,7 @@ describe('AlfrescoAuthenticationService', () => {
             });
         });
 
-        xit('should return ticket undefined when the credentials are wrong', (done) => {
+        xit('[BPM] should return ticket undefined when the credentials are wrong', (done) => {
             authService.login('fake-wrong-username', 'fake-wrong-password').subscribe(
                 (res) => {
                 },
@@ -300,7 +304,7 @@ describe('AlfrescoAuthenticationService', () => {
             });
         });
 
-        it('ticket should be deleted only after logout request is accepted', (done) => {
+        it('[BPM] ticket should be deleted only after logout request is accepted', (done) => {
 
             authService.login('fake-username', 'fake-password').subscribe(() => {
                 let logoutPromise = authService.logout();
@@ -324,7 +328,7 @@ describe('AlfrescoAuthenticationService', () => {
             });
         });
 
-        it('should return a ticket undefined after logout', (done) => {
+        it('[BPM] should return a ticket undefined after logout', (done) => {
             authService.login('fake-username', 'fake-password').subscribe(() => {
                 authService.logout().subscribe(() => {
                     expect(authService.isLoggedIn()).toBe(false);
@@ -343,7 +347,7 @@ describe('AlfrescoAuthenticationService', () => {
             });
         });
 
-        it('should return an error when the logout return error', (done) => {
+        it('[BPM] should return an error when the logout return error', (done) => {
             authService.logout().subscribe(
                 (res) => {
                 },
@@ -362,10 +366,10 @@ describe('AlfrescoAuthenticationService', () => {
     describe('when the setting is both ECM and BPM ', () => {
 
         beforeEach(() => {
-            settingsService.setProviders('ALL');
+            preferences.authType = 'ALL';
         });
 
-        it('should return both ECM and BPM tickets after the login done', (done) => {
+        it('[ALL] should return both ECM and BPM tickets after the login done', (done) => {
             authService.login('fake-username', 'fake-password').subscribe(() => {
                 expect(authService.isLoggedIn()).toBe(true);
                 expect(authService.getTicketEcm()).toEqual('fake-post-ticket');
@@ -386,7 +390,7 @@ describe('AlfrescoAuthenticationService', () => {
             });
         });
 
-        xit('should return login fail if only ECM call fail', (done) => {
+        xit('[ALL] should return login fail if only ECM call fail', (done) => {
             authService.login('fake-username', 'fake-password').subscribe(
                 (res) => {
                 },
@@ -407,7 +411,7 @@ describe('AlfrescoAuthenticationService', () => {
             });
         });
 
-        xit('should return login fail if only BPM call fail', (done) => {
+        xit('[ALL] should return login fail if only BPM call fail', (done) => {
             authService.login('fake-username', 'fake-password').subscribe(
                 (res) => {
                 },
@@ -430,7 +434,7 @@ describe('AlfrescoAuthenticationService', () => {
             });
         });
 
-        xit('should return ticket undefined when the credentials are wrong', (done) => {
+        xit('[ALL] should return ticket undefined when the credentials are wrong', (done) => {
             authService.login('fake-username', 'fake-password').subscribe(
                 (res) => {
                 },

--- a/ng2-components/ng2-alfresco-core/src/services/alfresco-authentication.service.spec.ts
+++ b/ng2-components/ng2-alfresco-core/src/services/alfresco-authentication.service.spec.ts
@@ -152,7 +152,7 @@ describe('AlfrescoAuthenticationService', () => {
             authService.login('fake-username', 'fake-password').subscribe(() => {
                 expect(authService.isLoggedIn()).toBe(true);
                 expect(authService.getTicketBpm()).toBeNull();
-                expect(authService.alfrescoApi.getInstance().bpmAuth.isLoggedIn()).toBeFalsy();
+                expect(apiService.getInstance().bpmAuth.isLoggedIn()).toBeFalsy();
                 done();
             });
 
@@ -277,7 +277,7 @@ describe('AlfrescoAuthenticationService', () => {
             authService.login('fake-username', 'fake-password').subscribe(() => {
                 expect(authService.isLoggedIn()).toBe(true);
                 expect(authService.getTicketEcm()).toBeNull();
-                expect(authService.alfrescoApi.getInstance().ecmAuth.isLoggedIn()).toBeFalsy();
+                expect(apiService.getInstance().ecmAuth.isLoggedIn()).toBeFalsy();
                 done();
             });
 

--- a/ng2-components/ng2-alfresco-core/src/services/alfresco-authentication.service.ts
+++ b/ng2-components/ng2-alfresco-core/src/services/alfresco-authentication.service.ts
@@ -34,7 +34,7 @@ export class AlfrescoAuthenticationService {
 
     constructor(
         private preferences: UserPreferencesService,
-        public alfrescoApi: AlfrescoApiService,
+        private alfrescoApi: AlfrescoApiService,
         private storage: StorageService,
         private cookie: CookieService,
         private logService: LogService) {

--- a/ng2-components/ng2-alfresco-core/src/services/alfresco-authentication.service.ts
+++ b/ng2-components/ng2-alfresco-core/src/services/alfresco-authentication.service.ts
@@ -18,10 +18,10 @@
 import { Injectable } from '@angular/core';
 import { Observable, Subject } from 'rxjs/Rx';
 import { AlfrescoApiService } from './alfresco-api.service';
-import { AlfrescoSettingsService } from './alfresco-settings.service';
 import { CookieService } from './cookie.service';
 import { LogService } from './log.service';
 import { StorageService } from './storage.service';
+import { UserPreferencesService } from './user-preferences.service';
 
 const REMEMBER_ME_COOKIE_KEY = 'ALFRESCO_REMEMBER_ME';
 const REMEMBER_ME_UNTIL = 1000 * 60 * 60 * 24 * 30 ;
@@ -33,7 +33,7 @@ export class AlfrescoAuthenticationService {
     onLogout: Subject<any> = new Subject<any>();
 
     constructor(
-        private settingsService: AlfrescoSettingsService,
+        private preferences: UserPreferencesService,
         public alfrescoApi: AlfrescoApiService,
         private storage: StorageService,
         private cookie: CookieService,
@@ -61,7 +61,10 @@ export class AlfrescoAuthenticationService {
                 this.saveRememberMeCookie(rememberMe);
                 this.saveTickets();
                 this.onLogin.next(response);
-                return { type: this.settingsService.getProviders(), ticket: response };
+                return {
+                    type: this.preferences.authType,
+                    ticket: response
+                };
             })
             .catch(err => this.handleError(err));
     }

--- a/ng2-components/ng2-alfresco-core/src/services/alfresco-content.service.spec.ts
+++ b/ng2-components/ng2-alfresco-core/src/services/alfresco-content.service.spec.ts
@@ -25,6 +25,7 @@ import { AppConfigModule } from './app-config.service';
 import { CookieService } from './cookie.service';
 import { LogService } from './log.service';
 import { StorageService } from './storage.service';
+import { UserPreferencesService } from './user-preferences.service';
 
 declare let jasmine: any;
 
@@ -51,6 +52,7 @@ describe('AlfrescoContentService', () => {
                 AlfrescoAuthenticationService,
                 AlfrescoSettingsService,
                 StorageService,
+                UserPreferencesService,
                 { provide: CookieService, useClass: CookieServiceMock },
                 LogService
             ]

--- a/ng2-components/ng2-alfresco-core/src/services/alfresco-settings.service.spec.ts
+++ b/ng2-components/ng2-alfresco-core/src/services/alfresco-settings.service.spec.ts
@@ -16,8 +16,11 @@
  */
 
 import { async, TestBed } from '@angular/core/testing';
+import { AlfrescoApiService } from './alfresco-api.service';
 import { AlfrescoSettingsService } from './alfresco-settings.service';
 import { AppConfigModule } from './app-config.service';
+import { StorageService } from './storage.service';
+import { UserPreferencesService } from './user-preferences.service';
 
 describe('AlfrescoSettingsService', () => {
 
@@ -28,10 +31,11 @@ describe('AlfrescoSettingsService', () => {
             imports: [
                 AppConfigModule
             ],
-            declarations: [
-            ],
             providers: [
-                AlfrescoSettingsService
+                AlfrescoApiService,
+                AlfrescoSettingsService,
+                UserPreferencesService,
+                StorageService
             ]
         }).compileComponents();
     }));

--- a/ng2-components/ng2-alfresco-core/src/services/alfresco-settings.service.ts
+++ b/ng2-components/ng2-alfresco-core/src/services/alfresco-settings.service.ts
@@ -16,57 +16,60 @@
  */
 
 import { Injectable } from '@angular/core';
-import { Subject } from 'rxjs/Subject';
 import { AppConfigService } from './app-config.service';
+import { UserPreferencesService } from './user-preferences.service';
 
 @Injectable()
 export class AlfrescoSettingsService {
 
-    static DEFAULT_CSRF_CONFIG: boolean = false;
+    constructor(
+        private appConfig: AppConfigService,
+        private preferences: UserPreferencesService) {
+    }
 
-    private _csrfDisabled: boolean = AlfrescoSettingsService.DEFAULT_CSRF_CONFIG;
-    private providers: string = 'ALL'; // ECM, BPM , ALL
-
-    public csrfSubject: Subject<boolean> = new Subject<boolean>();
-    public providerSubject: Subject<string> = new Subject<string>();
-
-    constructor(private appConfig: AppConfigService) {}
-
+    /** @deprecated in 1.6.0 */
     public get ecmHost(): string {
+        console.log('AlfrescoSettingsService.ecmHost is deprecated. Use AppConfigService instead.');
         return this.appConfig.get<string>('ecmHost');
     }
 
+    /** @deprecated in 1.7.0 */
     public set csrfDisabled(csrfDisabled: boolean) {
-        this.csrfSubject.next(csrfDisabled);
-        this._csrfDisabled = csrfDisabled;
+        console.log(`AlfrescoSettingsService.csrfDisabled is deprecated. Use UserPreferencesService.disableCSRF instead.`);
+        this.preferences.disableCSRF = csrfDisabled;
     }
 
-    /* @deprecated in 1.6.0 */
+    /** @deprecated in 1.6.0 */
     public set ecmHost(ecmHostUrl: string) {
         console.log('AlfrescoSettingsService.ecmHost is deprecated. Use AppConfigService instead.');
     }
 
+    /** @deprecated in 1.6.0 */
     public get bpmHost(): string {
+        console.log('AlfrescoSettingsService.bpmHost is deprecated. Use AppConfigService instead.');
         return this.appConfig.get<string>('bpmHost');
     }
 
-    /* @deprecated in 1.6.0 */
+    /** @deprecated in 1.6.0 */
     public set bpmHost(bpmHostUrl: string) {
         console.log('AlfrescoSettingsService.bpmHost is deprecated. Use AppConfigService instead.');
     }
 
-    /* @deprecated in 1.6.0 */
+    /** @deprecated in 1.6.0 */
     public getBPMApiBaseUrl(): string {
         console.log('AlfrescoSettingsService.getBPMApiBaseUrl is deprecated.');
         return this.bpmHost + '/activiti-app';
     }
 
+    /** @deprecated in 1.7.0 */
     public getProviders(): string {
-        return this.providers;
+        console.log(`AlfrescoSettingsService.getProviders is deprecated. Use UserPreferencesService.authType instead.`);
+        return this.preferences.authType;
     }
 
+    /** @deprecated in 1.7.0 */
     public setProviders(providers: string) {
-        this.providerSubject.next(providers);
-        this.providers = providers;
+        console.log(`AlfrescoSettingsService.getProviders is deprecated. Use UserPreferencesService.authType instead.`);
+        this.preferences.authType = providers;
     }
 }

--- a/ng2-components/ng2-alfresco-core/src/services/auth-guard-bpm.service.spec.ts
+++ b/ng2-components/ng2-alfresco-core/src/services/auth-guard-bpm.service.spec.ts
@@ -28,6 +28,7 @@ import { AuthGuardBpm } from './auth-guard-bpm.service';
 import { CookieService } from './cookie.service';
 import { LogService } from './log.service';
 import { StorageService } from './storage.service';
+import { UserPreferencesService } from './user-preferences.service';
 
 describe('AuthGuardService BPM', () => {
 
@@ -45,6 +46,7 @@ describe('AuthGuardService BPM', () => {
                 AlfrescoApiService,
                 AlfrescoAuthenticationService,
                 StorageService,
+                UserPreferencesService,
                 { provide: CookieService, useClass: CookieServiceMock },
                 LogService
             ]

--- a/ng2-components/ng2-alfresco-core/src/services/auth-guard-ecm.service.spec.ts
+++ b/ng2-components/ng2-alfresco-core/src/services/auth-guard-ecm.service.spec.ts
@@ -28,6 +28,7 @@ import { AuthGuardEcm } from './auth-guard-ecm.service';
 import { CookieService } from './cookie.service';
 import { LogService } from './log.service';
 import { StorageService } from './storage.service';
+import { UserPreferencesService } from './user-preferences.service';
 
 describe('AuthGuardService ECM', () => {
 
@@ -45,6 +46,7 @@ describe('AuthGuardService ECM', () => {
                 AlfrescoApiService,
                 AlfrescoAuthenticationService,
                 StorageService,
+                UserPreferencesService,
                 { provide: CookieService, useClass: CookieServiceMock },
                 LogService
             ]

--- a/ng2-components/ng2-alfresco-core/src/services/auth-guard.service.spec.ts
+++ b/ng2-components/ng2-alfresco-core/src/services/auth-guard.service.spec.ts
@@ -28,6 +28,7 @@ import { AuthGuard } from './auth-guard.service';
 import { CookieService } from './cookie.service';
 import { LogService } from './log.service';
 import { StorageService } from './storage.service';
+import { UserPreferencesService } from './user-preferences.service';
 
 describe('AuthGuardService', () => {
 
@@ -42,6 +43,7 @@ describe('AuthGuardService', () => {
                 AlfrescoSettingsService,
                 AlfrescoApiService,
                 AlfrescoAuthenticationService,
+                UserPreferencesService,
                 StorageService,
                 { provide: CookieService, useClass: CookieServiceMock },
                 LogService

--- a/ng2-components/ng2-alfresco-core/src/services/thumbnail.service.spec.ts
+++ b/ng2-components/ng2-alfresco-core/src/services/thumbnail.service.spec.ts
@@ -27,6 +27,7 @@ import { CookieService } from './cookie.service';
 import { LogService } from './log.service';
 import { StorageService } from './storage.service';
 import { ThumbnailService } from './thumbnail.service';
+import { UserPreferencesService } from './user-preferences.service';
 
 describe('ThumbnailService', () => {
 
@@ -38,6 +39,7 @@ describe('ThumbnailService', () => {
                 HttpModule
             ],
             providers: [
+                UserPreferencesService,
                 AlfrescoAuthenticationService,
                 AlfrescoContentService,
                 AlfrescoSettingsService,

--- a/ng2-components/ng2-alfresco-core/src/services/user-preferences.service.spec.ts
+++ b/ng2-components/ng2-alfresco-core/src/services/user-preferences.service.spec.ts
@@ -16,6 +16,7 @@
  */
 
 import { async, TestBed } from '@angular/core/testing';
+import { AlfrescoApiService } from './alfresco-api.service';
 import { AppConfigModule } from './app-config.service';
 import { StorageService } from './storage.service';
 import { UserPreferencesService } from './user-preferences.service';
@@ -36,6 +37,7 @@ describe('UserPreferencesService', () => {
                 })
             ],
             providers: [
+                AlfrescoApiService,
                 StorageService,
                 UserPreferencesService
             ]

--- a/ng2-components/ng2-alfresco-core/src/services/user-preferences.service.ts
+++ b/ng2-components/ng2-alfresco-core/src/services/user-preferences.service.ts
@@ -66,12 +66,12 @@ export class UserPreferencesService {
     }
 
     set authType(value: string) {
-        this.set('AUTH_TYPE', value);
+        this.storage.setItem('AUTH_TYPE', value);
         this.apiService.reset();
     }
 
     get authType(): string {
-        return this.get('AUTH_TYPE', 'ALL');
+        return this.storage.getItem('AUTH_TYPE') || 'ALL';
     }
 
     set disableCSRF(value: boolean) {

--- a/ng2-components/ng2-alfresco-core/src/services/user-preferences.service.ts
+++ b/ng2-components/ng2-alfresco-core/src/services/user-preferences.service.ts
@@ -16,6 +16,7 @@
  */
 
 import { Injectable } from '@angular/core';
+import { AlfrescoApiService } from './alfresco-api.service';
 import { AppConfigService } from './app-config.service';
 import { StorageService } from './storage.service';
 
@@ -36,7 +37,9 @@ export class UserPreferencesService {
 
     constructor(
         appConfig: AppConfigService,
-        private storage: StorageService) {
+        private storage: StorageService,
+        private apiService: AlfrescoApiService
+    ) {
         this.defaults.paginationSize = appConfig.get('pagination.size', 25);
     }
 
@@ -53,9 +56,31 @@ export class UserPreferencesService {
         );
     }
 
-    get(property: string): string {
+    get(property: string, defaultValue?: string): string {
         const key = this.getPropertyKey(property);
-        return this.storage.getItem(key);
+        const value = this.storage.getItem(key);
+        if (value === undefined) {
+            return defaultValue;
+        }
+        return value;
+    }
+
+    set authType(value: string) {
+        this.set('AUTH_TYPE', value);
+        this.apiService.reset();
+    }
+
+    get authType(): string {
+        return this.get('AUTH_TYPE', 'ALL');
+    }
+
+    set disableCSRF(value: boolean) {
+        this.set('DISABLE_CSRF', value);
+        this.apiService.reset();
+    }
+
+    get disableCSRF(): boolean {
+        return this.get('DISABLE_CSRF') === 'true';
     }
 
     set paginationSize(value: number) {


### PR DESCRIPTION
- fixes issue with the providers being switched to 'ALL'  after page reload