### PR TITLE
[ADF-1676] hide fake content in the viewer

### DIFF
--- a/docs/viewer.component.md
+++ b/docs/viewer.component.md
@@ -51,12 +51,13 @@ Using with file url:
 | showToolbar | boolean | true | Hide or show the toolbars |
 | displayName | string | | You can specify the name of the file |
 | allowGoBack | boolean | true | Allow `back` navigation |
-| allowOpenWith | boolean | true | Toggle `Open With` options |
+| allowOpenWith | boolean | false | Toggle `Open With` options |
 | allowDownload | boolean | true | Toggle download feature |
-| allowPrint | boolean | true | Toggle printing feature |
-| allowShare | boolean | true | Toggle sharing feature |
-| allowInfoDrawer | boolean | true | Toogle info drawer feature |
+| allowPrint | boolean | false | Toggle printing feature |
+| allowShare | boolean | false | Toggle sharing feature |
+| allowInfoDrawer | boolean |false | Toogle info drawer feature |
 | showInfoDrawer | boolean | false | Toggles info drawer visibility. Requires `allowInfoDrawer` to be set to `true`. |
+| allowMoreActions | boolean | false | Toggles `More actions` feature |
 
 ## Details
 

--- a/ng2-components/ng2-alfresco-viewer/src/components/pdfViewer.component.html
+++ b/ng2-components/ng2-alfresco-viewer/src/components/pdfViewer.component.html
@@ -8,14 +8,15 @@
     </div>
 </div>
 
-<div class="adf-pdf-viewer__toolbar">
+<div class="adf-pdf-viewer__toolbar" *ngIf="showToolbar">
     <adf-toolbar>
 
-        <button md-icon-button>
-            <md-icon>dashboard</md-icon>
-        </button>
-
-        <adf-toolbar-divider></adf-toolbar-divider>
+        <ng-container *ngIf="allowThumbnails">
+            <button md-icon-button>
+                <md-icon>dashboard</md-icon>
+            </button>
+            <adf-toolbar-divider></adf-toolbar-divider>
+        </ng-container>
 
         <button
             id="viewer-previous-page-button"

--- a/ng2-components/ng2-alfresco-viewer/src/components/pdfViewer.component.ts
+++ b/ng2-components/ng2-alfresco-viewer/src/components/pdfViewer.component.ts
@@ -46,6 +46,9 @@ export class PdfViewerComponent implements OnChanges, OnDestroy {
     @Input()
     showToolbar: boolean = true;
 
+    @Input()
+    allowThumbnails = false;
+
     currentPdfDocument: any;
     page: number;
     displayPage: number;

--- a/ng2-components/ng2-alfresco-viewer/src/components/viewer.component.html
+++ b/ng2-components/ng2-alfresco-viewer/src/components/viewer.component.html
@@ -54,23 +54,25 @@
                     <md-icon>share</md-icon>
                 </button>
 
-                <button md-icon-button [mdMenuTriggerFor]="mnuMoreActions" mdTooltip="More actions">
-                    <md-icon>more_vert</md-icon>
-                </button>
-                <md-menu #mnuMoreActions="mdMenu">
-                    <button md-menu-item>
-                        <md-icon>dialpad</md-icon>
-                        <span>Action One</span>
+                <ng-container *ngIf="allowMoreActions">
+                    <button md-icon-button [mdMenuTriggerFor]="mnuMoreActions" mdTooltip="More actions">
+                        <md-icon>more_vert</md-icon>
                     </button>
-                    <button md-menu-item disabled>
-                        <md-icon>voicemail</md-icon>
-                        <span>Action Two</span>
-                    </button>
-                    <button md-menu-item>
-                        <md-icon>notifications_off</md-icon>
-                        <span>Action Three</span>
-                    </button>
-                </md-menu>
+                    <md-menu #mnuMoreActions="mdMenu">
+                        <button md-menu-item>
+                            <md-icon>dialpad</md-icon>
+                            <span>Action One</span>
+                        </button>
+                        <button md-menu-item disabled>
+                            <md-icon>voicemail</md-icon>
+                            <span>Action Two</span>
+                        </button>
+                        <button md-menu-item>
+                            <md-icon>notifications_off</md-icon>
+                            <span>Action Three</span>
+                        </button>
+                    </md-menu>
+                </ng-container>
 
                 <ng-container *ngIf="allowInfoDrawer">
                     <adf-toolbar-divider></adf-toolbar-divider>

--- a/ng2-components/ng2-alfresco-viewer/src/components/viewer.component.ts
+++ b/ng2-components/ng2-alfresco-viewer/src/components/viewer.component.ts
@@ -54,22 +54,25 @@ export class ViewerComponent implements OnDestroy, OnChanges {
     allowGoBack = true;
 
     @Input()
-    allowOpenWith = true;
+    allowOpenWith = false;
 
     @Input()
     allowDownload = true;
 
     @Input()
-    allowPrint = true;
+    allowPrint = false;
 
     @Input()
-    allowShare = true;
+    allowShare = false;
 
     @Input()
-    allowInfoDrawer = true;
+    allowInfoDrawer = false;
 
     @Input()
     showInfoDrawer = false;
+
+    @Input()
+    allowMoreActions = false;
 
     @Output()
     goBack = new EventEmitter<BaseEvent<any>>();


### PR DESCRIPTION
- hide all demo/fake content by default: toolbar buttons and PDF viewer thumbnail button