### PR TITLE
[ADF-2228] Added missing space in French example

### DIFF
--- a/docs/translation.service.md
+++ b/docs/translation.service.md
@@ -60,7 +60,7 @@ If you wanted English and French translations then you would copy the built-in
 
     // fr.json
         ...
-      "WELCOME_MESSAGE": "Bienvenue!"
+      "WELCOME_MESSAGE": "Bienvenue !"
         ...
 
 To enable the new translations in your app, you also need to register them in your


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [x] Documentation
> - [ ] Other... Please describe:

**What is the new behaviour?**

Minor update: Gloria pointed out that the French example I used should have a space before the exclamation mark. The space is now added in correctly.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No

