### PR TITLE
[ADF-1911] disabled toolbar and drag area on search results page

### DIFF
--- a/demo-shell/resources/i18n/en.json
+++ b/demo-shell/resources/i18n/en.json
@@ -83,7 +83,8 @@
         "LOGIN_FOOTER": "Login footer"
     },
     "SEARCH": {
-        "RESULTS": "Search results"
+        "RESULTS": "Search results",
+        "NO_RESULT": "No results found"
     },
     "SOCIAL": {
         "LIKE":"Like component",

--- a/demo-shell/src/app/components/files/files.component.html
+++ b/demo-shell/src/app/components/files/files.component.html
@@ -5,6 +5,7 @@
     </div>
     <div class="document-list-container" fxLayout="row" fxLayoutAlign="start stretch" fxLayoutGap="16px">
         <adf-upload-drag-area fxFlex="1 1 auto"
+            [disabled]="disableDragArea"
             [parentId]="getDocumentListCurrentFolderId()"
             [versioning]="versioning"
             [adf-node-permission]="'create'"
@@ -15,7 +16,7 @@
                 </button>
                 <span class="error-message--text">{{errorMessage}}</span>
             </div>
-            <adf-toolbar [color]="toolbarColor" class="adf-files-toolbar">
+            <adf-toolbar *ngIf="!disableDragArea" [color]="toolbarColor" class="adf-files-toolbar">
                 <adf-toolbar-title fxFlex="0 1 auto">
                     <adf-breadcrumb fxShow fxHide.lt-sm="true"
                                     class="files-breadcrumb"
@@ -132,6 +133,13 @@
                 (preview)="showFile($event)"
                 (folderChange)="onFolderChange($event)"
                 (permissionError)="handlePermissionError($event)">
+                <empty-folder-content *ngIf="disableDragArea">
+                    <ng-template>
+                        <div class="adf-empty_template">
+                            <div class="adf-no-result-message">{{ 'SEARCH.NO_RESULT' | translate }}</div>
+                        </div>
+                    </ng-template>
+                </empty-folder-content>
                 <data-columns>
                     <data-column
                         key="$thumbnail"

--- a/demo-shell/src/app/components/files/files.component.scss
+++ b/demo-shell/src/app/components/files/files.component.scss
@@ -95,6 +95,28 @@ adf-document-list ::ng-deep adf-datatable > table > tbody > tr.is-selected > td.
     }
 }
 
+.adf-no-result__empty_doc_lib {
+    width: 565px;
+    height: 161px;
+    object-fit: contain;
+    margin-top: 17px;
+}
+
+.adf-empty_template {
+    text-align: center;
+    margin-top: 20px;
+    margin-bottom: 20px;
+}
+
+.adf-no-result-message{
+    height: 32px;
+    opacity: 0.26;
+    font-size: 24px;
+    line-height: 1.33;
+    letter-spacing: -1px;
+    color: #000000;
+}
+
 @media (max-width: $minimumDocumentListWidth) {
     adf-document-list ::ng-deep adf-datatable  {
         & ::ng-deep .adf-data-table-cell--fileSize {

--- a/demo-shell/src/app/components/files/files.component.scss
+++ b/demo-shell/src/app/components/files/files.component.scss
@@ -114,7 +114,6 @@ adf-document-list ::ng-deep adf-datatable > table > tbody > tr.is-selected > td.
     font-size: 24px;
     line-height: 1.33;
     letter-spacing: -1px;
-    color: #000000;
 }
 
 @media (max-width: $minimumDocumentListWidth) {

--- a/demo-shell/src/app/components/files/files.component.ts
+++ b/demo-shell/src/app/components/files/files.component.ts
@@ -96,6 +96,9 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
     @Input()
     pagination: Pagination;
 
+    @Input()
+    disableDragArea: boolean = false;
+
     @Output()
     documentListReady: EventEmitter<any> = new EventEmitter();
 
@@ -177,6 +180,7 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
             });
         }
 
+        // this.disableDragArea = false;
         this.uploadService.fileUploadComplete.asObservable().debounceTime(300).subscribe(value => this.onFileUploadEvent(value));
         this.uploadService.fileUploadDeleted.subscribe((value) => this.onFileUploadEvent(value));
         this.contentService.folderCreated.subscribe(value => this.onFolderCreated(value));
@@ -194,9 +198,21 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
 
     ngOnChanges(changes: SimpleChanges) {
         if (changes.nodeResult && changes.nodeResult.currentValue) {
-            this.nodeResult = <NodePaging> changes.nodeResult.currentValue;
+            this.nodeResult = <NodePaging>changes.nodeResult.currentValue;
             this.pagination = this.nodeResult.list.pagination;
         }
+        if (!this.pagination) {
+            this.giveDefaultPaginationWhenNotDefined();
+        }
+    }
+
+    giveDefaultPaginationWhenNotDefined() {
+        this.pagination =  <Pagination> {
+            maxItems: this.preference.paginationSize,
+            skipCount: 0,
+            totalItems: 0,
+            hasMoreItems: false
+        };
     }
 
     getCurrentDocumentListNode(): MinimalNodeEntity[] {

--- a/demo-shell/src/app/components/search/search-result.component.html
+++ b/demo-shell/src/app/components/search/search-result.component.html
@@ -8,6 +8,7 @@
 <adf-files-component
         [currentFolderId]="null"
         [nodeResult]="resultNodePageList"
+        [disableDragArea]="true"
         (documentListReady)="refreshResults($event)"
         (changedPageSize)="refreshPage($event)"
         (changedPageNumber)="refreshPage($event)"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
toolbar and drag & drop are allowed on search result page


**What is the new behaviour?**

toolbar and drag & drop are disabled on search result page

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
