### PR TITLE
[ADF-2486] input mask placeholder should be shown whenever it is present

### DIFF
--- a/lib/core/form/components/widgets/text/text.widget.html
+++ b/lib/core/form/components/widgets/text/text.widget.html
@@ -12,7 +12,7 @@
                (ngModelChange)="onFieldChanged(field)"
                [disabled]="field.readOnly || readOnly"
                [textMask]="{mask: mask, isReversed: isMaskReversed}"
-               placeholder="{{field.placeholder}}">
+               [placeholder]="placeholder">
     </mat-form-field>
     <error-widget [error]="field.validationSummary"></error-widget>
     <error-widget *ngIf="isInvalidFieldRequired()" required="{{ 'FORM.FIELD.REQUIRED' | translate }}"></error-widget>

--- a/lib/core/form/components/widgets/text/text.widget.spec.ts
+++ b/lib/core/form/components/widgets/text/text.widget.spec.ts
@@ -145,7 +145,6 @@ describe('TextWidgetComponent', () => {
             });
 
             it('should show the field placeholder', () => {
-                const inputElement: HTMLInputElement = <HTMLInputElement> element.querySelector('#text-id');
                 expect(inputElement).toBeDefined();
                 expect(inputElement).not.toBeNull();
                 expect(inputElement.placeholder).toBe('simple palceholder');
@@ -258,8 +257,6 @@ describe('TextWidgetComponent', () => {
 
         describe('and a mask placeholder is configured', () => {
 
-            let inputElement: HTMLInputElement;
-
             beforeEach(() => {
                 widget.field = new FormFieldModel(new FormModel({taskId: 'fake-task-id'}), {
                     id: 'text-id',
@@ -272,7 +269,6 @@ describe('TextWidgetComponent', () => {
                 });
 
                 fixture.detectChanges();
-                inputElement = <HTMLInputElement> element.querySelector('#text-id');
             });
 
             it('should show the input mask placeholder', () => {

--- a/lib/core/form/components/widgets/text/text.widget.spec.ts
+++ b/lib/core/form/components/widgets/text/text.widget.spec.ts
@@ -131,7 +131,8 @@ describe('TextWidgetComponent', () => {
                     value: '',
                     params: {inputMask: '##-##0,00%'},
                     type: FormFieldTypes.TEXT,
-                    readOnly: false
+                    readOnly: false,
+                    placeholder: 'simple palceholder'
                 });
 
                 fixture.detectChanges();
@@ -141,6 +142,13 @@ describe('TextWidgetComponent', () => {
             it('should show text widget', () => {
                 expect(element.querySelector('#text-id')).toBeDefined();
                 expect(element.querySelector('#text-id')).not.toBeNull();
+            });
+
+            it('should show the field placeholder', () => {
+                const inputElement: HTMLInputElement = <HTMLInputElement> element.querySelector('#text-id');
+                expect(inputElement).toBeDefined();
+                expect(inputElement).not.toBeNull();
+                expect(inputElement.placeholder).toBe('simple palceholder');
             });
 
             it('should prevent text to be written if is not allowed by the mask on keyUp event', async(() => {
@@ -246,6 +254,33 @@ describe('TextWidgetComponent', () => {
                     expect(textEle.value).toBe('12,34%');
                 });
             }));
+        });
+
+        describe('and a mask placeholder is configured', () => {
+
+            let inputElement: HTMLInputElement;
+
+            beforeEach(() => {
+                widget.field = new FormFieldModel(new FormModel({taskId: 'fake-task-id'}), {
+                    id: 'text-id',
+                    name: 'text-name',
+                    value: '',
+                    params: {inputMask: '##-##0,00%', inputMaskPlaceholder: 'Phone : (__) ___-___'},
+                    type: FormFieldTypes.TEXT,
+                    readOnly: false,
+                    placeholder: 'simple palceholder'
+                });
+
+                fixture.detectChanges();
+                inputElement = <HTMLInputElement> element.querySelector('#text-id');
+            });
+
+            it('should show the input mask placeholder', () => {
+                const inputElement: HTMLInputElement = <HTMLInputElement> element.querySelector('#text-id');
+                expect(inputElement).toBeDefined();
+                expect(inputElement).not.toBeNull();
+                expect(inputElement.placeholder).toBe('Phone : (__) ___-___');
+            });
         });
     });
 });

--- a/lib/core/form/components/widgets/text/text.widget.ts
+++ b/lib/core/form/components/widgets/text/text.widget.ts
@@ -31,6 +31,7 @@ import { baseHost , WidgetComponent } from './../widget.component';
 export class TextWidgetComponent extends WidgetComponent implements OnInit {
 
     mask: string;
+    placeholder: string;
     isMaskReversed: boolean;
 
     constructor(public formService: FormService) {
@@ -40,6 +41,7 @@ export class TextWidgetComponent extends WidgetComponent implements OnInit {
     ngOnInit() {
         if (this.field.params && this.field.params['inputMask']) {
             this.mask = this.field.params['inputMask'];
+            this.placeholder = this.field.params['inputMaskPlaceholder'] ? this.field.params['inputMaskPlaceholder'] : this.field.placeholder;
             this.isMaskReversed = this.field.params['inputMaskReversed'] ? this.field.params['inputMaskReversed'] : false;
         }
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
input mask placeholder is not showed when is set only the standard placeholder


**What is the new behaviour?**
when input mask placeholder is set, this is showed instead of the default one.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
