### PR TITLE
[ADF-2158] fallback to image preview if PDF rendition not available

### DIFF
--- a/demo-shell/package.json
+++ b/demo-shell/package.json
@@ -118,6 +118,6 @@
     "rimraf": "^2.6.2",
     "ts-node": "~3.2.0",
     "tslint": "^5.7.0",
-    "typescript": "~2.4.2"
+    "typescript": "2.6.2"
   }
 }

--- a/lib/core/services/renditions.service.ts
+++ b/lib/core/services/renditions.service.ts
@@ -71,7 +71,7 @@ export class RenditionsService {
     }
 
     getRenditionUrl(nodeId: string, encoding: string): string {
-        return this.apiService.contentApi.getRenditionUrl(nodeId, 'pdf');
+        return this.apiService.contentApi.getRenditionUrl(nodeId, encoding);
     }
 
     getRendition(nodeId: string, encoding: string): Observable<RenditionEntry> {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

- use special "image preview" rendition if PDF rendition not available (i.e. Apple Keynote/Numbers/Pages, etc)
- use image fallback for shared link rendering as well
- upgrade to latest Typescript that allows using try/catch with empty 'catch' block (reduces code)

That provides parity with how Share displays unsupported natively content.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
