### PR TITLE
[ADF-2095] Start Task - The start button should have the primary colour

### DIFF
--- a/lib/process-services/process-list/components/start-process.component.html
+++ b/lib/process-services/process-list/components/start-process.component.html
@@ -31,6 +31,6 @@
 	</mat-card-content>
 	<mat-card-actions *ngIf="!hasStartForm()">
 		<button mat-button *ngIf="!hasStartForm()" (click)="cancelStartProcess()" id="cancle_process" class=""> {{'ADF_PROCESS_LIST.START_PROCESS.FORM.ACTION.CANCEL'| translate}} </button>
-		<button mat-button *ngIf="!hasStartForm()" [disabled]="!validateForm()" (click)="startProcess()" data-automation-id="btn-start" id="button-start" class="btn-start"> {{'ADF_PROCESS_LIST.START_PROCESS.FORM.ACTION.START' | translate}} </button>
+		<button color="primary" mat-button *ngIf="!hasStartForm()" [disabled]="!validateForm()" (click)="startProcess()" data-automation-id="btn-start" id="button-start" class="btn-start"> {{'ADF_PROCESS_LIST.START_PROCESS.FORM.ACTION.START' | translate}} </button>
 	</mat-card-actions>
 </mat-card>

--- a/lib/process-services/process-list/components/start-process.component.scss
+++ b/lib/process-services/process-list/components/start-process.component.scss
@@ -16,6 +16,9 @@
         }
         mat-card-actions {
             text-align: right;
+            .mat-button {
+                text-transform: uppercase !important;
+            }
         }
     }
     &-process-input-container {

--- a/lib/process-services/task-list/components/start-task.component.html
+++ b/lib/process-services/task-list/components/start-task.component.html
@@ -74,7 +74,7 @@
                     <button mat-button (click)="onCancel()" id="button-cancle">
                         {{'ADF_TASK_LIST.START_TASK.FORM.ACTION.CANCEL'|translate}}
                     </button>
-                    <button mat-button [disabled]="!startTaskmodel.name || dateError" (click)="start()" id="button-start">
+                    <button color="primary" mat-button [disabled]="!startTaskmodel.name || dateError" (click)="start()" id="button-start">
                         {{'ADF_TASK_LIST.START_TASK.FORM.ACTION.START'|translate}}
                     </button>
                 </div>

--- a/lib/process-services/task-list/components/start-task.component.scss
+++ b/lib/process-services/task-list/components/start-task.component.scss
@@ -29,6 +29,9 @@
         float: left;
         width: calc(100% - 40px);
         text-align: right;
+        .mat-button {
+            text-transform: uppercase !important;
+        }
     }
 
     .adf-start-task-input-container {

--- a/lib/process-services/task-list/components/start-task.component.scss
+++ b/lib/process-services/task-list/components/start-task.component.scss
@@ -29,9 +29,6 @@
         float: left;
         width: calc(100% - 40px);
         text-align: right;
-        .mat-button {
-            text-transform: uppercase !important;
-        }
     }
 
     .adf-start-task-input-container {
@@ -48,6 +45,12 @@
 
     adf-start-task {
         .adf {
+
+            &-new-task-footer {
+                .mat-button {
+                    text-transform: uppercase !important;
+                }
+            }
 
             &-start-task-input-container .mat-input-wrapper {
                 padding-top: 8px;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

* Start Task/Process - The start button does not have the primary colour

**What is the new behaviour?**

* Start Task/Process - The start button have the primary colour.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
