### PR TITLE
[ADF-2601] added permission check to info editing button

### DIFF
--- a/lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.html
+++ b/lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.html
@@ -11,7 +11,7 @@
     </mat-card-content>
     <mat-card-footer class="adf-content-metadata-card-footer" fxLayout="row" fxLayoutAlign="space-between stretch">
         <div>
-            <button *ngIf="!readOnly"
+            <button *ngIf="!readOnly && hasPermission()"
                 mat-icon-button
                 (click)="toggleEdit()"
                 [attr.title]="'CORE.METADATA.ACTIONS.EDIT' | translate"

--- a/lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.spec.ts
+++ b/lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.spec.ts
@@ -141,7 +141,7 @@ describe('ContentMetadataCardComponent', () => {
 
     it('should toggle editable by clicking on the button', () => {
         component.editable = true;
-        component.node.allowableOperations = ['update'];
+        component.node.allowableOperations = [PermissionsEnum.UPDATE];
         fixture.detectChanges();
 
         const button = fixture.debugElement.query(By.css('[data-automation-id="mata-data-card-toggle-edit"]'));
@@ -199,7 +199,7 @@ describe('ContentMetadataCardComponent', () => {
 
     it('should show the edit button if node does has `update` permissions', () => {
         component.readOnly = false;
-        component.node.allowableOperations = ['update'];
+        component.node.allowableOperations = [PermissionsEnum.UPDATE];
         fixture.detectChanges();
 
         const button = fixture.debugElement.query(By.css('[data-automation-id="mata-data-card-toggle-edit"]'));

--- a/lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.spec.ts
+++ b/lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.spec.ts
@@ -28,6 +28,7 @@ import { BasicPropertiesService } from '../../services/basic-properties.service'
 import { PropertyGroupTranslatorService } from '../../services/property-groups-translator.service';
 import { PropertyDescriptorsService } from '../../services/property-descriptors.service';
 import { ContentMetadataConfigFactory } from '../../services/config/content-metadata-config.factory';
+import { ContentService, PermissionsEnum } from '@alfresco/adf-core';
 
 describe('ContentMetadataCardComponent', () => {
 
@@ -53,7 +54,8 @@ describe('ContentMetadataCardComponent', () => {
                 BasicPropertiesService,
                 PropertyGroupTranslatorService,
                 ContentMetadataConfigFactory,
-                PropertyDescriptorsService
+                PropertyDescriptorsService,
+                ContentService
             ]
         }).compileComponents();
     }));
@@ -139,6 +141,7 @@ describe('ContentMetadataCardComponent', () => {
 
     it('should toggle editable by clicking on the button', () => {
         component.editable = true;
+        component.node.allowableOperations = ['update'];
         fixture.detectChanges();
 
         const button = fixture.debugElement.query(By.css('[data-automation-id="mata-data-card-toggle-edit"]'));
@@ -177,16 +180,29 @@ describe('ContentMetadataCardComponent', () => {
         expect(buttonLabel.nativeElement.innerText.trim()).toBe('ADF_VIEWER.SIDEBAR.METADATA.LESS_INFORMATION');
     });
 
-    it('should show the edit button by default', () => {
-        const button = fixture.debugElement.query(By.css('[data-automation-id="mata-data-card-toggle-edit"]'));
-        expect(button).not.toBeNull();
-    });
-
-    it('should hode the edit button in readOnly is true', () => {
+    it('should hide the edit button in readOnly is true', () => {
         component.readOnly = true;
         fixture.detectChanges();
 
         const button = fixture.debugElement.query(By.css('[data-automation-id="mata-data-card-toggle-edit"]'));
         expect(button).toBeNull();
+    });
+
+    it('should hide the edit button if node does not have `update` permissions', () => {
+        component.readOnly = false;
+        component.node.allowableOperations = null;
+        fixture.detectChanges();
+
+        const button = fixture.debugElement.query(By.css('[data-automation-id="mata-data-card-toggle-edit"]'));
+        expect(button).toBeNull();
+    });
+
+    it('should show the edit button if node does has `update` permissions', () => {
+        component.readOnly = false;
+        component.node.allowableOperations = ['update'];
+        fixture.detectChanges();
+
+        const button = fixture.debugElement.query(By.css('[data-automation-id="mata-data-card-toggle-edit"]'));
+        expect(button).not.toBeNull();
     });
 });

--- a/lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.ts
+++ b/lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.ts
@@ -17,6 +17,7 @@
 
 import { Component, Input, ViewEncapsulation } from '@angular/core';
 import { MinimalNodeEntryEntity } from 'alfresco-js-api';
+import { ContentService, PermissionsEnum } from '@alfresco/adf-core';
 
 @Component({
     selector: 'adf-content-metadata-card',
@@ -44,11 +45,18 @@ export class ContentMetadataCardComponent {
     editable: boolean = false;
     expanded: boolean = false;
 
+    constructor(private contentService: ContentService) {
+    }
+
     toggleEdit(): void {
         this.editable = !this.editable;
     }
 
     toggleExpanded(): void {
         this.expanded = !this.expanded;
+    }
+
+    hasPermission() {
+        return this.contentService.hasPermission(this.node, PermissionsEnum.UPDATE);
     }
 }

--- a/lib/core/viewer/components/viewer.component.ts
+++ b/lib/core/viewer/components/viewer.component.ts
@@ -374,7 +374,7 @@ export class ViewerComponent implements OnChanges, OnInit, OnDestroy {
     toggleSidebar() {
         this.showSidebar = !this.showSidebar;
         if (this.showSidebar && this.fileNodeId) {
-            this.apiService.getInstance().nodes.getNodeInfo(this.fileNodeId)
+            this.apiService.getInstance().nodes.getNodeInfo(this.fileNodeId, {include: ['allowableOperations']})
                 .then((data: MinimalNodeEntryEntity) => {
                     this.sidebarTemplateContext.node = data;
                 });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
No node check permission was performed when use try to edit metadata for the selected node


**What is the new behaviour?**
edit button is not visibile if user doesn't have the `update` permission


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
