### PR TITLE
[ADF-1880] processDefinitionId parameter in adf-start-process

### DIFF
--- a/docs/start-process.component.md
+++ b/docs/start-process.component.md
@@ -18,6 +18,7 @@ Starts a process.
 | --- | --- |
 | appId |  (required): Limit the list of processes which can be started to those contained in the specified app |
 | name | (optional) name to assign to the current process |
+| processDefinitionId| (optional) definition ID of the process to start |
 | variables | Variables in input to the process [RestVariable](https://github.com/Alfresco/alfresco-js-api/tree/master/src/alfresco-activiti-rest-api/docs/RestVariable.md)|
 | values | Parameter to pass form field values in the start form if is associated |
 
@@ -28,6 +29,24 @@ Starts a process.
 | start | Raised when the process start |
 | cancel | Raised when the process canceled |
 | error | Raised when the start process fail |
+
+### Details
+
+- If your app has only one processDefintion it will be automaticaly gather from the ***adf-start-process***.
+- If your app has multiple processDefintion and you didn't define processDefinitionId parameter a drop down will allow you to select which use
+- If your app has multiple processDefintion and you defined the processDefinitionId parameter the ***adf-start-process*** will be automatically instantiated with the selected process.
+
+### Start a process with processDefinitionId
+
+```html
+ <adf-start-process 
+      [appId]="YOUR_APP_ID"
+      [processName]="PROCESS_NAME"
+      [processDefinitionId]="PROCESS_DEF_ID">
+ </adf-start-process>		 
+```
+
+If you have more then one process in yor app you can in this way preselect which is the process to start
 
 
 ### Custom data example

--- a/lib/process-services/mock/process/start-process.component.mock.ts
+++ b/lib/process-services/mock/process/start-process.component.mock.ts
@@ -35,7 +35,7 @@ export let testProcessDefinitions = [new ProcessDefinitionRepresentation({
     hasStartForm: false
 })];
 
-export let testProcessDefs = [new ProcessDefinitionRepresentation({
+export let testMultipleProcessDefs = [new ProcessDefinitionRepresentation({
     id: 'my:process1',
     name: 'My Process 1',
     hasStartForm: false

--- a/lib/process-services/mock/process/start-process.component.mock.ts
+++ b/lib/process-services/mock/process/start-process.component.mock.ts
@@ -29,6 +29,12 @@ export let testProcessDefRepr = new ProcessDefinitionRepresentation({
     hasStartForm: false
 });
 
+export let testProcessDefinitions = [new ProcessDefinitionRepresentation({
+    id: 'my:process1',
+    name: 'My Process 1',
+    hasStartForm: false
+})];
+
 export let testProcessDefs = [new ProcessDefinitionRepresentation({
     id: 'my:process1',
     name: 'My Process 1',

--- a/lib/process-services/process-list/components/start-process.component.html
+++ b/lib/process-services/process-list/components/start-process.component.html
@@ -8,14 +8,17 @@
 		<mat-form-field class="adf-process-input-container">
 			<input matInput placeholder="{{'ADF_PROCESS_LIST.START_PROCESS.FORM.LABEL.NAME'|translate}}" [(ngModel)]="name" id="processName" required />
 		</mat-form-field>
-        <mat-form-field>
-            <mat-select [compareWith]="compareProcessDef" placeholder="{{'ADF_PROCESS_LIST.START_PROCESS.FORM.LABEL.TYPE'|translate}}" [(ngModel)]="currentProcessDef.id" (ngModelChange)="onProcessDefChange($event)" required>
-                <mat-option>{{'ADF_PROCESS_LIST.START_PROCESS.FORM.TYPE_PLACEHOLDER' | translate}}</mat-option>
-                <mat-option *ngFor="let processDef of processDefinitions" [value]="processDef.id">
-                    {{ processDef.name }}
-                </mat-option>
-            </mat-select>
-        </mat-form-field>
+        <div *ngIf="hasMultipleProcessDefinitions()">
+            <mat-form-field>
+                <mat-select [compareWith]="compareProcessDef" placeholder="{{'ADF_PROCESS_LIST.START_PROCESS.FORM.LABEL.TYPE'|translate}}" [(ngModel)]="currentProcessDef.id" (ngModelChange)="onProcessDefChange($event)" required>
+                    <mat-option>{{'ADF_PROCESS_LIST.START_PROCESS.FORM.TYPE_PLACEHOLDER' | translate}}</mat-option>
+                    <mat-option *ngFor="let processDef of processDefinitions" [value]="processDef.id">
+                        {{ processDef.name }}
+                    </mat-option>
+                </mat-select>
+            </mat-form-field>
+        </div>
+
         <adf-start-form *ngIf="hasStartForm()"
                         [data]="values"
             [disableStartProcessButton]="!hasProcessName()"

--- a/lib/process-services/process-list/components/start-process.component.spec.ts
+++ b/lib/process-services/process-list/components/start-process.component.spec.ts
@@ -28,7 +28,7 @@ import { Observable } from 'rxjs/Observable';
 
 import { ProcessInstanceVariable } from '../models/process-instance-variable.model';
 import { ProcessService } from '../services/process.service';
-import { newProcess, taskFormMock, testProcessDefRepr, testProcessDefs, testProcessDefWithForm } from '../../mock';
+import { newProcess, taskFormMock, testProcessDefRepr, testProcessDefs, testProcessDefWithForm, testProcessDefinitions } from '../../mock';
 import { StartProcessInstanceComponent } from './start-process.component';
 
 describe('StartProcessInstanceComponent', () => {
@@ -168,6 +168,33 @@ describe('StartProcessInstanceComponent', () => {
                 expect(selectElement).not.toBeNull();
                 expect(selectElement).toBeDefined();
                 expect(selectElement.innerText).toBe('My Process 1');
+            });
+        });
+
+        it('should select processDefinition based on processDefinitionId input', () => {
+            let change = new SimpleChange(null, '123', true);
+            component.ngOnChanges({ 'appId': change });
+            component.processDefinitionId = 'my:process2';
+            component.processDefinitions = testProcessDefs;
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+                let selectElement = fixture.nativeElement.querySelector('mat-select > .mat-select-trigger');
+                expect(selectElement).not.toBeNull();
+                expect(selectElement).toBeDefined();
+                expect(selectElement.innerText).toBe('My Process 2');
+            });
+        });
+
+        it('should hide the process dropdown if the value is already selected', () => {
+            let change = new SimpleChange(null, '123', true);
+            component.ngOnChanges({'appId': change});
+            component.processDefinitions = testProcessDefinitions;
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+                let selectElement = fixture.nativeElement.querySelector('mat-select > .mat-select-trigger');
+                expect(selectElement).not.toBeNull();
+                expect(selectElement).toBeDefined();
+                expect(selectElement.nativeElement.hide).toBeTruthy();
             });
         });
     });
@@ -411,11 +438,11 @@ describe('StartProcessInstanceComponent', () => {
 
         describe('CS content connection', () => {
 
-            fit('alfrescoRepositoryName default configuration property', () => {
+            it('alfrescoRepositoryName default configuration property', () => {
                 expect(component.getAlfrescoRepositoryName()).toBe('alfresco-1Alfresco');
             });
 
-            fit('alfrescoRepositoryName configuration property should be fetched', () => {
+            it('alfrescoRepositoryName configuration property should be fetched', () => {
                 appConfig.config = Object.assign(appConfig.config, {
                     'alfrescoRepositoryName': 'alfresco-123'
                 };
@@ -423,7 +450,7 @@ describe('StartProcessInstanceComponent', () => {
                 expect(component.getAlfrescoRepositoryName()).toBe('alfresco-123Alfresco');
             });
 
-            fit('if values in input is a node should be linked in the process service', () => {
+            it('if values in input is a node should be linked in the process service', () => {
 
                 component.values = {};
                 component.values['file'] = {

--- a/lib/process-services/process-list/components/start-process.component.spec.ts
+++ b/lib/process-services/process-list/components/start-process.component.spec.ts
@@ -28,7 +28,14 @@ import { Observable } from 'rxjs/Observable';
 
 import { ProcessInstanceVariable } from '../models/process-instance-variable.model';
 import { ProcessService } from '../services/process.service';
-import { newProcess, taskFormMock, testProcessDefRepr, testProcessDefs, testProcessDefWithForm, testProcessDefinitions } from '../../mock';
+import {
+    newProcess,
+    taskFormMock,
+    testProcessDefRepr,
+    testMultipleProcessDefs,
+    testProcessDefWithForm,
+    testProcessDefinitions
+} from '../../mock';
 import { StartProcessInstanceComponent } from './start-process.component';
 
 describe('StartProcessInstanceComponent', () => {
@@ -71,7 +78,7 @@ describe('StartProcessInstanceComponent', () => {
         processService = fixture.debugElement.injector.get(ProcessService);
         formService = fixture.debugElement.injector.get(FormService);
 
-        getDefinitionsSpy = spyOn(processService, 'getProcessDefinitions').and.returnValue(Observable.of(testProcessDefs));
+        getDefinitionsSpy = spyOn(processService, 'getProcessDefinitions').and.returnValue(Observable.of(testMultipleProcessDefs));
         startProcessSpy = spyOn(processService, 'startProcess').and.returnValue(Observable.of(newProcess));
         getStartFormDefinitionSpy = spyOn(formService, 'getStartFormDefinition').and.returnValue(Observable.of(taskFormMock));
         spyOn(activitiContentService, 'applyAlfrescoNode').and.returnValue(Observable.of({ id: 1234 }));
@@ -96,7 +103,7 @@ describe('StartProcessInstanceComponent', () => {
             component.ngOnChanges({ 'appId': change });
             fixture.detectChanges();
 
-            expect(getDefinitionsSpy).toHaveBeenCalledWith(null);
+            expect(getDefinitionsSpy).not.toHaveBeenCalledWith(null);
         });
 
         it('should call service to fetch process definitions with appId when provided', () => {
@@ -119,7 +126,7 @@ describe('StartProcessInstanceComponent', () => {
         it('should display the option def details', () => {
             let change = new SimpleChange(null, '123', true);
             component.ngOnChanges({ 'appId': change });
-            component.processDefinitions = testProcessDefs;
+            component.processDefinitions = testMultipleProcessDefs;
             fixture.detectChanges();
             fixture.whenStable().then(() => {
                 let selectElement = fixture.nativeElement.querySelector('mat-select > .mat-select-trigger');
@@ -158,45 +165,66 @@ describe('StartProcessInstanceComponent', () => {
             });
         }));
 
-        it('should auto-select process def from dropdown if there is just one process def', () => {
+        it('should hide the process dropdown if the app contain only one processDefinition', async(() => {
+            getDefinitionsSpy = getDefinitionsSpy.and.returnValue(Observable.of(testProcessDefRepr));
             let change = new SimpleChange(null, '123', true);
+            component.appId = 123;
             component.ngOnChanges({ 'appId': change });
-            component.processDefinitions[0] = testProcessDefRepr;
             fixture.detectChanges();
             fixture.whenStable().then(() => {
                 let selectElement = fixture.nativeElement.querySelector('mat-select > .mat-select-trigger');
-                expect(selectElement).not.toBeNull();
-                expect(selectElement).toBeDefined();
-                expect(selectElement.innerText).toBe('My Process 1');
+                expect(selectElement).toBeNull();
             });
-        });
+        }));
 
-        it('should select processDefinition based on processDefinitionId input', () => {
+        it('should hide the process dropdown if the processDefinition is already selected', async(() => {
+            getDefinitionsSpy = getDefinitionsSpy.and.returnValue(Observable.of(testMultipleProcessDefs));
             let change = new SimpleChange(null, '123', true);
-            component.ngOnChanges({ 'appId': change });
+            component.appId = 123;
             component.processDefinitionId = 'my:process2';
-            component.processDefinitions = testProcessDefs;
+            component.ngOnChanges({ 'appId': change });
             fixture.detectChanges();
             fixture.whenStable().then(() => {
                 let selectElement = fixture.nativeElement.querySelector('mat-select > .mat-select-trigger');
-                expect(selectElement).not.toBeNull();
-                expect(selectElement).toBeDefined();
-                expect(selectElement.innerText).toBe('My Process 2');
+                expect(selectElement).toBeNull();
             });
-        });
+        }));
 
-        it('should hide the process dropdown if the value is already selected', () => {
+        it('should show the process dropdown if the processDefinition is not selected and the app contain multiple process', async(() => {
+            getDefinitionsSpy = getDefinitionsSpy.and.returnValue(Observable.of(testMultipleProcessDefs));
             let change = new SimpleChange(null, '123', true);
-            component.ngOnChanges({'appId': change});
-            component.processDefinitions = testProcessDefinitions;
+            component.appId = 123;
+            component.ngOnChanges({ 'appId': change });
             fixture.detectChanges();
             fixture.whenStable().then(() => {
                 let selectElement = fixture.nativeElement.querySelector('mat-select > .mat-select-trigger');
                 expect(selectElement).not.toBeNull();
-                expect(selectElement).toBeDefined();
-                expect(selectElement.nativeElement.hide).toBeTruthy();
             });
-        });
+        }));
+
+        it('should select processDefinition based on processDefinitionId input', async(() => {
+            getDefinitionsSpy = getDefinitionsSpy.and.returnValue(Observable.of(testMultipleProcessDefs));
+            let change = new SimpleChange(null, '123', true);
+            component.appId = 123;
+            component.processDefinitionId = 'my:process2';
+            component.ngOnChanges({ 'appId': change });
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+                expect(component.currentProcessDef.name).toBe(JSON.parse(JSON.stringify(testMultipleProcessDefs[1])).name);
+            });
+        }));
+
+        it('should select automatically the processDefinition if the app contain oly one', async(() => {
+            getDefinitionsSpy = getDefinitionsSpy.and.returnValue(Observable.of(testProcessDefinitions));
+            let change = new SimpleChange(null, '123', true);
+            component.appId = 123;
+            component.ngOnChanges({ 'appId': change });
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+                expect(component.currentProcessDef.name).toBe(JSON.parse(JSON.stringify(testProcessDefinitions[0])).name);
+            });
+        }));
+
     });
 
     describe('input changes', () => {
@@ -218,17 +246,12 @@ describe('StartProcessInstanceComponent', () => {
             expect(getDefinitionsSpy).toHaveBeenCalledWith(456);
         });
 
-        it('should reload processes when appId input changed to null', () => {
-            component.ngOnChanges({ appId: nullChange });
-            expect(getDefinitionsSpy).toHaveBeenCalledWith(null);
-        });
-
         it('should get current processDeff', () => {
             component.ngOnChanges({ appId: change });
             component.onProcessDefChange('my:Process');
             fixture.detectChanges();
             expect(getDefinitionsSpy).toHaveBeenCalled();
-            expect(component.processDefinitions).toBe(testProcessDefs);
+            expect(component.processDefinitions).toBe(testMultipleProcessDefs);
         });
     });
 
@@ -382,14 +405,14 @@ describe('StartProcessInstanceComponent', () => {
                 expect(startBtn.disabled).toBe(true);
             });
 
-            it('should enable start button when name and process filled out', () => {
+            it('should enable start button when name and process filled out', async(() => {
                 component.onProcessDefChange('my:process1');
                 fixture.detectChanges();
                 fixture.whenStable().then(() => {
                     startBtn = fixture.nativeElement.querySelector('#button-start');
                     expect(startBtn.disabled).toBe(false);
                 });
-            });
+            }));
 
             it('should disable the start process button when process name is empty', () => {
                 component.name = '';
@@ -450,7 +473,7 @@ describe('StartProcessInstanceComponent', () => {
                 expect(component.getAlfrescoRepositoryName()).toBe('alfresco-123Alfresco');
             });
 
-            it('if values in input is a node should be linked in the process service', () => {
+            it('if values in input is a node should be linked in the process service', async(() => {
 
                 component.values = {};
                 component.values['file'] = {
@@ -463,8 +486,7 @@ describe('StartProcessInstanceComponent', () => {
                 fixture.whenStable().then(() => {
                     expect(component.values.file[0].id).toBe(1234);
                 });
-            });
+            }));
         });
     });
-
 });

--- a/lib/process-services/process-list/components/start-process.component.spec.ts
+++ b/lib/process-services/process-list/components/start-process.component.spec.ts
@@ -230,7 +230,6 @@ describe('StartProcessInstanceComponent', () => {
     describe('input changes', () => {
 
         let change = new SimpleChange(123, 456, true);
-        let nullChange = new SimpleChange(123, null, true);
 
         beforeEach(async(() => {
             component.appId = 123;

--- a/lib/process-services/process-list/components/start-process.component.ts
+++ b/lib/process-services/process-list/components/start-process.component.ts
@@ -50,6 +50,9 @@ export class StartProcessInstanceComponent implements OnChanges {
     appId: number;
 
     @Input()
+    processDefinitionId: string;
+
+    @Input()
     variables: ProcessInstanceVariable[];
 
     @Input()
@@ -89,22 +92,37 @@ export class StartProcessInstanceComponent implements OnChanges {
             this.moveNodeFromCStoPS();
         }
 
-        let appIdChange = changes['appId'];
-        let appId = appIdChange ? appIdChange.currentValue : null;
-        this.load(appId);
+        this.loadStartProcess();
     }
 
-    public load(appId?: number) {
+    public loadStartProcess() {
         this.resetSelectedProcessDefinition();
         this.resetErrorMessage();
-        this.activitiProcess.getProcessDefinitions(appId).subscribe(
-            (res) => {
-                this.processDefinitions = res;
-            },
-            () => {
-                this.errorMessageId = 'ADF_PROCESS_LIST.START_PROCESS.ERROR.LOAD_PROCESS_DEFS';
-            }
-        );
+
+        if (this.appId) {
+            this.activitiProcess.getProcessDefinitions(this.appId).subscribe(
+                (processDefinitionRepresentations: ProcessDefinitionRepresentation[]) => {
+                    this.processDefinitions = processDefinitionRepresentations;
+
+                    if (this.processDefinitions.length === 1) {
+                        this.currentProcessDef = JSON.parse(JSON.stringify(this.processDefinitions[0]));
+                    } else {
+                        if (this.processDefinitionId) {
+                            this.processDefinitions = this.processDefinitions.filter((currentProcessDefinition) => {
+                                return currentProcessDefinition.id === this.processDefinitionId;
+                            });
+                            this.currentProcessDef = JSON.parse(JSON.stringify(this.processDefinitions[0]));
+                        }
+                    }
+                },
+                () => {
+                    this.errorMessageId = 'ADF_PROCESS_LIST.START_PROCESS.ERROR.LOAD_PROCESS_DEFS';
+                });
+        }
+    }
+
+    public hasMultipleProcessDefinitions(): boolean {
+        return this.processDefinitions.length > 1;
     }
 
     getAlfrescoRepositoryName(): string {

--- a/lib/process-services/process-list/components/start-process.component.ts
+++ b/lib/process-services/process-list/components/start-process.component.ts
@@ -92,6 +92,10 @@ export class StartProcessInstanceComponent implements OnChanges {
             this.moveNodeFromCStoPS();
         }
 
+        if (changes['appId'] && changes['appId'].currentValue) {
+            this.appId = changes['appId'].currentValue;
+        }
+
         this.loadStartProcess();
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Is not possible specify the processDefintion

**What is the new behaviour?**
- If your app has only one processDefintion it will be automaticaly gather from the ***adf-start-process***.
- If your app has multiple processDefintion and you didn't define processDefinitionId parameter a drop down will allow you to select which use
- If your app has multiple processDefintion and you defined the processDefinitionId parameter the ***adf-start-process*** will be automatically instantiated with the selected process.



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
