### PR TITLE
[ADF-SIDENAV] Add observable menu open state to the sidenav-layout component

### DIFF
--- a/docs/core/sidenav-layout.component.md
+++ b/docs/core/sidenav-layout.component.md
@@ -65,8 +65,7 @@ The layout will select between a small screen (ie, mobile) configuration and a l
 configuration according to the screen size in pixels (the `stepOver` property sets the
 number of pixels at which the switch will occur).
 
-The small screen layout uses the Angular Material
-[Sidenav component](https://material.angularjs.org/latest/api/directive/mdSidenav) which is
+The small screen layout uses the Angular Material [Sidenav component](https://material.angularjs.org/latest/api/directive/mdSidenav) which is
 described in detail on their website.
 
 The ADF-style (ie, large screen) Sidenav has two states: **expanded** and **compact**.
@@ -83,6 +82,12 @@ Desktop layout (screen width greater than the `stepOver` value):
 Mobile layout (screen width less than the `stepOver` value):
 ![Sidenav on mobile](../docassets/images/sidenav-layout-mobile.png)
 
+### Public attributes
+
+| Name | Type | Default | Description |
+| --- | --- | --- | --- |
+| menuOpenState$ | Observable&lt;boolean&gt; | true | Another way to listen to menu open/closed state |
+
 ### Template context
 
 Each template is given a context containing the following methods:
@@ -91,4 +96,13 @@ Each template is given a context containing the following methods:
     Triggers menu toggling.
 
 -   `isMenuMinimized(): boolean`
-    Is the menu in minimized/compacted state? Only works for large screen layouts.
+    The expanded/compact (minimized) state of the navigation. This one only makes sense in case of desktop size, when the screen size is above the value of stepOver.
+
+### menuOpenState$
+
+Beside the template context's **isMenuMinimized** variable, another way to listen to the component's menu's open/closed state is the menuOpenState$ observable, which is driven by a BehaviorSubject at the background. The value emitted on this observable is the opposite of the isMenuMinimized template variable.
+
+Every time the menu state is changed, the following values are emitted:
+
+- true, if the menu got into opened state
+- false, if the menu git into closed state

--- a/lib/core/sidenav-layout/components/sidenav-layout/sidenav-layout.component.spec.ts
+++ b/lib/core/sidenav-layout/components/sidenav-layout/sidenav-layout.component.spec.ts
@@ -294,21 +294,21 @@ describe('SidenavLayoutComponent', () => {
             component = fixture.componentInstance;
         });
 
-        it('should be false by default', (done) => {
-            fixture.detectChanges();
-
-            component.menuOpenState$.subscribe((value) => {
-                expect(value).toBe(false);
-                done();
-            });
-        });
-
-        it('should be the opposite as the expandedSidenav\'s value by default', (done) => {
-            component.expandedSidenav = false;
+        it('should be true by default', (done) => {
             fixture.detectChanges();
 
             component.menuOpenState$.subscribe((value) => {
                 expect(value).toBe(true);
+                done();
+            });
+        });
+
+        it('should be the same as the expandedSidenav\'s value by default', (done) => {
+            component.expandedSidenav = false;
+            fixture.detectChanges();
+
+            component.menuOpenState$.subscribe((value) => {
+                expect(value).toBe(false);
                 done();
             });
         });
@@ -320,7 +320,7 @@ describe('SidenavLayoutComponent', () => {
             component.toggleMenu();
 
             component.menuOpenState$.subscribe((value) => {
-                expect(value).toBe(false);
+                expect(value).toBe(true);
                 done();
             });
         });

--- a/lib/core/sidenav-layout/components/sidenav-layout/sidenav-layout.component.spec.ts
+++ b/lib/core/sidenav-layout/components/sidenav-layout/sidenav-layout.component.spec.ts
@@ -277,4 +277,52 @@ describe('SidenavLayoutComponent', () => {
             expect(component.isMenuMinimized).toBe(false);
         });
     });
+
+    describe('menuOpenState', () => {
+
+        let component;
+
+        beforeEach(async(() => {
+            TestBed.compileComponents();
+        }));
+
+        beforeEach(() => {
+            mediaMatcher = TestBed.get(MediaMatcher);
+            spyOn(mediaMatcher, 'matchMedia').and.returnValue(mediaQueryList);
+
+            fixture = TestBed.createComponent(SidenavLayoutComponent);
+            component = fixture.componentInstance;
+        });
+
+        it('should be false by default', (done) => {
+            fixture.detectChanges();
+
+            component.menuOpenState$.subscribe((value) => {
+                expect(value).toBe(false);
+                done();
+            });
+        });
+
+        it('should be the opposite as the expandedSidenav\'s value by default', (done) => {
+            component.expandedSidenav = false;
+            fixture.detectChanges();
+
+            component.menuOpenState$.subscribe((value) => {
+                expect(value).toBe(true);
+                done();
+            });
+        });
+
+        it('should emit value on toggleMenu action', (done) => {
+            component.expandedSidenav = false;
+            fixture.detectChanges();
+
+            component.toggleMenu();
+
+            component.menuOpenState$.subscribe((value) => {
+                expect(value).toBe(false);
+                done();
+            });
+        });
+    });
 });

