### PR TITLE
[ADF-1861] - Line breaks not displayed in "Display Text" widget in forms

### DIFF
--- a/ng2-components/ng2-activiti-form/src/components/widgets/display-text/display-text.widget.html
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/display-text/display-text.widget.html
@@ -1,3 +1,1 @@
-<div class="adf-display-text-widget {{field.className}}">
-    <span>{{field.value}}</span>
-</div>
+<div class="adf-display-text-widget {{field.className}}">{{field.value}}</div>

--- a/ng2-components/ng2-activiti-form/src/components/widgets/display-text/display-text.widget.scss
+++ b/ng2-components/ng2-activiti-form/src/components/widgets/display-text/display-text.widget.scss
@@ -1,1 +1,3 @@
-.adf-display-text-widget {}
+.adf-display-text-widget {
+    white-space: pre-wrap;
+}


### PR DESCRIPTION
Fixed

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
The text with line brakes is not wrapped correctly



**What is the new behaviour?**
Multiline text is displayed as it should (on multiline)
User defined whitespaces are not collapsed (wrapped)


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
