### PR TITLE
[ADF-2098] Start Process - the default process definition should be selected 

### DIFF
--- a/docs/start-process.component.md
+++ b/docs/start-process.component.md
@@ -1,6 +1,6 @@
 # Start Process component
 
-Displays Start Process, allowing the user to specify some basic details needed to start a new process instance.
+Displays Start Process, allowing the user to specify some details like process name and process definition, which are the most basic requirement to start a new process instance. The user have to select the process definition from a dropdown if there are more than one process definition available. If there is just one process definition available for the app, then it is auto-selected. There is a error message shown if no process definition is available.
 
 ![adf-start-process ](docassets/images/startProcess.png)
 

--- a/lib/process-services/process-list/components/start-process.component.html
+++ b/lib/process-services/process-list/components/start-process.component.html
@@ -9,7 +9,7 @@
 			<input matInput placeholder="{{'ADF_PROCESS_LIST.START_PROCESS.FORM.LABEL.NAME'|translate}}" [(ngModel)]="name" id="processName" required />
 		</mat-form-field>
         <mat-form-field>
-            <mat-select [compareWith]="selectDefaultProcessDef" placeholder="{{'ADF_PROCESS_LIST.START_PROCESS.FORM.LABEL.TYPE'|translate}}" [(ngModel)]="currentProcessDef.id" (ngModelChange)="onProcessDefChange($event)" required>
+            <mat-select [compareWith]="compareProcessDef" placeholder="{{'ADF_PROCESS_LIST.START_PROCESS.FORM.LABEL.TYPE'|translate}}" [(ngModel)]="currentProcessDef.id" (ngModelChange)="onProcessDefChange($event)" required>
                 <mat-option>{{'ADF_PROCESS_LIST.START_PROCESS.FORM.TYPE_PLACEHOLDER' | translate}}</mat-option>
                 <mat-option *ngFor="let processDef of processDefinitions" [value]="processDef.id">
                     {{ processDef.name }}

--- a/lib/process-services/process-list/components/start-process.component.html
+++ b/lib/process-services/process-list/components/start-process.component.html
@@ -9,7 +9,7 @@
 			<input matInput placeholder="{{'ADF_PROCESS_LIST.START_PROCESS.FORM.LABEL.NAME'|translate}}" [(ngModel)]="name" id="processName" required />
 		</mat-form-field>
         <mat-form-field>
-            <mat-select placeholder="{{'ADF_PROCESS_LIST.START_PROCESS.FORM.LABEL.TYPE'|translate}}" [(ngModel)]="currentProcessDef.id" (ngModelChange)="onProcessDefChange($event)" required>
+            <mat-select [compareWith]="matSelectCompareFn" placeholder="{{'ADF_PROCESS_LIST.START_PROCESS.FORM.LABEL.TYPE'|translate}}" [(ngModel)]="currentProcessDef.id" (ngModelChange)="onProcessDefChange($event)" required>
                 <mat-option>{{'ADF_PROCESS_LIST.START_PROCESS.FORM.TYPE_PLACEHOLDER' | translate}}</mat-option>
                 <mat-option *ngFor="let processDef of processDefinitions" [value]="processDef.id">
                     {{ processDef.name }}

--- a/lib/process-services/process-list/components/start-process.component.html
+++ b/lib/process-services/process-list/components/start-process.component.html
@@ -9,7 +9,7 @@
 			<input matInput placeholder="{{'ADF_PROCESS_LIST.START_PROCESS.FORM.LABEL.NAME'|translate}}" [(ngModel)]="name" id="processName" required />
 		</mat-form-field>
         <mat-form-field>
-            <mat-select [compareWith]="matSelectCompareFn" placeholder="{{'ADF_PROCESS_LIST.START_PROCESS.FORM.LABEL.TYPE'|translate}}" [(ngModel)]="currentProcessDef.id" (ngModelChange)="onProcessDefChange($event)" required>
+            <mat-select [compareWith]="selectDefaultProcessDef" placeholder="{{'ADF_PROCESS_LIST.START_PROCESS.FORM.LABEL.TYPE'|translate}}" [(ngModel)]="currentProcessDef.id" (ngModelChange)="onProcessDefChange($event)" required>
                 <mat-option>{{'ADF_PROCESS_LIST.START_PROCESS.FORM.TYPE_PLACEHOLDER' | translate}}</mat-option>
                 <mat-option *ngFor="let processDef of processDefinitions" [value]="processDef.id">
                     {{ processDef.name }}

