### PR TITLE
[ADF-1597] Dropdown widget should show the value in readonly mode

### DIFF
--- a/ng2-components/ng2-activiti-form/src/components/widgets/dropdown/dropdown.widget.html
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/dropdown/dropdown.widget.html
@@ -9,6 +9,7 @@
         <md-option *ngFor="let opt of field.options"
                    [value]="getOptionValue(opt, field.value)"
                    [id]="opt.id">{{opt.name}}</md-option>
+        <md-option id="readonlyOption" *ngIf="field.readOnly" [value]="field.value">{{field.value}}</md-option>
     </md-select>
     <error-widget [error]="field.validationSummary" ></error-widget>
     <error-widget class="adf-dropdown-required-message" *ngIf="isInvalidFieldRequired()" required="{{ 'FORM.FIELD.REQUIRED' | translate }}"></error-widget>

--- a/ng2-components/ng2-activiti-form/src/components/widgets/dropdown/dropdown.widget.spec.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/dropdown/dropdown.widget.spec.ts
@@ -288,6 +288,26 @@ describe('DropdownWidgetComponent', () => {
                         expect(dropDownElement.getAttribute('aria-disabled')).toBe('true');
                     });
             }));
+
+            it('should show the option value when the field is readonly', () => {
+                widget.field = new FormFieldModel(new FormModel({processDefinitionId: 'fake-process-id'}), {
+                    id: 'dropdown-id',
+                    name: 'date-name',
+                    type: 'dropdown',
+                    value: 'FakeValue',
+                    readOnly: true
+                });
+                const trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+                trigger.click();
+                fixture.detectChanges();
+                fixture.whenStable()
+                    .then(() => {
+                        fixture.detectChanges();
+                        expect(element.querySelector('#dropdown-id')).not.toBeNull();
+                        const option = fixture.debugElement.query(By.css('.mat-option')).nativeElement;
+                        expect(option.innerText).toEqual('FakeValue');
+                    });
+            });
         });
     });
 });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Drop-down doesn't display the value if the field is readonly



**What is the new behaviour?**
The drop-down should display the value if the field is readonly


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
