### PR TITLE
[ADF-1146] improve Angular CLI compatibility

### DIFF
--- a/ng2-components/ng2-alfresco-core/src/services/thumbnail.service.ts
+++ b/ng2-components/ng2-alfresco-core/src/services/thumbnail.service.ts
@@ -18,6 +18,8 @@
 import { Injectable } from '@angular/core';
 import { AlfrescoContentService } from './alfresco-content.service';
 
+declare var require: any;
+
 @Injectable()
 export class ThumbnailService {
 

--- a/ng2-components/ng2-alfresco-datatable/src/components/datatable/empty-list.component.ts
+++ b/ng2-components/ng2-alfresco-datatable/src/components/datatable/empty-list.component.ts
@@ -17,6 +17,8 @@
 
 import { Component, Input } from '@angular/core';
 
+declare var require: any;
+
 @Component({
     selector: 'adf-empty-list',
     styleUrls: ['./empty-list.component.css'],


### PR DESCRIPTION
solves issues with "Cannot find name 'require'." errors when linking to Angular CLI.