### PR TITLE
[ADF-2580] - changing the inherit permission button by status

### DIFF
--- a/demo-shell/resources/i18n/en.json
+++ b/demo-shell/resources/i18n/en.json
@@ -165,6 +165,7 @@
         "NODE_LIST":"Tag list By Node ID"
     },
     "DEMO_PERMISSION": {
-      "INHERIT_PERMISSION_BUTTON" :"Inherit Permission"
+       "INHERIT_PERMISSION_BUTTON" :"Inherit Permission" ,
+       "INHERITED_PERMISSIONS_BUTTON" : "Permission Inherited"
     }
 }

--- a/demo-shell/src/app/components/permissions/demo-permissions.component.html
+++ b/demo-shell/src/app/components/permissions/demo-permissions.component.html
@@ -1,8 +1,9 @@
 <div class="inherit_permission_button">
     <button mat-raised-button
-            color="primary"
+            [color]="toggleStatus?'accent':'primary'"
             adf-inherit-permission [nodeId]="nodeId"
-            (updated)="onUpdatedPermissions()">{{'DEMO_PERMISSION.INHERIT_PERMISSION_BUTTON' | translate}}</button>
+            (updated)="onUpdatedPermissions($event)">
+            {{ (toggleStatus?'DEMO_PERMISSION.INHERITED_PERMISSIONS_BUTTON':'DEMO_PERMISSION.INHERIT_PERMISSION_BUTTON') | translate}}</button>
 </div>
 <div>
 	<adf-permission-list #permissionList [nodeId]="nodeId">

--- a/demo-shell/src/app/components/permissions/demo-permissions.component.ts
+++ b/demo-shell/src/app/components/permissions/demo-permissions.component.ts
@@ -18,6 +18,8 @@
 import { Component, Optional, OnInit, ViewChild } from '@angular/core';
 import { ActivatedRoute, Params} from '@angular/router';
 import { PermissionListComponent } from '@alfresco/adf-content-services';
+import { MinimalNodeEntryEntity } from 'alfresco-js-api';
+import { NodesApiService } from '@alfresco/adf-core';
 
 @Component({
     selector: 'app-permissions',
@@ -30,8 +32,10 @@ export class DemoPermissionComponent implements OnInit {
     displayPermissionComponent: PermissionListComponent;
 
     nodeId: string;
+    toggleStatus = false;
 
-    constructor(@Optional() private route: ActivatedRoute) {
+    constructor(@Optional() private route: ActivatedRoute,
+                private nodeService: NodesApiService) {
     }
 
     ngOnInit() {
@@ -42,9 +46,13 @@ export class DemoPermissionComponent implements OnInit {
                 }
             });
         }
+        this.nodeService.getNode(this.nodeId, {include: ['permissions'] }).subscribe( (currentNode: MinimalNodeEntryEntity) => {
+            this.toggleStatus = currentNode.permissions.isInheritanceEnabled;
+        });
     }
 
-    onUpdatedPermissions() {
+    onUpdatedPermissions(node: MinimalNodeEntryEntity) {
+        this.toggleStatus = node.permissions.isInheritanceEnabled;
         this.displayPermissionComponent.reload();
     }
 

--- a/lib/content-services/permission-manager/components/inherited-button.directive.ts
+++ b/lib/content-services/permission-manager/components/inherited-button.directive.ts
@@ -41,7 +41,7 @@ export class InheritPermissionDirective {
     onInheritPermissionClicked() {
         this.nodeService.getNode(this.nodeId).subscribe((node: MinimalNodeEntryEntity) => {
             const nodeBody = { permissions : {isInheritanceEnabled : !node.permissions.isInheritanceEnabled} };
-            this.nodeService.updateNode(this.nodeId, nodeBody).subscribe((nodeUpdated: MinimalNodeEntryEntity) => {
+            this.nodeService.updateNode(this.nodeId, nodeBody, {include: ['permissions'] }).subscribe((nodeUpdated: MinimalNodeEntryEntity) => {
                 this.updated.emit(nodeUpdated);
             });
         });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [X] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Inherit permission button never change status when permission are inherited or not


**What is the new behaviour?**
Inherit permission button now changes color and labels reflecting the current node inheritance status


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
