### PR TITLE
[ADF-2414] Min length user message at login screen fixed

### DIFF
--- a/lib/core/i18n/de.json
+++ b/lib/core/i18n/de.json
@@ -138,7 +138,7 @@
     },
     "MESSAGES": {
       "USERNAME-REQUIRED": "Erforderlich",
-      "USERNAME-MIN": "Ihr Benutzername muss mindestens {{minLenght}} Zeichen lang sein.",
+      "USERNAME-MIN": "Ihr Benutzername muss mindestens {{minLength}} Zeichen lang sein.",
       "PASSWORD-REQUIRED": "Geben Sie Ihr Passwort ein, um sich anzumelden",
       "LOGIN-ERROR-CREDENTIALS": "Sie haben einen unbekannten Benutzernamen oder ein falsches Passwort eingegeben",
       "LOGIN-ERROR-PROVIDERS": "Provider müssen definiert werden",

--- a/lib/core/i18n/en.json
+++ b/lib/core/i18n/en.json
@@ -141,7 +141,7 @@
     },
     "MESSAGES": {
       "USERNAME-REQUIRED": "Required",
-      "USERNAME-MIN": "Your username needs to be at least {{minLenght}} characters.",
+      "USERNAME-MIN": "Your username needs to be at least {{ minLength }} characters.",
       "PASSWORD-REQUIRED": "Enter your password to sign in",
       "LOGIN-ERROR-CREDENTIALS": "You've entered an unknown username or password",
       "LOGIN-ERROR-PROVIDERS": "Providers cannot be undefined",

--- a/lib/core/i18n/es.json
+++ b/lib/core/i18n/es.json
@@ -138,7 +138,7 @@
     },
     "MESSAGES": {
       "USERNAME-REQUIRED": "Requerido",
-      "USERNAME-MIN": "Su nombre de usuario debe tener al menos {{minLenght}} caracteres.",
+      "USERNAME-MIN": "Su nombre de usuario debe tener al menos {{minLength}} caracteres.",
       "PASSWORD-REQUIRED": "Introduzca su contraseña para iniciar sesión",
       "LOGIN-ERROR-CREDENTIALS": "Ha introducido un nombre de usuario o contraseña desconocidos",
       "LOGIN-ERROR-PROVIDERS": "Los proveedores no pueden estar no definidos",

--- a/lib/core/i18n/fr.json
+++ b/lib/core/i18n/fr.json
@@ -138,7 +138,7 @@
     },
     "MESSAGES": {
       "USERNAME-REQUIRED": "Requis",
-      "USERNAME-MIN": "Votre nom d'utilisateur doit comporter au moins {{minLenght}} caractères.",
+      "USERNAME-MIN": "Votre nom d'utilisateur doit comporter au moins {{minLength}} caractères.",
       "PASSWORD-REQUIRED": "Entrez votre mot de passe pour vous connecter",
       "LOGIN-ERROR-CREDENTIALS": "Le nom d'utilisateur ou le mot de passe entré est inconnu",
       "LOGIN-ERROR-PROVIDERS": "Le fournisseur ne peut pas être non défini",

--- a/lib/core/i18n/it.json
+++ b/lib/core/i18n/it.json
@@ -138,7 +138,7 @@
     },
     "MESSAGES": {
       "USERNAME-REQUIRED": "Campo obbligatorio",
-      "USERNAME-MIN": "Il nome utente deve essere lungo almeno {{minLenght}} caratteri.",
+      "USERNAME-MIN": "Il nome utente deve essere lungo almeno {{minLength}} caratteri.",
       "PASSWORD-REQUIRED": "Immetti la password per accedere",
       "LOGIN-ERROR-CREDENTIALS": "Nome utente o password sconosciuti",
       "LOGIN-ERROR-PROVIDERS": "I provider non possono essere non definiti",

--- a/lib/core/i18n/ja.json
+++ b/lib/core/i18n/ja.json
@@ -138,7 +138,7 @@
     },
     "MESSAGES": {
       "USERNAME-REQUIRED": "必須",
-      "USERNAME-MIN": "ユーザー名は {{minLenght}} 文字以上でなければなりません。",
+      "USERNAME-MIN": "ユーザー名は {{minLength}} 文字以上でなければなりません。",
       "PASSWORD-REQUIRED": "サインイン用のパスワードを入力してください",
       "LOGIN-ERROR-CREDENTIALS": "入力したユーザー名またはパスワードが間違っています",
       "LOGIN-ERROR-PROVIDERS": "プロバイダは必ず定義する必要があります",

--- a/lib/core/i18n/nb.json
+++ b/lib/core/i18n/nb.json
@@ -138,7 +138,7 @@
     },
     "MESSAGES": {
       "USERNAME-REQUIRED": "Påkrevd",
-      "USERNAME-MIN": "Brukernavnet må ha minst {{minLenght}} tegn.",
+      "USERNAME-MIN": "Brukernavnet må ha minst {{minLength}} tegn.",
       "PASSWORD-REQUIRED": "Angi passordet for å logge på",
       "LOGIN-ERROR-CREDENTIALS": "Du har angitt ukjent brukernavn eller passord",
       "LOGIN-ERROR-PROVIDERS": "Leverandører kan ikke være udefinert",

--- a/lib/core/i18n/nl.json
+++ b/lib/core/i18n/nl.json
@@ -138,7 +138,7 @@
     },
     "MESSAGES": {
       "USERNAME-REQUIRED": "Vereist",
-      "USERNAME-MIN": "Uw gebruikersnaam moet uit minstens {{minLenght}} tekens bestaan.",
+      "USERNAME-MIN": "Uw gebruikersnaam moet uit minstens {{minLength}} tekens bestaan.",
       "PASSWORD-REQUIRED": "Voer uw wachtwoord in om u aan te melden",
       "LOGIN-ERROR-CREDENTIALS": "U hebt een onbekende gebruikersnaam of een onbekend wachtwoord ingevoerd",
       "LOGIN-ERROR-PROVIDERS": "De definitie van providers kan niet ongedaan worden gemaakt",

--- a/lib/core/i18n/ru.json
+++ b/lib/core/i18n/ru.json
@@ -138,7 +138,7 @@
     },
     "MESSAGES": {
       "USERNAME-REQUIRED": "Обязательное поле",
-      "USERNAME-MIN": "Имя пользователя должно быть не меньше {{minLenght}} символов.",
+      "USERNAME-MIN": "Имя пользователя должно быть не меньше {{minLength}} символов.",
       "PASSWORD-REQUIRED": "Введите пароль для входа",
       "LOGIN-ERROR-CREDENTIALS": "Вы ввели неверное имя пользователя или пароль",
       "LOGIN-ERROR-PROVIDERS": "Поставщики не могут оставаться неопределенными",

--- a/lib/core/i18n/zh-CN.json
+++ b/lib/core/i18n/zh-CN.json
@@ -138,7 +138,7 @@
     },
     "MESSAGES": {
       "USERNAME-REQUIRED": "必需",
-      "USERNAME-MIN": "您的用户名需要至少 {{minLenght}} 个字符。",
+      "USERNAME-MIN": "您的用户名需要至少 {{minLength}} 个字符。",
       "PASSWORD-REQUIRED": "输入登录密码",
       "LOGIN-ERROR-CREDENTIALS": "您已输入未知用户名或密码",
       "LOGIN-ERROR-PROVIDERS": "提供商未定义",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Minimum length for user field not displaying error message correctly due to misspelt variable


**What is the new behaviour?**
Now it displays the proper value


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
