### PR TITLE
removing node_modules after every publish will reduce the load on the…

### DIFF
--- a/scripts/npm-publish.sh
+++ b/scripts/npm-publish.sh
@@ -137,7 +137,8 @@ do
 
   echo "====== PUBLISHING: ${DESTDIR} ===== npm publish ${OPTIONS}"
   npm publish ${OPTIONS} || exit 1
-
+  rm -rf node_modules
+  
   if $EXEC_CHANGE_REGISTRY == true; then
       npm run rimraf .npmrc
   fi


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Every time we publish a new package, we don't delete the node_modules folder created as a byproduct of the build. This can clog the machine disk space and lead to an Error: No Space left on devide

**What is the new behaviour?**
Now after publishing every module, before changing folder, the local node_modules folder (relative to the package) gets deleted.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
