### PR TITLE
[ADF-1740] disabling start process button when the process name is empty

### DIFF
--- a/docs/form.component.md
+++ b/docs/form.component.md
@@ -114,6 +114,7 @@ and store the form field as metadata. The param nameNode is optional.
 | showTitle | boolean | true | Toggle rendering of the form title. |
 | showCompleteButton | boolean | true | Toggle rendering of the `Complete` outcome button. |
 | disableCompleteButton | boolean | false | The `Complete` outcome button is shown but it will be disabled. |
+| disableStartProcessButton | boolean | false | The `Start Process` outcome button is shown but it will be disabled. |
 | showSaveButton | boolean | true | Toggle rendering of the `Save` outcome button. |
 | readOnly | boolean | false | Toggle readonly state of the form. Enforces all form widgets render readonly if enabled. |
 | showRefreshButton | boolean | true | Toggle rendering of the `Refresh` button. |

--- a/ng2-components/ng2-activiti-form/src/assets/start-form.component.mock.ts
+++ b/ng2-components/ng2-activiti-form/src/assets/start-form.component.mock.ts
@@ -577,6 +577,10 @@ export let startMockForm = {
         {
             id: 'complete',
             name: 'Complete'
+        },
+        {
+            id: 'start_process',
+            name: 'Start Process'
         }
     ],
     javascriptEvents: [],

--- a/ng2-components/ng2-activiti-form/src/components/form.component.spec.ts
+++ b/ng2-components/ng2-activiti-form/src/components/form.component.spec.ts
@@ -775,6 +775,17 @@ describe('FormComponent', () => {
         expect(formComponent.isOutcomeButtonEnabled(completeOutcome)).toBeFalsy();
     });
 
+    it('should disable start process outcome button when disableStartProcessButton is true', () => {
+        let formModel = new FormModel();
+        formComponent.form = formModel;
+        formComponent.disableStartProcessButton = true;
+
+        expect(formModel.isValid).toBeTruthy();
+        let startProcessOutcome = formComponent.form.outcomes.find(outcome => outcome.name === FormOutcomeModel.START_PROCESS_ACTION);
+
+        expect(formComponent.isOutcomeButtonEnabled(startProcessOutcome)).toBeFalsy();
+    });
+
     it('should raise [executeOutcome] event for formService', (done) => {
         formService.executeOutcome.subscribe(() => {
             done();

--- a/ng2-components/ng2-activiti-form/src/components/form.component.ts
+++ b/ng2-components/ng2-activiti-form/src/components/form.component.ts
@@ -76,6 +76,9 @@ export class FormComponent implements OnInit, OnChanges {
     disableCompleteButton: boolean = false;
 
     @Input()
+    disableStartProcessButton: boolean = false;
+
+    @Input()
     showSaveButton: boolean = true;
 
     @Input()
@@ -147,6 +150,9 @@ export class FormComponent implements OnInit, OnChanges {
             }
             if (outcome.name === FormOutcomeModel.COMPLETE_ACTION) {
                 return this.disableCompleteButton ? false : this.form.isValid;
+            }
+            if (outcome.name === FormOutcomeModel.START_PROCESS_ACTION) {
+                return this.disableStartProcessButton ? false : this.form.isValid;
             }
             return this.form.isValid;
         }

--- a/ng2-components/ng2-activiti-processlist/src/components/start-process.component.html
+++ b/ng2-components/ng2-activiti-processlist/src/components/start-process.component.html
@@ -16,7 +16,8 @@
                 </mat-option>
             </mat-select>
         </mat-form-field>
-		<activiti-start-form *ngIf="hasStartForm()"
+        <activiti-start-form *ngIf="hasStartForm()"
+            [disableStartProcessButton]="!hasProcessName()"
 			[processDefinitionId]="currentProcessDef.id"
 			(outcomeClick)="onOutcomeClick($event)"
 		    [showRefreshButton]="false">

--- a/ng2-components/ng2-activiti-processlist/src/components/start-process.component.spec.ts
+++ b/ng2-components/ng2-activiti-processlist/src/components/start-process.component.spec.ts
@@ -322,7 +322,7 @@ describe('StartProcessInstanceComponent', () => {
 
     });
 
-    fdescribe('start forms', () => {
+    describe('start forms', () => {
 
         let startBtn;
 

--- a/ng2-components/ng2-activiti-processlist/src/components/start-process.component.spec.ts
+++ b/ng2-components/ng2-activiti-processlist/src/components/start-process.component.spec.ts
@@ -322,7 +322,7 @@ describe('StartProcessInstanceComponent', () => {
 
     });
 
-    describe('start forms', () => {
+    fdescribe('start forms', () => {
 
         let startBtn;
 
@@ -353,7 +353,14 @@ describe('StartProcessInstanceComponent', () => {
             it('should enable start button when name and process filled out', async(() => {
                 fixture.detectChanges();
                 let startButton = fixture.nativeElement.querySelector('#button-start');
-                expect(startButton.enable).toBeFalsy();
+                expect(startButton.disabled).toBeFalsy();
+            }));
+
+            it('should disable the start process button when process name is empty', async(() => {
+                component.name = '';
+                fixture.detectChanges();
+                let startButton = fixture.nativeElement.querySelector('#button-start');
+                expect(startButton.disabled).toBeTruthy();
             }));
 
         });

--- a/ng2-components/ng2-activiti-processlist/src/components/start-process.component.ts
+++ b/ng2-components/ng2-activiti-processlist/src/components/start-process.component.ts
@@ -154,4 +154,8 @@ export class StartProcessInstanceComponent implements OnChanges {
         }
         this.resetErrorMessage();
     }
+
+    hasProcessName(): boolean {
+        return this.name ? true : false;
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Start process button is disabled only when the form is invalid


**What is the new behaviour?**
Start process button is disabled when the form is invalid and when the process name is empty


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
