### PR TITLE
[ADF-2175] Document List requests are executed twice when opening the copy and move dialog

### DIFF
--- a/lib/content-services/document-list/components/document-list.component.spec.ts
+++ b/lib/content-services/document-list/components/document-list.component.spec.ts
@@ -1204,4 +1204,22 @@ describe('DocumentList', () => {
 
         expect(documentList.reload).not.toHaveBeenCalled();
     });
+
+    it('should NOT reload data on first call of onNgChanges', () => {
+        spyOn(documentList, 'reload').and.stub();
+
+        const firstChange = true;
+        documentList.ngOnChanges({ skipCount: new SimpleChange(undefined, 10, firstChange) });
+
+        expect(documentList.reload).not.toHaveBeenCalled();
+    });
+
+    it('should reload data on NON-first calls of onNgChanges', () => {
+        spyOn(documentList, 'reload').and.stub();
+
+        const firstChange = true;
+        documentList.ngOnChanges({ skipCount: new SimpleChange(undefined, 10, !firstChange) });
+
+        expect(documentList.reload).toHaveBeenCalled();
+    });
 });

--- a/lib/content-services/document-list/components/document-list.component.ts
+++ b/lib/content-services/document-list/components/document-list.component.ts
@@ -567,17 +567,17 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
 
     private isSkipCountChanged(changePage: SimpleChanges) {
         return changePage.skipCount &&
+            !changePage.skipCount.isFirstChange() &&
             changePage.skipCount.currentValue !== null &&
             changePage.skipCount.currentValue !== undefined &&
-            changePage.skipCount.currentValue !== changePage.skipCount.previousValue &&
-            changePage.skipCount.firstChange === false;
+            changePage.skipCount.currentValue !== changePage.skipCount.previousValue;
     }
 
     private isMaxItemsChanged(changePage: SimpleChanges) {
         return changePage.maxItems &&
+            !changePage.maxItems.isFirstChange() &&
             changePage.maxItems.currentValue &&
-            changePage.maxItems.currentValue !== changePage.maxItems.previousValue &&
-            changePage.maxItems.firstChange === false;
+            changePage.maxItems.currentValue !== changePage.maxItems.previousValue;
     }
 
     private loadTrashcan(merge: boolean = false): void {

--- a/lib/content-services/document-list/components/document-list.component.ts
+++ b/lib/content-services/document-list/components/document-list.component.ts
@@ -569,13 +569,15 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
         return changePage.skipCount &&
             changePage.skipCount.currentValue !== null &&
             changePage.skipCount.currentValue !== undefined &&
-            changePage.skipCount.currentValue !== changePage.skipCount.previousValue;
+            changePage.skipCount.currentValue !== changePage.skipCount.previousValue &&
+            changePage.skipCount.firstChange === false;
     }
 
     private isMaxItemsChanged(changePage: SimpleChanges) {
         return changePage.maxItems &&
             changePage.maxItems.currentValue &&
-            changePage.maxItems.currentValue !== changePage.maxItems.previousValue;
+            changePage.maxItems.currentValue !== changePage.maxItems.previousValue &&
+            changePage.maxItems.firstChange === false;
     }
 
     private loadTrashcan(merge: boolean = false): void {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Please see Jira issue https://issues.alfresco.com/jira/browse/ADF-2175


**What is the new behaviour?**
Fixed issue.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
