### PR TITLE
[ADF-2019] removed refresh button from JSON example form

### DIFF
--- a/demo-shell/src/app/components/form/form.component.html
+++ b/demo-shell/src/app/components/form/form.component.html
@@ -1,4 +1,6 @@
 <div class="form-container">
-    <adf-form [form]="form">
+    <adf-form
+        [showRefreshButton]="false"
+        [form]="form">
     </adf-form>
 </div>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
The whole page is refreshed when clicking refresh form button on fake form example


**What is the new behaviour?**
We removed the button due the fact that there is nothing to refresh into that form 'cause it is loaded always from the same json.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
