### PR TITLE
[ADF-720] replace 'template' with 'ng-template'

### DIFF
--- a/demo-shell-ng2/app/components/files/files.component.html
+++ b/demo-shell-ng2/app/components/files/files.component.html
@@ -96,9 +96,9 @@
                     title="{{'DOCUMENT_LIST.COLUMNS.TAG' | translate}}"
                     key="id"
                     class="full-width ellipsis-cell">
-                    <template let-entry="$implicit">
+                    <ng-template let-entry="$implicit">
                         <alfresco-tag-node-list  [nodeId]="entry.data.getValue(entry.row, entry.col)"></alfresco-tag-node-list>
-                    </template>
+                    </ng-template>
                 </data-column>
                 -->
                 <data-column

--- a/ng2-components/ng2-alfresco-documentlist/src/components/content-node-selector/content-node-selector.component.html
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/content-node-selector/content-node-selector.component.html
@@ -45,9 +45,9 @@
                     [enablePagination]="false"
                     data-automation-id="content-node-selector-document-list">
             <empty-folder-content>
-                <template>
+                <ng-template>
                     <div>{{ 'NODE_SELECTOR.NO_RESULTS' | translate }}</div>
-                </template>
+                </ng-template>
             </empty-folder-content>
         </adf-document-list>
     </div>


### PR DESCRIPTION
Replace last occurrences of 'template' in Angular components (moved to 'ng-template')