### PR TITLE
[ADF-1618] Login component - should not check the username minLength as default

### DIFF
--- a/ng2-components/ng2-alfresco-login/src/components/login.component.spec.ts
+++ b/ng2-components/ng2-alfresco-login/src/components/login.component.spec.ts
@@ -17,6 +17,8 @@
 
 import { DebugElement } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { Validators } from '@angular/forms';
+
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AlfrescoAuthenticationService, CoreModule } from 'ng2-alfresco-core';
@@ -214,7 +216,27 @@ describe('AlfrescoLogin', () => {
         expect(element.querySelector('#login-action-register')).toBe(null);
     });
 
-    it('should render validation min-length error when the username is just 1 character', () => {
+    it('should not render a validation min-length as default', () => {
+        usernameInput.value = '1';
+        usernameInput.dispatchEvent(new Event('input'));
+
+        fixture.detectChanges();
+
+        expect(component.formError).toBeDefined();
+        expect(component.formError.username).toBeDefined();
+        expect(component.formError.username).toBe('');
+        expect(element.querySelector('#username-error')).toBeNull();
+    });
+
+    it('should render validation min-length error when the username is just 1 character with a custom validation Validators.minLength(3)', () => {
+        component.fieldsValidation = {
+            username: ['', Validators.compose([Validators.required, Validators.minLength(3)])],
+            password: ['', Validators.required]
+        };
+        component.addCustomValidationError('username', 'minlength', 'LOGIN.MESSAGES.USERNAME-MIN');
+        component.ngOnInit();
+        fixture.detectChanges();
+
         usernameInput.value = '1';
         usernameInput.dispatchEvent(new Event('input'));
 
@@ -227,8 +249,16 @@ describe('AlfrescoLogin', () => {
         expect(element.querySelector('#username-error').innerText).toEqual('LOGIN.MESSAGES.USERNAME-MIN');
     });
 
-    it('should render validation min-length error when the username is lower than 2 characters', () => {
-        usernameInput.value = '1';
+    it('should render validation min-length error when the username is lower than 3 characters with a custom validation Validators.minLength(3)', () => {
+        component.fieldsValidation = {
+            username: ['', Validators.compose([Validators.required, Validators.minLength(3)])],
+            password: ['', Validators.required]
+        };
+        component.addCustomValidationError('username', 'minlength', 'LOGIN.MESSAGES.USERNAME-MIN');
+        component.ngOnInit();
+        fixture.detectChanges();
+
+        usernameInput.value = '12';
         usernameInput.dispatchEvent(new Event('input'));
 
         fixture.detectChanges();

--- a/ng2-components/ng2-alfresco-login/src/components/login.component.ts
+++ b/ng2-components/ng2-alfresco-login/src/components/login.component.ts
@@ -325,7 +325,7 @@ export class LoginComponent implements OnInit {
 
     private initFormFieldsDefault() {
         this.form = this._fb.group({
-            username: ['', Validators.compose([Validators.required, Validators.minLength(this.minLength)])],
+            username: ['', Validators.required],
             password: ['', Validators.required]
         });
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
the login component is checking the 3 characters minLength for the username


**What is the new behaviour?**
should not check the minLength as default


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
