### PR TITLE
[ADF-1533] Multi-line form max length 

### DIFF
--- a/ng2-components/ng2-activiti-form/src/components/widgets/multiline-text/multiline-text.widget.html
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/multiline-text/multiline-text.widget.html
@@ -6,7 +6,6 @@
                   md-autosize
                   type="text"
                   rows="3"
-                  [maxlength]="field.maxLength"
                   [id]="field.id"
                   [required]="isRequired()"
                   [(ngModel)]="field.value"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

In the new multi-line field in ADF 1.8, a red required warning line is shown incorrectly in a few scenarios. Looks like the current implementation always expect a max length in the configuration!


**What is the new behaviour?**
Not  always expect a max length


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
