### PR TITLE
[ADF-2463] Update doc tools to work with subfolders

### DIFF
--- a/lib/config/DocProcessor/docProcessor.js
+++ b/lib/config/DocProcessor/docProcessor.js
@@ -23,9 +23,9 @@ function initPhase(aggData) {
 }
 
 
-function readPhase(srcFolder, filenames, aggData) {
+function readPhase(filenames, aggData) {
     for (var i = 0; i < filenames.length; i++) {
-        var pathname = path.resolve(srcFolder, filenames[i]);
+        var pathname = filenames[i];//path.resolve(srcFolder, filenames[i]);
         
         var src = fs.readFileSync(pathname);
         var tree = remark().use(frontMatter, ["yaml"]).parse(src);
@@ -46,9 +46,9 @@ function aggPhase(aggData) {
 }
 
 
-function updatePhase(srcFolder, destFolder, filenames, aggData) {
+function updatePhase(filenames, aggData) {
     for (var i = 0; i < filenames.length; i++) {
-        var pathname = path.resolve(srcFolder, filenames[i]);
+        var pathname = filenames[i]; // path.resolve(srcFolder, filenames[i]);
         
         var src = fs.readFileSync(pathname);
         var tree = remark().use(frontMatter, ["yaml"]).parse(src)
@@ -60,8 +60,9 @@ function updatePhase(srcFolder, destFolder, filenames, aggData) {
         });
         
         if (modified)
-            fs.writeFileSync(path.resolve(destFolder, filenames[i]), remark().use(frontMatter, {type: 'yaml', fence: '---'}).data("settings", {paddedTable: false}).stringify(tree));
-            //console.log(JSON.stringify(tree));
+            fs.writeFileSync(filenames[i], remark().use(frontMatter, {type: 'yaml', fence: '---'}).data("settings", {paddedTable: false}).stringify(tree));
+        
+        //console.log(JSON.stringify(tree));
     }
 }
 
@@ -91,8 +92,24 @@ function loadToolConfig(configFilePath) {
 }
 
 
+function getAllDocFilePaths(docFolder, files) {
+    var items = fs.readdirSync(docFolder);
+
+    for (var i = 0; i < items.length; i++) {
+        var itemPath = path.resolve(docFolder, items[i]);
+        var itemInfo = fs.statSync(itemPath);
+
+        if (itemInfo.isFile()){
+            files.push(itemPath);
+        } else if (itemInfo.isDirectory()) {
+            getAllDocFilePaths(itemPath, files);
+        }
+    }
+}
+
+
 program
-.usage("[options] <source> [dest]")
+.usage("[options] <source>")
 .parse(process.argv);
 
 if (program.args.length === 0) {
@@ -104,6 +121,7 @@ if (program.args.length === 0) {
 var sourcePath = path.resolve(program.args[0]);
 var sourceInfo = fs.statSync(sourcePath);
 
+/*
 var destPath;
 var destInfo;
 
@@ -119,19 +137,21 @@ if (sourceInfo.isDirectory() && !destInfo.isDirectory()) {
     console.log("Error: The <dest> argument must be a directory");
     return 0;
 }
+*/
 
 var toolModules = loadToolModules();
 var toolList = loadToolConfig(path.resolve(__dirname, configFileName));
 
 
-var files;
+var files = [];
 
 if (sourceInfo.isDirectory()) {
-    files = fs.readdirSync(sourcePath);
+    getAllDocFilePaths(sourcePath, files);
 } else if (sourceInfo.isFile()) {
-    files = [ path.basename(sourcePath) ];
-    sourcePath = path.dirname(sourcePath);
-    destPath = path.dirname(destPath);
+    files = [ sourcePath ];
+    //files = [ path.basename(sourcePath) ];
+    //sourcePath = path.dirname(sourcePath);
+    //destPath = path.dirname(destPath);
 }
 
 files = files.filter(filename => 
@@ -145,13 +165,13 @@ console.log("Initialising...");
 initPhase(aggData);
 
 console.log("Analysing Markdown files...");
-readPhase(sourcePath, files, aggData);
+readPhase(files, aggData);
 
 console.log("Computing aggregate data...");
 aggPhase(aggData);
 
 console.log("Updating Markdown files...");
-updatePhase(sourcePath, destPath, files, aggData);
+updatePhase(files, aggData);
 
 
 

--- a/lib/config/DocProcessor/tools/index.js
+++ b/lib/config/DocProcessor/tools/index.js
@@ -39,7 +39,7 @@ function initPhase(aggData) {
     aggData.srcData = {};
     aggData.mdFileDesc = [];
     aggData.mdFileStatus = [];
-
+    aggData.mdFilePath = [];
     searchLibraryRecursive(aggData.srcData, path.resolve(rootFolder));
 
     //console.log(JSON.stringify(aggData.srcData));
@@ -50,7 +50,7 @@ function readPhase(tree, pathname, aggData) {
     var itemName = path.basename(pathname, ".md");
 
     // Look for the first paragraph in the file by skipping other items.
-    // Should usually be a position 1 in the tree.
+    // Should usually be at position 1 in the tree.
     var s;
     var briefDesc;
 
@@ -80,6 +80,10 @@ function readPhase(tree, pathname, aggData) {
         }
 
     }
+
+    var linkPath = pathname.replace(/\\/g, '/');
+    linkPath = linkPath.substr(linkPath.indexOf("docs") + 5);
+    aggData.mdFilePath[itemName] = linkPath;
 }
 
 function aggPhase(aggData) {
@@ -159,6 +163,7 @@ function prepareIndexSections(aggData) {
         var briefDesc = aggData.mdFileDesc[itemName];
 
         var displayName = ngHelpers.ngNameToDisplayName(itemName);
+        var pathname = aggData.mdFilePath[itemName];
 
         var status = "";
 
@@ -169,6 +174,7 @@ function prepareIndexSections(aggData) {
             sections[libName][srcData.type].documented.push({
                 "displayName": displayName,
                 "mdName": itemName + ".md",
+                "mdPath": pathname,
                 "srcPath": srcData.path,
                 "briefDesc": briefDesc,
                 "status": status
@@ -280,7 +286,7 @@ function makeMDUndocumentedListItem(docItem) {
 
 
 function makeMDDocumentedTableRow(docItem) {
-    var mdFileLink = unist.makeLink(unist.makeText(docItem.displayName), docItem.mdName);
+    var mdFileLink = unist.makeLink(unist.makeText(docItem.displayName), docItem.mdPath);
     var srcFileLink = unist.makeLink(unist.makeText("Source"), "../lib/" + docItem.srcPath);
     var desc = docItem.briefDesc;
 

--- a/lib/config/DocProcessor/tools/versionIndex.js
+++ b/lib/config/DocProcessor/tools/versionIndex.js
@@ -31,7 +31,7 @@ function initPhase(aggData) {
 
 
 function readPhase(tree, pathname, aggData) {
-    var compName = path.basename(pathname, ".md");
+    var compName = pathname; //path.basename(pathname, ".md");
     var angNameRegex = /([a-zA-Z0-9\-]+)\.((component)|(directive)|(model)|(pipe)|(service)|(widget))/;
 
     if (!compName.match(angNameRegex))
@@ -86,13 +86,20 @@ function aggPhase(aggData) {
     for (var i = 0; i < keys.length; i++) {
         var version = keys[i];
         var versionItems = aggData.versions[version];
-        versionItems.sort();
+        versionItems.sort((a, b) => {
+            var aa = path.basename(a, ".md");
+            var bb = path.basename(b, ".md");
+
+            return aa.localeCompare(bb);
+        });
 
         var versListItems = [];
 
         for (var v = 0; v < versionItems.length; v++) {
-            var displayName = ngHelpers.ngNameToDisplayName(versionItems[v]);
-            var pageLink = versionItems[v] + ".md";
+            var displayName = ngHelpers.ngNameToDisplayName(path.basename(versionItems[v], ".md"));
+            var pageLink = versionItems[v];// + ".md";
+            pageLink = pageLink.replace(/\\/g, '/');
+            pageLink = pageLink.substr(pageLink.indexOf("docs") + 5);
 
             versListItems.push(
                 unist.makeListItem(


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [x] Documentation
> - [ ] Other... Please describe:

**What is the new behaviour?**

Updated doc tools so that they can find and index files correctly from subfolders within the docs folder. This will allow for gradual migration of doc files into folders corresponding to the ADF libraries.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
