### PR TITLE
[ADF-1677] reset pagination on data source change

### DIFF
--- a/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.spec.ts
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.spec.ts
@@ -972,4 +972,11 @@ describe('DocumentList', () => {
 
         expect(documentList.reload).toHaveBeenCalledTimes(2);
     });
+
+    it('should reset pagination when switching sources', () => {
+        spyOn(documentList, 'resetPagination').and.callThrough();
+        documentList.loadFolderByNodeId('-trashcan-');
+        documentList.loadFolderByNodeId('-sites-');
+        expect(documentList.resetPagination).toHaveBeenCalledTimes(2);
+    });
 });

--- a/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.ts
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.ts
@@ -404,7 +404,9 @@ export class DocumentListComponent implements OnInit, OnChanges, AfterContentIni
     // gets folder node and its content
     loadFolderByNodeId(nodeId: string) {
         this.loading = true;
+
         this.resetSelection();
+        this.resetPagination();
 
         if (nodeId === '-trashcan-') {
             this.loadTrashcan();
@@ -421,7 +423,6 @@ export class DocumentListComponent implements OnInit, OnChanges, AfterContentIni
                 .getFolderNode(nodeId).then(node => {
                     this.folderNode = node;
                     this.currentFolderId = node.id;
-                    this.skipCount = 0;
                     this.currentNodeAllowableOperations = node['allowableOperations'] ? node['allowableOperations'] : [];
                     this.loadFolderNodesByFolderNodeId(node.id, this.pageSize, this.skipCount).catch(err => this.error.emit(err));
                 })
@@ -465,6 +466,10 @@ export class DocumentListComponent implements OnInit, OnChanges, AfterContentIni
     resetSelection() {
         this.dataTable.resetSelection();
         this.selection = [];
+    }
+
+    resetPagination() {
+        this.skipCount = 0;
     }
 
     private loadTrashcan(): void {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

When switching to different source the pagination settings are still used for the old one.

**What is the new behaviour?**

Reset pagination settings on data source change

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
