### PR TITLE
[ADF-711] Drag and drop doesn't have the acceptedFilesType property

### DIFF
--- a/docs/content-services/upload-drag-area.component.md
+++ b/docs/content-services/upload-drag-area.component.md
@@ -34,6 +34,7 @@ export class AppComponent {
 | disabled | boolean | false | Toggle component disabled state |
 | parentId | string | '-root-' | The ID of the folder in which the files will be uploaded. |
 | versioning | boolean | false |  Versioning false is the default uploader behaviour and it renames the file using an integer suffix if there is a name clash. Versioning true to indicate that a major version should be created  | 
+| acceptedFilesType | `string` | `'*'` | List of allowed file extensions, for example: ".jpg,.gif,.png,.svg".  |
 
 ### Events
 

--- a/lib/content-services/upload/components/base-upload/upload-base.ts
+++ b/lib/content-services/upload/components/base-upload/upload-base.ts
@@ -1,0 +1,47 @@
+/*!
+ * @license
+ * Copyright 2016 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FileModel } from '@alfresco/adf-core';
+import { Input } from '@angular/core';
+
+export abstract class UploadBase {
+
+    @Input()
+    acceptedFilesType: string = '*';
+
+    constructor() {}
+    /**
+     * Checks if the given file is allowed by the extension filters
+     *
+     * @param file FileModel
+     */
+    protected isFileAcceptable(file: FileModel): boolean {
+        if (this.acceptedFilesType === '*') {
+            return true;
+        }
+
+        const allowedExtensions = this.acceptedFilesType
+            .split(',')
+            .map(ext => ext.replace(/^\./, ''));
+
+        if (allowedExtensions.indexOf(file.extension) !== -1) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/lib/content-services/upload/components/upload-button.component.ts
+++ b/lib/content-services/upload/components/upload-button.component.ts
@@ -41,6 +41,7 @@ import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
 import { PermissionModel } from '../../document-list/models/permissions.model';
 import 'rxjs/add/observable/throw';
+import { UploadBase } from './base-upload/upload-base';
 
 @Component({
     selector: 'adf-upload-button',
@@ -51,7 +52,7 @@ import 'rxjs/add/observable/throw';
     ],
     encapsulation: ViewEncapsulation.None
 })
-export class UploadButtonComponent implements OnInit, OnChanges, NodePermissionSubject {
+export class UploadButtonComponent extends UploadBase implements OnInit, OnChanges, NodePermissionSubject {
 
     /** Toggles component disabled state (if there is no node permission checking). */
     @Input()
@@ -68,10 +69,6 @@ export class UploadButtonComponent implements OnInit, OnChanges, NodePermissionS
     /** Toggles versioning. */
     @Input()
     versioning: boolean = false;
-
-    /** List of allowed file extensions, for example: ".jpg,.gif,.png,.svg". */
-    @Input()
-    acceptedFilesType: string = '*';
 
     /** Sets a limit on the maximum size (in bytes) of a file to be uploaded.
      * Has no effect if undefined.
@@ -118,6 +115,7 @@ export class UploadButtonComponent implements OnInit, OnChanges, NodePermissionS
                 protected translateService: TranslationService,
                 protected logService: LogService
             ) {
+                super();
     }
 
     ngOnInit() {
@@ -188,27 +186,6 @@ export class UploadButtonComponent implements OnInit, OnChanges, NodePermissionS
             parentId: this.rootFolderId,
             path: (file.webkitRelativePath || '').replace(/\/[^\/]*$/, '')
         });
-    }
-
-    /**
-     * Checks if the given file is allowed by the extension filters
-     *
-     * @param file FileModel
-     */
-    protected isFileAcceptable(file: FileModel): boolean {
-        if (this.acceptedFilesType === '*') {
-            return true;
-        }
-
-        const allowedExtensions = this.acceptedFilesType
-            .split(',')
-            .map(ext => ext.replace(/^\./, ''));
-
-        if (allowedExtensions.indexOf(file.extension) !== -1) {
-            return true;
-        }
-
-        return false;
     }
 
     /**

--- a/lib/content-services/upload/public-api.ts
+++ b/lib/content-services/upload/public-api.ts
@@ -23,3 +23,5 @@ export * from './components/file-uploading-list.component';
 export * from './components/file-uploading-list-row.component';
 
 export * from './directives/file-draggable.directive';
+
+export * from './components/base-upload/upload-base';


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
* https://issues.alfresco.com/jira/browse/ADF-711

**What is the new behaviour?**
* Added acceptedFilesType property for upload-drag-area component.
* Only those files will be uploaded which are included in acceptedFilesType.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
