### PR TITLE
[ADF-993] toolbar improvements

### DIFF
--- a/demo-shell-ng2/app/components/files/files.component.html
+++ b/demo-shell-ng2/app/components/files/files.component.html
@@ -3,10 +3,6 @@
         [rootFolderId]="documentList.currentFolderId"
         [versioning]="versioning"
         [enabled]="documentList.hasCreatePermission()">
-        <adf-breadcrumb
-            [target]="documentList"
-            [folderNode]="documentList.folderNode">
-        </adf-breadcrumb>
         <div *ngIf="errorMessage" class="error-message">
             <button (click)="resetError()" class="mdl-button mdl-js-button mdl-button--icon">
                 <i class="material-icons">highlight_off</i>
@@ -14,7 +10,13 @@
             <span class="error-message--text">{{errorMessage}}</span>
         </div>
         <ng-container *ngIf="useCustomToolbar">
-            <adf-toolbar title="Toolbar">
+            <adf-toolbar>
+                <adf-toolbar-title>
+                    <adf-breadcrumb
+                        [target]="documentList"
+                        [folderNode]="documentList.folderNode">
+                    </adf-breadcrumb>
+                </adf-toolbar-title>
                 <button md-icon-button (click)="onCreateFolderClicked($event)">
                     <md-icon>create_new_folder</md-icon>
                 </button>

--- a/ng2-components/ng2-alfresco-core/index.ts
+++ b/ng2-components/ng2-alfresco-core/index.ts
@@ -24,14 +24,14 @@ import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 
 import { CollapsableModule } from './src/components/collapsable/collapsable.module';
 import { ContextMenuModule } from './src/components/context-menu/context-menu.module';
-import { ToolbarComponent } from './src/components/toolbar/toolbar.component';
+import { ToolbarModule } from './src/components/toolbar/toolbar.module';
 import { CardViewModule } from './src/components/view/card-view.module';
 import { MaterialModule } from './src/material.module';
+import { AppConfigModule } from './src/services/app-config.service';
 
 import { AlfrescoApiService } from './src/services/alfresco-api.service';
 import { AlfrescoContentService } from './src/services/alfresco-content.service';
 import { AlfrescoSettingsService } from './src/services/alfresco-settings.service';
-import { AppConfigModule } from './src/services/app-config.service';
 import { AppConfigService } from './src/services/app-config.service';
 import { InitAppConfigServiceProvider } from './src/services/app-config.service';
 import { AuthGuardBpm } from './src/services/auth-guard-bpm.service';
@@ -167,6 +167,7 @@ export function createTranslateLoader(http: Http, logService: LogService) {
         }),
         MaterialModule,
         AppConfigModule,
+        ToolbarModule,
         ContextMenuModule,
         CardViewModule,
         CollapsableModule
@@ -177,8 +178,7 @@ export function createTranslateLoader(http: Http, logService: LogService) {
         DataColumnComponent,
         DataColumnListComponent,
         FileSizePipe,
-        HighlightPipe,
-        ToolbarComponent
+        HighlightPipe
     ],
     providers: providers(),
     exports: [
@@ -192,13 +192,13 @@ export function createTranslateLoader(http: Http, logService: LogService) {
         ContextMenuModule,
         CardViewModule,
         CollapsableModule,
+        ToolbarModule,
         ...obsoleteMdlDirectives(),
         UploadDirective,
         DataColumnComponent,
         DataColumnListComponent,
         FileSizePipe,
-        HighlightPipe,
-        ToolbarComponent
+        HighlightPipe
     ]
 })
 export class CoreModule {

--- a/ng2-components/ng2-alfresco-core/src/components/toolbar/toolbar-title.component.ts
+++ b/ng2-components/ng2-alfresco-core/src/components/toolbar/toolbar-title.component.ts
@@ -15,22 +15,11 @@
  * limitations under the License.
  */
 
-import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
-    selector: 'adf-toolbar',
-    templateUrl: './toolbar.component.html',
-    styleUrls: ['./toolbar.component.css'],
-    changeDetection: ChangeDetectionStrategy.OnPush,
-    encapsulation: ViewEncapsulation.None,
-    host: { 'class': 'adf-toolbar' }
+    selector: 'adf-toolbar-title',
+    template: '<ng-content></ng-content>',
+    host: { 'class': 'adf-toolbar-title' }
 })
-export class ToolbarComponent {
-
-    @Input()
-    title: string = '';
-
-    @Input()
-    color: string;
-
-}
+export class ToolbarTitleComponent {}

