### PR TITLE
[ADF-2504] Add read-only mode for the content meta-data component

### DIFF
--- a/docs/content-services/content-metadata.component.md
+++ b/docs/content-services/content-metadata.component.md
@@ -27,7 +27,7 @@ The different aspects and their properties to be shown can be configured as appl
 | --- | --- | --- | --- |
 | node | MinimalNodeEntryEntity | - | (**required**) The node entity to fetch metadata about |
 | displayEmpty | boolean | false | Display empty values in card view or not |
-| canEdit | boolean | true | Whether the edit button to be shown or not |
+| readOnly | boolean | true | Whether the edit button to be shown or not |
 | multi | boolean | false | multi parameter of the underlying material expansion panel |
 | preset | string | "*" | The metadata preset's name, which defines aspects and their properties |
 

--- a/docs/content-services/content-metadata.component.md
+++ b/docs/content-services/content-metadata.component.md
@@ -28,6 +28,7 @@ The different aspects and their properties to be shown can be configured as appl
 | node | MinimalNodeEntryEntity | - | (**required**) The node entity to fetch metadata about |
 | displayEmpty | boolean | false | Display empty values in card view or not |
 | canEdit | boolean | true | Whether the edit button to be shown or not |
+| multi | boolean | false | multi parameter of the underlying material expansion panel |
 | preset | string | "*" | The metadata preset's name, which defines aspects and their properties |
 
 ## Details

--- a/docs/content-services/content-metadata.component.md
+++ b/docs/content-services/content-metadata.component.md
@@ -27,6 +27,7 @@ The different aspects and their properties to be shown can be configured as appl
 | --- | --- | --- | --- |
 | node | MinimalNodeEntryEntity | - | (**required**) The node entity to fetch metadata about |
 | displayEmpty | boolean | false | Display empty values in card view or not |
+| canEdit | boolean | true | Whether the edit button to be shown or not |
 | preset | string | "*" | The metadata preset's name, which defines aspects and their properties |
 
 ## Details

--- a/lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.html
+++ b/lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.html
@@ -5,6 +5,7 @@
             [displayEmpty]="displayEmpty"
             [editable]="editable"
             [expanded]="expanded"
+            [multi]="multi"
             [preset]="preset">
         </adf-content-metadata>
     </mat-card-content>

--- a/lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.html
+++ b/lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.html
@@ -11,7 +11,7 @@
     </mat-card-content>
     <mat-card-footer class="adf-content-metadata-card-footer" fxLayout="row" fxLayoutAlign="space-between stretch">
         <div>
-            <button *ngIf="canEdit" mat-icon-button (click)="toggleEdit()" data-automation-id="mata-data-card-toggle-edit">
+            <button *ngIf="!readOnly" mat-icon-button (click)="toggleEdit()" data-automation-id="mata-data-card-toggle-edit">
                 <mat-icon>mode_edit</mat-icon>
             </button>
         </div>

--- a/lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.html
+++ b/lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.html
@@ -10,7 +10,7 @@
     </mat-card-content>
     <mat-card-footer class="adf-content-metadata-card-footer" fxLayout="row" fxLayoutAlign="space-between stretch">
         <div>
-            <button mat-icon-button (click)="toggleEdit()" data-automation-id="mata-data-card-toggle-edit">
+            <button *ngIf="canEdit" mat-icon-button (click)="toggleEdit()" data-automation-id="mata-data-card-toggle-edit">
                 <mat-icon>mode_edit</mat-icon>
             </button>
         </div>

--- a/lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.spec.ts
+++ b/lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.spec.ts
@@ -170,4 +170,17 @@ describe('ContentMetadataCardComponent', () => {
 
         expect(buttonLabel.nativeElement.innerText.trim()).toBe('ADF_VIEWER.SIDEBAR.METADATA.LESS_INFORMATION');
     });
+
+    it('should show the edit button by default', () => {
+        const button = fixture.debugElement.query(By.css('[data-automation-id="mata-data-card-toggle-edit"]'));
+        expect(button).not.toBeNull();
+    });
+
+    it('should hode the edit button in canEdit is false', () => {
+        component.canEdit = false;
+        fixture.detectChanges();
+
+        const button = fixture.debugElement.query(By.css('[data-automation-id="mata-data-card-toggle-edit"]'));
+        expect(button).toBeNull();
+    });
 });

--- a/lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.spec.ts
+++ b/lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.spec.ts
@@ -114,6 +114,14 @@ describe('ContentMetadataCardComponent', () => {
         expect(contentMetadataComponent.editable).toBe(true);
     });
 
+    it('should pass through the multi to the underlying component', () => {
+        component.multi = true;
+        fixture.detectChanges();
+        const contentMetadataComponent = fixture.debugElement.query(By.directive(ContentMetadataComponent)).componentInstance;
+
+        expect(contentMetadataComponent.multi).toBe(true);
+    });
+
     it('should pass through the expanded to the underlying component', () => {
         component.expanded = true;
         fixture.detectChanges();

--- a/lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.spec.ts
+++ b/lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.spec.ts
@@ -184,8 +184,8 @@ describe('ContentMetadataCardComponent', () => {
         expect(button).not.toBeNull();
     });
 
-    it('should hode the edit button in canEdit is false', () => {
-        component.canEdit = false;
+    it('should hode the edit button in readOnly is true', () => {
+        component.readOnly = true;
         fixture.detectChanges();
 
         const button = fixture.debugElement.query(By.css('[data-automation-id="mata-data-card-toggle-edit"]'));

--- a/lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.ts
+++ b/lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.ts
@@ -35,6 +35,9 @@ export class ContentMetadataCardComponent {
     @Input()
     preset: string;
 
+    @Input()
+    canEdit = true;
+
     editable: boolean = false;
     expanded: boolean = false;
 

--- a/lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.ts
+++ b/lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.ts
@@ -36,7 +36,7 @@ export class ContentMetadataCardComponent {
     preset: string;
 
     @Input()
-    canEdit = true;
+    readOnly = false;
 
     @Input()
     multi = false;

--- a/lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.ts
+++ b/lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.ts
@@ -38,6 +38,9 @@ export class ContentMetadataCardComponent {
     @Input()
     canEdit = true;
 
+    @Input()
+    multi = false;
+
     editable: boolean = false;
     expanded: boolean = false;
 

--- a/lib/content-services/content-metadata/components/content-metadata/content-metadata.component.html
+++ b/lib/content-services/content-metadata/components/content-metadata/content-metadata.component.html
@@ -1,5 +1,5 @@
 <div class="adf-metadata-properties">
-    <mat-accordion displayMode="flat">
+    <mat-accordion displayMode="flat" [multi]="multi">
         <mat-expansion-panel [expanded]="!expanded" [hideToggle]="!expanded">
             <mat-expansion-panel-header>
                 <mat-panel-title>

--- a/lib/content-services/content-metadata/components/content-metadata/content-metadata.component.ts
+++ b/lib/content-services/content-metadata/components/content-metadata/content-metadata.component.ts
@@ -45,6 +45,9 @@ export class ContentMetadataComponent implements OnChanges, OnInit {
     expanded: boolean = false;
 
     @Input()
+    multi = false;
+
+    @Input()
     preset: string;
 
     nodeHasBeenUpdated: boolean = false;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-2504


**What is the new behaviour?**
Implemented


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
