### PR TITLE
[ADF-2357] Updated index for 2.2.0

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,8 +28,9 @@ that the component is complete and suitable for normal use. The other status lev
 
 <!--guide start-->
 
--   [Form Extensibility and Customisation](extensibility.md)
 -   [Angular Material Design](angular-material-design.md)
+-   [Form Extensibility and Customisation](extensibility.md)
+-   [Internationalization in ADF](internationalization.md)
 -   [Theming](theming.md)
 -   [Typography](typography.md)
 -   [Walkthrough - adding indicators to highlight information about a node](metadata-indicators.md)
@@ -203,7 +204,6 @@ for more information about installing and using the source code.
 | [Version list component](version-list.component.md) ![Experimental](docassets/images/ExperimentalIcon.png) | Displays the version history of a node in a [Version Manager component](version-manager.component.md) | [Source](../lib/content-services/version-manager/version-list.component.ts) |
 | [Version manager component](version-manager.component.md) ![Experimental](docassets/images/ExperimentalIcon.png) | Displays the version history of a node with the ability to upload a new version. | [Source](../lib/content-services/version-manager/version-manager.component.ts) |
 | [Webscript component](webscript.component.md) | Provides access to Webscript features. | [Source](../lib/content-services/webscript/webscript.component.ts) |
-| _Empty search result component_ | _Not currently documented_ | [Source](../lib/content-services/search/components/empty-search-result.component.ts) |
 
 ## Directives
 
@@ -231,7 +231,6 @@ for more information about installing and using the source code.
 | [Folder actions service](folder-actions.service.md) | Implements the folder menu actions for the Document List component. | [Source](../lib/content-services/document-list/services/folder-actions.service.ts) |
 | [Rating service](rating.service.md) | Manages ratings for items in Content Services. | [Source](../lib/content-services/social/services/rating.service.ts) |
 | [Tag service](tag.service.md) | Manages tags in Content Services. | [Source](../lib/content-services/tag/services/tag.service.ts) |
-| _Property groups translator service_ | _Not currently documented_ | [Source](../lib/content-services/content-metadata/services/property-groups-translator.service.ts) |
 
 <!--content-services end-->
 
@@ -273,8 +272,6 @@ for more information about installing and using the source code.
 | [Task filters component](task-filters.component.md) | Shows all available filters. | [Source](../lib/process-services/task-list/components/task-filters.component.ts) |
 | [Task header component](task-header.component.md) | Shows all the information related to a task. | [Source](../lib/process-services/task-list/components/task-header.component.ts) |
 | [Task list component](task-list.component.md) | Renders a list containing all the tasks matched by the parameters specified. | [Source](../lib/process-services/task-list/components/task-list.component.ts) |
-| _People search field component_ | _Not currently documented_ | [Source](../lib/process-services/people/components/people-search-field/people-search-field.component.ts) |
-| _People selector component_ | _Not currently documented_ | [Source](../lib/process-services/people/components/people-selector/people-selector.component.ts) |
 
 ## Directives
 
@@ -282,8 +279,6 @@ for more information about installing and using the source code.
 | ---- | ----------- | ----------- |
 | [Process audit directive](process-audit.directive.md) | Fetches the Process Audit information in the pdf or json format. | [Source](../lib/process-services/process-list/components/process-audit.directive.ts) |
 | [Task audit directive](task-audit.directive.md) | Fetches the Task Audit information in the pdf or json format. | [Source](../lib/process-services/task-list/components/task-audit.directive.ts) |
-| _People search action label directive_ | _Not currently documented_ | [Source](../lib/process-services/people/directives/people-search-action-label.directive.ts) |
-| _People search title directive_ | _Not currently documented_ | [Source](../lib/process-services/people/directives/people-search-title.directive.ts) |
 
 ## Models
 

--- a/docs/summary.json
+++ b/docs/summary.json
@@ -1,6 +1,7 @@
 [
-    { "title": "Form Extensibility and Customisation", "file": "extensibility.md" },
     { "title": "Angular Material Design", "file": "angular-material-design.md" },
+    { "title": "Form Extensibility and Customisation", "file": "extensibility.md" },
+    { "title": "Internationalization in ADF", "file": "internationalization.md" },
     { "title": "Theming", "file": "theming.md" },
     { "title": "Typography", "file": "typography.md" },
     { "title": "Walkthrough - adding indicators to highlight information about a node", "file": "metadata-indicators.md" }

--- a/docs/undocStoplist.json
+++ b/docs/undocStoplist.json
@@ -46,5 +46,9 @@
     "task-upload",
     "aspect-whitelist",
     "basic-properties",
-    "content-metadata"
+    "content-metadata",
+    "empty-search-result",
+    "property-group",
+    "people-search-",
+    "people-selector"
 ]


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [x] Documentation
> - [ ] Other... Please describe:

**What is the new behaviour?**

Removed undocumented components from the index (none of the ones added so far need documentation for 2.2.0, according to Andras's advice). Also restored the I18n article that had been lost from the guide section somehow.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No

