### PR TITLE
[ADF-2051] Involve people name is not displayed properly.

### DIFF
--- a/lib/process-services/people/people.component.scss
+++ b/lib/process-services/people/people.component.scss
@@ -51,10 +51,18 @@
         padding: 0px;
     }
 
-    adf-people-list ::ng-deep adf-datatable ::ng-deep {
+    
+
+    adf-people-list adf-datatable {
         thead {
             display: none;
         }
+        
+        .adf-data-table .adf-data-table-cell .cell-container {
+            flex-direction: column;
+            align-items: left;
+        }
+
         .people-email {
             opacity: 0.54;
         }


### PR DESCRIPTION
This issue is now fixed

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
The details for people  involved in a user task are displayed on one line
https://issues.alfresco.com/jira/secure/attachment/98560/98560_Screen+Shot+2017-11-29+at+15.14.25.png


**What is the new behaviour?**
The details for people involved in a user taks are displayed as they should be
https://issues.alfresco.com/jira/secure/thumbnail/98561/_thumb_98561.png


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
