### PR TITLE
[ADF-2358] splitted copy and move opening mechanism

### DIFF
--- a/lib/content-services/content-node-selector/content-node-dialog.service.spec.ts
+++ b/lib/content-services/content-node-selector/content-node-dialog.service.spec.ts
@@ -86,13 +86,18 @@ describe('ContentNodeDialogService', () => {
         expect(service).not.toBeNull();
     });
 
-    it('should be able to open the dialog when node has permission', () => {
-        service.openCopyMoveDialog('fake-action', fakeNode, '!update');
+    it('should be able to open the move dialog when node has permission', () => {
+        service.openMoveDialog('fake-action', fakeNode, '!update');
+        expect(spyOnDialogOpen).toHaveBeenCalled();
+    });
+
+    it('should be able to always open the copy dialog', () => {
+        service.openCopyDialog('fake-action', fakeNode);
         expect(spyOnDialogOpen).toHaveBeenCalled();
     });
 
     it('should NOT be able to open the dialog when node has NOT permission', () => {
-        service.openCopyMoveDialog('fake-action', fakeNode, 'noperm').subscribe(
+        service.openMoveDialog('fake-action', fakeNode, 'noperm').subscribe(
             () => { },
             (error) => {
                 expect(spyOnDialogOpen).not.toHaveBeenCalled();
@@ -183,7 +188,7 @@ describe('ContentNodeDialogService', () => {
                 testContentNodeSelectorComponentData = config.data;
                 return {componentInstance: {}};
             });
-            service.openCopyMoveDialog('fake-action', fakeNode, '!update');
+            service.openMoveDialog('fake-action', fakeNode, '!update');
         });
 
         it('should NOT allow selection for sites', () => {

--- a/lib/content-services/content-node-selector/content-node-dialog.service.ts
+++ b/lib/content-services/content-node-selector/content-node-dialog.service.ts
@@ -72,33 +72,40 @@ export class ContentNodeDialogService {
     /** @param action Name of the action (eg, "Copy" or "Move") to show in the title */
     /** @param contentEntry Item to be copied or moved */
     /** @param permission Permission for the operation */
-    openCopyMoveDialog(action: string, contentEntry: MinimalNodeEntryEntity, permission?: string): Observable<MinimalNodeEntryEntity[]> {
+    openMoveDialog(action: string, contentEntry: MinimalNodeEntryEntity, permission?: string): Observable<MinimalNodeEntryEntity[]> {
         if (this.contentService.hasPermission(contentEntry, permission)) {
-
-            const select = new Subject<MinimalNodeEntryEntity[]>();
-            select.subscribe({
-                complete: this.close.bind(this)
-            });
-
-            const title = this.getTitleTranslation(action, contentEntry.name);
-
-            const data: ContentNodeSelectorComponentData = {
-                title: title,
-                actionName: action,
-                currentFolderId: contentEntry.parentId,
-                imageResolver: this.imageResolver.bind(this),
-                rowFilter : this.rowFilter.bind(this, contentEntry.id),
-                isSelectionValid: this.isCopyMoveSelectionValid.bind(this),
-                select: select
-            };
-
-            this.openContentNodeDialog(data, 'adf-content-node-selector-dialog', '630px');
-
-            return select;
+            this.openDialog(action, contentEntry);
         } else {
-            let errors = new Error(JSON.stringify({ error: { statusCode: 403 } } ));
+            let errors = new Error(JSON.stringify({ error: { statusCode: 403 } }));
             return Observable.throw(errors);
         }
+    }
+
+    openCopyDialog(action: string, contentEntry: MinimalNodeEntryEntity): Observable<MinimalNodeEntryEntity[]> {
+        return this.openDialog(action, contentEntry);
+    }
+
+    private openDialog(action: string, contentEntry: MinimalNodeEntryEntity): Subject<MinimalNodeEntryEntity[]> {
+        const select = new Subject<MinimalNodeEntryEntity[]>();
+        select.subscribe({
+            complete: this.close.bind(this)
+        });
+
+        const title = this.getTitleTranslation(action, contentEntry.name);
+
+        const data: ContentNodeSelectorComponentData = {
+            title: title,
+            actionName: action,
+            currentFolderId: contentEntry.parentId,
+            imageResolver: this.imageResolver.bind(this),
+            rowFilter: this.rowFilter.bind(this, contentEntry.id),
+            isSelectionValid: this.isCopyMoveSelectionValid.bind(this),
+            select: select
+        };
+
+        this.openContentNodeDialog(data, 'adf-content-node-selector-dialog', '630px');
+
+        return select;
     }
 
     /** Gets the translation of the dialog title. */

--- a/lib/content-services/document-list/services/node-actions.service.service.spec.ts
+++ b/lib/content-services/document-list/services/node-actions.service.service.spec.ts
@@ -59,7 +59,7 @@ describe('NodeActionsService', () => {
 
     it('should be able to copy content', async(() => {
         spyOn(documentListService, 'copyNode').and.returnValue(Observable.of('FAKE-OK'));
-        spyOn(contentDialogService, 'openCopyMoveDialog').and.returnValue(Observable.of([fakeNode]));
+        spyOn(contentDialogService, 'openCopyDialog').and.returnValue(Observable.of([fakeNode]));
 
         service.copyContent(fakeNode, 'allowed').subscribe((value) => {
             expect(value).toBe('OPERATION.SUCCES.CONTENT.COPY');
@@ -68,7 +68,7 @@ describe('NodeActionsService', () => {
 
     it('should be able to move content', async(() => {
         spyOn(documentListService, 'moveNode').and.returnValue(Observable.of('FAKE-OK'));
-        spyOn(contentDialogService, 'openCopyMoveDialog').and.returnValue(Observable.of([fakeNode]));
+        spyOn(contentDialogService, 'openMoveDialog').and.returnValue(Observable.of([fakeNode]));
 
         service.moveContent(fakeNode, 'allowed').subscribe((value) => {
             expect(value).toBe('OPERATION.SUCCES.CONTENT.MOVE');
@@ -77,7 +77,7 @@ describe('NodeActionsService', () => {
 
     it('should be able to move folder', async(() => {
         spyOn(documentListService, 'moveNode').and.returnValue(Observable.of('FAKE-OK'));
-        spyOn(contentDialogService, 'openCopyMoveDialog').and.returnValue(Observable.of([fakeNode]));
+        spyOn(contentDialogService, 'openMoveDialog').and.returnValue(Observable.of([fakeNode]));
 
         service.moveFolder(fakeNode, 'allowed').subscribe((value) => {
             expect(value).toBe('OPERATION.SUCCES.FOLDER.MOVE');
@@ -86,16 +86,26 @@ describe('NodeActionsService', () => {
 
     it('should be able to copy folder', async(() => {
         spyOn(documentListService, 'copyNode').and.returnValue(Observable.of('FAKE-OK'));
-        spyOn(contentDialogService, 'openCopyMoveDialog').and.returnValue(Observable.of([fakeNode]));
+        spyOn(contentDialogService, 'openCopyDialog').and.returnValue(Observable.of([fakeNode]));
 
         service.copyFolder(fakeNode, 'allowed').subscribe((value) => {
             expect(value).toBe('OPERATION.SUCCES.FOLDER.COPY');
         });
     }));
 
-    it('should be able to propagate the dialog error', async(() => {
+    it('should be able to propagate the dialog error on move', async(() => {
+        spyOn(documentListService, 'moveNode').and.returnValue(Observable.throw('FAKE-KO'));
+        spyOn(contentDialogService, 'openMoveDialog').and.returnValue(Observable.of([fakeNode]));
+
+        service.moveFolder(fakeNode, '!allowed').subscribe((value) => {
+        }, (error) => {
+            expect(error).toBe('FAKE-KO');
+        });
+    }));
+
+    it('should be able to propagate the dialog error on copy', async(() => {
         spyOn(documentListService, 'copyNode').and.returnValue(Observable.throw('FAKE-KO'));
-        spyOn(contentDialogService, 'openCopyMoveDialog').and.returnValue(Observable.of([fakeNode]));
+        spyOn(contentDialogService, 'openCopyDialog').and.returnValue(Observable.of([fakeNode]));
 
         service.copyFolder(fakeNode, '!allowed').subscribe((value) => {
         }, (error) => {

--- a/lib/content-services/document-list/services/node-actions.service.ts
+++ b/lib/content-services/document-list/services/node-actions.service.ts
@@ -45,7 +45,7 @@ export class NodeActionsService {
      * @param permission permission which is needed to apply the action
      */
     public copyContent(contentEntry: MinimalNodeEntryEntity, permission?: string): Subject<string> {
-        return this.doFileOperation('copy', 'content', contentEntry, permission);
+        return this.doCopyOperation('content', contentEntry);
     }
 
     /**
@@ -55,7 +55,7 @@ export class NodeActionsService {
      * @param permission permission which is needed to apply the action
      */
     public copyFolder(contentEntry: MinimalNodeEntryEntity, permission?: string): Subject<string> {
-        return this.doFileOperation('copy', 'folder', contentEntry, permission);
+        return this.doCopyOperation('content', contentEntry);
     }
 
     /**
@@ -65,7 +65,7 @@ export class NodeActionsService {
      * @param permission permission which is needed to apply the action
      */
     public moveContent(contentEntry: MinimalNodeEntryEntity, permission?: string): Subject<string> {
-        return this.doFileOperation('move', 'content', contentEntry, permission);
+        return this.doMoveOperation('content', contentEntry, permission);
     }
 
     /**
@@ -75,27 +75,54 @@ export class NodeActionsService {
      * @param permission permission which is needed to apply the action
      */
     public moveFolder(contentEntry: MinimalNodeEntryEntity, permission?: string): Subject<string> {
-        return this.doFileOperation('move', 'folder', contentEntry, permission);
+        return this.doMoveOperation('folder', contentEntry, permission);
     }
 
     /**
-     * General method for performing the given operation (copy|move)
+     * Method for performing the move operation
      *
-     * @param action the action to perform (copy|move)
+     * @param action the action to perform
      * @param type type of the content (content|folder)
      * @param contentEntry the contentEntry which has to have the action performed on
      * @param permission permission which is needed to apply the action
      */
-    private doFileOperation(action: string, type: string, contentEntry: MinimalNodeEntryEntity, permission?: string): Subject<string> {
+    private doMoveOperation(type: string, contentEntry: MinimalNodeEntryEntity, permission?: string): Subject<string> {
         const observable: Subject<string> = new Subject<string>();
 
         this.contentDialogService
-            .openCopyMoveDialog(action, contentEntry, permission)
+            .openMoveDialog('move', contentEntry, permission)
             .subscribe((selections: MinimalNodeEntryEntity[]) => {
                 const selection = selections[0];
-                this.documentListService[`${action}Node`].call(this.documentListService, contentEntry.id, selection.id)
+                this.documentListService[`moveNode`].call(this.documentListService, contentEntry.id, selection.id)
                     .subscribe(
-                    observable.next.bind(observable, `OPERATION.SUCCES.${type.toUpperCase()}.${action.toUpperCase()}`),
+                    observable.next.bind(observable, `OPERATION.SUCCES.${type.toUpperCase()}.${'move'.toUpperCase()}`),
+                    observable.error.bind(observable)
+                    );
+            },
+            (error) => {
+                observable.error(error);
+                return observable;
+            });
+        return observable;
+    }
+
+    /**
+     * Method for performing the copy operation
+     *
+     * @param action the action to perform (copy|move)
+     * @param type type of the content (content|folder)
+     * @param contentEntry the contentEntry which has to have the action performed on
+     */
+    private doCopyOperation(type: string, contentEntry: MinimalNodeEntryEntity): Subject<string> {
+        const observable: Subject<string> = new Subject<string>();
+
+        this.contentDialogService
+            .openCopyDialog('copy', contentEntry)
+            .subscribe((selections: MinimalNodeEntryEntity[]) => {
+                const selection = selections[0];
+                this.documentListService[`copyNode`].call(this.documentListService, contentEntry.id, selection.id)
+                    .subscribe(
+                    observable.next.bind(observable, `OPERATION.SUCCES.${type.toUpperCase()}.${'copy'.toUpperCase()}`),
                     observable.error.bind(observable)
                     );
             },


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Copy dialog checks if the current node has permission and this is not how CS works.


**What is the new behaviour?**
Copyis always be possible, move only if user has permissions


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
