### PR TITLE
[ADF-1828] Folder title shrinks when it's too long to display it in a…

### DIFF
--- a/lib/content-services/breadcrumb/dropdown-breadcrumb.component.scss
+++ b/lib/content-services/breadcrumb/dropdown-breadcrumb.component.scss
@@ -7,7 +7,8 @@
         &-dropdown-breadcrumb {
             display: flex;
             justify-content: flex-start;
-            height: 25px;
+            width: 65%;
+            max-width: 200px;
         }
 
         &-dropdown-breadcumb-trigger {
@@ -36,9 +37,11 @@
         &-current-folder {
             margin-left: $dropdownHorizontalOffset;
             line-height: 26px;
-            white-space: pre-wrap;
+            white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
+            display: inline-block;
+            width: 100%;
         }
 
         &-current-folder.isRoot {


### PR DESCRIPTION
… small screen

**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Folder titles is not properly displayed when using a small screen device


**What is the new behaviour?**
Folder titles shrink when they are too long to fit in the space


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
