### PR TITLE
[ADF-1711] The <adf-task-attachment-list component displays drag-and-…

### DIFF
--- a/demo-shell/src/app/components/process-service/process-attachments.component.html
+++ b/demo-shell/src/app/components/process-service/process-attachments.component.html
@@ -3,8 +3,7 @@
     <div class="adf-no-form-container">
         <adf-upload-drag-area
             [parentId]="processInstanceId"
-            [disabled]="isCompletedProcess()"
-            [showNotificationBar]="false">
+            [disabled]="isCompletedProcess()">
             <adf-process-attachment-list #processAttachList
                 *ngIf="processInstanceId"
                 [disabled]="isCompletedProcess()"

--- a/demo-shell/src/app/components/process-service/process-attachments.component.ts
+++ b/demo-shell/src/app/components/process-service/process-attachments.component.ts
@@ -17,16 +17,13 @@
 
 import { Component, Input, OnChanges, OnInit, ViewChild } from '@angular/core';
 import { ProcessInstance, ProcessService ,
-    ProcessAttachmentListComponent, ProcessUploadService } from '@alfresco/adf-process-services';
+    ProcessAttachmentListComponent } from '@alfresco/adf-process-services';
 import { UploadService } from '@alfresco/adf-core';
 
 @Component({
     selector: 'app-process-attachments',
     templateUrl: './process-attachments.component.html',
-    styleUrls: ['./process-attachments.component.css'],
-    providers: [
-        {provide: UploadService, useClass: ProcessUploadService}
-    ]
+    styleUrls: ['./process-attachments.component.css']
 })
 
 export class ProcessAttachmentsComponent implements OnInit, OnChanges {

--- a/demo-shell/src/app/components/process-service/process-service.component.ts
+++ b/demo-shell/src/app/components/process-service/process-service.component.ts
@@ -50,7 +50,6 @@ import {
     TaskFiltersComponent,
     TaskListComponent,
     TaskListService,
-    TaskAttachmentListComponent,
     ProcessUploadService
 } from '@alfresco/adf-process-services';
 import { LogService } from '@alfresco/adf-core';
@@ -72,8 +71,8 @@ const currentTaskIdNew = '__NEW__';
     templateUrl: './process-service.component.html',
     styleUrls: ['./process-service.component.scss'],
     providers: [
-                { provide: UploadService, useClass: ProcessUploadService }
-               ],
+        { provide: UploadService, useClass: ProcessUploadService }
+    ],
     encapsulation: ViewEncapsulation.None
 })
 export class ProcessServiceComponent implements AfterViewInit, OnDestroy, OnInit {
@@ -83,9 +82,6 @@ export class ProcessServiceComponent implements AfterViewInit, OnDestroy, OnInit
 
     @ViewChild(TaskListComponent)
     taskList: TaskListComponent;
-
-    @ViewChild(TaskAttachmentListComponent)
-    taskAttachList: TaskAttachmentListComponent;
 
     @ViewChild(ProcessFiltersComponent)
     activitiprocessfilter: ProcessFiltersComponent;
@@ -155,8 +151,7 @@ export class ProcessServiceComponent implements AfterViewInit, OnDestroy, OnInit
                 private apiService: AlfrescoApiService,
                 private logService: LogService,
                 formRenderingService: FormRenderingService,
-                formService: FormService,
-                private uploadService: UploadService) {
+                formService: FormService) {
         this.dataTasks = new ObjectDataTableAdapter();
         this.dataTasks.setSorting(new DataSorting('created', 'desc'));
 
@@ -256,8 +251,6 @@ export class ProcessServiceComponent implements AfterViewInit, OnDestroy, OnInit
             this.currentProcessInstanceId = null;
         });
         this.layoutType = AppsListComponent.LAYOUT_GRID;
-        this.uploadService.fileUploadComplete.subscribe(value => this.onTaskFileUploadComplete(value.data));
-
     }
 
     ngOnDestroy() {
@@ -378,10 +371,6 @@ export class ProcessServiceComponent implements AfterViewInit, OnDestroy, OnInit
         this.processList.reload();
     }
 
