### PR TITLE
[ADF-2042] Fixed incorrect property name on Upload Button component docs

### DIFF
--- a/docs/start-process.component.md
+++ b/docs/start-process.component.md
@@ -4,18 +4,6 @@ Displays Start Process, allowing the user to specify some basic details needed t
 
 ![adf-start-process ](docassets/images/startProcess.png)
 
-<!-- markdown-toc start - Don't edit this section.  npm run toc to generate it-->
-
-<!-- toc -->
-
-- [Basic Usage](#basic-usage)
-  * [Properties](#properties)
-  * [Events](#events)
-
-<!-- tocstop -->
-
-<!-- markdown-toc end -->
-
 ## Basic Usage
 
 ```html

--- a/docs/start-task.component.md
+++ b/docs/start-task.component.md
@@ -4,18 +4,6 @@ Creates/Starts new task for the specified app
 
 ![adf-start-task](docassets/images/adf-start-task.png)
 
-<!-- markdown-toc start - Don't edit this section.  npm run toc to generate it-->
-
-<!-- toc -->
-
-- [Basic Usage](#basic-usage)
-  * [Properties](#properties)
-  * [Events](#events)
-
-<!-- tocstop -->
-
-<!-- markdown-toc end -->
-
 ## Basic Usage
 
 ```html

--- a/docs/tag-actions.component.md
+++ b/docs/tag-actions.component.md
@@ -2,17 +2,6 @@
 
 ![Custom columns](docassets/images/tag3.png)
 
-<!-- markdown-toc start - Don't edit this section.  npm run toc to generate it-->
-
-<!-- toc -->
-
-- [Basic Usage](#basic-usage)
-  * [Properties](#properties)
-
-<!-- tocstop -->
-
-<!-- markdown-toc end -->
-
 ## Basic Usage
 
 ```html

--- a/docs/tag-node-list.component.md
+++ b/docs/tag-node-list.component.md
@@ -2,17 +2,6 @@
 
 ![Custom columns](docassets/images/tag1.png)
 
-<!-- markdown-toc start - Don't edit this section.  npm run toc to generate it-->
-
-<!-- toc -->
-
-- [Basic Usage](#basic-usage)
-  * [Properties](#properties)
-
-<!-- tocstop -->
-
-<!-- markdown-toc end -->
-
 ## Basic Usage
 
 ```html

--- a/docs/task-attachment-list.component.md
+++ b/docs/task-attachment-list.component.md
@@ -4,19 +4,6 @@ Displays attached documents on a specified task.
 
 ![task-attachment-list-sample](docassets/images/task-attachment-list.png)
 
-<!-- markdown-toc start - Don't edit this section.  npm run toc to generate it-->
-
-<!-- toc -->
-
-- [Basic Usage](#basic-usage)
-  * [Drag and Drop Functionality](#how-to-add-drag-and-drop-functionality)
-  * [Properties](#properties)
-  * [Events](#events)
-
-<!-- tocstop -->
-
-<!-- markdown-toc end -->
-
 ## Basic Usage
 
 ```html

--- a/docs/task-details.component.md
+++ b/docs/task-details.component.md
@@ -2,20 +2,6 @@
 
 Shows the details of the task id passed in input
 
-<!-- markdown-toc start - Don't edit this section.  npm run toc to generate it-->
-
-<!-- toc -->
-
-- [Basic Usage](#basic-usage)
-  * [Properties](#properties)
-  * [Events](#events)
-- [Details](#details)
-  * [Custom 'empty Activiti Task Details' template](#custom-empty-activiti-task-details-template)
-
-<!-- tocstop -->
-
-<!-- markdown-toc end -->
-
 ## Basic Usage
 
 ```html

--- a/docs/task-filter.service.md
+++ b/docs/task-filter.service.md
@@ -1,4 +1,5 @@
 # Task Filter Service
+
 Manage Task Filters, which are pre-configured Task Instance queries. 
 
 ## Importing

--- a/docs/task-header.component.md
+++ b/docs/task-header.component.md
@@ -4,19 +4,6 @@ Shows all the information related to a task.
 
 ![adf-task-header](docassets/images/adf-task-header.png)
 
-<!-- markdown-toc start - Don't edit this section.  npm run toc to generate it-->
-
-<!-- toc -->
-
-- [Basic Usage](#basic-usage)
-  * [Properties](#properties)
-  * [Events](#events)
-- [Details](#details)
-
-<!-- tocstop -->
-
-<!-- markdown-toc end -->
-
 ## Basic Usage
 
 ```html

--- a/docs/tasklist.service.md
+++ b/docs/tasklist.service.md
@@ -1,4 +1,5 @@
 # Tasklist Service
+
 Manage Task Instances. 
 
 ## Importing

--- a/docs/toolbar-divider.component.md
+++ b/docs/toolbar-divider.component.md
@@ -2,16 +2,6 @@
 
 Divides groups of elements in a Toolbar with a visual separator.
 
-<!-- markdown-toc start - Don't edit this section.  npm run toc to generate it-->
-
-<!-- toc -->
-
-- [Basic Usage](#basic-usage)
-
-<!-- tocstop -->
-
-<!-- markdown-toc end -->
-
 ## Basic Usage
 
 ```html

--- a/docs/toolbar-title.component.md
+++ b/docs/toolbar-title.component.md
@@ -4,17 +4,6 @@ Supplies custom HTML to be included in a Toolbar component title.
 
 ![](docassets/images/adf-toolbar-02.png)
 
-<!-- markdown-toc start - Don't edit this section.  npm run toc to generate it-->
-
-<!-- toc -->
-
-- [Basic Usage](#basic-usage)
-- [Details](#details)
-
-<!-- tocstop -->
-
-<!-- markdown-toc end -->
-
 ## Basic Usage
 
 ```html

--- a/docs/translation.service.md
+++ b/docs/translation.service.md
@@ -2,18 +2,6 @@
 
 Supports localisation.
 
-<!-- markdown-toc start - Don't edit this section.  npm run toc to generate it-->
-
-<!-- toc -->
-
-- [Details](#details)
-  * [Registering translation sources](#registering-translation-sources)
-  * [Switching languages](#switching-languages)
-
-<!-- tocstop -->
-
-<!-- markdown-toc end -->
-
 ## Details
 
 ### Registering translation sources

--- a/docs/upload-button.component.md
+++ b/docs/upload-button.component.md
@@ -1,24 +1,10 @@
 # Upload Button Component
 
-<!-- markdown-toc start - Don't edit this section.  npm run toc to generate it-->
-
-<!-- toc -->
-
-- [Basic Usage](#basic-usage)
-  * [Properties](#properties)
-  * [Events](#events)
-- [Details](#details)
-  * [How to show notification message with no permission](#how-to-show-notification-message-with-no-permission)
-
-<!-- tocstop -->
-
-<!-- markdown-toc end -->
-
 ## Basic Usage
 
 ```html
 <adf-upload-button 
-    [parentId]="-my-"
+    [rootFolderId]="-my-"
     [uploadFolders]="true"
     [multipleFiles]="false"
     [acceptedFilesType]=".jpg,.gif,.png,.svg"
@@ -37,7 +23,7 @@
 | multipleFiles | boolean | false | Allow/disallow multiple files |
 | acceptedFilesType | string | * |  array of allowed file extensions , example: ".jpg,.gif,.png,.svg" |
 | maxFilesSize | number |  |  if defined allow to upload files only with this max file size. the size of a file is in bytes  |
-| parentId | string | empty | The ID of the root. It can be the nodeId if you are using the upload for the Content Service or taskId/processId for the Process Service. |
+| rootFolderId | string | '-root-' | The ID of the root. It can be the nodeId if you are using the upload for the Content Service or taskId/processId for the Process Service. |
 | versioning | boolean | false | Versioning false is the default uploader behaviour and it renames the file using an integer suffix if there is a name clash. Versioning true to indicate that a major version should be created |
 | staticTitle | string | (predefined) | define the text of the upload button |
 | tooltip | string | | Custom tooltip |
@@ -59,7 +45,7 @@ You can subscribe to this event from your component and use the NotificationServ
 
 ```html
 <adf-upload-button
-    [parentId]="currentFolderId"
+    [rootFolderId]="currentFolderId"
     (permissionEvent)="onUploadPermissionFailed($event)">
 </adf-upload-button>
 ```

--- a/docs/upload-drag-area.component.md
+++ b/docs/upload-drag-area.component.md
@@ -2,18 +2,6 @@
 
 Adds a drag and drop area to upload files to Alfresco.
 
-<!-- markdown-toc start - Don't edit this section.  npm run toc to generate it-->
-
-<!-- toc -->
-
-- [Basic Usage](#basic-usage)
-  * [Properties](#properties)
-  * [Events](#events)
-
-<!-- tocstop -->
-
-<!-- markdown-toc end -->
-
 ## Basic Usage
 
 ```html

--- a/docs/upload.service.md
+++ b/docs/upload.service.md
@@ -2,19 +2,6 @@
 
 Provides access to various APIs related to file upload features.
 
-<!-- markdown-toc start - Don't edit this section.  npm run toc to generate it-->
-
-<!-- toc -->
-
-- [Basic Usage](#basic-usage)
-  * [Events](#events)
-- [Details](#details)
-  * [Ignore list configuration](#ignore-list-configuration)
-
-<!-- tocstop -->
-
-<!-- markdown-toc end -->
-
 ## Basic Usage
 
 ### Events

--- a/docs/user-info.component.md
+++ b/docs/user-info.component.md
@@ -1,17 +1,5 @@
 # Alfresco User Info component
 
-<!-- markdown-toc start - Don't edit this section.  npm run toc to generate it-->
-
-<!-- toc -->
-
-- [Basic usage](#basic-usage)
-  * [Properties](#properties)
-- [Details](#details)
-
-<!-- tocstop -->
-
-<!-- markdown-toc end -->
-
 ## Basic usage
 
 ```html

--- a/docs/viewer.component.md
+++ b/docs/viewer.component.md
@@ -169,7 +169,7 @@ You can enable custom "Open With" menu by providing at least one action inside t
         </button>
     </adf-viewer-open-with>
 
-</adv-viewer>
+</adf-viewer>
 ```
 
 ![Open with](docassets/images/viewer-open-with.png)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [x] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Upload button docs showed a "parentId" property which is now obsolete.

**What is the new behaviour?**

The property is now updated to "rootFolderId". Also removed some unnecessary ToCs from other doc files.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
