### PR TITLE
[ADF-1188] Upload related components, unify interfaces, deprecate disableWithNoPermission

### DIFF
--- a/demo-shell-ng2/app/components/files/files.component.html
+++ b/demo-shell-ng2/app/components/files/files.component.html
@@ -6,7 +6,7 @@
     <alfresco-upload-drag-area
         [parentId]="documentList.currentFolderId"
         [versioning]="versioning"
-        [enabled]="documentList.hasCreatePermission()">
+        [disabled]="!documentList.hasCreatePermission()">
         <div *ngIf="errorMessage" class="error-message">
             <button (click)="resetError()" md-icon-button>
                 <md-icon>highlight_off</md-icon>

--- a/demo-shell-ng2/app/components/files/files.component.html
+++ b/demo-shell-ng2/app/components/files/files.component.html
@@ -275,7 +275,8 @@
             [multipleFiles]="multipleFileUpload"
             [uploadFolders]="folderUpload"
             [versioning]="versioning"
-            [disableWithNoPermission]="disableWithNoPermission"
+            [adf-node-permission]="'create'"
+            [adf-nodes]="getCurrentDocumentListNode()"
             (permissionEvent)="handlePermissionError($event)">
         </alfresco-upload-button>
     </div>
@@ -290,7 +291,8 @@
             [multipleFiles]="multipleFileUpload"
             [uploadFolders]="folderUpload"
             [versioning]="versioning"
-            [disableWithNoPermission]="disableWithNoPermission"
+            [adf-node-permission]="'create'"
+            [adf-nodes]="getCurrentDocumentListNode()"
             (permissionEvent)="handlePermissionError($event)">
         </alfresco-upload-button>
     </div>

--- a/demo-shell-ng2/app/components/files/files.component.html
+++ b/demo-shell-ng2/app/components/files/files.component.html
@@ -6,7 +6,8 @@
     <alfresco-upload-drag-area
         [parentId]="documentList.currentFolderId"
         [versioning]="versioning"
-        [disabled]="!documentList.hasCreatePermission()">
+        [adf-node-permission]="'create'"
+        [adf-nodes]="getCurrentDocumentListNode()">
         <div *ngIf="errorMessage" class="error-message">
             <button (click)="resetError()" md-icon-button>
                 <md-icon>highlight_off</md-icon>

--- a/demo-shell-ng2/app/components/files/files.component.ts
+++ b/demo-shell-ng2/app/components/files/files.component.ts
@@ -143,6 +143,14 @@ export class FilesComponent implements OnInit {
         // this.permissionsStyle.push(new PermissionStyleModel('document-list__disable', PermissionsEnum.NOT_CREATE, false, true));
     }
 
