### PR TITLE
 [ADF-645] added claim and unclaim event for task details action

### DIFF
--- a/docs/task-details.component.md
+++ b/docs/task-details.component.md
@@ -46,6 +46,8 @@ Shows the details of the task id passed in input
 | error | `EventEmitter<any>` | Emitted when an error occurs. |
 | executeOutcome | `EventEmitter<any>` | Emitted when any outcome is executed. Default behaviour can be prevented via `event.preventDefault()`. |
 | assignTask | `EventEmitter<void>` | Emitted when a task is assigned. |
+| claimedTask | `EventEmitter<string>` | Emitted when a task is claimed. |
+| unClaimedTask | `EventEmitter<string>` | Emitted when a task is unclaimed. |
 
 ## Details
 

--- a/lib/process-services/task-list/components/task-details.component.html
+++ b/lib/process-services/task-list/components/task-details.component.html
@@ -69,7 +69,7 @@
                         [taskDetails]="taskDetails"
                         [formName]="taskFormName"
                         (claim)="onClaimAction($event)"
-                        (unclaim)="onClaimAction($event)">
+                        (unclaim)="onUnclaimAction($event)">
                     </adf-task-header>
                     <adf-people *ngIf="showInvolvePeople" #people
                                 [people]="taskPeople"

--- a/lib/process-services/task-list/components/task-details.component.spec.ts
+++ b/lib/process-services/task-list/components/task-details.component.spec.ts
@@ -108,6 +108,20 @@ describe('TaskDetailsComponent', () => {
         expect(getTaskDetailsSpy).not.toHaveBeenCalled();
     });
 
+    it('should send a claim task event when a task is claimed', async(() => {
+        component.claimedTask.subscribe((taskId) => {
+            expect(taskId).toBe('FAKE-TASK-CLAIM');
+        });
+        component.onClaimAction('FAKE-TASK-CLAIM');
+    }));
+
+    it('should send a unclaim task event when a task is unclaimed', async(() => {
+        component.claimedTask.subscribe((taskId) => {
+            expect(taskId).toBe('FAKE-TASK-UNCLAIM');
+        });
+        component.onUnclaimAction('FAKE-TASK-UNCLAIM');
+    }));
+
     it('should set a placeholder message when taskId not initialised', () => {
         fixture.detectChanges();
         expect(fixture.nativeElement.innerText).toBe('ADF_TASK_LIST.DETAILS.MESSAGES.NONE');

--- a/lib/process-services/task-list/components/task-details.component.ts
+++ b/lib/process-services/task-list/components/task-details.component.ts
@@ -160,6 +160,14 @@ export class TaskDetailsComponent implements OnInit, OnChanges {
     @Output()
     assignTask: EventEmitter<void> = new EventEmitter<void>();
 
+    /** Emitted when a task is claimed. */
+    @Output()
+    claimedTask: EventEmitter<string> = new EventEmitter<string>();
+
+    /** Emitted when a task is unclaimed. */
+    @Output()
+    unClaimedTask: EventEmitter<string> = new EventEmitter<string>();
+
     taskDetails: TaskDetailsModel;
     taskFormName: string = null;
 
@@ -375,6 +383,12 @@ export class TaskDetailsComponent implements OnInit, OnChanges {
     }
 
     onClaimAction(taskId: string): void {
+        this.claimedTask.emit(taskId);
+        this.loadDetails(taskId);
+    }
+
+    onUnclaimAction(taskId: string): void {
+        this.unClaimedTask.emit(taskId);
         this.loadDetails(taskId);
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [X] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
No event is raised when user claim/unclaim a task


**What is the new behaviour?**
claim task and unclaim task event are raised when user claim/unclaim a task


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
