### PR TITLE
[ADF-1458] wrongly named input attribute - renamed disabled into disable

### DIFF
--- a/demo-shell-ng2/app/components/files/files.component.html
+++ b/demo-shell-ng2/app/components/files/files.component.html
@@ -268,10 +268,10 @@
         </md-input-container>
     </section>
     <div *ngIf="!acceptedFilesTypeShow">
-        <alfresco-upload-button
+        <adf-upload-button
             #uploadButton
             tooltip="Custom tooltip"
-            [disabled]="!enableUpload"
+            [disable]="!enableUpload"
             data-automation-id="multiple-file-upload"
             [rootFolderId]="documentList.currentFolderId"
             [multipleFiles]="multipleFileUpload"
@@ -280,13 +280,13 @@
             [adf-node-permission]="'create'"
             [adf-nodes]="getCurrentDocumentListNode()"
             (permissionEvent)="handlePermissionError($event)">
-        </alfresco-upload-button>
+        </adf-upload-button>
     </div>
     <div *ngIf="acceptedFilesTypeShow">
         <alfresco-upload-button
             #uploadButton
             tooltip="Custom tooltip"
-            [disabled]="!enableUpload"
+            [disable]="!enableUpload"
             data-automation-id="multiple-file-upload"
             [rootFolderId]="documentList.currentFolderId"
             [acceptedFilesType]="acceptedFilesType"

--- a/ng2-components/ng2-alfresco-core/src/directives/node-permission.directive.spec.ts
+++ b/ng2-components/ng2-alfresco-core/src/directives/node-permission.directive.spec.ts
@@ -23,7 +23,7 @@ import { NodePermissionDirective, NodePermissionSubject } from './node-permissio
     selector: 'adf-text-subject'
 })
 class TestComponent implements NodePermissionSubject {
-    disabled: boolean = false;
+    disable: boolean = false;
 }
 
 describe('NodePermissionDirective', () => {
@@ -126,13 +126,13 @@ describe('NodePermissionDirective', () => {
             spyOn(contentService, 'hasPermission').and.returnValue(false);
 
             let testComponent = new TestComponent();
-            testComponent.disabled = false;
+            testComponent.disable = false;
             const directive = new NodePermissionDirective(null, null, contentService, testComponent);
             directive.nodes = <any> [{}, {}];
 
             directive.updateElement();
 
-            expect(testComponent.disabled).toBeTruthy();
+            expect(testComponent.disable).toBeTruthy();
         });
 
         it('enables decorated component', () => {
@@ -140,13 +140,13 @@ describe('NodePermissionDirective', () => {
             spyOn(contentService, 'hasPermission').and.returnValue(true);
 
             let testComponent = new TestComponent();
-            testComponent.disabled = true;
+            testComponent.disable = true;
             const directive = new NodePermissionDirective(null, null, contentService, testComponent);
             directive.nodes = <any> [{}, {}];
 
             directive.updateElement();
 
-            expect(testComponent.disabled).toBeFalsy();
+            expect(testComponent.disable).toBeFalsy();
         });
     });
 });

