### PR TITLE
[ADF-1625] removed wrong select into typeahed widget, readded validati…

### DIFF
--- a/ng2-components/ng2-activiti-form/src/components/widgets/core/form-field-validator.spec.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/core/form-field-validator.spec.ts
@@ -18,6 +18,7 @@
 import { FormFieldOption } from './form-field-option';
 import { FormFieldTypes } from './form-field-types';
 import {
+    FixedValueFieldValidator,
     MaxLengthFieldValidator,
     MaxValueFieldValidator,
     MinLengthFieldValidator,
@@ -29,7 +30,7 @@ import {
 import { FormFieldModel } from './form-field.model';
 import { FormModel } from './form.model';
 
-describe('FormFieldValidator', () => {
+fdescribe('FormFieldValidator', () => {
 
     describe('RequiredFieldValidator', () => {
 
@@ -527,6 +528,59 @@ describe('FormFieldValidator', () => {
                 type: FormFieldTypes.TEXT,
                 value: 'some value',
                 regexPattern: 'pattern'
+            });
+
+            expect(validator.validate(field)).toBeFalsy();
+        });
+
+    });
+
+    describe('FixedValueFieldValidator', () => {
+
+        let validator: FixedValueFieldValidator;
+
+        beforeEach(() => {
+            validator = new FixedValueFieldValidator();
+        });
+
+        it('should support only typeahead field', () => {
+            let field = new FormFieldModel(new FormModel(), {
+                type: FormFieldTypes.TEXT
+            });
+            expect(validator.isSupported(field)).toBeFalsy();
+
+            field = new FormFieldModel(new FormModel(), {
+                type: FormFieldTypes.TYPEAHEAD
+            });
+
+            expect(validator.isSupported(field)).toBeTruthy();
+        });
+
+        it('should allow empty values', () => {
+            let field = new FormFieldModel(new FormModel(), {
+                type: FormFieldTypes.TYPEAHEAD,
+                value: null,
+                regexPattern: 'pattern'
+            });
+
+            expect(validator.validate(field)).toBeTruthy();
+        });
+
+        it('should succeed for a valid input value in options', () => {
+            let field = new FormFieldModel(new FormModel(), {
+                type: FormFieldTypes.TYPEAHEAD,
+                value: '1',
+                options: [{id: '1', name: 'Leanne Graham'}, {id: '2', name: 'Ervin Howell'}]
+            });
+
+            expect(validator.validate(field)).toBeTruthy();
+        });
+
+        it('should fail for an invalid input value in options', () => {
+            let field = new FormFieldModel(new FormModel(), {
+                type: FormFieldTypes.TYPEAHEAD,
+                value: 'Lean',
+                options: [{id: '1', name: 'Leanne Graham'}, {id: '2', name: 'Ervin Howell'}]
             });
 
             expect(validator.validate(field)).toBeFalsy();

--- a/ng2-components/ng2-activiti-form/src/components/widgets/core/form-field-validator.spec.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/core/form-field-validator.spec.ts
@@ -30,7 +30,7 @@ import {
 import { FormFieldModel } from './form-field.model';
 import { FormModel } from './form.model';
 
-fdescribe('FormFieldValidator', () => {
+describe('FormFieldValidator', () => {
 
     describe('RequiredFieldValidator', () => {
 

--- a/ng2-components/ng2-activiti-form/src/components/widgets/core/form-field-validator.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/core/form-field-validator.ts
@@ -381,19 +381,25 @@ export class FixedValueFieldValidator implements FormFieldValidator {
     }
 
     hasValidName(field: FormFieldModel) {
-        return field.options.find(item => item.name && item.name.toLocaleLowerCase() === field.value) ? true : false;
+        return field.options.find(item => item.name && item.name.toLocaleLowerCase() === field.value.toLocaleLowerCase()) ? true : false;
     }
 
     hasValidId(field: FormFieldModel) {
-        return field.options[field.value] ? true : false;
+        return field.options[field.value - 1] ? true : false;
+    }
+
+    hasStringValue(field: FormFieldModel) {
+        return field.value && typeof field.value === 'string';
+    }
+
+    hasOptions(field: FormFieldModel) {
+        return field.options && field.options.length > 0;
     }
 
     validate(field: FormFieldModel): boolean {
         if (this.isSupported(field)) {
-            if (!field.value || this.hasValidNameOrValidId(field)) {
-                return true;
-            } else {
-                field.validationSummary = 'Invalid value';
+            if (this.hasStringValue(field) && this.hasOptions(field) && !this.hasValidNameOrValidId(field)) {
+                field.validationSummary = 'Invalid data inserted';
                 return false;
             }
         }

--- a/ng2-components/ng2-activiti-form/src/components/widgets/core/form-field-validator.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/core/form-field-validator.ts
@@ -366,6 +366,41 @@ export class RegExFieldValidator implements FormFieldValidator {
 
 }
 
+export class FixedValueFieldValidator implements FormFieldValidator {
+
+    private supportedTypes = [
+        FormFieldTypes.TYPEAHEAD
+    ];
+
+    isSupported(field: FormFieldModel): boolean {
+        return field && this.supportedTypes.indexOf(field.type) > -1;
+    }
+
+    hasValidNameOrValidId(field: FormFieldModel): boolean {
+        return this.hasValidName(field) || this.hasValidId(field);
+    }
+
+    hasValidName(field: FormFieldModel) {
+        return field.options.find(item => item.name && item.name.toLocaleLowerCase() === field.value) ? true : false;
+    }
+
+    hasValidId(field: FormFieldModel) {
+        return field.options[field.value] ? true : false;
+    }
+
+    validate(field: FormFieldModel): boolean {
+        if (this.isSupported(field)) {
+            if (!field.value || this.hasValidNameOrValidId(field)) {
+                return true;
+            } else {
+                field.validationSummary = 'Invalid value';
+                return false;
+            }
+        }
+        return true;
+    }
+}
+
 export const FORM_FIELD_VALIDATORS = [
     new RequiredFieldValidator(),
     new NumberFieldValidator(),
@@ -376,5 +411,6 @@ export const FORM_FIELD_VALIDATORS = [
     new RegExFieldValidator(),
     new DateFieldValidator(),
     new MinDateFieldValidator(),
-    new MaxDateFieldValidator()
+    new MaxDateFieldValidator(),
+    new FixedValueFieldValidator()
 ];

--- a/ng2-components/ng2-activiti-form/src/components/widgets/typeahead/typeahead.widget.html
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/typeahead/typeahead.widget.html
@@ -10,7 +10,6 @@
                    type="text"
                    [id]="field.id"
                    [(ngModel)]="value"
-                   (ngModelChange)="flushValue()"
                    (keyup)="onKeyUp($event)"
                    [disabled]="field.readOnly"
                    placeholder="{{field.placeholder}}"

--- a/ng2-components/ng2-activiti-form/src/components/widgets/typeahead/typeahead.widget.html
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/typeahead/typeahead.widget.html
@@ -10,12 +10,13 @@
                    type="text"
                    [id]="field.id"
                    [(ngModel)]="value"
+                   (ngModelChange)="validate()"
                    (keyup)="onKeyUp($event)"
                    [disabled]="field.readOnly"
                    placeholder="{{field.placeholder}}"
                    [mdAutocomplete]="auto">
             <md-autocomplete #auto="mdAutocomplete" (optionSelected)="onItemSelect($event.option.value)">
-                <md-option *ngFor="let item of options" (click)="onItemClick(item, $event)"  [value]="item">
+                <md-option *ngFor="let item of options" [value]="item">
                     <span>{{item.name}}</span>
                 </md-option>
             </md-autocomplete>

--- a/ng2-components/ng2-activiti-form/src/components/widgets/typeahead/typeahead.widget.html
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/typeahead/typeahead.widget.html
@@ -11,6 +11,7 @@
                    [id]="field.id"
                    [(ngModel)]="value"
                    (keyup)="onKeyUp($event)"
+                   (blur)="onBlur()"
                    [disabled]="field.readOnly"
                    placeholder="{{field.placeholder}}"
                    [mdAutocomplete]="auto">
@@ -19,9 +20,6 @@
                     <span>{{item.name}}</span>
                 </md-option>
             </md-autocomplete>
-            <md-select class="adf-select" [id]="field.id" [(ngModel)]="field.value">
-                <md-option id="readonlyOption" *ngIf="isReadOnlyType()" [value]="field.value">{{field.value}}</md-option>
-            </md-select>
         </md-input-container>
 
         <error-widget [error]="field.validationSummary"></error-widget>

--- a/ng2-components/ng2-activiti-form/src/components/widgets/typeahead/typeahead.widget.html
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/typeahead/typeahead.widget.html
@@ -17,7 +17,7 @@
                    [mdAutocomplete]="auto">
             <md-autocomplete #auto="mdAutocomplete" (optionSelected)="onItemSelect($event.option.value)">
                 <md-option *ngFor="let item of options" [value]="item">
-                    <span>{{item.name}}</span>
+                    <span [id]="field.name+'_option_'+item.id">{{item.name}}</span>
                 </md-option>
             </md-autocomplete>
         </md-input-container>

--- a/ng2-components/ng2-activiti-form/src/components/widgets/typeahead/typeahead.widget.html
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/typeahead/typeahead.widget.html
@@ -10,8 +10,8 @@
                    type="text"
                    [id]="field.id"
                    [(ngModel)]="value"
+                   (ngModelChange)="flushValue()"
                    (keyup)="onKeyUp($event)"
-                   (blur)="onBlur()"
                    [disabled]="field.readOnly"
                    placeholder="{{field.placeholder}}"
                    [mdAutocomplete]="auto">

--- a/ng2-components/ng2-activiti-form/src/components/widgets/typeahead/typeahead.widget.spec.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/typeahead/typeahead.widget.spec.ts
@@ -275,6 +275,7 @@ describe('TypeaheadWidgetComponent', () => {
 
         expect(widget.value).toBeNull();
         expect(widget.field.value).toBeNull();
+        expect(widget.options.length).toBe(0);
     });
 
     it('should emit field change event on item click', () => {
@@ -355,6 +356,21 @@ describe('TypeaheadWidgetComponent', () => {
                 });
             }));
 
+            it('should show error message when the value is not valid', async(() => {
+                typeaheadWidgetComponent.value = 'Fake Name';
+                typeaheadWidgetComponent.field.value = 'Fake Name';
+                typeaheadWidgetComponent.field.options = fakeOptionList;
+                expect(element.querySelector('.adf-error-text')).toBeNull();
+                let keyboardEvent = new KeyboardEvent('keypress');
+                typeaheadWidgetComponent.onKeyUp(keyboardEvent);
+                fixture.detectChanges();
+                fixture.whenStable().then(() => {
+                    fixture.detectChanges();
+                    expect(element.querySelector('.adf-error-text')).not.toBeNull();
+                    expect(element.querySelector('.adf-error-text').textContent).toContain('Invalid value');
+                });
+            }));
+
             it('should hide not visible typeahead', async(() => {
                 typeaheadWidgetComponent.field.isVisible = false;
                 fixture.detectChanges();
@@ -368,10 +384,12 @@ describe('TypeaheadWidgetComponent', () => {
                     new FormModel({ taskId: 'fake-task-id', processVariables: [{ name: 'typeahead-id_LABEL', value: 'FakeProcessValue' }] }), {
                     id: 'typeahead-id',
                     name: 'typeahead-name',
+                    options: fakeOptionList,
                     type: 'readonly',
                     value: '9',
                     params: { field: { id: 'typeahead-id', name: 'typeahead-name', type: 'typeahead' } }
                 });
+                typeaheadWidgetComponent.value = 'Fake Name 2';
                 fixture.detectChanges();
                 const trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;
                 trigger.click();

--- a/ng2-components/ng2-activiti-form/src/components/widgets/typeahead/typeahead.widget.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/typeahead/typeahead.widget.ts
@@ -112,28 +112,15 @@ export class TypeaheadWidgetComponent extends WidgetComponent implements OnInit 
     }
 
     onKeyUp(event: KeyboardEvent) {
-        if (this.value && this.value.trim().length >= this.minTermLength  && this.oldValue !== this.value) {
+        if (this.value && this.value.trim().length >= this.minTermLength && this.oldValue !== this.value) {
             if (event.keyCode !== ESCAPE && event.keyCode !== ENTER) {
                 if (this.value.length >= this.minTermLength) {
                     this.options = this.getOptions();
                     this.oldValue = this.value;
+                    this.field.value = this.value;
                 }
             }
-        }else {
-            this.options = [];
-        }
-    }
-
-    flushValue() {
-        let options = this.field.options || [];
-        let lValue = this.value && this.value ? this.value.toLocaleLowerCase() : null;
-
-        let field = options.find(item => item.name && item.name.toLocaleLowerCase() === lValue);
-        if (field) {
-            this.field.value = field.id;
-            this.value = field.name;
         } else {
-            this.field.value = this.value;
             this.options = [];
         }
     }

--- a/ng2-components/ng2-activiti-form/src/components/widgets/typeahead/typeahead.widget.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/typeahead/typeahead.widget.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
- /* tslint:disable:component-selector  */
+/* tslint:disable:component-selector  */
 
 import { ENTER, ESCAPE } from '@angular/cdk/keycodes';
 import { Component, OnInit, ViewEncapsulation } from '@angular/core';
@@ -23,7 +23,7 @@ import { LogService } from 'ng2-alfresco-core';
 import { WidgetVisibilityService } from '../../../services/widget-visibility.service';
 import { FormService } from './../../../services/form.service';
 import { FormFieldOption } from './../core/form-field-option';
-import { baseHost , WidgetComponent } from './../widget.component';
+import { baseHost, WidgetComponent } from './../widget.component';
 
 @Component({
     selector: 'typeahead-widget',
@@ -42,7 +42,7 @@ export class TypeaheadWidgetComponent extends WidgetComponent implements OnInit 
     constructor(public formService: FormService,
                 private visibilityService: WidgetVisibilityService,
                 private logService: LogService) {
-         super(formService);
+        super(formService);
     }
 
     ngOnInit() {
@@ -51,55 +51,58 @@ export class TypeaheadWidgetComponent extends WidgetComponent implements OnInit 
         } else if (this.field.form.processDefinitionId) {
             this.getValuesByProcessDefinitionId();
         }
+        if (this.isReadOnlyType()) {
+            this.value = this.field.value;
+        }
     }
 
     getValuesByTaskId() {
         this.formService
             .getRestFieldValues(
-                this.field.form.taskId,
-                this.field.id
+            this.field.form.taskId,
+            this.field.id
             )
             .subscribe(
-                (result: FormFieldOption[]) => {
-                    let options = result || [];
-                    this.field.options = options;
+            (result: FormFieldOption[]) => {
+                let options = result || [];
+                this.field.options = options;
 
-                    let fieldValue = this.field.value;
-                    if (fieldValue) {
-                        let toSelect = options.find(item => item.id === fieldValue);
-                        if (toSelect) {
-                            this.value = toSelect.name;
-                        }
+                let fieldValue = this.field.value;
+                if (fieldValue) {
+                    let toSelect = options.find(item => item.id === fieldValue);
+                    if (toSelect) {
+                        this.value = toSelect.name;
                     }
-                    this.field.updateForm();
-                    this.visibilityService.refreshEntityVisibility(this.field);
-                },
-                err => this.handleError(err)
+                }
+                this.field.updateForm();
+                this.visibilityService.refreshEntityVisibility(this.field);
+            },
+            err => this.handleError(err)
             );
     }
 
     getValuesByProcessDefinitionId() {
         this.formService
             .getRestFieldValuesByProcessId(
-                this.field.form.processDefinitionId,
-                this.field.id
+            this.field.form.processDefinitionId,
+            this.field.id
             )
             .subscribe(
-                (result: FormFieldOption[]) => {
-                    let options = result || [];
-                    this.field.options = options;
+            (result: FormFieldOption[]) => {
+                let options = result || [];
+                this.field.options = options;
 
-                    let fieldValue = this.field.value;
-                    if (fieldValue) {
-                        let toSelect = options.find(item => item.id === fieldValue);
-                        if (toSelect) {
-                            this.value = toSelect.name;
-                        }
+                let fieldValue = this.field.value;
+                if (fieldValue) {
+                    let toSelect = options.find(item => item.id === fieldValue);
+                    if (toSelect) {
+                        this.value = toSelect.name;
                     }
-                    this.field.updateForm();
-                    this.visibilityService.refreshEntityVisibility(this.field);
-                },
-                err => this.handleError(err)
+                }
+                this.field.updateForm();
+                this.visibilityService.refreshEntityVisibility(this.field);
+            },
+            err => this.handleError(err)
             );
     }
 
@@ -111,28 +114,26 @@ export class TypeaheadWidgetComponent extends WidgetComponent implements OnInit 
         });
     }
 
+    isValidOptionName(optionName: string): boolean {
+        let option = this.field.options.find(item => item.name && item.name.toLocaleLowerCase() === optionName.toLocaleLowerCase());
+        return option ? true : false;
+    }
+
     onKeyUp(event: KeyboardEvent) {
         if (this.value && this.value.trim().length >= this.minTermLength && this.oldValue !== this.value) {
             if (event.keyCode !== ESCAPE && event.keyCode !== ENTER) {
                 if (this.value.length >= this.minTermLength) {
                     this.options = this.getOptions();
                     this.oldValue = this.value;
-                    this.field.value = this.value;
+                    if (this.isValidOptionName(this.value)) {
+                        this.field.value = this.options[0].id;
+                    }
                 }
             }
-        } else {
+        }
+        if (this.isValueDefined() && this.value.trim().length === 0) {
+            this.oldValue = this.value;
             this.options = [];
-        }
-    }
-
-    onItemClick(item: FormFieldOption, event: Event) {
-        if (item) {
-            this.field.value = item.id;
-            this.value = item.name;
-            this.checkVisibility();
-        }
-        if (event) {
-            event.preventDefault();
         }
     }
 
@@ -142,6 +143,14 @@ export class TypeaheadWidgetComponent extends WidgetComponent implements OnInit 
             this.value = item.name;
             this.checkVisibility();
         }
+    }
+
+    validate() {
+        this.field.value = this.value;
+    }
+
+    isValueDefined() {
+        return this.value !== null && this.value !== undefined;
     }
 
     handleError(error: any) {

--- a/ng2-components/ng2-activiti-form/src/components/widgets/typeahead/typeahead.widget.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/typeahead/typeahead.widget.ts
@@ -104,7 +104,7 @@ export class TypeaheadWidgetComponent extends WidgetComponent implements OnInit 
     }
 
     getOptions(): FormFieldOption[] {
-        let val = this.value.toLocaleLowerCase();
+        let val = this.value.trim().toLocaleLowerCase();
         return this.field.options.filter(item => {
             let name = item.name.toLocaleLowerCase();
             return name.indexOf(val) > -1;
@@ -112,14 +112,23 @@ export class TypeaheadWidgetComponent extends WidgetComponent implements OnInit 
     }
 
     onKeyUp(event: KeyboardEvent) {
-        if (this.value && this.value.length >= this.minTermLength  && this.oldValue !== this.value) {
+        if (this.value && this.value.trim().length >= this.minTermLength  && this.oldValue !== this.value) {
             if (event.keyCode !== ESCAPE && event.keyCode !== ENTER) {
                 if (this.value.length >= this.minTermLength) {
                     this.options = this.getOptions();
                     this.oldValue = this.value;
                 }
             }
+        }else {
+            this.options = [];
         }
+    }
+
+    onBlur() {
+        setTimeout(() => {
+            this.flushValue();
+            this.checkVisibility();
+        }, 200);
     }
 
     flushValue() {
@@ -133,9 +142,8 @@ export class TypeaheadWidgetComponent extends WidgetComponent implements OnInit 
         } else {
             this.field.value = null;
             this.value = null;
+            this.options = [];
         }
-
-        this.field.updateForm();
     }
 
     onItemClick(item: FormFieldOption, event: Event) {

--- a/ng2-components/ng2-activiti-form/src/components/widgets/typeahead/typeahead.widget.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/typeahead/typeahead.widget.ts
@@ -124,24 +124,16 @@ export class TypeaheadWidgetComponent extends WidgetComponent implements OnInit 
         }
     }
 
-    onBlur() {
-        setTimeout(() => {
-            this.flushValue();
-            this.checkVisibility();
-        }, 200);
-    }
-
     flushValue() {
         let options = this.field.options || [];
-        let lValue = this.value ? this.value.toLocaleLowerCase() : null;
+        let lValue = this.value && this.value ? this.value.toLocaleLowerCase() : null;
 
         let field = options.find(item => item.name && item.name.toLocaleLowerCase() === lValue);
         if (field) {
             this.field.value = field.id;
             this.value = field.name;
         } else {
-            this.field.value = null;
-            this.value = null;
+            this.field.value = this.value;
             this.options = [];
         }
     }


### PR DESCRIPTION
…on on blur

**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
A wrong select element is added into typeahead widget and is wrongly rendered.
No validation is applied on blur.


**What is the new behaviour?**
removed the select to use only material autosuggestion.
reapplied the value validation on blur


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
