### PR TITLE
[ADF-2139] extra cookie availability check

### DIFF
--- a/lib/core/mock/cookie.service.mock.ts
+++ b/lib/core/mock/cookie.service.mock.ts
@@ -15,7 +15,9 @@
  * limitations under the License.
  */
 
-export class CookieServiceMock {
+import { CookieService } from '../services/cookie.service';
+
+export class CookieServiceMock extends CookieService {
 
     getItem(key: string): string | null {
         return this[key] && this[key].data || null;

--- a/lib/core/services/authentication.service.spec.ts
+++ b/lib/core/services/authentication.service.spec.ts
@@ -75,7 +75,7 @@ describe('AuthenticationService', () => {
         jasmine.Ajax.uninstall();
     });
 
-    describe('remembe me', () => {
+    describe('remember me', () => {
 
         beforeEach(() => {
             preferences.authType = 'ECM';
@@ -137,6 +137,24 @@ describe('AuthenticationService', () => {
 
         beforeEach(() => {
             preferences.authType = 'ECM';
+        });
+
+        it('should require remember me set for ECM check', () => {
+            spyOn(cookie, 'isEnabled').and.returnValue(true);
+            spyOn(authService, 'isRememberMeSet').and.returnValue(false);
+            spyOn(apiService, 'getInstance').and.callThrough();
+
+            expect(authService.isEcmLoggedIn()).toBeFalsy();
+            expect(apiService.getInstance).not.toHaveBeenCalled();
+        });
+
+        it('should not require cookie service enabled for ECM check', () => {
+            spyOn(cookie, 'isEnabled').and.returnValue(false);
+            spyOn(authService, 'isRememberMeSet').and.returnValue(false);
+            spyOn(apiService, 'getInstance').and.callThrough();
+
+            expect(authService.isEcmLoggedIn()).toBeFalsy();
+            expect(apiService.getInstance).toHaveBeenCalled();
         });
 
         it('[ECM] should return an ECM ticket after the login done', (done) => {
@@ -264,6 +282,24 @@ describe('AuthenticationService', () => {
 
         beforeEach(() => {
             preferences.authType = 'BPM';
+        });
+
+        it('should require remember me set for BPM check', () => {
+            spyOn(cookie, 'isEnabled').and.returnValue(true);
+            spyOn(authService, 'isRememberMeSet').and.returnValue(false);
+            spyOn(apiService, 'getInstance').and.callThrough();
+
+            expect(authService.isBpmLoggedIn()).toBeFalsy();
+            expect(apiService.getInstance).not.toHaveBeenCalled();
+        });
+
+        it('should not require cookie service enabled for BPM check', () => {
+            spyOn(cookie, 'isEnabled').and.returnValue(false);
+            spyOn(authService, 'isRememberMeSet').and.returnValue(false);
+            spyOn(apiService, 'getInstance').and.callThrough();
+
+            expect(authService.isBpmLoggedIn()).toBeFalsy();
+            expect(apiService.getInstance).toHaveBeenCalled();
         });
 
         it('[BPM] should return an BPM ticket after the login done', (done) => {

--- a/lib/core/services/authentication.service.ts
+++ b/lib/core/services/authentication.service.ts
@@ -95,7 +95,7 @@ export class AuthenticationService {
      *
      * @returns {boolean}
      */
-    private isRememberMeSet(): boolean {
+    isRememberMeSet(): boolean {
         return (this.cookie.getItem(REMEMBER_ME_COOKIE_KEY) === null) ? false : true;
     }
 

--- a/lib/core/services/authentication.service.ts
+++ b/lib/core/services/authentication.service.ts
@@ -199,7 +199,10 @@ export class AuthenticationService {
      * @returns {boolean}
      */
     isEcmLoggedIn(): boolean {
-        return this.isRememberMeSet() && this.alfrescoApi.getInstance().ecmAuth && !!this.alfrescoApi.getInstance().ecmAuth.isLoggedIn();
+        if (this.cookie.isEnabled() && !this.isRememberMeSet()) {
+            return false;
+        }
+        return this.alfrescoApi.getInstance().ecmAuth && !!this.alfrescoApi.getInstance().ecmAuth.isLoggedIn();
     }
 
     /**
@@ -208,7 +211,10 @@ export class AuthenticationService {
      * @returns {boolean}
      */
     isBpmLoggedIn(): boolean {
-        return this.isRememberMeSet() && this.alfrescoApi.getInstance().bpmAuth && !!this.alfrescoApi.getInstance().bpmAuth.isLoggedIn();
+        if (this.cookie.isEnabled() && !this.isRememberMeSet()) {
+            return false;
+        }
+        return this.alfrescoApi.getInstance().bpmAuth && !!this.alfrescoApi.getInstance().bpmAuth.isLoggedIn();
     }
 
     /**

--- a/lib/core/services/cookie.service.ts
+++ b/lib/core/services/cookie.service.ts
@@ -20,6 +20,16 @@ import { Injectable } from '@angular/core';
 @Injectable()
 export class CookieService {
 
+    isEnabled(): boolean {
+        // for certain scenarios Chrome may say 'true' but have cookies still disabled
+        if (navigator.cookieEnabled === false) {
+            return false;
+        }
+
+        document.cookie = "test-cookie";
+        return document.cookie.indexOf("test-cookie") > 0;
+    }
+
     /**
      * Retrieve cookie by key.
      *

--- a/lib/core/services/cookie.service.ts
+++ b/lib/core/services/cookie.service.ts
@@ -26,8 +26,8 @@ export class CookieService {
             return false;
         }
 
-        document.cookie = "test-cookie";
-        return document.cookie.indexOf("test-cookie") > 0;
+        document.cookie = 'test-cookie';
+        return document.cookie.indexOf('test-cookie') > 0;
     }
 
     /**


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

For certain scenarios (loading with `file://` protocol within Electron for instance) the Cookies are disabled by the platform. That leads to `AuthenticationService.isEcmLoggedIn` to always evaluate to `false` when switching off the `remember me` feature.

**What is the new behaviour?**

- adds an extra check for Cookies being available and working indeed for the given document

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
