### PR TITLE
[ADF-1595] Typeahead - Fetch the value from the process variables

### DIFF
--- a/ng2-components/ng2-activiti-form/src/components/start-form.component.ts
+++ b/ng2-components/ng2-activiti-form/src/components/start-form.component.ts
@@ -102,19 +102,21 @@ export class StartFormComponent extends FormComponent implements OnChanges, OnIn
     }
 
     loadStartForm(processId: string) {
-        this.formService
-            .getStartFormInstance(processId)
-            .subscribe(
-                form => {
-                    this.formName = form.name;
-                    form.processDefinitionId = this.processDefinitionId;
-                    this.form = this.parseForm(form);
-                    this.form.readOnly = this.readOnlyForm;
-                    // this.form.processDefinitionId = this.processDefinitionId;
-                    this.onFormLoaded(this.form);
-                },
-                error => this.handleError(error)
-            );
+        this.formService.getProcessVarablesById(processId)
+            .subscribe((processVariables: any) => {
+                this.formService
+                    .getStartFormInstance(processId)
+                    .subscribe(
+                    form => {
+                        this.formName = form.name;
+                        form.processVariables = processVariables;
+                        this.form = this.parseForm(form);
+                        this.form.readOnly = this.readOnlyForm;
+                        this.onFormLoaded(this.form);
+                    },
+                    error => this.handleError(error)
+                    );
+            });
     }
 
     getStartFormDefinition(processId: string) {

--- a/ng2-components/ng2-activiti-form/src/components/widgets/core/form.model.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/core/form.model.ts
@@ -62,6 +62,7 @@ export class FormModel {
     readonly selectedOutcome: string;
 
     values: FormValues = {};
+    processVariables: any;
 
     readonly json: any;
 
@@ -93,6 +94,8 @@ export class FormModel {
             this.className = json.className || '';
 
             let tabCache: FormWidgetModelCache<TabModel> = {};
+
+            this.processVariables = json.processVariables;
 
             this.tabs = (json.tabs || []).map(t => {
                 let model = new TabModel(this, t);

--- a/ng2-components/ng2-activiti-form/src/components/widgets/dropdown/dropdown.widget.html
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/dropdown/dropdown.widget.html
@@ -9,7 +9,7 @@
         <md-option *ngFor="let opt of field.options"
                    [value]="getOptionValue(opt, field.value)"
                    [id]="opt.id">{{opt.name}}</md-option>
-        <md-option id="readonlyOption" *ngIf="field.readOnly" [value]="field.value">{{field.value}}</md-option>
+        <md-option id="readonlyOption" *ngIf="isReadOnlyType()" [value]="field.value">{{field.value}}</md-option>
     </md-select>
     <error-widget [error]="field.validationSummary" ></error-widget>
     <error-widget class="adf-dropdown-required-message" *ngIf="isInvalidFieldRequired()" required="{{ 'FORM.FIELD.REQUIRED' | translate }}"></error-widget>

--- a/ng2-components/ng2-activiti-form/src/components/widgets/dropdown/dropdown.widget.spec.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/dropdown/dropdown.widget.spec.ts
@@ -289,17 +289,18 @@ describe('DropdownWidgetComponent', () => {
                     });
             }));
 
-            it('should show the option value when the field is readonly', () => {
-                widget.field = new FormFieldModel(new FormModel({processDefinitionId: 'fake-process-id'}), {
+            it('should show the option value when the field is readonly', async(() => {
+                widget.field = new FormFieldModel(new FormModel({ processDefinitionId: 'fake-process-id' }), {
                     id: 'dropdown-id',
                     name: 'date-name',
-                    type: 'dropdown',
+                    type: 'readonly',
                     value: 'FakeValue',
-                    readOnly: true
+                    readOnly: true,
+                    params: { field: { name: 'date-name', type: 'dropdown' } }
                 });
-                const trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
-                trigger.click();
-                fixture.detectChanges();
+
+                openSelect();
+
                 fixture.whenStable()
                     .then(() => {
                         fixture.detectChanges();
@@ -307,7 +308,7 @@ describe('DropdownWidgetComponent', () => {
                         const option = fixture.debugElement.query(By.css('.mat-option')).nativeElement;
                         expect(option.innerText).toEqual('FakeValue');
                     });
-            });
+            }));
         });
     });
 });

--- a/ng2-components/ng2-activiti-form/src/components/widgets/dropdown/dropdown.widget.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/dropdown/dropdown.widget.ts
@@ -105,4 +105,8 @@ export class DropdownWidgetComponent extends WidgetComponent implements OnInit {
         this.logService.error(error);
     }
 
