### PR TITLE
[ADF-1765] - info drawer

### DIFF
--- a/ng2-components/ng2-alfresco-core/src/components/info-drawer/info-drawer-layout.component.scss
+++ b/ng2-components/ng2-alfresco-core/src/components/info-drawer/info-drawer-layout.component.scss
@@ -17,6 +17,7 @@
                 font-weight: bold;
                 text-align: left;
                 color: mat-color($primary);
+                text-transform: uppercase;
             }
 
             &-header {
@@ -26,6 +27,7 @@
                 margin-bottom: 40px;
 
                 &-buttons {
+                    padding-right:18px; 
                     mat-icon {
                         cursor: pointer;
                     }

--- a/ng2-components/ng2-alfresco-core/src/components/view/card-view-dateitem.component.scss
+++ b/ng2-components/ng2-alfresco-core/src/components/view/card-view-dateitem.component.scss
@@ -9,10 +9,17 @@
             border: none;
             margin: 0;
             padding: 0;
+            display: none;
         }
 
         &-dateitem-editable {
             cursor: pointer;
+
+            button.mat-icon-button {
+                line-height: 20px;
+                height: 20px;
+                width: 20px;
+            }
 
             mat-icon {
                 width: 16px;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-1765
-  info drawer close button is too close to the right margin
-  tab labels are sentence cased
-  editable date time field is not positioned correctly

**What is the new behaviour?**
 - info drawer close button position to the right margin is 18px
 - tab labels are uppercased
 - editable date time field is now inline with all the infodrawer elements

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
