### PR TITLE
[ADF-1778] optional port number

### DIFF
--- a/ng2-components/ng2-alfresco-core/src/services/app-config.service.spec.ts
+++ b/ng2-components/ng2-alfresco-core/src/services/app-config.service.spec.ts
@@ -62,6 +62,33 @@ describe('AppConfigService', () => {
         expect(service).toBeDefined();
     });
 
+    it('should skip the optional port number', () => {
+        appConfigService.config.testUrl = 'http://{hostname}{:port}';
+
+        spyOn(appConfigService, 'getLocationHostname').and.returnValue('localhost');
+        spyOn(appConfigService, 'getLocationPort').and.returnValue('');
+
+        expect(appConfigService.get('testUrl')).toBe('http://localhost');
+    });
+
+    it('should set the optional port number', () => {
+        appConfigService.config.testUrl = 'http://{hostname}{:port}';
+
+        spyOn(appConfigService, 'getLocationHostname').and.returnValue('localhost');
+        spyOn(appConfigService, 'getLocationPort').and.returnValue(':9090');
+
+        expect(appConfigService.get('testUrl')).toBe('http://localhost:9090');
+    });
+
+    it('should set the mandatory port number', () => {
+        appConfigService.config.testUrl = 'http://{hostname}:{port}';
+
+        spyOn(appConfigService, 'getLocationHostname').and.returnValue('localhost');
+        spyOn(appConfigService, 'getLocationPort').and.returnValue('9090');
+
+        expect(appConfigService.get('testUrl')).toBe('http://localhost:9090');
+    });
+
     it('should load external settings', () => {
         appConfigService.load().then(config => {
             expect(config).toEqual(mockResponse);

--- a/ng2-components/ng2-alfresco-core/src/services/app-config.service.ts
+++ b/ng2-components/ng2-alfresco-core/src/services/app-config.service.ts
@@ -28,8 +28,8 @@ export class AppConfigService {
         application: {
             name: 'Alfresco ADF Application'
         },
-        ecmHost: 'http://{hostname}:{port}/ecm',
-        bpmHost: 'http://{hostname}:{port}/bpm'
+        ecmHost: 'http://{hostname}{:port}/ecm',
+        bpmHost: 'http://{hostname}{:port}/bpm'
     };
 
     constructor(private http: Http) {}
@@ -38,14 +38,23 @@ export class AppConfigService {
         let result: any = ObjectUtils.getValue(this.config, key);
         if (typeof result === 'string') {
             const map = new Map<string, string>();
-            map.set('hostname', location.hostname);
-            map.set('port', location.port);
+            map.set('hostname', this.getLocationHostname());
+            map.set(':port', this.getLocationPort(':'));
+            map.set('port', this.getLocationPort());
             result = this.formatString(result, map);
         }
         if (result === undefined) {
             return defaultValue;
         }
         return <T> result;
+    }
+
+    getLocationHostname(): string {
+        return location.hostname;
+    }
+
+    getLocationPort(prefix: string = ''): string {
+        return location.port ? prefix + location.port : '';
     }
 
     load(): Promise<any> {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

Add support for optional port number, `{:port}` emits `:8080` if port is 8080, or empty string for default port 80.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
