### PR TITLE
[ADF-1747] Task service - findAllTaskByState return a wrong list.

### DIFF
--- a/ng2-components/ng2-activiti-tasklist/src/assets/tasklist-service.mock.ts
+++ b/ng2-components/ng2-activiti-tasklist/src/assets/tasklist-service.mock.ts
@@ -222,3 +222,49 @@ export let fakeFormList = {
         tenantId: null
     }]
 };
+
+export let fakeTaskOpen1 = {
+        id: '1', name: 'FakeOpenTask1', description: null, category: null,
+        assignee: fakeUser1,
+        created: '2017-07-15T11:19:17.440+0000',
+        dueDate: null,
+        endDate: null
+    };
+
+export let fakeTaskOpen2 = {
+        id: '1', name: 'FakeOpenTask2', description: null, category: null,
+        assignee: { id: 1, email: 'fake-open-email@dom.com', firstName: 'firstName', lastName: 'lastName' },
+        created: '2017-07-15T11:19:17.440+0000',
+        dueDate: null,
+        endDate: null
+    };
+
+export let fakeTaskCompleted1 = {
+        id: '1', name: 'FakeCompletedTaskName1', description: null, category: null,
+        assignee: { id: 1, email: 'fake-completed-email@dom.com', firstName: 'firstName', lastName: 'lastName' },
+        created: '2016-07-15T11:19:17.440+0000',
+        dueDate: null,
+        endDate: '2016-11-03T15:25:42.749+0000'
+    };
+
+export let fakeTaskCompleted2 = {
+        id: '1', name: 'FakeCompletedTaskName2', description: null, category: null,
+        assignee: fakeUser1,
+        created: null,
+        dueDate: null,
+        endDate: '2016-11-03T15:25:42.749+0000'
+    };
+
+export let fakeOpenTaskList = {
+    size: 2,
+    total: 2,
+    start: 0,
+    data: [fakeTaskOpen1, fakeTaskOpen2]
+};
+
+export let fakeCompletedTaskList = {
+    size: 2,
+    total: 2,
+    start: 0,
+    data: [fakeTaskCompleted1, fakeTaskCompleted2]
+};

--- a/ng2-components/ng2-activiti-tasklist/src/services/tasklist.service.spec.ts
+++ b/ng2-components/ng2-activiti-tasklist/src/services/tasklist.service.spec.ts
@@ -333,6 +333,34 @@ describe('Activiti TaskList Service', () => {
             );
         });
 
