### PR TITLE
[ADF-2526] Fixed interpolation marker issue in doc files

### DIFF
--- a/docs/content-services/search.component.md
+++ b/docs/content-services/search.component.md
@@ -39,6 +39,8 @@ Searches items for supplied search terms.
 
 You have to add a template that will be shown when the results are loaded.
 
+<!-- {% raw %} -->
+
 ```html
 <adf-search [searchTerm]="searchTerm">
     <ng-template let-result>
@@ -51,11 +53,15 @@ You have to add a template that will be shown when the results are loaded.
 </adf-search>
 ```
 
+<!-- {% endraw %} -->
+
 The results are provided via the [$implicit variable of angular2](https://angular.io/api/common/NgTemplateOutlet) and can be accessed via the sugar sintax 'let-yourChosenName'. As per example above the result will be something like : 
 
 ![adf-search-control](../docassets/images/search-component-simple-template.png)
 
 But you can define even a more complex template : 
+
+<!-- {% raw %} -->
 
 ```html
 <adf-search class="adf-search-result-autocomplete"
@@ -97,6 +103,8 @@ But you can define even a more complex template :
 </adf-search>
 ```
 
+<!-- {% endraw %} -->
+
 Which will look like :
 
 ![adf-search-control](../docassets/images/search-component-complex-template.png)
@@ -105,6 +113,8 @@ Which will look like :
 
 You can also attach your input field to the adf-search component via the trigger [searchAutocomplete]
 Yuo can do this by exporting the adf-search panel instance into a local template variable (here we called it "search"), and binding that variable to the input's searchAutocomplete property.
+
+<!-- {% raw %} -->
 
 ```html
 <input type="text" [searchAutocomplete]="search">
@@ -117,6 +127,8 @@ Yuo can do this by exporting the adf-search panel instance into a local template
     </ng-template>
 </adf-search>        
 ```
+
+<!-- {% endraw %} -->
 
 In this way it is possible to fetch the results from the word typed into the input text straight into the adf-search component via the custom template variable.
 

--- a/docs/core/data-column.component.md
+++ b/docs/core/data-column.component.md
@@ -135,6 +135,8 @@ context.row.getValue('createdByUser.displayName')
 
 You may want using **row** api to get raw value access.
 
+<!-- {% raw %} -->
+
 ```html
 <data-column title="Name" key="name" sortable="true" class="full-width ellipsis-cell">
     <ng-template let-context="$implicit">
@@ -144,9 +146,13 @@ You may want using **row** api to get raw value access.
 </data-column>
 ```
 
+<!-- {% endraw %} -->
+
 Use **data** api to get values with post-processing, like datetime/icon conversion.\_
 
 In the Example below we will prepend `Hi!` to each file and folder name in the list: 
+
+<!-- {% raw %} -->
 
 ```html
 <data-column title="Name" key="name" sortable="true" class="full-width ellipsis-cell">
@@ -156,8 +162,12 @@ In the Example below we will prepend `Hi!` to each file and folder name in the l
 </data-column>
 ```
 
+<!-- {% endraw %} -->
+
 In the Example below we will integrate the [adf-tag-node-list](../content-services/tag-node-list.component.md) component
 with the document list.
+
+<!-- {% raw %} -->
 
 ```html
 <data-column
@@ -170,6 +180,8 @@ with the document list.
     </ng-template>
 </data-column>
 ```
+
+<!-- {% endraw %} -->
 
 ![Tag component in document List](../docassets/images/document-list-tag-template.png)
 

--- a/docs/core/file-size.pipe.md
+++ b/docs/core/file-size.pipe.md
@@ -8,11 +8,15 @@ Converts a number of bytes to the equivalent in KB, MB, etc.
 
 ## Basic Usage
 
+<!-- {% raw %} -->
+
 ```HTML
 <div>
     File Size: {{ sizeInBytes | adfFileSize:"2" }}
 </div>
 ```
+
+<!-- {% endraw %} -->
 
 ## Details
 

--- a/docs/core/mime-type-icon.pipe.md
+++ b/docs/core/mime-type-icon.pipe.md
@@ -8,11 +8,15 @@ Retrieves an icon to represent a MIME type.
 
 ## Basic Usage
 
+<!-- {% raw %} -->
+
 ```HTML
 <div>
     <img src='{{ "image/jpeg" | adfMimeTypeIcon }}' />
 </div>
 ```
+
+<!-- {% endraw %} -->
 
 ## Details
 

--- a/docs/core/node-favorite.directive.md
+++ b/docs/core/node-favorite.directive.md
@@ -51,6 +51,8 @@ export class MyComponent {
 The `NodeFavoriteDirective` instance can be bound to a template variable through **adfFavorite** reference,
 which provides a method to help further style the element.
 
+<!-- {% raw %} -->
+
 ```html
 <button
     mat-menu-item
@@ -62,6 +64,8 @@ which provides a method to help further style the element.
     </mat-icon>
 </button>
 ```
+
+<!-- {% endraw %} -->
 
 The directive performs as follows:
 

--- a/docs/core/node-name-tooltip.pipe.md
+++ b/docs/core/node-name-tooltip.pipe.md
@@ -8,6 +8,8 @@ Formats the tooltip for a Node.
 
 ## Basic Usage
 
+<!-- {% raw %} -->
+
 ```html
 <data-column
     key="name"
@@ -17,6 +19,8 @@ Formats the tooltip for a Node.
     </ng-template>
 </data-column>
 ```
+
+<!-- {% endraw %} -->
 
 ## Details
 

--- a/docs/core/text-highlight.pipe.md
+++ b/docs/core/text-highlight.pipe.md
@@ -8,11 +8,15 @@ Adds highlighting to words or sections of text that match a search string.
 
 ## Basic Usage
 
+<!-- {% raw %} -->
+
 ```HTML
 <div>
     Some rude words have been detected in your summary: {{ summary | highlight:rudeWordList }}
 </div>
 ```
+
+<!-- {% endraw %} -->
 
 ## Details
 

--- a/docs/core/time-ago.pipe.md
+++ b/docs/core/time-ago.pipe.md
@@ -8,11 +8,15 @@ Converts a recent past date into a number of days ago.
 
 ## Basic Usage
 
+<!-- {% raw %} -->
+
 ```HTML
 <div>
     Last modified: {{ date | adfTimeAgo }}
 </div>
 ```
+
+<!-- {% endraw %} -->
 
 ## Details
 

--- a/docs/core/translation.service.md
+++ b/docs/core/translation.service.md
@@ -30,7 +30,11 @@ In the `get` and `instant` methods, the `interpolateParams` parameter supplies
 interpolation strings for keys that include them. For example, in the standard
 `en.json`, the `CORE.PAGINATION.ITEMS_RANGE` key is defined as:
 
+<!-- {% raw %} -->
+
     "Showing {{ range }} of {{ total }}"
+
+<!-- {% endraw %} -->
 
 The `range` and `total` interpolations are supplied to the `get` method using
 an object with fields of the same name:

--- a/docs/core/user-initial.pipe.md
+++ b/docs/core/user-initial.pipe.md
@@ -8,11 +8,15 @@ Takes the name fields of a UserProcessModel object and extracts and formats the 
 
 ## Basic Usage
 
+<!-- {% raw %} -->
+
 ```HTML
 <div>
     Project Leader: {{ user | usernameInitials:"initialsClass" }}
 </div>
 ```
+
+<!-- {% endraw %} -->
 
 ## Details
 

--- a/docs/process-services/people-list.component.md
+++ b/docs/process-services/people-list.component.md
@@ -43,6 +43,8 @@ export class SomeComponent implements OnInit {
 
 In the component template use the people list component:
 
+<!-- {% raw %} -->
+
 ```html
 <adf-people-list
   [users]="people"
@@ -63,6 +65,8 @@ In the component template use the people list component:
   </data-columns>
 </adf-people-list>
 ```
+
+<!-- {% endraw %} -->
 
 Note that the people list component is based on the
 [Datatable component](../core/datatable.component.md).

--- a/docs/process-services/people-search.component.md
+++ b/docs/process-services/people-search.component.md
@@ -28,6 +28,8 @@ Searches users/people.
 
 ## Details
 
+<!-- {% raw %} -->
+
 ```html
 <adf-people-search
        (searchPeople)="searchUser($event)"
@@ -38,3 +40,5 @@ Searches users/people.
            <action-button-label>{{ 'PEOPLE.ADD_USER' | translate }}</action-button-label>
        </adf-people-search>
 ```
+
+<!-- {% endraw %} -->

--- a/docs/process-services/process-attachment-list.component.md
+++ b/docs/process-services/process-attachment-list.component.md
@@ -59,6 +59,8 @@ export class MyCustomProcessAttachmentComponent {
 
 If we want user to be able to upload attachments for empty lists, We can wrap our component with upload drag area component. In that case, We should also pass a custom _no content template_ as shown below with our component urging the user to drag files to upload whenever the list is empty.
 
+<!-- {% raw %} -->
+
 ```html
 <adf-upload-drag-area
     [parentId]="YOUR_PROCESS_ID"
@@ -77,6 +79,8 @@ If we want user to be able to upload attachments for empty lists, We can wrap ou
     </adf-process-attachment-list>
 </adf-upload-drag-area>
 ```
+
+<!-- {% endraw %} -->
 
 If the List is empty, the custom no-content template we passed is displayed.
 

--- a/docs/process-services/process-list.component.md
+++ b/docs/process-services/process-list.component.md
@@ -73,6 +73,8 @@ You can also use both HTML-based and app.config.json custom schema declaration a
 }
 ```
 
+<!-- {% raw %} -->
+
 ```html
 <adf-process-instance-list
     [appId]="'1'" 
@@ -86,6 +88,8 @@ You can also use both HTML-based and app.config.json custom schema declaration a
     </data-columns>
 </adf-process-instance-list>
 ```
+
+<!-- {% endraw %} -->
 
 ### Pagination strategy
 

--- a/docs/process-services/task-attachment-list.component.md
+++ b/docs/process-services/task-attachment-list.component.md
@@ -46,6 +46,8 @@ to enable the user to upload attachments for empty lists. When you do this, you 
 a custom _no content template_ as shown below. The component invites the user to drag files to
 upload whenever the list is empty.
 
+<!-- {% raw %} -->
+
 ```html
 <adf-upload-drag-area
     [parentId]="YOUR_TASK_ID"
@@ -62,6 +64,8 @@ upload whenever the list is empty.
     </adf-task-attachment-list>
 </adf-upload-drag-area>
 ```
+
+<!-- {% endraw %} -->
 
 ```ts
 import { UploadService } from '@alfresco/adf-core';

--- a/docs/process-services/task-list.component.md
+++ b/docs/process-services/task-list.component.md
@@ -151,6 +151,8 @@ You can use an HTML-based schema and an `app.config.json` custom schema declarat
 }
 ```
 
+<!-- {% raw %} -->
+
 ```html
 <adf-tasklist
     [appId]="'1'" 
@@ -164,6 +166,8 @@ You can use an HTML-based schema and an `app.config.json` custom schema declarat
     </data-columns>
 </adf-tasklist>
 ```
+
+<!-- {% endraw %} -->
 
 ### Pagination strategy
 

--- a/docs/user-guide/internationalization.md
+++ b/docs/user-guide/internationalization.md
@@ -101,9 +101,13 @@ export class HomeComponent implements OnInit {
 
 ...with very simple corresponding HTML:
 
+<!-- {% raw %} -->
+
 ```html
 {{translatedText}}
 ```
+
+<!-- {% endraw %} -->
 
 In the browser, this is displayed as:
 
@@ -139,7 +143,11 @@ corresponding text. For example, the following will display the
 "Start Form" text as above but without any code or variables in the
 component's `.ts` file:
 
+<!-- {% raw %} -->
+
     {{ "FORM.START_FORM.TITLE" | translate }}
+
+<!-- {% endraw %} -->
 
 ## Adding your own messages
 
@@ -156,6 +164,8 @@ string at a specified position within a message). This is very useful for
 messages whose content can change at runtime. For example, in the built-in
 `en.json` there is the `CORE.PAGINATION.ITEMS_RANGE` key:
 
+<!-- {% raw %} -->
+
 ```json
   ...
 "CORE": {
@@ -167,6 +177,8 @@ messages whose content can change at runtime. For example, in the built-in
       },
     ...
 ```
+
+<!-- {% endraw %} -->
 
 The sections in curly braces are _interpolation variables_ that you supply
 at runtime. You can specify them by passing an extra parameter to
@@ -187,7 +199,11 @@ this.trans.get(
 
 You can use interpolations with the `translate` pipe in a similar way:
 
+<!-- {% raw %} -->
+
     {{ "CORE.PAGINATION.ITEMS_RANGE" | translate: { range: "1..10", total: "122"} }}
+
+<!-- {% endraw %} -->
 
 ## Selecting the display language
 

--- a/docs/user-guide/metadata-indicators.md
+++ b/docs/user-guide/metadata-indicators.md
@@ -72,6 +72,8 @@ So once rendered our component will automatically have access to entire set of n
 
 For demonstration purposes we are going to display several icons if underlying node has version `2.0`, and just a plain text version value for all other versions.
 
+<!-- {% raw %} -->
+
 ```html
 <div *ngIf="metadata">
     <ng-container *ngIf="metadata['cm:versionLabel'] === '2.0'">
@@ -84,6 +86,8 @@ For demonstration purposes we are going to display several icons if underlying n
     </div>
 </div>
 ```
+
+<!-- {% endraw %} -->
 
 Note: For a list of the icons that can be used with `<mat-icon>` component please refer to this resource: [material.io/icons](https://material.io/icons/)
 
@@ -105,6 +109,8 @@ You can see on the screenshot above that only files with version `2.0` got extra
 ## Conclusion
 
 The full source code of the component can be found below:
+
+<!-- {% raw %} -->
 
 ```ts
 import { Component, Input } from '@angular/core';
@@ -131,5 +137,7 @@ export class MetadataIconsComponent {
 
 }
 ```
+
+<!-- {% endraw %} -->
 
 You can use this idea to build more complex indication experience based on the actual metadata state. 

--- a/docs/user-guide/stencils.md
+++ b/docs/user-guide/stencils.md
@@ -40,12 +40,16 @@ This value will be used as field type when form gets rendered.
 
 This should be a valid Angular component template that you want to render in `<activiti-form>` component:
 
+<!-- {% raw %} -->
+
 ```html
 <div>
     <div>Angular Component</div>
     <div>Created by: {{name}}</div>
 </div>
 ```
+
+<!-- {% endraw %} -->
 
 ## Form editor template
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [x] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Interpolation markers ("{{... }}") in Markdown code samples trigger off the interpolation feature in Jekyll and cause errors.

**What is the new behaviour?**

The code samples that cause the errors are now wrapped in a Jekyll tag that switches off processing. This isn't an ideal solution but it should be only temporary - the Jekyll team know about this issue and they say they have code to fix it for the next major release.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
