### PR TITLE
[ADF-2759] Updated doc script to allow multiple config profiles

### DIFF
--- a/lib/config/DocProcessor/docProcessor.js
+++ b/lib/config/DocProcessor/docProcessor.js
@@ -85,10 +85,9 @@ function loadToolModules() {
 }
 
 
-function loadToolConfig(configFilePath) {
-    var config = JSON.parse(fs.readFileSync(configFilePath));
-
-    return config.enabledTools;
+function loadConfig() {
+    var configFilePath = path.resolve(__dirname, configFileName)
+    return JSON.parse(fs.readFileSync(configFilePath));
 }
 
 
@@ -110,38 +109,33 @@ function getAllDocFilePaths(docFolder, files) {
 
 program
 .usage("[options] <source>")
+.option("-p, --profile [profileName]", "Select named config profile", "index")
 .parse(process.argv);
 
+var sourcePath;
+
 if (program.args.length === 0) {
-    console.log("Error: source argument required");
-    return 0;
+    sourcePath = path.resolve("..", "docs");
+} else {
+    sourcePath = path.resolve(program.args[0]);
 }
 
-
-var sourcePath = path.resolve(program.args[0]);
 var sourceInfo = fs.statSync(sourcePath);
 
-/*
-var destPath;
-var destInfo;
+var toolModules = loadToolModules();
 
-if (program.args.length >= 2) {
-    destPath = path.resolve(program.args[1]);
-    destInfo = fs.statSync(sourcePath);
+var config = loadConfig();
+
+var toolList;
+
+if (config.profiles[program.profile]){
+    toolList = config.profiles[program.profile];
+    var toolListText = toolList.join(", ");
+    console.log(`Using '${program.profile}' profile: ${toolListText}`);
 } else {
-    destPath = sourcePath;
-    destInfo = sourceInfo;
-}
-
-if (sourceInfo.isDirectory() && !destInfo.isDirectory()) {
-    console.log("Error: The <dest> argument must be a directory");
+    console.log(`Aborting: unknown profile '${program.profile}`);
     return 0;
 }
-*/
-
-var toolModules = loadToolModules();
-var toolList = loadToolConfig(path.resolve(__dirname, configFileName));
-
 
 var files = [];
 
@@ -149,9 +143,6 @@ if (sourceInfo.isDirectory()) {
     getAllDocFilePaths(sourcePath, files);
 } else if (sourceInfo.isFile()) {
     files = [ sourcePath ];
-    //files = [ path.basename(sourcePath) ];
-    //sourcePath = path.dirname(sourcePath);
-    //destPath = path.dirname(destPath);
 }
 
 files = files.filter(filename => 

--- a/lib/config/DocProcessor/doctool.config.json
+++ b/lib/config/DocProcessor/doctool.config.json
@@ -1,7 +1,13 @@
 {
-    "enabledTools": [
-        "index",
-        "versionIndex",
-        "tutorialIndex"
-    ]
+    "profiles": {
+        "index": [
+            "index",
+            "versionIndex",
+            "tutorialIndex"
+        ],
+        "enhance": [
+            "tsInfo",
+            "toc"
+        ]
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [x] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Doc script can only have a single set of tools configured at a time. Changing configuration for different tasks (indexing and JSDocs) requires editing the config file.

**What is the new behaviour?**

Doc script config now contains multiple profiles that you can select with a command line option. Default behaviour (with no profile specified) is identical to the previous behaviour.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
