### PR TITLE
[ADF-1865] [Document List] "Empty View" does not wrap long text

### DIFF
--- a/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.scss
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.scss
@@ -92,13 +92,14 @@
         }
 
         &-drag-drop {
-            height: 56px;
+            min-height: 56px;
             opacity: 0.54;
             font-size: 53px;
             line-height: 1;
             letter-spacing: -2px;
             color: mat-color($foreground, text);
             margin-top: 40px;
+            word-break: break-all;
 
             @media screen and ($mat-xsmall) {
                 font-size: 48px;
@@ -106,13 +107,14 @@
         }
 
         &-any-files-here-to-add {
-            height: 24px;
+            min-height: 24px;
             opacity: 0.54;
             font-size: 16px;
             line-height: 1.5;
             letter-spacing: -0.4px;
             color: mat-color($foreground, text);
             margin-top: 17px;
+            word-break: break-all;
         }
 
         &-image {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
the whole layout becomes broken if the "drag and drop" translated text is too long (ex: japanese translation is breaking the layout)


**What is the new behaviour?**
the text is wrapping ok on multiple lines if is longer than the width of the container


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
