### PR TITLE
fix base path

### DIFF
--- a/demo-shell-ng2/src/index.html
+++ b/demo-shell-ng2/src/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>ACS APS ADF Application with Angular CLI</title>
-  <base href="./">
+  <base href="/">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/png" href="favicon-96x96.png" sizes="96x96">


### PR DESCRIPTION
fix the issue with reloading the page when HTML5 routing is used

note: the dot might be needed for Tomcat deployments and when using "#" for the routes, can be changed via `--base-href` flag (https://github.com/angular/angular-cli/wiki/build) when building the app.