### PR TITLE
run clean-lock command first to prevent incomplete clean up

### DIFF
--- a/scripts/npm-clean.sh
+++ b/scripts/npm-clean.sh
@@ -19,11 +19,11 @@ done
 npm install rimraf
 
 cd "$DIR/../demo-shell"
-npm run clean
 npm run clean-lock
+npm run clean
 
 cd "$DIR/../lib"
-npm run clean
 npm run clean-lock
+npm run clean
 
 cd ${DIR}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
When running the 'npm-clean.sh' script, 
the clean-lock command fails with message "sh: rimraf: command not found".
(The problem appears when the package rimraf is not installed globally.)

**What is the new behaviour?**
When running the './npm-clean.sh' script,
the clean-lock command is run first with success and after that the clean command with success.
(No need for the rimraf package to be installed globally.)

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
