### PR TITLE
[ADF-1003] Stop polling after viewer is closed.

### DIFF
--- a/ng2-components/ng2-alfresco-viewer/src/components/notSupportedFormat.component.html
+++ b/ng2-components/ng2-alfresco-viewer/src/components/notSupportedFormat.component.html
@@ -3,12 +3,25 @@
         <div *ngIf="!isConversionStarted" class="viewer-download-text mdl-card__supporting-text">
             <h4>File '<span>{{nameFile}}</span>' is of an unsupported format</h4>
         </div>
-        <md-spinner *ngIf="isConversionStarted" id="conversion-spinner" class="adf-conversion-spinner" color="primary"></md-spinner>
+        
+        <md-spinner *ngIf="isConversionStarted" 
+            id="conversion-spinner" 
+            class="adf-conversion-spinner" 
+            color="primary"
+            data-automation-id="viewer-conversion-spinner"></md-spinner>
+
         <div class="button-container mdl-card__actions">
             <button md-button id="viewer-download-button" aria-label="Download" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent" (click)="download()">
                 <md-icon class="viewer-button-icon">cloud_download</md-icon>   Download
             </button>
-            <button md-button *ngIf="convertible" [disabled]="isConversionStarted" id="viewer-convert-button" aria-label="Convert to PDF" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--primary" (click)="convertToPdf()">
+            <button *ngIf="convertible"
+                md-button
+                id="viewer-convert-button"
+                aria-label="Convert to PDF"
+                class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--primary"
+                [disabled]="isConversionStarted"
+                (click)="convertToPdf()"
+                data-automation-id="viewer-convert-button">
                 <md-icon class="viewer-button-icon">insert_drive_file</md-icon>   Convert to PDF
             </button>
             <button md-button *ngIf="displayable" id="viewer-display-button" aria-label="Show PDF" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--primary" (click)="showPDF()">
@@ -18,4 +31,9 @@
     </div>
 </section>
 
-<pdf-viewer *ngIf="isConversionFinished" id="pdf-rendition-viewer" [showToolbar]="showToolbar" [urlFile]="renditionUrl" [nameFile]="nameFile"></pdf-viewer>
+<pdf-viewer *ngIf="isConversionFinished" 
+    id="pdf-rendition-viewer" 
+    [showToolbar]="showToolbar" 
+    [urlFile]="renditionUrl" 
+    [nameFile]="nameFile"
+    data-automation-id="pdf-rendition-viewer"></pdf-viewer>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Polling of bigger files' rendition creation was continued after the viewer was closed.


**What is the new behaviour?**
The rendition conversion polling requests stop as the user leaves the viewer.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
