### PR TITLE
[ADF-1949] Allow customization of the dropdown menu on document picker

### DIFF
--- a/ng2-components/ng2-alfresco-documentlist/src/components/content-node-selector/content-node-selector.component.html
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/content-node-selector/content-node-selector.component.html
@@ -28,6 +28,8 @@
 
     <adf-sites-dropdown
         (change)="siteChanged($event)"
+        [hideMyFiles]="dropdownHideMyFiles"
+        [siteList]="dropdownSiteList"
         data-automation-id="content-node-selector-sites-combo"></adf-sites-dropdown>
 
     <adf-toolbar>

--- a/ng2-components/ng2-alfresco-documentlist/src/components/content-node-selector/content-node-selector.component.ts
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/content-node-selector/content-node-selector.component.ts
@@ -27,6 +27,8 @@ import { ContentNodeSelectorService } from './content-node-selector.service';
 export interface ContentNodeSelectorComponentData {
     title: string;
     currentFolderId?: string;
+    dropdownHideMyFiles?: boolean;
+    dropdownSiteList?: any[];
     rowFilter?: RowFilter;
     imageResolver?: ImageResolver;
     select: EventEmitter<MinimalNodeEntryEntity[]>;
@@ -59,6 +61,12 @@ export class ContentNodeSelectorComponent implements OnInit {
     currentFolderId: string | null = null;
 
     @Input()
+    dropdownHideMyFiles: boolean = false;
+
+    @Input()
+    dropdownSiteList: any[] = null;
+
+    @Input()
     rowFilter: RowFilter = null;
 
     @Input()
@@ -84,6 +92,8 @@ export class ContentNodeSelectorComponent implements OnInit {
             this.title = data.title;
             this.select = data.select;
             this.currentFolderId = data.currentFolderId;
+            this.dropdownHideMyFiles = data.dropdownHideMyFiles;
+            this.dropdownSiteList = data.dropdownSiteList;
             this.rowFilter = data.rowFilter;
             this.imageResolver = data.imageResolver;
         }

--- a/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.ts
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.ts
@@ -427,6 +427,10 @@ export class DocumentListComponent implements OnInit, OnChanges, AfterContentIni
         }
 
         let nodeId = this.folderNode ? this.folderNode.id : this.currentFolderId;
+
+        if (!this.hasCustomLayout) {
+            this.setupDefaultColumns(nodeId);
+        }
         if (nodeId) {
             this.loadFolderNodesByFolderNodeId(nodeId, this.pageSize, this.skipCount, merge).catch(err => this.error.emit(err));
         }
@@ -557,9 +561,12 @@ export class DocumentListComponent implements OnInit, OnChanges, AfterContentIni
                 let page: NodePaging = {
                     list: {
                         entries: result.list.entries
-                            .map(({ entry: { site }}: any) => ({
+                            .map(({ entry: { site }}: any) => {
+                            site.allowableOperations = site.allowableOperations ? site.allowableOperations : [ this.CREATE_PERMISSION ];
+                            return {
                                 entry: site
-                            })),
+                            };
+                        }),
                         pagination: result.list.pagination
                     }
                 };
@@ -697,7 +704,7 @@ export class DocumentListComponent implements OnInit, OnChanges, AfterContentIni
         }
     }
 
