### PR TITLE
[ADF-662] fix readonly button for upload and added event for show fil…

### DIFF
--- a/ng2-components/ng2-activiti-form/src/components/widgets/upload/upload.widget.html
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/upload/upload.widget.html
@@ -6,9 +6,13 @@
         <div>
             <md-list *ngIf="hasFile">
                 <md-list-item class="adf-upload-files-row" *ngFor="let file of field.value">
-                    <img md-list-icon class="adf-upload-widget__icon" [src]="getIcon(file.mimeType)" [alt]="mimeTypeIcon"/>
+                    <img md-list-icon class="adf-upload-widget__icon"
+                            [id]="'file-'+file.id+'-icon'"
+                            [src]="getIcon(file.mimeType)"
+                            [alt]="mimeTypeIcon"
+                            (click)="fileClicked(file)"/>
                     <span md-line id="{{'file-'+file.id}}" class="adf-file">{{decode(file.name)}}</span>
-                    <button md-icon-button [id]="'file-'+file.id+'-remove'" (click)="reset(file);" (keyup.enter)="reset(file);">
+                    <button *ngIf="!field.readOnly" md-icon-button [id]="'file-'+file.id+'-remove'" (click)="reset(file);" (keyup.enter)="reset(file);">
                         <md-icon class="md-24">highlight_off</md-icon>
                     </button>
                 </md-list-item>
@@ -24,4 +28,5 @@
                (change)="onFileChanged($event)">
     </div>
     <error-widget [error]="field.validationSummary" ></error-widget>
+
 </div>

--- a/ng2-components/ng2-activiti-form/src/components/widgets/upload/upload.widget.scss
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/upload/upload.widget.scss
@@ -18,6 +18,7 @@
     &-upload-widget__icon {
         padding: 6px;
         float: left;
+        cursor: pointer;
     }
 
     &-adf-file {

--- a/ng2-components/ng2-activiti-form/src/components/widgets/upload/upload.widget.spec.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/upload/upload.widget.spec.ts
@@ -112,6 +112,7 @@ describe('UploadWidgetComponent', () => {
         let element: HTMLInputElement;
         let debugElement: DebugElement;
         let inputElement: HTMLInputElement;
+        let formServiceInstance: FormService;
 
         beforeEach(async(() => {
             TestBed.configureTestingModule({
@@ -140,6 +141,7 @@ describe('UploadWidgetComponent', () => {
                 type: FormFieldTypes.UPLOAD,
                 readOnly: false
             });
+            formServiceInstance = TestBed.get(FormService);
             jasmine.Ajax.install();
         });
 
@@ -248,6 +250,33 @@ describe('UploadWidgetComponent', () => {
                 expect(uploadWidgetComponent.field.value.length).toBe(1);
             });
         }));
+
+        it('should emit form content clicked event on icon click', (done) => {
+
+            formServiceInstance.formContentClicked.subscribe((content: any) => {
+                expect(content.name).toBe(fakeJpgAnswer.name);
+                expect(content.id).toBe(fakeJpgAnswer.id);
+                expect(content.contentBlob).not.toBeNull();
+                done();
+            });
+
+            uploadWidgetComponent.field.params.multiple = true;
+            uploadWidgetComponent.field.value = [];
+            uploadWidgetComponent.field.value.push(fakeJpgAnswer);
+            uploadWidgetComponent.field.value.push(fakePngAnswer);
+            fixture.detectChanges();
+
+            fixture.whenStable().then(() => {
+                let fileJpegIcon = debugElement.query(By.css('#file-1156-icon'));
+                fileJpegIcon.nativeElement.dispatchEvent(new MouseEvent('click'));
+                jasmine.Ajax.requests.mostRecent().respondWith({
+                    status: 200,
+                    contentType: 'json',
+                    responseText: new Blob()
+                });
+            });
+
+        });
 
     });
 

--- a/ng2-components/ng2-activiti-form/src/components/widgets/upload/upload.widget.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/upload/upload.widget.ts
@@ -21,6 +21,7 @@ import { Component, OnInit, ViewEncapsulation } from '@angular/core';
 import { LogService, ThumbnailService } from 'ng2-alfresco-core';
 import { Observable } from 'rxjs/Rx';
 import { FormService } from '../../../services/form.service';
+import { ContentLinkModel } from '../core/content-link.model';
 import { baseHost, WidgetComponent } from './../widget.component';
 
 @Component({
@@ -115,6 +116,18 @@ export class UploadWidgetComponent extends WidgetComponent implements OnInit {
 
     getIcon(mimeType) {
         return this.thumbnailService.getMimeTypeIcon(mimeType);
+    }
+
+    fileClicked(file: ContentLinkModel): void {
+        this.formService.getFileRawContent(file.id).subscribe(
+            (blob: Blob) => {
+                file.contentBlob = blob;
+                this.formService.formContentClicked.next(file);
+            },
+            (error) => {
+                this.logService.error('Unable to send evento for file ' + file.name);
+            }
+        );
     }
 
 }


### PR DESCRIPTION
…e in viewer

**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Remove button is wrongly showed on readonly form.
No file preview is showed


**What is the new behaviour?**
fileContentClicked event is raised when user click on file icon
remove button is not showed on readonly form.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