--- a/lib/process-services/process-list/components/start-process.component.spec.ts
+++ b/lib/process-services/process-list/components/start-process.component.spec.ts
@@ -154,6 +154,18 @@ describe('StartProcessInstanceComponent', () => {
             });
         }));
 
+        it('should auto-select process def from dropdown if there is just one process def', () => {
+            let change = new SimpleChange(null, '123', true);
+            component.ngOnChanges({'appId': change});
+            component.processDefinitions[0] = testProcessDefRepr;
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+                let selectElement = fixture.nativeElement.querySelector('mat-select > .mat-select-trigger');
+                expect(selectElement).not.toBeNull();
+                expect(selectElement).toBeDefined();
+                expect(selectElement.innerText).toBe('My Process 1');
+            });
+        });
     });
 
     describe('input changes', () => {
@@ -321,35 +333,39 @@ describe('StartProcessInstanceComponent', () => {
                 let change = new SimpleChange(null, '123', true);
                 component.ngOnChanges({'appId': change});
                 fixture.detectChanges();
-                component.onProcessDefChange('my:process1');
-                fixture.whenStable();
-                startBtn = fixture.nativeElement.querySelector('#button-start');
             }));
 
             it('should have start button disabled when name not filled out', async(() => {
                 component.name = '';
                 fixture.detectChanges();
-                expect(startBtn.disabled).toBe(true);
+                fixture.whenStable().then(() => {
+                    startBtn = fixture.nativeElement.querySelector('#button-start');
+                    expect(startBtn.disabled).toBe(true);
+                });
             }));
 
-            it('should have start button disabled when no process is selected', async(() => {
+            it('should have start button disabled when no process is selected', () => {
                 component.onProcessDefChange('');
                 fixture.detectChanges();
+                startBtn = fixture.nativeElement.querySelector('#button-start');
                 expect(startBtn.disabled).toBe(true);
-            }));
+            });
 
-            it('should enable start button when name and process filled out', async(() => {
+            it('should enable start button when name and process filled out', () => {
+                component.onProcessDefChange('my:process1');
                 fixture.detectChanges();
-                let startButton = fixture.nativeElement.querySelector('#button-start');
-                expect(startButton.disabled).toBeFalsy();
-            }));
+                fixture.whenStable().then(() => {
+                    startBtn = fixture.nativeElement.querySelector('#button-start');
+                    expect(startBtn.disabled).toBe(false);
+                });
+            });
 
-            it('should disable the start process button when process name is empty', async(() => {
+            it('should disable the start process button when process name is empty', () => {
                 component.name = '';
                 fixture.detectChanges();
                 let startButton = fixture.nativeElement.querySelector('#button-start');
-                expect(startButton.disabled).toBeTruthy();
-            }));
+                expect(startButton.disabled).toBe(true);
+            });
 
         });
 

--- a/lib/process-services/process-list/components/start-process.component.ts
+++ b/lib/process-services/process-list/components/start-process.component.ts
@@ -95,6 +95,13 @@ export class StartProcessInstanceComponent implements OnChanges {
         }
     }
 
+    matSelectCompareFn = (processDefId) => {
+        if (this.processDefinitions && this.processDefinitions.length === 1 && processDefId === this.processDefinitions[0].id) {
+            this.onProcessDefChange(processDefId);
+            return true;
+        }
+    }
+
     onProcessDefChange(processDefinitionId) {
         let processDef = this.processDefinitions.find((processDefinition) => {
             return processDefinition.id === processDefinitionId;

--- a/lib/process-services/process-list/components/start-process.component.ts
+++ b/lib/process-services/process-list/components/start-process.component.ts
@@ -95,7 +95,7 @@ export class StartProcessInstanceComponent implements OnChanges {
         }
     }
 
-    selectDefaultProcessDef = (processDefId) => {
+    compareProcessDef = (processDefId) => {
         if (this.processDefinitions && this.processDefinitions.length === 1 && processDefId === this.processDefinitions[0].id) {
             this.onProcessDefChange(processDefId);
             return true;

--- a/lib/process-services/process-list/components/start-process.component.ts
+++ b/lib/process-services/process-list/components/start-process.component.ts
@@ -95,7 +95,7 @@ export class StartProcessInstanceComponent implements OnChanges {
         }
     }
 
-    matSelectCompareFn = (processDefId) => {
+    selectDefaultProcessDef = (processDefId) => {
         if (this.processDefinitions && this.processDefinitions.length === 1 && processDefId === this.processDefinitions[0].id) {
             this.onProcessDefChange(processDefId);
             return true;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Even If there is only one processDef present in process-start-form drop down,We have to manually select it 


**What is the new behaviour?**
ProcessDef is automatically selected if there is just one processDef in option


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