--- a/ng2-components/ng2-alfresco-core/src/directives/node-permission.directive.ts
+++ b/ng2-components/ng2-alfresco-core/src/directives/node-permission.directive.ts
@@ -21,7 +21,7 @@ import { EXTENDIBLE_COMPONENT } from './../interface/injection.tokens';
 import { AlfrescoContentService } from './../services/alfresco-content.service';
 
 export interface NodePermissionSubject {
-    disabled: boolean;
+    disable: boolean;
 }
 
 @Directive({
@@ -74,7 +74,7 @@ export class NodePermissionDirective implements OnChanges, AfterViewInit {
 
     private enable(): void {
         if (this.parentComponent) {
-            this.parentComponent.disabled = false;
+            this.parentComponent.disable = false;
         } else {
             this.enableElement();
         }
@@ -82,7 +82,7 @@ export class NodePermissionDirective implements OnChanges, AfterViewInit {
 
     private disable(): void {
         if (this.parentComponent) {
-            this.parentComponent.disabled = true;
+            this.parentComponent.disable = true;
         } else {
             this.disableElement();
         }

--- a/ng2-components/ng2-alfresco-upload/README.md
+++ b/ng2-components/ng2-alfresco-upload/README.md
@@ -58,7 +58,7 @@ Contains components for handling uploads to Content Services.
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| disabled | boolean | false | Toggle component disabled state |
+| disable | boolean | false | Toggle component disabled state |
 | **(deprecated)** showNotificationBar | boolean | true | Hide/show notification bar. **Deprecated in 1.6.0: use UploadService events and NotificationService api instead.** |
 | uploadFolders | boolean | false | Allow/disallow upload folders (only for Chrome) |
 | multipleFiles | boolean | false | Allow/disallow multiple files |

--- a/ng2-components/ng2-alfresco-upload/src/components/upload-button.component.ts
+++ b/ng2-components/ng2-alfresco-upload/src/components/upload-button.component.ts
@@ -54,8 +54,8 @@ export class UploadButtonComponent implements OnInit, OnChanges, NodePermissionS
     @Input()
     disableWithNoPermission: boolean = false;
 
-    @Input('disabled')
-    disabled: boolean = false;
+    @Input()
+    disable: boolean = false;
 
     @Input()
     uploadFolders: boolean = false;
@@ -119,7 +119,7 @@ export class UploadButtonComponent implements OnInit, OnChanges, NodePermissionS
     }
 
     isForceDisable(): boolean {
-        return this.disabled ? true : undefined;
+        return this.disable ? true : undefined;
     }
 
     /** @deprecated Deprecated in 1.8.0, use the button with combination of adf-node-permission directive */

--- a/ng2-components/ng2-alfresco-upload/src/components/upload-drag-area.component.ts
+++ b/ng2-components/ng2-alfresco-upload/src/components/upload-drag-area.component.ts
@@ -42,13 +42,13 @@ export class UploadDragAreaComponent implements NodePermissionSubject {
     @Input()
     set enabled(enabled: boolean) {
         console.warn('Deprecated: enabled input property should not be used for UploadDragAreaComponent. Please use disabled instead.');
-        this.disabled = !enabled;
+        this.disable = !enabled;
     }
 
     /** @deprecated Deprecated in favor of disabled input property */
     get enabled(): boolean {
         console.warn('Deprecated: enabled input property should not be used for UploadDragAreaComponent. Please use disabled instead.');
-        return !this.disabled;
+        return !this.disable;
     }
 
     /** @deprecated Deprecated in 1.6.0, you can use UploadService events and NotificationService api instead. */
@@ -63,8 +63,8 @@ export class UploadDragAreaComponent implements NodePermissionSubject {
     @Input()
     rootFolderId: string = '-root-';
 
-    @Input('disabled')
-    disabled: boolean = false;
+    @Input()
+    disable: boolean = false;
 
     @Input()
     versioning: boolean = false;
@@ -86,7 +86,7 @@ export class UploadDragAreaComponent implements NodePermissionSubject {
      * @param {File[]} files - files dropped in the drag area.
      */
     onFilesDropped(files: File[]): void {
-        if (!this.disabled && files.length) {
+        if (!this.disable && files.length) {
             const fileModels = files.map(file => new FileModel(file, {
                 newVersion: this.versioning,
                 path: '/',
@@ -107,7 +107,7 @@ export class UploadDragAreaComponent implements NodePermissionSubject {
      * @param item - FileEntity
      */
     onFilesEntityDropped(item: any): void {
-        if (!this.disabled) {
+        if (!this.disable) {
             item.file((file: File) => {
                 const fileModel = new FileModel(file, {
                     newVersion: this.versioning,
@@ -129,7 +129,7 @@ export class UploadDragAreaComponent implements NodePermissionSubject {
      * @param folder - name of the dropped folder
      */
     onFolderEntityDropped(folder: any): void {
-        if (!this.disabled && folder.isDirectory) {
+        if (!this.disable && folder.isDirectory) {
             FileUtils.flattern(folder).then(entries => {
                 let files = entries.map(entry => {
                     return new FileModel(entry.file, {
@@ -176,7 +176,7 @@ export class UploadDragAreaComponent implements NodePermissionSubject {
 
     /** Returns true or false considering the component options and node permissions */
     isDroppable(): boolean {
-        return !this.disabled;
+        return !this.disable;
     }
 
     /**


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Upload button is not disabled when the attribute disabled is changed, this is due overlapping of the attributes with the standard html one mapped by angular.


**What is the new behaviour?**
Renamed disabled into disable to allow the correct attribute mapping by angular.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
