### PR TITLE
[ADF-1115] selection management for DT/DL components

### DIFF
--- a/demo-shell-ng2/app/components/files/files.component.html
+++ b/demo-shell-ng2/app/components/files/files.component.html
@@ -56,6 +56,8 @@
                 [contextMenuActions]="true"
                 [contentActions]="true"
                 [allowDropFiles]="true"
+                [selectionMode]="selectionMode"
+                [multiselect]="multiselect"
                 (error)="onNavigationError($event)"
                 (success)="resetError()"
                 (preview)="showFile($event)"
@@ -133,6 +135,10 @@
 
 <div class="container">
     <section>
+        <md-slide-toggle [(ngModel)]="multiselect">Multiselect (with checkboxes)</md-slide-toggle>
+    </section>
+
+    <section>
         <md-slide-toggle [(ngModel)]="useDropdownBreadcrumb">Dropdown breadcrumb</md-slide-toggle>
     </section>
 
@@ -196,6 +202,15 @@
     <section>
         <md-checkbox [(ngModel)]="enableUpload">Enable upload (demoing enabled/disabled state)</md-checkbox>
     </section>
+</div>
+
+<div class="p-10">
+    <p>For 'Multiple' selection mode use Cmd (macOS) or Ctrl (Win) to toggle selection of multiple items.</p>
+    <md-select placeholder="Selection Mode" [(ngModel)]="selectionMode" name="food">
+        <md-option *ngFor="let mode of selectionModes" [value]="mode.value">
+            {{mode.viewValue}}
+        </md-option>
+    </md-select>
 </div>
 
 <file-uploading-dialog #fileDialog></file-uploading-dialog>

--- a/demo-shell-ng2/app/components/files/files.component.html
+++ b/demo-shell-ng2/app/components/files/files.component.html
@@ -133,6 +133,15 @@
 
 <context-menu-holder></context-menu-holder>
 
+<div class="p-10">
+    Selected Nodes:
+    <ul>
+        <li *ngFor="let node of documentList.selection">
+            {{ node.entry.name }}
+        </li>
+    </ul>
+</div>
+
 <div class="container">
     <section>
         <md-slide-toggle [(ngModel)]="multiselect">Multiselect (with checkboxes)</md-slide-toggle>

