### PR TITLE
[ADF-1455]  long app name are displayed under the logo in the applist

### DIFF
--- a/ng2-components/ng2-activiti-tasklist/src/components/apps-list.component.css
+++ b/ng2-components/ng2-activiti-tasklist/src/components/apps-list.component.css
@@ -4,6 +4,7 @@
 
 .application-title {
     color: white;
+    width: 80%;
 }
 
 .logo {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
When an app has a long name, is displayed under the logo.


**What is the new behaviour?**
long name are not displayed under the logo

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
