### PR TITLE
[ADF-1854] Use https to get specific alfresco-js-api branch

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -75,7 +75,7 @@ enable_test() {
 }
 
 enable_js_api_git_link() {
-    GIT_ISH='git://github.com/Alfresco/alfresco-js-api.git#'$1
+    GIT_ISH='git+https://github.com/Alfresco/alfresco-js-api.git#'$1
     EXEC_GIT_NPM_INSTALL_JSAPI=true
 }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
git:// seems to require port 9418 which isn’t a standard port that corporate firewalls always allow.