--- a/demo-shell-ng2/app/components/files/files.component.ts
+++ b/demo-shell-ng2/app/components/files/files.component.ts
@@ -39,6 +39,18 @@ export class FilesComponent implements OnInit {
     useCustomToolbar = true;
     useDropdownBreadcrumb = true;
 
+    selectionModes = [
+        { value: 'none', viewValue: 'None' },
+        { value: 'single', viewValue: 'Single' },
+        { value: 'multiple', viewValue: 'Multiple' }
+    ];
+
+    @Input()
+    selectionMode = 'multiple';
+
+    @Input()
+    multiselect = false;
+
     @Input()
     multipleFileUpload: boolean = false;
 

--- a/ng2-components/ng2-alfresco-datatable/README.md
+++ b/ng2-components/ng2-alfresco-datatable/README.md
@@ -189,14 +189,17 @@ Here's the list of available properties you can define for a Data Column definit
 
 ### DataTable DOM Events
 
-Below are the DOM events raised by DataTable component. 
+Below are the DOM events raised by DataTable component.
+These events bubble up the component tree and can be handled by any parent component.
 
 | Name | Description |
 | --- | --- |
-| row-click | Emitted when user clicks the row |
-| row-dblclick | Emitted when user double-clicks the row |
+| row-click | Raised when user clicks a row |
+| row-dblclick | Raised when user double-clicks a row |
+| row-select | Raised after user selects a row |
+| row-unselect | Raised after user unselects a row |
 
-These events are bubbled up the element tree and can be subscribed to from within parent components.
+For example:
 
 ```html
 <root-component (row-click)="onRowClick($event)">

--- a/ng2-components/ng2-alfresco-datatable/README.md
+++ b/ng2-components/ng2-alfresco-datatable/README.md
@@ -161,6 +161,7 @@ export class DataTableDemo {
 | allowDropFiles | boolean | false | Toggle file drop support for rows (see **ng2-alfresco-core/UploadDirective** for more details) |
 | loading | boolean | false | Flag that indicate if the datable is in loading state and need to show the loading template. Read the documentation above to know how to configure a loading template  |
 | showHeader | boolean | true | Toggles header visibility |
+| selection | DataRow[] | [] | Contains selected rows |
 
 ### DataColumn Properties
 

--- a/ng2-components/ng2-alfresco-datatable/src/components/datatable/datatable.component.html
+++ b/ng2-components/ng2-alfresco-datatable/src/components/datatable/datatable.component.html
@@ -55,7 +55,10 @@
             </td>
 
             <td *ngIf="multiselect">
-                <md-checkbox [(ngModel)]="row.isSelected"></md-checkbox>
+                <md-checkbox
+                    [checked]="row.isSelected"
+                    (change)="onCheckboxChange(row, $event)">
+                </md-checkbox>
             </td>
             <td *ngFor="let col of data.getColumns()"
                 class="adf-data-table-cell adf-data-table-cell--{{col.type || 'text'}} {{col.cssClass}}"

--- a/ng2-components/ng2-alfresco-datatable/src/components/datatable/datatable.component.ts
+++ b/ng2-components/ng2-alfresco-datatable/src/components/datatable/datatable.component.ts
@@ -48,6 +48,9 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck 
     selectionMode: string = 'single'; // none|single|multiple
 
     @Input()
+    selection = new Array<DataRow>();
+
+    @Input()
     multiselect: boolean = false;
 
     @Input()
@@ -253,17 +256,17 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck 
                 });
 
                 if (this.isSingleSelectionMode()) {
-                    rows.forEach(r => r.isSelected = false);
-                    row.isSelected = newValue;
+                    this.resetSelection();
+                    this.selectRow(row, newValue);
                     this.elementRef.nativeElement.dispatchEvent(domEvent);
                 }
 
                 if (this.isMultiSelectionMode()) {
                     const modifier = e.metaKey || e.ctrlKey;
                     if (!modifier) {
-                        rows.forEach(r => r.isSelected = false);
+                        this.resetSelection();
                     }
-                    row.isSelected = newValue;
+                    this.selectRow(row, newValue);
                     this.elementRef.nativeElement.dispatchEvent(domEvent);
                 }
             }
@@ -279,7 +282,9 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck 
             if (rows && rows.length > 0) {
                 rows.forEach(r => r.isSelected = false);
             }
+            this.selection.splice(0);
         }
+        this.isSelectAllChecked = false;
     }
 
     onRowDblClick(row: DataRow, e?: Event) {
@@ -308,10 +313,14 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck 
             let rows = this.data.getRows();
             if (rows && rows.length > 0) {
                 for (let i = 0; i < rows.length; i++) {
-                    rows[i].isSelected = e.checked;
+                    this.selectRow(rows[i], e.checked);
                 }
             }
         }
+    }
+
+    onCheckboxChange(row: DataRow, event: MdCheckboxChange) {
+        this.selectRow(row, event.checked);
     }
 
     onImageLoadingError(event: Event) {
@@ -389,5 +398,24 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck 
         row.cssClass = row.cssClass ? row.cssClass : '';
         this.rowStyleClass = this.rowStyleClass ? this.rowStyleClass : '';
         return `${row.cssClass} ${this.rowStyleClass}`;
+    }
+
+    private selectRow(row: DataRow, value: boolean) {
+        if (row) {
+            row.isSelected = value;
+            const idx = this.selection.indexOf(row);
+
+            if (value) {
+                if (idx < 0) {
+                    this.selection.push(row);
+                }
+            } else {
+                if (idx > -1) {
+                    this.selection.splice(idx, 1);
+                }
+            }
+        }
+
+        console.log(this.selection);
     }
 }

--- a/ng2-components/ng2-alfresco-datatable/src/components/datatable/datatable.component.ts
+++ b/ng2-components/ng2-alfresco-datatable/src/components/datatable/datatable.component.ts
@@ -48,9 +48,6 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck 
     selectionMode: string = 'single'; // none|single|multiple
 
     @Input()
-    selection = new Array<DataRow>();
-
-    @Input()
     multiselect: boolean = false;
 
     @Input()
@@ -95,10 +92,11 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck 
     @Input()
     loading: boolean = false;
 
-    public noContentTemplate: TemplateRef<any>;
-    public loadingTemplate: TemplateRef<any>;
+    noContentTemplate: TemplateRef<any>;
+    loadingTemplate: TemplateRef<any>;
 
     isSelectAllChecked: boolean = false;
+    selection = new Array<DataRow>();
 
     private clickObserver: Observer<DataRowEvent>;
     private click$: Observable<DataRowEvent>;
@@ -251,7 +249,10 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck 
 
                 const domEventName = newValue ? 'row-select' : 'row-unselect';
                 const domEvent = new CustomEvent(domEventName, {
-                    detail: row,
+                    detail: {
+                        row: row,
+                        selection: this.selection
+                    },
                     bubbles: true
                 });
 
@@ -320,7 +321,20 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck 
     }
 
     onCheckboxChange(row: DataRow, event: MdCheckboxChange) {
-        this.selectRow(row, event.checked);
+        const newValue = event.checked;
+
+        this.selectRow(row, newValue);
+
+        const domEventName = newValue ? 'row-select' : 'row-unselect';
+        const domEvent = new CustomEvent(domEventName, {
+            detail: {
+                row: row,
+                selection: this.selection
+            },
+            bubbles: true
+        });
+
+        this.elementRef.nativeElement.dispatchEvent(domEvent);
     }
 
     onImageLoadingError(event: Event) {
@@ -415,7 +429,5 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck 
                 }
             }
         }
-
-        console.log(this.selection);
     }
 }

--- a/ng2-components/ng2-alfresco-datatable/src/directives/loading-template.directive.spec.ts
+++ b/ng2-components/ng2-alfresco-datatable/src/directives/loading-template.directive.spec.ts
@@ -15,31 +15,42 @@
  * limitations under the License.
  */
 
-import { Injector } from '@angular/core';
-import { getTestBed, TestBed } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { CoreModule } from 'ng2-alfresco-core';
+import { DataTableCellComponent } from '../components/datatable/datatable-cell.component';
 import { DataTableComponent } from '../components/datatable/datatable.component';
+import { MaterialModule } from '../material.module';
 import { LoadingContentTemplateDirective } from './loading-template.directive';
 
 describe('LoadingContentTemplateDirective', () => {
-    let injector: Injector;
-    let loadingContentTemplateDirective: LoadingContentTemplateDirective;
 
-    beforeEach(() => {
+    let dataTable: DataTableComponent;
+    let directive: LoadingContentTemplateDirective;
+
+    beforeEach(async(() => {
         TestBed.configureTestingModule({
             imports: [
+                MaterialModule,
                 CoreModule.forRoot()
             ],
-            providers: [
-                LoadingContentTemplateDirective,
-                DataTableComponent
+            declarations: [
+                DataTableComponent,
+                DataTableCellComponent,
+                LoadingContentTemplateDirective
             ]
-        });
-        injector = getTestBed();
-        loadingContentTemplateDirective = injector.get(LoadingContentTemplateDirective);
+        }).compileComponents();
+    }));
+
+    beforeEach(() => {
+        let fixture = TestBed.createComponent(DataTableComponent);
+        dataTable = fixture.componentInstance;
+        directive = new LoadingContentTemplateDirective(dataTable);
     });
 
-    it('is defined', () => {
-        expect(loadingContentTemplateDirective).toBeDefined();
+    it('applies template to the datatable', () => {
+        const template = {};
+        directive.template = template;
+        directive.ngAfterContentInit();
+        expect(dataTable.loadingTemplate).toBe(template);
     });
 });

--- a/ng2-components/ng2-alfresco-datatable/src/directives/loading-template.directive.ts
+++ b/ng2-components/ng2-alfresco-datatable/src/directives/loading-template.directive.ts
@@ -30,7 +30,9 @@ export class LoadingContentTemplateDirective implements AfterContentInit {
     }
 
     ngAfterContentInit() {
-        this.dataTable.loadingTemplate = this.template;
+        if (this.dataTable) {
+            this.dataTable.loadingTemplate = this.template;
+        }
     }
 
 }

--- a/ng2-components/ng2-alfresco-datatable/src/directives/no-content-template.directive.spec.ts
+++ b/ng2-components/ng2-alfresco-datatable/src/directives/no-content-template.directive.spec.ts
@@ -15,31 +15,42 @@
  * limitations under the License.
  */
 
-import { Injector } from '@angular/core';
-import { getTestBed, TestBed } from '@angular/core/testing';
+import { async, getTestBed, TestBed } from '@angular/core/testing';
 import { CoreModule } from 'ng2-alfresco-core';
+import { DataTableCellComponent } from '../components/datatable/datatable-cell.component';
 import { DataTableComponent } from '../components/datatable/datatable.component';
+import { MaterialModule } from '../material.module';
 import { NoContentTemplateDirective } from './no-content-template.directive';
 
 describe('NoContentTemplateDirective', () => {
-    let injector: Injector;
-    let noContentTemplateDirective: NoContentTemplateDirective;
 
-    beforeEach(() => {
+    let dataTable: DataTableComponent;
+    let directive: NoContentTemplateDirective;
+
+    beforeEach(async(() => {
         TestBed.configureTestingModule({
             imports: [
+                MaterialModule,
                 CoreModule.forRoot()
             ],
-            providers: [
-                NoContentTemplateDirective,
-                DataTableComponent
+            declarations: [
+                DataTableComponent,
+                DataTableCellComponent,
+                NoContentTemplateDirective
             ]
-        });
-        injector = getTestBed();
-        noContentTemplateDirective = injector.get(NoContentTemplateDirective);
+        }).compileComponents();
+    }));
+
+    beforeEach(() => {
+        let fixture = TestBed.createComponent(DataTableComponent);
+        dataTable = fixture.componentInstance;
+        directive = new NoContentTemplateDirective(dataTable);
     });
 
-    it('is defined', () => {
-        expect(noContentTemplateDirective).toBeDefined();
+    it('applies template to the datatable', () => {
+        const template = {};
+        directive.template = template;
+        directive.ngAfterContentInit();
+        expect(dataTable.noContentTemplate).toBe(template);
     });
 });

--- a/ng2-components/ng2-alfresco-datatable/src/directives/no-content-template.directive.ts
+++ b/ng2-components/ng2-alfresco-datatable/src/directives/no-content-template.directive.ts
@@ -30,6 +30,8 @@ export class NoContentTemplateDirective implements AfterContentInit {
     }
 
     ngAfterContentInit() {
-        this.dataTable.noContentTemplate = this.template;
+        if (this.dataTable) {
+            this.dataTable.noContentTemplate = this.template;
+        }
     }
 }

--- a/ng2-components/ng2-alfresco-documentlist/README.md
+++ b/ng2-components/ng2-alfresco-documentlist/README.md
@@ -85,6 +85,7 @@ The properties currentFolderId, folderNode and node are the entry initialization
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | selectionMode | string | 'single' | Row selection mode. Can be none, `single` or `multiple`. For `multiple` mode you can use Cmd (macOS) or Ctrl (Win) modifier key to toggle selection for multiple rows.  |
+| selection | Array<MinimalNodeEntity> | [] | Contains selected nodes |
 | rowStyle | string | | The inline style to apply to every row, see [NgStyle](https://angular.io/docs/ts/latest/api/common/index/NgStyle-directive.html) docs for more details and usage examples |
 | rowStyleClass | string | | The CSS class to apply to every row |
 | currentFolderId | string | null | Initial node ID of displayed folder. Can be `-root-`, `-shared-`, `-my-`, or a fixed node ID  |
@@ -128,6 +129,8 @@ All of them are `bubbling`, meaning you can handle them in any component up the 
 | --- | --- |
 | node-click | Raised when user clicks the node |
 | node-dblclick | Raised when user double-clicks the node |
+| node-select | Raised when user selects a node |
+| node-unselect | Raised when user unselects a node |
 
 Every event is represented by a [CustomEvent](https://developer.mozilla.org/en/docs/Web/API/CustomEvent) instance, having at least the following properties as part of the `Event.detail` property value:
 
@@ -137,6 +140,8 @@ Every event is represented by a [CustomEvent](https://developer.mozilla.org/en/d
     node: MinimalNodeEntity
 }
 ```
+
+Please refer to the DataTable documentation to find details about additional DOM events the DocumentList component bubbles up from the DataTable.
 
 ### Handling DOM events
 

--- a/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.html
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.html
@@ -20,8 +20,10 @@
     (showRowContextMenu)="onShowRowContextMenu($event)"
     (showRowActionsMenu)="onShowRowActionsMenu($event)"
     (executeRowAction)="onExecuteRowAction($event)"
-    (rowClick)="onRowClick($event)"
-    (rowDblClick)="onRowDblClick($event)">
+    (rowClick)="onNodeClick($event.value?.node)"
+    (rowDblClick)="onNodeDblClick($event.value?.node)"
+    (row-select)="onNodeSelect($event.detail)"
+    (row-unselect)="onNodeUnselect($event.detail)">
     <div *ngIf="!isEmptyTemplateDefined()">
         <no-content-template>
             <ng-template>

--- a/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.spec.ts
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.spec.ts
@@ -748,47 +748,43 @@ describe('DocumentList', () => {
     it('should emit [nodeClick] event on row click', () => {
         let node = new NodeMinimalEntry();
         let row = new ShareDataRow(node, null, null);
-        let event = new DataRowEvent(row, null);
 
         spyOn(documentList, 'onNodeClick').and.callThrough();
-        documentList.onRowClick(event);
+        documentList.onNodeClick(node);
         expect(documentList.onNodeClick).toHaveBeenCalledWith(node);
     });
 
     it('should emit node-click DOM event', (done) => {
         let node = new NodeMinimalEntry();
         let row = new ShareDataRow(node, null, null);
-        let event = new DataRowEvent(row, null);
 
         const htmlElement = fixture.debugElement.nativeElement as HTMLElement;
         htmlElement.addEventListener('node-click', (e: CustomEvent) => {
             done();
         });
 
-        documentList.onRowClick(event);
+        documentList.onNodeClick(node);
     });
 
     it('should emit [nodeDblClick] event on row double-click', () => {
         let node = new NodeMinimalEntry();
         let row = new ShareDataRow(node, null, null);
-        let event = new DataRowEvent(row, null);
 
         spyOn(documentList, 'onNodeDblClick').and.callThrough();
-        documentList.onRowDblClick(event);
+        documentList.onNodeDblClick(node);
         expect(documentList.onNodeDblClick).toHaveBeenCalledWith(node);
     });
 
     it('should emit node-dblclick DOM event', (done) => {
         let node = new NodeMinimalEntry();
         let row = new ShareDataRow(node, null, null);
-        let event = new DataRowEvent(row, null);
 
         const htmlElement = fixture.debugElement.nativeElement as HTMLElement;
         htmlElement.addEventListener('node-dblclick', (e: CustomEvent) => {
             done();
         });
 
-        documentList.onRowDblClick(event);
+        documentList.onNodeDblClick(node);
     });
 
     it('should load folder by ID on init', () => {


### PR DESCRIPTION
DataTable

- `row-select` and `row-unselect` DOM events
- `selection` property that holds current selection (rows)
- improved selection management for the "checkboxes" mode

DocumentList

- `node-select` and `node-unselect` DOM events
- `selection` property that holds current selection (nodes)
- updated demo shell
  - selection modes picker
  - toggle "checkboxes" mode
  - show current selection in another element