--- a/lib/core/sidenav-layout/components/sidenav-layout/sidenav-layout.component.ts
+++ b/lib/core/sidenav-layout/components/sidenav-layout/sidenav-layout.component.ts
@@ -97,7 +97,7 @@ export class SidenavLayoutComponent implements OnInit, AfterViewInit, OnDestroy 
 
     set isMenuMinimized(menuState: boolean) {
         this._isMenuMinimized = menuState;
-        this.menuOpenStateSubject.next(menuState);
+        this.menuOpenStateSubject.next(!menuState);
     }
 
     get isHeaderInside() {

--- a/lib/core/sidenav-layout/components/sidenav-layout/sidenav-layout.component.ts
+++ b/lib/core/sidenav-layout/components/sidenav-layout/sidenav-layout.component.ts
@@ -20,6 +20,8 @@ import { MediaMatcher } from '@angular/cdk/layout';
 import { SidenavLayoutContentDirective } from '../../directives/sidenav-layout-content.directive';
 import { SidenavLayoutHeaderDirective } from '../../directives/sidenav-layout-header.directive';
 import { SidenavLayoutNavigationDirective } from '../../directives/sidenav-layout-navigation.directive';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import { Observable } from 'rxjs/Observable';
 
 @Component({
     selector: 'adf-sidenav-layout',
@@ -40,11 +42,15 @@ export class SidenavLayoutComponent implements OnInit, AfterViewInit, OnDestroy 
     @ContentChild(SidenavLayoutNavigationDirective) navigationDirective: SidenavLayoutNavigationDirective;
     @ContentChild(SidenavLayoutContentDirective) contentDirective: SidenavLayoutContentDirective;
 
+    private menuOpenStateSubject: BehaviorSubject<boolean>;
+    public menuOpenState$: Observable<boolean>;
+
     @ViewChild('container') container: any;
     @ViewChild('emptyTemplate') emptyTemplate: any;
 
     mediaQueryList: MediaQueryList;
-    isMenuMinimized;
+    _isMenuMinimized;
+
     templateContext = {
         toggleMenu: () => {},
         isMenuMinimized: () => this.isMenuMinimized
@@ -55,8 +61,14 @@ export class SidenavLayoutComponent implements OnInit, AfterViewInit, OnDestroy 
     }
 
     ngOnInit() {
+        const initialMenuState = !this.expandedSidenav;
+
+        this.menuOpenStateSubject = new BehaviorSubject<boolean>(initialMenuState);
+        this.menuOpenState$ = this.menuOpenStateSubject.asObservable();
+
         const stepOver = this.stepOver || SidenavLayoutComponent.STEP_OVER;
-        this.isMenuMinimized = !this.expandedSidenav;
+        this.isMenuMinimized = initialMenuState;
+
         this.mediaQueryList = this.mediaMatcher.matchMedia(`(max-width: ${stepOver}px)`);
         this.mediaQueryList.addListener(this.onMediaQueryChange);
     }
@@ -77,6 +89,15 @@ export class SidenavLayoutComponent implements OnInit, AfterViewInit, OnDestroy 
         }
 
         this.container.toggleMenu();
+    }
+
+    get isMenuMinimized() {
+        return this._isMenuMinimized;
+    }
+
+    set isMenuMinimized(menuState: boolean) {
+        this._isMenuMinimized = menuState;
+        this.menuOpenStateSubject.next(menuState);
     }
 
     get isHeaderInside() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Observable menu open state variable was not present.


**What is the new behaviour?**
Implements


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
