### PR TITLE
[ADF-2259] emit "sorting-changed" DOM event (DataTable)

### DIFF
--- a/docs/datatable.component.md
+++ b/docs/datatable.component.md
@@ -172,6 +172,7 @@ These events bubble up the component tree and can be handled by any parent compo
 | row-select | Raised after user selects a row |
 | row-unselect | Raised after user unselects a row |
 | row-keyup | Raised on the 'keyup' event for the focused row. |
+| sorting-changed | Raised after user clicks the sortable column header. |
 
 For example:
 

--- a/lib/core/datatable/components/datatable/datatable.component.spec.ts
+++ b/lib/core/datatable/components/datatable/datatable.component.spec.ts
@@ -51,6 +51,27 @@ describe('DataTable', () => {
         element = fixture.debugElement.nativeElement;
     });
 
+    it('should emit "sorting-changed" DOM event', (done) => {
+        const column = new ObjectDataColumn({ key: 'name', sortable: true, direction: 'asc' });
+        dataTable.data = new ObjectDataTableAdapter(
+            [
+                { name: '1' },
+                { name: '2' }
+            ],
+            [ column ]
+        );
+        dataTable.data.setSorting(new DataSorting('name', 'desc'));
+
+        fixture.nativeElement.addEventListener('sorting-changed', (event: CustomEvent) => {
+            expect(event.detail.key).toBe('name');
+            expect(event.detail.direction).toBe('asc');
+            done();
+        });
+
+        dataTable.ngOnChanges({});
+        dataTable.onColumnHeaderClick(column);
+    });
+
     it('should change the rows on changing of the data', () => {
         let newData = new ObjectDataTableAdapter(
             [

--- a/lib/core/datatable/components/datatable/datatable.component.ts
+++ b/lib/core/datatable/components/datatable/datatable.component.ts
@@ -369,6 +369,7 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck 
                 newDirection = current.direction === 'asc' ? 'desc' : 'asc';
             }
             this.data.setSorting(new DataSorting(column.key, newDirection));
+            this.emitSortingChangedEvent(column.key, newDirection);
         }
     }
 
@@ -514,6 +515,17 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck 
             detail: {
                 row: row,
                 selection: this.selection
+            },
+            bubbles: true
+        });
+        this.elementRef.nativeElement.dispatchEvent(domEvent);
+    }
+
+    private emitSortingChangedEvent(key: string, direction: string) {
+        const domEvent = new CustomEvent('sorting-changed', {
+            detail: {
+                key,
+                direction
             },
             bubbles: true
         });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

Raise DOM bubbling "sorting-changed" event each time user clicks on sortable colum.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
