### PR TITLE
[ADF-1653] cleaned user suggestion when input type is an empty string

### DIFF
--- a/ng2-components/ng2-activiti-form/src/components/widgets/core/form-field.model.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/core/form-field.model.ts
@@ -112,6 +112,10 @@ export class FormFieldModel extends FormWidgetModel {
         return this._isValid;
     }
 
+    markAsInvalid() {
+        this._isValid = false;
+    }
+
     validate(): boolean {
         this.validationSummary = null;
 

--- a/ng2-components/ng2-activiti-form/src/components/widgets/core/form.model.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/core/form.model.ts
@@ -166,6 +166,10 @@ export class FormModel {
         return result;
     }
 
+    markAsInvalid() {
+        this._isValid = false;
+    }
+
     /**
      * Validates entire form and all form fields.
      *

--- a/ng2-components/ng2-activiti-form/src/components/widgets/people/people.widget.html
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/people/people.widget.html
@@ -17,8 +17,7 @@
                placeholder="{{field.placeholder}}"
                [mdAutocomplete]="auto">
         <md-autocomplete #auto="mdAutocomplete" (optionSelected)="onItemSelect($event.option.value)">
-            <md-option *ngFor="let user of users; let i = index"
-                       (click)="onItemClick(user, $event)" [value]="user">
+            <md-option *ngFor="let user of users; let i = index" [value]="user">
                 <div class="adf-people-widget-row" id="adf-people-widget-user-{{i}}">
                     <div class="adf-people-widget-pic">
                         {{getInitialUserName(user.firstName, user.lastName)}}

--- a/ng2-components/ng2-activiti-form/src/components/widgets/people/people.widget.spec.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/people/people.widget.spec.ts
@@ -27,7 +27,7 @@ import { ErrorWidgetComponent } from '../error/error.component';
 import { EcmModelService } from './../../../services/ecm-model.service';
 import { PeopleWidgetComponent } from './people.widget';
 
-fdescribe('PeopleWidgetComponent', () => {
+describe('PeopleWidgetComponent', () => {
 
     let widget: PeopleWidgetComponent;
     let fixture: ComponentFixture<PeopleWidgetComponent>;

--- a/ng2-components/ng2-activiti-form/src/components/widgets/people/people.widget.spec.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/people/people.widget.spec.ts
@@ -27,7 +27,7 @@ import { ErrorWidgetComponent } from '../error/error.component';
 import { EcmModelService } from './../../../services/ecm-model.service';
 import { PeopleWidgetComponent } from './people.widget';
 
-describe('PeopleWidgetComponent', () => {
+fdescribe('PeopleWidgetComponent', () => {
 
     let widget: PeopleWidgetComponent;
     let fixture: ComponentFixture<PeopleWidgetComponent>;
@@ -98,20 +98,6 @@ describe('PeopleWidgetComponent', () => {
         );
 
         widget.ngOnInit();
-        expect(widget.value).toBe('John Doe');
-    });
-
-    it('should prevent default behaviour on option item click', () => {
-        let event = jasmine.createSpyObj('event', ['preventDefault']);
-        widget.onItemClick(null, event);
-        expect(event.preventDefault).toHaveBeenCalled();
-    });
-
-    it('should update values on item click', () => {
-        let item = new LightUserRepresentation({firstName: 'John', lastName: 'Doe'});
-
-        widget.onItemClick(item, null);
-        expect(widget.field.value).toBe(item);
         expect(widget.value).toBe('John Doe');
     });
 
@@ -204,42 +190,15 @@ describe('PeopleWidgetComponent', () => {
         expect(formService.getWorkflowUsers).not.toHaveBeenCalled();
     });
 
-    it('should update form on value flush', () => {
-        spyOn(widget.field, 'updateForm').and.callThrough();
-        widget.flushValue();
-        expect(widget.field.updateForm).toHaveBeenCalled();
+    it('should reset users when the input field is blank string', () => {
+        let fakeUser = new LightUserRepresentation({id: '1', email: 'ffff@fff'});
+        widget.users.push(fakeUser);
+
+        let keyboardEvent = new KeyboardEvent('keypress');
+        widget.value = '';
+        widget.onKeyUp(keyboardEvent);
+
+        expect(widget.users).toEqual([]);
     });
 
-    it('should flush value and update field', () => {
-        widget.users = [
-            new LightUserRepresentation({firstName: 'Tony', lastName: 'Stark'}),
-            new LightUserRepresentation({firstName: 'John', lastName: 'Doe'})
-        ];
-        widget.value = 'John Doe';
-        widget.flushValue();
-
-        expect(widget.value).toBe('John Doe');
-        expect(widget.field.value).toBe(widget.users[1]);
-    });
-
-    it('should be case insensitive when flushing field', () => {
-        widget.users = [
-            new LightUserRepresentation({firstName: 'Tony', lastName: 'Stark'}),
-            new LightUserRepresentation({firstName: 'John', lastName: 'Doe'})
-        ];
-        widget.value = 'TONY sTaRk';
-        widget.flushValue();
-
-        expect(widget.value).toBe('Tony Stark');
-        expect(widget.field.value).toBe(widget.users[0]);
-    });
-
-    it('should reset value and field on flush', () => {
-        widget.value = 'Missing User';
-        widget.field.value = {};
-        widget.flushValue();
-
-        expect(widget.value).toBeNull();
-        expect(widget.field.value).toBeNull();
-    });
 });

--- a/ng2-components/ng2-activiti-form/src/components/widgets/people/people.widget.spec.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/people/people.widget.spec.ts
@@ -217,7 +217,7 @@ describe('PeopleWidgetComponent', () => {
         expect(widget.users).toEqual([]);
     });
 
-    fdescribe('when template is ready', () => {
+    describe('when template is ready', () => {
 
         let fakeUserResult = [
             { id: 1001, firstName: 'Test01', lastName: 'Test01', email: 'test' },

--- a/ng2-components/ng2-activiti-form/src/components/widgets/people/people.widget.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/people/people.widget.ts
@@ -73,6 +73,7 @@ export class PeopleWidgetComponent extends WidgetComponent implements OnInit {
         }
         if (this.isValueDefined() && this.value.trim().length === 0) {
           this.oldValue = this.value;
+          this.field.validationSummary = '';
           this.users = [];
         }
     }
@@ -85,7 +86,26 @@ export class PeopleWidgetComponent extends WidgetComponent implements OnInit {
         this.formService.getWorkflowUsers(this.value, this.groupId)
             .subscribe((result: LightUserRepresentation[]) => {
                 this.users = result || [];
+                this.validateValue();
             });
+    }
+
+    validateValue() {
+        let validUserName = this.getUserFromValue();
+        if (validUserName) {
+            this.field.validationSummary = '';
+            this.field.value = validUserName;
+            this.value = this.getDisplayName(validUserName);
+        } else {
+            this.field.value = '';
+            this.field.validationSummary = 'Invalid value provided';
+            this.field.markAsInvalid();
+            this.field.form.markAsInvalid();
+          }
+    }
+
+    getUserFromValue() {
+        return this.users.find((user) => this.getDisplayName(user).toLocaleLowerCase() === this.value.toLocaleLowerCase());
     }
 
     getDisplayName(model: LightUserRepresentation) {
@@ -93,7 +113,6 @@ export class PeopleWidgetComponent extends WidgetComponent implements OnInit {
             let displayName = `${model.firstName || ''} ${model.lastName || ''}`;
             return displayName.trim();
         }
-
         return '';
     }
 

--- a/ng2-components/ng2-activiti-form/src/components/widgets/people/people.widget.ts
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/people/people.widget.ts
@@ -71,6 +71,14 @@ export class PeopleWidgetComponent extends WidgetComponent implements OnInit {
                 }
             }
         }
+        if (this.isValueDefined() && this.value.trim().length === 0) {
+          this.oldValue = this.value;
+          this.users = [];
+        }
+    }
+
+    isValueDefined() {
+        return this.value !== null && this.value !== undefined;
     }
 
     searchUsers() {
@@ -80,23 +88,6 @@ export class PeopleWidgetComponent extends WidgetComponent implements OnInit {
             });
     }
 
-    flushValue() {
-        let option = this.users.find(item => {
-            let fullName = this.getDisplayName(item).toLocaleLowerCase();
-            return (this.value && fullName === this.value.toLocaleLowerCase());
-        });
-
-        if (option) {
-            this.field.value = option;
-            this.value = this.getDisplayName(option);
-        } else {
-            this.field.value = null;
-            this.value = null;
-        }
-
-        this.field.updateForm();
-    }
-
     getDisplayName(model: LightUserRepresentation) {
         if (model) {
             let displayName = `${model.firstName || ''} ${model.lastName || ''}`;
@@ -104,16 +95,6 @@ export class PeopleWidgetComponent extends WidgetComponent implements OnInit {
         }
 
         return '';
-    }
-
-    onItemClick(item: LightUserRepresentation, event: Event) {
-        if (item) {
-            this.field.value = item;
-            this.value = this.getDisplayName(item);
-        }
-        if (event) {
-            event.preventDefault();
-        }
     }
 
     onItemSelect(item: LightUserRepresentation) {

--- a/ng2-components/ng2-activiti-form/src/services/form.service.ts
+++ b/ng2-components/ng2-activiti-form/src/services/form.service.ts
@@ -387,6 +387,7 @@ export class FormService {
                     return Observable.of(user);
                 })
             .combineAll()
+            .defaultIfEmpty([])
             .catch(err => this.handleError(err));
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
User suggestion keeps being showed when user has cleared the input text


**What is the new behaviour?**
No suggestion is showed on empty string input 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
