### PR TITLE
[ADF-1615] Datatable - The ellipsis class doesn't work for a custom template

### DIFF
--- a/ng2-components/ng2-alfresco-core/prebuilt-themes/adf-blue-orange.css
+++ b/ng2-components/ng2-alfresco-core/prebuilt-themes/adf-blue-orange.css
@@ -2002,6 +2002,10 @@ input.mat-input-element {
   position: relative;
   top: 5px; }
 
+.adf-analytics-report-list .activiti-filters__label {
+  white-space: nowrap;
+  overflow: hidden; }
+
 .adf-analytics-report-list .mat-nav-list .mat-list-item .mat-list-item-content {
   line-height: 48px; }
 
@@ -2324,8 +2328,6 @@ container-widget .mat-grid-tile {
 
 .adf-datatable /deep/ table {
   border: none !important; }
-  .adf-datatable /deep/ table thead {
-    display: none; }
   .adf-datatable /deep/ table tbody td {
     padding: 0px !important;
     border-top: none !important; }
@@ -2712,14 +2714,21 @@ adf-people-list /deep/ adf-datatable /deep/ .people-pic {
     /* cell stretching content */ }
     .adf-data-table .ellipsis-cell .cell-container {
       height: 1em; }
-    .adf-data-table .ellipsis-cell .cell-value {
+    .adf-data-table .ellipsis-cell .cell-container > * {
       display: block;
       position: absolute;
-      max-width: 100%;
+      max-width: calc(100% - 2em);
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
-      /* for vertical align of text */
+      line-height: 1.12em; }
+    .adf-data-table .ellipsis-cell .cell-value {
+      display: block;
+      position: absolute;
+      max-width: calc(100% - 2em);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
       line-height: 1.12em; }
     .adf-data-table .ellipsis-cell > div:after {
       content: attr(title);

--- a/ng2-components/ng2-alfresco-core/prebuilt-themes/adf-blue-purple.css
+++ b/ng2-components/ng2-alfresco-core/prebuilt-themes/adf-blue-purple.css
@@ -2002,6 +2002,10 @@ input.mat-input-element {
   position: relative;
   top: 5px; }
 
+.adf-analytics-report-list .activiti-filters__label {
+  white-space: nowrap;
+  overflow: hidden; }
+
 .adf-analytics-report-list .mat-nav-list .mat-list-item .mat-list-item-content {
   line-height: 48px; }
 
@@ -2324,8 +2328,6 @@ container-widget .mat-grid-tile {
 
 .adf-datatable /deep/ table {
   border: none !important; }
-  .adf-datatable /deep/ table thead {
-    display: none; }
   .adf-datatable /deep/ table tbody td {
     padding: 0px !important;
     border-top: none !important; }
@@ -2712,14 +2714,21 @@ adf-people-list /deep/ adf-datatable /deep/ .people-pic {
     /* cell stretching content */ }
     .adf-data-table .ellipsis-cell .cell-container {
       height: 1em; }
-    .adf-data-table .ellipsis-cell .cell-value {
+    .adf-data-table .ellipsis-cell .cell-container > * {
       display: block;
       position: absolute;
-      max-width: 100%;
+      max-width: calc(100% - 2em);
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
-      /* for vertical align of text */
+      line-height: 1.12em; }
+    .adf-data-table .ellipsis-cell .cell-value {
+      display: block;
+      position: absolute;
+      max-width: calc(100% - 2em);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
       line-height: 1.12em; }
     .adf-data-table .ellipsis-cell > div:after {
       content: attr(title);

--- a/ng2-components/ng2-alfresco-core/prebuilt-themes/adf-cyan-orange.css
+++ b/ng2-components/ng2-alfresco-core/prebuilt-themes/adf-cyan-orange.css
@@ -2002,6 +2002,10 @@ input.mat-input-element {
   position: relative;
   top: 5px; }
 
+.adf-analytics-report-list .activiti-filters__label {
+  white-space: nowrap;
+  overflow: hidden; }
+
 .adf-analytics-report-list .mat-nav-list .mat-list-item .mat-list-item-content {
   line-height: 48px; }
 
@@ -2324,8 +2328,6 @@ container-widget .mat-grid-tile {
 
 .adf-datatable /deep/ table {
   border: none !important; }
-  .adf-datatable /deep/ table thead {
-    display: none; }
   .adf-datatable /deep/ table tbody td {
     padding: 0px !important;
     border-top: none !important; }
@@ -2712,14 +2714,21 @@ adf-people-list /deep/ adf-datatable /deep/ .people-pic {
     /* cell stretching content */ }
     .adf-data-table .ellipsis-cell .cell-container {
       height: 1em; }
-    .adf-data-table .ellipsis-cell .cell-value {
+    .adf-data-table .ellipsis-cell .cell-container > * {
       display: block;
       position: absolute;
-      max-width: 100%;
+      max-width: calc(100% - 2em);
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
-      /* for vertical align of text */
+      line-height: 1.12em; }
+    .adf-data-table .ellipsis-cell .cell-value {
+      display: block;
+      position: absolute;
+      max-width: calc(100% - 2em);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
       line-height: 1.12em; }
     .adf-data-table .ellipsis-cell > div:after {
       content: attr(title);

--- a/ng2-components/ng2-alfresco-core/prebuilt-themes/adf-cyan-purple.css
+++ b/ng2-components/ng2-alfresco-core/prebuilt-themes/adf-cyan-purple.css
@@ -2002,6 +2002,10 @@ input.mat-input-element {
   position: relative;
   top: 5px; }
 
+.adf-analytics-report-list .activiti-filters__label {
+  white-space: nowrap;
+  overflow: hidden; }
+
 .adf-analytics-report-list .mat-nav-list .mat-list-item .mat-list-item-content {
   line-height: 48px; }
 
@@ -2324,8 +2328,6 @@ container-widget .mat-grid-tile {
 
 .adf-datatable /deep/ table {
   border: none !important; }
-  .adf-datatable /deep/ table thead {
-    display: none; }
   .adf-datatable /deep/ table tbody td {
     padding: 0px !important;
     border-top: none !important; }
@@ -2712,14 +2714,21 @@ adf-people-list /deep/ adf-datatable /deep/ .people-pic {
     /* cell stretching content */ }
     .adf-data-table .ellipsis-cell .cell-container {
       height: 1em; }
-    .adf-data-table .ellipsis-cell .cell-value {
+    .adf-data-table .ellipsis-cell .cell-container > * {
       display: block;
       position: absolute;
-      max-width: 100%;
+      max-width: calc(100% - 2em);
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
-      /* for vertical align of text */
+      line-height: 1.12em; }
+    .adf-data-table .ellipsis-cell .cell-value {
+      display: block;
+      position: absolute;
+      max-width: calc(100% - 2em);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
       line-height: 1.12em; }
     .adf-data-table .ellipsis-cell > div:after {
       content: attr(title);

--- a/ng2-components/ng2-alfresco-core/prebuilt-themes/adf-green-orange.css
+++ b/ng2-components/ng2-alfresco-core/prebuilt-themes/adf-green-orange.css
@@ -2002,6 +2002,10 @@ input.mat-input-element {
   position: relative;
   top: 5px; }
 
+.adf-analytics-report-list .activiti-filters__label {
+  white-space: nowrap;
+  overflow: hidden; }
+
 .adf-analytics-report-list .mat-nav-list .mat-list-item .mat-list-item-content {
   line-height: 48px; }
 
@@ -2324,8 +2328,6 @@ container-widget .mat-grid-tile {
 
 .adf-datatable /deep/ table {
   border: none !important; }
-  .adf-datatable /deep/ table thead {
-    display: none; }
   .adf-datatable /deep/ table tbody td {
     padding: 0px !important;
     border-top: none !important; }
@@ -2712,14 +2714,21 @@ adf-people-list /deep/ adf-datatable /deep/ .people-pic {
     /* cell stretching content */ }
     .adf-data-table .ellipsis-cell .cell-container {
       height: 1em; }
-    .adf-data-table .ellipsis-cell .cell-value {
+    .adf-data-table .ellipsis-cell .cell-container > * {
       display: block;
       position: absolute;
-      max-width: 100%;
+      max-width: calc(100% - 2em);
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
-      /* for vertical align of text */
+      line-height: 1.12em; }
+    .adf-data-table .ellipsis-cell .cell-value {
+      display: block;
+      position: absolute;
+      max-width: calc(100% - 2em);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
       line-height: 1.12em; }
     .adf-data-table .ellipsis-cell > div:after {
       content: attr(title);

--- a/ng2-components/ng2-alfresco-core/prebuilt-themes/adf-green-purple.css
+++ b/ng2-components/ng2-alfresco-core/prebuilt-themes/adf-green-purple.css
@@ -2002,6 +2002,10 @@ input.mat-input-element {
   position: relative;
   top: 5px; }
 
+.adf-analytics-report-list .activiti-filters__label {
+  white-space: nowrap;
+  overflow: hidden; }
+
 .adf-analytics-report-list .mat-nav-list .mat-list-item .mat-list-item-content {
   line-height: 48px; }
 
@@ -2324,8 +2328,6 @@ container-widget .mat-grid-tile {
 
 .adf-datatable /deep/ table {
   border: none !important; }
-  .adf-datatable /deep/ table thead {
-    display: none; }
   .adf-datatable /deep/ table tbody td {
     padding: 0px !important;
     border-top: none !important; }
@@ -2712,14 +2714,21 @@ adf-people-list /deep/ adf-datatable /deep/ .people-pic {
     /* cell stretching content */ }
     .adf-data-table .ellipsis-cell .cell-container {
       height: 1em; }
-    .adf-data-table .ellipsis-cell .cell-value {
+    .adf-data-table .ellipsis-cell .cell-container > * {
       display: block;
       position: absolute;
-      max-width: 100%;
+      max-width: calc(100% - 2em);
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
-      /* for vertical align of text */
+      line-height: 1.12em; }
+    .adf-data-table .ellipsis-cell .cell-value {
+      display: block;
+      position: absolute;
+      max-width: calc(100% - 2em);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
       line-height: 1.12em; }
     .adf-data-table .ellipsis-cell > div:after {
       content: attr(title);

--- a/ng2-components/ng2-alfresco-core/prebuilt-themes/adf-indigo-pink.css
+++ b/ng2-components/ng2-alfresco-core/prebuilt-themes/adf-indigo-pink.css
@@ -2002,6 +2002,10 @@ input.mat-input-element {
   position: relative;
   top: 5px; }
 
+.adf-analytics-report-list .activiti-filters__label {
+  white-space: nowrap;
+  overflow: hidden; }
+
 .adf-analytics-report-list .mat-nav-list .mat-list-item .mat-list-item-content {
   line-height: 48px; }
 
@@ -2324,8 +2328,6 @@ container-widget .mat-grid-tile {
 
 .adf-datatable /deep/ table {
   border: none !important; }
-  .adf-datatable /deep/ table thead {
-    display: none; }
   .adf-datatable /deep/ table tbody td {
     padding: 0px !important;
     border-top: none !important; }
@@ -2712,14 +2714,21 @@ adf-people-list /deep/ adf-datatable /deep/ .people-pic {
     /* cell stretching content */ }
     .adf-data-table .ellipsis-cell .cell-container {
       height: 1em; }
-    .adf-data-table .ellipsis-cell .cell-value {
+    .adf-data-table .ellipsis-cell .cell-container > * {
       display: block;
       position: absolute;
-      max-width: 100%;
+      max-width: calc(100% - 2em);
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
-      /* for vertical align of text */
+      line-height: 1.12em; }
+    .adf-data-table .ellipsis-cell .cell-value {
+      display: block;
+      position: absolute;
+      max-width: calc(100% - 2em);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
       line-height: 1.12em; }
     .adf-data-table .ellipsis-cell > div:after {
       content: attr(title);

--- a/ng2-components/ng2-alfresco-core/prebuilt-themes/adf-pink-bluegrey.css
+++ b/ng2-components/ng2-alfresco-core/prebuilt-themes/adf-pink-bluegrey.css
@@ -2002,6 +2002,10 @@ input.mat-input-element {
   position: relative;
   top: 5px; }
 
+.adf-analytics-report-list .activiti-filters__label {
+  white-space: nowrap;
+  overflow: hidden; }
+
 .adf-analytics-report-list .mat-nav-list .mat-list-item .mat-list-item-content {
   line-height: 48px; }
 
@@ -2324,8 +2328,6 @@ container-widget .mat-grid-tile {
 
 .adf-datatable /deep/ table {
   border: none !important; }
-  .adf-datatable /deep/ table thead {
-    display: none; }
   .adf-datatable /deep/ table tbody td {
     padding: 0px !important;
     border-top: none !important; }
@@ -2712,14 +2714,21 @@ adf-people-list /deep/ adf-datatable /deep/ .people-pic {
     /* cell stretching content */ }
     .adf-data-table .ellipsis-cell .cell-container {
       height: 1em; }
-    .adf-data-table .ellipsis-cell .cell-value {
+    .adf-data-table .ellipsis-cell .cell-container > * {
       display: block;
       position: absolute;
-      max-width: 100%;
+      max-width: calc(100% - 2em);
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
-      /* for vertical align of text */
+      line-height: 1.12em; }
+    .adf-data-table .ellipsis-cell .cell-value {
+      display: block;
+      position: absolute;
+      max-width: calc(100% - 2em);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
       line-height: 1.12em; }
     .adf-data-table .ellipsis-cell > div:after {
       content: attr(title);

--- a/ng2-components/ng2-alfresco-core/prebuilt-themes/adf-purple-green.css
+++ b/ng2-components/ng2-alfresco-core/prebuilt-themes/adf-purple-green.css
@@ -2002,6 +2002,10 @@ input.mat-input-element {
   position: relative;
   top: 5px; }
 
+.adf-analytics-report-list .activiti-filters__label {
+  white-space: nowrap;
+  overflow: hidden; }
+
 .adf-analytics-report-list .mat-nav-list .mat-list-item .mat-list-item-content {
   line-height: 48px; }
 
@@ -2324,8 +2328,6 @@ container-widget .mat-grid-tile {
 
 .adf-datatable /deep/ table {
   border: none !important; }
-  .adf-datatable /deep/ table thead {
-    display: none; }
   .adf-datatable /deep/ table tbody td {
     padding: 0px !important;
     border-top: none !important; }
@@ -2712,14 +2714,21 @@ adf-people-list /deep/ adf-datatable /deep/ .people-pic {
     /* cell stretching content */ }
     .adf-data-table .ellipsis-cell .cell-container {
       height: 1em; }
-    .adf-data-table .ellipsis-cell .cell-value {
+    .adf-data-table .ellipsis-cell .cell-container > * {
       display: block;
       position: absolute;
-      max-width: 100%;
+      max-width: calc(100% - 2em);
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
-      /* for vertical align of text */
+      line-height: 1.12em; }
+    .adf-data-table .ellipsis-cell .cell-value {
+      display: block;
+      position: absolute;
+      max-width: calc(100% - 2em);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
       line-height: 1.12em; }
     .adf-data-table .ellipsis-cell > div:after {
       content: attr(title);

--- a/ng2-components/ng2-alfresco-datatable/src/components/datatable/datatable.component.scss
+++ b/ng2-components/ng2-alfresco-datatable/src/components/datatable/datatable.component.scss
@@ -202,15 +202,24 @@
                 height: 1em;
             }
 
+            .cell-container > * {
+                display: block;
+                position: absolute;
+                max-width: calc(100% - 2em);
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                line-height: 1.12em;
+            }
+
             /* visible content */
             .cell-value {
                 display: block;
                 position: absolute;
-                max-width: 100%;
+                max-width: calc(100% - 2em);
                 white-space: nowrap;
                 overflow: hidden;
                 text-overflow: ellipsis;
-                /* for vertical align of text */
                 line-height: 1.12em;
             }
 


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Ellipsis property was not working in data columns using custom HTML templates


**What is the new behaviour?**
Fixed


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
