### PR TITLE
[ADF-1712] The <adf-task-header component displays a Requeue button for none pooled tasks

### DIFF
--- a/lib/process-services/mock/task/task-details.mock.ts
+++ b/lib/process-services/mock/task/task-details.mock.ts
@@ -52,7 +52,82 @@ export let taskDetailsMock = new TaskDetailsModel({
     'memberOfCandidateGroup': false
 });
 
-export let taskDetailsWithOutProcessInstanceMock = new TaskDetailsModel({
+export let claimableTaskDetailsMock = new TaskDetailsModel({
+    'id': '91',
+    'name': 'Request translation',
+    'description': null,
+    'category': null,
+    'assignee': null,
+    'created': '2016-11-03T15:25:42.749+0000',
+    'dueDate': null,
+    'endDate': null,
+    'duration': null,
+    'priority': 50,
+    'parentTaskId': null,
+    'parentTaskName': null,
+    'processInstanceId': '86',
+    'processInstanceName': null,
+    'processDefinitionId': 'TranslationProcess:2:8',
+    'processDefinitionName': 'Translation Process',
+    'involvedGroups': [{'id': 7007, 'name': 'group1', 'externalId': null, 'status': 'active', 'groups': null},
+                       {'id': 8008, 'name': 'group2', 'externalId': null, 'status': 'active', 'groups': null}],
+    'involvedPeople': [],
+    'managerOfCandidateGroup': true,
+    'memberOfCandidateGroup': true,
+    'memberOfCandidateUsers': false
+});
+
+export let  claimedTaskDetailsMock = new TaskDetailsModel({
+    'id': '91',
+    'name': 'Request translation',
+    'description': null,
+    'category': null,
+    'assignee': {'id': 1001, 'firstName': 'Wilbur', 'lastName': 'Adams', 'email': 'wilbur@app.activiti.com'},
+    'created': '2016-11-03T15:25:42.749+0000',
+    'dueDate': null,
+    'endDate': null,
+    'duration': null,
+    'priority': 50,
+    'parentTaskId': null,
+    'parentTaskName': null,
+    'processInstanceId': '86',
+    'processInstanceName': null,
+    'processDefinitionId': 'TranslationProcess:2:8',
+    'processDefinitionName': 'Translation Process',
+    'involvedGroups': [{'id': 7007, 'name': 'group1', 'externalId': null, 'status': 'active', 'groups': null}],
+    'involvedPeople': [{'id': 1001, 'firstName': 'Wilbur', 'lastName': 'Adams', 'email': 'wilbur@app.activiti.com'},
+                       {'id': 111, 'firstName': 'fake-first-name', 'lastName': 'fake-last-name', 'email': 'fake@app.activiti.com'}],
+    'managerOfCandidateGroup': true,
+    'memberOfCandidateGroup': true,
+    'memberOfCandidateUsers': true
+});
+
+export let claimedByGroupMemberMock = new TaskDetailsModel({
+    'id': '91',
+    'name': 'Request translation',
+    'description': null,
+    'category': null,
+    'assignee': {'id': 111, 'firstName': 'fake-first-name', 'lastName': 'fake-last-name', 'email': 'fake@app.activiti.com'},
+    'created': '2016-11-03T15:25:42.749+0000',
+    'dueDate': null,
+    'endDate': null,
+    'duration': null,
+    'priority': 50,
+    'parentTaskId': null,
+    'parentTaskName': null,
+    'processInstanceId': '86',
+    'processInstanceName': null,
+    'processDefinitionId': 'TranslationProcess:2:8',
+    'processDefinitionName': 'Translation Process',
+    'involvedGroups': [{'id': 7007, 'name': 'group1', 'externalId': null, 'status': 'active', 'groups': null}],
+    'involvedPeople': [{'id': 1001, 'firstName': 'Wilbur', 'lastName': 'Adams', 'email': 'wilbur@app.activiti.com'},
+                       {'id': 111, 'firstName': 'fake-first-name', 'lastName': 'fake-last-name', 'email': 'fake@app.activiti.com'}],
+    'managerOfCandidateGroup': true,
+    'memberOfCandidateGroup': true,
+    'memberOfCandidateUsers': true
+});
+
+export let taskDetailsWithOutCandidateGroup = new TaskDetailsModel({
     'id': '91',
     'name': 'Request translation',
     'description': null,
@@ -69,6 +144,9 @@ export let taskDetailsWithOutProcessInstanceMock = new TaskDetailsModel({
     'processInstanceName': null,
     'processDefinitionId': 'TranslationProcess:2:8',
     'processDefinitionName': 'Translation Process',
+    'managerOfCandidateGroup': false,
+    'memberOfCandidateGroup': false,
+    'memberOfCandidateUsers': false,
     'involvedGroups': [],
     'involvedPeople': [{'id': 1001, 'firstName': 'Wilbur', 'lastName': 'Adams', 'email': 'wilbur@app.activiti.com'},
                        {'id': 111, 'firstName': 'fake-first-name', 'lastName': 'fake-last-name', 'email': 'fake@app.activiti.com'}]
@@ -92,95 +170,10 @@ export let completedTaskDetailsMock = new TaskDetailsModel({
     'processDefinitionId': 'TranslationProcess:2:8',
     'processDefinitionName': 'Translation Process',
     'involvedGroups': [],
-    'involvedPeople': []
-});
-
-export let taskDetailsWithOutAssigneeMock = new TaskDetailsModel({
-    'id': '91',
-    'name': 'Request translation',
-    'description': null,
-    'category': null,
-    'assignee': null,
-    'created': '2016-11-03T15:25:42.749+0000',
-    'dueDate': null,
-    'endDate': null,
-    'duration': null,
-    'priority': 50,
-    'parentTaskId': null,
-    'parentTaskName': null,
-    'processInstanceId': '86',
-    'processInstanceName': null,
-    'processDefinitionId': 'TranslationProcess:2:8',
-    'processDefinitionName': 'Translation Process',
-    'involvedGroups': [{'id': 7007, 'name': 'group1', 'externalId': null, 'status': 'active', 'groups': null},
-                       {'id': 8008, 'name': 'group2', 'externalId': null, 'status': 'active', 'groups': null}],
-    'involvedPeople': []
-});
-
-export let taskDetailsWithInvolvedGroupMock = new TaskDetailsModel({
-    'id': '91',
-    'name': 'Request translation',
-    'description': null,
-    'category': null,
-    'assignee': {'id': 1001, 'firstName': 'Wilbur', 'lastName': 'Adams', 'email': 'wilbur@app.activiti.com'},
-    'created': '2016-11-03T15:25:42.749+0000',
-    'dueDate': null,
-    'endDate': null,
-    'duration': null,
-    'priority': 50,
-    'parentTaskId': null,
-    'parentTaskName': null,
-    'processInstanceId': '86',
-    'processInstanceName': null,
-    'processDefinitionId': 'TranslationProcess:2:8',
-    'processDefinitionName': 'Translation Process',
-    'involvedGroups': [{'id': 7007, 'name': 'group1', 'externalId': null, 'status': 'active', 'groups': null},
-                       {'id': 8008, 'name': 'group2', 'externalId': null, 'status': 'active', 'groups': null}],
-    'involvedPeople': []
-});
-
-export let taskDetailsWithInvolvedPeopleMock = new TaskDetailsModel({
-    'id': '91',
-    'name': 'Request translation',
-    'description': null,
-    'category': null,
-    'assignee': {'id': 1001, 'firstName': 'Wilbur', 'lastName': 'Adams', 'email': 'wilbur@app.activiti.com'},
-    'created': '2016-11-03T15:25:42.749+0000',
-    'dueDate': null,
-    'endDate': null,
-    'duration': null,
-    'priority': 50,
-    'parentTaskId': null,
-    'parentTaskName': null,
-    'processInstanceId': '86',
-    'processInstanceName': null,
-    'processDefinitionId': 'TranslationProcess:2:8',
-    'processDefinitionName': 'Translation Process',
-    'involvedGroups': [],
-    'involvedPeople': [{'id': 1001, 'firstName': 'Wilbur', 'lastName': 'Adams', 'email': 'wilbur@app.activiti.com'},
-                       {'id': 111, 'firstName': 'fake-first-name', 'lastName': 'fake-last-name', 'email': 'fake@app.activiti.com'}]
-});
-
-export let taskDetailsWithAssigneeMock = new TaskDetailsModel({
-    'id': '91',
-    'name': 'Request translation',
-    'description': null,
-    'category': null,
-    'assignee': {'id': 111, 'firstName': 'fake-first-name', 'lastName': 'fake-last-name', 'email': 'fake@app.activiti.com'},
-    'created': '2016-11-03T15:25:42.749+0000',
-    'dueDate': null,
-    'endDate': null,
-    'duration': null,
-    'priority': 50,
-    'parentTaskId': null,
-    'parentTaskName': null,
-    'processInstanceId': '86',
-    'processInstanceName': null,
-    'processDefinitionId': 'TranslationProcess:2:8',
-    'processDefinitionName': 'Translation Process',
-    'involvedGroups': [],
-    'involvedPeople': [{'id': 1001, 'firstName': 'Wilbur', 'lastName': 'Adams', 'email': 'wilbur@app.activiti.com'},
-                       {'id': 111, 'firstName': 'fake-first-name', 'lastName': 'fake-last-name', 'email': 'fake@app.activiti.com'}]
+    'involvedPeople': [],
+    'managerOfCandidateGroup': true,
+    'memberOfCandidateGroup': true,
+    'memberOfCandidateUsers': false
 });
 
 export let taskFormMock = new TaskDetailsModel({

--- a/lib/process-services/mock/task/task-details.mock.ts
+++ b/lib/process-services/mock/task/task-details.mock.ts
@@ -52,6 +52,28 @@ export let taskDetailsMock = new TaskDetailsModel({
     'memberOfCandidateGroup': false
 });
 
+export let taskDetailsWithOutProcessInstanceMock = new TaskDetailsModel({
+    'id': '91',
+    'name': 'Request translation',
+    'description': null,
+    'category': null,
+    'assignee': {'id': 1001, 'firstName': 'Wilbur', 'lastName': 'Adams', 'email': 'wilbur@app.activiti.com'},
+    'created': '2016-11-03T15:25:42.749+0000',
+    'dueDate': null,
+    'endDate': null,
+    'duration': null,
+    'priority': 50,
+    'parentTaskId': null,
+    'parentTaskName': null,
+    'processInstanceId': null,
+    'processInstanceName': null,
+    'processDefinitionId': 'TranslationProcess:2:8',
+    'processDefinitionName': 'Translation Process',
+    'involvedGroups': [],
+    'involvedPeople': [{'id': 1001, 'firstName': 'Wilbur', 'lastName': 'Adams', 'email': 'wilbur@app.activiti.com'},
+                       {'id': 111, 'firstName': 'fake-first-name', 'lastName': 'fake-last-name', 'email': 'fake@app.activiti.com'}]
+});
+
 export let completedTaskDetailsMock = new TaskDetailsModel({
     'id': '91',
     'name': 'Request translation',

--- a/lib/process-services/task-list/components/task-header.component.html
+++ b/lib/process-services/task-list/components/task-header.component.html
@@ -4,7 +4,7 @@
     </mat-card-content>
 
     <mat-card-actions class="adf-controls">
-        <button *ngIf="isTaskClaimedByCandidateUser()" mat-button data-automation-id="header-unclaim-button" id="unclaim-task" (click)="unclaimTask(taskDetails.id)" class="adf-claim-controls">{{ 'ADF_TASK_LIST.DETAILS.BUTTON.UNCLAIM' | translate }}
+        <button *ngIf="isTaskClaimedByCandidateMember()" mat-button data-automation-id="header-unclaim-button" id="unclaim-task" (click)="unclaimTask(taskDetails.id)" class="adf-claim-controls">{{ 'ADF_TASK_LIST.DETAILS.BUTTON.UNCLAIM' | translate }}
         </button>
         <button *ngIf="isTaskClaimable()" mat-button data-automation-id="header-claim-button" id="claim-task" (click)="claimTask(taskDetails.id)" class="adf-claim-controls">{{ 'ADF_TASK_LIST.DETAILS.BUTTON.CLAIM' | translate }}
         </button>

--- a/lib/process-services/task-list/components/task-header.component.html
+++ b/lib/process-services/task-list/components/task-header.component.html
@@ -4,7 +4,7 @@
     </mat-card-content>
 
     <mat-card-actions class="adf-controls">
-        <button *ngIf="isTaskClaimedByCurrentUser()" mat-button data-automation-id="header-unclaim-button" id="unclaim-task" (click)="unclaimTask(taskDetails.id)" class="adf-claim-controls">{{ 'ADF_TASK_LIST.DETAILS.BUTTON.UNCLAIM' | translate }}
+        <button *ngIf="isTaskClaimedByCandidateUser()" mat-button data-automation-id="header-unclaim-button" id="unclaim-task" (click)="unclaimTask(taskDetails.id)" class="adf-claim-controls">{{ 'ADF_TASK_LIST.DETAILS.BUTTON.UNCLAIM' | translate }}
         </button>
         <button *ngIf="isTaskClaimable()" mat-button data-automation-id="header-claim-button" id="claim-task" (click)="claimTask(taskDetails.id)" class="adf-claim-controls">{{ 'ADF_TASK_LIST.DETAILS.BUTTON.CLAIM' | translate }}
         </button>

--- a/lib/process-services/task-list/components/task-header.component.spec.ts
+++ b/lib/process-services/task-list/components/task-header.component.spec.ts
@@ -28,7 +28,8 @@ import {
     taskDetailsWithAssigneeMock,
     taskDetailsWithInvolvedGroupMock,
     taskDetailsWithInvolvedPeopleMock,
-    taskDetailsWithOutAssigneeMock } from '../../mock';
+    taskDetailsWithOutAssigneeMock,
+    taskDetailsWithOutProcessInstanceMock } from '../../mock';
 
 import { TaskDetailsModel } from '../models/task-details.model';
 import { TaskListService } from './../services/tasklist.service';
@@ -141,12 +142,22 @@ describe('TaskHeaderComponent', () => {
             expect(claimButton.nativeElement.innerText).toBe('ADF_TASK_LIST.DETAILS.BUTTON.CLAIM');
         });
 
-        it('should display the claim button to the invovled group', () => {
+        it('should display the claim button if the task has invovled group/people', () => {
             component.taskDetails = new TaskDetailsModel(taskDetailsWithOutAssigneeMock);
             component.ngOnChanges({});
             fixture.detectChanges();
             let claimButton = fixture.debugElement.query(By.css('[data-automation-id="header-claim-button"]'));
             expect(claimButton.nativeElement.innerText).toBe('ADF_TASK_LIST.DETAILS.BUTTON.CLAIM');
+        });
+
+        it('should not display the claim/requeue button if the task does not have processInstanceId ', () => {
+            component.taskDetails = new TaskDetailsModel(taskDetailsWithOutProcessInstanceMock);
+            component.ngOnChanges({});
+            fixture.detectChanges();
+            let claimButton = fixture.debugElement.query(By.css('[data-automation-id="header-claim-button"]'));
+            let unclaimButton = fixture.debugElement.query(By.css('[data-automation-id="header-unclaim-button"]'));
+            expect(unclaimButton).toBeNull();
+            expect(claimButton).toBeNull();
         });
     });
 

--- a/lib/process-services/task-list/components/task-header.component.spec.ts
+++ b/lib/process-services/task-list/components/task-header.component.spec.ts
@@ -157,7 +157,7 @@ describe('TaskHeaderComponent', () => {
             let claimButton = fixture.debugElement.query(By.css('[data-automation-id="header-claim-button"]'));
             let unclaimButton = fixture.debugElement.query(By.css('[data-automation-id="header-unclaim-button"]'));
             expect(component.isTaskClaimable()).toBeFalsy();
-            expect(component.isTaskClaimedByCandidateUser()).toBeFalsy();
+            expect(component.isTaskClaimedByCandidateMember()).toBeFalsy();
             expect(unclaimButton).toBeNull();
             expect(claimButton).toBeNull();
         });
@@ -168,26 +168,26 @@ describe('TaskHeaderComponent', () => {
         component.ngOnChanges({});
         fixture.detectChanges();
         let unclaimButton = fixture.debugElement.query(By.css('[data-automation-id="header-unclaim-button"]'));
-        expect(component.isTaskClaimedByCandidateUser()).toBeTruthy();
+        expect(component.isTaskClaimedByCandidateMember()).toBeTruthy();
         expect(unclaimButton.nativeElement.innerText).toBe('ADF_TASK_LIST.DETAILS.BUTTON.UNCLAIM');
     });
 
-    it('should not display the requeue button if task is claimed by others', () => {
+    it('should not display the requeue button to logged in user if task is claimed by other candidate member', () => {
         component.taskDetails = new TaskDetailsModel(claimedByGroupMemberMock);
         component.ngOnChanges({});
         fixture.detectChanges();
         let unclaimButton = fixture.debugElement.query(By.css('[data-automation-id="header-unclaim-button"]'));
-        expect(component.isTaskClaimedByCandidateUser()).toBeFalsy();
+        expect(component.isTaskClaimedByCandidateMember()).toBeFalsy();
         expect(unclaimButton).toBeNull();
     });
 
-    it('should display the claime button if the task is claimable by the current logged-in user', () => {
+    it('should display the claime button if the task is claimable by candidates members', () => {
         component.taskDetails = new TaskDetailsModel(claimableTaskDetailsMock);
         component.ngOnChanges({});
         fixture.detectChanges();
         let claimButton = fixture.debugElement.query(By.css('[data-automation-id="header-claim-button"]'));
         expect(component.isTaskClaimable()).toBeTruthy();
-        expect(component.isTaskClaimedByCandidateUser()).toBeFalsy();
+        expect(component.isTaskClaimedByCandidateMember()).toBeFalsy();
         expect(claimButton.nativeElement.innerText).toBe('ADF_TASK_LIST.DETAILS.BUTTON.CLAIM');
     });
 

--- a/lib/process-services/task-list/components/task-header.component.ts
+++ b/lib/process-services/task-list/components/task-header.component.ts
@@ -211,17 +211,24 @@ export class TaskHeaderComponent implements OnChanges, OnInit {
     }
 
     /**
+     * Return true if the task has ProcessInstance
+     */
+    public hasProcessInstance() {
+        return !!this.taskDetails.processInstanceId;
+    }
+
+    /**
      * Return true if the task claimable
      */
     public isTaskClaimable(): boolean {
-        return !this.isCompleted() && (this.hasInvolvedGroup() || this.hasInvolvedPeople()) && !this.hasAssignee() ;
+        return !this.isCompleted() && (this.hasInvolvedGroup() || this.hasInvolvedPeople()) && !this.hasAssignee() && this.hasProcessInstance();
     }
 
     /**
      * Return true if the task claimed by currentUser
      */
     public isTaskClaimedByCurrentUser(): boolean {
-        return !this.isCompleted() && (this.hasInvolvedGroup() || this.hasInvolvedPeople()) && this.isAssignedToCurrentUser();
+        return !this.isCompleted() && (this.hasInvolvedGroup() || this.hasInvolvedPeople()) && this.isAssignedToCurrentUser() && this.hasProcessInstance();
     }
 
     /**

--- a/lib/process-services/task-list/components/task-header.component.ts
+++ b/lib/process-services/task-list/components/task-header.component.ts
@@ -197,9 +197,9 @@ export class TaskHeaderComponent implements OnChanges, OnInit {
     }
 
     /**
-     * Return true if the user is a candidate user
+     * Return true if the user is a candidate member
      */
-    isCandidateUser() {
+    isCandidateMember() {
         return this.taskDetails.managerOfCandidateGroup || this.taskDetails.memberOfCandidateGroup || this.taskDetails.memberOfCandidateUsers;
     }
 
@@ -207,14 +207,14 @@ export class TaskHeaderComponent implements OnChanges, OnInit {
      * Return true if the task claimable
      */
     public isTaskClaimable(): boolean {
-        return !this.hasAssignee() && this.isCandidateUser();
+        return !this.hasAssignee() && this.isCandidateMember();
     }
 
     /**
-     * Return true if the task claimed by candidate user
+     * Return true if the task claimed by candidate member.
      */
-    public isTaskClaimedByCandidateUser(): boolean {
-        return this.isCandidateUser() && this.isAssignedToCurrentUser() && !this.isCompleted();
+    public isTaskClaimedByCandidateMember(): boolean {
+        return this.isCandidateMember() && this.isAssignedToCurrentUser() && !this.isCompleted();
     }
 
     /**

--- a/lib/process-services/task-list/components/task-header.component.ts
+++ b/lib/process-services/task-list/components/task-header.component.ts
@@ -197,38 +197,24 @@ export class TaskHeaderComponent implements OnChanges, OnInit {
     }
 
     /**
-     * Return true if the task has involvedGroup
+     * Return true if the user is a candidate user
      */
-    public hasInvolvedGroup(): boolean {
-        return this.taskDetails.involvedGroups.length > 0 ? true : false;
-    }
-
-    /**
-     * Return true if the task has involvedPeople
-     */
-    public hasInvolvedPeople(): boolean {
-        return this.taskDetails.involvedPeople.length > 0 ? true : false;
-    }
-
-    /**
-     * Return true if the task has ProcessInstance
-     */
-    public hasProcessInstance() {
-        return !!this.taskDetails.processInstanceId;
+    isCandidateUser() {
+        return this.taskDetails.managerOfCandidateGroup || this.taskDetails.memberOfCandidateGroup || this.taskDetails.memberOfCandidateUsers;
     }
 
     /**
      * Return true if the task claimable
      */
     public isTaskClaimable(): boolean {
-        return !this.isCompleted() && (this.hasInvolvedGroup() || this.hasInvolvedPeople()) && !this.hasAssignee() && this.hasProcessInstance();
+        return !this.hasAssignee() && this.isCandidateUser();
     }
 
     /**
-     * Return true if the task claimed by currentUser
+     * Return true if the task claimed by candidate user
      */
-    public isTaskClaimedByCurrentUser(): boolean {
-        return !this.isCompleted() && (this.hasInvolvedGroup() || this.hasInvolvedPeople()) && this.isAssignedToCurrentUser() && this.hasProcessInstance();
+    public isTaskClaimedByCandidateUser(): boolean {
+        return this.isCandidateUser() && this.isAssignedToCurrentUser() && !this.isCompleted();
     }
 
     /**


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

* When assigning a user to a simple task, Requeue option displayed.

**What is the new behaviour?**

* When assigning a user to a simple task, Requeue option will not  display.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
