### PR TITLE
[ADF-2692] - refresh must be done on tab changes otherwise ViewChild obj refrence are null

### DIFF
--- a/demo-shell/src/app/components/process-service/process-service.component.ts
+++ b/demo-shell/src/app/components/process-service/process-service.component.ts
@@ -79,7 +79,7 @@ export class ProcessServiceComponent implements AfterViewInit, OnDestroy, OnInit
     @ViewChild('activitifilter')
     activitifilter: TaskFiltersComponent;
 
-    @ViewChild('banano')
+    @ViewChild('processListPagination')
     processListPagination: PaginationComponent;
 
     @ViewChild('taskListPagination')

--- a/demo-shell/src/app/components/process-service/process-service.component.ts
+++ b/demo-shell/src/app/components/process-service/process-service.component.ts
@@ -79,7 +79,7 @@ export class ProcessServiceComponent implements AfterViewInit, OnDestroy, OnInit
     @ViewChild('activitifilter')
     activitifilter: TaskFiltersComponent;
 
-    @ViewChild('processListPagination')
+    @ViewChild('banano')
     processListPagination: PaginationComponent;
 
     @ViewChild('taskListPagination')
@@ -243,6 +243,12 @@ export class ProcessServiceComponent implements AfterViewInit, OnDestroy, OnInit
     onTabChange(event: any): void {
         this.showProcessPagination = event.index === 1;
         this.paginationPageSize = this.preferenceService.paginationSize;
+        if (this.processList) {
+            this.processList.reload();
+        }
+        if (this.taskList) {
+            this.taskList.reload();
+        }
     }
 
     onChangePageSize(event: Pagination): void {
@@ -367,7 +373,9 @@ export class ProcessServiceComponent implements AfterViewInit, OnDestroy, OnInit
 
     onFormCompleted(form): void {
         this.currentTaskId = null;
-        this.taskPage = this.taskListPagination.current - 1;
+        if (this.taskListPagination) {
+            this.taskPage = this.taskListPagination.current - 1;
+        }
         if (this.taskList) {
             this.taskList.reload();
         } else {

--- a/demo-shell/src/app/components/process-service/process-service.component.ts
+++ b/demo-shell/src/app/components/process-service/process-service.component.ts
@@ -376,13 +376,8 @@ export class ProcessServiceComponent implements AfterViewInit, OnDestroy, OnInit
         if (this.taskListPagination) {
             this.taskPage = this.taskListPagination.current - 1;
         }
-        if (this.taskList) {
-            this.taskList.reload();
-        } else {
+        if (!this.taskList) {
             this.navigateToProcess();
-        }
-        if (this.processList) {
-            this.processList.reload();
         }
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
On demoshell at the moment when we click on the active task from the process and then we complete the task, the processlist is not reloaded cause it is unreferenced due the tab.


**What is the new behaviour?**
When we click on tab we will reload the relative list that we are going to see so we will always have the correct results.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
