### PR TITLE
[ADF-2174] Menus background color is not properly displayed in black themes

### DIFF
--- a/lib/core/sidebar/sidebar-action-menu.component.html
+++ b/lib/core/sidebar/sidebar-action-menu.component.html
@@ -8,7 +8,7 @@
         <ng-content select="[sidebar-menu-expand-icon]"></ng-content>
     </div>
 
-    <mat-menu #adfSidebarMenu="matMenu" [overlapTrigger]="false" yPosition="below">
+    <mat-menu #adfSidebarMenu="matMenu" class="adf-sidebar-action-menu-panel" [overlapTrigger]="false" yPosition="below">
         <div class="adf-sidebar-action-menu-options">
             <ng-content select="[sidebar-menu-options]"></ng-content>
         </div>

--- a/lib/core/sidebar/sidebar-action-menu.component.scss
+++ b/lib/core/sidebar/sidebar-action-menu.component.scss
@@ -11,61 +11,58 @@
     $adf-sidebar-action-menu-item-opacity: 0.87;
     $adf-sidebar-action-menu-item-line-spacing: -0.4px;
 
-.adf {
-    &-sidebar-action-menu {
-        & .mat-raised-button {
-            width: 100%;
-            height: 37.5px;
-            font-weight: bold;
-            background-color: mat-color($primary);
-            color: mat-color($primary, default-contrast) !important;
-            border-radius: $adf-sidebar-action-menu-button-border-radius;
-            & mat-icon {
-                width: 24px;
-                height: 25px;
+    .adf {
+        &-sidebar-action-menu {
+            & .mat-raised-button {
+                width: 100%;
+                height: 37.5px;
+                font-weight: bold;
+                background-color: mat-color($primary);
                 color: mat-color($primary, default-contrast) !important;
+                border-radius: $adf-sidebar-action-menu-button-border-radius;
+                & mat-icon {
+                    width: 24px;
+                    height: 25px;
+                    color: mat-color($primary, default-contrast) !important;
+                }
+            }
+            &-text {
+                width: 100%;
+                height: 20px;
+                text-align: left;
             }
         }
-        &-text {
-            width: 100%;
-            height: 20px;
-            text-align: left;
+        &-sidebar-action-menu-icon {
+            margin: 18px 0px 0px 20px;
+            opacity: $adf-sidebar-action-menu-opacity;
+            cursor: pointer;
+            &:hover {
+                color: mat-color($primary);
+                opacity: inherit;
+            }
         }
-    }
-    &-sidebar-action-menu-icon {
-        margin: 18px 0px 0px 20px;
-        opacity: $adf-sidebar-action-menu-opacity;
-        cursor: pointer;
-        &:hover {
-            color: mat-color($primary);
-            opacity: inherit;
-        }
-    }
-    &-sidebar-action-menu-options {
-        width: $adf-sidebar-action-menu-button-option-width;
-        opacity: 0.87;
-        text-align: left;
-        letter-spacing: -0.4px;
-        color: #000000;
-        .mat-menu-item {
+        &-sidebar-action-menu-options {
             width: $adf-sidebar-action-menu-button-option-width;
-            opacity: $adf-sidebar-action-menu-item-opacity;
+            opacity: 0.87;
             text-align: left;
-            line-height: 1.5;
-            letter-spacing: $adf-sidebar-action-menu-item-line-spacing;
+            letter-spacing: -0.4px;
             color: #000000;
+            .mat-menu-item {
+                width: $adf-sidebar-action-menu-button-option-width;
+                opacity: $adf-sidebar-action-menu-item-opacity;
+                text-align: left;
+                line-height: 1.5;
+                letter-spacing: $adf-sidebar-action-menu-item-line-spacing;
+            }
+            .mat-menu-item:hover {
+                color: mat-color($primary);
+                opacity: inherit;
+            }
         }
-        .mat-menu-item:hover {
-            color: mat-color($primary);
-            opacity: inherit;
+        &-sidebar-action-menu-panel {
+            margin-top: 7.5px;
+            border-radius: 2px;
+            box-shadow: 0 8px 8px 0 rgba(0, 0, 0, 0.26), 0 0 8px 0 rgba(0, 0, 0, 0.12);
         }
     }
-}
-
-.mat-menu-panel {
-    margin-top: 7.5px;
-    border-radius: 2px;
-    background-color: mat-color($primary, default-contrast) !important;
-    box-shadow: 0 8px 8px 0 rgba(0, 0, 0, 0.26), 0 0 8px 0 rgba(0, 0, 0, 0.12);
-}
 }

--- a/lib/core/sidebar/sidebar-action-menu.component.scss
+++ b/lib/core/sidebar/sidebar-action-menu.component.scss
@@ -1,8 +1,6 @@
 @mixin  adf-sidebar-action-menu-theme($theme) {
 
     $primary: map-get($theme, primary);
-    $foreground: map-get($theme, foreground);
-    $background: map-get($theme, background);
 
     $adf-sidebar-action-menu-button-option-width: 205px;
     $adf-sidebar-action-menu-button-height: 37.5px;
@@ -43,10 +41,9 @@
         }
         &-sidebar-action-menu-options {
             width: $adf-sidebar-action-menu-button-option-width;
-            opacity: 0.87;
+            opacity: $adf-sidebar-action-menu-item-opacity;
             text-align: left;
-            letter-spacing: -0.4px;
-            color: #000000;
+            letter-spacing: $adf-sidebar-action-menu-item-line-spacing;
             .mat-menu-item {
                 width: $adf-sidebar-action-menu-button-option-width;
                 opacity: $adf-sidebar-action-menu-item-opacity;

--- a/lib/core/sidebar/sidebar-action-menu.component.scss
+++ b/lib/core/sidebar/sidebar-action-menu.component.scss
@@ -1,8 +1,8 @@
 @mixin  adf-sidebar-action-menu-theme($theme) {
 
     $primary: map-get($theme, primary);
+    $foreground: map-get($theme, foreground);
 
-    $adf-sidebar-action-menu-button-option-width: 205px;
     $adf-sidebar-action-menu-button-height: 37.5px;
     $adf-sidebar-action-menu-button-border-radius: 4px;
     $adf-sidebar-action-menu-opacity: 0.54;
@@ -13,7 +13,7 @@
         &-sidebar-action-menu {
             & .mat-raised-button {
                 width: 100%;
-                height: 37.5px;
+                height: $adf-sidebar-action-menu-button-height;
                 font-weight: bold;
                 background-color: mat-color($primary);
                 color: mat-color($primary, default-contrast) !important;
@@ -32,21 +32,17 @@
         }
         &-sidebar-action-menu-icon {
             margin: 18px 0px 0px 20px;
-            opacity: $adf-sidebar-action-menu-opacity;
+            color: mat-color($foreground, text, $adf-sidebar-action-menu-opacity);
             cursor: pointer;
             &:hover {
                 color: mat-color($primary);
-                opacity: inherit;
             }
         }
         &-sidebar-action-menu-options {
-            width: $adf-sidebar-action-menu-button-option-width;
-            opacity: $adf-sidebar-action-menu-item-opacity;
             text-align: left;
             letter-spacing: $adf-sidebar-action-menu-item-line-spacing;
             .mat-menu-item {
-                width: $adf-sidebar-action-menu-button-option-width;
-                opacity: $adf-sidebar-action-menu-item-opacity;
+                color: mat-color($foreground, text, $adf-sidebar-action-menu-item-opacity);
                 text-align: left;
                 line-height: 1.5;
                 letter-spacing: $adf-sidebar-action-menu-item-line-spacing;


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

* Overlay elements have wrong opacity and wrong bg color in dark themes.

**What is the new behaviour?**

* Removed global mat-menu-panel class style overriding
* Overly elements have expected bg color and opacity.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
