### PR TITLE
[ADF-1769] Added script to generate props tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ src/environments/
 package-lock.*
 /ng2-components/ng2-alfresco-core/prebuilt-themes/
 .ng_pkg_build/
+docs/documentation.json

--- a/docs/data-column.component.md
+++ b/docs/data-column.component.md
@@ -7,7 +7,7 @@ Defines column properties for DataTable, Tasklist, Document List and other compo
 <!-- toc -->
 
 - [Basic Usage](#basic-usage)
-  * [Properties and events](#properties-and-events)
+  * [Properties](#properties)
 - [Details](#details)
   * [Automatic column header translation](#automatic-column-header-translation)
   * [Custom tooltips](#custom-tooltips)
@@ -35,12 +35,19 @@ Defines column properties for DataTable, Tasklist, Document List and other compo
 </adf-datatable>
 ```
 
-### Properties and events
-
 <!-- propsection start -->
-See the documentation comments in the
-[source file](../lib/core/data-column/data-column.component.ts)
-for full descriptions of properties and events.
+### Properties
+
+| Name | Type | Default value | Description |
+| -- | -- | -- | -- |
+| class | string |  | <p>Additional CSS class to be applied to column (header and cells) </p> |
+| format | string |  | <p>Value format (if supported by components), for example format of the date </p> |
+| formatTooltip | Function |  | <p>Custom tooltip formatter function. </p> |
+| key | string |  | <p>Data source key, can be either column/property key like <code>title</code> or property path like <code>createdBy.name</code></p> |
+| sortable | boolean | true | <p>Toggles ability to sort by this column, for example by clicking the column header </p> |
+| sr-title | string |  | <p>Title to be used for screen readers. </p> |
+| title | string | '' | <p>Display title of the column, typically used for column headers. You can use the i18n resouce key to get it translated automatically.</p> |
+| type | string | 'text' | <p>Value type for the column. Possible settings are &#39;text&#39;, &#39;image&#39;, &#39;date&#39;, &#39;fileSize&#39; and &#39;location&#39;.</p> |
 <!-- propsection end -->
 
 ## Details

--- a/docs/data-column.component.md
+++ b/docs/data-column.component.md
@@ -7,7 +7,7 @@ Defines column properties for DataTable, Tasklist, Document List and other compo
 <!-- toc -->
 
 - [Basic Usage](#basic-usage)
-  * [Properties](#properties)
+  * [Properties and events](#properties-and-events)
 - [Details](#details)
   * [Automatic column header translation](#automatic-column-header-translation)
   * [Custom tooltips](#custom-tooltips)
@@ -35,19 +35,13 @@ Defines column properties for DataTable, Tasklist, Document List and other compo
 </adf-datatable>
 ```
 
-### Properties
+### Properties and events
 
-| Name | Type | Default | Description |
-| --- | --- | --- | --- |
-| key | string | | Data source key, can be either column/property key like `title` or property path like `createdBy.name` |
-| type | string | text | Value type for the column. Possible settings are 'text', 'image', 'date', 'fileSize' and 'location'. |
-| format | string | | Value format (if supported by components), for example format of the date |
-| sortable | boolean | true | Toggles ability to sort by this column, for example by clicking the column header |
-| title | string | | Display title of the column, typically used for column headers. You can use the i18n resouce key to get it translated automatically. |
-| template | `TemplateRef` | | Custom column template |
-| sr-title | string | | Screen reader title, used for accessibility purposes |
-| class | string | | Additional CSS class to be applied to column (header and cells) |
-| formatTooltip | Function | | Custom tooltip formatter function. |
+<!-- propsection start -->
+See the documentation comments in the
+[source file](../lib/core/data-column/data-column.component.ts)
+for full descriptions of properties and events.
+<!-- propsection end -->
 
 ## Details
 

--- a/docs/datatable.component.md
+++ b/docs/datatable.component.md
@@ -11,15 +11,14 @@ See it live: [DataTable Quickstart](https://embed.plnkr.co/80qr4YFBeHjLMdAV0F6l/
 <!-- toc -->
 
 - [Basic usage](#basic-usage)
-  * [Properties](#properties)
-  * [Events](#events)
+  * [Properties and events](#properties-and-events)
 - [Details](#details)
   * [Supplying data for the table](#supplying-data-for-the-table)
   * [Customizing columns](#customizing-columns)
   * [DataTable DOM Events](#datatable-dom-events)
   * [Custom Empty content template](#custom-empty-content-template)
   * [Loading content template](#loading-content-template)
-  * [Events](#events-1)
+  * [Events](#events)
     + [row-keyup DOM event](#row-keyup-dom-event)
     + [rowClick event](#rowclick-event)
     + [rowDblClick event](#rowdblclick-event)
@@ -124,34 +123,13 @@ export class DataTableDemo {
 }
 ```
 
-### Properties
+### Properties and events
 
-| Name | Type | Default | Description |
-| --- | --- | --- | --- |
-| selectionMode | string | 'single' | Row selection mode. Can be none, `single` or `multiple`. For `multiple` mode you can use Cmd (macOS) or Ctrl (Win) modifier key to toggle selection for multiple rows.  |
-| rowStyle | string | | The inline style to apply to every row, see [NgStyle](https://angular.io/docs/ts/latest/api/common/index/NgStyle-directive.html) docs for more details and usage examples |
-| rowStyleClass | string | | The CSS class to apply to every row |
-| data | DataTableAdapter | instance of **ObjectDataTableAdapter** | data source |
-| rows | Object[] | [] | The rows that the datatable should show |
-| multiselect | boolean | false | Toggles multiple row selection, renders checkboxes at the beginning of each row |
-| actions | boolean | false | Toggles data actions column |
-| actionsPosition | string (left\|right) | right | Position of the actions dropdown menu. | 
-| fallbackThumbnail | string |  | Fallback image for row where thumbnail is missing|
-| contextMenu | boolean | false | Toggles custom context menu for the component |
-| allowDropFiles | boolean | false | Toggle file drop support for rows (see **ng2-alfresco-core/UploadDirective** for more details) |
-| loading | boolean | false | Flag that indicates if the datatable is in loading state and needs to show the loading template. Read the documentation above to see how to configure a loading template  |
-| showHeader | boolean | true | Toggles header visibility |
-| selection | DataRow[] | [] | Contains selected rows |
-
-### Events
-
-| Name | Description
-| --- | --- |
-| [rowClick](#rowclick-event) | Emitted when user clicks the row |
-| [rowDblClick](#rowdblclick-event) | Emitted when user double-clicks the row |
-| [showRowContextMenu](#showrowcontextmenu-event) | Emitted before context menu is displayed for a row |
-| [showRowActionsMenu](#showrowactionsmenu-event) | Emitted before actions menu is displayed for a row |
-| [executeRowAction](#executerowaction-event) | Emitted when row action is executed by user |
+<!-- propsection start -->
+See the documentation comments in the
+[source file](../lib/core/datatable/components/datatable/datatable.component.ts)
+for full descriptions of properties and events.
+<!-- propsection end -->
 
 ## Details
 

--- a/docs/datatable.component.md
+++ b/docs/datatable.component.md
@@ -11,14 +11,15 @@ See it live: [DataTable Quickstart](https://embed.plnkr.co/80qr4YFBeHjLMdAV0F6l/
 <!-- toc -->
 
 - [Basic usage](#basic-usage)
-  * [Properties and events](#properties-and-events)
+  * [Properties](#properties)
+  * [Events](#events)
 - [Details](#details)
   * [Supplying data for the table](#supplying-data-for-the-table)
   * [Customizing columns](#customizing-columns)
   * [DataTable DOM Events](#datatable-dom-events)
   * [Custom Empty content template](#custom-empty-content-template)
   * [Loading content template](#loading-content-template)
-  * [Events](#events)
+  * [Events](#events-1)
     + [row-keyup DOM event](#row-keyup-dom-event)
     + [rowClick event](#rowclick-event)
     + [rowDblClick event](#rowdblclick-event)
@@ -123,13 +124,34 @@ export class DataTableDemo {
 }
 ```
 
-### Properties and events
+### Properties
 
-<!-- propsection start -->
-See the documentation comments in the
-[source file](../lib/core/datatable/components/datatable/datatable.component.ts)
-for full descriptions of properties and events.
-<!-- propsection end -->
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| selectionMode | string | 'single' | Row selection mode. Can be none, `single` or `multiple`. For `multiple` mode you can use Cmd (macOS) or Ctrl (Win) modifier key to toggle selection for multiple rows.  |
+| rowStyle | string | | The inline style to apply to every row, see [NgStyle](https://angular.io/docs/ts/latest/api/common/index/NgStyle-directive.html) docs for more details and usage examples |
+| rowStyleClass | string | | The CSS class to apply to every row |
+| data | DataTableAdapter | instance of **ObjectDataTableAdapter** | data source |
+| rows | Object[] | [] | The rows that the datatable should show |
+| multiselect | boolean | false | Toggles multiple row selection, renders checkboxes at the beginning of each row |
+| actions | boolean | false | Toggles data actions column |
+| actionsPosition | string (left\|right) | right | Position of the actions dropdown menu. | 
+| fallbackThumbnail | string |  | Fallback image for row where thumbnail is missing|
+| contextMenu | boolean | false | Toggles custom context menu for the component |
+| allowDropFiles | boolean | false | Toggle file drop support for rows (see **ng2-alfresco-core/UploadDirective** for more details) |
+| loading | boolean | false | Flag that indicates if the datatable is in loading state and needs to show the loading template. Read the documentation above to see how to configure a loading template  |
+| showHeader | boolean | true | Toggles header visibility |
+| selection | DataRow[] | [] | Contains selected rows |
+
+### Events
+
+| Name | Description
+| --- | --- |
+| [rowClick](#rowclick-event) | Emitted when user clicks the row |
+| [rowDblClick](#rowdblclick-event) | Emitted when user double-clicks the row |
+| [showRowContextMenu](#showrowcontextmenu-event) | Emitted before context menu is displayed for a row |
+| [showRowActionsMenu](#showrowactionsmenu-event) | Emitted before actions menu is displayed for a row |
+| [executeRowAction](#executerowaction-event) | Emitted when row action is executed by user |
 
 ## Details
 

--- a/docs/document-list.component.md
+++ b/docs/document-list.component.md
@@ -9,9 +9,10 @@ Displays the documents from a repository.
 <!-- toc -->
 
 - [Basic Usage](#basic-usage)
-  * [Properties and events](#properties-and-events)
-- [Details](#details)
   * [Properties](#properties)
+  * [Events](#events)
+- [Details](#details)
+  * [Properties](#properties-1)
   * [DOM Events](#dom-events)
   * [Pagination strategy](#pagination-strategy)
   * [Data Sources](#data-sources)
@@ -48,12 +49,50 @@ Displays the documents from a repository.
 </adf-document-list>
 ```
 
-### Properties and events
-
 <!-- propsection start -->
-See the documentation comments in the
-[source file](../lib/content-services/document-list/components/document-list.component.ts)
-for full descriptions of properties and events.
+### Properties
+
+| Name | Type | Default value | Description |
+| -- | -- | -- | -- |
+| allowDropFiles | boolean | false | <p>Toggle file drop support for rows (see UploadDirective for more details) </p> |
+| contentActions | boolean | false | <p>Toggles content actions for each row </p> |
+| contentActionsPosition | string | 'right' | <p>Position of the content actions dropdown menu (can be &#39;left&#39; or &#39;right&#39;) </p> |
+| contextMenuActions | boolean | false | <p>Toggles context menus for each row </p> |
+| currentFolderId | string | null | <p>The ID of the folder node to display or a reserved string alias for special sources </p> |
+| emptyFolderImageUrl | string | './assets/images/empty_doc_lib.svg' | <p>Custom image for empty folder </p> |
+| enableInfiniteScrolling | boolean | false | <p>Enable infinite scrolling mode </p> |
+| folderNode | MinimalNodeEntryEntity | null | <p>Currently displayed folder node </p> |
+| imageResolver | any | null | null | <p>Custom image resolver </p> |
+| loading | boolean | false | <p>Toggles the loading state and animated spinners for the component. Used in combination with <code>navigate=false</code> to perform custom navigation and loading state
+indication.</p> |
+| locationFormat | string | '/' | <p>The default route for all the location-based columns (if declared). </p> |
+| maxItems | number |  | <p>The page size for the document list </p> |
+| multiselect | boolean | false | <p>Toggles multiselect mode </p> |
+| navigate | boolean | true | <p>Toggles navigation to folder content or file preview </p> |
+| navigationMode | string | DocumentListComponent.DOUBLE_CLICK_NAVIGATION | <p>User interaction for folder navigation or file preview </p> |
+| node | NodePaging | null | <p>DocumentList will show all the nodes contained in the NodePaging entity </p> |
+| permissionsStyle | PermissionStyleModel[] | [] | <p>Define a set of CSS styles to apply depending on the permission of the user on that node.</p> |
+| rowFilter | any | null | null | <p>Custom row filter </p> |
+| rowStyle | string |  | <p>The inline style to apply to every row, see <a href="https://angular.io/docs/ts/latest/api/common/index/NgStyle-directive.html">NgStyle</a>
+docs for more details and usage examples</p> |
+| rowStyleClass | string |  | <p>CSS class to apply to every row </p> |
+| selectionMode | string | 'single' | <p>Row selection mode. Can be none, <code>single</code> or <code>multiple</code>. For <code>multiple</code> mode you can use Cmd (macOS) or Ctrl (Win) modifier keys to toggle
+selection of multiple rows.</p> |
+| skipCount | number | 0 | <p>The start offset of the current page&#39;s first item (for pagination purposes) </p> |
+| sorting | string[] |  | <p>Defines default sorting. The format is an array of 2 strings <code>[key, direction]</code> i.e. <code>[&#39;name&#39;, &#39;desc&#39;]</code> or <code>[&#39;name&#39;, &#39;asc&#39;]</code>. Set this value only if you want
+to override default sorting detected by the component based on columns.</p> |
+| thumbnails | boolean | false | <p>Show document thumbnails rather than icons </p> |
+
+### Events
+
+| Name | Type | Description |
+| -- | -- | -- |
+| error | EventEmitter<any> | <p>Emitted when the API fails to get the data for the DocumentList </p> |
+| folderChange | EventEmitter<NodeEntryEvent> | <p>Emitted when the current display folder changes </p> |
+| nodeClick | EventEmitter<NodeEntityEvent> | <p>Emitted when the user clicks a list node </p> |
+| nodeDblClick | EventEmitter<NodeEntityEvent> | <p>Emitted when the user double-clicks a list node </p> |
+| preview | EventEmitter<NodeEntityEvent> | <p>Emitted when the user acts upon files with either single or double click (depends on <code>navigation-mode</code>). Useful integration with the Viewer Component.</p> |
+| ready | EventEmitter<NodePaging> | <p>Emitted when the DocumentList is ready and has loaded all the elements </p> |
 <!-- propsection end -->
 
 ## Details

--- a/docs/document-list.component.md
+++ b/docs/document-list.component.md
@@ -9,9 +9,9 @@ Displays the documents from a repository.
 <!-- toc -->
 
 - [Basic Usage](#basic-usage)
-  * [Properties](#properties)
-  * [Events](#events)
+  * [Properties and events](#properties-and-events)
 - [Details](#details)
+  * [Properties](#properties)
   * [DOM Events](#dom-events)
   * [Pagination strategy](#pagination-strategy)
   * [Data Sources](#data-sources)
@@ -30,6 +30,7 @@ Displays the documents from a repository.
   * [Custom row filter](#custom-row-filter)
   * [Custom image resolver](#custom-image-resolver)
   * [Custom 'empty folder' template](#custom-empty-folder-template)
+  * [Custom 'permission denied' template](#custom-permission-denied-template)
 - [See also](#see-also)
 
 <!-- tocstop -->
@@ -47,50 +48,19 @@ Displays the documents from a repository.
 </adf-document-list>
 ```
 
-### Properties
+### Properties and events
 
-The properties currentFolderId, folderNode and node are the entry initialization properties of the document list. They cannot be used together, choose the one that suites more your use case.
-
-| Name | Type | Default | Description |
-| --- | --- | --- | --- |
-| permissionsStyle | [PermissionStyleModel[]](permissions-style.model.md) | null | Define a set of CSS styles styles to apply depending on the permission of the user on that node. See the [Permission Style model](permissions-style.model.md) page for further details and examples. | 
-| locationFormat | string | '/' | The default route for all the location-based columns (if declared). |
-| navigate | boolean | true | Toggles navigation to folder content or file preview |
-| navigationMode | string (click,dblclick) | dblclick | User interaction for folder navigation or file preview |
-| thumbnails | boolean | false | Show document thumbnails rather than icons |
-| selectionMode | string | 'single' | Row selection mode. Can be none, `single` or `multiple`. For `multiple` mode you can use Cmd (macOS) or Ctrl (Win) modifier key to toggle selection for multiple rows.  |
-| multiselect | boolean | false | Toggles multiselect mode |
-| contentActions | boolean | false | Toggles content actions for each row |
-| contentActionsPosition | string (left\|right) | right | Position of the content actions dropdown menu. |
-| contextMenuActions | boolean | false | Toggles context menus for each row |
-| emptyFolderImageUrl | string | assets/images/empty_doc_lib.svg | Custom image for empty folder |
-| allowDropFiles | boolean | false | Toggle file drop support for rows (see **ng2-alfresco-core/UploadDirective** for more details) |
-| sorting | string[] | | Defines default sorting. The format is an array of 2 strings `[key, direction]` i.e. `['name', 'desc']` or `['name', 'asc']`. Set this value only if you want to override default sorting detected by the component based on columns. |
-| rowStyle | string | | The inline style to apply to every row, see [NgStyle](https://angular.io/docs/ts/latest/api/common/index/NgStyle-directive.html) docs for more details and usage examples |
-| rowStyleClass | string | | The CSS class to apply to every row |
-| loading | boolean | false | Toggles the loading state and animated spinners for the component. Used in combination with `navigate=false` to perform custom navigation and loading state indication. |
-| rowFilter | `RowFilter` | | Custom row filter, [see more](#custom-row-filter). |
-| imageResolver | `ImageResolver` | | Custom image resolver, [see more](#custom-image-resolver). |
-| currentFolderId | string | null | The ID of the folder node to display or a reserved string alias for special sources (see **Data Sources**) |
-| folderNode | [MinimalNodeEntryEntity](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/NodeMinimalEntry.md) | null | Currently displayed folder node | 
-| node | [NodePaging](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/NodePaging.md) | null | Document list will show all the nodes contained in the NodePaging entity  | 
-| maxItems | number | Default value is stored into user preference settings | determine the size of the page for the element into document list |
-| skipCount | number | 0 | element to skip over for pagination purpose |
-| enableInfiniteScrolling | boolean | true | Enable documentlist to work into infinite scrolling mode |
-
-### Events
-
-| Name | Description |
-| --- | --- |
-| nodeClick | emitted when user clicks a list node |
-| nodeDblClick | emitted when user double-clicks list node |
-| folderChange | emitted once current display folder has changed |
-| preview | emitted when user acts upon files with either single or double click (depends on `navigation-mode`), recommended for Viewer components integration  |
-| permissionError | emitted when user is attempting to create a folder via action menu without having the permission to do it |
-| ready | emitted when the documentList is ready and loads all the elements|
-| error | emitted when API fails to get documentList data|
+<!-- propsection start -->
+See the documentation comments in the
+[source file](../lib/content-services/document-list/components/document-list.component.ts)
+for full descriptions of properties and events.
+<!-- propsection end -->
 
 ## Details
+
+### Properties
+
+The properties `currentFolderId`, `folderNode` and `node` are the entry initialization properties of the document list. They cannot be used together, so choose the one that best suits your use case.
 
 ### DOM Events
 

--- a/docs/form.component.md
+++ b/docs/form.component.md
@@ -1,15 +1,15 @@
-# Activiti Form component
+# Form component
 
-The component shows a Form from Activiti (see it live: [Form Quickstart](https://embed.plnkr.co/YSLXTqb3DtMhVJSqXKkE/))
+Shows a Process Services form.
+
+(See it live: [Form Quickstart](https://embed.plnkr.co/YSLXTqb3DtMhVJSqXKkE/))
 
 <!-- markdown-toc start - Don't edit this section.  npm run toc to generate it-->
 
 <!-- toc -->
 
 - [Basic Usage](#basic-usage)
-  * [Properties](#properties)
-  * [Advanced properties](#advanced-properties)
-  * [Events](#events)
+  * [Properties and events](#properties-and-events)
 - [Details](#details)
   * [Custom empty form template](#custom-empty-form-template)
   * [Controlling outcome execution behaviour](#controlling-outcome-execution-behaviour)
@@ -101,48 +101,13 @@ and store the form field as metadata. The param nameNode is optional.
 </adf-form>
 ```
 
-### Properties
+### Properties and events
 
-| Name | Type | Default | Description |
-| --- | --- | --- | --- |
-| taskId | string | | Task id to fetch corresponding form and values. |
-| formId | string | | The id of the form definition to load and display with custom values. |
-| formName | string | | Name of the form definition to load and display with custom values. |
-| data | FormValues | | Custom form values map to be used with the rendered form. |
-| showTitle | boolean | true | Toggle rendering of the form title. |
-| showCompleteButton | boolean | true | Toggle rendering of the `Complete` outcome button. |
-| disableCompleteButton | boolean | false | The `Complete` outcome button is shown but it will be disabled. |
-| disableStartProcessButton | boolean | false | The `Start Process` outcome button is shown but it will be disabled. |
-| showSaveButton | boolean | true | Toggle rendering of the `Save` outcome button. |
-| readOnly | boolean | false | Toggle readonly state of the form. Enforces all form widgets render readonly if enabled. |
-| showRefreshButton | boolean | true | Toggle rendering of the `Refresh` button. |
-| showValidationIcon | boolean | true | Toggle rendering of the validation icon next form title. |
-| saveMetadata | boolean | false | Store the value of the form as metadata. |
-| path | string |  |  Path of the folder where to store the metadata. |
-| nameNode | string | true | Name to assign to the new node where the metadata are stored. |
-| fieldValidators | FormFieldValidator[] | See [Field Validators](#field-validators) section below | Contains a list of form field validator instances. |
-
-### Advanced properties
-
- The following properties are for complex customisation purposes:
-
-| Name | Type | Default | Description |
-| --- | --- | --- | --- |
-| form | FormModel | | Underlying form model instance. |
-| showDebugButton | boolean | false | Toggle debug options. |
-| debugMode | boolean | false | Toggle debug mode, allows displaying additional data for development and debugging purposes. |
-
-### Events
-
-| Name |  Return Type | Description |
-| --- | --- | --- |
-| formLoaded | [FormModel](https://github.com/Alfresco/alfresco-ng2-components/blob/master/ng2-components/ng2-activiti-form/src/components/widgets/core/form.model.ts) | Invoked when form is loaded or reloaded. |
-| formSaved | [FormModel](https://github.com/Alfresco/alfresco-ng2-components/blob/master/ng2-components/ng2-activiti-form/src/components/widgets/core/form.model.ts)  | Invoked when form is submitted with `Save` or custom outcomes.  |
-| formCompleted | [FormModel](https://github.com/Alfresco/alfresco-ng2-components/blob/master/ng2-components/ng2-activiti-form/src/components/widgets/core/form.model.ts)  | Invoked when form is submitted with `Complete` outcome.  |
-| formDataRefreshed | [FormModel](https://github.com/Alfresco/alfresco-ng2-components/blob/master/ng2-components/ng2-activiti-form/src/components/widgets/core/form.model.ts) | Invoked when form values are refreshed due to a data property change  |
-| executeOutcome | [FormOutcomeEvent](https://github.com/Alfresco/alfresco-ng2-components/blob/master/ng2-components/ng2-activiti-form/src/components/widgets/core/form-outcome-event.model.ts) | Invoked when any outcome is executed, default behaviour can be prevented via `event.preventDefault()` |
-| error | any | Invoked at any error |
-
+<!-- propsection start -->
+See the documentation comments in the
+[source file](../lib/core/form/components/form.component.ts)
+for full descriptions of properties and events.
+<!-- propsection end -->
 ## Details
 
 All `form*` events receive an instance of the `FormModel` as event argument for ease of development:

--- a/docs/form.component.md
+++ b/docs/form.component.md
@@ -9,7 +9,8 @@ Shows a Process Services form.
 <!-- toc -->
 
 - [Basic Usage](#basic-usage)
-  * [Properties and events](#properties-and-events)
+  * [Properties](#properties)
+  * [Events](#events)
 - [Details](#details)
   * [Custom empty form template](#custom-empty-form-template)
   * [Controlling outcome execution behaviour](#controlling-outcome-execution-behaviour)
@@ -101,13 +102,44 @@ and store the form field as metadata. The param nameNode is optional.
 </adf-form>
 ```
 
-### Properties and events
-
 <!-- propsection start -->
-See the documentation comments in the
-[source file](../lib/core/form/components/form.component.ts)
-for full descriptions of properties and events.
+### Properties
+
+| Name | Type | Default value | Description |
+| -- | -- | -- | -- |
+| data | FormValues |  | <p>Custom form values map to be used with the rendered form. </p> |
+| disableCompleteButton | boolean | false | <p>Toggles whether the <code>Complete</code> outcome button is disabled (but still shown). </p> |
+| disableStartProcessButton | boolean | false | <p>Toggles whether the <code>Start Process</code> outcome button is disabled (but still shown). </p> |
+| fieldValidators | FormFieldValidator[] | [] | <p>Contains a list of form field validator instances. </p> |
+| form | FormModel |  | <p>Underlying form model instance. </p> |
+| formId | string |  | <p>The id of the form definition to load and display with custom values. </p> |
+| formName | string |  | <p>Name of the form definition to load and display with custom values. </p> |
+| nameNode | string |  | <p>Name to assign to the new node where the metadata is stored. </p> |
+| nodeId | string |  | <p>Content Services node to fetch corresponding form for </p> |
+| path | string |  | <p>Path of the folder where the metadata is stored. </p> |
+| readOnly | boolean | false | <p>Toggle readonly state of the form. All form widgets are rendered as readonly if enabled. </p> |
+| saveMetadata | boolean | false | <p>Toggles storing the value of the form as metadata. </p> |
+| showCompleteButton | boolean | true | <p>Toggle rendering of the <code>Complete</code> outcome button. </p> |
+| showDebugButton | boolean | false | <p>Toggle debug options. </p> |
+| showRefreshButton | boolean | true | <p>Toggle rendering of the <code>Refresh</code> button. </p> |
+| showSaveButton | boolean | true | <p>Toggle rendering of the <code>Save</code> outcome button. </p> |
+| showTitle | boolean | true | <p>Toggle rendering of the form title. </p> |
+| showValidationIcon | boolean | true | <p>Toggle rendering of the validation icon next to the form title. </p> |
+| taskId | string |  | <p>Task id to fetch corresponding form and values. </p> |
+
+### Events
+
+| Name | Type | Description |
+| -- | -- | -- |
+| executeOutcome | EventEmitter<FormOutcomeEvent> | <p>Emitted when any outcome is executed. Default behaviour can be prevented via <code>event.preventDefault()</code> </p> |
+| formCompleted | EventEmitter<FormModel> | <p>Emitted when the form is submitted with <code>Complete</code> outcome. </p> |
+| formContentClicked | EventEmitter<ContentLinkModel> | <p>Emitted when form content is clicked. </p> |
+| formDataRefreshed | EventEmitter<FormModel> | <p>Emitted when form values are refreshed due to a data property change </p> |
+| formLoaded | EventEmitter<FormModel> | <p>Emitted when the form is loaded or reloaded. </p> |
+| formSaved | EventEmitter<FormModel> | <p>Emitted when the form is submitted with <code>Save</code> or custom outcomes. </p> |
+| onError | EventEmitter<any> | <p>Emitted when any error occurs </p> |
 <!-- propsection end -->
+
 ## Details
 
 All `form*` events receive an instance of the `FormModel` as event argument for ease of development:

--- a/docs/login.component.md
+++ b/docs/login.component.md
@@ -9,7 +9,8 @@ Authenticates to Alfresco Content Services and Alfresco Process Services.
 <!-- toc -->
 
 - [Basic usage](#basic-usage)
-  * [Properties and events](#properties-and-events)
+  * [Properties](#properties)
+  * [Events](#events)
 - [Details](#details)
   * [Handling events](#handling-events)
   * [Change footer content](#change-footer-content)
@@ -32,13 +33,33 @@ Authenticates to Alfresco Content Services and Alfresco Process Services.
 </adf-login>
 ```
 
-### Properties and events
-
 <!-- propsection start -->
-See the documentation comments in the
-[source file](../lib/core/login/components/login.component.ts)
-for full descriptions of properties and events.
+### Properties
+
+| Name | Type | Default value | Description |
+| -- | -- | -- | -- |
+| backgroundImageUrl | string | './assets/images/background.svg' | <p>Sets a custom background image </p> |
+| copyrightText | string | '\u00A9 2016 Alfresco Software, Inc. All Rights Reserved.' | <p>Copyright message shown below the login box </p> |
+| disableCsrf | boolean |  | <p>Prevents CSRF Token from being submitted (Process Services only) </p> |
+| fieldsValidation | any |  | <p>Supplies custom validation rules for the login form </p> |
+| logoImageUrl | string | './assets/images/alfresco-logo.svg' | <p>Sets a custom logo image </p> |
+| needHelpLink | string | '' | <p>Sets the URL of the &#39;need help&#39; link in the footer </p> |
+| providers | string |  | <p>Possible valid values are ECM, BPM or ALL. The default behaviour of this component will log in only in the ECM . If you want to log in in both systems the correct value
+to use is ALL.</p> |
+| registerLink | string | '' | <p>Sets the URL of the &#39;register&#39; link in the footer </p> |
+| showLoginActions | boolean | true | <p>Toggle extra actions visibility (<code>Need Help</code>, <code>Register</code>, etc.) </p> |
+| showRememberMe | boolean | true | <p>Toggle <code>Remember me</code> checkbox visibility </p> |
+| successRoute | string | null | <p>Route to redirect to upon successful login. </p> |
+
+### Events
+
+| Name | Type | Description |
+| -- | -- | -- |
+| error | EventEmitter | <p>Emitted when the login fails </p> |
+| executeSubmit | EventEmitter | <p>Emitted when the login form is submitted </p> |
+| success | EventEmitter | <p>Emitted when a successful login occurs </p> |
 <!-- propsection end -->
+
 ## Details
 
 ### Handling events

--- a/docs/login.component.md
+++ b/docs/login.component.md
@@ -9,8 +9,7 @@ Authenticates to Alfresco Content Services and Alfresco Process Services.
 <!-- toc -->
 
 - [Basic usage](#basic-usage)
-  * [Properties](#properties)
-  * [Events](#events)
+  * [Properties and events](#properties-and-events)
 - [Details](#details)
   * [Handling events](#handling-events)
   * [Change footer content](#change-footer-content)
@@ -33,30 +32,13 @@ Authenticates to Alfresco Content Services and Alfresco Process Services.
 </adf-login>
 ```
 
-### Properties
+### Properties and events
 
-| Name | Type | Default Value | Description |
-| --- | --- | --- | --- |
-| providers | string | | Possible valid values are ECM, BPM or ALL. The default behaviour of this component will log in only in the ECM . If you want to log in in both systems the correct value to use is ALL. |
-| successRoute | string | | Route to redirect to upon successful login. |
-| disableCsrf | boolean | false | To prevent the CSRF Token from being submitted. Only for Alfresco Process Services call |
-| needHelpLink | string | | It will change the url of the NEED HELP link in the footer  |
-| registerLink | string | | It will change the url of the REGISTER link in the footer |
-| logoImageUrl | string | \<ADF logo image> | To change the logo image with a customised image |
-| copyrightText | string | \<ADF copyright string> | The copyright text below the login box |
-| backgroundImageUrl | string | \<ADF background image> | To change the background image with a customised image |
-| fieldsValidation | { [key: string]: any; }, extra?: { [key: string]: any; } |  | Use it to customise the validation rules of the login form |
-| showRememberMe | boolean | false | Toggle `Remember me` checkbox visibility |
-| showLoginActions | boolean | false | Toggle extra actions visibility (`Need Help`, `Register`, etc.) |
-
-### Events
-
-| Name | Description |
-| --- | --- |
-| success | Raised when the login is done |
-| error | Raised when the login fails |
-| executeSubmit | Raised when the form is submitted |
-
+<!-- propsection start -->
+See the documentation comments in the
+[source file](../lib/core/login/components/login.component.ts)
+for full descriptions of properties and events.
+<!-- propsection end -->
 ## Details
 
 ### Handling events

--- a/lib/config/addPropTables.js
+++ b/lib/config/addPropTables.js
@@ -1,0 +1,145 @@
+var fs = require('fs');
+var path = require('path');
+
+var docDataFilePath = 'docs';
+var docDataFileName = 'documentation.json';
+
+var mdSourceFolder = 'docs';
+
+
+function initialCap(str) {
+    return str[0].toUpperCase() + str.substr(1);
+}
+
+
+function fixCompodocFilename(rawName) {
+	var name = rawName.replace(/\]|\(|\)/g, '');
+	
+    var fileNameSections = name.split('.');
+    var compNameSections = fileNameSections[0].split('-');
+    
+    var outCompName = '';
+    
+    for (var i = 0; i < compNameSections.length; i++) {
+        outCompName = outCompName + initialCap(compNameSections[i]);
+    }
+    
+    var itemTypeIndicator = '';
+    
+    if (fileNameSections.length > 1) {
+        itemTypeIndicator = initialCap(fileNameSections[1]);
+    }
+	
+    var finalName = outCompName + itemTypeIndicator;
+	
+    return finalName;
+}
+
+
+function replacePropSection(text, replacementText) {
+    var propStartMarker = '<!-- propsection start -->';
+    var propEndMarker = '<!-- propsection end -->';
+    var contentRegex = new RegExp('(?:' + propStartMarker + ')([\\s\\S]*)(?:' + propEndMarker + ')');
+    return text.replace(contentRegex, propStartMarker + '\n' + replacementText + propEndMarker);
+}
+
+function buildClassNameDict(mainData) {
+    var result = {};
+
+    for (var i = 0; i < mainData.components.length; i++) {
+        result[mainData.components[i].name] = mainData.components[i];
+    }
+
+    return result;
+}
+
+
+function makePropsTable(props) {
+    if (props.length === 0) {
+        return '';
+    }
+
+    var result = '';
+
+    result += '### Properties\n\n';
+    result += '| Name | Type | Default value | Description |\n';
+    result += '| -- | -- | -- | -- |\n';
+    
+    for (var i = 0; i < props.length; i++){
+        var pName = props[i].name;
+        var pType = props[i].type;
+        var pDefault = props[i].defaultValue || '';
+        var pDesc = props[i].description;
+
+        if (pDesc) {
+            pDesc = pDesc.trim().replace(/[\n\r]+/, ' ');
+        }
+
+        result += `| ${pName} | ${pType} | ${pDefault} | ${pDesc} |\n`;
+    }
+
+    return result;
+}
+
+function makeEventsTable(events) {
+    var result = '';
+
+    result += '### Events\n\n';
+    result += '| Name | Type | Description |\n';
+    result += '| -- | -- | -- |\n';
+    
+    for (var i = 0; i < events.length; i++){
+        var eName = events[i].name;
+        var eType = events[i].type;
+        var eDesc = events[i].description;
+
+        if (eDesc) {
+            eDesc = eDesc.trim().replace(/[\n\r]+/, ' ');
+        }
+
+        result += `| ${eName} | ${eType} | ${eDesc} |\n`;
+    }
+
+    return result;
+}
+
+var docData = JSON.parse(fs.readFileSync(path.resolve('..', docDataFilePath, docDataFileName)));
+var classNameDict = buildClassNameDict(docData);
+
+var mdFiles = fs.readdirSync(path.resolve('..', mdSourceFolder));
+
+for (var i = 0; i < mdFiles.length; i++) {
+    var currFileName = mdFiles[i];
+
+    if (currFileName.match(/component/)) {
+        var className = fixCompodocFilename(currFileName);
+
+        var classDocs = classNameDict[className];
+
+        var propsText = '';
+
+        if (classDocs) {
+            if (classDocs.inputsClass && classDocs.inputsClass.length > 0) {
+                propsText += makePropsTable(classDocs.inputsClass);
+            }
+
+            if (classDocs.outputsClass && classDocs.outputsClass.length > 0) {
+                if (classDocs.inputsClass && classDocs.inputsClass.length > 0) {
+                    propsText += '\n';
+                }
+
+                propsText += makeEventsTable(classDocs.outputsClass);
+            }
+        }
+
+        var currFilePath = path.resolve('..', mdSourceFolder, currFileName);
+
+        var mdText = fs.readFileSync(currFilePath, 'utf8');
+
+        mdText = replacePropSection(mdText, propsText);
+
+        fs.writeFileSync(currFilePath, mdText);
+    }
+}
+
+

--- a/lib/content-services/document-list/components/document-list.component.ts
+++ b/lib/content-services/document-list/components/document-list.component.ts
@@ -70,94 +70,133 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
 
     @ContentChild(DataColumnListComponent) columnList: DataColumnListComponent;
 
+    /** Define a set of CSS styles to apply depending on the permission of the
+     *  user on that node. */
     @Input()
     permissionsStyle: PermissionStyleModel[] = [];
 
+    /** The default route for all the location-based columns (if declared). */
     @Input()
     locationFormat: string = '/';
 
+    /** Toggles navigation to folder content or file preview */
     @Input()
     navigate: boolean = true;
 
+    /** User interaction for folder navigation or file preview */
     @Input()
     navigationMode: string = DocumentListComponent.DOUBLE_CLICK_NAVIGATION; // click|dblclick
 
+    /** Show document thumbnails rather than icons */
     @Input()
     thumbnails: boolean = false;
 
+    /** Row selection mode. Can be none, `single` or `multiple`. For `multiple`
+     * mode you can use Cmd (macOS) or Ctrl (Win) modifier keys to toggle 
+     * selection of multiple rows. */
     @Input()
     selectionMode: string = 'single'; // null|single|multiple
 
+    /** Toggles multiselect mode */
     @Input()
     multiselect: boolean = false;
 
+    /** Toggles content actions for each row */
     @Input()
     contentActions: boolean = false;
 
+    /** Position of the content actions dropdown menu (can be 'left' or 'right') */
     @Input()
     contentActionsPosition: string = 'right'; // left|right
 
+    /** Toggles context menus for each row */
     @Input()
     contextMenuActions: boolean = false;
 
+    /** Custom image for empty folder */
     @Input()
     emptyFolderImageUrl: string = './assets/images/empty_doc_lib.svg';
 
+    /** Toggle file drop support for rows (see UploadDirective for more details) */
     @Input()
     allowDropFiles: boolean = false;
 
+    /** Defines default sorting. The format is an array of 2 strings `[key, direction]`
+     *  i.e. `['name', 'desc']` or `['name', 'asc']`. Set this value only if you want
+     * to override default sorting detected by the component based on columns. */
     @Input()
     sorting: string[];
 
+    /** The inline style to apply to every row, see
+     * [NgStyle](https://angular.io/docs/ts/latest/api/common/index/NgStyle-directive.html)
+     * docs for more details and usage examples */
     @Input()
     rowStyle: string;
 
+    /** CSS class to apply to every row */
     @Input()
     rowStyleClass: string;
 
+    /** Toggles the loading state and animated spinners for the component. Used in
+     * combination with `navigate=false` to perform custom navigation and loading state
+     * indication. */
     @Input()
     loading: boolean = false;
 
+    /** Custom row filter */
     @Input()
     rowFilter: any | null = null;
 
+    /** Custom image resolver */
     @Input()
     imageResolver: any | null = null;
 
-    // The identifier of a node. You can also use one of these well-known aliases: -my- | -shared- | -root-
+    /** The ID of the folder node to display or a reserved string alias for special sources */
     @Input()
     currentFolderId: string = null;
 
+    /** Currently displayed folder node */
     @Input()
     folderNode: MinimalNodeEntryEntity = null;
 
+    /** DocumentList will show all the nodes contained in the NodePaging entity */
     @Input()
     node: NodePaging = null;
 
+    /** The page size for the document list */
     @Input()
     maxItems: number;
 
+    /** The start offset of the current page's first item (for pagination purposes) */
     @Input()
     skipCount: number = 0;
 
+    /** Enable infinite scrolling mode */
     @Input()
     enableInfiniteScrolling: boolean = false;
 
+    /** Emitted when the user clicks a list node */
     @Output()
     nodeClick: EventEmitter<NodeEntityEvent> = new EventEmitter<NodeEntityEvent>();
 
+    /** Emitted when the user double-clicks a list node */
     @Output()
     nodeDblClick: EventEmitter<NodeEntityEvent> = new EventEmitter<NodeEntityEvent>();
 
+    /** Emitted when the current display folder changes */
     @Output()
     folderChange: EventEmitter<NodeEntryEvent> = new EventEmitter<NodeEntryEvent>();
 
+    /** Emitted when the user acts upon files with either single or double click
+     * (depends on `navigation-mode`). Useful integration with the Viewer Component. */
     @Output()
     preview: EventEmitter<NodeEntityEvent> = new EventEmitter<NodeEntityEvent>();
 
+    /** Emitted when the DocumentList is ready and has loaded all the elements */
     @Output()
     ready: EventEmitter<NodePaging> = new EventEmitter();
 
+    /** Emitted when the API fails to get the data for the DocumentList */
     @Output()
     error: EventEmitter<any> = new EventEmitter();
 

--- a/lib/content-services/document-list/components/document-list.component.ts
+++ b/lib/content-services/document-list/components/document-list.component.ts
@@ -71,7 +71,8 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
     @ContentChild(DataColumnListComponent) columnList: DataColumnListComponent;
 
     /** Define a set of CSS styles to apply depending on the permission of the
-     *  user on that node. */
+     *  user on that node.
+     */
     @Input()
     permissionsStyle: PermissionStyleModel[] = [];
 
@@ -93,7 +94,8 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
 
     /** Row selection mode. Can be none, `single` or `multiple`. For `multiple`
      * mode you can use Cmd (macOS) or Ctrl (Win) modifier keys to toggle 
-     * selection of multiple rows. */
+     * selection of multiple rows.
+     */
     @Input()
     selectionMode: string = 'single'; // null|single|multiple
 
@@ -123,13 +125,15 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
 
     /** Defines default sorting. The format is an array of 2 strings `[key, direction]`
      *  i.e. `['name', 'desc']` or `['name', 'asc']`. Set this value only if you want
-     * to override default sorting detected by the component based on columns. */
+     * to override default sorting detected by the component based on columns.
+     */
     @Input()
     sorting: string[];
 
     /** The inline style to apply to every row, see
      * [NgStyle](https://angular.io/docs/ts/latest/api/common/index/NgStyle-directive.html)
-     * docs for more details and usage examples */
+     * docs for more details and usage examples 
+     */
     @Input()
     rowStyle: string;
 
@@ -139,7 +143,8 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
 
     /** Toggles the loading state and animated spinners for the component. Used in
      * combination with `navigate=false` to perform custom navigation and loading state
-     * indication. */
+     * indication.
+     */
     @Input()
     loading: boolean = false;
 
@@ -188,7 +193,8 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
     folderChange: EventEmitter<NodeEntryEvent> = new EventEmitter<NodeEntryEvent>();
 
     /** Emitted when the user acts upon files with either single or double click
-     * (depends on `navigation-mode`). Useful integration with the Viewer Component. */
+     * (depends on `navigation-mode`). Useful integration with the Viewer Component.
+     */
     @Output()
     preview: EventEmitter<NodeEntityEvent> = new EventEmitter<NodeEntityEvent>();
 

--- a/lib/content-services/document-list/components/document-list.component.ts
+++ b/lib/content-services/document-list/components/document-list.component.ts
@@ -93,7 +93,7 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
     thumbnails: boolean = false;
 
     /** Row selection mode. Can be none, `single` or `multiple`. For `multiple`
-     * mode you can use Cmd (macOS) or Ctrl (Win) modifier keys to toggle 
+     * mode you can use Cmd (macOS) or Ctrl (Win) modifier keys to toggle
      * selection of multiple rows.
      */
     @Input()
@@ -132,7 +132,7 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
 
     /** The inline style to apply to every row, see
      * [NgStyle](https://angular.io/docs/ts/latest/api/common/index/NgStyle-directive.html)
-     * docs for more details and usage examples 
+     * docs for more details and usage examples
      */
     @Input()
     rowStyle: string;

--- a/lib/core/data-column/data-column.component.ts
+++ b/lib/core/data-column/data-column.component.ts
@@ -25,33 +25,43 @@ import { Component, ContentChild, Input, OnInit, TemplateRef } from '@angular/co
 })
 export class DataColumnComponent implements OnInit {
 
+    /** Data source key, can be either column/property key like `title`
+     *  or property path like `createdBy.name` */
     @Input()
     key: string;
 
+    /** Value type for the column. Possible settings are 'text', 'image', 'date',
+     *  'fileSize' and 'location'. */
     @Input()
     type: string = 'text';
 
+    /** Value format (if supported by components), for example format of the date */
     @Input()
     format: string;
 
+    /** Toggles ability to sort by this column, for example by clicking the column header */
     @Input()
     sortable: boolean = true;
 
+    /** Display title of the column, typically used for column headers. You can use the
+     *  i18n resouce key to get it translated automatically. */
     @Input()
     title: string = '';
 
+    /** Custom column template */
     @ContentChild(TemplateRef)
     template: any;
 
+    /** Custom tooltip formatter function. */
     @Input()
     formatTooltip: Function;
 
-    /**
-     * Title to be used for screen readers.
-     */
+    
+    /** Title to be used for screen readers. */
     @Input('sr-title')
     srTitle: string;
 
+    /** Additional CSS class to be applied to column (header and cells) */
     @Input('class')
     cssClass: string;
 

--- a/lib/core/data-column/data-column.component.ts
+++ b/lib/core/data-column/data-column.component.ts
@@ -59,7 +59,6 @@ export class DataColumnComponent implements OnInit {
     @Input()
     formatTooltip: Function;
 
-    
     /** Title to be used for screen readers. */
     @Input('sr-title')
     srTitle: string;

--- a/lib/core/data-column/data-column.component.ts
+++ b/lib/core/data-column/data-column.component.ts
@@ -26,12 +26,14 @@ import { Component, ContentChild, Input, OnInit, TemplateRef } from '@angular/co
 export class DataColumnComponent implements OnInit {
 
     /** Data source key, can be either column/property key like `title`
-     *  or property path like `createdBy.name` */
+     *  or property path like `createdBy.name`
+     */
     @Input()
     key: string;
 
     /** Value type for the column. Possible settings are 'text', 'image', 'date',
-     *  'fileSize' and 'location'. */
+     *  'fileSize' and 'location'.
+     */
     @Input()
     type: string = 'text';
 
@@ -44,7 +46,8 @@ export class DataColumnComponent implements OnInit {
     sortable: boolean = true;
 
     /** Display title of the column, typically used for column headers. You can use the
-     *  i18n resouce key to get it translated automatically. */
+     *  i18n resouce key to get it translated automatically.
+     */
     @Input()
     title: string = '';
 

--- a/lib/core/datatable/components/datatable/datatable.component.ts
+++ b/lib/core/datatable/components/datatable/datatable.component.ts
@@ -49,60 +49,85 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck 
     @ContentChild(DataColumnListComponent)
     columnList: DataColumnListComponent;
 
+    /** Data source for the table */
     @Input()
     data: DataTableAdapter;
 
+    /** The rows that the datatable shows */
     @Input()
     rows: any[] = [];
 
+    /** Row selection mode. Can be none, `single` or `multiple`. For `multiple`
+     * mode you can use Cmd (macOS) or Ctrl (Win) modifier key to toggle selection
+     * for multiple rows. */
     @Input()
     selectionMode: string = 'single'; // none|single|multiple
 
+    /** Toggles multiple row selection, renders checkboxes at the beginning of
+     * each row */
     @Input()
     multiselect: boolean = false;
 
+    /** Toggles data actions column */
     @Input()
     actions: boolean = false;
 
+    /** Position of the actions dropdown menu (can be 'left' or 'right') */
     @Input()
     actionsPosition: string = 'right'; // left|right
 
+    /** Fallback image for rows where the thumbnail is missing */
     @Input()
     fallbackThumbnail: string;
 
+    /** Toggles the custom context menu for the component */
     @Input()
     contextMenu: boolean = false;
 
+    /** Toggle file drop support for rows (see UploadDirective for more details) */
     @Input()
     allowDropFiles: boolean = false;
 
+    /** The inline style to apply to every row, see
+     * [NgStyle](https://angular.io/docs/ts/latest/api/common/index/NgStyle-directive.html)
+     * docs for more details and usage examples */
     @Input()
     rowStyle: string;
 
+    /** The CSS class to apply to every row */
     @Input()
     rowStyleClass: string = '';
 
+    /** Toggles header visibility */
     @Input()
     showHeader: boolean = true;
 
+    /** Emitted when the user clicks a row */
     @Output()
     rowClick = new EventEmitter<DataRowEvent>();
 
+    /** Emitted when the user double-clicks a row */
     @Output()
     rowDblClick = new EventEmitter<DataRowEvent>();
 
+    /** Emitted just before the context menu is displayed for a row */
     @Output()
     showRowContextMenu = new EventEmitter<DataCellEvent>();
 
+    /** Emitted just before the actions menu is displayed for a row */
     @Output()
     showRowActionsMenu = new EventEmitter<DataCellEvent>();
 
+    /** Emitted when a row action is executed by the user */
     @Output()
     executeRowAction = new EventEmitter<DataRowActionEvent>();
 
+    /** Indicates when the datatable is in the loading state and needs to show the
+     * loading template. */
     @Input()
     loading: boolean = false;
 
+    /** Indicates when the datatable needs to show the no permission template */
     @Input()
     noPermission: boolean = false;
 

--- a/lib/core/datatable/components/datatable/datatable.component.ts
+++ b/lib/core/datatable/components/datatable/datatable.component.ts
@@ -59,12 +59,14 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck 
 
     /** Row selection mode. Can be none, `single` or `multiple`. For `multiple`
      * mode you can use Cmd (macOS) or Ctrl (Win) modifier key to toggle selection
-     * for multiple rows. */
+     * for multiple rows.
+     */
     @Input()
     selectionMode: string = 'single'; // none|single|multiple
 
     /** Toggles multiple row selection, renders checkboxes at the beginning of
-     * each row */
+     * each row
+     */
     @Input()
     multiselect: boolean = false;
 
@@ -90,7 +92,8 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck 
 
     /** The inline style to apply to every row, see
      * [NgStyle](https://angular.io/docs/ts/latest/api/common/index/NgStyle-directive.html)
-     * docs for more details and usage examples */
+     * docs for more details and usage examples
+     */
     @Input()
     rowStyle: string;
 
@@ -123,7 +126,8 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck 
     executeRowAction = new EventEmitter<DataRowActionEvent>();
 
     /** Indicates when the datatable is in the loading state and needs to show the
-     * loading template. */
+     * loading template.
+     */
     @Input()
     loading: boolean = false;
 

--- a/lib/core/form/components/form.component.ts
+++ b/lib/core/form/components/form.component.ts
@@ -39,84 +39,111 @@ export class FormComponent implements OnInit, OnChanges {
     static START_PROCESS_OUTCOME_ID: string = '$startProcess';
     static CUSTOM_OUTCOME_ID: string = '$custom';
 
+    /** Underlying form model instance. */
     @Input()
     form: FormModel;
 
+    /** Task id to fetch corresponding form and values. */
     @Input()
     taskId: string;
 
+    /** Content Services node to fetch corresponding form for */
     @Input()
     nodeId: string;
 
+    /** The id of the form definition to load and display with custom values. */
     @Input()
     formId: string;
 
+    /** Name of the form definition to load and display with custom values. */
     @Input()
     formName: string;
 
+    /** Toggles storing the value of the form as metadata. */
     @Input()
     saveMetadata: boolean = false;
 
+    /** Custom form values map to be used with the rendered form. */
     @Input()
     data: FormValues;
 
+    /** Path of the folder where the metadata is stored. */
     @Input()
     path: string;
 
+    /** Name to assign to the new node where the metadata is stored. */
     @Input()
     nameNode: string;
 
+    /** Toggle rendering of the form title. */
     @Input()
     showTitle: boolean = true;
 
+    /** Toggle rendering of the `Complete` outcome button. */
     @Input()
     showCompleteButton: boolean = true;
 
+    /** Toggles whether the `Complete` outcome button is disabled (but still shown). */
     @Input()
     disableCompleteButton: boolean = false;
 
+    /** Toggles whether the `Start Process` outcome button is disabled (but still shown). */
     @Input()
     disableStartProcessButton: boolean = false;
 
+    /** Toggle rendering of the `Save` outcome button. */
     @Input()
     showSaveButton: boolean = true;
 
+    /** Toggle debug options. */
     @Input()
     showDebugButton: boolean = false;
 
+    /** Toggle readonly state of the form. All form widgets are rendered as readonly if enabled. */
     @Input()
     readOnly: boolean = false;
 
+    /** Toggle rendering of the `Refresh` button. */
     @Input()
     showRefreshButton: boolean = true;
 
+    /** Toggle rendering of the validation icon next to the form title. */
     @Input()
     showValidationIcon: boolean = true;
 
+    /** Contains a list of form field validator instances. */
     @Input()
     fieldValidators: FormFieldValidator[] = [];
 
+    /** Emitted when the form is submitted with `Save` or custom outcomes. */
     @Output()
     formSaved: EventEmitter<FormModel> = new EventEmitter<FormModel>();
 
+    /** Emitted when the form is submitted with `Complete` outcome. */
     @Output()
     formCompleted: EventEmitter<FormModel> = new EventEmitter<FormModel>();
 
+    /** Emitted when form content is clicked. */
     @Output()
     formContentClicked: EventEmitter<ContentLinkModel> = new EventEmitter<ContentLinkModel>();
 
+    /** Emitted when the form is loaded or reloaded. */
     @Output()
     formLoaded: EventEmitter<FormModel> = new EventEmitter<FormModel>();
 
+    /** Emitted when form values are refreshed due to a data property change */
     @Output()
     formDataRefreshed: EventEmitter<FormModel> = new EventEmitter<FormModel>();
 
+    /** Emitted when any outcome is executed. Default behaviour can be prevented via `event.preventDefault()` */
     @Output()
     executeOutcome: EventEmitter<FormOutcomeEvent> = new EventEmitter<FormOutcomeEvent>();
 
+    /** Emitted when any error occurs */
     @Output()
     onError: EventEmitter<any> = new EventEmitter<any>();
 
+    /** Toggle debug mode. Displays additional data for development and debugging purposes. */
     debugMode: boolean = false;
 
     constructor(protected formService: FormService,

--- a/lib/core/login/components/login.component.ts
+++ b/lib/core/login/components/login.component.ts
@@ -55,45 +55,59 @@ export class LoginComponent implements OnInit {
 
     isPasswordShow: boolean = false;
 
+    /** Toggle `Remember me` checkbox visibility */
     @Input()
     showRememberMe: boolean = true;
 
+    /** Toggle extra actions visibility (`Need Help`, `Register`, etc.) */
     @Input()
     showLoginActions: boolean = true;
 
+    /** Sets the URL of the 'need help' link in the footer */
     @Input()
     needHelpLink: string = '';
 
+    /** Sets the URL of the 'register' link in the footer */
     @Input()
     registerLink: string = '';
 
+    /** Sets a custom logo image */
     @Input()
     logoImageUrl: string = './assets/images/alfresco-logo.svg';
 
+    /** Sets a custom background image */
     @Input()
     backgroundImageUrl: string = './assets/images/background.svg';
 
+    /** Copyright message shown below the login box */
     @Input()
     copyrightText: string = '\u00A9 2016 Alfresco Software, Inc. All Rights Reserved.';
 
+    /** Possible valid values are ECM, BPM or ALL. The default behaviour of this component will log in only in the ECM . If you want to log in in both systems the correct value to use is ALL. */
     @Input()
     providers: string;
 
+    /** Supplies custom validation rules for the login form */
     @Input()
     fieldsValidation: any;
 
+    /** Prevents CSRF Token from being submitted (Process Services only) */
     @Input()
     disableCsrf: boolean;
 
+    /** Route to redirect to upon successful login. */
     @Input()
     successRoute: string = null;
 
+    /** Emitted when a successful login occurs */
     @Output()
     success = new EventEmitter<LoginSuccessEvent>();
 
+    /** Emitted when the login fails */
     @Output()
     error = new EventEmitter<LoginErrorEvent>();
 
+    /** Emitted when the login form is submitted */
     @Output()
     executeSubmit = new EventEmitter<LoginSubmitEvent>();
 

--- a/lib/core/login/components/login.component.ts
+++ b/lib/core/login/components/login.component.ts
@@ -83,7 +83,10 @@ export class LoginComponent implements OnInit {
     @Input()
     copyrightText: string = '\u00A9 2016 Alfresco Software, Inc. All Rights Reserved.';
 
-    /** Possible valid values are ECM, BPM or ALL. The default behaviour of this component will log in only in the ECM . If you want to log in in both systems the correct value to use is ALL. */
+    /** Possible valid values are ECM, BPM or ALL. The default behaviour of this component
+     * will log in only in the ECM . If you want to log in in both systems the correct value
+     * to use is ALL.
+     */
     @Input()
     providers: string;
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [x] Documentation
> - [ ] Other... Please describe:

**What is the new behaviour?**

Added a new script to get property and event details from JSDocs in the sources (via Compodoc) and insert prop/event tables into Markdown files. Currently, this depends on having a separate untracked documentation.json file in the docs which is generated by a separate Compodoc build. It will be better to incorporate Compodoc fully into the repo but this will depend on a few other changes that need to be implemented first.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
