### PR TITLE
[ADF-2007] Info Drawer - currentTab event should return a key not the label

### DIFF
--- a/lib/core/info-drawer/info-drawer.component.html
+++ b/lib/core/info-drawer/info-drawer.component.html
@@ -7,7 +7,7 @@
     <ng-container info-drawer-content *ngIf="showTabLayout(); then tabLayout else singleLayout"></ng-container>
 
     <ng-template #tabLayout>
-        <mat-tab-group class="adf-info-drawer-tabs" (selectChange)="onTabChange($event)">
+        <mat-tab-group class="adf-info-drawer-tabs" (selectedTabChange)="onTabChange($event)">
             <ng-container *ngFor="let contentBlock of contentBlocks">
                 <mat-tab [label]="contentBlock.label" class="adf-info-drawer-tab">
                     <ng-container *ngTemplateOutlet="contentBlock.content"></ng-container>

--- a/lib/core/info-drawer/info-drawer.component.spec.ts
+++ b/lib/core/info-drawer/info-drawer.component.spec.ts
@@ -17,6 +17,7 @@
 
 import { Component } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatTabChangeEvent } from '@angular/material';
 import { By } from '@angular/platform-browser';
 import { MaterialModule } from '../material.module';
 import { InfoDrawerLayoutComponent } from './info-drawer-layout.component';
@@ -57,9 +58,8 @@ describe('InfoDrawerComponent', () => {
     it('should emit when tab is changed', () => {
         let tabEmitSpy = spyOn(component.currentTab, 'emit');
         let event = {index: 1, tab: {textLabel: 'DETAILS'}};
-        component.onTabChange(event);
-        expect(tabEmitSpy).toHaveBeenCalled();
-        expect(tabEmitSpy).toHaveBeenCalledWith(event.tab);
+        component.onTabChange(<MatTabChangeEvent> event);
+        expect(tabEmitSpy).toHaveBeenCalledWith(1);
     });
 
     it('should render the title', () => {

--- a/lib/core/info-drawer/info-drawer.component.spec.ts
+++ b/lib/core/info-drawer/info-drawer.component.spec.ts
@@ -59,7 +59,7 @@ describe('InfoDrawerComponent', () => {
         let event = {index: 1, tab: {textLabel: 'DETAILS'}};
         component.onTabChange(event);
         expect(tabEmitSpy).toHaveBeenCalled();
-        expect(tabEmitSpy).toHaveBeenCalledWith('DETAILS');
+        expect(tabEmitSpy).toHaveBeenCalledWith(event.tab);
     });
 
     it('should render the title', () => {

--- a/lib/core/info-drawer/info-drawer.component.ts
+++ b/lib/core/info-drawer/info-drawer.component.ts
@@ -16,6 +16,7 @@
  */
 
 import { Component, ContentChildren, EventEmitter, Input, Output, QueryList, TemplateRef, ViewChild, ViewEncapsulation } from '@angular/core';
+import { MatTabChangeEvent } from '@angular/material';
 @Component({
     selector: 'adf-info-drawer-tab',
     template: '<ng-template><ng-content></ng-content></ng-template>'
@@ -37,7 +38,7 @@ export class InfoDrawerComponent {
     title: string|null = null;
 
     @Output()
-    currentTab: EventEmitter<any> = new EventEmitter<any>();
+    currentTab: EventEmitter<number> = new EventEmitter<number>();
 
     @ContentChildren(InfoDrawerTabComponent)
     contentBlocks: QueryList<InfoDrawerTabComponent>;
@@ -46,7 +47,7 @@ export class InfoDrawerComponent {
         return this.contentBlocks.length > 0;
     }
 
-    onTabChange(event: any) {
-        this.currentTab.emit(event.tab);
+    onTabChange(event: MatTabChangeEvent) {
+        this.currentTab.emit(event.index);
     }
 }

--- a/lib/core/info-drawer/info-drawer.component.ts
+++ b/lib/core/info-drawer/info-drawer.component.ts
@@ -47,7 +47,6 @@ export class InfoDrawerComponent {
     }
 
     onTabChange(event: any) {
-        const tab = event.tab;
-        this.currentTab.emit(tab.textLabel);
+        this.currentTab.emit(event.tab);
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Info drawer emits only the tab label as currentTab event data.


**What is the new behaviour?**
Info drawer emit the tab index.


**Does this PR introduce a breaking change?** (check one with "x")

> - [x] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

The currentTab event data has been changed. Instead of returning only the current active tab label, we return the entire tab object



**Other information**:
Info drawer will emit the current active tab instead of the tab label
Also updated the test spec