-    onNodeDblClick(node: MinimalNodeEntity) {
+    onNodeDblClick(node: any) {
         const domEvent = new CustomEvent('node-dblclick', {
             detail: {
                 sender: this,
@@ -719,6 +726,17 @@ export class DocumentListComponent implements OnInit, OnChanges, AfterContentIni
 
                     if (node.entry.isFolder) {
                         this.performNavigation(node);
+                    }
+
+                    if (node.entry.guid) {
+                        const options = {
+                            include: ['path', 'properties', 'allowableOperations']
+                        };
+
+                        this.apiService.nodesApi.getNode(node.entry.guid, options)
+                            .then(documentLibrary => {
+                                this.performNavigation(documentLibrary);
+                            });
                     }
                 }
             }
@@ -822,6 +840,10 @@ export class DocumentListComponent implements OnInit, OnChanges, AfterContentIni
     }
 
     canNavigateFolder(node: MinimalNodeEntity): boolean {
+        if (this.currentFolderId === '-mysites-') {
+            return true;
+        }
+
         if (this.isCustomSource(this.currentFolderId)) {
             return false;
         }

--- a/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.ts
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/document-list.component.ts
@@ -704,7 +704,7 @@ export class DocumentListComponent implements OnInit, OnChanges, AfterContentIni
         }
     }
 
-    onNodeDblClick(node: any) {
+    onNodeDblClick(node: MinimalNodeEntity) {
         const domEvent = new CustomEvent('node-dblclick', {
             detail: {
                 sender: this,

--- a/ng2-components/ng2-alfresco-documentlist/src/components/site-dropdown/sites-dropdown.component.html
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/site-dropdown/sites-dropdown.component.html
@@ -10,7 +10,7 @@
             (ngModelChange)="selectedSite()">
             <mat-option *ngIf="!hideMyFiles" data-automation-id="site-my-files-option" id="default_site_option" [value]="MY_FILES_VALUE">{{'DROPDOWN.MY_FILES_OPTION' | translate}}</mat-option>
             <mat-option *ngFor="let site of siteList" [value]="site.guid">
-                {{ site.title }}
+                {{ site.title | translate }}
             </mat-option>
         </mat-select>
     </mat-form-field>

--- a/ng2-components/ng2-alfresco-documentlist/src/components/site-dropdown/sites-dropdown.component.ts
+++ b/ng2-components/ng2-alfresco-documentlist/src/components/site-dropdown/sites-dropdown.component.ts
@@ -28,22 +28,28 @@ export class DropdownSitesComponent implements OnInit {
     @Input()
     hideMyFiles: boolean = false;
 
+    @Input()
+    siteList: any[] = null;
+
     @Output()
     change: EventEmitter<SiteModel> = new EventEmitter();
 
     public MY_FILES_VALUE = 'default';
-
-    siteList = [];
 
     public siteSelected: string;
 
     constructor(private sitesService: SitesApiService) {}
 
     ngOnInit() {
-        this.sitesService.getSites().subscribe((result) => {
-            this.siteList = result;
-        },
-        (error) => {});
+        // fetch sites data only if siteList input has not been given a value
+        if (!this.siteList) {
+
+            this.siteList = [];
+            this.sitesService.getSites().subscribe((result) => {
+                    this.siteList = result;
+                },
+                (error) => {});
+        }
     }
 
     selectedSite() {

--- a/ng2-components/ng2-alfresco-documentlist/src/i18n/en.json
+++ b/ng2-components/ng2-alfresco-documentlist/src/i18n/en.json
@@ -1,4 +1,6 @@
 {
+    "PERSONAL_FILES": "Personal Files",
+    "FILE_LIBRARIES": "File Libraries",
     "ADF-DOCUMENT-LIST": {
         "EMPTY": {
             "HEADER": "This folder is empty"

--- a/ng2-components/ng2-alfresco-documentlist/src/services/node-actions.service.ts
+++ b/ng2-components/ng2-alfresco-documentlist/src/services/node-actions.service.ts
@@ -87,8 +87,6 @@ export class NodeActionsService {
             const data: ContentNodeSelectorComponentData = {
                 title: `${action} ${contentEntry.name} to ...`,
                 currentFolderId: contentEntry.parentId,
-                dropdownHideMyFiles: true,
-                dropdownSiteList: [{title:'PERSONAL_FILES', guid: '-my-'}, {title:'FILE_LIBRARIES', guid: '-mysites-'}],
                 rowFilter: this.rowFilter.bind(this, contentEntry.id),
                 imageResolver: this.imageResolver.bind(this),
                 select: new EventEmitter<MinimalNodeEntryEntity[]>()

--- a/ng2-components/ng2-alfresco-documentlist/src/services/node-actions.service.ts
+++ b/ng2-components/ng2-alfresco-documentlist/src/services/node-actions.service.ts
@@ -87,6 +87,8 @@ export class NodeActionsService {
             const data: ContentNodeSelectorComponentData = {
                 title: `${action} ${contentEntry.name} to ...`,
                 currentFolderId: contentEntry.parentId,
+                dropdownHideMyFiles: true,
+                dropdownSiteList: [{title:'PERSONAL_FILES', guid: '-my-'}, {title:'FILE_LIBRARIES', guid: '-mysites-'}],
                 rowFilter: this.rowFilter.bind(this, contentEntry.id),
                 imageResolver: this.imageResolver.bind(this),
                 select: new EventEmitter<MinimalNodeEntryEntity[]>()


### PR DESCRIPTION
- add as input properties the 'dropdownHideMyFiles' and the 'dropdownSiteList' to the destination picker, so the list of sites from the dropdown can be customized, if wanted
- add navigation on '-mysites-' entries on document-list
- use custom dropdown on the copy/move document picker

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Please see Jira task https://issues.alfresco.com/jira/browse/ADF-1949


**What is the new behaviour?**
The dropdown from the document picker can display what list of sites the developer wants, as long as it is the right format.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
