### PR TITLE
[ADF-2505] ADF Processlist multi selection issues.

### DIFF
--- a/docs/process-services/process-list.component.md
+++ b/docs/process-services/process-list.component.md
@@ -34,6 +34,7 @@ Renders a list containing all the process instances matched by the parameters sp
 | data | DataTableAdapter |  | Data source to define the datatable. |
 | multiselect | boolean | false | Toggles multiple row selection, renders checkboxes at the beginning of each row. |
 | selectionMode | string | 'single' | Row selection mode. Can be none, `single` or `multiple`. For `multiple` mode you can use Cmd (macOS) or Ctrl (Win) modifier key to toggle selection for multiple rows. |
+| selectFirstRow | boolean | true | Toggles default selection of the first row. |
 
 ### Events
 

--- a/lib/process-services/process-list/components/process-list.component.html
+++ b/lib/process-services/process-list/components/process-list.component.html
@@ -1,5 +1,4 @@
-<div *ngIf="!requestNode">{{ 'ADF_PROCESS_LIST.FILTERS.MESSAGES.NONE' | translate }}</div>
-<div *ngIf="requestNode">
+<div>
     <adf-datatable #dataTable
         [data]="data"
         [loading]="isLoading"
@@ -21,7 +20,7 @@
             <!--Add your custom empty template here-->
             <ng-template>
                 <div class="no-content-message">
-                    {{ 'ADF_PROCESS_LIST.LIST.NONE' | translate }}
+                    {{ (requestNode ? 'ADF_PROCESS_LIST.LIST.NONE' : 'ADF_PROCESS_LIST.FILTERS.MESSAGES.NONE') | translate }}
                 </div>
             </ng-template>
         </no-content-template>

--- a/lib/process-services/process-list/components/process-list.component.html
+++ b/lib/process-services/process-list/components/process-list.component.html
@@ -1,6 +1,6 @@
 <div *ngIf="!requestNode">{{ 'ADF_PROCESS_LIST.FILTERS.MESSAGES.NONE' | translate }}</div>
 <div *ngIf="requestNode">
-    <adf-datatable
+    <adf-datatable #dataTable
         [data]="data"
         [loading]="isLoading"
         [selectionMode]="selectionMode"

--- a/lib/process-services/process-list/components/process-list.component.spec.ts
+++ b/lib/process-services/process-list/components/process-list.component.spec.ts
@@ -279,6 +279,27 @@ describe('ProcessInstanceListComponent', () => {
         expect(dataRow[1].isSelected).toEqual(false);
     });
 
+    it('should not select first row when selectFirstRow is false', () => {
+        component.data = new ObjectDataTableAdapter(
+            [
+                { id: '999', name: 'Fake-name' },
+                { id: '888', name: 'Fake-name-888' }
+            ],
+            [
+                { type: 'text', key: 'id', title: 'Id' },
+                { type: 'text', key: 'name', title: 'Name' }
+            ]
+        );
+        component.selectFirstRow = false;
+        component.selectFirst();
+        const dataRow = component.data.getRows();
+        expect(dataRow).toBeDefined();
+        expect(dataRow[0].getValue('id')).toEqual('999');
+        expect(dataRow[0].isSelected).toEqual(false);
+        expect(dataRow[1].getValue('id')).toEqual('888');
+        expect(dataRow[1].isSelected).toEqual(false);
+    });
+
     it('should throw an exception when the response is wrong', fakeAsync(() => {
         let emitSpy: jasmine.Spy = spyOn(component.error, 'emit');
         let mockError = 'Fake server error';

--- a/lib/process-services/process-list/components/process-list.component.ts
+++ b/lib/process-services/process-list/components/process-list.component.ts
@@ -19,6 +19,7 @@ import {
     DataColumn,
     DataRowEvent,
     DataSorting,
+    DataTableComponent,
     DataTableAdapter,
     ObjectDataColumn,
     ObjectDataRow,
@@ -41,7 +42,8 @@ import {
     Input,
     OnChanges,
     Output,
-    SimpleChanges
+    SimpleChanges,
+    ViewChild
 } from '@angular/core';
 import { ProcessFilterParamRepresentationModel } from '../models/filter-process.model';
 import { processPresetsDefaultModel } from '../models/process-preset.model';
@@ -58,6 +60,8 @@ import { ProcessListModel } from '../models/process-list.model';
 export class ProcessInstanceListComponent implements OnChanges, AfterContentInit, PaginatedComponent {
 
     @ContentChild(DataColumnListComponent) columnList: DataColumnListComponent;
+
+    @ViewChild('dataTable') dataTable: DataTableComponent;
 
     /** The id of the app. */
     @Input()
@@ -247,6 +251,7 @@ export class ProcessInstanceListComponent implements OnChanges, AfterContentInit
      */
     private renderInstances(instances: any[]) {
         instances = this.optimizeNames(instances);
+        this.dataTable.resetSelection();
         this.setDatatableSorting();
         this.data.setRows(instances);
     }

--- a/lib/process-services/process-list/components/process-list.component.ts
+++ b/lib/process-services/process-list/components/process-list.component.ts
@@ -108,6 +108,10 @@ export class ProcessInstanceListComponent implements OnChanges, AfterContentInit
     @Input()
     selectionMode: string = 'single'; // none|single|multiple
 
+    /* Toggles default selection of the first instance */
+    @Input()
+    selectFirstRow: boolean = true;
+
     /** Emitted when a row in the process list is clicked. */
     @Output()
     rowClick: EventEmitter<string> = new EventEmitter<string>();
@@ -266,16 +270,18 @@ export class ProcessInstanceListComponent implements OnChanges, AfterContentInit
      * Select the first instance of a list if present
      */
     selectFirst() {
-        if (!this.isListEmpty()) {
-            let row = this.data.getRows()[0];
-            row.isSelected = true;
-            this.data.selectedRow = row;
-            this.currentInstanceId = row.getValue('id');
-        } else {
-            if (this.data) {
-                this.data.selectedRow = null;
+        if (this.selectFirstRow) {
+            if (!this.isListEmpty()) {
+                let row = this.data.getRows()[0];
+                row.isSelected = true;
+                this.data.selectedRow = row;
+                this.currentInstanceId = row.getValue('id');
+            } else {
+                if (this.data) {
+                    this.data.selectedRow = null;
+                }
+                this.currentInstanceId = null;
             }
-            this.currentInstanceId = null;
         }
     }
 

--- a/lib/process-services/process-list/components/process-list.component.ts
+++ b/lib/process-services/process-list/components/process-list.component.ts
@@ -112,7 +112,7 @@ export class ProcessInstanceListComponent implements OnChanges, AfterContentInit
     @Input()
     selectionMode: string = 'single'; // none|single|multiple
 
-    /* Toggles default selection of the first instance */
+    /* Toggles default selection of the first row */
     @Input()
     selectFirstRow: boolean = true;
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

* First row is selected by default and there is no way to disable this behaviour.
* Once processlist.reload() method is called then row-select and row-unselect events of data-table gives wrong number of rows than actual selection

https://issues.alfresco.com/jira/browse/ADF-2505

**What is the new behaviour?**

* Added input to disable default first row selection
* Reset data-table selection when data is reloaded

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