--- a/ng2-components/ng2-alfresco-core/src/components/toolbar/toolbar.component.css
+++ b/ng2-components/ng2-alfresco-core/src/components/toolbar/toolbar.component.css
@@ -1,3 +1,0 @@
-.adf-toolbar--spacer {
-  flex: 1 1 auto;
-}

--- a/ng2-components/ng2-alfresco-core/src/components/toolbar/toolbar.component.html
+++ b/ng2-components/ng2-alfresco-core/src/components/toolbar/toolbar.component.html
@@ -1,5 +1,6 @@
 <md-toolbar [color]="color">
-    <span>{{ title }}</span>
+    <span *ngIf="title">{{ title }}</span>
+    <ng-content select="adf-toolbar-title"></ng-content>
     <span class="adf-toolbar--spacer"></span>
     <ng-content></ng-content>
 </md-toolbar>

--- a/ng2-components/ng2-alfresco-core/src/components/toolbar/toolbar.component.scss
+++ b/ng2-components/ng2-alfresco-core/src/components/toolbar/toolbar.component.scss
@@ -1,0 +1,29 @@
+@import 'theming';
+
+$adf-toolbar-height: 48px;
+$adf-toolbar-font-size: 14px;
+
+.adf-toolbar--spacer {
+  flex: 1 1 auto;
+}
+
+.adf-toolbar {
+
+    .mat-toolbar {
+        min-height: $adf-toolbar-height;
+    }
+
+    .mat-toolbar-row {
+        height: $adf-toolbar-height;
+        font-size: $adf-toolbar-font-size;
+
+        & > button {
+            color: $alfresco-secondary-text-color;
+            @include material-animation-default(0.28s);
+
+            &:hover {
+                color: $alfresco-primary-text-color;
+            }
+        }
+    }
+}

--- a/ng2-components/ng2-alfresco-core/src/components/toolbar/toolbar.component.scss
+++ b/ng2-components/ng2-alfresco-core/src/components/toolbar/toolbar.component.scss
@@ -11,6 +11,7 @@ $adf-toolbar-font-size: 14px;
 
     .mat-toolbar {
         min-height: $adf-toolbar-height;
+        border: 1px solid $alfresco-divider-color;
     }
 
     .mat-toolbar-row {

--- a/ng2-components/ng2-alfresco-core/src/components/toolbar/toolbar.component.ts
+++ b/ng2-components/ng2-alfresco-core/src/components/toolbar/toolbar.component.ts
@@ -20,7 +20,7 @@ import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@a
 @Component({
     selector: 'adf-toolbar',
     templateUrl: './toolbar.component.html',
-    styleUrls: ['./toolbar.component.css'],
+    styleUrls: ['./toolbar.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     host: { 'class': 'adf-toolbar' }

--- a/ng2-components/ng2-alfresco-core/src/components/toolbar/toolbar.module.ts
+++ b/ng2-components/ng2-alfresco-core/src/components/toolbar/toolbar.module.ts
@@ -15,22 +15,26 @@
  * limitations under the License.
  */
 
-import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { MdToolbarModule } from '@angular/material';
 
-@Component({
-    selector: 'adf-toolbar',
-    templateUrl: './toolbar.component.html',
-    styleUrls: ['./toolbar.component.css'],
-    changeDetection: ChangeDetectionStrategy.OnPush,
-    encapsulation: ViewEncapsulation.None,
-    host: { 'class': 'adf-toolbar' }
+import { ToolbarTitleComponent } from './toolbar-title.component';
+import { ToolbarComponent } from './toolbar.component';
+
+@NgModule({
+    imports: [
+        CommonModule,
+        MdToolbarModule
+    ],
+    declarations: [
+        ToolbarComponent,
+        ToolbarTitleComponent
+    ],
+    exports: [
+        MdToolbarModule,
+        ToolbarComponent,
+        ToolbarTitleComponent
+    ]
 })
-export class ToolbarComponent {
-
-    @Input()
-    title: string = '';
-
-    @Input()
-    color: string;
-
-}
+export class ToolbarModule {}


### PR DESCRIPTION
- simple "title" property to render toolbar title
- advanced "adf-toolbar-title" element for compound toolbars
- separate "ToolbarModule" module 
- extended demo shell to show breadcrumb as part of the title
- SASS styles

<img width="1432" alt="screenshot 2017-07-16 11 31 27" src="https://user-images.githubusercontent.com/503991/28246820-d468cec2-6a1a-11e7-91e6-af12f63f649a.png">

