### PR TITLE
[ADF-2484] moved translation into the context menu action

### DIFF
--- a/demo-shell/src/app/components/files/files.component.html
+++ b/demo-shell/src/app/components/files/files.component.html
@@ -247,12 +247,12 @@
                     <!-- common actions -->
                     <content-action
                         icon="get_app"
-                        title="{{'DOCUMENT_LIST.ACTIONS.DOWNLOAD' | translate}}"
+                        title="DOCUMENT_LIST.ACTIONS.DOWNLOAD"
                         handler="download">
                     </content-action>
                     <content-action
                         icon="content_copy"
-                        title="{{'DOCUMENT_LIST.ACTIONS.FOLDER.COPY' | translate}}"
+                        title="DOCUMENT_LIST.ACTIONS.FOLDER.COPY"
                         permission="copy"
                         [disableWithNoPermission]="true"
                         (error)="onContentActionError($event)"
@@ -261,7 +261,7 @@
                     </content-action>
                     <content-action
                         icon="redo"
-                        title="{{'DOCUMENT_LIST.ACTIONS.FOLDER.MOVE' | translate}}"
+                        title="DOCUMENT_LIST.ACTIONS.FOLDER.MOVE"
                         permission="update"
                         [disableWithNoPermission]="true"
                         (error)="onContentActionError($event)"
@@ -272,28 +272,28 @@
                         icon="delete"
                         permission="delete"
                         [disableWithNoPermission]="true"
-                        title="{{'DOCUMENT_LIST.ACTIONS.FOLDER.DELETE' | translate}}"
+                        title="DOCUMENT_LIST.ACTIONS.FOLDER.DELETE"
                         (permissionEvent)="handlePermissionError($event)"
                         (success)="onDeleteActionSuccess($event)"
                         handler="delete">
                     </content-action>
                     <content-action
                         icon="info"
-                        title="{{'DOCUMENT_LIST.ACTIONS.METADATA' | translate}}"
+                        title="DOCUMENT_LIST.ACTIONS.METADATA"
                         (execute)="onManageMetadata($event)">
                     </content-action>
                     <!-- document actions -->
                     <content-action
                         icon="storage"
                         target="document"
-                        title="{{'DOCUMENT_LIST.ACTIONS.VERSIONS' | translate}}"
+                        title="DOCUMENT_LIST.ACTIONS.VERSIONS"
                         (execute)="onManageVersions($event)">
                     </content-action>
                     <content-action
                         *ngIf="authenticationService.isBpmLoggedIn()"
                         icon="play_arrow"
                         target="document" 
-                        title="{{'DOCUMENT_LIST.ACTIONS.DOCUMENT.PROCESS_ACTION' | translate}}"
+                        title="DOCUMENT_LIST.ACTIONS.DOCUMENT.PROCESS_ACTION"
                         (execute)="startProcesAction($event)">
                     </content-action>
                 </content-actions>
@@ -344,7 +344,7 @@
     </div>
 </div>
 
-<context-menu-holder></context-menu-holder>
+<adf-context-menu-holder></adf-context-menu-holder>
 
 <div *ngIf="processId">
     <adf-start-process

--- a/docs/content-services/content-action.component.md
+++ b/docs/content-services/content-action.component.md
@@ -80,7 +80,7 @@ export class MyView {
 
 | Name | Type | Default value | Description |
 | ---- | ---- | ------------- | ----------- |
-| title | `string` | `'Action'` | The title of the action as shown in the menu.  |
+| title | `string` | `'Action'` | The title of the action as shown in the menu. If the title is a translation key the translation will be automatically showed.  |
 | icon | `string` |  | The name of the icon to display next to the menu command (can be left blank).  |
 | handler | `string` |  | System actions. Can be "delete", "download", "copy" or "move".  |
 | target | `string` | [ContentActionTarget.All](https://github.com/Alfresco/alfresco-ng2-components/blob/development/lib/content-services/document-list/models/content-action.model.ts) | Type of item that the action applies to. Can be one of the values provided by the enum : **All**, **Folder**, **Document**  |

--- a/lib/core/context-menu/context-menu-holder.component.ts
+++ b/lib/core/context-menu/context-menu-holder.component.ts
@@ -21,7 +21,9 @@ import { Component, HostListener, Input, OnDestroy, OnInit, Renderer2, ViewChild
 import { MatMenuTrigger } from '@angular/material';
 import { Subscription } from 'rxjs/Subscription';
 import { ContextMenuService } from './context-menu.service';
-
+/**
+ * @deprecated: context-menu-holder is deprecated, use adf-context-menu-holder instead.
+ */
 @Component({
     selector: 'adf-context-menu-holder, context-menu-holder',
     template: `
@@ -35,7 +37,7 @@ import { ContextMenuService } from './context-menu.service';
                 <mat-icon *ngIf="showIcons && link.model?.icon">
                     {{ link.model?.icon }}
                 </mat-icon>
-                    {{link.title || link.model?.title}}
+                    {{ (link.title || link.model?.title) | translate}}
             </button>
         </mat-menu>
     `

--- a/lib/core/context-menu/context-menu.module.ts
+++ b/lib/core/context-menu/context-menu.module.ts
@@ -18,6 +18,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { MaterialModule } from '../material.module';
+import { TranslateModule } from '@ngx-translate/core';
 
 import { ContextMenuHolderComponent } from './context-menu-holder.component';
 import { ContextMenuDirective } from './context-menu.directive';
@@ -26,7 +27,8 @@ import { ContextMenuService } from './context-menu.service';
 @NgModule({
     imports: [
         CommonModule,
-        MaterialModule
+        MaterialModule,
+        TranslateModule
     ],
     declarations: [
         ContextMenuHolderComponent,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
context menu is not translated on the fly


**What is the new behaviour?**
the translation is applied inside the context menu holder component so when a new key is given the translation is changed on the fly


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
