### PR TITLE
[ADF-2358] Always enabling copy action

### DIFF
--- a/demo-shell/src/app/components/files/files.component.html
+++ b/demo-shell/src/app/components/files/files.component.html
@@ -251,7 +251,7 @@
                     <content-action
                         icon="content_copy"
                         title="{{'DOCUMENT_LIST.ACTIONS.FOLDER.COPY' | translate}}"
-                        permission="update"
+                        permission="copy"
                         [disableWithNoPermission]="true"
                         (error)="onContentActionError($event)"
                         (success)="onContentActionSuccess($event)"

--- a/lib/content-services/document-list/components/document-list.component.spec.ts
+++ b/lib/content-services/document-list/components/document-list.component.spec.ts
@@ -344,6 +344,27 @@ describe('DocumentList', () => {
 
     });
 
+    it('should not disable the action if there is copy permission', () => {
+        let documentMenu = new ContentActionModel({
+            disableWithNoPermission: true,
+            permission: 'copy',
+            target: 'document',
+            title: 'FileAction'
+        });
+
+        documentList.actions = [
+            documentMenu
+        ];
+
+        let nodeFile = { entry: { isFile: true, name: 'xyz', allowableOperations: ['create', 'update'] } };
+
+        let actions = documentList.getNodeActions(nodeFile);
+        expect(actions.length).toBe(1);
+        expect(actions[0].title).toEqual('FileAction');
+        expect(actions[0].disabled).toBeFalsy();
+
+    });
+
     it('should disable the action if there is no permission for the folder and disableWithNoPermission true', () => {
         let documentMenu = new ContentActionModel({
             disableWithNoPermission: true,

--- a/lib/content-services/document-list/components/document-list.component.ts
+++ b/lib/content-services/document-list/components/document-list.component.ts
@@ -24,7 +24,8 @@ import {
     DisplayMode,
     ObjectDataColumn,
     PaginatedComponent,
-    PaginationQueryParams
+    PaginationQueryParams,
+    PermissionsEnum
 } from '@alfresco/adf-core';
 import { AlfrescoApiService, AppConfigService, DataColumnListComponent, UserPreferencesService } from '@alfresco/adf-core';
 import {
@@ -420,7 +421,7 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
     }
 
     checkPermission(node: any, action: ContentActionModel): ContentActionModel {
-        if (action.permission) {
+        if (action.permission && action.permission !== PermissionsEnum.COPY) {
             if (this.hasPermissions(node)) {
                 let permissions = node.entry.allowableOperations;
                 let findPermission = permissions.find(permission => permission === action.permission);

--- a/lib/core/models/permissions.enum.ts
+++ b/lib/core/models/permissions.enum.ts
@@ -19,6 +19,7 @@ export class PermissionsEnum extends String {
     static DELETE: string = 'delete';
     static UPDATE: string = 'update';
     static CREATE: string = 'create';
+    static COPY: string = 'copy';
     static UPDATEPERMISSIONS: string = 'updatePermissions';
     static NOT_DELETE: string = '!delete';
     static NOT_UPDATE: string = '!update';

--- a/lib/core/services/content.service.spec.ts
+++ b/lib/core/services/content.service.spec.ts
@@ -151,6 +151,11 @@ describe('ContentService', () => {
         expect(contentService.hasPermission(permissionNode, null)).toBeFalsy();
     });
 
+    it('should havePermission return true if permission parameter is copy', () => {
+        let permissionNode = null;
+        expect(contentService.hasPermission(permissionNode, 'copy')).toBeTruthy();
+    });
+
     describe('Download blob', () => {
 
         it('Should use native msSaveOrOpenBlob if the browser is IE', (done) => {

--- a/lib/core/services/content.service.ts
+++ b/lib/core/services/content.service.ts
@@ -213,6 +213,10 @@ export class ContentService {
             }
         }
 
+        if (permission === PermissionsEnum.COPY) {
+            hasPermission = true;
+        }
+
         return hasPermission;
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Copy action is not allowed even if the user has the relative 'read' permission on that folder.


**What is the new behaviour?**
As per content services behaviour when user has 'read' permission it should be allowed to copy the contnet.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
