### PR TITLE
[ADF-1522] allow loading layout presets from app.config

### DIFF
--- a/demo-shell-ng2/app.config-dev.json
+++ b/demo-shell-ng2/app.config-dev.json
@@ -25,5 +25,230 @@
                 }
             ]
         }
+    },
+    "document-list": {
+        "presets": {
+            "-trashcan-": [
+                {
+                    "key": "$thumbnail",
+                    "type": "image",
+                    "srTitle": "ADF-DOCUMENT-LIST.LAYOUT.THUMBNAIL",
+                    "sortable": false
+                },
+                {
+                    "key": "name",
+                    "type": "text",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.NAME",
+                    "cssClass": "full-width ellipsis-cell",
+                    "sortable": true
+                },
+                {
+                    "key": "path",
+                    "type": "location",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.LOCATION",
+                    "format": "/files",
+                    "sortable": true
+                },
+                {
+                    "key": "content.sizeInBytes",
+                    "type": "fileSize",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.SIZE",
+                    "sortable": true
+                },
+                {
+                    "key": "archivedAt",
+                    "type": "date",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.DELETED_ON",
+                    "format": "timeAgo",
+                    "sortable": true
+                },
+                {
+                    "key": "archivedByUser.displayName",
+                    "type": "text",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.DELETED_BY",
+                    "sortable": true
+                }
+            ],
+            "-sites-": [
+                {
+                    "key": "$thumbnail",
+                    "type": "image",
+                    "srTitle": "ADF-DOCUMENT-LIST.LAYOUT.THUMBNAIL",
+                    "sortable": false
+                },
+                {
+                    "key": "title",
+                    "type": "text",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.NAME",
+                    "cssClass": "full-width ellipsis-cell",
+                    "sortable": true
+                },
+                {
+                    "key": "visibility",
+                    "type": "text",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.STATUS",
+                    "sortable": true
+                }
+            ],
+            "-favorites-": [
+                {
+                    "key": "$thumbnail",
+                    "type": "image",
+                    "srTitle": "ADF-DOCUMENT-LIST.LAYOUT.THUMBNAIL",
+                    "sortable": false
+                },
+                {
+                    "key": "name",
+                    "type": "text",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.NAME",
+                    "cssClass": "full-width ellipsis-cell",
+                    "sortable": true
+                },
+                {
+                    "key": "path",
+                    "type": "location",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.LOCATION",
+                    "format": "/files",
+                    "sortable": true
+                },
+                {
+                    "key": "content.sizeInBytes",
+                    "type": "fileSize",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.SIZE",
+                    "sortable": true
+                },
+                {
+                    "key": "modifiedAt",
+                    "type": "date",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.MODIFIED_ON",
+                    "format": "timeAgo",
+                    "sortable": true
+                },
+                {
+                    "key": "modifiedByUser.displayName",
+                    "type": "text",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.MODIFIED_BY",
+                    "sortable": true
+                }
+            ],
+            "-recent-": [
+                {
+                    "key": "$thumbnail",
+                    "type": "image",
+                    "srTitle": "ADF-DOCUMENT-LIST.LAYOUT.THUMBNAIL",
+                    "sortable": false
+                },
+                {
+                    "key": "name",
+                    "type": "text",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.NAME",
+                    "cssClass": "full-width ellipsis-cell",
+                    "sortable": true
+                },
+                {
+                    "key": "path",
+                    "type": "location",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.LOCATION",
+                    "cssClass": "ellipsis-cell",
+                    "format": "/files",
+                    "sortable": true
+                },
+                {
+                    "key": "content.sizeInBytes",
+                    "type": "fileSize",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.SIZE",
+                    "sortable": true
+                },
+                {
+                    "key": "modifiedAt",
+                    "type": "date",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.MODIFIED_ON",
+                    "format": "timeAgo",
+                    "sortable": true
+                }
+            ],
+            "-sharedlinks-": [
+                {
+                    "key": "$thumbnail",
+                    "type": "image",
+                    "srTitle": "ADF-DOCUMENT-LIST.LAYOUT.THUMBNAIL",
+                    "sortable": false
+                },
+                {
+                    "key": "name",
+                    "type": "text",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.NAME",
+                    "cssClass": "full-width ellipsis-cell",
+                    "sortable": true
+                },
+                {
+                    "key": "path",
+                    "type": "location",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.LOCATION",
+                    "cssClass": "ellipsis-cell",
+                    "format": "/files",
+                    "sortable": true
+                },
+                {
+                    "key": "content.sizeInBytes",
+                    "type": "fileSize",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.SIZE",
+                    "sortable": true
+                },
+                {
+                    "key": "modifiedAt",
+                    "type": "date",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.MODIFIED_ON",
+                    "format": "timeAgo",
+                    "sortable": true
+                },
+                {
+                    "key": "modifiedByUser.displayName",
+                    "type": "text",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.MODIFIED_BY",
+                    "sortable": true
+                },
+                {
+                    "key": "sharedByUser.displayName",
+                    "type": "text",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.SHARED_BY",
+                    "sortable": true
+                }
+            ],
+            "default": [
+                {
+                    "key": "$thumbnail",
+                    "type": "image",
+                    "srTitle": "ADF-DOCUMENT-LIST.LAYOUT.THUMBNAIL",
+                    "sortable": false
+                },
+                {
+                    "key": "name",
+                    "type": "text",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.NAME",
+                    "cssClass": "full-width ellipsis-cell",
+                    "sortable": true
+                },
+                {
+                    "key": "content.sizeInBytes",
+                    "type": "fileSize",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.SIZE",
+                    "sortable": true
+                },
+                {
+                    "key": "modifiedAt",
+                    "type": "date",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.MODIFIED_ON",
+                    "format": "timeAgo",
+                    "sortable": true
+                },
+                {
+                    "key": "modifiedByUser.displayName",
+                    "type": "text",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.MODIFIED_BY",
+                    "sortable": true
+                }
+            ]
+        }
     }
 }

