### PR TITLE
[ADF-2374] Add callback for VersionUploadComponent and VersionManagerComponent

### DIFF
--- a/docs/version-manager.component.md
+++ b/docs/version-manager.component.md
@@ -9,14 +9,25 @@ Displays the version history of a node with the ability to upload a new version.
 ## Basic Usage
 
 ```html
-<adf-version-manager [node]="aMinimalNodeEntryEntity"></adf-version-manager>
+<adf-version-manager 
+    [node]="aMinimalNodeEntryEntity"
+    (uploadSuccess)="customMethod($event)"
+    (uploadError)="customMethod2($event)">
+</adf-version-manager>
 ```
 
 ### Properties
 
-| Name | Type | Default value | Description |
-| ---- | ---- | ------------- | ----------- |
-| node | `MinimalNodeEntryEntity` |  | The node whose version history you want to manage.  |
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| node | [MinimalNodeEntryEntity](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/NodeMinimalEntry.md) | The node you want to manage the version history of. |
+
+### Events
+
+| Name | Description |
+| --- | --- |
+| uploadSuccess | Raised when the file is uploaded |
+| uploadError | Emitted when an error occurs.|
 
 ## Details
 

--- a/lib/content-services/version-manager/version-manager.component.html
+++ b/lib/content-services/version-manager/version-manager.component.html
@@ -1,5 +1,5 @@
 <div class="adf-new-version-uploader-container" fxLayout="row" fxLayoutAlign="end center">
-    <adf-version-upload [node]="node"></adf-version-upload>
+    <adf-version-upload [node]="node" (success)="onUploadSuccess($event)" (error)="onUploadError($event)"></adf-version-upload>
 </div>
 <div class="adf-version-list-container">
     <adf-version-list [id]="node.id"></adf-version-list>

--- a/lib/content-services/version-manager/version-manager.component.ts
+++ b/lib/content-services/version-manager/version-manager.component.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Component, Input, ViewEncapsulation } from '@angular/core';
+import { Component, Input, ViewEncapsulation, Output, EventEmitter } from '@angular/core';
 import { MinimalNodeEntryEntity } from 'alfresco-js-api';
 
 @Component({
@@ -26,7 +26,21 @@ import { MinimalNodeEntryEntity } from 'alfresco-js-api';
 })
 export class VersionManagerComponent {
 
-    /** The node whose version history you want to manage. */
     @Input()
     node: MinimalNodeEntryEntity;
+
+    @Output()
+    uploadSuccess: EventEmitter<any> = new EventEmitter();
+
+    @Output()
+    uploadError: EventEmitter<any> = new EventEmitter();
+
+    onUploadSuccess(event): void {
+        this.uploadSuccess.emit(event);
+    }
+
+    onUploadError(event): any {
+        this.uploadError.emit(event);
+    }
 }
+

--- a/lib/content-services/version-manager/version-upload.component.html
+++ b/lib/content-services/version-manager/version-upload.component.html
@@ -4,5 +4,7 @@
     staticTitle="Upload new version"
     [rootFolderId]="node.parentId"
     tooltip="Restriction: upload file with the same name to create a new version of it"
-    [versioning]="true">
+    [versioning]="true"
+    (success)="onUploadSuccess($event)"
+    (error)="onUploadError($event)">
 </adf-upload-button>

--- a/lib/content-services/version-manager/version-upload.component.ts
+++ b/lib/content-services/version-manager/version-upload.component.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Component, Input, ViewEncapsulation } from '@angular/core';
+import { Component, Input, ViewEncapsulation, Output, EventEmitter } from '@angular/core';
 import { MinimalNodeEntryEntity } from 'alfresco-js-api';
 
 @Component({
@@ -30,4 +30,20 @@ export class VersionUploadComponent {
 
     @Input()
     node: MinimalNodeEntryEntity;
+
+    @Output()
+    success: EventEmitter<any> = new EventEmitter();
+
+    @Output()
+    error: EventEmitter<any> = new EventEmitter();
+
+    onUploadSuccess(event): void {
+        this.success.emit(event);
+    }
+
+    onUploadError(event): void {
+        this.error.emit(event);
+    }
+
 }
+


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [X] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [X] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
No callback on VersionUploadComponent and VersionManagerComponent. User will not know when file is uploaded or error occurs.

**What is the new behaviour?**
Add success and error EvenEmitter to VersionUploadComponent. Add uploadSuccess and uploadError EventEmiiter to VersionManagerComponent.

These EventEmitter will let developer custom thier callback function. For example, Refresh component when file version is uploaded

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
