### PR TITLE
[ADF-2048] Removed form stencils page from User Guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,6 @@ to the appropriate source file.
 
 <!-- guide start -->
 - [Form Extensibility and Customisation](extensibility.md)
-- [Form Stencils](stencils.md)
 - [Angular Material Design](angular-material-design.md)
 - [Theming](theming.md)
 - [Typography](typography.md)
@@ -119,9 +118,7 @@ for more information about installing and using the source code.
 - [People content service](people-content.service.md)
 - [People process service](people-process.service.md)
 - [Renditions service](renditions.service.md)
-- [Search api service](search-api.service.md)
 - [Shared links api service](shared-links-api.service.md)
-- [Sites api service](sites.service.md)
 - [Storage service](storage.service.md)
 - [Thumbnail service](thumbnail.service.md)
 - [Translation service](translation.service.md)
@@ -129,6 +126,7 @@ for more information about installing and using the source code.
 - [User preferences service](user-preferences.service.md)
 - [Bpm user service](bpm-user.service.md)
 - [Ecm user service](ecm-user.service.md)
+- [*Sites service](../lib/core/services/sites.service.ts)
 
 ### Widgets
 
@@ -247,6 +245,7 @@ for more information about installing and using the source code.
 - [Process service](process.service.md)
 - [Task filter service](task-filter.service.md)
 - [Tasklist service](tasklist.service.md)
+- [*Task upload service](../lib/process-services/task-list/services/task-upload.service.ts)
 <!-- process-services end -->
 
 [(Back to Contents)](#contents)

--- a/docs/summary.json
+++ b/docs/summary.json
@@ -1,6 +1,5 @@
 [
     { "title": "Form Extensibility and Customisation", "file": "extensibility.md" },
-    { "title": "Form Stencils", "file": "stencils.md" },
     { "title": "Angular Material Design", "file": "angular-material-design.md" },
     { "title": "Theming", "file": "theming.md" },
     { "title": "Typography", "file": "typography.md" },


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [x] Documentation
> - [ ] Other... Please describe:


**What is the new behaviour?**

Removed the Form Stencils page from the User Guide index (Ole believes that it doesn't work properly with 2.0, so we should remove it for release and fix later).

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
