### PR TITLE
[ADF-2077] [Destination picker] User should not be able to copy / mo…

### DIFF
--- a/lib/content-services/content-node-selector/content-node-dialog.service.spec.ts
+++ b/lib/content-services/content-node-selector/content-node-dialog.service.spec.ts
@@ -128,30 +128,30 @@ describe('ContentNodeDialogService', () => {
         expect(materialDialog.closeAll).toHaveBeenCalled();
     });
 
-    describe('hasEntityCreatePermission', () => {
+    describe('for the copy/move dialog', () => {
         const siteNode: MinimalNodeEntryEntity = <MinimalNodeEntryEntity> {
             id: 'site',
-            name: 'site-name',
+            name: 'siteNode',
             nodeType: 'st:site'
         };
         const sites: MinimalNodeEntryEntity = <MinimalNodeEntryEntity> {
             id: 'sites',
-            name: 'sites-name',
+            name: 'sites',
             nodeType: 'st:sites'
         };
         const site: MinimalNodeEntryEntity = <MinimalNodeEntryEntity> {
             id: 'site-id',
-            name: 'site-entry-name',
+            name: 'site',
             guid: 'any-guid'
         };
         const nodeEntryWithRightPermissions: MinimalNodeEntryEntity = <MinimalNodeEntryEntity> {
             id: 'node-id',
-            name: 'node-name',
+            name: 'nodeWithRightPermissions',
             allowableOperations: ['create']
         };
         const nodeEntryNoPermissions: MinimalNodeEntryEntity = <MinimalNodeEntryEntity> {
             id: 'node-id',
-            name: 'node-name',
+            name: 'nodeWithNoPermissions',
             allowableOperations: []
         };
 
@@ -184,7 +184,7 @@ describe('ContentNodeDialogService', () => {
         ];
 
         fixture.forEach((testData) => {
-            it(`should be \'${testData.expected}\' for given node with ${testData.infoKey} = \'${testData.node[testData.infoKey]}\'`, () => {
+            it(`should ${testData.expected ? '' : 'NOT '}allow selection for ${testData.node.name} (${testData.infoKey} = \'${testData.node[testData.infoKey]}\')`, () => {
 
                 let testContentNodeSelectorComponentData;
                 spyOnDialogOpen.and.callFake((contentNodeSelectorComponent: any, config: any) => {

--- a/lib/content-services/content-node-selector/content-node-dialog.service.spec.ts
+++ b/lib/content-services/content-node-selector/content-node-dialog.service.spec.ts
@@ -55,6 +55,7 @@ describe('ContentNodeDialogService', () => {
     let documentListService: DocumentListService;
     let sitesService: SitesService;
     let materialDialog: MatDialog;
+    let spyOnDialogOpen: jasmine.Spy;
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({
@@ -76,7 +77,7 @@ describe('ContentNodeDialogService', () => {
         documentListService = TestBed.get(DocumentListService);
         materialDialog = TestBed.get(MatDialog);
         sitesService =  TestBed.get(SitesService);
-        spyOn(materialDialog, 'open').and.stub();
+        spyOnDialogOpen = spyOn(materialDialog, 'open').and.stub();
         spyOn(materialDialog, 'closeAll').and.stub();
 
     });
@@ -87,14 +88,14 @@ describe('ContentNodeDialogService', () => {
 
     it('should be able to open the dialog when node has permission', () => {
         service.openCopyMoveDialog('fake-action', fakeNode, '!update');
-        expect(materialDialog.open).toHaveBeenCalled();
+        expect(spyOnDialogOpen).toHaveBeenCalled();
     });
 
     it('should NOT be able to open the dialog when node has NOT permission', () => {
         service.openCopyMoveDialog('fake-action', fakeNode, 'noperm').subscribe(
             () => { },
             (error) => {
-                expect(materialDialog.open).not.toHaveBeenCalled();
+                expect(spyOnDialogOpen).not.toHaveBeenCalled();
                 expect(JSON.parse(error.message).error.statusCode).toBe(403);
             });
     });
@@ -103,7 +104,7 @@ describe('ContentNodeDialogService', () => {
         spyOn(documentListService, 'getFolderNode').and.returnValue(Promise.resolve(fakeNode));
         service.openFileBrowseDialogByFolderId('fake-folder-id').subscribe();
         tick();
-        expect(materialDialog.open).toHaveBeenCalled();
+        expect(spyOnDialogOpen).toHaveBeenCalled();
     }));
 
     it('should be able to open the dialog for files using the first user site', fakeAsync(() => {
@@ -111,7 +112,7 @@ describe('ContentNodeDialogService', () => {
         spyOn(documentListService, 'getFolderNode').and.returnValue(Promise.resolve(fakeNode));
         service.openFileBrowseDialogBySite().subscribe();
         tick();
-        expect(materialDialog.open).toHaveBeenCalled();
+        expect(spyOnDialogOpen).toHaveBeenCalled();
     }));
 
     it('should be able to open the dialog for folder using the first user site', fakeAsync(() => {
@@ -119,12 +120,84 @@ describe('ContentNodeDialogService', () => {
         spyOn(documentListService, 'getFolderNode').and.returnValue(Promise.resolve(fakeNode));
         service.openFolderBrowseDialogBySite().subscribe();
         tick();
-        expect(materialDialog.open).toHaveBeenCalled();
+        expect(spyOnDialogOpen).toHaveBeenCalled();
     }));
 
     it('should be able to close the material dialog', () => {
         service.close();
         expect(materialDialog.closeAll).toHaveBeenCalled();
+    });
+
+    describe('hasEntityCreatePermission', () => {
+        const siteNode: MinimalNodeEntryEntity = <MinimalNodeEntryEntity> {
+            id: 'site',
+            name: 'site-name',
+            nodeType: 'st:site'
+        };
+        const sites: MinimalNodeEntryEntity = <MinimalNodeEntryEntity> {
+            id: 'sites',
+            name: 'sites-name',
+            nodeType: 'st:sites'
+        };
+        const site: MinimalNodeEntryEntity = <MinimalNodeEntryEntity> {
+            id: 'site-id',
+            name: 'site-entry-name',
+            guid: 'any-guid'
+        };
+        const nodeEntryWithRightPermissions: MinimalNodeEntryEntity = <MinimalNodeEntryEntity> {
+            id: 'node-id',
+            name: 'node-name',
+            allowableOperations: ['create']
+        };
+        const nodeEntryNoPermissions: MinimalNodeEntryEntity = <MinimalNodeEntryEntity> {
+            id: 'node-id',
+            name: 'node-name',
+            allowableOperations: []
+        };
+
+        const fixture = [
+            {
+                node: siteNode,
+                infoKey: 'nodeType',
+                expected: false
+            },
+            {
+                node: sites,
+                infoKey: 'nodeType',
+                expected: false
+            },
+            {
+                node: site,
+                infoKey: 'guid',
+                expected: false
+            },
+            {
+                node: nodeEntryWithRightPermissions,
+                infoKey: 'allowableOperations',
+                expected: true
+            },
+            {
+                node: nodeEntryNoPermissions,
+                infoKey: 'allowableOperations',
+                expected: false
+            }
+        ];
+
+        fixture.forEach((testData) => {
+            it(`should be \'${testData.expected}\' for given node with ${testData.infoKey} = \'${testData.node[testData.infoKey]}\'`, () => {
+
+                let testContentNodeSelectorComponentData;
+                spyOnDialogOpen.and.callFake((contentNodeSelectorComponent: any, config: any) => {
+                    testContentNodeSelectorComponentData = config.data;
+                    return {componentInstance: {}};
+                });
+                service.openCopyMoveDialog('fake-action', fakeNode, '!update');
+
+                expect(spyOnDialogOpen.calls.count()).toEqual(1);
+                expect(testContentNodeSelectorComponentData.isSelectionValid(testData.node)).toBe(testData.expected);
+            });
+
+        });
     });
 
 });

--- a/lib/content-services/content-node-selector/content-node-dialog.service.spec.ts
+++ b/lib/content-services/content-node-selector/content-node-dialog.service.spec.ts
@@ -130,73 +130,74 @@ describe('ContentNodeDialogService', () => {
 
     describe('for the copy/move dialog', () => {
         const siteNode: MinimalNodeEntryEntity = <MinimalNodeEntryEntity> {
-            id: 'site',
-            name: 'siteNode',
+            id: 'site-node-id',
             nodeType: 'st:site'
         };
         const sites: MinimalNodeEntryEntity = <MinimalNodeEntryEntity> {
-            id: 'sites',
-            name: 'sites',
+            id: 'sites-id',
             nodeType: 'st:sites'
         };
         const site: MinimalNodeEntryEntity = <MinimalNodeEntryEntity> {
             id: 'site-id',
-            name: 'site',
             guid: 'any-guid'
         };
         const nodeEntryWithRightPermissions: MinimalNodeEntryEntity = <MinimalNodeEntryEntity> {
             id: 'node-id',
-            name: 'nodeWithRightPermissions',
             allowableOperations: ['create']
         };
         const nodeEntryNoPermissions: MinimalNodeEntryEntity = <MinimalNodeEntryEntity> {
             id: 'node-id',
-            name: 'nodeWithNoPermissions',
             allowableOperations: []
         };
 
-        const fixture = [
+        const siteFixture = [
             {
                 node: siteNode,
-                infoKey: 'nodeType',
                 expected: false
             },
             {
                 node: sites,
-                infoKey: 'nodeType',
                 expected: false
             },
             {
                 node: site,
-                infoKey: 'guid',
-                expected: false
-            },
-            {
-                node: nodeEntryWithRightPermissions,
-                infoKey: 'allowableOperations',
-                expected: true
-            },
-            {
-                node: nodeEntryNoPermissions,
-                infoKey: 'allowableOperations',
                 expected: false
             }
         ];
 
-        fixture.forEach((testData) => {
-            it(`should ${testData.expected ? '' : 'NOT '}allow selection for ${testData.node.name} (${testData.infoKey} = \'${testData.node[testData.infoKey]}\')`, () => {
+        const permissionFixture = [
+            {
+                node: nodeEntryWithRightPermissions,
+                expected: true
+            },
+            {
+                node: nodeEntryNoPermissions,
+                expected: false
+            }
+        ];
 
-                let testContentNodeSelectorComponentData;
-                spyOnDialogOpen.and.callFake((contentNodeSelectorComponent: any, config: any) => {
-                    testContentNodeSelectorComponentData = config.data;
-                    return {componentInstance: {}};
-                });
-                service.openCopyMoveDialog('fake-action', fakeNode, '!update');
+        let testContentNodeSelectorComponentData;
 
-                expect(spyOnDialogOpen.calls.count()).toEqual(1);
+        beforeEach(() => {
+            spyOnDialogOpen.and.callFake((contentNodeSelectorComponent: any, config: any) => {
+                testContentNodeSelectorComponentData = config.data;
+                return {componentInstance: {}};
+            });
+            service.openCopyMoveDialog('fake-action', fakeNode, '!update');
+        });
+
+        it('should NOT allow selection for sites', () => {
+            expect(spyOnDialogOpen.calls.count()).toEqual(1);
+            siteFixture.forEach((testData) => {
                 expect(testContentNodeSelectorComponentData.isSelectionValid(testData.node)).toBe(testData.expected);
             });
+        });
 
+        it('should allow selection only for nodes with the right permission', () => {
+            expect(spyOnDialogOpen.calls.count()).toEqual(1);
+            permissionFixture.forEach((testData) => {
+                expect(testContentNodeSelectorComponentData.isSelectionValid(testData.node)).toBe(testData.expected);
+            });
         });
     });
 

--- a/lib/content-services/content-node-selector/content-node-dialog.service.ts
+++ b/lib/content-services/content-node-selector/content-node-dialog.service.ts
@@ -189,7 +189,11 @@ export class ContentNodeDialogService {
     }
 
     private hasEntityCreatePermission(entry: MinimalNodeEntryEntity): boolean {
-        return this.contentService.hasPermission(entry, 'create');
+        return this.contentService.hasPermission(entry, 'create') && !this.isSite(entry);
+    }
+
+    private isSite(entry) {
+        return !!entry.guid || entry.nodeType === 'st:site' || entry.nodeType === 'st:sites';
     }
 
     /** Closes the currently open dialog. */

--- a/lib/content-services/content-node-selector/content-node-dialog.service.ts
+++ b/lib/content-services/content-node-selector/content-node-dialog.service.ts
@@ -88,7 +88,7 @@ export class ContentNodeDialogService {
                 currentFolderId: contentEntry.parentId,
                 imageResolver: this.imageResolver.bind(this),
                 rowFilter : this.rowFilter.bind(this, contentEntry.id),
-                isSelectionValid: this.canCopyMoveInsideIt.bind(this),
+                isSelectionValid: this.isCopyMoveSelectionValid.bind(this),
                 select: select
             };
 
@@ -188,7 +188,7 @@ export class ContentNodeDialogService {
         return entry.isFolder;
     }
 
-    private canCopyMoveInsideIt(entry: MinimalNodeEntryEntity): boolean {
+    private isCopyMoveSelectionValid(entry: MinimalNodeEntryEntity): boolean {
         return this.hasEntityCreatePermission(entry) && !this.isSite(entry);
     }
 

--- a/lib/content-services/content-node-selector/content-node-dialog.service.ts
+++ b/lib/content-services/content-node-selector/content-node-dialog.service.ts
@@ -88,7 +88,7 @@ export class ContentNodeDialogService {
                 currentFolderId: contentEntry.parentId,
                 imageResolver: this.imageResolver.bind(this),
                 rowFilter : this.rowFilter.bind(this, contentEntry.id),
-                isSelectionValid: this.hasEntityCreatePermission.bind(this),
+                isSelectionValid: this.canCopyMoveInsideIt.bind(this),
                 select: select
             };
 
@@ -188,8 +188,12 @@ export class ContentNodeDialogService {
         return entry.isFolder;
     }
 
+    private canCopyMoveInsideIt(entry: MinimalNodeEntryEntity): boolean {
+        return this.hasEntityCreatePermission(entry) && !this.isSite(entry);
+    }
+
     private hasEntityCreatePermission(entry: MinimalNodeEntryEntity): boolean {
-        return this.contentService.hasPermission(entry, 'create') && !this.isSite(entry);
+        return this.contentService.hasPermission(entry, 'create');
     }
 
     private isSite(entry) {


### PR DESCRIPTION
…ve items into a site outside of the documentLibrary

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Please see https://issues.alfresco.com/jira/browse/ADF-2077


**What is the new behaviour?**
The expected result described in the issue first: "COPY / MOVE button should be disabled at this point in the destination picker. When double-clicking on the site, user can see the documentLibrary folder and on that folder the button should be enabled." Please see https://issues.alfresco.com/jira/browse/ADF-2077


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
