### PR TITLE
[ADF-1951] fixed parsing date value when on readonly mode

### DIFF
--- a/lib/core/form/components/widgets/core/form-field.model.spec.ts
+++ b/lib/core/form/components/widgets/core/form-field.model.spec.ts
@@ -224,6 +224,31 @@ describe('FormFieldModel', () => {
         expect(form.values['ddmmyyy']).toEqual('2017-04-28T00:00:00.000Z');
     });
 
+    it('should parse the date with the format DD-MM-YYYY when it is readonly', () => {
+        let form = new FormModel();
+        let field = new FormFieldModel(form, {
+            fieldType: 'FormFieldRepresentation',
+            id: 'ddmmyyy',
+            name: 'DD-MM-YYYY',
+            type: 'readonly',
+            value: '2017-04-28T00:00:00.000+0000',
+            required: false,
+            readOnly: true,
+            params: {
+                field: {
+                    id: 'ddmmyyy',
+                    name: 'DD-MM-YYYY',
+                    type: 'date',
+                    value: null,
+                    required: false,
+                    readOnly: false
+                }
+            },
+            dateDisplayFormat: 'DD-MM-YYYY'
+        });
+        expect(field.value).toBe('28-04-2017');
+    });
+
     it('should return the label of selected dropdown value ', () => {
         let field = new FormFieldModel(new FormModel(), {
             type: FormFieldTypes.DROPDOWN,

--- a/lib/core/form/components/widgets/core/form-field.model.ts
+++ b/lib/core/form/components/widgets/core/form-field.model.ts
@@ -311,7 +311,7 @@ export class FormFieldModel extends FormWidgetModel {
          This is needed due to Activiti displaying/editing dates in d-M-YYYY format
          but storing on server in ISO8601 format (i.e. 2013-02-04T22:44:30.652Z)
          */
-        if (json.type === FormFieldTypes.DATE) {
+        if (this.isDateField(json)) {
             if (value) {
                 let dateValue;
                 if (NumberFieldValidator.isNumber(value)) {
@@ -416,5 +416,12 @@ export class FormFieldModel extends FormWidgetModel {
 
     hasOptions() {
         return this.options && this.options.length > 0;
+    }
+
+    private isDateField(json: any) {
+        return (json.params &&
+                json.params.field &&
+                json.params.field.type === FormFieldTypes.DATE ) ||
+                json.type === FormFieldTypes.DATE;
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
We are not correctly formatting data value when we retrieve it from APS


**What is the new behaviour?**
We are now formatting the data retrieved from APS


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
