### PR TITLE
[ADF-2391] skipCount is not reset on document-list when choosing a custom source from adf-sites-dropdown, nor the currentFolderId and folderNode

### DIFF
--- a/lib/content-services/document-list/components/document-list.component.spec.ts
+++ b/lib/content-services/document-list/components/document-list.component.spec.ts
@@ -1218,6 +1218,27 @@ describe('DocumentList', () => {
         expect(documentList.folderNode).toBeNull();
     });
 
+    it('should reset folder node on loading folder by node id', () => {
+        documentList.folderNode = <any> {};
+
+        const sitesApi = apiService.getInstance().core.sitesApi;
+        spyOn(sitesApi, 'getSites').and.returnValue(Promise.resolve(null));
+
+        documentList.loadFolderByNodeId('-sites-');
+
+        expect(documentList.folderNode).toBeNull();
+    });
+
+    it('should have correct currentFolderId on loading folder by node id', () => {
+        documentList.currentFolderId = '12345-some-id-6789';
+
+        const peopleApi = apiService.getInstance().core.peopleApi;
+        spyOn(peopleApi, 'getSiteMembership').and.returnValue(Promise.resolve());
+
+        documentList.loadFolderByNodeId('-mysites-');
+        expect(documentList.currentFolderId).toBe('-mysites-');
+    });
+
     it('should update pagination settings', () => {
         spyOn(documentList, 'reload').and.stub();
 
@@ -1303,5 +1324,22 @@ describe('DocumentList', () => {
         });
 
         expect(documentList.reload).toHaveBeenCalled();
+    });
+
+    it('should reset skipCount from  pagination settings on loading folder by node id', () => {
+        spyOn(documentList, 'reload').and.stub();
+        const favoritesApi = apiService.getInstance().core.favoritesApi;
+        spyOn(favoritesApi, 'getFavorites').and.returnValue(Promise.resolve(null));
+
+        documentList.maxItems = 0;
+        documentList.skipCount = 0;
+
+        documentList.updatePagination({
+            maxItems: 10,
+            skipCount: 10
+        });
+
+        documentList.loadFolderByNodeId('-favorites-');
+        expect(documentList.skipCount).toBe(0, 'skipCount is reset');
     });
 });

--- a/lib/content-services/document-list/components/document-list.component.ts
+++ b/lib/content-services/document-list/components/document-list.component.ts
@@ -468,6 +468,14 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
         this.folderChange.emit(new NodeEntryEvent(node.entry));
     }
 
+    updateCustomSourceData(nodeId: string, merge: boolean): void {
+        this.folderNode = null;
+        this.currentFolderId = nodeId;
+        if (!merge) {
+            this.skipCount = 0;
+        }
+    }
+
     /**
      * Invoked when executing content action for a document or folder.
      * @param node Node to be the context of the execution.
@@ -589,9 +597,7 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
     }
 
     private loadTrashcan(merge: boolean = false): void {
-        this.folderNode = null;
-        this.currentFolderId = '-trashcan-';
-        this.skipCount = 0;
+        this.updateCustomSourceData('-trashcan-', merge);
 
         const options = {
             include: ['path', 'properties'],
@@ -604,9 +610,7 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
     }
 
     private loadSharedLinks(merge: boolean = false): void {
-        this.folderNode = null;
-        this.currentFolderId = '-sharedlinks-';
-        this.skipCount = 0;
+        this.updateCustomSourceData('-sharedlinks-', merge);
 
         const options = {
             include: ['properties', 'allowableOperations', 'path'],
@@ -619,9 +623,7 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
     }
 
     private loadSites(merge: boolean = false): void {
-        this.folderNode = null;
-        this.currentFolderId = '-sites-';
-        this.skipCount = 0;
+        this.updateCustomSourceData('-sites-', merge);
 
         const options = {
             include: ['properties'],
@@ -643,9 +645,7 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
     }
 
     private loadMemberSites(merge: boolean = false): void {
-        this.folderNode = null;
-        this.currentFolderId = '-mysites-';
-        this.skipCount = 0;
+        this.updateCustomSourceData('-mysites-', merge);
 
         const options = {
             include: ['properties'],
@@ -675,9 +675,7 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
     }
 
     private loadFavorites(merge: boolean = false): void {
-        this.folderNode = null;
-        this.currentFolderId = '-favorites-';
-        this.skipCount = 0;
+        this.updateCustomSourceData('-favorites-', merge);
 
         const options = {
             maxItems: this.maxItems,
@@ -710,9 +708,7 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
     }
 
     private loadRecent(merge: boolean = false): void {
-        this.folderNode = null;
-        this.currentFolderId = '-recent-';
-        this.skipCount = 0;
+        this.updateCustomSourceData('-recent-', merge);
 
         this.getRecentFiles('-me-')
             .then((page: NodePaging) => this.onPageLoaded(page, merge))

--- a/lib/content-services/document-list/components/document-list.component.ts
+++ b/lib/content-services/document-list/components/document-list.component.ts
@@ -589,6 +589,10 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
     }
 
     private loadTrashcan(merge: boolean = false): void {
+        this.folderNode = null;
+        this.currentFolderId = '-trashcan-';
+        this.skipCount = 0;
+
         const options = {
             include: ['path', 'properties'],
             maxItems: this.maxItems,
@@ -600,6 +604,10 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
     }
 
     private loadSharedLinks(merge: boolean = false): void {
+        this.folderNode = null;
+        this.currentFolderId = '-sharedlinks-';
+        this.skipCount = 0;
+
         const options = {
             include: ['properties', 'allowableOperations', 'path'],
             maxItems: this.maxItems,
@@ -611,6 +619,10 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
     }
 
     private loadSites(merge: boolean = false): void {
+        this.folderNode = null;
+        this.currentFolderId = '-sites-';
+        this.skipCount = 0;
+
         const options = {
             include: ['properties'],
             maxItems: this.maxItems,
@@ -631,6 +643,10 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
     }
 
     private loadMemberSites(merge: boolean = false): void {
+        this.folderNode = null;
+        this.currentFolderId = '-mysites-';
+        this.skipCount = 0;
+
         const options = {
             include: ['properties'],
             maxItems: this.maxItems,
@@ -659,6 +675,10 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
     }
 
     private loadFavorites(merge: boolean = false): void {
+        this.folderNode = null;
+        this.currentFolderId = '-favorites-';
+        this.skipCount = 0;
+
         const options = {
             maxItems: this.maxItems,
             skipCount: this.skipCount,
@@ -690,6 +710,10 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
     }
 
     private loadRecent(merge: boolean = false): void {
+        this.folderNode = null;
+        this.currentFolderId = '-recent-';
+        this.skipCount = 0;
+
         this.getRecentFiles('-me-')
             .then((page: NodePaging) => this.onPageLoaded(page, merge))
             .catch(error => this.error.emit(error));


### PR DESCRIPTION
fix and tests added

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Please check https://issues.alfresco.com/jira/browse/ADF-2391


**What is the new behaviour?**
Fixed https://issues.alfresco.com/jira/browse/ADF-2391


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
