### PR TITLE
[ADF-2170] fixed condition for file size equal zero

### DIFF
--- a/lib/content-services/upload/components/upload-button.component.spec.ts
+++ b/lib/content-services/upload/components/upload-button.component.spec.ts
@@ -216,6 +216,17 @@ describe('UploadButtonComponent', () => {
             expect(addToQueueSpy.calls.mostRecent()).toBeUndefined();
         });
 
+        it('should allow file of 0 size when the max file size is set to 0', () => {
+            const zeroFiles: File[] = [
+                <File> { name: 'zeroFile.png', size: 0 }
+            ];
+            component.maxFilesSize = 0;
+
+            component.uploadFiles(zeroFiles);
+
+            expect(addToQueueSpy.calls.mostRecent()).toBeDefined();
+        });
+
         it('should filter out all files if maxFilesSize is <0', () => {
             component.maxFilesSize = -2;
 

--- a/lib/content-services/upload/components/upload-button.component.ts
+++ b/lib/content-services/upload/components/upload-button.component.ts
@@ -201,7 +201,7 @@ export class UploadButtonComponent implements OnInit, OnChanges, NodePermissionS
     private isFileSizeAcceptable(file: FileModel): boolean {
         let acceptableSize = true;
 
-        if ((this.maxFilesSize !== undefined && this.maxFilesSize !== null ) && (this.maxFilesSize <= 0 || file.size > this.maxFilesSize)) {
+        if ((this.maxFilesSize !== undefined && this.maxFilesSize !== null ) && (this.maxFilesSize < 0 || file.size > this.maxFilesSize)) {
             acceptableSize = false;
 
             this.translateService.get('FILE_UPLOAD.MESSAGES.EXCEED_MAX_FILE_SIZE', {fileName: file.name}).subscribe((message: string) => {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Setting max file for upload button to 0 prevent file with 0 size to be uploaded


**What is the new behaviour?**
Setting max file for upload button to 0 allow file with 0 size to be uploaded


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
