### PR TITLE
[ADF-1328] Fix closing search bar has not to trigger search

### DIFF
--- a/ng2-components/ng2-alfresco-search/src/components/search-control.component.html
+++ b/ng2-components/ng2-alfresco-search/src/components/search-control.component.html
@@ -1,13 +1,13 @@
 <form #f="ngForm" (ngSubmit)="onSearch(f.value)" class="adf-search-form">
     <div class="adf-search-container"
         [@transitionMessages]="subscriptAnimationState">
-        <button md-button
+        <a md-button
                 *ngIf="expandable"
                 id="adf-search-button"
             (click)="toggleSearchBar()"
             class="adf-search-button">
             <md-icon aria-label="search button">search</md-icon>
-        </button>
+        </a>
         <div class="adf-search-field">
             <md-input-container>
                 <input

--- a/ng2-components/ng2-alfresco-search/src/components/search-control.component.spec.ts
+++ b/ng2-components/ng2-alfresco-search/src/components/search-control.component.spec.ts
@@ -340,6 +340,28 @@ describe('SearchControlComponent', () => {
             }, 500);
         });
 
+        it('click on the search button should not trigger the search when you click on it to close the search bar', (done) => {
+            spyOn(searchService, 'getQueryNodesPromise')
+                .and.returnValue(Promise.resolve(results));
+
+            component.liveSearchTerm = 'test';
+
+            fixture.detectChanges();
+            component.subscriptAnimationState = 'active';
+
+            let searchButton: any = element.querySelector('#adf-search-button');
+            searchButton.click();
+
+            setTimeout(() => {
+                fixture.detectChanges();
+                expect(component.liveSearchComponent.panelAnimationState).not.toBe('void');
+                let resultElement: Element = element.querySelector('#adf-search-results');
+                expect(resultElement).toBe(null);
+                done();
+                done();
+            }, 500);
+        });
+
         it('click on the search button should open the input box when is close', (done) => {
             fixture.detectChanges();
             component.subscriptAnimationState = 'inactive';


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Click on the Search Icon.
Add input.
Click on the search icon again: 
-Actual result: The Search Results are displayed on the Search Page. The search icon is acting like 'enter' key.

**What is the new behaviour?**

The same behaviour as clicking somewhere else on the page. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
