### PR TITLE
[ADF-2529] click will unselect the selected row

### DIFF
--- a/lib/core/datatable/components/datatable/datatable.component.spec.ts
+++ b/lib/core/datatable/components/datatable/datatable.component.spec.ts
@@ -28,7 +28,7 @@ import { ObjectDataColumn } from '../../data/object-datacolumn.model';
 import { ObjectDataTableAdapter } from '../../data/object-datatable-adapter';
 
 import { DataTableComponent } from './datatable.component';
-
+/*tslint:disable:ban*/
 describe('DataTable', () => {
 
     let fixture: ComponentFixture<DataTableComponent>;
@@ -312,6 +312,9 @@ describe('DataTable', () => {
         expect(rows[0].isSelected).toBeTruthy();
 
         dataTable.onRowClick(rows[0], null);
+        expect(rows[0].isSelected).toBeFalsy();
+
+        dataTable.onRowClick(rows[0], <any> { metaKey: true, preventDefault() {} });
         expect(rows[0].isSelected).toBeTruthy();
 
         dataTable.onRowClick(rows[0], <any> { metaKey: true, preventDefault() {} });

--- a/lib/core/datatable/components/datatable/datatable.component.spec.ts
+++ b/lib/core/datatable/components/datatable/datatable.component.spec.ts
@@ -28,7 +28,7 @@ import { ObjectDataColumn } from '../../data/object-datacolumn.model';
 import { ObjectDataTableAdapter } from '../../data/object-datatable-adapter';
 
 import { DataTableComponent } from './datatable.component';
-/*tslint:disable:ban*/
+
 describe('DataTable', () => {
 
     let fixture: ComponentFixture<DataTableComponent>;

--- a/lib/core/datatable/components/datatable/datatable.component.ts
+++ b/lib/core/datatable/components/datatable/datatable.component.ts
@@ -317,7 +317,12 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck 
 
             if (this.isMultiSelectionMode()) {
                 const modifier = e && (e.metaKey || e.ctrlKey);
-                const newValue = modifier ? !row.isSelected : true;
+                let newValue: boolean;
+                if (this.selection.length === 1) {
+                    newValue = !row.isSelected;
+                } else {
+                    newValue = modifier ? !row.isSelected : true;
+                }
                 const domEventName = newValue ? 'row-select' : 'row-unselect';
 
                 if (!modifier) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Once selected a single line with click another click won't unselect it


**What is the new behaviour?**
Click once on a row will select it , clicking once again will unselect it


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
