### PR TITLE
[ADF-1786] fix delete and permission on the same button case

### DIFF
--- a/ng2-components/ng2-alfresco-core/src/directives/node-delete.directive.spec.ts
+++ b/ng2-components/ng2-alfresco-core/src/directives/node-delete.directive.spec.ts
@@ -73,7 +73,7 @@ describe('NodeDeleteDirective', () => {
                 fixture = TestBed.createComponent(TestComponent);
                 fixtureWithPermissions = TestBed.createComponent(TestWithPermissionsComponent);
                 component = fixture.componentInstance;
-                componentWithPermissions  = fixtureWithPermissions.componentInstance;
+                componentWithPermissions = fixtureWithPermissions.componentInstance;
                 element = fixture.debugElement.query(By.directive(NodeDeleteDirective));
                 elementWithPermissions = fixtureWithPermissions.debugElement.query(By.directive(NodeDeleteDirective));
 
@@ -101,7 +101,7 @@ describe('NodeDeleteDirective', () => {
         it('should process node successfully', fakeAsync(() => {
             spyOn(nodeApi, 'deleteNode').and.returnValue(Promise.resolve());
 
-            component.selection = <any> [{entry: {id: '1', name: 'name1'}}];
+            component.selection = <any> [{ entry: { id: '1', name: 'name1' } }];
 
             fixture.detectChanges();
             element.triggerEventHandler('click', null);
@@ -115,7 +115,7 @@ describe('NodeDeleteDirective', () => {
         it('should notify failed node deletion', fakeAsync(() => {
             spyOn(nodeApi, 'deleteNode').and.returnValue(Promise.reject('error'));
 
-            component.selection = [{entry: {id: '1', name: 'name1'}}];
+            component.selection = [{ entry: { id: '1', name: 'name1' } }];
 
             fixture.detectChanges();
             element.triggerEventHandler('click', null);
@@ -130,8 +130,8 @@ describe('NodeDeleteDirective', () => {
             spyOn(nodeApi, 'deleteNode').and.returnValue(Promise.resolve());
 
             component.selection = [
-                {entry: {id: '1', name: 'name1'}},
-                {entry: {id: '2', name: 'name2'}}
+                { entry: { id: '1', name: 'name1' } },
+                { entry: { id: '2', name: 'name2' } }
             ];
 
             fixture.detectChanges();
@@ -147,8 +147,8 @@ describe('NodeDeleteDirective', () => {
             spyOn(nodeApi, 'deleteNode').and.returnValue(Promise.reject('error'));
 
             component.selection = [
-                {entry: {id: '1', name: 'name1'}},
-                {entry: {id: '2', name: 'name2'}}
+                { entry: { id: '1', name: 'name1' } },
+                { entry: { id: '2', name: 'name2' } }
             ];
 
             fixture.detectChanges();
@@ -170,8 +170,8 @@ describe('NodeDeleteDirective', () => {
             });
 
             component.selection = [
-                {entry: {id: '1', name: 'name1'}},
-                {entry: {id: '2', name: 'name2'}}
+                { entry: { id: '1', name: 'name1' } },
+                { entry: { id: '2', name: 'name2' } }
             ];
 
             fixture.detectChanges();
@@ -199,9 +199,9 @@ describe('NodeDeleteDirective', () => {
             });
 
             component.selection = [
-                {entry: {id: '1', name: 'name1'}},
-                {entry: {id: '2', name: 'name2'}},
-                {entry: {id: '3', name: 'name3'}}
+                { entry: { id: '1', name: 'name1' } },
+                { entry: { id: '2', name: 'name2' } },
+                { entry: { id: '3', name: 'name3' } }
             ];
 
             fixture.detectChanges();
@@ -217,7 +217,7 @@ describe('NodeDeleteDirective', () => {
             component.done.calls.reset();
             spyOn(nodeApi, 'deleteNode').and.returnValue(Promise.resolve());
 
-            component.selection = <any> [{entry: {id: '1', name: 'name1'}}];
+            component.selection = <any> [{ entry: { id: '1', name: 'name1' } }];
 
             fixture.detectChanges();
             element.triggerEventHandler('click', null);
@@ -244,9 +244,9 @@ describe('NodeDeleteDirective', () => {
 
         it('should enable the button if nodes are selected', fakeAsync(() => {
             component.selection = [
-                {entry: {id: '1', name: 'name1'}},
-                {entry: {id: '2', name: 'name2'}},
-                {entry: {id: '3', name: 'name3'}}
+                { entry: { id: '1', name: 'name1' } },
+                { entry: { id: '2', name: 'name2' } },
+                { entry: { id: '3', name: 'name3' } }
             ];
 
             fixture.detectChanges();
@@ -261,9 +261,9 @@ describe('NodeDeleteDirective', () => {
             fixtureWithPermissions.detectChanges();
 
             componentWithPermissions.selection = [
-                {entry: {id: '1', name: 'name1'}},
-                {entry: {id: '2', name: 'name2'}},
-                {entry: {id: '3', name: 'name3'}}
+                { entry: { id: '1', name: 'name1' } },
+                { entry: { id: '2', name: 'name2' } },
+                { entry: { id: '3', name: 'name3' } }
             ];
 
             fixtureWithPermissions.detectChanges();

--- a/ng2-components/ng2-alfresco-core/src/directives/node-permission.directive.spec.ts
+++ b/ng2-components/ng2-alfresco-core/src/directives/node-permission.directive.spec.ts
@@ -15,150 +15,99 @@
  * limitations under the License.
  */
 
-import { ChangeDetectorRef, Component, ElementRef, SimpleChange } from '@angular/core';
+import { Component, DebugElement } from '@angular/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { CoreModule } from '../../index';
 import { AlfrescoContentService } from './../services/alfresco-content.service';
-import { NodePermissionDirective, NodePermissionSubject } from './node-permission.directive';
+import { NodePermissionDirective } from './node-permission.directive';
 
 @Component({
-    selector: 'adf-text-subject'
+    template: `
+        <div [adf-node-permission]="'delete'" [adf-nodes]="selection">
+        </div>`
 })
-class TestComponent implements NodePermissionSubject {
-    disabled: boolean = false;
+class TestComponent {
+    selection = [];
+    disabled = false;
+    done = jasmine.createSpy('done');
 }
 
 describe('NodePermissionDirective', () => {
+    let fixture: ComponentFixture<TestComponent>;
+    let element: DebugElement;
+    let component: TestComponent;
+    let alfrescoContentService: AlfrescoContentService;
 
-    let changeDetectorMock: ChangeDetectorRef;
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            imports: [
+                CoreModule
+            ],
+            declarations: [
+                TestComponent
+            ]
+        })
+            .compileComponents()
+            .then(() => {
+                fixture = TestBed.createComponent(TestComponent);
+                alfrescoContentService = TestBed.get(AlfrescoContentService);
+                component = fixture.componentInstance;
+                element = fixture.debugElement.query(By.directive(NodePermissionDirective));
+            });
+    }));
 
-    beforeEach(() => {
-        changeDetectorMock = <ChangeDetectorRef> { detectChanges: () => {} };
+    it('Should be disabled if no nodes are passed', () => {
+        component.selection = undefined;
+
+        fixture.detectChanges();
+
+        component.selection = null;
+
+        fixture.detectChanges();
+
+        expect(element.nativeElement.disabled).toEqual(true);
     });
 
-    describe('HTML nativeElement as subject', () => {
+    it('Should be disabled if nodes is an empty array', () => {
+        component.selection = null;
 
-        it('updates element once it is loaded', () => {
-            const directive = new NodePermissionDirective(null, null, null, changeDetectorMock);
-            spyOn(directive, 'updateElement').and.stub();
+        fixture.detectChanges();
 
-            const nodes = [{}, {}];
-            const change = new SimpleChange([], nodes, false);
-            directive.ngOnChanges({ nodes: change });
+        component.selection = [];
 
-            expect(directive.updateElement).toHaveBeenCalled();
-        });
+        fixture.detectChanges();
 
-        it('updates element on nodes change', () => {
-            const directive = new NodePermissionDirective(null, null, null, changeDetectorMock);
-            spyOn(directive, 'updateElement').and.stub();
-
-            const nodes = [{}, {}];
-            const change = new SimpleChange([], nodes, false);
-            directive.ngOnChanges({ nodes: change });
-
-            expect(directive.updateElement).toHaveBeenCalled();
-        });
-
-        it('updates element only on subsequent change', () => {
-            const directive = new NodePermissionDirective(null, null, null, changeDetectorMock);
-            spyOn(directive, 'updateElement').and.stub();
-
-            const nodes = [{}, {}];
-            const change = new SimpleChange([], nodes, true);
-            directive.ngOnChanges({ nodes: change });
-
-            expect(directive.updateElement).not.toHaveBeenCalled();
-        });
-
-        it('enables decorated element', () => {
-            const renderer = jasmine.createSpyObj('renderer', ['removeAttribute']);
-            const elementRef = new ElementRef({});
-            const directive = new NodePermissionDirective(elementRef, renderer, null, changeDetectorMock);
-
-            directive.enableElement();
-
-            expect(renderer.removeAttribute).toHaveBeenCalledWith(elementRef.nativeElement, 'disabled');
-        });
-
-        it('disables decorated element', () => {
-            const renderer = jasmine.createSpyObj('renderer', ['setAttribute']);
-            const elementRef = new ElementRef({});
-            const directive = new NodePermissionDirective(elementRef, renderer, null, changeDetectorMock);
-
-            directive.disableElement();
-
-            expect(renderer.setAttribute).toHaveBeenCalledWith(elementRef.nativeElement, 'disabled', 'true');
-        });
-
-        it('disables element when nodes not available', () => {
-            const directive = new NodePermissionDirective(null, null, null, changeDetectorMock);
-            spyOn(directive, 'disableElement').and.stub();
-
-            directive.nodes = null;
-            expect(directive.updateElement()).toBeFalsy();
-
-            directive.nodes = [];
-            expect(directive.updateElement()).toBeFalsy();
-        });
-
-        it('enables element when all nodes have expected permission', () => {
-            const contentService = new AlfrescoContentService(null, null, null);
-            spyOn(contentService, 'hasPermission').and.returnValue(true);
-
-            const directive = new NodePermissionDirective(null, null, contentService, changeDetectorMock);
-            spyOn(directive, 'enableElement').and.stub();
-
-            directive.nodes = <any> [{}, {}];
-
-            expect(directive.updateElement()).toBeTruthy();
-            expect(directive.enableElement).toHaveBeenCalled();
-        });
-
-        it('disables element when one of the nodes have no permission', () => {
-            const contentService = new AlfrescoContentService(null, null, null);
-            spyOn(contentService, 'hasPermission').and.returnValue(false);
-
-            const directive = new NodePermissionDirective(null, null, contentService, changeDetectorMock);
-            spyOn(directive, 'disableElement').and.stub();
-
-            directive.nodes = <any> [{}, {}];
-
-            expect(directive.updateElement()).toBeFalsy();
-            expect(directive.disableElement).toHaveBeenCalled();
-        });
+        expect(element.nativeElement.disabled).toEqual(true);
     });
 
-    describe('Angular component as subject', () => {
+    it('enables element when all nodes have expected permission', () => {
+        spyOn(alfrescoContentService, 'hasPermission').and.returnValue(true);
 
-        it('disables decorated component', () => {
-            const contentService = new AlfrescoContentService(null, null, null);
-            spyOn(contentService, 'hasPermission').and.returnValue(false);
-            spyOn(changeDetectorMock, 'detectChanges');
+        component.selection = null;
 
-            let testComponent = new TestComponent();
-            testComponent.disabled = false;
-            const directive = new NodePermissionDirective(null, null, contentService, changeDetectorMock, testComponent);
-            directive.nodes = <any> [{}, {}];
+        fixture.detectChanges();
 
-            directive.updateElement();
+        component.selection = <any> [{entry: {id: '1', name: 'name1'}}];
 
-            expect(testComponent.disabled).toBeTruthy();
-            expect(changeDetectorMock.detectChanges).toHaveBeenCalledTimes(1);
-        });
+        fixture.detectChanges();
 
-        it('enables decorated component', () => {
-            const contentService = new AlfrescoContentService(null, null, null);
-            spyOn(contentService, 'hasPermission').and.returnValue(true);
-            spyOn(changeDetectorMock, 'detectChanges');
+        expect(element.nativeElement.disabled).toEqual(false);
+    });
 
-            let testComponent = new TestComponent();
-            testComponent.disabled = true;
-            const directive = new NodePermissionDirective(null, null, contentService, changeDetectorMock, testComponent);
-            directive.nodes = <any> [{}, {}];
+    it('disables element when one of the nodes have no permission', () => {
+        spyOn(alfrescoContentService, 'hasPermission').and.returnValue(false);
 
-            directive.updateElement();
+        component.selection = null;
 
-            expect(testComponent.disabled).toBeFalsy();
-            expect(changeDetectorMock.detectChanges).toHaveBeenCalledTimes(1);
-        });
+        fixture.detectChanges();
+
+        component.selection = <any> [{entry: {id: '1', name: 'name1'}}];
+
+        fixture.detectChanges();
+
+        expect(element.nativeElement.disabled).toEqual(true);
     });
 });
+
+})

--- a/ng2-components/ng2-alfresco-core/src/directives/node-permission.directive.ts
+++ b/ng2-components/ng2-alfresco-core/src/directives/node-permission.directive.ts
@@ -15,9 +15,8 @@
  * limitations under the License.
  */
 
-import { ChangeDetectorRef, Directive, ElementRef, Host, Inject, Input, OnChanges, Optional, Renderer2, SimpleChanges } from '@angular/core';
+import { Directive, ElementRef, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { MinimalNodeEntity } from 'alfresco-js-api';
-import { EXTENDIBLE_COMPONENT } from './../interface/injection.tokens';
 import { AlfrescoContentService } from './../services/alfresco-content.service';
 
 export interface NodePermissionSubject {
@@ -30,19 +29,13 @@ export interface NodePermissionSubject {
 export class NodePermissionDirective implements OnChanges {
 
     @Input('adf-node-permission')
-    permission: string  = null;
+    permission: string = null;
 
     @Input('adf-nodes')
     nodes: MinimalNodeEntity[] = [];
 
     constructor(private elementRef: ElementRef,
-                private renderer: Renderer2,
-                private contentService: AlfrescoContentService,
-                private changeDetector: ChangeDetectorRef,
-
-                @Host()
-                @Optional()
-                @Inject(EXTENDIBLE_COMPONENT) private parentComponent?: NodePermissionSubject) {
+                private contentService: AlfrescoContentService) {
     }
 
     ngOnChanges(changes: SimpleChanges) {
@@ -52,57 +45,17 @@ export class NodePermissionDirective implements OnChanges {
     }
 
     /**
-     * Updates disabled state for the decorated elememtn
-     *
-     * @returns {boolean} True if decorated element got disabled, otherwise False
-     * @memberof NodePermissionDirective
-     */
-    updateElement(): boolean {
-        let enable = this.hasPermission(this.nodes, this.permission);
-
-        if (enable) {
-            this.enable();
-        } else {
-            this.disable();
-        }
-
-        return enable;
-    }
-
-    private enable(): void {
-        if (this.parentComponent) {
-            this.parentComponent.disabled = false;
-            this.changeDetector.detectChanges();
-        } else {
-            this.enableElement();
-        }
-    }
-
-    private disable(): void {
-        if (this.parentComponent) {
-            this.parentComponent.disabled = true;
-            this.changeDetector.detectChanges();
-        } else {
-            this.disableElement();
-        }
-    }
-
-    /**
-     * Enables decorated element
+     * Updates disabled state for the decorated element
      *
      * @memberof NodePermissionDirective
      */
-    enableElement(): void {
-        this.renderer.removeAttribute(this.elementRef.nativeElement, 'disabled');
+    updateElement(): void {
+        let hasPermission = this.hasPermission(this.nodes, this.permission);
+        this.setDisableAttribute(!hasPermission);
     }
 
-    /**
-     * Disables decorated element
-     *
-     * @memberof NodePermissionDirective
-     */
-    disableElement(): void {
-        this.renderer.setAttribute(this.elementRef.nativeElement, 'disabled', 'true');
+    private setDisableAttribute(disable: boolean) {
+        this.elementRef.nativeElement.disabled = disable;
     }
 
     /**

--- a/ng2-components/ng2-alfresco-core/src/directives/node-restore.directive.ts
+++ b/ng2-components/ng2-alfresco-core/src/directives/node-restore.directive.ts
@@ -32,9 +32,11 @@ export class NodeRestoreDirective {
     @Input('adf-restore')
     selection: DeletedNodeEntry[];
 
-    @Input() location: string = '';
+    @Input()
+    location: string = '';
 
-    @Output() restore: EventEmitter<any> = new EventEmitter();
+    @Output()
+    restore: EventEmitter<any> = new EventEmitter();
 
     @HostListener('click')
     onClick() {

--- a/ng2-components/ng2-alfresco-documentlist/index.ts
+++ b/ng2-components/ng2-alfresco-documentlist/index.ts
@@ -16,10 +16,10 @@
  */
 
 import { NgModule } from '@angular/core';
+import { FlexLayoutModule } from '@angular/flex-layout';
 import { CoreModule, TRANSLATION_PROVIDER } from 'ng2-alfresco-core';
 import { DataTableModule } from 'ng2-alfresco-datatable';
 import { UploadModule } from 'ng2-alfresco-upload';
-import { FlexLayoutModule } from '@angular/flex-layout';
 
 import { BreadcrumbComponent } from './src/components/breadcrumb/breadcrumb.component';
 import { DropdownBreadcrumbComponent } from './src/components/breadcrumb/dropdown-breadcrumb.component';

--- a/ng2-components/ng2-alfresco-tag/src/components/tag-node-list.component.scss
+++ b/ng2-components/ng2-alfresco-tag/src/components/tag-node-list.component.scss
@@ -1,4 +1,5 @@
 .adf-tag-chips-delete {
+    overflow: visible;
     cursor: pointer;
     height: 17px;
     width: 20px;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

1. Click on an empty folder:
Expected result: The delete icon button is disabled.
Actual result: The delete icon button is enabled.
2. Click on a folder on which the user has no delete permissions:
Expected result: The delete icon button is disabled.
Actual result: The delete icon button is enabled


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
