### PR TITLE
[ADF-1456]  timeAgo Pipe - Return invalid date when the input is empty.

### DIFF
--- a/ng2-components/ng2-alfresco-core/src/pipes/time-ago.pipe.spec.ts
+++ b/ng2-components/ng2-alfresco-core/src/pipes/time-ago.pipe.spec.ts
@@ -1,0 +1,42 @@
+/*!
+ * @license
+ * Copyright 2016 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TimeAgoPipe } from './time-ago.pipe';
+
+describe('TimeAgoPipe', () => {
+
+    let pipe: TimeAgoPipe;
+
+    beforeEach(() => {
+        pipe = new TimeAgoPipe();
+    });
+
+    it('should return time difference for a given date', () => {
+        let date = new Date();
+        expect(pipe.transform(date)).toBe('a few seconds ago');
+    });
+
+    it('should return exact date if given date is more than seven days ', () => {
+        let date = new Date('1990-11-03T15:25:42.749+0000');
+        expect(pipe.transform(date)).toBe('03/11/1990 20:55');
+    });
+
+    it('should return empty string if given date is empty', () => {
+        expect(pipe.transform(null)).toBe('');
+        expect(pipe.transform(undefined)).toBe('');
+    });
+});

--- a/ng2-components/ng2-alfresco-core/src/pipes/time-ago.pipe.spec.ts
+++ b/ng2-components/ng2-alfresco-core/src/pipes/time-ago.pipe.spec.ts
@@ -31,8 +31,8 @@ describe('TimeAgoPipe', () => {
     });
 
     it('should return exact date if given date is more than seven days ', () => {
-        let date = new Date('1990-11-03T15:25:42.749+0000');
-        expect(pipe.transform(date)).toBe('03/11/1990 20:55');
+        let date = new Date('1990-11-03T15:25:42.749');
+        expect(pipe.transform(date)).toBe('03/11/1990 15:25');
     });
 
     it('should return empty string if given date is empty', () => {

--- a/ng2-components/ng2-alfresco-core/src/pipes/time-ago.pipe.ts
+++ b/ng2-components/ng2-alfresco-core/src/pipes/time-ago.pipe.ts
@@ -25,8 +25,11 @@ import { Pipe, PipeTransform } from '@angular/core';
 export class TimeAgoPipe implements PipeTransform {
 
     transform(value: Date) {
-        const then = moment(value);
-        const diff = moment().diff(then, 'days');
-        return diff > 7 ? then.format('DD/MM/YYYY HH:mm') : then.fromNow();
+        if (value !== null && value !== undefined ) {
+            const then = moment(value);
+            const diff = moment().diff(then, 'days');
+            return diff > 7 ? then.format('DD/MM/YYYY HH:mm') : then.fromNow();
+        }
+        return '';
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

* Returns "invalid date" when the input is empty.

**What is the new behaviour?**

* Returns Empty string if the input is empty.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