+        it('should add  the task list to the tasklistSubject with all tasks filtered without state', (done) => {
+            spyOn(service, 'getTasks').and.returnValue(Observable.of(fakeTaskList));
+            spyOn(service, 'getTotalTasks').and.returnValue(Observable.of(fakeTaskList));
+
+            service.tasksList$.subscribe(
+                 (res) => {
+                    expect(res).toBeDefined();
+                    expect(res.data).toBeDefined();
+                    expect(res.data.length).toEqual(2);
+                    expect(res.data[0].name).toEqual('FakeNameTask');
+                    expect(res.data[1].assignee.email).toEqual('fake-email@dom.com');
+                });
+
+            service.findAllTasksWhitoutState(<TaskQueryRequestRepresentationModel> fakeFilter).subscribe(
+                res => {
+                    expect(res).toBeDefined();
+                    expect(res.data).toBeDefined();
+                    expect(res.data.length).toEqual(2);
+                    expect(res.data[0].name).toEqual('FakeNameTask');
+                    expect(res.data[0].assignee.email).toEqual('fake-email@dom.com');
+
+                    expect(res.data[1].name).toEqual('FakeNameTask');
+                    expect(res.data[1].assignee.email).toEqual('fake-email@dom.com');
+                    done();
+                }
+            );
+        });
+
         it('should return the task details ', (done) => {
             service.getTaskDetails('999').subscribe(
                 (res: TaskDetailsModel) => {

--- a/ng2-components/ng2-activiti-tasklist/src/services/tasklist.service.spec.ts
+++ b/ng2-components/ng2-activiti-tasklist/src/services/tasklist.service.spec.ts
@@ -22,10 +22,12 @@ import { AppConfigServiceMock } from '../assets/app-config.service.mock';
 import {
     fakeAppFilter,
     fakeAppPromise,
+    fakeCompletedTaskList,
     fakeErrorTaskList,
     fakeFilter,
     fakeFilters,
     fakeFormList,
+    fakeOpenTaskList,
     fakeRepresentationFilter1,
     fakeRepresentationFilter2,
     fakeTaskDetails,
@@ -333,6 +335,24 @@ describe('Activiti TaskList Service', () => {
             );
         });
 
+        it('Should return both open and completed task', (done) => {
+            spyOn(service, 'findTasksByState').and.returnValue(Observable.of(fakeOpenTaskList));
+            spyOn(service, 'findAllTaskByState').and.returnValue(Observable.of(fakeCompletedTaskList));
+            service.findAllTasksWhitoutState(<TaskQueryRequestRepresentationModel> fakeFilter).subscribe(
+                res => {
+                    expect(res).toBeDefined();
+                    expect(res.data).toBeDefined();
+                    expect(res.data.length).toEqual(4);
+                    expect(res.data[0].name).toEqual('FakeOpenTask1');
+                    expect(res.data[1].assignee.email).toEqual('fake-open-email@dom.com');
+                    expect(res.data[2].name).toEqual('FakeCompletedTaskName1');
+                    expect(res.data[2].assignee.email).toEqual('fake-completed-email@dom.com');
+                    expect(res.data[3].name).toEqual('FakeCompletedTaskName2');
+                    done();
+                }
+            );
+        });
+
         it('should add  the task list to the tasklistSubject with all tasks filtered without state', (done) => {
             spyOn(service, 'getTasks').and.returnValue(Observable.of(fakeTaskList));
             spyOn(service, 'getTotalTasks').and.returnValue(Observable.of(fakeTaskList));
@@ -345,7 +365,6 @@ describe('Activiti TaskList Service', () => {
                     expect(res.data[0].name).toEqual('FakeNameTask');
                     expect(res.data[1].assignee.email).toEqual('fake-email@dom.com');
                 });
-
             service.findAllTasksWhitoutState(<TaskQueryRequestRepresentationModel> fakeFilter).subscribe(
                 res => {
                     expect(res).toBeDefined();
@@ -353,7 +372,6 @@ describe('Activiti TaskList Service', () => {
                     expect(res.data.length).toEqual(2);
                     expect(res.data[0].name).toEqual('FakeNameTask');
                     expect(res.data[0].assignee.email).toEqual('fake-email@dom.com');
-
                     expect(res.data[1].name).toEqual('FakeNameTask');
                     expect(res.data[1].assignee.email).toEqual('fake-email@dom.com');
                     done();

--- a/ng2-components/ng2-activiti-tasklist/src/services/tasklist.service.ts
+++ b/ng2-components/ng2-activiti-tasklist/src/services/tasklist.service.ts
@@ -163,15 +163,16 @@ export class TaskListService {
      */
     findAllTasksWhitoutState(requestNode: TaskQueryRequestRepresentationModel): Observable<TaskListModel> {
         return Observable.forkJoin(
-            this.findTasksByState(requestNode, 'open'),
-            this.findAllTaskByState(requestNode, 'completed'),
-            (activeTasks: TaskListModel, completedTasks: TaskListModel) => {
-                const tasks = Object.assign({}, activeTasks);
-                tasks.total += completedTasks.total;
-                tasks.data = tasks.data.concat(completedTasks.data);
-                return tasks;
-            }
-        );
+                this.findTasksByState(requestNode, 'open'),
+                this.findAllTaskByState(requestNode, 'completed'),
+                (activeTasks: TaskListModel, completedTasks: TaskListModel) => {
+                    const tasks = Object.assign({}, activeTasks);
+                    tasks.total += completedTasks.total;
+                    tasks.data = tasks.data.concat(completedTasks.data);
+                    this.tasksListSubject.next(tasks);
+                    return tasks;
+                }
+            );
     }
 
     /**


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

* From DW side we use the method findAllTaskByState to fetch the active and completed status, but 
 after the pagination refactoring this method doesn't work properly. 

**What is the new behaviour?**

* Refactored findAllTaskByState method.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
