### PR TITLE
[ADF-2625] updating viewer and document list on node editing

### DIFF
--- a/demo-shell/src/app/components/files/files.component.ts
+++ b/demo-shell/src/app/components/files/files.component.ts
@@ -233,7 +233,8 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
     }
 
     ngOnDestroy() {
-        this.subscriptions.forEach(s => s.unsubscribe());
+        this.subscriptions.forEach(subscription => subscription.unsubscribe());
+        this.subscriptions = [];
     }
 
     ngOnChanges(changes: SimpleChanges) {

--- a/docs/content-services/content-metadata.component.md
+++ b/docs/content-services/content-metadata.component.md
@@ -29,7 +29,13 @@ The different aspects and their properties to be shown can be configured as appl
 | displayEmpty | boolean | false | Display empty values in card view or not |
 | readOnly | boolean | true | Whether the edit button to be shown or not |
 | multi | boolean | false | multi parameter of the underlying material expansion panel |
-| preset | string | "*" | The metadata preset's name, which defines aspects and their properties |
+| preset | string | "*" | The name of the metadata preset, which defines aspects and their properties |
+
+### Events
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| nodeUpdated | `EventEmitter<MinimalNodeEntryEntity>` | Emitted when underlying node gets updated. |
 
 ## Details
 
@@ -57,7 +63,7 @@ If you don't have any preset configured manually in you application config, this
 
 ### Aspect oriented config
 
-With this type of configuration you are able to "whitelist" aspects and properties for a preset, but everything will be grouped by aspects and there is no further way to group properties. If you want to group different properties in groups you define, scroll down a bit and have a look at on the layout oriented configruration.
+With this type of configuration you are able to "whitelist" aspects and properties for a preset, but everything will be grouped by aspects and there is no further way to group properties. If you want to group different properties in groups you define, scroll down a bit and have a look at on the layout oriented configuration.
 
 #### Whitelisting only a few aspects in the default preset
 

--- a/docs/content-services/content-metadata.component.md
+++ b/docs/content-services/content-metadata.component.md
@@ -31,12 +31,6 @@ The different aspects and their properties to be shown can be configured as appl
 | multi | boolean | false | multi parameter of the underlying material expansion panel |
 | preset | string | "*" | The name of the metadata preset, which defines aspects and their properties |
 
-### Events
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| nodeUpdated | `EventEmitter<MinimalNodeEntryEntity>` | Emitted when underlying node gets updated. |
-
 ## Details
 
 ### Application config presets

--- a/lib/content-services/content-metadata/components/content-metadata/content-metadata.component.ts
+++ b/lib/content-services/content-metadata/components/content-metadata/content-metadata.component.ts
@@ -55,7 +55,7 @@ export class ContentMetadataComponent implements OnChanges, OnInit {
 
     constructor(private contentMetadataService: ContentMetadataService,
                 private cardViewUpdateService: CardViewUpdateService,
-                private api: AlfrescoApiService,
+                private alfrescoApiService: AlfrescoApiService,
                 private logService: LogService) {}
 
     ngOnInit() {
@@ -65,7 +65,7 @@ export class ContentMetadataComponent implements OnChanges, OnInit {
                 (node) => {
                     this.nodeHasBeenUpdated = true;
                     this.node = node;
-                    this.api.nodeUpdated.next(node);
+                    this.alfrescoApiService.nodeUpdated.next(node);
                 },
                 error => this.logService.error(error)
             );
@@ -84,7 +84,7 @@ export class ContentMetadataComponent implements OnChanges, OnInit {
 
     private saveNode({ changed: nodeBody }): Observable<MinimalNodeEntryEntity> {
         return Observable.fromPromise(
-            this.api.nodesApi
+            this.alfrescoApiService.nodesApi
                 .updateNode(this.node.id, nodeBody)
                 .then(entity => entity.entry)
         );

--- a/lib/content-services/content-metadata/components/content-metadata/content-metadata.component.ts
+++ b/lib/content-services/content-metadata/components/content-metadata/content-metadata.component.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Component, Input, OnChanges, OnInit, SimpleChanges, SimpleChange, ViewEncapsulation } from '@angular/core';
+import { Component, Input, OnChanges, OnInit, SimpleChanges, SimpleChange, ViewEncapsulation, EventEmitter, Output } from '@angular/core';
 import { MinimalNodeEntryEntity } from 'alfresco-js-api';
 import { Observable } from 'rxjs/Observable';
 import { CardViewItem, NodesApiService, LogService, CardViewUpdateService } from '@alfresco/adf-core';
@@ -49,6 +49,9 @@ export class ContentMetadataComponent implements OnChanges, OnInit {
     @Input()
     preset: string;
 
+    @Output()
+    nodeUpdated = new EventEmitter<MinimalNodeEntryEntity>();
+
     nodeHasBeenUpdated: boolean = false;
     basicProperties$: Observable<CardViewItem[]>;
     groupedProperties$: Observable<CardViewGroup[]>;
@@ -65,6 +68,7 @@ export class ContentMetadataComponent implements OnChanges, OnInit {
                 (node) => {
                     this.nodeHasBeenUpdated = true;
                     this.node = node;
+                    this.nodeUpdated.next(node);
                 },
                 error => this.logService.error(error)
             );

--- a/lib/content-services/content-metadata/components/content-metadata/content-metadata.component.ts
+++ b/lib/content-services/content-metadata/components/content-metadata/content-metadata.component.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Component, Input, OnChanges, OnInit, SimpleChanges, SimpleChange, ViewEncapsulation, EventEmitter, Output } from '@angular/core';
+import { Component, Input, OnChanges, OnInit, SimpleChanges, SimpleChange, ViewEncapsulation } from '@angular/core';
 import { MinimalNodeEntryEntity } from 'alfresco-js-api';
 import { Observable } from 'rxjs/Observable';
 import { CardViewItem, LogService, CardViewUpdateService, AlfrescoApiService } from '@alfresco/adf-core';

--- a/lib/core/services/alfresco-api.service.ts
+++ b/lib/core/services/alfresco-api.service.ts
@@ -19,14 +19,20 @@ import { Injectable } from '@angular/core';
 import {
     AlfrescoApi, ContentApi, FavoritesApi, NodesApi,
     PeopleApi, RenditionsApi, SharedlinksApi, SitesApi,
-    VersionsApi, ClassesApi, SearchApi, GroupsApi
+    VersionsApi, ClassesApi, SearchApi, GroupsApi, MinimalNodeEntryEntity
 } from 'alfresco-js-api';
 import * as alfrescoApi from 'alfresco-js-api';
 import { AppConfigService } from '../app-config/app-config.service';
 import { StorageService } from './storage.service';
+import { Subject } from 'rxjs/Subject';
 
 @Injectable()
 export class AlfrescoApiService {
+
+    /**
+     * Publish/subscribe to events related to node updates.
+     */
+    nodeUpdated = new Subject<MinimalNodeEntryEntity>();
 
     protected alfrescoApi: AlfrescoApi;
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Issues addressed:

- ADF-2638: Event for other components when Content Metadata updates node
- ADF-2625: Node name not updated when changing its value in metadata component

Details:

- add a global `nodeUpdated` pub/sub event in the AlfrescoApiService, to be able to raise/listen "node changed" events, and use other APIs of the same AlfrescoApiService to perform other calls (reduces number of imported services if/when we have multiple events)

- Viewer updates itself in case the same Node has been updated elsewhere
- Demo Shell provides an example on reloading document list if a Node has been updated elsewhere (this scenario needs more clean approach)

**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