+    isReadOnlyType(): boolean {
+        return this.field.type === 'readonly' ? true : false;
+    }
+
 }

--- a/ng2-components/ng2-activiti-form/src/components/widgets/typeahead/typeahead.widget.html
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/typeahead/typeahead.widget.html
@@ -15,12 +15,13 @@
                    placeholder="{{field.placeholder}}"
                    [mdAutocomplete]="auto">
             <md-autocomplete #auto="mdAutocomplete" (optionSelected)="onItemSelect($event.option.value)">
-
                 <md-option *ngFor="let item of options" (click)="onItemClick(item, $event)"  [value]="item">
                     <span>{{item.name}}</span>
                 </md-option>
             </md-autocomplete>
-
+            <md-select class="adf-select" [id]="field.id" [(ngModel)]="field.value">
+                <md-option id="readonlyOption" *ngIf="isReadOnlyType()" [value]="field.value">{{field.value}}</md-option>
+            </md-select>
         </md-input-container>
 
         <error-widget [error]="field.validationSummary"></error-widget>

--- a/ng2-components/ng2-activiti-form/src/components/widgets/typeahead/typeahead.widget.spec.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/typeahead/typeahead.widget.spec.ts
@@ -363,6 +363,26 @@ describe('TypeaheadWidgetComponent', () => {
                 });
             }));
 
+            it('should show typeahead value when the type is readonly', async(() => {
+                typeaheadWidgetComponent.field = new FormFieldModel(
+                    new FormModel({ taskId: 'fake-task-id', processVariables: [{ name: 'typeahead-name_LABEL', value: 'FakeProcessValue' }] }), {
+                    id: 'typeahead-id',
+                    name: 'typeahead-name',
+                    type: 'readonly',
+                    value: '9',
+                    params: { field: { name: 'typeahead-name', type: 'typeahead' } }
+                });
+                fixture.detectChanges();
+                const trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
+                trigger.click();
+                fixture.detectChanges();
+                fixture.whenStable().then(() => {
+                    expect(element.querySelector('#typeahead-id')).not.toBeNull();
+                    let optionElement: HTMLElement = <HTMLElement> document.body.querySelector('.mat-option');
+                    expect(optionElement.innerText).toEqual('FakeProcessValue');
+                });
+            }));
+
         });
 
         describe('and typeahead is populated via processDefinitionId', () => {

--- a/ng2-components/ng2-activiti-form/src/components/widgets/typeahead/typeahead.widget.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/typeahead/typeahead.widget.ts
@@ -48,7 +48,7 @@ export class TypeaheadWidgetComponent extends WidgetComponent implements OnInit 
     ngOnInit() {
         if (this.field.form.taskId) {
             this.getValuesByTaskId();
-        } else {
+        } else if (this.field.form.processDefinitionId) {
             this.getValuesByProcessDefinitionId();
         }
     }
@@ -163,6 +163,10 @@ export class TypeaheadWidgetComponent extends WidgetComponent implements OnInit 
 
     checkVisibility() {
         this.visibilityService.refreshVisibility(this.field.form);
+    }
+
+    isReadOnlyType(): boolean {
+        return this.field.type === 'readonly' ? true : false;
     }
 
 }

--- a/ng2-components/ng2-activiti-form/src/services/form.service.ts
+++ b/ng2-components/ng2-activiti-form/src/services/form.service.ts
@@ -76,6 +76,10 @@ export class FormService {
         return this.apiService.getInstance().activiti.processApi;
     }
 
+    private get processInstanceVariablesApi(): any {
+        return this.apiService.getInstance().activiti.processInstanceVariablesApi;
+    }
+
     private get usersWorkflowApi(): any {
         return this.apiService.getInstance().activiti.usersWorkflowApi;
     }
@@ -197,6 +201,12 @@ export class FormService {
     getProcessDefinitions(): Observable<any> {
         return Observable.fromPromise(this.processApi.getProcessDefinitions({}))
             .map(this.toJsonArray)
+            .catch(err => this.handleError(err));
+    }
+
+    getProcessVarablesById(processInstanceId: string): Observable<any[]> {
+        return Observable.fromPromise(this.processInstanceVariablesApi.getProcessInstanceVariables(processInstanceId))
+            .map(this.toJson)
             .catch(err => this.handleError(err));
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
After a process is started, the value is fetch using the processDefinition instead it should fetched by the process Variables


**What is the new behaviour?**
The typeahead value is fetched from the process variables


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
