### PR TITLE
[ADF-2717] Long names fixed in lock dialog

### DIFF
--- a/lib/content-services/dialogs/folder.dialog.scss
+++ b/lib/content-services/dialogs/folder.dialog.scss
@@ -6,6 +6,22 @@
     width: 100%;
 }
 
+.adf-lock-file-name {
+    .mat-checkbox-layout{
+        width: 100%;
+    }
+
+    .mat-checkbox-label{
+        text-overflow: ellipsis;
+        overflow: hidden;
+    }
+
+    .mat-checkbox-inner-container{
+        margin: auto 0;
+        margin-right: 8px;
+    }
+}
+
 @mixin adf-dialog-theme($theme) {
 
     $primary: map-get($theme, primary);

--- a/lib/content-services/dialogs/node-lock.dialog.html
+++ b/lib/content-services/dialogs/node-lock.dialog.html
@@ -5,20 +5,20 @@
 <mat-dialog-content>
     <br />
     <form [formGroup]="form" (submit)="submit()">
-        <mat-checkbox [formControl]="form.controls['isLocked']" ngDefaultControl>
+        <mat-checkbox class="adf-lock-file-name" [formControl]="form.controls['isLocked']" ngDefaultControl>
             {{ 'CORE.FILE_DIALOG.FILE_LOCK_CHECKBOX' | translate }} <strong>"{{ nodeName }}"</strong>
         </mat-checkbox>
 
         <br />
 
         <div *ngIf="form.value.isLocked">
-            <mat-checkbox [formControl]="form.controls['allowOwner']" ngDefaultControl>
+            <mat-checkbox class="adf-lock-file-name" [formControl]="form.controls['allowOwner']" ngDefaultControl>
                 {{ 'CORE.FILE_DIALOG.ALLOW_OTHERS_CHECKBOX' | translate }}
             </mat-checkbox>
 
             <br />
 
-            <mat-checkbox [formControl]="form.controls['isTimeLock']" ngDefaultControl>
+            <mat-checkbox class="adf-lock-file-name" [formControl]="form.controls['isTimeLock']" ngDefaultControl>
                 {{ 'CORE.FILE_DIALOG.TIME_LOCK_CHECKBOX' | translate }}
             </mat-checkbox>
 

--- a/lib/content-services/version-manager/version-list.component.spec.ts
+++ b/lib/content-services/version-manager/version-list.component.spec.ts
@@ -16,7 +16,7 @@
  */
 
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { ComponentFixture, TestBed, tick, fakeAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { VersionListComponent } from './version-list.component';
 import { AlfrescoApiService, setupTestBed, CoreModule, AlfrescoApiServiceMock } from '@alfresco/adf-core';


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Long names overflow in Lock dialog window


**What is the new behaviour?**
Long names now wrap to fit in Lock dialog window


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
