### PR TITLE
[ADF-1889] support for explicit viewer type for URL

### DIFF
--- a/docs/viewer.component.md
+++ b/docs/viewer.component.md
@@ -45,6 +45,7 @@ Using with file url:
 | --- | --- | --- | --- |
 | fileNodeId | string | | Node Id of the file to load |
 | urlFile | string | | If you want to load an external file that does not come from ECM you can use this Url where to load the file |
+| urlFileViewer | string | null | Viewer to use with the `urlFile` address (`pdf`, `image`, `media`, `text`). Used when `urlFile` has no filename and extension. |
 | urlBlob | Blob | | If you want to load a Blob File |
 | overlayMode | boolean | false | If `true` show the Viewer full page over the present content otherwise will fit the parent div |
 | showViewer | boolean | true | Hide or show the viewer |

--- a/lib/core/viewer/components/viewer.component.ts
+++ b/lib/core/viewer/components/viewer.component.ts
@@ -53,6 +53,9 @@ export class ViewerComponent implements OnDestroy, OnChanges {
     urlFile = '';
 
     @Input()
+    urlFileViewer: string = null;
+
+    @Input()
     blobFile: Blob;
 
     @Input()
@@ -174,7 +177,7 @@ export class ViewerComponent implements OnDestroy, OnChanges {
                     this.downloadUrl = this.urlFile;
                     this.fileName = this.displayName;
 
-                    this.viewerType = this.getViewerTypeByExtension(this.extension);
+                    this.viewerType = this.urlFileViewer || this.getViewerTypeByExtension(this.extension);
                     if (this.viewerType === 'unknown') {
                         this.viewerType = this.getViewerTypeByMimeType(this.mimeType);
                     }
@@ -342,13 +345,20 @@ export class ViewerComponent implements OnDestroy, OnChanges {
     }
 
     /**
-     * Get the token from the local storage
+     * Get file extension from the string.
+     * Supports the URL formats like:
+     * http://localhost/test.jpg?cache=1000
+     * http://localhost/test.jpg#cache=1000
      *
      * @param {string} fileName - file name
      * @returns {string} file name extension
      */
     getFileExtension(fileName: string): string {
-        return fileName.split('.').pop().toLowerCase();
+        if (fileName) {
+            const match = fileName.match(/\.([^\./\?\#]+)($|\?|\#)/);
+            return match ? match[1] : null;
+        }
+        return null;
     }
 
     isCustomViewerExtension(extension: string): boolean {


### PR DESCRIPTION
Add support for setting explicit viewer type when using URL values without file name and/or extension.
To be added post 2.0.