### PR TITLE
[ADF-2723] preventing document list to restart always from -my- folder

### DIFF
--- a/demo-shell/src/app/components/files/files.component.html
+++ b/demo-shell/src/app/components/files/files.component.html
@@ -192,6 +192,7 @@
                 (success)="resetError()"
                 (ready)="emitReadyEvent($event)"
                 (preview)="showFile($event)"
+                (folderChange)="onFolderChange($event)"
                 (permissionError)="handlePermissionError($event)">
                 <empty-folder-content *ngIf="disableDragArea">
                     <ng-template>

--- a/demo-shell/src/app/components/files/files.component.ts
+++ b/demo-shell/src/app/components/files/files.component.ts
@@ -377,7 +377,6 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
 
     onSiteChange(site: SiteEntry) {
         this.currentFolderId = site.entry.guid;
-        // this.currentSiteid = site.entry.guid;
     }
 
     getDocumentListCurrentFolderId() {

--- a/demo-shell/src/app/components/files/files.component.ts
+++ b/demo-shell/src/app/components/files/files.component.ts
@@ -16,11 +16,11 @@
  */
 
 import {
-    Component, Input, OnInit, OnChanges, OnDestroy,
+    Component, Input, OnInit, OnChanges, OnDestroy, Optional,
     EventEmitter, ViewChild, SimpleChanges, Output
 } from '@angular/core';
 import { MatDialog } from '@angular/material';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Params, Router } from '@angular/router';
 import { MinimalNodeEntity, NodePaging, Pagination, MinimalNodeEntryEntity, SiteEntry } from 'alfresco-js-api';
 import {
     AuthenticationService, AppConfigService, ContentService, TranslationService,
@@ -146,6 +146,7 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
     permissionsStyle: PermissionStyleModel[] = [];
     infiniteScrolling: boolean;
     supportedPages: number[];
+    currentSiteid = '';
 
     private onCreateFolder: Subscription;
     private onEditFolder: Subscription;
@@ -159,6 +160,7 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
                 private logService: LogService,
                 private preference: UserPreferencesService,
                 private appConfig: AppConfigService,
+                @Optional() private route: ActivatedRoute,
                 public authenticationService: AuthenticationService) {
         this.preference.select(UserPreferenceValues.SupportedPageSizes)
             .subscribe((pages) => {
@@ -185,6 +187,14 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
                 maxItems: this.preference.paginationSize,
                 skipCount: 0
             };
+        }
+
+        if (this.route) {
+            this.route.params.forEach((params: Params) => {
+                if (params['id'] && this.currentFolderId !== params['id']) {
+                    this.currentFolderId = params['id'];
+                }
+            });
         }
 
         // this.disableDragArea = false;
@@ -262,6 +272,10 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
         }
     }
 
+    onFolderChange($event) {
+       this.router.navigate(['/files', $event.value.id]);
+    }
+
     handlePermissionError(event: any) {
         this.translateService.get('PERMISSON.LACKOF', {
             permission: event.permission,
@@ -281,7 +295,6 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
 
     emitReadyEvent(event: NodePaging) {
         this.documentListReady.emit(event);
-        this.router.navigate(['/files', event.list.source.id]);
     }
 
     pageIsEmpty(node: NodePaging) {
@@ -364,6 +377,7 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
 
     onSiteChange(site: SiteEntry) {
         this.currentFolderId = site.entry.guid;
+        // this.currentSiteid = site.entry.guid;
     }
 
     getDocumentListCurrentFolderId() {

--- a/lib/content-services/document-list/components/document-list.component.ts
+++ b/lib/content-services/document-list/components/document-list.component.ts
@@ -373,7 +373,8 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
             this.currentFolderId = changes.folderNode.currentValue.id;
             this.resetNewFolderPagination();
             this.loadFolder();
-        } else if (changes.currentFolderId && changes.currentFolderId.currentValue) {
+        } else if (changes.currentFolderId &&
+                   changes.currentFolderId.currentValue !== changes.currentFolderId.previousValue) {
             this.resetNewFolderPagination();
             this.loadFolder();
         } else if (this.data) {
@@ -740,6 +741,7 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
         this.currentFolderId = nodeId;
         this.resetNewFolderPagination();
         this.loadFolder();
+        this.folderChange.emit(new NodeEntryEvent({id: nodeId}));
     }
 
     private resetNewFolderPagination() {

--- a/lib/content-services/document-list/components/document-list.component.ts
+++ b/lib/content-services/document-list/components/document-list.component.ts
@@ -374,6 +374,7 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
             this.resetNewFolderPagination();
             this.loadFolder();
         } else if (changes.currentFolderId &&
+                   changes.currentFolderId.currentValue &&
                    changes.currentFolderId.currentValue !== changes.currentFolderId.previousValue) {
             this.resetNewFolderPagination();
             this.loadFolder();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
When navigating to search results or after closing a previewed file document list restarts always from -my- folder.


**What is the new behaviour?**
The current node id is updated whenever a folder is changed preventing the double reload of the document list.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
