### PR TITLE
[ADF-1538] fix memory leaks for pdf viewers

### DIFF
--- a/ng2-components/ng2-alfresco-viewer/src/components/pdfViewer.component.ts
+++ b/ng2-components/ng2-alfresco-viewer/src/components/pdfViewer.component.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Component, HostListener, Input, OnChanges, ViewEncapsulation } from '@angular/core';
+import { Component, HostListener, Input, OnChanges, OnDestroy, ViewEncapsulation } from '@angular/core';
 import { LogService } from 'ng2-alfresco-core';
 import { RenderingQueueServices } from '../services/rendering-queue.services';
 
@@ -32,7 +32,7 @@ declare let PDFJS: any;
     host: { 'class': 'adf-pdf-viewer' },
     encapsulation: ViewEncapsulation.None
 })
-export class PdfViewerComponent implements OnChanges {
+export class PdfViewerComponent implements OnChanges, OnDestroy {
 
     @Input()
     urlFile: string;
@@ -62,6 +62,8 @@ export class PdfViewerComponent implements OnChanges {
 
     constructor(private renderingQueueServices: RenderingQueueServices,
                 private logService: LogService) {
+        // needed to preserve "this" context when setting as a global document event listener
+        this.onDocumentScroll = this.onDocumentScroll.bind(this);
     }
 
     ngOnChanges(changes) {
@@ -127,9 +129,7 @@ export class PdfViewerComponent implements OnChanges {
         let documentContainer = document.getElementById('viewer-pdf-container');
         let viewer: any = document.getElementById('viewer-viewerPdf');
 
-        window.document.addEventListener('scroll', (event) => {
-            this.watchScroll(event.target);
-        }, true);
+        window.document.addEventListener('scroll', this.onDocumentScroll, true);
 
         this.pdfViewer = new PDFJS.PDFViewer({
             container: documentContainer,
@@ -140,6 +140,10 @@ export class PdfViewerComponent implements OnChanges {
         this.renderingQueueServices.setViewer(this.pdfViewer);
 
         this.pdfViewer.setDocument(pdfDocument);
+    }
+
+    ngOnDestroy() {
+        window.document.removeEventListener('scroll', this.onDocumentScroll, true);
     }
 
     /**
@@ -394,6 +398,12 @@ export class PdfViewerComponent implements OnChanges {
             this.nextPage();
         } else if (key === 37) {// left arrow
             this.previousPage();
+        }
+    }
+
+    onDocumentScroll(event: Event) {
+        if (event && event.target) {
+            this.watchScroll(event.target);
         }
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

The PDF viewers (both standard and the lightweight version for the Viewer Dialog) have memory leaks related to global document scrolling handler.

**What is the new behaviour?**

Update viewers to remove global scroll listeners on destroy phase.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
