### PR TITLE
[ADF-1560] Process fields are not translated when starting a process and on process page

### DIFF
--- a/ng2-components/ng2-activiti-processlist/src/i18n/en.json
+++ b/ng2-components/ng2-activiti-processlist/src/i18n/en.json
@@ -70,8 +70,8 @@
                 "TITLE": "Couldn't complete that action",
                 "DESCRIPTION": "You might not have the required access level, check with your IT Team."
             }
-        }
     },
+    
     "START_PROCESS": {
         "BUTTON": "Start Process",
         "NO_PROCESS_DEFINITIONS": "You can't start a process as there are no process definitions available",


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

* Process fields are not translated when starting a process and on process page

**What is the new behaviour?**

* Process fields are translating when starting a process and on process page.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
