### PR TITLE
[ADF-1574] Info Drawer - Add a mechanism to know the current active tab

### DIFF
--- a/ng2-components/ng2-alfresco-core/src/components/info-drawer/info-drawer.component.html
+++ b/ng2-components/ng2-alfresco-core/src/components/info-drawer/info-drawer.component.html
@@ -7,7 +7,7 @@
     <ng-container info-drawer-content *ngIf="showTabLayout(); then tabLayout else singleLayout"></ng-container>
 
     <ng-template #tabLayout>
-        <md-tab-group class="adf-info-drawer-tabs">
+        <md-tab-group class="adf-info-drawer-tabs" (selectChange)="onTabChange($event)">
             <ng-container *ngFor="let contentBlock of contentBlocks">
                 <md-tab [label]="contentBlock.label" class="adf-info-drawer-tab">
                     <ng-container *ngTemplateOutlet="contentBlock.content"></ng-container>

--- a/ng2-components/ng2-alfresco-core/src/components/info-drawer/info-drawer.component.spec.ts
+++ b/ng2-components/ng2-alfresco-core/src/components/info-drawer/info-drawer.component.spec.ts
@@ -1,0 +1,72 @@
+/*!
+ * @license
+ * Copyright 2016 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { DebugElement } from '@angular/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MaterialModule } from '../../material.module';
+import { InfoDrawerLayoutComponent } from './info-drawer-layout.component';
+import { InfoDrawerComponent } from './info-drawer.component';
+
+declare let jasmine: any;
+
+describe('InfoDrawerComponent', () => {
+    let componentHandler: any;
+    let debugElement: DebugElement;
+    let element: HTMLElement;
+    let component: InfoDrawerComponent;
+    let fixture: ComponentFixture<InfoDrawerComponent>;
+
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [
+                InfoDrawerComponent,
+                InfoDrawerLayoutComponent
+            ],
+            imports: [
+                MaterialModule
+            ]
+        }).compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(InfoDrawerComponent);
+        component = fixture.componentInstance;
+        element = fixture.nativeElement;
+        debugElement = fixture.debugElement;
+        componentHandler = jasmine.createSpyObj('componentHandler', [
+            'upgradeAllRegistered',
+            'upgradeElement'
+        ]);
+        window['componentHandler'] = componentHandler;
+    });
+
+    it('should create instance of InfoDrawerComponent', () => {
+        expect(fixture.componentInstance instanceof InfoDrawerComponent).toBe(true, 'should create InfoDrawerComponent');
+    });
+
+    it('should define InfoDrawerTabLayout', () => {
+        let infoDrawerTabLayout = element.querySelector('adf-info-drawer-layout');
+        expect(infoDrawerTabLayout).toBeDefined();
+    });
+
+    it('should emit when tab is changed', () => {
+        let tabEmitSpy = spyOn(component.currentTab, 'emit');
+        let event = {index: 1, tab: {textLabel: 'DETAILS'}};
+        component.onTabChange(event);
+        expect(tabEmitSpy).toHaveBeenCalled();
+        expect(tabEmitSpy).toHaveBeenCalledWith('DETAILS');
+    });
+});

--- a/ng2-components/ng2-alfresco-core/src/components/info-drawer/info-drawer.component.ts
+++ b/ng2-components/ng2-alfresco-core/src/components/info-drawer/info-drawer.component.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Component, ContentChildren, Input, QueryList, TemplateRef, ViewChild, ViewEncapsulation } from '@angular/core';
+import { Component, ContentChildren, Input, QueryList, TemplateRef, ViewChild, ViewEncapsulation, Output, EventEmitter } from '@angular/core';
 @Component({
     selector: 'adf-info-drawer-tab',
     template: '<ng-template><ng-content></ng-content></ng-template>'
@@ -36,10 +36,18 @@ export class InfoDrawerComponent {
     @Input()
     title: string|null = null;
 
+    @Output()
+    tabChangeEvent: EventEmitter<any> =new EventEmitter<any>();
+
     @ContentChildren(InfoDrawerTabComponent)
     contentBlocks: QueryList<InfoDrawerTabComponent>;
 
     showTabLayout(): boolean {
         return this.contentBlocks.length > 0;
+    }
+
+    onTabChange(event: any) {
+        let tab = event.tab;
+        this.tabChangeEvent.emit(tab.textLabel);
     }
 }

--- a/ng2-components/ng2-alfresco-core/src/components/info-drawer/info-drawer.component.ts
+++ b/ng2-components/ng2-alfresco-core/src/components/info-drawer/info-drawer.component.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Component, ContentChildren, Input, QueryList, TemplateRef, ViewChild, ViewEncapsulation, Output, EventEmitter } from '@angular/core';
+import { Component, ContentChildren, EventEmitter, Input, Output, QueryList, TemplateRef, ViewChild, ViewEncapsulation } from '@angular/core';
 @Component({
     selector: 'adf-info-drawer-tab',
     template: '<ng-template><ng-content></ng-content></ng-template>'
@@ -37,7 +37,7 @@ export class InfoDrawerComponent {
     title: string|null = null;
 
     @Output()
-    tabChangeEvent: EventEmitter<any> =new EventEmitter<any>();
+    currentTab: EventEmitter<any> = new EventEmitter<any>();
 
     @ContentChildren(InfoDrawerTabComponent)
     contentBlocks: QueryList<InfoDrawerTabComponent>;
@@ -47,7 +47,7 @@ export class InfoDrawerComponent {
     }
 
     onTabChange(event: any) {
-        let tab = event.tab;
-        this.tabChangeEvent.emit(tab.textLabel);
+        const tab = event.tab;
+        this.currentTab.emit(tab.textLabel);
     }
 }

--- a/ng2-components/ng2-alfresco-core/src/components/info-drawer/info-drawer.md
+++ b/ng2-components/ng2-alfresco-core/src/components/info-drawer/info-drawer.md
@@ -53,19 +53,19 @@ The InfoDrawerLayoutComponent (as the name says) is basically just a layout with
 
 ## InfoDrawerComponent
 
-The InfoDrawerComponent is on top of the InfoDrawerLayoutComponent. This version of the info drawer is supposed to be used if you need tabbing behaviour. Additionally you can set a title (if it only contains a string) with the **title** input property.
-This component has the same 3 regions as described above, but if you want to leverage the tabbing functionality, you have to use the **adf-info-drawer-tab** component to organize your content. The only input paramter of the adf-info-drawer-tab component is the **"label"**, with you can specify the tab label with.
+The InfoDrawerComponent is on top of the InfoDrawerLayoutComponent. This version of the info drawer is supposed to be used if you need tabbing behaviour. You can set a title (if it only contains a string) with the **title** input property. Additionally, It also provides a **currentTab** output property. This component has the same 3 regions as described above, but if you want to leverage the tabbing functionality, you have to use the **adf-info-drawer-tab** component to organize your content. The only input paramter of the adf-info-drawer-tab component is the **"label"**, with you can specify the tab label with.
 
 ### Properties
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | title | string | null | The title of the info drawer component|
+| currentTab | any | null | The current active tab |
 
 ### Example
 
 ```html
-<adf-info-drawer title="Activities">
+<adf-info-drawer title="Activities" (currentTab)="getActiveTab($event)">
     <div info-drawer-buttons>
         <md-icon (click)="close()">clear</md-icon>
     </div>


### PR DESCRIPTION


**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**
A output event in adf-info-drawer component to get the current active tab


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
