### PR TITLE
[ADF-2208] The width of the 'New Task' option is smaller then Create Task drop down

### DIFF
--- a/lib/core/sidebar/sidebar-action-menu.component.scss
+++ b/lib/core/sidebar/sidebar-action-menu.component.scss
@@ -4,6 +4,7 @@
     $foreground: map-get($theme, foreground);
 
     $adf-sidebar-action-menu-button-height: 37.5px;
+    $adf-sidebar-action-menu-button-width: 202px;
     $adf-sidebar-action-menu-button-border-radius: 4px;
     $adf-sidebar-action-menu-opacity: 0.54;
     $adf-sidebar-action-menu-item-opacity: 0.87;
@@ -12,7 +13,7 @@
     .adf {
         &-sidebar-action-menu {
             & .mat-raised-button {
-                width: 100%;
+                width: $adf-sidebar-action-menu-button-width;
                 height: $adf-sidebar-action-menu-button-height;
                 font-weight: bold;
                 background-color: mat-color($primary);
@@ -56,6 +57,7 @@
             margin-top: 7.5px;
             border-radius: 2px;
             box-shadow: 0 8px 8px 0 rgba(0, 0, 0, 0.26), 0 0 8px 0 rgba(0, 0, 0, 0.12);
+            min-width: $adf-sidebar-action-menu-button-width !important;
         }
     }
 }


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

* New Task option is smaller then Create Task drop down

**What is the new behaviour?**

* Width is for menu and button

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
