### PR TITLE
[ADF-2561] View comments on previous versions

### DIFF
--- a/docs/content-services/version-list.component.md
+++ b/docs/content-services/version-list.component.md
@@ -17,6 +17,7 @@ Displays the version history of a node in a Version Manager component
 | Name | Type | Default value | Description |
 | ---- | ---- | ------------- | ----------- |
 | id | `string` |  | ID of the node whose version history you want to display.  |
+| showComments | `boolean` | true |  Set this to false if version comments should not be displayed.  |
 
 ## Details
 

--- a/docs/content-services/version-manager.component.md
+++ b/docs/content-services/version-manager.component.md
@@ -22,9 +22,10 @@ Displays the version history of a node with the ability to upload a new version.
 
 ### Properties
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| node | [MinimalNodeEntryEntity](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/NodeMinimalEntry.md) | The node you want to manage the version history of. |
+| Name | Type | Default value | Description |
+| ---- | ---- | --- | ----------- |
+| node | [MinimalNodeEntryEntity](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/NodeMinimalEntry.md) | |The node you want to manage the version history of. |
+| showComments | `boolean` | true | Set this to false if version comments should not be displayed. |
 
 ### Events
 

--- a/lib/content-services/version-manager/version-list.component.html
+++ b/lib/content-services/version-manager/version-list.component.html
@@ -6,7 +6,7 @@
             <span class="adf-version-list-item-version">{{version.entry.id}}</span> -
             <span class="adf-version-list-item-date">{{version.entry.modifiedAt | date}}</span>
         </p>
-        <p mat-line class="adf-version-list-item-comment">{{version.entry.versionComment}}</p>
+        <p mat-line class="adf-version-list-item-comment" *ngIf="showComments">{{version.entry.versionComment}}</p>
 
         <mat-menu #versionMenu="matMenu" yPosition="below" xPosition="before">
             <button mat-menu-item (click)="restore(version.entry.id)"> Restore </button>

--- a/lib/content-services/version-manager/version-list.component.ts
+++ b/lib/content-services/version-manager/version-list.component.ts
@@ -38,6 +38,9 @@ export class VersionListComponent implements OnChanges {
     @Input()
     id: string;
 
+    @Input()
+    showComments: boolean = true;
+
     constructor(private alfrescoApi: AlfrescoApiService) {
         this.versionsApi = this.alfrescoApi.versionsApi;
     }

--- a/lib/content-services/version-manager/version-manager.component.html
+++ b/lib/content-services/version-manager/version-manager.component.html
@@ -2,5 +2,5 @@
     <adf-version-upload [node]="node" (success)="onUploadSuccess($event)" (error)="onUploadError($event)"></adf-version-upload>
 </div>
 <div class="adf-version-list-container">
-    <adf-version-list #versionList [id]="node.id"></adf-version-list>
+    <adf-version-list #versionList [id]="node.id" [showComments]="showComments"></adf-version-list>
 </div>

--- a/lib/content-services/version-manager/version-manager.component.spec.ts
+++ b/lib/content-services/version-manager/version-manager.component.spec.ts
@@ -1,0 +1,111 @@
+/*!
+ * @license
+ * Copyright 2016 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { AlfrescoApiService } from '@alfresco/adf-core';
+import { MinimalNodeEntryEntity } from 'alfresco-js-api';
+import { VersionManagerComponent } from './version-manager.component';
+import { VersionListComponent } from './version-list.component';
+
+describe('VersionManagerComponent', () => {
+    let component: VersionManagerComponent;
+    let fixture: ComponentFixture<VersionManagerComponent>;
+    let spyOnListVersionHistory: jasmine.Spy;
+
+    const expectedComment = 'test-version-comment';
+    const  node: MinimalNodeEntryEntity = {
+        id: '1234',
+        name: 'TEST-NODE',
+        isFile: true
+    };
+    const versionEntry = {
+       entry: {
+           id: '1.0',
+           name: node.name,
+           versionComment: expectedComment
+       }
+    };
+
+    beforeEach(async(() => {
+        TestBed.configureTestingModule({
+            declarations: [
+                VersionManagerComponent, VersionListComponent
+            ],
+            schemas: [CUSTOM_ELEMENTS_SCHEMA]
+        }).compileComponents();
+    }));
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(VersionManagerComponent);
+        component = fixture.componentInstance;
+        component.node = node;
+
+        const alfrescoApiService = TestBed.get(AlfrescoApiService);
+        spyOnListVersionHistory = spyOn(alfrescoApiService.versionsApi, 'listVersionHistory').and
+            .callFake(() => Promise.resolve({ list: { entries: [ versionEntry ] }}));
+    });
+
+    it('should load the versions for a given node', () => {
+        fixture.detectChanges();
+        expect(spyOnListVersionHistory).toHaveBeenCalledWith(node.id);
+    });
+
+    it('should display comments for versions when not configured otherwise', async(() => {
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+            fixture.detectChanges();
+            let versionCommentEl = fixture.debugElement.query(By.css('.adf-version-list-item-comment'));
+
+            expect(versionCommentEl).not.toBeNull();
+            expect(versionCommentEl.nativeElement.innerText).toBe(expectedComment);
+        });
+    }));
+
+    it('should not display comments for versions when configured not to show them', async(() => {
+        component.showComments = false;
+        fixture.detectChanges();
+
+        fixture.whenStable().then(() => {
+            fixture.detectChanges();
+            let versionCommentEl = fixture.debugElement.query(By.css('.adf-version-list-item-comment'));
+
+            expect(versionCommentEl).toBeNull();
+        });
+    }));
+
+    it('should emit success event upon successful upload of a new version', () => {
+        fixture.detectChanges();
+
+        const emittedData = { value: { entry: node }};
+        component.uploadSuccess.subscribe(event => {
+            expect(event).toBe(emittedData);
+        });
+        component.onUploadSuccess(emittedData);
+    });
+
+    it('should emit error event upon failure to upload a new version', () => {
+        fixture.detectChanges();
+
+        const errorEvent = new CustomEvent('error');
+        component.uploadError.subscribe(event => {
+            expect(event).toBe(errorEvent);
+        });
+        component.onUploadError(errorEvent);
+    });
+});

--- a/lib/content-services/version-manager/version-manager.component.ts
+++ b/lib/content-services/version-manager/version-manager.component.ts
@@ -30,6 +30,9 @@ export class VersionManagerComponent {
     @Input()
     node: MinimalNodeEntryEntity;
 
+    @Input()
+    showComments: boolean = true;
+
     @Output()
     uploadSuccess: EventEmitter<any> = new EventEmitter();
 


### PR DESCRIPTION
add input property to enable/disable viewing version comments

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe:
Further improvement on file versioning. Please see https://issues.alfresco.com/jira/browse/ADF-2561

**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
