### PR TITLE
[ADF-2443] renaming getDifferentPageSize to getDefaultPageSize

### DIFF
--- a/demo-shell/src/app/components/files/files.component.ts
+++ b/demo-shell/src/app/components/files/files.component.ts
@@ -205,7 +205,7 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
         this.contentService.folderCreated.subscribe(value => this.onFolderCreated(value));
         this.onCreateFolder = this.contentService.folderCreate.subscribe(value => this.onFolderAction(value));
         this.onEditFolder = this.contentService.folderEdit.subscribe(value => this.onFolderAction(value));
-        this.supportedPages = this.preference.getDifferentPageSizes();
+        this.supportedPages = this.preference.getDefaultPageSizes();
 
         // this.permissionsStyle.push(new PermissionStyleModel('document-list__create', PermissionsEnum.CREATE));
         // this.permissionsStyle.push(new PermissionStyleModel('document-list__disable', PermissionsEnum.NOT_CREATE, false, true));

--- a/demo-shell/src/app/components/process-service/process-service.component.ts
+++ b/demo-shell/src/app/components/process-service/process-service.component.ts
@@ -225,7 +225,7 @@ export class ProcessServiceComponent implements AfterViewInit, OnDestroy, OnInit
             this.currentProcessInstanceId = null;
         });
         this.layoutType = AppsListComponent.LAYOUT_GRID;
-        this.supportedPages = this.preferenceService.getDifferentPageSizes();
+        this.supportedPages = this.preferenceService.getDefaultPageSizes();
     }
 
     ngOnDestroy() {

--- a/lib/content-services/document-list/components/document-list.component.ts
+++ b/lib/content-services/document-list/components/document-list.component.ts
@@ -940,7 +940,7 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
     }
 
     get supportedPageSizes(): number[] {
-        return this.preferences.getDifferentPageSizes();
+        return this.preferences.getDefaultPageSizes();
     }
 
     ngOnDestroy() {

--- a/lib/core/services/user-preferences.service.spec.ts
+++ b/lib/core/services/user-preferences.service.spec.ts
@@ -72,7 +72,7 @@ describe('UserPreferencesService', () => {
     });
 
     it('should return supported page sizes defined in the app config', () => {
-        const supportedPages = preferences.getDifferentPageSizes();
+        const supportedPages = preferences.getDefaultPageSizes();
         expect(supportedPages).toEqual(supportedPaginationSize);
     });
 

--- a/lib/core/services/user-preferences.service.ts
+++ b/lib/core/services/user-preferences.service.ts
@@ -130,7 +130,7 @@ export class UserPreferencesService {
     }
 
     /** Gets an array containing the available page sizes. */
-    getDifferentPageSizes(): number[] {
+    getDefaultPageSizes(): number[] {
         return this.defaults.supportedPageSizes;
     }
 

--- a/lib/process-services/process-list/components/process-list.component.ts
+++ b/lib/process-services/process-list/components/process-list.component.ts
@@ -407,6 +407,6 @@ export class ProcessInstanceListComponent implements OnChanges, AfterContentInit
     }
 
     get supportedPageSizes(): number[] {
-        return this.userPreferences.getDifferentPageSizes();
+        return this.userPreferences.getDefaultPageSizes();
     }
 }

--- a/lib/process-services/task-list/components/task-list.component.ts
+++ b/lib/process-services/task-list/components/task-list.component.ts
@@ -439,6 +439,6 @@ export class TaskListComponent implements OnChanges, AfterContentInit, Paginated
     }
 
     get supportedPageSizes(): number[] {
-        return this.userPreferences.getDifferentPageSizes();
+        return this.userPreferences.getDefaultPageSizes();
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [X] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
getDifferentPageSize is misbehaving


**What is the new behaviour?**
getDifferentPageSize is renamed as getDefaultPageSize


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
