### PR TITLE
ADF Toolbar - Rollback background color.

### DIFF
--- a/ng2-components/ng2-alfresco-core/src/components/toolbar/toolbar.component.scss
+++ b/ng2-components/ng2-alfresco-core/src/components/toolbar/toolbar.component.scss
@@ -1,8 +1,6 @@
 
 @mixin adf-toolbar-theme($theme) {
     $foreground: map-get($theme, foreground);
-    $background: map-get($theme, background);
-    $adf-toolbar-background-color: mat-color($background, background) !default;
     $adf-toolbar-height: 48px;
     $adf-toolbar-font-size: 14px;
 
@@ -15,7 +13,6 @@
         .mat-toolbar {
             min-height: $adf-toolbar-height;
             border: 1px solid mat-color($foreground, text, .07);
-            background-color: $adf-toolbar-background-color;
         }
 
         .mat-toolbar-row {


### PR DESCRIPTION
By default, toolbars use a neutral background color based on the current theme (light or dark). This can be changed to 'primary', 'accent', or 'warn'.

**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
By default, toolbars use a neutral background color based on the current theme (light or dark). This can be changed to 'primary', 'accent', or 'warn'.


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