-    onSuccessNewProcess(data: any): void {
-        this.processList.reload();
-    }
-
     onFormCompleted(form): void {
         this.currentTaskId = null;
         this.taskPagination.totalItems--;
@@ -482,16 +471,9 @@ export class ProcessServiceComponent implements AfterViewInit, OnDestroy, OnInit
         this.logService.log(event);
     }
 
-    isTaskCompleted(): boolean {
-        return this.activitidetails.isCompletedTask();
-    }
-
     onAssignTask() {
         this.taskList.reload();
         this.currentTaskId = null;
     }
 
-    onTaskFileUploadComplete(content: any) {
-        this.taskAttachList.add(content);
-    }
 }

--- a/demo-shell/src/app/components/process-service/task-attachments.component.html
+++ b/demo-shell/src/app/components/process-service/task-attachments.component.html
@@ -1,13 +1,12 @@
 <div id="attachment-task-list" *ngIf="taskId">
     <div class="adf-no-form-container">
         <adf-upload-drag-area
-            [parentId]="currentTaskId"
-            [showNotificationBar]="false">
+            [parentId]="taskId">
 
             <adf-task-attachment-list #taskAttachList
                                       [disabled]="isCompletedTask()"
                                       (attachmentClick)="onAttachmentClick($event)"
-                                      [taskId]="currentTaskId">
+                                      [taskId]="taskId">
                 <div adf-empty-list>
                     <div adf-empty-list-header class="adf-empty-list-header"> {{'ADF_TASK_LIST.ATTACHMENT.EMPTY.HEADER' | translate}} </div>
                     <div adf-empty-list-body>

--- a/demo-shell/src/app/components/process-service/task-attachments.component.ts
+++ b/demo-shell/src/app/components/process-service/task-attachments.component.ts
@@ -16,19 +16,19 @@
  */
 
 import { Component, Input, OnChanges, OnInit, ViewChild } from '@angular/core';