--- a/demo-shell-ng2/app.config-prod.json
+++ b/demo-shell-ng2/app.config-prod.json
@@ -25,5 +25,230 @@
                 }
             ]
         }
+    },
+    "document-list": {
+        "presets": {
+            "-trashcan-": [
+                {
+                    "key": "$thumbnail",
+                    "type": "image",
+                    "srTitle": "ADF-DOCUMENT-LIST.LAYOUT.THUMBNAIL",
+                    "sortable": false
+                },
+                {
+                    "key": "name",
+                    "type": "text",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.NAME",
+                    "cssClass": "full-width ellipsis-cell",
+                    "sortable": true
+                },
+                {
+                    "key": "path",
+                    "type": "location",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.LOCATION",
+                    "format": "/files",
+                    "sortable": true
+                },
+                {
+                    "key": "content.sizeInBytes",
+                    "type": "fileSize",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.SIZE",
+                    "sortable": true
+                },
+                {
+                    "key": "archivedAt",
+                    "type": "date",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.DELETED_ON",
+                    "format": "timeAgo",
+                    "sortable": true
+                },
+                {
+                    "key": "archivedByUser.displayName",
+                    "type": "text",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.DELETED_BY",
+                    "sortable": true
+                }
+            ],
+            "-sites-": [
+                {
+                    "key": "$thumbnail",
+                    "type": "image",
+                    "srTitle": "ADF-DOCUMENT-LIST.LAYOUT.THUMBNAIL",
+                    "sortable": false
+                },
+                {
+                    "key": "title",
+                    "type": "text",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.NAME",
+                    "cssClass": "full-width ellipsis-cell",
+                    "sortable": true
+                },
+                {
+                    "key": "visibility",
+                    "type": "text",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.STATUS",
+                    "sortable": true
+                }
+            ],
+            "-favorites-": [
+                {
+                    "key": "$thumbnail",
+                    "type": "image",
+                    "srTitle": "ADF-DOCUMENT-LIST.LAYOUT.THUMBNAIL",
+                    "sortable": false
+                },
+                {
+                    "key": "name",
+                    "type": "text",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.NAME",
+                    "cssClass": "full-width ellipsis-cell",
+                    "sortable": true
+                },
+                {
+                    "key": "path",
+                    "type": "location",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.LOCATION",
+                    "format": "/files",
+                    "sortable": true
+                },
+                {
+                    "key": "content.sizeInBytes",
+                    "type": "fileSize",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.SIZE",
+                    "sortable": true
+                },
+                {
+                    "key": "modifiedAt",
+                    "type": "date",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.MODIFIED_ON",
+                    "format": "timeAgo",
+                    "sortable": true
+                },
+                {
+                    "key": "modifiedByUser.displayName",
+                    "type": "text",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.MODIFIED_BY",
+                    "sortable": true
+                }
+            ],
+            "-recent-": [
+                {
+                    "key": "$thumbnail",
+                    "type": "image",
+                    "srTitle": "ADF-DOCUMENT-LIST.LAYOUT.THUMBNAIL",
+                    "sortable": false
+                },
+                {
+                    "key": "name",
+                    "type": "text",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.NAME",
+                    "cssClass": "full-width ellipsis-cell",
+                    "sortable": true
+                },
+                {
+                    "key": "path",
+                    "type": "location",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.LOCATION",
+                    "cssClass": "ellipsis-cell",
+                    "format": "/files",
+                    "sortable": true
+                },
+                {
+                    "key": "content.sizeInBytes",
+                    "type": "fileSize",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.SIZE",
+                    "sortable": true
+                },
+                {
+                    "key": "modifiedAt",
+                    "type": "date",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.MODIFIED_ON",
+                    "format": "timeAgo",
+                    "sortable": true
+                }
+            ],
+            "-sharedlinks-": [
+                {
+                    "key": "$thumbnail",
+                    "type": "image",
+                    "srTitle": "ADF-DOCUMENT-LIST.LAYOUT.THUMBNAIL",
+                    "sortable": false
+                },
+                {
+                    "key": "name",
+                    "type": "text",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.NAME",
+                    "cssClass": "full-width ellipsis-cell",
+                    "sortable": true
+                },
+                {
+                    "key": "path",
+                    "type": "location",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.LOCATION",
+                    "cssClass": "ellipsis-cell",
+                    "format": "/files",
+                    "sortable": true
+                },
+                {
+                    "key": "content.sizeInBytes",
+                    "type": "fileSize",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.SIZE",
+                    "sortable": true
+                },
+                {
+                    "key": "modifiedAt",
+                    "type": "date",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.MODIFIED_ON",
+                    "format": "timeAgo",
+                    "sortable": true
+                },
+                {
+                    "key": "modifiedByUser.displayName",
+                    "type": "text",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.MODIFIED_BY",
+                    "sortable": true
+                },
+                {
+                    "key": "sharedByUser.displayName",
+                    "type": "text",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.SHARED_BY",
+                    "sortable": true
+                }
+            ],
+            "default": [
+                {
+                    "key": "$thumbnail",
+                    "type": "image",
+                    "srTitle": "ADF-DOCUMENT-LIST.LAYOUT.THUMBNAIL",
+                    "sortable": false
+                },
+                {
+                    "key": "name",
+                    "type": "text",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.NAME",
+                    "cssClass": "full-width ellipsis-cell",
+                    "sortable": true
+                },
+                {
+                    "key": "content.sizeInBytes",
+                    "type": "fileSize",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.SIZE",
+                    "sortable": true
+                },
+                {
+                    "key": "modifiedAt",
+                    "type": "date",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.MODIFIED_ON",
+                    "format": "timeAgo",
+                    "sortable": true
+                },
+                {
+                    "key": "modifiedByUser.displayName",
+                    "type": "text",
+                    "title": "ADF-DOCUMENT-LIST.LAYOUT.MODIFIED_BY",
+                    "sortable": true
+                }
+            ]
+        }
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

For the moment layout presets are hard coded into the document list.

**What is the new behaviour?**

Allows providing layout presets in the "app.config.json" file. The Document List should overwrite the layout or use default (hard coded) one if no custom settings found.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
