### PR TITLE
[ADF-2397] Sometimes Load more on Content Node Selector does not load next page of results

### DIFF
--- a/lib/content-services/content-node-selector/content-node-selector-panel.component.spec.ts
+++ b/lib/content-services/content-node-selector/content-node-selector-panel.component.spec.ts
@@ -139,6 +139,20 @@ describe('ContentNodeSelectorComponent', () => {
 
                 component.chosenNode = expectedNode;
             });
+
+            it('should update skipCount on folder loaded', () => {
+                component.skipCount = 8;
+
+                component.onFolderLoaded({
+                    list: {
+                        pagination: {
+                            skipCount: 10
+                        }
+                    }
+                });
+
+                expect(component.skipCount).toBe(10, 'skipCount is updated');
+            });
         });
 
         describe('Breadcrumbs', () => {

--- a/lib/content-services/content-node-selector/content-node-selector-panel.component.ts
+++ b/lib/content-services/content-node-selector/content-node-selector-panel.component.ts
@@ -317,6 +317,7 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
     onFolderLoaded(nodePage: NodePaging): void {
         this.attemptNodeSelection(this.documentList.folderNode);
         this.pagination = nodePage.list.pagination;
+        this.skipCount = nodePage.list.pagination.skipCount;
     }
 
     /**


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Please see https://issues.alfresco.com/jira/browse/ADF-2397


**What is the new behaviour?**
fixed bug


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
