### PR TITLE
[ADF-1586] Fixed incorrect import declarations in docs

### DIFF
--- a/docs/FormFieldValidator.md
+++ b/docs/FormFieldValidator.md
@@ -10,7 +10,7 @@ Defines how the input fields of [ADF Form](form.component.md) and
 ```
 
 ```ts
-import { FORM_FIELD_VALIDATORS } from 'lib/core/form/components/widgets/core';
+import { FORM_FIELD_VALIDATORS } from '@alfresco/adf-core';
 
 @Component({...})
 export class AppComponent {
@@ -85,7 +85,7 @@ The validator in the example
 below simply checks that "admin" is not entered into a text field:
 
 ```ts
-import { FormFieldModel, FormFieldTypes, FormFieldValidator } from 'lib/core/form/components/widgets/core';
+import { FormFieldModel, FormFieldTypes, FormFieldValidator } from '@alfresco/adf-core';
 
 export class DemoFieldValidator implements FormFieldValidator {
 

--- a/docs/activiti-alfresco.service.md
+++ b/docs/activiti-alfresco.service.md
@@ -20,7 +20,7 @@ And also import it in the way shown below.
 ## Importing
 
 ```ts
-import { ActivitiAlfrescoContentService } from 'lib/core/form/services/activiti-alfresco.service';
+import { ActivitiAlfrescoContentService } from '@alfresco/adf-core';
 
 export class SomePageComponent implements OnInit {
 

--- a/docs/app-config.service.md
+++ b/docs/app-config.service.md
@@ -65,7 +65,7 @@ Below is a simple example of using the AppConfigService in practice.
 **app.component.ts**
 
 ```ts
-import { AppConfigService } from 'lib/core/app-config';
+import { AppConfigService } from '@alfresco/adf-core';
 
 @Component({...})
 export class AppComponent {

--- a/docs/authentication.service.md
+++ b/docs/authentication.service.md
@@ -19,7 +19,7 @@ Provides authentication for use with the Login component.
 **app.component.ts**
 
 ```ts
-import { AuthenticationService } from 'lib/core/services';
+import { AuthenticationService } from '@alfresco/adf-core';
 
 @Component({...})
 export class AppComponent {

--- a/docs/card-view.component.md
+++ b/docs/card-view.component.md
@@ -197,7 +197,7 @@ Your model has to extend the **CardViewBaseItemModel** and implement the **CardV
 *(You can check how the CardViewTextItemModel is implemented for further guidance.)*
 
 ```js
-import { CardViewBaseItemModel, CardViewItem, DynamicComponentModel } from 'lib/core/card-view';
+import { CardViewBaseItemModel, CardViewItem, DynamicComponentModel } from '@alfresco/adf-core';
 
 export class CardViewStarDateItemModel extends CardViewBaseItemModel implements
 CardViewItem, DynamicComponentModel {

--- a/docs/data-column.component.md
+++ b/docs/data-column.component.md
@@ -81,7 +81,7 @@ You can create custom tooltips for the table cells by providing a `formatTooltip
 And the code in this case will be similar to the following:
 
 ```ts
-import { DataColumn, DataRow } from 'lib/core/data-column';
+import { DataColumn, DataRow } from '@alfresco/adf-core';
 
 @Component({...})
 export class MyComponent {

--- a/docs/datatable.component.md
+++ b/docs/datatable.component.md
@@ -45,7 +45,7 @@ See it live: [DataTable Quickstart](https://embed.plnkr.co/80qr4YFBeHjLMdAV0F6l/
 **app.component.ts**
 
 ```ts
-import { ObjectDataTableAdapter }  from 'lib/core/datatable/data';
+import { ObjectDataTableAdapter }  from '@alfresco/adf-core';
 
 @Component({...})
 export class DataTableDemo {
@@ -94,7 +94,7 @@ You can also use HTML-based schema declaration like shown below:
 ```
 
 ```ts
-import { ObjectDataTableAdapter } from 'lib/core/datatable/data';
+import { ObjectDataTableAdapter } from '@alfresco/adf-core';
 
 @Component({...})
 export class DataTableDemo {
@@ -430,7 +430,7 @@ corresponding menu item.
 ```
 
 ```ts
-import { DataCellEvent, DataRowActionEvent } from 'lib/core/datatable/components/datatable';
+import { DataCellEvent, DataRowActionEvent } from '@alfresco/adf-core';
 
 onShowRowActionsMenu(event: DataCellEvent) {
     let myAction = {

--- a/docs/document-actions.service.md
+++ b/docs/document-actions.service.md
@@ -18,7 +18,7 @@ This action will invoke the `myDocumentActionHandler` function each time it is s
 from the Document List menu.
 
 ```ts
-import { DocumentActionsService } from 'lib/content-services/document-list/services';
+import { DocumentActionsService } from '@alfresco/adf-content-services';
 
 export class MyView {
 

--- a/docs/document-list.component.md
+++ b/docs/document-list.component.md
@@ -295,7 +295,7 @@ For the sake of simplicity example below shows only main points you may need to 
 
 ```ts
 import { ChangeDetectorRef } from '@angular/core';
-import { AlfrescoApiService } from 'lib/core/services';
+import { AlfrescoApiService } from '@alfresco/adf-core';
 
 export class FilesComponent implements OnInit {
 
@@ -368,7 +368,7 @@ Note the `#documentList` ID we've just added to be able referencing this compone
 
 ```ts
 import { ViewChild, AfterViewInit } from '@angular/core';
-import { DocumentListComponent } from 'lib/content-services/document-list/components';
+import { DocumentListComponent } from '@alfresco/adf-content-services';
 
 @Component({...})
 export class MyAppComponent implements AfterViewInit {
@@ -624,7 +624,7 @@ _Note that for the sake of simplicity the example code below was reduced to the 
 **View1.component.ts**
 
 ```ts
-import { RowFilter, ShareDataRow } from 'lib/content-services/document-list/data';
+import { RowFilter, ShareDataRow } from '@alfresco/adf-content-services';
 
 export class View1 {
 
@@ -682,8 +682,8 @@ _Note that for the sake of simplicity the example code below was reduced to the 
 **View1.component.ts**
 
 ```ts
-import { DataColumn, DataRow } from 'lib/core/datatable/data';
-import { ImageResolver } from 'lib/content-services/document-list/data';
+import { DataColumn, DataRow } from '@alfresco/adf-core';
+import { ImageResolver } from '@alfresco/adf-content-services';
 
 export class View1 {
 

--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -97,7 +97,7 @@ Every custom widget must inherit `WidgetComponent` class in order to function pr
 
 ```ts
 import { Component } from '@angular/core';
-import { WidgetComponent } from 'lib/core/form/components/widgets';
+import { WidgetComponent } from '@alfresco/adf-core';
 
 @Component({
     selector: 'custom-editor',
@@ -196,7 +196,7 @@ Let's create an Angular 2 component to render missing content:
 
 ```ts
 import { Component } from '@angular/core';
-import { WidgetComponent } from 'lib/core/form/components/widgets';
+import { WidgetComponent } from '@alfresco/adf-core';
 
 @Component({
     selector: 'custom-stencil-01',

--- a/docs/folder-actions.service.md
+++ b/docs/folder-actions.service.md
@@ -18,7 +18,7 @@ This action will invoke the `myFolderActionHandler` function each time it is sel
 from the Document List menu.
 
 ```ts
-import { FolderActionsService } from 'lib/content-services/document-list/services';
+import { FolderActionsService } from '@alfresco/adf-content-services';
 
 export class MyView {
 

--- a/docs/form.component.md
+++ b/docs/form.component.md
@@ -201,7 +201,7 @@ Alternatively you may want just running additional code on outcome execution wit
 **MyView.component.ts**
 
 ```ts
-import { FormOutcomeEvent } from 'lib/core/form/components/widgets/core';
+import { FormOutcomeEvent } from '@alfresco/adf-core';
 
 export class MyView {
 

--- a/docs/form.service.md
+++ b/docs/form.service.md
@@ -5,8 +5,7 @@ Implements Process Services form methods
 ## Basic Usage
 
 ```ts
-import { FormService } from 'lib/core/form/services';
-import { FormEvent, FormFieldEvent } from 'lib/core/form/events';
+import { FormService, FormEvent, FormFieldEvent } from '@alfresco/adf-core';
 
 @Component(...)
 class MyComponent {

--- a/docs/log.service.md
+++ b/docs/log.service.md
@@ -7,7 +7,7 @@ Provide a log functionality for your ADF application.
 **app.component.ts**
 
 ```ts
-import { LogService } from 'lib/core/services';
+import { LogService } from '@alfresco/adf-core';
 
 @Component({...})
 export class AppComponent {

--- a/docs/node-permission.directive.md
+++ b/docs/node-permission.directive.md
@@ -80,7 +80,7 @@ When designing a component you want to work this directive with, you have two im
 The component has to implement the NodePermissionSubject interface which basically means it has to have a boolean **disabled** property. This is the property which will be set by the directive.
 
 ```js
-import { NodePermissionSubject } from 'lib/core/directives';
+import { NodePermissionSubject } from '@alfresco/adf-core';
 
 @Component({...})
 export class UploadDragAreaComponent implements NodePermissionSubject {
@@ -98,7 +98,7 @@ The directive will look up the component in the dependency injection tree, up to
 - because of the emphasized second sentence you have to provide your component as a viewProvider.
 
 ```js
-import { EXTENDIBLE_COMPONENT } from 'lib/core/interface';
+import { EXTENDIBLE_COMPONENT } from '@alfresco/adf-core';
 
 @Component({
     ...

--- a/docs/nodes-api.service.md
+++ b/docs/nodes-api.service.md
@@ -101,7 +101,7 @@ use the Nodes Api service to "decode" the ID string into a MinimalNodeEntryEntit
 ```ts
 import { ActivatedRoute, Router } from '@angular/router';
 import { Component, OnInit } from '@angular/core';
-import { NodesApiService } from 'lib/core/services';
+import { NodesApiService } from '@alfresco/adf-core';
 import { MinimalNodeEntryEntity } from 'alfresco-js-api';
     ...
 

--- a/docs/notification.service.md
+++ b/docs/notification.service.md
@@ -18,7 +18,7 @@ The Notification Service is implemented on top of the Angular 2 Material Design 
 Use this service to show a notification message, and optionally get feedback from it.
 
 ```ts
-import { NotificationService } from 'lib/core/services';
+import { NotificationService } from '@alfresco/adf-core';
 
 export class MyComponent implements OnInit {
 
@@ -34,7 +34,7 @@ export class MyComponent implements OnInit {
 ```
 
 ```ts
-import { NotificationService } from 'lib/core/services';
+import { NotificationService } from '@alfresco/adf-core';
 
 export class MyComponent implements OnInit {
 

--- a/docs/translation.service.md
+++ b/docs/translation.service.md
@@ -12,7 +12,7 @@ and register its parent `i18n` folder with your component or application module.
 For example:
 
 ```ts
-import { TRANSLATION_PROVIDER } from 'lib/core/services';
+import { TRANSLATION_PROVIDER } from '@alfresco/adf-core';
 
 @NgModule({
     ...

--- a/docs/user-preferences.service.md
+++ b/docs/user-preferences.service.md
@@ -9,7 +9,7 @@ The preferences are bound to a particular `prefix` so the application can switch
 For example upon login you can set the `prefix` as current username:
 
 ```ts
-import { UserPreferencesService, AuthenticationService } from 'lib/core/services';
+import { UserPreferencesService, AuthenticationService } from '@alfresco/adf-core';
 
 @Component({...})
 class AppComponent {

--- a/docs/widget.component.md
+++ b/docs/widget.component.md
@@ -6,7 +6,7 @@ Base class for standard and custom widget classes.
 
 ```ts
 import { Component } from '@angular/core';
-import { WidgetComponent } from 'lib/core/form/components/widgets';
+import { WidgetComponent } from '@alfresco/adf-core';
 
 @Component({
     selector: 'custom-editor',


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [x] Documentation
> - [ ] Other... Please describe:


**What is the new behaviour?**

Fix for an earlier PR that used path-style notation in import lines (eg, "lib/core/services") when they should have had the package notation ("@alfresco/adf-core"). Fortunately, Martin spotted my mistake :-) 

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
