### PR TITLE
[ADF-1784] - [Mobile] - Empty folder image should not display drag an…

### DIFF
--- a/ng2-components/ng2-activiti-processlist/index.ts
+++ b/ng2-components/ng2-activiti-processlist/index.ts
@@ -16,6 +16,7 @@
  */
 
 import { NgModule } from '@angular/core';
+import { FlexLayoutModule } from '@angular/flex-layout';
 import {
     MatButtonModule,
     MatCardModule,
@@ -127,7 +128,8 @@ export const ACTIVITI_PROCESSLIST_PROVIDERS: [any] = [
         MatCardModule,
         MatInputModule,
         MatChipsModule,
-        MatSelectModule
+        MatSelectModule,
+        FlexLayoutModule
     ],
     declarations: [
         ...ACTIVITI_PROCESSLIST_DIRECTIVES

--- a/ng2-components/ng2-activiti-processlist/src/components/process-attachment-list.component.html
+++ b/ng2-components/ng2-activiti-processlist/src/components/process-attachment-list.component.html
@@ -4,8 +4,8 @@
     <adf-empty-list *ngIf="isEmpty()">
         <div adf-empty-list-header class="adf-empty-list-header"> {{'ADF_PROCESS_LIST.PROCESS-ATTACHMENT.EMPTY.HEADER' | translate}} </div>
         <div adf-empty-list-body *ngIf="!isDisabled()">
-            <div class="adf-empty-list-drag_drop">{{'ADF_PROCESS_LIST.PROCESS-ATTACHMENT.EMPTY.DRAG-AND-DROP.TITLE' | translate}}</div>
-            <div class="adf-empty-list__any-files-here-to-add"> {{'ADF_PROCESS_LIST.PROCESS-ATTACHMENT.EMPTY.DRAG-AND-DROP.SUBTITLE' | translate}} </div>
+            <div fxHide.lt-md="true" class="adf-empty-list-drag_drop">{{'ADF_PROCESS_LIST.PROCESS-ATTACHMENT.EMPTY.DRAG-AND-DROP.TITLE' | translate}}</div>
+            <div fxHide.lt-md="true" class="adf-empty-list__any-files-here-to-add"> {{'ADF_PROCESS_LIST.PROCESS-ATTACHMENT.EMPTY.DRAG-AND-DROP.SUBTITLE' | translate}} </div>
         </div>
         <div adf-empty-list-footer *ngIf="!isDisabled()">
             <img class="adf-empty-list__empty_doc_lib" [src]="emptyListImageUrl">

--- a/ng2-components/ng2-activiti-processlist/src/components/process-attachment-list.component.scss
+++ b/ng2-components/ng2-activiti-processlist/src/components/process-attachment-list.component.scss
@@ -1,3 +1,5 @@
+@import '~@angular/material/theming';
+
 adf-datatable ::ng-deep th span {
     color: #232323;
 }
@@ -45,4 +47,8 @@ adf-datatable ::ng-deep .data-cell {
     height: 161px;
     object-fit: contain;
     margin-top: 17px;
+
+    @media screen and ($mat-xsmall) {
+        width: 250px;
+    }
 }

--- a/ng2-components/ng2-activiti-tasklist/src/components/task-attachment-list.component.html
+++ b/ng2-components/ng2-activiti-tasklist/src/components/task-attachment-list.component.html
@@ -3,8 +3,8 @@
     <adf-empty-list *ngIf="isEmpty()">
         <div adf-empty-list-header class="adf-empty-list-header"> {{'ADF_TASK_LIST.ATTACHMENT.EMPTY.HEADER' | translate}} </div>
         <div adf-empty-list-body *ngIf="!isDisabled()">
-            <div class="adf-empty-list-drag_drop">{{'ADF_TASK_LIST.ATTACHMENT.EMPTY.DRAG-AND-DROP.TITLE' | translate}}</div>
-            <div class="adf-empty-list__any-files-here-to-add"> {{'ADF_TASK_LIST.ATTACHMENT.EMPTY.DRAG-AND-DROP.SUBTITLE' | translate}} </div>
+            <div fxHide.lt-md="true" class="adf-empty-list-drag_drop">{{'ADF_TASK_LIST.ATTACHMENT.EMPTY.DRAG-AND-DROP.TITLE' | translate}}</div>
+            <div fxHide.lt-md="true" class="adf-empty-list__any-files-here-to-add"> {{'ADF_TASK_LIST.ATTACHMENT.EMPTY.DRAG-AND-DROP.SUBTITLE' | translate}} </div>
         </div>
         <div adf-empty-list-footer *ngIf="!isDisabled()">
             <img class="adf-empty-list__empty_doc_lib" [src]="emptyListImageUrl">


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
"Drag and drop  to upload" message is displayed on mobile devices


**What is the new behaviour?**
The message is no longer displayed



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
