### PR TITLE
improved "start:dist" script

### DIFF
--- a/demo-shell-ng2/package.json
+++ b/demo-shell-ng2/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "npm run server-versions && rimraf dist && npm run webpack -- --config  config/webpack.prod.js --progress --profile --bail",
     "build:dev": "npm run server-versions && rimraf dist && npm run webpack -- --config  config/webpack.dev.js --progress --profile --bail",
-    "start:dist": "npm run server-versions && wsrv -s dist/ -p 3000 -a 0.0.0.0",
+    "start:dist": "npm run server-versions && wsrv",
     "start": "npm run server-versions && npm run webpack-dev-server -- --config config/webpack.prod.js --progress  --content-base app/",
     "start:dev": "npm run server-versions && npm run webpack-dev-server -- --config config/webpack.dev.js --progress --content-base app/",
     "test": "rimraf coverage && karma start --single-run",
@@ -147,6 +147,6 @@
     "webpack": "2.2.1",
     "webpack-dev-server": "2.3.0",
     "webpack-merge": "2.6.1",
-    "wsrv": "0.1.7"
+    "wsrv": "0.2.2"
   }
 }

--- a/demo-shell-ng2/wsrv-config.js
+++ b/demo-shell-ng2/wsrv-config.js
@@ -1,0 +1,26 @@
+module.exports = {
+    "host": "0.0.0.0",
+    "port": 3000,
+    "dir": "./dist",
+    "spa": true,
+    "proxy": {
+        "/ecm/{p*}": {
+            "options": {
+                "uri": "http://0.0.0.0:8080/{p}"
+            }
+        },
+        "/bpm/{p*}": {
+            "options": {
+                "uri": "http://0.0.0.0:9999/{p}"
+            }
+        }
+    },
+    onResHeaders(headers) {
+        if (headers) {
+            const authHeader = headers['www-authenticate'];
+            if (authHeader) {
+                headers['www-authenticate'] = `x${authHeader}`;
+            }
+        }
+    }
+}


### PR DESCRIPTION
- proxy settings for `/ecm` and `/bpm`, can now use the same `app.config.json`
- workaround for `www-authenticate` issue