### PR TITLE
[ADF-2251] ContentWidgetModule is not exposed from ADF

### DIFF
--- a/lib/process-services/index.ts
+++ b/lib/process-services/index.ts
@@ -23,6 +23,7 @@ export * from './app-list/apps-list.module';
 export * from './attachment/attachment.module';
 export * from './comments/comments.module';
 export * from './people/people.module';
+export * from './content-widget/content-widget.module';
 
 export * from './process-list';
 export * from './task-list';
@@ -30,3 +31,4 @@ export * from './app-list';
 export * from './attachment';
 export * from './comments';
 export * from './people';
+export * from './content-widget';


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

* ContentWidget Module and related classes are not exposed

**What is the new behaviour?**

* ContentWidget Module and related classes are exposed

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
