### PR TITLE
[ADF-2048] Fixed corrupted link in User Guide

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ to the appropriate source file.
 - [Angular Material Design](angular-material-design.md)
 - [Theming](theming.md)
 - [Typography](typography.md)
-- [Walkthrough: adding indicators to highlight information about a node](metadata-indicators.md)
+- [Walkthrough - adding indicators to highlight information about a node](metadata-indicators.md)
 
 <!-- guide end -->
 [(Back to Contents)](#contents)

--- a/docs/summary.json
+++ b/docs/summary.json
@@ -3,5 +3,5 @@
     { "title": "Angular Material Design", "file": "angular-material-design.md" },
     { "title": "Theming", "file": "theming.md" },
     { "title": "Typography", "file": "typography.md" },
-    { "title": "Walkthrough: adding indicators to highlight information about a node", "file": "metadata-indicators.md" }
+    { "title": "Walkthrough - adding indicators to highlight information about a node", "file": "metadata-indicators.md" }
 ]


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Link to Metadata Indicators Walkthrough page in user guide gets corrupted when processed by Compodoc (it uses the title as the filename and chokes on the colon character).

**What is the new behaviour?**

Replaced the colon with a dash and Compodoc now processes it correctly.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
