### PR TITLE
[ADF-1636] fix issues with i18n resource composing

### DIFF
--- a/ng2-components/ng2-alfresco-core/src/services/translate-loader.service.ts
+++ b/ng2-components/ng2-alfresco-core/src/services/translate-loader.service.ts
@@ -20,6 +20,7 @@ import { Http, Response } from '@angular/http';
 import { TranslateLoader } from '@ngx-translate/core';
 import { Observable } from 'rxjs/Rx';
 import { ComponentTranslationModel } from '../models/component.model';
+import { ObjectUtils } from '../utils/object-utils';
 import { LogService } from './log.service';
 
 @Injectable()
@@ -78,17 +79,27 @@ export class AlfrescoTranslateLoader implements TranslateLoader {
         return (this.queue[lang] || []).find(x => x === name) ? true : false;
     }
 
-    getFullTranslationJSON(lang: string) {
-        let fullTranslation: string = '';
-        let cloneList = this.providers.slice(0);
-        cloneList.reverse().forEach((component) => {
-            if (component.json && component.json[lang]) {
-                fullTranslation += JSON.stringify(component.json[lang]);
-            }
-        });
-        if (fullTranslation !== '') {
-            return JSON.parse(fullTranslation.replace(/}{/g, ','));
-        }
+    getFullTranslationJSON(lang: string): any {
+        let result = {};
+
+        this.providers
+            .slice(0)
+            .sort((a, b) => {
+                if (a.name === 'app') {
+                    return 1;
+                }
+                if (b.name === 'app') {
+                    return -1;
+                }
+                return a.name.localeCompare(b.name);
+            })
+            .forEach(model => {
+                if (model.json && model.json[lang]) {
+                    result = ObjectUtils.merge(result, model.json[lang]);
+                }
+            });
+
+        return result;
     }
 
     getTranslation(lang: string): Observable<any> {

--- a/ng2-components/ng2-alfresco-core/src/utils/object-utils.spec.ts
+++ b/ng2-components/ng2-alfresco-core/src/utils/object-utils.spec.ts
@@ -51,4 +51,83 @@ describe('ObjectUtils', () => {
         expect(ObjectUtils.getValue(null, 'id')).toBeUndefined();
     });
 
+    describe('merge', () => {
+        it('should merge top level properties', () => {
+            const obj1 = {
+                prop1: 'value1'
+            };
+
+            const obj2 = {
+                prop2: 'value2'
+            };
+
+            const result = ObjectUtils.merge(obj1, obj2);
+            expect(result).toEqual({
+                prop1: 'value1',
+                prop2: 'value2'
+            });
+        });
+
+        it('should merge object properties', () => {
+            const obj1 = {
+                child: {
+                    prop1: 1
+                },
+                prop: 1
+            };
+            const obj2 = {
+                child: {
+                    prop1: 2,
+                    prop2: 3
+                }
+            };
+
+            const result = ObjectUtils.merge(obj1, obj2);
+            expect(result).toEqual({
+                child: {
+                    prop1: 2,
+                    prop2: 3
+                },
+                prop: 1
+            });
+        });
+
+        it('should merge arrays', () => {
+            const obj1 = {
+                arr: [1, 2, 3]
+            };
+            const obj2 = {
+                arr: [4, 5, 6]
+            };
+
+            const result = ObjectUtils.merge(obj1, obj2);
+            expect(result).toEqual({
+                arr: [1, 2, 3, 4, 5, 6]
+            });
+        });
+
+        it('shoud overwrite only single property in the object', () => {
+            const obj1 = {
+                child: {
+                    prop1: 1,
+                    prop2: 2,
+                    prop3: 3
+                }
+            };
+            const obj2 = {
+                child: {
+                    prop3: 0
+                }
+            };
+
+            const result = ObjectUtils.merge(obj1, obj2);
+            expect(result).toEqual({
+                child: {
+                    prop1: 1,
+                    prop2: 2,
+                    prop3: 0
+                }
+            });
+        });
+    });
 });

--- a/ng2-components/ng2-alfresco-core/src/utils/object-utils.ts
+++ b/ng2-components/ng2-alfresco-core/src/utils/object-utils.ts
@@ -47,4 +47,22 @@ export class ObjectUtils {
 
         return target;
     }
+
+    static merge(...objects): any {
+        let result = {};
+
+        objects.forEach(source => {
+            Object.keys(source).forEach(prop => {
+                if (prop in result && Array.isArray(result[prop])) {
+                    result[prop] = result[prop].concat(source[prop]);
+                } else if (prop in result && typeof result[prop] === 'object') {
+                    result[prop] = ObjectUtils.merge(result[prop], source[prop]);
+                } else {
+                    result[prop] = source[prop];
+                }
+            });
+        });
+
+        return result;
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

it is not possible to override ADF resource strings from the application

**What is the new behaviour?**

- merge resources (`.json` files) instead of concatenating
- make 'app' resource always load last (on top of other files)

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
