### PR TITLE
[ADF-1097] Don't upload file if extension is not acceptable

### DIFF
--- a/ng2-components/ng2-alfresco-core/src/models/file.model.spec.ts
+++ b/ng2-components/ng2-alfresco-core/src/models/file.model.spec.ts
@@ -1,0 +1,48 @@
+/*!
+ * @license
+ * Copyright 2016 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FileModel } from './file.model';
+
+describe('FileModel', () => {
+
+    describe('extension', () => {
+
+        it('should return the extension if file has it', () => {
+            const file = new FileModel(<File> { name: 'tyrion-lannister.doc' });
+
+            expect(file.extension).toBe('doc');
+        });
+
+        it('should return the empty string if file has NOT got it', () => {
+            const file = new FileModel(<File> { name: 'daenerys-targaryen' });
+
+            expect(file.extension).toBe('');
+        });
+
+        it('should return the empty string if file is starting with . and doesn\'t have extension', () => {
+            const file = new FileModel(<File> { name: '.white-walkers' });
+
+            expect(file.extension).toBe('');
+        });
+
+        it('should return the last extension string if file contains many dot', () => {
+            const file = new FileModel(<File> { name: 'you.know.nothing.jon.snow.exe' });
+
+            expect(file.extension).toBe('exe');
+        });
+    });
+});

--- a/ng2-components/ng2-alfresco-core/src/models/file.model.ts
+++ b/ng2-components/ng2-alfresco-core/src/models/file.model.ts
@@ -73,4 +73,8 @@ export class FileModel {
             return v.toString(16);
         });
     }
+
+    get extension(): string {
+        return this.name.slice((Math.max(0, this.name.lastIndexOf('.')) || Infinity) + 1);
+    }
 }

--- a/ng2-components/ng2-alfresco-upload/src/components/upload-button.component.spec.ts
+++ b/ng2-components/ng2-alfresco-upload/src/components/upload-button.component.spec.ts
@@ -261,4 +261,60 @@ describe('UploadButtonComponent', () => {
         fixture.detectChanges();
         expect(compiled.querySelector('#uploadFolder-label-static').textContent).toEqual('test-text');
     });
+
+    describe('uploadFiles', () => {
+
+        const files: File[] = [
+            <File> { name: 'phobos.jpg' },
+            <File> { name: 'deimos.png' },
+            <File> { name: 'ganymede.bmp' }
+        ];
+
+        let addToQueueSpy;
+
+        beforeEach(() => {
+            addToQueueSpy = spyOn(uploadService, 'addToQueue');
+        });
+
+        it('should filter out file, which is not part of the acceptedFilesType', () => {
+            component.acceptedFilesType = '.jpg';
+
+            component.uploadFiles(files);
+
+            const filesCalledWith = addToQueueSpy.calls.mostRecent().args;
+            expect(filesCalledWith.length).toBe(1, 'Files should contain only one element');
+            expect(filesCalledWith[0].name).toBe('phobos.jpg', 'png file should be filtered out');
+        });
+
+        it('should filter out files, which are not part of the acceptedFilesType', () => {
+            component.acceptedFilesType = '.jpg,.png';
+
+            component.uploadFiles(files);
+
+            const filesCalledWith = addToQueueSpy.calls.mostRecent().args;
+            expect(filesCalledWith.length).toBe(2, 'Files should contain two elements');
+            expect(filesCalledWith[0].name).toBe('phobos.jpg');
+            expect(filesCalledWith[1].name).toBe('deimos.png');
+        });
+
+        it('should not filter out anything if acceptedFilesType is wildcard', () => {
+            component.acceptedFilesType = '*';
+
+            component.uploadFiles(files);
+
+            const filesCalledWith = addToQueueSpy.calls.mostRecent().args;
+            expect(filesCalledWith.length).toBe(3, 'Files should contain all elements');
+            expect(filesCalledWith[0].name).toBe('phobos.jpg');
+            expect(filesCalledWith[1].name).toBe('deimos.png');
+            expect(filesCalledWith[2].name).toBe('ganymede.bmp');
+        });
+
+        it('should not add any file to que if everything is filtered out', () => {
+            component.acceptedFilesType = 'doc';
+
+            component.uploadFiles(files);
+
+            expect(addToQueueSpy).not.toHaveBeenCalled();
+        });
+    });
 });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
File with unaccepted extension is uploaded when 'Format' in browser's File upload dialog is set to 'All files'


**What is the new behaviour?**
No matter what the "Format" in the browser's File upload dialog is set, only the allowed files will be uploaded


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
