### PR TITLE
[ADF-1586] Added boilerplate files to doc folder

### DIFF
--- a/docs/boilerplate.component.md
+++ b/docs/boilerplate.component.md
@@ -1,0 +1,63 @@
+# Boilerplate component
+
+Shows how to write a Markdown file for a component.
+
+![Screenshot goes here if necessary](docassets/images/adf-toolbar-01.png)
+
+<!-- Most doc files don't need a table of contents. Delete this part unless
+you have added about five subsections in the Details part.
+-->
+<!-- markdown-toc start - Don't edit this section.  npm run toc to generate it-->
+
+<!-- toc -->
+
+<!-- tocstop -->
+
+<!-- markdown-toc end -->
+
+## Basic Usage
+<!-- Delete any Basic Usage parts that you don't need (eg, some components don't
+have any properties). -->
+
+```html
+<adf-document-list
+    #documentList
+    [currentFolderId]="'-my-'"
+    [contextMenuActions]="true"
+    [contentActions]="true">
+</adf-document-list>
+```
+
+### Properties
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| prop1 | string | 'hello' | The property description in the table should be no more than a few sentences. Add extra description in the Details section if you need to. |
+| prop2 | boolean | true | Prop tables should have name, type, default and description, in that order. Leave default value blank if appropriate. |
+
+### Events
+
+| Name | Description |
+| --- | --- |
+| someEvent | Keep description short for the table. Usually starts with "Emitted when..." |
+| anotherEvent | Emitted when the user double-clicks a list node |
+
+## Details
+
+**Note: This is not a real component!**
+
+Copy the contents of this file when you create a new component doc and edit or remove bits of it
+as necessary. Usually, the title should be derived from the Angular name with the kebab-case expanded
+(so "task-details.component" becomes "Task Details component") but there is no need to stick to this
+if it looks wrong to you.
+
+### Subsection
+
+You don't need to make subsections in the Details part but add them if they help with the
+explanation. Add them as level 3 headings in the Details part only - to keep the consistency
+of the docs, you shouldn't normally add any new level 1 or 2 sections to the Markdown.
+
+<!-- Don't edit the See also section. Edit seeAlsoGraph.json and run config/generateSeeAlso.js -->
+<!-- seealso start -->
+
+<!-- seealso end -->

--- a/docs/boilerplate.service.md
+++ b/docs/boilerplate.service.md
@@ -1,0 +1,42 @@
+# Boilerplate service
+
+Shows how to write a Markdown file for a service.
+
+## Methods
+
+`someMethod(value: string = '')`<br/>
+Shows how to document a method.
+
+`anotherMethod(value: string = '')`<br/>
+Shows how to document a method.
+
+## Properties
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| prop1 | string | 'hello' | Many services don't need a properties table. Delete this section if you don't need it. |
+| prop2 | boolean | true | Prop tables should have name, type, default and description, in that order. Leave default blank if appropriate. |
+
+## Details
+
+**Note: This is not a real component!**
+
+Copy the contents of this file when you create a new service doc and edit or remove bits of it
+as necessary. Usually, the title should be derived from the Angular name with the kebab-case expanded
+(so "page-title.service" becomes "Page Title service") but there is no need to stick to this
+if it looks wrong to you.
+
+The main difference between service and component docs is that services usually have methods. Replace
+the method signature and description with your own text but keep the &lt;br&gt; at the end of the
+signature line.
+
+### Subsection
+
+You don't need to make subsections in the Details part but add them if they help with the
+explanation. Add them as level 3 headings in the Details part only - to keep the consistency
+of the docs, you shouldn't normally add any new level 1 or 2 sections to the Markdown.
+
+<!-- Don't edit the See also section. Edit seeAlsoGraph.json and run config/generateSeeAlso.js -->
+<!-- seealso start -->
+
+<!-- seealso end -->


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [x] Documentation
> - [ ] Other... Please describe:

**What is the new behaviour?**
Added "boilerplate" files that can be used as templates for starting new component and service docs. The indexing script doesn't list them and Compodoc will ignore them, so it seems like a good idea to put them in the docs folder with the other files. I'll add some separate instructions for writing docs in a wiki page and then link to that from the boilerplate page.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
