### PR TITLE
[ADF-1752] disable completely sidebar when allowSidebar option is false

### DIFF
--- a/lib/core/viewer/components/viewer.component.html
+++ b/lib/core/viewer/components/viewer.component.html
@@ -103,7 +103,7 @@
 
         <div *ngIf="!isLoading" fxLayout="row" fxFlex="1 1 auto">
 
-            <ng-container *ngIf="showSidebar">
+            <ng-container *ngIf="allowSidebar && showSidebar">
                 <div class="adf-viewer__sidebar" fxFlexOrder="{{sidebarPosition === 'left'? 1: 2 }}">
                     <ng-container *ngIf="sidebarTemplate">
                         <ng-container *ngTemplateOutlet="sidebarTemplate;context:sidebarTemplateContext"></ng-container>

--- a/lib/core/viewer/components/viewer.component.spec.ts
+++ b/lib/core/viewer/components/viewer.component.spec.ts
@@ -112,7 +112,7 @@ class ViewerWithCustomOpenWithComponent {}
 })
 class ViewerWithCustomMoreActionsComponent {}
 
-describe('ViewerComponent', () => {
+fdescribe('ViewerComponent', () => {
 
     let component: ViewerComponent;
     let fixture: ComponentFixture<ViewerComponent>;
@@ -208,8 +208,18 @@ describe('ViewerComponent', () => {
         expect(customElement.querySelector('.adf-viewer-container-more-actions')).toBeDefined();
     });
 
+    it('should NOT display sidebar if is not allowed', () => {
+        component.showSidebar = true;
+        component.allowSidebar = false;
+        component.sidebarPosition = 'left';
+        fixture.detectChanges();
+        let sidebar = element.querySelector('.adf-viewer__sidebar');
+        expect(sidebar).toBeNull();
+    });
+
     it('should display sidebar on the left side', () => {
         component.showSidebar = true;
+        component.allowSidebar = true;
         component.sidebarPosition = 'left';
         fixture.detectChanges();
         let sidebar = element.querySelector('.adf-viewer__sidebar');
@@ -218,6 +228,7 @@ describe('ViewerComponent', () => {
 
     it('should display sidebar on the right side', () => {
         component.showSidebar = true;
+        component.allowSidebar = true;
         component.sidebarPosition = 'right';
         fixture.detectChanges();
         let sidebar = element.querySelector('.adf-viewer__sidebar');
@@ -226,6 +237,7 @@ describe('ViewerComponent', () => {
 
     it('should display sidebar on the right side as fallback', () => {
         component.showSidebar = true;
+        component.allowSidebar = true;
         component.sidebarPosition = 'unknown-value';
         fixture.detectChanges();
         let sidebar = element.querySelector('.adf-viewer__sidebar');


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

setting showSidebar to true will show the sidebar even when the allowSidebar option is false

**What is the new behaviour?**
showSidebar option has no effect if allowSidebar is false


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
