### PR TITLE
[ADF-2393] fixed reloading on delete with infinite scrolling

### DIFF
--- a/demo-shell/src/app/components/files/files.component.ts
+++ b/demo-shell/src/app/components/files/files.component.ts
@@ -328,15 +328,16 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
     onContentActionSuccess(message) {
         const translatedMessage: any = this.translateService.get(message);
         this.notificationService.openSnackMessage(translatedMessage.value, 4000);
-        if (this.infiniteScrolling) {
-            this.documentList.skipCount = 0;
-            this.documentList.reload();
-        }
+        this.reloadForInfiniteScrolling();
     }
 
     onDeleteActionSuccess(message) {
         this.uploadService.fileDeleted.next(message);
         this.deleteElementSuccess.emit();
+        this.reloadForInfiniteScrolling();
+    }
+
+    private reloadForInfiniteScrolling() {
         if (this.infiniteScrolling) {
             this.documentList.skipCount = 0;
             this.documentList.reload();

--- a/demo-shell/src/app/components/files/files.component.ts
+++ b/demo-shell/src/app/components/files/files.component.ts
@@ -295,7 +295,7 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
     }
 
     emitReadyEvent(event: any) {
-        if (this.pageIsEmpty(event)) {
+        if (this.standardPagination && this.pageIsEmpty(event)) {
             this.standardPagination.goPrevious();
         } else {
             this.documentListReady.emit(event);
@@ -328,11 +328,19 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
     onContentActionSuccess(message) {
         const translatedMessage: any = this.translateService.get(message);
         this.notificationService.openSnackMessage(translatedMessage.value, 4000);
+        if (this.infiniteScrolling) {
+            this.documentList.skipCount = 0;
+            this.documentList.reload();
+        }
     }
 
     onDeleteActionSuccess(message) {
         this.uploadService.fileDeleted.next(message);
         this.deleteElementSuccess.emit();
+        if (this.infiniteScrolling) {
+            this.documentList.skipCount = 0;
+            this.documentList.reload();
+        }
     }
 
     onManageVersions(event) {

--- a/lib/content-services/document-list/services/document-actions.service.spec.ts
+++ b/lib/content-services/document-list/services/document-actions.service.spec.ts
@@ -204,19 +204,6 @@ describe('DocumentActionsService', () => {
         expect(documentListService.deleteNode).not.toHaveBeenCalled();
     });
 
-    it('should reload target upon node deletion', () => {
-        spyOn(documentListService, 'deleteNode').and.returnValue(Observable.of(true));
-
-        let target = jasmine.createSpyObj('obj', ['reload']);
-        let permission = 'delete';
-        let file: any = new FileNode();
-        file.entry.allowableOperations = ['delete'];
-        service.getHandler('delete')(file, target, permission);
-
-        expect(documentListService.deleteNode).toHaveBeenCalled();
-        expect(target.reload).toHaveBeenCalled();
-    });
-
     it('should emit success event upon node deletion', (done) => {
         service.success.subscribe((nodeId) => {
             expect(nodeId).not.toBeNull();

--- a/lib/content-services/document-list/services/document-actions.service.ts
+++ b/lib/content-services/document-list/services/document-actions.service.ts
@@ -101,10 +101,7 @@ export class DocumentActionsService {
     private prepareHandlers(actionObservable, type: string, action: string, target?: any, permission?: string): void {
         actionObservable.subscribe(
             (fileOperationMessage) => {
-                if (target && typeof target.reload === 'function') {
-                    target.reload();
-                }
-                this.success.next(fileOperationMessage);
+                  this.success.next(fileOperationMessage);
             },
             this.error.next.bind(this.error)
         );
@@ -117,9 +114,6 @@ export class DocumentActionsService {
             if (this.contentService.hasPermission(node.entry, permission)) {
                 handlerObservable = this.documentListService.deleteNode(node.entry.id);
                 handlerObservable.subscribe(() => {
-                    if (target && typeof target.reload === 'function') {
-                        target.reload();
-                    }
                     this.success.next(node.entry.id);
                 });
                 return handlerObservable;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
When infinite scrolling is enabled the document list is not correctly refreshed


**What is the new behaviour?**
Document list is now correctly refreshed on element delete


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