-import { ProcessUploadService, TaskListService, TaskAttachmentListComponent } from '@alfresco/adf-process-services';
+import { TaskListService, TaskAttachmentListComponent } from '@alfresco/adf-process-services';
 import { UploadService } from '@alfresco/adf-core';
 
 @Component({
     selector: 'app-task-attachments',
     templateUrl: './task-attachments.component.html',
-    styleUrls: ['./task-attachments.component.css'],
-    providers: [
-        { provide: UploadService, useClass: ProcessUploadService }
-    ]
+    styleUrls: ['./task-attachments.component.css']
 })
 
 export class TaskAttachmentsComponent implements OnInit, OnChanges {
+
+    @ViewChild(TaskAttachmentListComponent)
+    taskAttachList: TaskAttachmentListComponent;
 
     @Input()
     taskId: string;
@@ -73,4 +73,5 @@ export class TaskAttachmentsComponent implements OnInit, OnChanges {
     isCompletedTask(): boolean {
         return this.taskDetails && this.taskDetails.endDate !== undefined && this.taskDetails.endDate !== null;
     }
+
 }

--- a/docs/upload-drag-area.component.md
+++ b/docs/upload-drag-area.component.md
@@ -40,10 +40,7 @@ export class AppComponent {
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | disabled | boolean | false | Toggle component disabled state |
-| **(deprecated)** enabled | boolean | true | Toggle component enabled state |
-| **(deprecated)** showNotificationBar | boolean | true |  Hide/show notification bar. **Deprecated in 1.6.0: use UploadService events and NotificationService api instead.** |
 | rootFolderId | string | '-root-' | The ID of the root folder node. |
-| **(deprecated)** currentFolderPath | string | '/' | define the path where the files are uploaded. **Deprecated in 1.6.0: use rootFolderId instead.** |
 | versioning | boolean | false |  Versioning false is the default uploader behaviour and it renames the file using an integer suffix if there is a name clash. Versioning true to indicate that a major version should be created  | 
 
 ### Events

--- a/lib/content-services/upload/components/upload-drag-area.component.ts
+++ b/lib/content-services/upload/components/upload-drag-area.component.ts
@@ -38,31 +38,6 @@ import { Component, EventEmitter, forwardRef, Input, Output, ViewEncapsulation }
 })
 export class UploadDragAreaComponent implements NodePermissionSubject {
 
-    /** @deprecated Deprecated in favor of disabled input property */
-    @Input()
-    set enabled(enabled: boolean) {
-        console.warn('Deprecated: enabled input property should not be used for UploadDragAreaComponent. Please use disabled instead.');
-        this.disabled = !enabled;
-    }
-
-    /** @deprecated Deprecated in favor of disabled input property */
-    get enabled(): boolean {
-        console.warn('Deprecated: enabled input property should not be used for UploadDragAreaComponent. Please use disabled instead.');
-        return !this.disabled;
-    }
-
-    /** @deprecated Deprecated in 1.6.0, you can use UploadService events and NotificationService api instead. */
-    @Input()
-    showNotificationBar: boolean = true;
-
-    /** @deprecated Deprecated in 1.6.0, this property is not used for couple of releases already. Use rootFolderId instead. */
-    @Input()
-    currentFolderPath: string = '/';
-
-    /** @deprecated Deprecated in 1.6.2, this property is not used for couple of releases already. Use parentId instead. */
-    @Input()
-    rootFolderId: string = '-root-';
-
     @Input()
     disabled: boolean = false;
 
@@ -90,14 +65,10 @@ export class UploadDragAreaComponent implements NodePermissionSubject {
             const fileModels = files.map(file => new FileModel(file, {
                 newVersion: this.versioning,
                 path: '/',
-                parentId: this.parentId || this.rootFolderId
+                parentId: this.parentId
             }));
             this.uploadService.addToQueue(...fileModels);
             this.uploadService.uploadFilesInTheQueue(this.success);
-            let latestFilesAdded = this.uploadService.getQueue();
-            if (this.showNotificationBar) {
-                this.showUndoNotificationBar(latestFilesAdded);
-            }
         }
     }
 
@@ -111,15 +82,12 @@ export class UploadDragAreaComponent implements NodePermissionSubject {
             item.file((file: File) => {
                 const fileModel = new FileModel(file, {
                     newVersion: this.versioning,
-                    parentId: this.parentId || this.rootFolderId,
+                    parentId: this.parentId,
                     path: item.fullPath.replace(item.name, '')
                 });
                 this.uploadService.addToQueue(fileModel);
                 this.uploadService.uploadFilesInTheQueue(this.success);
             });
-            if (this.showNotificationBar) {
-                this.showUndoNotificationBar(item);
-            }
         }
     }
 
@@ -134,16 +102,11 @@ export class UploadDragAreaComponent implements NodePermissionSubject {
                 let files = entries.map(entry => {
                     return new FileModel(entry.file, {
                         newVersion: this.versioning,
-                        parentId: this.parentId || this.rootFolderId,
+                        parentId: this.parentId,
                         path: entry.relativeFolder
                     });
                 });
                 this.uploadService.addToQueue(...files);
-                /* @deprecated in 1.6.0 */
-                if (this.showNotificationBar) {
-                    let latestFilesAdded = this.uploadService.getQueue();
-                    this.showUndoNotificationBar(latestFilesAdded);
-                }
                 this.uploadService.uploadFilesInTheQueue(this.success);
             });
         }
