### PR TITLE
[ADF-2405] Add new service to get all process definition versions - REVERT

### DIFF
--- a/lib/process-services/process-list/services/process.service.spec.ts
+++ b/lib/process-services/process-list/services/process.service.spec.ts
@@ -341,65 +341,6 @@ describe('ProcessService', () => {
 
     });
 
-    describe('process definition versions', () => {
-
-        let getProcessDefinitionVersions: jasmine.Spy;
-
-        beforeEach(() => {
-            getProcessDefinitionVersions = spyOn(alfrescoApi.activiti.processApi, 'getProcessDefinitions')
-                .and
-                .returnValue(Promise.resolve({ data: [ fakeProcessDef, fakeProcessDef ] }));
-        });
-
-        it('should return the correct number of process defs', async(() => {
-            service.getProcessDefinitionVersions().subscribe((defs) => {
-                expect(defs.length).toBe(2);
-            });
-        }));
-
-        it('should return the correct process def data', async(() => {
-            service.getProcessDefinitionVersions().subscribe((defs) => {
-                expect(defs[0].id).toBe(fakeProcessDef.id);
-                expect(defs[0].key).toBe(fakeProcessDef.key);
-                expect(defs[0].name).toBe(fakeProcessDef.name);
-            });
-        }));
-
-        it('should call API with correct parameters when no appId provided', () => {
-            service.getProcessDefinitionVersions();
-            expect(getProcessDefinitionVersions).toHaveBeenCalledWith({});
-        });
-
-        it('should call API with correct parameters when appId provided', () => {
-            const appId = 1;
-            service.getProcessDefinitionVersions(appId);
-            expect(getProcessDefinitionVersions).toHaveBeenCalledWith({
-                appDefinitionId: appId
-            });
-        });
-
-        it('should pass on any error that is returned by the API', async(() => {
-            getProcessDefinitionVersions = getProcessDefinitionVersions.and.returnValue(Promise.reject(mockError));
-            service.getProcessDefinitionVersions().subscribe(
-                () => {},
-                (res) => {
-                    expect(res).toBe(mockError);
-                }
-            );
-        }));
-
-        it('should return a default error if no data is returned by the API', async(() => {
-            getProcessDefinitionVersions = getProcessDefinitionVersions.and.returnValue(Promise.reject(null));
-            service.getProcessDefinitionVersions().subscribe(
-                () => {},
-                (res) => {
-                    expect(res).toBe('Server error');
-                }
-            );
-        }));
-
-    });
-
     describe('process instance tasks', () => {
 
         const processId = '1001';

--- a/lib/process-services/process-list/services/process.service.ts
+++ b/lib/process-services/process-list/services/process.service.ts
@@ -120,21 +120,6 @@ export class ProcessService {
     }
 
     /**
-     * Gets the versions of process definitions associated with an app.
-     * @param appId ID of a target app
-     */
-    getProcessDefinitionVersions(appId?: number): Observable<ProcessDefinitionRepresentation[]> {
-        const opts = appId ? { appDefinitionId: appId } : {};
-
-        return Observable.fromPromise(
-            this.alfrescoApiService.getInstance().activiti.processApi.getProcessDefinitions(opts)
-        )
-            .map(this.extractData)
-            .map(processDefs => processDefs.map((pd) => new ProcessDefinitionRepresentation(pd)))
-            .catch(err => this.handleProcessError(err));
-    }
-
-    /**
      * Starts a process based on a process definition, name, form values or variables.
      * @param processDefinitionId Process definition ID
      * @param name Process name


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe:

Reverting the [PR](https://github.com/Alfresco/alfresco-ng2-components/pull/3023) for [ADF-2405 Add new service to get all process definition versions](https://issues.alfresco.com/jira/browse/ADF-2405) as there is an existing service that fulfills requirement.

**What is the current behaviour?** (You can also link to an open issue here)

* Added a new service to get all process definition versions.

**What is the new behaviour?**

* Reverted the new service as there is an existing service (AnalyticsService.getProcessDefinitionsValues()) that fulfills requirement.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
