### PR TITLE
[ADF-2254] always update display name for ACS nodes

### DIFF
--- a/lib/core/viewer/components/viewer.component.spec.ts
+++ b/lib/core/viewer/components/viewer.component.spec.ts
@@ -18,7 +18,7 @@
 import { Location } from '@angular/common';
 import { SpyLocation } from '@angular/common/testing';
 import { Component } from '@angular/core';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { AlfrescoApiService, RenditionsService } from '../../services';
 
 import { MaterialModule } from './../../material.module';
@@ -155,6 +155,40 @@ describe('ViewerComponent', () => {
         }).compileComponents();
     }));
 
+    beforeEach(() => {
+        fixture = TestBed.createComponent(ViewerComponent);
+        element = fixture.nativeElement;
+        component = fixture.componentInstance;
+
+        alfrescoApiService = TestBed.get(AlfrescoApiService);
+    });
+
+    it('should change display name every time node changes', fakeAsync(() => {
+        spyOn(alfrescoApiService.nodesApi, 'getNodeInfo').and.returnValues(
+            Promise.resolve({ name: 'file1', content: {} }),
+            Promise.resolve({ name: 'file2', content: {} })
+        );
+
+        component.urlFile = null;
+        component.displayName = null;
+        component.blobFile = null;
+        component.showViewer = true;
+
+        component.fileNodeId = 'id1';
+        component.ngOnChanges({});
+        tick();
+
+        expect(alfrescoApiService.nodesApi.getNodeInfo).toHaveBeenCalledWith('id1');
+        expect(component.displayName).toBe('file1');
+
+        component.fileNodeId = 'id2';
+        component.ngOnChanges({});
+        tick();
+
+        expect(alfrescoApiService.nodesApi.getNodeInfo).toHaveBeenCalledWith('id2');
+        expect(component.displayName).toBe('file2');
+    }));
+
     describe('Viewer Example Component Rendering', () => {
 
         it('should use custom toolbar', () => {
@@ -193,14 +227,9 @@ describe('ViewerComponent', () => {
     describe('Base component', () => {
 
         beforeEach(() => {
-            fixture = TestBed.createComponent(ViewerComponent);
-            element = fixture.nativeElement;
-            component = fixture.componentInstance;
             component.showToolbar = true;
             component.urlFile = 'base/src/assets/fake-test-file.pdf';
             component.mimeType = 'application/pdf';
-
-            alfrescoApiService = TestBed.get(AlfrescoApiService);
 
             fixture.detectChanges();
         });

--- a/lib/core/viewer/components/viewer.component.ts
+++ b/lib/core/viewer/components/viewer.component.ts
@@ -240,7 +240,7 @@ export class ViewerComponent implements OnChanges {
                 this.setUpUrlFile();
             } else if (this.fileNodeId) {
                 this.isLoading = true;
-                this.apiService.getInstance().nodes.getNodeInfo(this.fileNodeId).then(
+                this.apiService.nodesApi.getNodeInfo(this.fileNodeId).then(
                     (data: MinimalNodeEntryEntity) => {
                         this.setUpNodeFile(data);
                     },
@@ -295,12 +295,12 @@ export class ViewerComponent implements OnChanges {
 
     private setUpNodeFile(data: MinimalNodeEntryEntity) {
         this.mimeType = data.content.mimeType;
-        this.displayName = this.getDisplayName(data.name);
-        this.urlFileContent = this.apiService.getInstance().content.getContentUrl(data.id);
+        this.displayName = data.name;
+        this.urlFileContent = this.apiService.contentApi.getContentUrl(data.id);
         this.extension = this.getFileExtension(data.name);
 
         this.fileName = data.name;
-        this.downloadUrl = this.apiService.getInstance().content.getContentUrl(data.id, true);
+        this.downloadUrl = this.apiService.contentApi.getContentUrl(data.id, true);
 
         this.viewerType = this.getViewerTypeByExtension(this.extension);
         if (this.viewerType === 'unknown') {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

When changing "fileNodeId" value at runtime, the "displayName" is never changed and is always the first evaluated value

**What is the new behaviour?**

For the ACS nodes always assign "displayName"

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
