### PR TITLE
[ADF-2465] Sometimes, navigating using the breadcrumb opens another folder instead of the clicked one - after search performed on the Content Node Selector

### DIFF
--- a/lib/content-services/content-node-selector/content-node-selector-panel.component.html
+++ b/lib/content-services/content-node-selector/content-node-selector-panel.component.html
@@ -38,7 +38,7 @@
             </ng-container>
             <adf-dropdown-breadcrumb *ngIf="needBreadcrumbs()"
                 class="adf-content-node-selector-content-breadcrumb"
-                (navigate)="clear()"
+                (navigate)="clearSearch()"
                 [target]="documentList"
                 [transform]="breadcrumbTransform"
                 [folderNode]="breadcrumbFolderNode"

--- a/lib/content-services/content-node-selector/content-node-selector-panel.component.spec.ts
+++ b/lib/content-services/content-node-selector/content-node-selector-panel.component.spec.ts
@@ -483,6 +483,43 @@ describe('ContentNodeSelectorComponent', () => {
                 expect(component.showingSearchResults).toBeFalsy();
             });
 
+            it('should clear the search field, nodes and chosenNode when deleting the search input',  async(() => {
+                spyOn(component, 'clear').and.callThrough();
+                typeToSearchBox('a');
+
+                setTimeout(() => {
+                    expect(searchSpy.calls.count()).toBe(1);
+
+                    typeToSearchBox('');
+
+                    setTimeout(() => {
+                        expect(searchSpy.calls.count()).toBe(1, 'no other search has been performed');
+                        expect(component.clear).toHaveBeenCalled();
+                        expect(component.folderIdToShow).toBe('cat-girl-nuku-nuku', 'back to the folder in which the search was performed');
+                    }, 300);
+                }, 300);
+
+            }));
+
+            it('should clear the search field, nodes and chosenNode on folder navigation in the results list', (done) => {
+                spyOn(component, 'clearSearch').and.callThrough();
+                typeToSearchBox('a');
+
+                setTimeout(() => {
+                    respondWithSearchResults(ONE_FOLDER_RESULT);
+                    fixture.whenStable().then(() => {
+                        fixture.detectChanges();
+
+                        component.onFolderChange();
+                        fixture.detectChanges();
+
+                        expect(component.clearSearch).toHaveBeenCalled();
+                        done();
+                    });
+                }, 300);
+
+            });
+
             it('should show nodes from the same folder as selected in the dropdown on clearing the search input', (done) => {
                 typeToSearchBox('piccolo');
 

--- a/lib/content-services/content-node-selector/content-node-selector-panel.component.ts
+++ b/lib/content-services/content-node-selector/content-node-selector-panel.component.ts
@@ -205,15 +205,22 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
     }
 
     /**
-     * Clear the search input
+     * Clear the search input and reset to last folder node in which search was performed
      */
     clear(): void {
+        this.clearSearch();
+        this.folderIdToShow = this.siteId || this.currentFolderId;
+    }
+
+    /**
+     * Clear the search input and search related data
+     */
+    clearSearch() {
         this.searchTerm = '';
         this.nodes = null;
         this.skipCount = 0;
         this.chosenNode = null;
         this.showingSearchResults = false;
-        this.folderIdToShow = this.siteId || this.currentFolderId;
     }
 
     /**
@@ -221,7 +228,7 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
      */
     private updateResults(): void {
         if (this.searchTerm.length === 0) {
-            this.folderIdToShow = this.siteId || this.currentFolderId;
+            this.clear();
         } else {
             this.startNewSearch();
         }
@@ -306,9 +313,8 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
      * Sets showingSearchResults state to be able to differentiate between search results or folder results
      */
     onFolderChange(): void {
-        this.skipCount = 0;
         this.infiniteScroll = false;
-        this.showingSearchResults = false;
+        this.clearSearch();
     }
 
     /**


### PR DESCRIPTION
fixed bug
added tests
made sure that deleting search input field clears all search related data

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Please see https://issues.alfresco.com/jira/browse/ADF-2465


**What is the new behaviour?**
Fixed bug.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
