### PR TITLE
remove mdl from "Content Services" page (demo shell)

### DIFF
--- a/demo-shell-ng2/app/components/files/files.component.html
+++ b/demo-shell-ng2/app/components/files/files.component.html
@@ -8,8 +8,8 @@
         [versioning]="versioning"
         [enabled]="documentList.hasCreatePermission()">
         <div *ngIf="errorMessage" class="error-message">
-            <button (click)="resetError()" class="mdl-button mdl-js-button mdl-button--icon">
-                <i class="material-icons">highlight_off</i>
+            <button (click)="resetError()" md-icon-button>
+                <md-icon>highlight_off</md-icon>
             </button>
             <span class="error-message--text">{{errorMessage}}</span>
         </div>


### PR DESCRIPTION
Minor update to remove the 'MDL' usage from the "Content Services" demo page (demo shell)