### PR TITLE
[ADF-1640] Start form - Get the variables from the process instance API

### DIFF
--- a/ng2-components/ng2-activiti-form/src/components/start-form.component.ts
+++ b/ng2-components/ng2-activiti-form/src/components/start-form.component.ts
@@ -102,14 +102,16 @@ export class StartFormComponent extends FormComponent implements OnChanges, OnIn
     }
 
     loadStartForm(processId: string) {
-        this.formService.getProcessVarablesById(processId)
-            .subscribe((processVariables: any) => {
+        this.formService.getProcessIntance(processId)
+            .subscribe((intance: any) => {
                 this.formService
                     .getStartFormInstance(processId)
                     .subscribe(
                     form => {
                         this.formName = form.name;
-                        form.processVariables = processVariables;
+                        if (intance.variables) {
+                            form.processVariables = intance.variables;
+                        }
                         this.form = this.parseForm(form);
                         this.form.readOnly = this.readOnlyForm;
                         this.onFormLoaded(this.form);

--- a/ng2-components/ng2-activiti-form/src/components/widgets/core/form-field.model.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/core/form-field.model.ts
@@ -205,7 +205,7 @@ export class FormFieldModel extends FormWidgetModel {
     private getProcessVariableValue(field: any, form: FormModel) {
         let fieldName = field.name;
         if (this.isTypeaHeadFieldType(field.type)) {
-            fieldName = this.getFieldNameWithLabel(field.name);
+            fieldName = this.getFieldNameWithLabel(field.id);
         }
         return this.findProcessVariableValue(fieldName, form);
     }

--- a/ng2-components/ng2-activiti-form/src/components/widgets/typeahead/typeahead.widget.spec.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/typeahead/typeahead.widget.spec.ts
@@ -370,7 +370,7 @@ describe('TypeaheadWidgetComponent', () => {
                     name: 'typeahead-name',
                     type: 'readonly',
                     value: '9',
-                    params: { field: { name: 'typeahead-name', type: 'typeahead' } }
+                    params: { field: { id: 'typeahead-id', name: 'typeahead-name', type: 'typeahead' } }
                 });
                 fixture.detectChanges();
                 const trigger = fixture.debugElement.query(By.css('.mat-select-trigger')).nativeElement;

--- a/ng2-components/ng2-activiti-form/src/components/widgets/typeahead/typeahead.widget.spec.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/typeahead/typeahead.widget.spec.ts
@@ -365,7 +365,7 @@ describe('TypeaheadWidgetComponent', () => {
 
             it('should show typeahead value when the type is readonly', async(() => {
                 typeaheadWidgetComponent.field = new FormFieldModel(
-                    new FormModel({ taskId: 'fake-task-id', processVariables: [{ name: 'typeahead-name_LABEL', value: 'FakeProcessValue' }] }), {
+                    new FormModel({ taskId: 'fake-task-id', processVariables: [{ name: 'typeahead-id_LABEL', value: 'FakeProcessValue' }] }), {
                     id: 'typeahead-id',
                     name: 'typeahead-name',
                     type: 'readonly',

--- a/ng2-components/ng2-activiti-form/src/services/form.service.ts
+++ b/ng2-components/ng2-activiti-form/src/services/form.service.ts
@@ -313,6 +313,12 @@ export class FormService {
             .catch(err => this.handleError(err));
     }
 
+    getProcessIntance(processId: string): Observable<any> {
+        return Observable.fromPromise(this.processApi.getProcessInstance(processId))
+            .map(this.toJson)
+            .catch(err => this.handleError(err));
+    }
+
     /**
      * Get start form definition for a given process
      * @param processId Process definition ID


### PR DESCRIPTION
/api/enterprise/process-instances/XXX
instead of
/api/enterprise/process-instances/382/variables
because the latest api returns 404 if the process is completed

**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
The variables are fetch using the api 
/api/enterprise/process-instances/xxx/variables
this api return 404 if the process has been completed


**What is the new behaviour?**
Fetch the variables  using the api 
/api/enterprise/process-instances/xxx


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
