### PR TITLE
[ADF-1262] Fix breadcrumb ellipsis issue in the toolbar

### DIFF
--- a/demo-shell-ng2/app/components/files/files.component.css
+++ b/demo-shell-ng2/app/components/files/files.component.css
@@ -8,6 +8,10 @@
     }
 }
 
+.files-toolbar-title {
+    max-width: calc(100% - 160px);
+}
+
 .error-message {
     text-align: left;
 }

--- a/demo-shell-ng2/app/components/files/files.component.html
+++ b/demo-shell-ng2/app/components/files/files.component.html
@@ -15,7 +15,7 @@
         </div>
         <ng-container *ngIf="useCustomToolbar">
             <adf-toolbar [color]="toolbarColor">
-                <adf-toolbar-title>
+                <adf-toolbar-title class="files-toolbar-title">
                     <adf-breadcrumb *ngIf="!useDropdownBreadcrumb"
                         class="files-breadcrumb"
                         [target]="documentList"

--- a/ng2-components/ng2-alfresco-documentlist/src/components/breadcrumb/breadcrumb.component.scss
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/breadcrumb/breadcrumb.component.scss
@@ -45,6 +45,7 @@ $breadcrumb-chevron-spacer: 2px;
 
         &.active {
             display: block;
+            overflow: visible;
         }
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Too long breadcrumb in the Demo shell's toolbar was not ellipsied.


**What is the new behaviour?**
Ellipsis is applied on toolbar breadcrumb if the breadcrumb has more element than is able to see without ellipsis.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
