### PR TITLE
[ADF-1866] Accordion menu - Doesn't collapse

### DIFF
--- a/ng2-components/ng2-alfresco-core/src/components/collapsable/accordion-group.component.scss
+++ b/ng2-components/ng2-alfresco-core/src/components/collapsable/accordion-group.component.scss
@@ -22,7 +22,7 @@
         float: left;
     }
 
-    .adf-panel-collapse {
+    .adf-panel-body {
         display: inline-block;
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Try to click on the icon to close the menu, nothing happens 


**What is the new behaviour?**
Try to click on the icon to close the menu, the menu collapse



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
