### PR TITLE
[ADF-1772] fix for application name title translation

### DIFF
--- a/ng2-components/ng2-activiti-tasklist/src/components/apps-list.component.spec.ts
+++ b/ng2-components/ng2-activiti-tasklist/src/components/apps-list.component.spec.ts
@@ -129,9 +129,9 @@ describe('AppsListComponent', () => {
         expect(emitSpy).toHaveBeenCalled();
     });
 
-    describe('intenationalization', () => {
+    describe('internationalization', () => {
 
-        fit('should provide a translation for the default application name, when app name is not provided', () => {
+        it('should provide a translation for the default application name, when app name is not provided', () => {
             const appDataMock = {
                 defaultAppId: 'tasks',
                 name: null
@@ -141,7 +141,7 @@ describe('AppsListComponent', () => {
             });
         });
 
-        fit('should provide the application name, when it exists', () => {
+        it('should provide the application name, when it exists', () => {
             const appDataMock = {
                 defaultAppId: 'uiu',
                 name: 'the-name'


### PR DESCRIPTION
Fix spec declaration typo
fix it() declarations (used fit() instead of it())

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
test suite declaration has typo
the test execution will run only the new tests because the test uses fit instead of it


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
