### PR TITLE
[ADF-1714] added selection mechanism for enter key pressed on datatable

### DIFF
--- a/lib/core/datatable/components/datatable/datatable.component.html
+++ b/lib/core/datatable/components/datatable/datatable.component.html
@@ -85,6 +85,7 @@
                      [attr.filename]="getFilename(row)"
                      tabindex="0"
                      (click)="onRowClick(row, $event)"
+                     (keydown.enter)="onEnterKeyPressed(row, $event)"
                      [context-menu]="getContextMenuActions(row, col)"
                      [context-menu-enabled]="contextMenu">
                     <div *ngIf="!col.template" class="cell-container">

--- a/lib/core/datatable/components/datatable/datatable.component.spec.ts
+++ b/lib/core/datatable/components/datatable/datatable.component.spec.ts
@@ -234,6 +234,50 @@ describe('DataTable', () => {
         expect(rows[1].isSelected).toBeTruthy();
     });
 
+    it('should select only one row with [single] selection mode pressing enter key', () => {
+        dataTable.selectionMode = 'single';
+        dataTable.data = new ObjectDataTableAdapter(
+            [
+                { name: '1' },
+                { name: '2' }
+            ],
+            [ new ObjectDataColumn({ key: 'name'}) ]
+        );
+        const rows = dataTable.data.getRows();
+
+        dataTable.ngOnChanges({});
+        dataTable.onEnterKeyPressed(rows[0], null);
+        expect(rows[0].isSelected).toBeTruthy();
+        expect(rows[1].isSelected).toBeFalsy();
+
+        dataTable.onEnterKeyPressed(rows[1], null);
+        expect(rows[0].isSelected).toBeFalsy();
+        expect(rows[1].isSelected).toBeTruthy();
+    });
+
+    it('should select multiple rows with [multiple] selection mode pressing enter key', () => {
+        dataTable.selectionMode = 'multiple';
+        dataTable.data = new ObjectDataTableAdapter(
+            [
+                { name: '1' },
+                { name: '2' }
+            ],
+            [ new ObjectDataColumn({ key: 'name'}) ]
+        );
+        const rows = dataTable.data.getRows();
+
+        const event = new KeyboardEvent('enter', {
+            metaKey: true
+        });
+
+        dataTable.ngOnChanges({});
+        dataTable.onEnterKeyPressed(rows[0], event);
+        dataTable.onEnterKeyPressed(rows[1], event);
+
+        expect(rows[0].isSelected).toBeTruthy();
+        expect(rows[1].isSelected).toBeTruthy();
+    });
+
     it('should not unselect the row with [single] selection mode', () => {
         dataTable.selectionMode = 'single';
         dataTable.data = new ObjectDataTableAdapter(

--- a/lib/core/datatable/components/datatable/datatable.component.ts
+++ b/lib/core/datatable/components/datatable/datatable.component.ts
@@ -292,28 +292,37 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck 
         }
 
         if (row) {
-            if (this.data) {
-                if (this.isSingleSelectionMode()) {
-                    this.resetSelection();
-                    this.selectRow(row, true);
-                    this.emitRowSelectionEvent('row-select', row);
-                }
-
-                if (this.isMultiSelectionMode()) {
-                    const modifier = e && (e.metaKey || e.ctrlKey);
-                    const newValue = modifier ? !row.isSelected : true;
-                    const domEventName = newValue ? 'row-select' : 'row-unselect';
-
-                    if (!modifier) {
-                        this.resetSelection();
-                    }
-                    this.selectRow(row, newValue);
-                    this.emitRowSelectionEvent(domEventName, row);
-                }
-            }
-
+            this.handleRowSelection(row, e);
             const dataRowEvent = new DataRowEvent(row, e, this);
             this.clickObserver.next(dataRowEvent);
+        }
+    }
+
+    onEnterKeyPressed(row: DataRow, e: KeyboardEvent) {
+        if (row) {
+            this.handleRowSelection(row, e);
+        }
+    }
+
+    private handleRowSelection(row: DataRow, e: KeyboardEvent | MouseEvent) {
+        if (this.data) {
+            if (this.isSingleSelectionMode()) {
+                this.resetSelection();
+                this.selectRow(row, true);
+                this.emitRowSelectionEvent('row-select', row);
+            }
+
+            if (this.isMultiSelectionMode()) {
+                const modifier = e && (e.metaKey || e.ctrlKey);
+                const newValue = modifier ? !row.isSelected : true;
+                const domEventName = newValue ? 'row-select' : 'row-unselect';
+
+                if (!modifier) {
+                    this.resetSelection();
+                }
+                this.selectRow(row, newValue);
+                this.emitRowSelectionEvent(domEventName, row);
+            }
         }
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Pressing enter key throws the pressed key event but not trigger the row selection


**What is the new behaviour?**
Pressin enter key will select correctly the datatable row


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
