### PR TITLE
[ADF-224] fix the rendering of custom stencils when form is opened in readonly state.

### DIFF
--- a/ng2-components/ng2-activiti-form/src/components/form-field/form-field.component.ts
+++ b/ng2-components/ng2-activiti-form/src/components/form-field/form-field.component.ts
@@ -53,7 +53,7 @@ declare var adf: any;
 })
 export class FormFieldComponent implements OnInit, OnDestroy {
 
-    @ViewChild('container', {read: ViewContainerRef})
+    @ViewChild('container', { read: ViewContainerRef })
     container: ViewContainerRef;
 
     @Input()
@@ -70,25 +70,26 @@ export class FormFieldComponent implements OnInit, OnDestroy {
     }
 
     ngOnInit() {
-        if (this.field) {
-            let customTemplate = this.field.form.customFieldTemplates[this.field.type];
-            if (customTemplate && this.hasController(this.field.type)) {
-                let factory = this.getComponentFactorySync(this.field.type, customTemplate);
+        let field = this.getField();
+        if (field) {
+            let customTemplate = this.field.form.customFieldTemplates[field.type];
+            if (customTemplate && this.hasController(field.type)) {
+                let factory = this.getComponentFactorySync(field.type, customTemplate);
                 this.componentRef = this.container.createComponent(factory);
                 let instance: any = this.componentRef.instance;
                 if (instance) {
-                    instance.field = this.field;
+                    instance.field = field;
                 }
             } else {
-                let componentType = this.formRenderingService.resolveComponentType(this.field);
+                let componentType = this.formRenderingService.resolveComponentType(field);
                 if (componentType) {
                     let factory = this.componentFactoryResolver.resolveComponentFactory(componentType);
                     this.componentRef = this.container.createComponent(factory);
                     let instance = <WidgetComponent> this.componentRef.instance;
                     instance.field = this.field;
                     instance.fieldChanged.subscribe(field => {
-                        if (field && field.form) {
-                            this.visibilityService.refreshVisibility(field.form);
+                        if (field && this.field.form) {
+                            this.visibilityService.refreshVisibility(this.field.form);
                         }
                     });
                 }
@@ -101,6 +102,10 @@ export class FormFieldComponent implements OnInit, OnDestroy {
             this.componentRef.destroy();
             this.componentRef = null;
         }
+    }
+
+    private getField() {
+        return (this.field.params && this.field.params.field) ? this.field.params.field : this.field;
     }
 
     private hasController(type: string): boolean {
@@ -126,10 +131,10 @@ export class FormFieldComponent implements OnInit, OnDestroy {
 
     private createComponentFactorySync(compiler: Compiler, metadata: Component, componentClass: any): ComponentFactory<any> {
         const cmpClass = componentClass || class RuntimeComponent {
-            };
+        };
         const decoratedCmp = Component(metadata)(cmpClass);
 
-        @NgModule({imports: [CoreModule], declarations: [decoratedCmp]})
+        @NgModule({ imports: [CoreModule], declarations: [decoratedCmp] })
         class RuntimeComponentModule {
         }
 

--- a/ng2-components/ng2-activiti-form/src/components/form-field/form-field.component.ts
+++ b/ng2-components/ng2-activiti-form/src/components/form-field/form-field.component.ts
@@ -70,18 +70,18 @@ export class FormFieldComponent implements OnInit, OnDestroy {
     }
 
     ngOnInit() {
-        let field = this.getField();
-        if (field) {
-            let customTemplate = this.field.form.customFieldTemplates[field.type];
-            if (customTemplate && this.hasController(field.type)) {
-                let factory = this.getComponentFactorySync(field.type, customTemplate);
+        let originalField = this.getField();
+        if (originalField) {
+            let customTemplate = this.field.form.customFieldTemplates[originalField.type];
+            if (customTemplate && this.hasController(originalField.type)) {
+                let factory = this.getComponentFactorySync(originalField.type, customTemplate);
                 this.componentRef = this.container.createComponent(factory);
                 let instance: any = this.componentRef.instance;
                 if (instance) {
-                    instance.field = field;
+                    instance.field = originalField;
                 }
             } else {
-                let componentType = this.formRenderingService.resolveComponentType(field);
+                let componentType = this.formRenderingService.resolveComponentType(originalField);
                 if (componentType) {
                     let factory = this.componentFactoryResolver.resolveComponentFactory(componentType);
                     this.componentRef = this.container.createComponent(factory);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
When a form is opened in readonly state the custom component registered is not used, but is showed just a default field.


**What is the new behaviour?**
When the form is opened in readonly mode the custom component is used


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
