### PR TITLE
[ADF-1982] fix the issue with breadcrumb after material upgrade

### DIFF
--- a/lib/content-services/breadcrumb/dropdown-breadcrumb.component.scss
+++ b/lib/content-services/breadcrumb/dropdown-breadcrumb.component.scss
@@ -22,7 +22,7 @@
         }
 
         &-dropdown-breadcrumb-path {
-            width: 0;
+            width: 0 !important;
             height: 0;
             overflow: hidden;
             margin-top: 35px;


### PR DESCRIPTION
Relates to [ADF-1982], fixes issue with the `width` property being overwritten by material