+    getCurrentDocumentListNode(): MinimalNodeEntity[] {
+        if (this.documentList.folderNode) {
+            return [ { entry: this.documentList.folderNode } ];
+        } else {
+            return [];
+        }
+    }
+
     onNavigationError(err: any) {
         if (err) {
             this.errorMessage = err.message || 'Navigation error';

--- a/ng2-components/ng2-alfresco-core/index.ts
+++ b/ng2-components/ng2-alfresco-core/index.ts
@@ -127,11 +127,13 @@ export { CardViewModule } from './src/components/view/card-view.module';
 export { CollapsableModule } from './src/components/collapsable/collapsable.module';
 export { CardViewItem } from './src/interface/card-view-item.interface';
 export { TimeAgoPipe } from './src/pipes/time-ago.pipe';
+export { EXTENDIBLE_COMPONENT } from './src/interface/injection.tokens';
 
 export * from './src/components/data-column/data-column.component';
 export * from './src/components/data-column/data-column-list.component';
 export * from './src/directives/upload.directive';
 export * from './src/directives/highlight.directive';
+export * from './src/directives/node-permission.directive';
 export * from './src/utils/index';
 export * from './src/events/base.event';
 export * from './src/events/base-ui.event';

--- a/ng2-components/ng2-alfresco-core/src/directives/node-permission.directive.spec.ts
+++ b/ng2-components/ng2-alfresco-core/src/directives/node-permission.directive.spec.ts
@@ -15,98 +15,138 @@
  * limitations under the License.
  */
 
-import { ElementRef, SimpleChange } from '@angular/core';
+import { Component, ElementRef, SimpleChange } from '@angular/core';
 import { AlfrescoContentService } from './../services/alfresco-content.service';
-import { NodePermissionDirective } from './node-permission.directive';
+import { NodePermissionDirective, NodePermissionSubject } from './node-permission.directive';
+
+@Component({
+    selector: 'adf-text-subject'
+})
+class TestComponent implements NodePermissionSubject {
+    disabled: boolean = false;
+}
 
 describe('NodePermissionDirective', () => {
 
-    it('updates element once it is loaded', () => {
-        const directive = new NodePermissionDirective(null, null, null);
-        spyOn(directive, 'updateElement').and.stub();
+    describe('HTML nativeElement as subject', () => {
 
-        directive.ngAfterViewInit();
+        it('updates element once it is loaded', () => {
+            const directive = new NodePermissionDirective(null, null, null);
+            spyOn(directive, 'updateElement').and.stub();
 
-        expect(directive.updateElement).toHaveBeenCalled();
+            directive.ngAfterViewInit();
+
+            expect(directive.updateElement).toHaveBeenCalled();
+        });
+
+        it('updates element on nodes change', () => {
+            const directive = new NodePermissionDirective(null, null, null);
+            spyOn(directive, 'updateElement').and.stub();
+
+            const nodes = [{}, {}];
+            const change = new SimpleChange([], nodes, false);
+            directive.ngOnChanges({ nodes: change });
+
+            expect(directive.updateElement).toHaveBeenCalled();
+        });
+
+        it('updates element only on subsequent change', () => {
+            const directive = new NodePermissionDirective(null, null, null);
+            spyOn(directive, 'updateElement').and.stub();
+
+            const nodes = [{}, {}];
+            const change = new SimpleChange([], nodes, true);
+            directive.ngOnChanges({ nodes: change });
+
+            expect(directive.updateElement).not.toHaveBeenCalled();
+        });
+
+        it('enables decorated element', () => {
+            const renderer = jasmine.createSpyObj('renderer', ['removeAttribute']);
+            const elementRef = new ElementRef({});
+            const directive = new NodePermissionDirective(elementRef, renderer, null);
+
+            directive.enableElement();
+
+            expect(renderer.removeAttribute).toHaveBeenCalledWith(elementRef.nativeElement, 'disabled');
+        });
+
+        it('disables decorated element', () => {
+            const renderer = jasmine.createSpyObj('renderer', ['setAttribute']);
+            const elementRef = new ElementRef({});
+            const directive = new NodePermissionDirective(elementRef, renderer, null);
+
+            directive.disableElement();
+
+            expect(renderer.setAttribute).toHaveBeenCalledWith(elementRef.nativeElement, 'disabled', 'true');
+        });
+
+        it('disables element when nodes not available', () => {
+            const directive = new NodePermissionDirective(null, null, null);
+            spyOn(directive, 'disableElement').and.stub();
+
+            directive.nodes = null;
+            expect(directive.updateElement()).toBeFalsy();
+
+            directive.nodes = [];
+            expect(directive.updateElement()).toBeFalsy();
+        });
+
+        it('enables element when all nodes have expected permission', () => {
+            const contentService = new AlfrescoContentService(null, null, null);
+            spyOn(contentService, 'hasPermission').and.returnValue(true);
+
+            const directive = new NodePermissionDirective(null, null, contentService);
+            spyOn(directive, 'enableElement').and.stub();
+
+            directive.nodes = <any> [{}, {}];
+
+            expect(directive.updateElement()).toBeTruthy();
+            expect(directive.enableElement).toHaveBeenCalled();
+        });
+
+        it('disables element when one of the nodes have no permission', () => {
+            const contentService = new AlfrescoContentService(null, null, null);
+            spyOn(contentService, 'hasPermission').and.returnValue(false);
+
+            const directive = new NodePermissionDirective(null, null, contentService);
+            spyOn(directive, 'disableElement').and.stub();
+
+            directive.nodes = <any> [{}, {}];
+
+            expect(directive.updateElement()).toBeFalsy();
+            expect(directive.disableElement).toHaveBeenCalled();
+        });
     });
 
-    it('updates element on nodes change', () => {
-        const directive = new NodePermissionDirective(null, null, null);
-        spyOn(directive, 'updateElement').and.stub();
+    describe('Angular component as subject', () => {
 
-        const nodes = [{}, {}];
-        const change = new SimpleChange([], nodes, false);
-        directive.ngOnChanges({ nodes: change });
+        it('disables decorated component', () => {
+            const contentService = new AlfrescoContentService(null, null, null);
+            spyOn(contentService, 'hasPermission').and.returnValue(false);
 
-        expect(directive.updateElement).toHaveBeenCalled();
+            let testComponent = new TestComponent();
+            testComponent.disabled = false;
+            const directive = new NodePermissionDirective(null, null, contentService, testComponent);
+            directive.nodes = <any> [{}, {}];
+
+            directive.updateElement();
+
+            expect(testComponent.disabled).toBeTruthy();
+        });
+
+        it('enables decorated component', () => {
+            const contentService = new AlfrescoContentService(null, null, null);
+            spyOn(contentService, 'hasPermission').and.returnValue(true);
+
+            let testComponent = new TestComponent();
+            testComponent.disabled = true;
+            const directive = new NodePermissionDirective(null, null, contentService, testComponent);
+            directive.nodes = <any> [{}, {}];
+
+            directive.updateElement();
+
+            expect(testComponent.disabled).toBeFalsy();
+        });
     });
-
-    it('updates element only on subsequent change', () => {
-        const directive = new NodePermissionDirective(null, null, null);
-        spyOn(directive, 'updateElement').and.stub();
-
-        const nodes = [{}, {}];
-        const change = new SimpleChange([], nodes, true);
-        directive.ngOnChanges({ nodes: change });
-
-        expect(directive.updateElement).not.toHaveBeenCalled();
-    });
-
-    it('enables decorated element', () => {
-        const renderer = jasmine.createSpyObj('renderer', ['removeAttribute']);
-        const elementRef = new ElementRef({});
-        const directive = new NodePermissionDirective(elementRef, renderer, null);
-
-        directive.enableElement();
-
-        expect(renderer.removeAttribute).toHaveBeenCalledWith(elementRef.nativeElement, 'disabled');
-    });
-
-    it('disables decorated element', () => {
-        const renderer = jasmine.createSpyObj('renderer', ['setAttribute']);
-        const elementRef = new ElementRef({});
-        const directive = new NodePermissionDirective(elementRef, renderer, null);
-
-        directive.disableElement();
-
-        expect(renderer.setAttribute).toHaveBeenCalledWith(elementRef.nativeElement, 'disabled', 'true');
-    });
-
-    it('disables element when nodes not available', () => {
-        const directive = new NodePermissionDirective(null, null, null);
-        spyOn(directive, 'disableElement').and.stub();
-
-        directive.nodes = null;
-        expect(directive.updateElement()).toBeFalsy();
-
-        directive.nodes = [];
-        expect(directive.updateElement()).toBeFalsy();
-    });
-
-    it('enables element when all nodes have expected permission', () => {
-        const contentService = new AlfrescoContentService(null, null, null);
-        spyOn(contentService, 'hasPermission').and.returnValue(true);
-
-        const directive = new NodePermissionDirective(null, null, contentService);
-        spyOn(directive, 'enableElement').and.stub();
-
-        directive.nodes = <any> [{}, {}];
-
-        expect(directive.updateElement()).toBeTruthy();
-        expect(directive.enableElement).toHaveBeenCalled();
-    });
-
-    it('disables element when one of the nodes have no permission', () => {
-        const contentService = new AlfrescoContentService(null, null, null);
-        spyOn(contentService, 'hasPermission').and.returnValue(false);
-
-        const directive = new NodePermissionDirective(null, null, contentService);
-        spyOn(directive, 'disableElement').and.stub();
-
-        directive.nodes = <any> [{}, {}];
-
-        expect(directive.updateElement()).toBeFalsy();
-        expect(directive.disableElement).toHaveBeenCalled();
-    });
-
 });

--- a/ng2-components/ng2-alfresco-core/src/directives/node-permission.directive.ts
+++ b/ng2-components/ng2-alfresco-core/src/directives/node-permission.directive.ts
@@ -15,9 +15,14 @@
  * limitations under the License.
  */
 
-import { AfterViewInit, Directive, ElementRef, Input, OnChanges, Renderer2, SimpleChanges } from '@angular/core';
+import { AfterViewInit, Directive, ElementRef, Host, Inject, Input, OnChanges, Optional, Renderer2, SimpleChanges } from '@angular/core';
 import { MinimalNodeEntity } from 'alfresco-js-api';
+import { EXTENDIBLE_COMPONENT } from './../interface/injection.tokens';
 import { AlfrescoContentService } from './../services/alfresco-content.service';
+
+export interface NodePermissionSubject {
+    setEnabled(enabled: boolean);
+}
 
 @Directive({
     selector: '[adf-node-permission]'
@@ -32,7 +37,11 @@ export class NodePermissionDirective implements OnChanges, AfterViewInit {
 
     constructor(private elementRef: ElementRef,
                 private renderer: Renderer2,
-                private contentService: AlfrescoContentService) {
+                private contentService: AlfrescoContentService,
+
+                @Host()
+                @Optional()
+                @Inject(EXTENDIBLE_COMPONENT) private parentComponent?: NodePermissionSubject) {
     }
 
     ngAfterViewInit() {
@@ -55,12 +64,28 @@ export class NodePermissionDirective implements OnChanges, AfterViewInit {
         let enable = this.hasPermission(this.nodes, this.permission);
 
         if (enable) {
-            this.enableElement();
+            this.enable();
         } else {
-            this.disableElement();
+            this.disable();
         }
 
         return enable;
+    }
+
+    private enable(): void {
+        if (this.parentComponent) {
+            this.parentComponent.setEnabled(true);
+        } else {
+            this.enableElement();
+        }
+    }
+
+    private disable(): void {
+        if (this.parentComponent) {
+            this.parentComponent.setEnabled(false);
+        } else {
+            this.disableElement();
+        }
     }
 
     /**

--- a/ng2-components/ng2-alfresco-core/src/directives/node-permission.directive.ts
+++ b/ng2-components/ng2-alfresco-core/src/directives/node-permission.directive.ts
@@ -21,7 +21,7 @@ import { EXTENDIBLE_COMPONENT } from './../interface/injection.tokens';
 import { AlfrescoContentService } from './../services/alfresco-content.service';
 
 export interface NodePermissionSubject {
-    setEnabled(enabled: boolean);
+    disabled: boolean;
 }
 
 @Directive({
@@ -74,7 +74,7 @@ export class NodePermissionDirective implements OnChanges, AfterViewInit {
 
     private enable(): void {
         if (this.parentComponent) {
-            this.parentComponent.setEnabled(true);
+            this.parentComponent.disabled = false;
         } else {
             this.enableElement();
         }
@@ -82,7 +82,7 @@ export class NodePermissionDirective implements OnChanges, AfterViewInit {
 
     private disable(): void {
         if (this.parentComponent) {
-            this.parentComponent.setEnabled(false);
+            this.parentComponent.disabled = true;
         } else {
             this.disableElement();
         }

--- a/ng2-components/ng2-alfresco-core/src/directives/node-permission.md
+++ b/ng2-components/ng2-alfresco-core/src/directives/node-permission.md
@@ -1,5 +1,19 @@
 # Node Permission Directive
 
+<!-- markdown-toc start - Don't edit this section.  npm run toc to generate it-->
+
+<!-- toc -->
+
+- [Properties](#properties)
+- [HTML element example](#html-element-example)
+- [Angular component example](#angular-component-example)
+  * [Implementing the NodePermissionSubject interface](#implementing-the-nodepermissionsubject-interface)
+  * [Defining your components as an EXTENDIBLE_COMPONENT parent component](#defining-your-components-as-an-extendible_component-parent-component)
+
+<!-- tocstop -->
+
+<!-- markdown-toc end -->
+
 The `NodePermissionDirective` allows you to disable an HTML element or Angular component 
 by taking a collection of the `MinimalNodeEntity` instances and checking the particular permission.
 
@@ -8,7 +22,14 @@ The decorated element will be disabled if:
 - there are no nodes in the collection
 - at least one of the nodes has no expected permission
 
-## Basic example
+## Properties
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| adf-node-permission | [Permissions](https://github.com/Alfresco/alfresco-ng2-components/blob/master/ng2-components/ng2-alfresco-core/src/models/permissions.enum.ts) | null | Node permission to check (create, delete, update, updatePermissions, !create, !delete, !update, !updatePermissions)|
+| adf-nodes | MinimalNodeEntity[] | [] | Nodes to check permission for |
+
+## HTML element example
 
 The best example to show `NodePermissionDirective` in action is by binding DocumentList selection property to a toolbar button.
 
@@ -30,9 +51,47 @@ For example the "Delete" button should be disabled if no selection is present or
 
 The button will become disabled by default, and is going to change its state once user selects/unselects one or multiple documents that current user has permission to delete.
 
-## Properties
+## Angular component example
 
-| Name | Type | Default | Description |
-| --- | --- | --- | --- |
-| adf-node-permission | [Permissions](https://github.com/Alfresco/alfresco-ng2-components/blob/master/ng2-components/ng2-alfresco-core/src/models/permissions.enum.ts) | null | Node permission to check (create, delete, update, updatePermissions, !create, !delete, !update, !updatePermissions)|
-| adf-nodes | MinimalNodeEntity[] | [] | Nodes to check permission for |
+You can apply the directive on any angular component which implements the NodePermissionSubject interface. The upload drag area component can be a good candidate, since this one implements that interface. Applying the directive on an angular component is pretty much the same as applying it on an html element.
+
+```html
+<alfresco-upload-drag-area
+        [parentId]="..."
+        [versioning]="..."
+        [adf-node-permission]="'create'"
+        [adf-nodes]="getCurrentDocumentListNode()">
+ ...
+</alfresco-upload-drag-area>
+```
+
+When designing a component you want to work this directive with, you have two important things to care about.
+
+### Implementing the NodePermissionSubject interface
+
+The component has to implement the NodePermissionSubject interface which basically means it has to have a boolean **disabled** property. This is the property which will be set by the directive.
+
+```js
+import { NodePermissionSubject } from 'ng2-alfresco-core';
+
+@Component({...})
+export class UploadDragAreaComponent implements NodePermissionSubject {
+    public disabled: boolean = false;
+}
+```
+
+### Defining your components as an EXTENDIBLE_COMPONENT parent component
+
+The directive will look up the component in the dependency injection tree, up to at most one step above the current DI level (@Host). Because of this, you have to provide your component with forward referencing as the EXTENDIBLE_COMPONENT.
+
+```js
+import { EXTENDIBLE_COMPONENT } from 'ng2-alfresco-core';
+
+@Component({
+    ...
+    providers: [
+        { provide: EXTENDIBLE_COMPONENT, useExisting: forwardRef(() => UploadDragAreaComponent)}
+    ]
+})
+export class UploadDragAreaComponent implements NodePermissionSubject { ... }
+```

--- a/ng2-components/ng2-alfresco-core/src/interface/injection.tokens.ts
+++ b/ng2-components/ng2-alfresco-core/src/interface/injection.tokens.ts
@@ -17,4 +17,4 @@
 
 import { Component, InjectionToken } from '@angular/core';
 
-export const EXTENDIBLE_COMPONENT = new InjectionToken<Component>('exntedible.component');
+export const EXTENDIBLE_COMPONENT = new InjectionToken<Component>('extendible.component');

--- a/ng2-components/ng2-alfresco-core/src/interface/injection.tokens.ts
+++ b/ng2-components/ng2-alfresco-core/src/interface/injection.tokens.ts
@@ -1,0 +1,20 @@
+/*!
+ * @license
+ * Copyright 2016 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, InjectionToken } from '@angular/core';
+
+export const EXTENDIBLE_COMPONENT = new InjectionToken<Component>('exntedible.component');

--- a/ng2-components/ng2-alfresco-upload/README.md
+++ b/ng2-components/ng2-alfresco-upload/README.md
@@ -92,7 +92,7 @@ npm install ng2-alfresco-upload
 | parentId | string | empty | The ID of the root. It can be the nodeId if you are using the upload for the Content Service or taskId/processId for the Process Service. |
 | versioning | boolean | false | Versioning false is the default uploader behaviour and it renames the file using an integer suffix if there is a name clash. Versioning true to indicate that a major version should be created |
 | staticTitle | string | (predefined) | define the text of the upload button |
-| disableWithNoPermission | boolean | false |  If the value is true and the user doesn't have the permission to delete the node the button will be disabled |
+| **(deprecated)** disableWithNoPermission ***use node permission directive from core instead*** | boolean | false |  If the value is true and the user doesn't have the permission to delete the node the button will be disabled |
 | tooltip | string | | Custom tooltip |
 
 ### Events
@@ -171,7 +171,8 @@ export class AppComponent {
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| enabled | boolean | true | Toggle component enabled state |
+| disabled | boolean | false | Toggle component disabled state |
+| **(deprecated)** enabled | boolean | true | Toggle component enabled state |
 | **(deprecated)** showNotificationBar | boolean | true |  Hide/show notification bar. **Deprecated in 1.6.0: use UploadService events and NotificationService api instead.** |
 | rootFolderId | string | '-root-' | The ID of the root folder node. |
 | **(deprecated)** currentFolderPath | string | '/' | define the path where the files are uploaded. **Deprecated in 1.6.0: use rootFolderId instead.** |

--- a/ng2-components/ng2-alfresco-upload/src/components/upload-button.component.ts
+++ b/ng2-components/ng2-alfresco-upload/src/components/upload-button.component.ts
@@ -109,15 +109,6 @@ export class UploadButtonComponent implements OnInit, OnChanges, NodePermissionS
         });
     }
 
-    /**
-     * Connector method for the NodePermissionSubject
-     *
-     * @param enabled
-     */
-    setEnabled(enabled: boolean) {
-        this.disabled = !enabled;
-    }
-
     ngOnChanges(changes: SimpleChanges) {
         let rootFolderId = changes['rootFolderId'];
         if (rootFolderId && rootFolderId.currentValue) {

--- a/ng2-components/ng2-alfresco-upload/src/components/upload-button.component.ts
+++ b/ng2-components/ng2-alfresco-upload/src/components/upload-button.component.ts
@@ -98,9 +98,6 @@ export class UploadButtonComponent implements OnInit, OnChanges, NodePermissionS
                 private logService: LogService,
                 private notificationService: NotificationService,
                 private apiService: AlfrescoApiService) {
-        if (translateService) {
-            translateService.addTranslationFolder('ng2-alfresco-upload', 'assets/ng2-alfresco-upload');
-        }
     }
 
     ngOnInit() {

--- a/ng2-components/ng2-alfresco-upload/src/components/upload-button.component.ts
+++ b/ng2-components/ng2-alfresco-upload/src/components/upload-button.component.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges } from '@angular/core';
+import { Component, ElementRef, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges } from '@angular/core';
 import { MinimalNodeEntryEntity } from 'alfresco-js-api';
 import { AlfrescoApiService, AlfrescoTranslationService, FileModel, FileUtils, LogService, NotificationService, UploadService } from 'ng2-alfresco-core';
 import { Observable, Subject } from 'rxjs/Rx';
@@ -28,17 +28,20 @@ import { PermissionModel } from '../models/permissions.model';
 })
 export class UploadButtonComponent implements OnInit, OnChanges {
 
-    @Input()
-    disabled: boolean = false;
-
-    /**
-     * @deprecated Deprecated in 1.6.0, you can use UploadService events and NotificationService api instead.
-     *
-     * @type {boolean}
-     * @memberof UploadButtonComponent
-     */
+    /** @deprecated Deprecated in 1.6.0, you can use UploadService events and NotificationService api instead. */
     @Input()
     showNotificationBar: boolean = true;
+
+    /** @deprecated Deprecated in 1.6.0, this property is not used for couple of releases already. */
+    @Input()
+    currentFolderPath: string = '/';
+
+    /** @deprecated Deprecated in 1.8.0, use the button with combination of adf-node-permission directive */
+    @Input()
+    disableWithNoPermission: boolean = false;
+
+    @Input()
+    disabled: boolean = false;
 
     @Input()
     uploadFolders: boolean = false;
@@ -58,20 +61,8 @@ export class UploadButtonComponent implements OnInit, OnChanges {
     @Input()
     tooltip: string = null;
 
-    /**
-     * @deprecated Deprecated in 1.6.0, this property is not used for couple of releases already.
-     *
-     * @type {string}
-     * @memberof UploadDragAreaComponent
-     */
-    @Input()
-    currentFolderPath: string = '/';
-
     @Input()
     rootFolderId: string = '-root-';
-
-    @Input()
-    disableWithNoPermission: boolean = false;
 
     @Output()
     onSuccess = new EventEmitter();
@@ -93,7 +84,11 @@ export class UploadButtonComponent implements OnInit, OnChanges {
                 private translateService: AlfrescoTranslationService,
                 private logService: LogService,
                 private notificationService: NotificationService,
-                private apiService: AlfrescoApiService) {
+                private apiService: AlfrescoApiService,
+                private elementRef: ElementRef) {
+        if (translateService) {
+            translateService.addTranslationFolder('ng2-alfresco-upload', 'assets/ng2-alfresco-upload');
+        }
     }
 
     ngOnInit() {
@@ -114,9 +109,10 @@ export class UploadButtonComponent implements OnInit, OnChanges {
     }
 
     isForceDisable(): boolean {
-        return this.disabled ? true : undefined;
+        return this.disabled || !!this.elementRef.nativeElement.getAttribute('disabled') ? true : undefined;
     }
 
+    /** @deprecated Deprecated in 1.8.0, use the button with combination of adf-node-permission directive */
     isDisableWithNoPermission(): boolean {
         return !this.hasPermission && this.disableWithNoPermission ? true : undefined;
     }

--- a/ng2-components/ng2-alfresco-upload/src/components/upload-button.component.ts
+++ b/ng2-components/ng2-alfresco-upload/src/components/upload-button.component.ts
@@ -109,6 +109,11 @@ export class UploadButtonComponent implements OnInit, OnChanges, NodePermissionS
         });
     }
 
+    /**
+     * Connector method for the NodePermissionSubject
+     *
+     * @param enabled
+     */
     setEnabled(enabled: boolean) {
         this.disabled = !enabled;
     }

--- a/ng2-components/ng2-alfresco-upload/src/components/upload-button.component.ts
+++ b/ng2-components/ng2-alfresco-upload/src/components/upload-button.component.ts
@@ -15,18 +15,31 @@
  * limitations under the License.
  */
 
-import { Component, ElementRef, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges } from '@angular/core';
+import { Component, EventEmitter, forwardRef, Input, OnChanges, OnInit, Output, SimpleChanges } from '@angular/core';
 import { MinimalNodeEntryEntity } from 'alfresco-js-api';
-import { AlfrescoApiService, AlfrescoTranslationService, FileModel, FileUtils, LogService, NotificationService, UploadService } from 'ng2-alfresco-core';
+import {
+    AlfrescoApiService,
+    AlfrescoTranslationService,
+    EXTENDIBLE_COMPONENT,
+    FileModel,
+    FileUtils,
+    LogService,
+    NodePermissionSubject,
+    NotificationService,
+    UploadService
+} from 'ng2-alfresco-core';
 import { Observable, Subject } from 'rxjs/Rx';
 import { PermissionModel } from '../models/permissions.model';
 
 @Component({
     selector: 'adf-upload-button, alfresco-upload-button',
     templateUrl: './upload-button.component.html',
-    styleUrls: ['./upload-button.component.css']
+    styleUrls: ['./upload-button.component.css'],
+    providers: [
+        { provide: EXTENDIBLE_COMPONENT, useExisting: forwardRef(() => UploadButtonComponent)}
+    ]
 })
-export class UploadButtonComponent implements OnInit, OnChanges {
+export class UploadButtonComponent implements OnInit, OnChanges, NodePermissionSubject {
 
     /** @deprecated Deprecated in 1.6.0, you can use UploadService events and NotificationService api instead. */
     @Input()
@@ -84,8 +97,7 @@ export class UploadButtonComponent implements OnInit, OnChanges {
                 private translateService: AlfrescoTranslationService,
                 private logService: LogService,
                 private notificationService: NotificationService,
-                private apiService: AlfrescoApiService,
-                private elementRef: ElementRef) {
+                private apiService: AlfrescoApiService) {
         if (translateService) {
             translateService.addTranslationFolder('ng2-alfresco-upload', 'assets/ng2-alfresco-upload');
         }
@@ -95,6 +107,10 @@ export class UploadButtonComponent implements OnInit, OnChanges {
         this.permissionValue.subscribe((permission: boolean) => {
             this.hasPermission = permission;
         });
+    }
+
+    setEnabled(enabled: boolean) {
+        this.disabled = !enabled;
     }
 
     ngOnChanges(changes: SimpleChanges) {
@@ -109,7 +125,7 @@ export class UploadButtonComponent implements OnInit, OnChanges {
     }
 
     isForceDisable(): boolean {
-        return this.disabled || !!this.elementRef.nativeElement.getAttribute('disabled') ? true : undefined;
+        return this.disabled ? true : undefined;
     }
 
     /** @deprecated Deprecated in 1.8.0, use the button with combination of adf-node-permission directive */

--- a/ng2-components/ng2-alfresco-upload/src/components/upload-drag-area.component.html
+++ b/ng2-components/ng2-alfresco-upload/src/components/upload-drag-area.component.html
@@ -1,4 +1,4 @@
-<div [file-draggable]="enabled" id="UploadBorder" class="upload-border"
+<div [file-draggable]="isDroppable()" id="UploadBorder" class="upload-border"
      (onFilesDropped)="onFilesDropped($event)"
      (onFilesEntityDropped)="onFilesEntityDropped($event)"
      (onFolderEntityDropped)="onFolderEntityDropped($event)"

--- a/ng2-components/ng2-alfresco-upload/src/components/upload-drag-area.component.ts
+++ b/ng2-components/ng2-alfresco-upload/src/components/upload-drag-area.component.ts
@@ -15,15 +15,27 @@
  * limitations under the License.
  */
 
-import { Component, EventEmitter, Input, Output } from '@angular/core';
-import { AlfrescoTranslationService, FileInfo, FileModel, FileUtils, NotificationService, UploadService } from 'ng2-alfresco-core';
+import { Component, EventEmitter, forwardRef, Input, Output } from '@angular/core';
+import {
+    AlfrescoTranslationService,
+    EXTENDIBLE_COMPONENT,
+    FileInfo,
+    FileModel,
+    FileUtils,
+    NodePermissionSubject,
+    NotificationService,
+    UploadService
+} from 'ng2-alfresco-core';
 
 @Component({
     selector: 'adf-upload-drag-area, alfresco-upload-drag-area',
     templateUrl: './upload-drag-area.component.html',
-    styleUrls: ['./upload-drag-area.component.css']
+    styleUrls: ['./upload-drag-area.component.css'],
+    providers: [
+        { provide: EXTENDIBLE_COMPONENT, useExisting: forwardRef(() => UploadDragAreaComponent)}
+    ]
 })
-export class UploadDragAreaComponent {
+export class UploadDragAreaComponent implements NodePermissionSubject {
 
     /** @deprecated Deprecated in favor of disabled input property */
     @Input()
@@ -65,6 +77,15 @@ export class UploadDragAreaComponent {
     constructor(private uploadService: UploadService,
                 private translateService: AlfrescoTranslationService,
                 private notificationService: NotificationService) {
+    }
+
+    /**
+     * Connector method for the NodePermissionSubject
+     *
+     * @param enabled
+     */
+    setEnabled(enabled: boolean) {
+        this.disabled = !enabled;
     }
 
     /**

--- a/ng2-components/ng2-alfresco-upload/src/components/upload-drag-area.component.ts
+++ b/ng2-components/ng2-alfresco-upload/src/components/upload-drag-area.component.ts
@@ -25,8 +25,22 @@ import { AlfrescoTranslationService, FileInfo, FileModel, FileUtils, Notificatio
 })
 export class UploadDragAreaComponent {
 
+    /** @deprecated
+     *
+     * Deprecated in favor of disabled input property
+     */
     @Input()
-    enabled: boolean = true;
+    set enabled(enabled: boolean) {
+        console.warn('Deprecated: enabled input property should not be used for UploadDragAreaComponent. Please use disabled instead.');
+        this.disabled = !enabled;
+    }
+
+    get enabled(): boolean {
+        return !this.disabled;
+    }
+
+    @Input()
+    disabled: boolean = false;
 
     /**
      * @deprecated Deprecated in 1.6.0, you can use UploadService events and NotificationService api instead.
@@ -100,7 +114,7 @@ export class UploadDragAreaComponent {
      * @param {File[]} files - files dropped in the drag area.
      */
     onFilesDropped(files: File[]): void {
-        if (this.enabled && files.length) {
+        if (!this.disabled && files.length) {
             const fileModels = files.map(file => new FileModel(file, {
                 newVersion: this.versioning,
                 path: '/',
@@ -120,7 +134,7 @@ export class UploadDragAreaComponent {
      * @param item - FileEntity
      */
     onFilesEntityDropped(item: any): void {
-        if (this.enabled) {
+        if (!this.disabled) {
             item.file((file: File) => {
                 const fileModel = new FileModel(file, {
                     newVersion: this.versioning,
@@ -141,7 +155,7 @@ export class UploadDragAreaComponent {
      * @param folder - name of the dropped folder
      */
     onFolderEntityDropped(folder: any): void {
-        if (this.enabled && folder.isDirectory) {
+        if (!this.disabled && folder.isDirectory) {
             FileUtils.flattern(folder).then(entries => {
                 let files = entries.map(entry => {
                     return new FileModel(entry.file, {
@@ -206,6 +220,6 @@ export class UploadDragAreaComponent {
     }
 
     private isAllowed(node: any) {
-        return this.enabled || this.hasCreatePermission(node);
+        return !this.disabled || this.hasCreatePermission(node);
     }
 }

--- a/ng2-components/ng2-alfresco-upload/src/components/upload-drag-area.component.ts
+++ b/ng2-components/ng2-alfresco-upload/src/components/upload-drag-area.component.ts
@@ -80,15 +80,6 @@ export class UploadDragAreaComponent implements NodePermissionSubject {
     }
 
     /**
-     * Connector method for the NodePermissionSubject
-     *
-     * @param enabled
-     */
-    setEnabled(enabled: boolean) {
-        this.disabled = !enabled;
-    }
-
-    /**
      * Method called when files are dropped in the drag area.
      *
      * @param {File[]} files - files dropped in the drag area.


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [x] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Upload button and upload drag area component are too different in interfaces, try to make them more similar. disableWithNoPermission property is not deprecated.


**What is the new behaviour?**
Fixes for all of the listed above.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
