### PR TITLE
extend proxy config with native auth dialog fix

### DIFF
--- a/demo-shell-ng2/package.json
+++ b/demo-shell-ng2/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "ng": "ng",
     "start": "npm run server-versions && rimraf dist && ng serve --host 0.0.0.0 --app=0 --open --aot=true",
-    "start:dev": "npm run clean-ng2-component-angular && npm run server-versions && rimraf dist && ng serve --host 0.0.0.0 --app=1 pp-dev --proxy-config proxy.conf.json --open",
+    "start:dev": "npm run clean-ng2-component-angular && npm run server-versions && rimraf dist && ng serve --host 0.0.0.0 --app=1 pp-dev --proxy-config proxy.conf.js --open",
     "start:dist": "npm run server-versions && rimraf dist && ng serve --host 0.0.0.0 --disable-host-check --aot=false --prod --app=0",
     "build": "npm run server-versions && rimraf dist && ng build  -app=0",
     "build:dev": "npm run server-versions && rimraf dist && ng build -app=1",

--- a/demo-shell-ng2/proxy.conf.js
+++ b/demo-shell-ng2/proxy.conf.js
@@ -1,11 +1,18 @@
-{
+module.exports = {
   "/alfresco": {
     "target": "http://localhost:8080",
     "secure": false,
     "pathRewrite": {
       "^/alfresco/alfresco": ""
     },
-    "changeOrigin": true
+    "changeOrigin": true,
+    // workaround for REPO-2260
+    onProxyRes: function (proxyRes, req, res) {
+      const header = proxyRes.headers['www-authenticate'];
+      if (header && header.startsWith('Basic')) {
+          proxyRes.headers['www-authenticate'] = 'x' + header;
+      }
+    }
   },
   "/activiti-app": {
     "target": "http://localhost:9999",
@@ -15,4 +22,4 @@
     },
     "changeOrigin": true
   }
-}
+};


### PR DESCRIPTION
suppress native auth dialogue for ACS connections when running locally (dev mode)