### PR TITLE
[ADF-1208] remove useless date conversion

### DIFF
--- a/ng2-components/ng2-alfresco-core/src/services/favorites-api.service.ts
+++ b/ng2-components/ng2-alfresco-core/src/services/favorites-api.service.ts
@@ -35,9 +35,6 @@ export class FavoritesApiService {
     }
 
     static remapEntry({ entry }: any): any {
-        entry.createdAt = new Date(entry.createdAt);
-        entry.modifiedAt = new Date(entry.modifiedAt);
-
         entry.properties = {
             'cm:title': entry.title,
             'cm:description': entry.description


### PR DESCRIPTION
fixes the bug for Safari when dates get corrupted on double conversion (createdAt/modifiedAt are already dates)