@@ -191,9 +154,9 @@ export class UploadDragAreaComponent implements NodePermissionSubject {
         if (isAllowed) {
             let files: FileInfo[] = event.detail.files;
             if (files && files.length > 0) {
-                let parentId = this.parentId || this.rootFolderId;
+                let parentId = this.parentId;
                 if (event.detail.data && event.detail.data.obj.entry.isFolder) {
-                    parentId = event.detail.data.obj.entry.id || this.parentId || this.rootFolderId;
+                    parentId = event.detail.data.obj.entry.id || this.parentId;
                 }
                 const fileModels = files.map(fileInfo => new FileModel(fileInfo.file, {
                     newVersion: this.versioning,
@@ -214,10 +177,6 @@ export class UploadDragAreaComponent implements NodePermissionSubject {
         if (files.length) {
             this.uploadService.addToQueue(...files);
             this.uploadService.uploadFilesInTheQueue(this.success);
-            let latestFilesAdded = this.uploadService.getQueue();
-            if (this.showNotificationBar) {
-                this.showUndoNotificationBar(latestFilesAdded);
-            }
         }
     }
 

--- a/lib/process-services/attachment/process-attachment-list.component.ts
+++ b/lib/process-services/attachment/process-attachment-list.component.ts
@@ -17,12 +17,16 @@
 
 import { ContentService, ThumbnailService } from '@alfresco/adf-core';
 import { Component, EventEmitter, Input, NgZone, OnChanges, Output, SimpleChanges } from '@angular/core';
-import { ProcessContentService } from '@alfresco/adf-core';
+import { ProcessContentService, UploadService } from '@alfresco/adf-core';
+import { ProcessUploadService } from '../task-list/services/process-upload.service';
 
 @Component({
     selector: 'adf-process-attachment-list',
     styleUrls: ['./process-attachment-list.component.scss'],
-    templateUrl: './process-attachment-list.component.html'
+    templateUrl: './process-attachment-list.component.html',
+    providers: [
+        { provide: UploadService, useClass: ProcessUploadService }
+    ]
 })
 export class ProcessAttachmentListComponent implements OnChanges {
 

--- a/lib/process-services/attachment/task-attachment-list.component.ts
+++ b/lib/process-services/attachment/task-attachment-list.component.ts
@@ -17,13 +17,17 @@
 
 import { ContentService, ThumbnailService } from '@alfresco/adf-core';
 import { AfterViewInit, Component, ElementRef, EventEmitter, Input, NgZone, OnChanges, Output, SimpleChanges, ViewChild, ViewEncapsulation } from '@angular/core';
-import { ProcessContentService } from '@alfresco/adf-core';
+import { ProcessContentService, UploadService } from '@alfresco/adf-core';
+import { ProcessUploadService } from '../task-list/services/process-upload.service';
 
 @Component({
     selector: 'adf-task-attachment-list',
     styleUrls: ['./task-attachment-list.component.scss'],
     templateUrl: './task-attachment-list.component.html',
-    encapsulation: ViewEncapsulation.None
+    encapsulation: ViewEncapsulation.None,
+    providers: [
+        { provide: UploadService, useClass: ProcessUploadService }
+    ]
 })
 export class TaskAttachmentListComponent implements OnChanges, AfterViewInit {
 

--- a/lib/process-services/task-list/services/process-upload.service.ts
+++ b/lib/process-services/task-list/services/process-upload.service.ts
@@ -35,7 +35,11 @@ export class ProcessUploadService extends UploadService {
             isRelatedContent: true
         };
         let taskId = file.options.parentId;
-        return this.instanceApi.getInstance().activiti.contentApi.createRelatedContentOnTask(taskId, file.file, opts).catch(err => this.handleError(err));
+        let promise = this.instanceApi.getInstance().activiti.contentApi.createRelatedContentOnTask(taskId, file.file, opts);
+
+        promise.catch(err => this.handleError(err));
+
+        return promise;
     }
 
     private handleError(error: any) {


### PR DESCRIPTION
…drop area that is not working

**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://issues.alfresco.com/jira/browse/ADF-1711
The <adf-task-attachment-list component displays a list of associated files. If there are no files attached, then a drag-and-drop area is displayed. However, drag-and-drop does not work as there is no backing <adf-upload-drag-area component wrapping the <adf-task-attachmnent-list. Page template config example here.

**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
