### PR TITLE
[ADF-1545] configurable 'supportedPageSizes' for document list

### DIFF
--- a/demo-shell-ng2/app.config-dev.json
+++ b/demo-shell-ng2/app.config-dev.json
@@ -27,6 +27,7 @@
         }
     },
     "document-list": {
+        "supportedPageSizes": [5, 10, 15, 20],
         "presets": {
             "-trashcan-": [
                 {

--- a/demo-shell-ng2/app.config-prod.json
+++ b/demo-shell-ng2/app.config-prod.json
@@ -27,6 +27,7 @@
         }
     },
     "document-list": {
+        "supportedPageSizes": [5, 10, 15, 20],
         "presets": {
             "-trashcan-": [
                 {

--- a/ng2-components/ng2-alfresco-documentlist/README.md
+++ b/ng2-components/ng2-alfresco-documentlist/README.md
@@ -111,6 +111,7 @@ The properties currentFolderId, folderNode and node are the entry initialization
 | allowDropFiles | boolean | false | Toggle file drop support for rows (see **ng2-alfresco-core/UploadDirective** for more details) |
 | sorting | string[] | | Defines default sorting. The format is an array of 2 strings `[key, direction]` i.e. `['name', 'desc']` or `['name', 'asc']`. Set this value only if you want to override default sorting detected by the component based on columns. |
 | locationFormat | string | '/' | The default route for all the location-based columns (if declared). |
+| supportedPageSizes | number[] | [5, 10, 15, 20] | Supported page sizes for the pagination component. You can also use application configuration file to set it as a global setting using `document-list.supportedPageSizes` key. |
 
 #### Events
 

--- a/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.html
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.html
@@ -58,7 +58,7 @@
         (nextPage)="onNextPage($event)"
         (prevPage)="onPrevPage($event)"
         [pagination]="pagination"
-        [supportedPageSizes]="[5, 10, 15, 20]">
+        [supportedPageSizes]="supportedPageSizes">
     </adf-pagination>
 
     <adf-infinite-pagination

--- a/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.ts
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.ts
@@ -107,6 +107,9 @@ export class DocumentListComponent implements OnInit, OnChanges, AfterContentIni
     @Input()
     paginationStrategy: PaginationStrategy = PaginationStrategy.Finite;
 
+    @Input()
+    supportedPageSizes: number[];
+
     infiniteLoading: boolean = false;
 
     selection = new Array<MinimalNodeEntity>();
@@ -165,6 +168,7 @@ export class DocumentListComponent implements OnInit, OnChanges, AfterContentIni
                 private elementRef: ElementRef,
                 private apiService: AlfrescoApiService,
                 private appConfig: AppConfigService) {
+        this.supportedPageSizes = appConfig.get('document-list.supportedPageSizes', [5, 10, 15, 20]);
     }
 
     private get nodesApi() {


### PR DESCRIPTION
Allow setting `supportedPageSizes` property for DocumentList via HTML attributes or global app config.