### PR TITLE
[ADF-2764] Added tool to add links to type names in Markdown files

### DIFF
--- a/lib/config/DocProcessor/doctool.config.json
+++ b/lib/config/DocProcessor/doctool.config.json
@@ -8,6 +8,10 @@
         "enhance": [
             "tsInfo",
             "toc"
+        ],
+        "dev": [
+            "tsInfo",
+            "typeLinker"
         ]
     }
 }

--- a/lib/config/DocProcessor/ngHelpers.js
+++ b/lib/config/DocProcessor/ngHelpers.js
@@ -13,6 +13,12 @@ function ngNameToDisplayName(ngName) {
 }
 
 
+function displayNameToNgName(name) {
+    var noSpaceName = ngName.replace(/ ([a-zA-Z])/, "$1".toUpperCase());
+    return noSpaceName.substr(0, 1).toUpperCase() + noSpaceName.substr(1);
+}
+
+
 function dekebabifyName(name) {
     var result = name.replace(/-/g, " ");
     result = result.substr(0, 1).toUpperCase() + result.substr(1);

--- a/lib/config/DocProcessor/ngHelpers.js
+++ b/lib/config/DocProcessor/ngHelpers.js
@@ -1,6 +1,7 @@
 module.exports = {
     "ngNameToDisplayName": ngNameToDisplayName,
     "dekebabifyName": dekebabifyName,
+    "kebabifyClassName": kebabifyClassName,
     "classTypes": ["component", "directive", "model", "pipe", "service", "widget"]
 }
 
@@ -16,4 +17,13 @@ function dekebabifyName(name) {
     var result = name.replace(/-/g, " ");
     result = result.substr(0, 1).toUpperCase() + result.substr(1);
     return result;
+}
+
+function kebabifyClassName(name) {
+    var result = name.replace(/(Component|Directive|Interface|Model|Pipe|Service|Widget)$/, match => {
+        return "." + match.toLowerCase();
+    });
+
+    result = result.replace(/([A-Z])/g, "-$1");
+    return result.substr(1).toLowerCase();
 }

--- a/lib/config/DocProcessor/tools/typeLinker.js
+++ b/lib/config/DocProcessor/tools/typeLinker.js
@@ -1,0 +1,100 @@
+"use strict";
+exports.__esModule = true;
+var path = require("path");
+var fs = require("fs");
+var typedoc_1 = require("typedoc");
+var unist = require("../unistHelpers");
+var ngHelpers = require("../ngHelpers");
+var includedNodeTypes = [
+    "root", "paragraph", "inlineCode", "list", "listItem",
+    "table", "tableRow", "tableCell", "emphasis", "strong",
+    "link", "text"
+];
+var docFolder = path.resolve("..", "docs");
+var adfLibNames = ["core", "content-services", "insights", "process-services"];
+function initPhase(aggData) {
+    aggData.docFiles = {};
+    adfLibNames.forEach(function (libName) {
+        var libFolderPath = path.resolve(docFolder, libName);
+        var files = fs.readdirSync(libFolderPath);
+        files.forEach(function (file) {
+            if (path.extname(file) === ".md") {
+                var relPath = libFolderPath.substr(libFolderPath.indexOf("docs") + 5).replace(/\\/, "/") + "/" + file;
+                var compName = path.basename(file, ".md");
+                aggData.docFiles[compName] = relPath;
+            }
+        });
+    });
+}
+exports.initPhase = initPhase;
+function readPhase(tree, pathname, aggData) { }
+exports.readPhase = readPhase;
+function aggPhase(aggData) {
+}
+exports.aggPhase = aggPhase;
+function updatePhase(tree, pathname, aggData) {
+    traverseMDTree(tree);
+    return true;
+    function traverseMDTree(node) {
+        if (!includedNodeTypes.includes(node.type)) {
+            return;
+        }
+        if (node.type === "inlineCode") {
+            var possClassName = cleanClassName(node.value);
+            var ref = aggData.projData.findReflectionByName(possClassName);
+            if (ref && isLinkable(ref.kind)) {
+                var kebabName = ngHelpers.kebabifyClassName(possClassName);
+                console.log(kebabName);
+                var possDocFile = aggData.docFiles[kebabName];
+                var url = "../../lib/" + ref.sources[0].fileName;
+                if (possDocFile) {
+                    url = "../" + possDocFile;
+                }
+                convertNodeToTypeLink(node, node.value, url);
+            }
+        }
+        else if (node.type === "link") {
+            if (node.children && ((node.children[0].type === "inlineCode") ||
+                (node.children[0].type === "text"))) {
+                var possClassName = cleanClassName(node.children[0].value);
+                var ref = aggData.projData.findReflectionByName(possClassName);
+                if (ref && isLinkable(ref.kind)) {
+                    var kebabName = ngHelpers.kebabifyClassName(possClassName);
+                    console.log(kebabName);
+                    var possDocFile = aggData.docFiles[kebabName];
+                    var url = "../../lib/" + ref.sources[0].fileName;
+                    if (possDocFile) {
+                        url = "../" + possDocFile;
+                    }
+                    convertNodeToTypeLink(node, node.children[0].value, url);
+                }
+            }
+        }
+        else if (node.children) {
+            node.children.forEach(function (element) {
+                traverseMDTree(element);
+            });
+        }
+    }
+}
+exports.updatePhase = updatePhase;
+function cleanClassName(text) {
+    var matches = text.match(/[a-zA-Z0-9_]+<([a-zA-Z0-9_]+)>/);
+    if (matches) {
+        return matches[1];
+    }
+    else {
+        return text;
+    }
+}
+function isLinkable(kind) {
+    return (kind === typedoc_1.ReflectionKind.Class) ||
+        (kind === typedoc_1.ReflectionKind.Interface) ||
+        (kind === typedoc_1.ReflectionKind.Enum);
+}
+function convertNodeToTypeLink(node, text, url) {
+    var linkDisplayText = unist.makeInlineCode(text);
+    node.type = "link";
+    node.url = url;
+    node.children = [linkDisplayText];
+}

--- a/lib/config/DocProcessor/tools/typeLinker.js
+++ b/lib/config/DocProcessor/tools/typeLinker.js
@@ -40,44 +40,98 @@ function updatePhase(tree, pathname, aggData) {
             return;
         }
         if (node.type === "inlineCode") {
-            var possClassName = cleanClassName(node.value);
-            var ref = aggData.projData.findReflectionByName(possClassName);
-            if (ref && isLinkable(ref.kind)) {
-                var kebabName = ngHelpers.kebabifyClassName(possClassName);
-                console.log(kebabName);
-                var possDocFile = aggData.docFiles[kebabName];
-                var url = "../../lib/" + ref.sources[0].fileName;
-                if (possDocFile) {
-                    url = "../" + possDocFile;
-                }
-                convertNodeToTypeLink(node, node.value, url);
+            var link = resolveTypeLink(aggData, node.value);
+            if (link) {
+                convertNodeToTypeLink(node, node.value, link);
             }
         }
         else if (node.type === "link") {
             if (node.children && ((node.children[0].type === "inlineCode") ||
                 (node.children[0].type === "text"))) {
-                var possClassName = cleanClassName(node.children[0].value);
-                var ref = aggData.projData.findReflectionByName(possClassName);
-                if (ref && isLinkable(ref.kind)) {
-                    var kebabName = ngHelpers.kebabifyClassName(possClassName);
-                    console.log(kebabName);
-                    var possDocFile = aggData.docFiles[kebabName];
-                    var url = "../../lib/" + ref.sources[0].fileName;
-                    if (possDocFile) {
-                        url = "../" + possDocFile;
-                    }
-                    convertNodeToTypeLink(node, node.children[0].value, url);
+                var link = resolveTypeLink(aggData, node.children[0].value);
+                if (link) {
+                    convertNodeToTypeLink(node, node.children[0].value, link);
                 }
             }
         }
+        else if (node.type === "paragraph") {
+            node.children.forEach(function (child, index) {
+                if (child.type === "text") {
+                    var newNodes = handleLinksInBodyText(aggData, child.value);
+                    node.children = node.children.slice(0, index).concat(newNodes, node.children.slice(index + 1));
+                }
+                else {
+                    traverseMDTree(child);
+                }
+            });
+        }
         else if (node.children) {
-            node.children.forEach(function (element) {
-                traverseMDTree(element);
+            node.children.forEach(function (child) {
+                traverseMDTree(child);
             });
         }
     }
 }
 exports.updatePhase = updatePhase;
+var WordScanner = /** @class */ (function () {
+    function WordScanner(text) {
+        this.text = text;
+        this.index = -1;
+        this.nextIndex = 0;
+        this.next();
+    }
+    WordScanner.prototype.finished = function () {
+        return this.index >= this.text.length;
+    };
+    WordScanner.prototype.next = function () {
+        this.index = this.nextIndex + 1;
+        this.nextIndex = this.text.indexOf(" ", this.index);
+        if (this.nextIndex === -1) {
+            this.nextIndex = this.text.length;
+        }
+        this.current = this.text.substring(this.index, this.nextIndex);
+    };
+    return WordScanner;
+}());
+function handleLinksInBodyText(aggData, text) {
+    var result = [];
+    var currTextStart = 0;
+    for (var scanner = new WordScanner(text); !scanner.finished(); scanner.next()) {
+        var word = scanner.current
+            .replace(/'s$/, "")
+            .replace(/^[;:,\."']+/g, "")
+            .replace(/[;:,\."']+$/g, "");
+        var link = resolveTypeLink(aggData, word);
+        if (link) {
+            var linkNode = unist.makeLink(unist.makeText(scanner.current), link);
+            var prevText = text.substring(currTextStart, scanner.index);
+            result.push(unist.makeText(prevText));
+            result.push(linkNode);
+            currTextStart = scanner.nextIndex;
+        }
+    }
+    var remainingText = text.substring(currTextStart, text.length);
+    if (remainingText) {
+        result.push(unist.makeText(remainingText));
+    }
+    return result;
+}
+function resolveTypeLink(aggData, text) {
+    var possClassName = cleanClassName(text);
+    var ref = aggData.projData.findReflectionByName(possClassName);
+    if (ref && isLinkable(ref.kind)) {
+        var kebabName = ngHelpers.kebabifyClassName(possClassName);
+        var possDocFile = aggData.docFiles[kebabName];
+        var url = "../../lib/" + ref.sources[0].fileName;
+        if (possDocFile) {
+            url = "../" + possDocFile;
+        }
+        return url;
+    }
+    else {
+        return "";
+    }
+}
 function cleanClassName(text) {
     var matches = text.match(/[a-zA-Z0-9_]+<([a-zA-Z0-9_]+)>/);
     if (matches) {

--- a/lib/config/DocProcessor/tools/typeLinker.js
+++ b/lib/config/DocProcessor/tools/typeLinker.js
@@ -32,7 +32,7 @@ function initPhase(aggData) {
             aggData.nameLookup.addName(currClass.name);
         }
     });
-    console.log(JSON.stringify(aggData.nameLookup));
+    //console.log(JSON.stringify(aggData.nameLookup));
 }
 exports.initPhase = initPhase;
 function readPhase(tree, pathname, aggData) { }
@@ -66,11 +66,12 @@ function updatePhase(tree, pathname, aggData) {
             node.children.forEach(function (child, index) {
                 if (child.type === "text") {
                     var newNodes = handleLinksInBodyText(aggData, child.value);
-                    node.children = node.children.slice(0, index).concat(newNodes, node.children.slice(index + 1));
+                    (_a = node.children).splice.apply(_a, [index, 1].concat(newNodes));
                 }
                 else {
                     traverseMDTree(child);
                 }
+                var _a;
             });
         }
         else if (node.children) {
@@ -94,36 +95,55 @@ var SplitNameNode = /** @class */ (function () {
     };
     return SplitNameNode;
 }());
+var SplitNameMatchElement = /** @class */ (function () {
+    function SplitNameMatchElement(node, textPos) {
+        this.node = node;
+        this.textPos = textPos;
+    }
+    return SplitNameMatchElement;
+}());
+var SplitNameMatchResult = /** @class */ (function () {
+    function SplitNameMatchResult(value, startPos) {
+        this.value = value;
+        this.startPos = startPos;
+    }
+    return SplitNameMatchResult;
+}());
 var SplitNameMatcher = /** @class */ (function () {
     function SplitNameMatcher(root) {
         this.root = root;
         this.reset();
     }
     /* Returns all names that match when this word is added. */
-    SplitNameMatcher.prototype.nextWord = function (word) {
+    SplitNameMatcher.prototype.nextWord = function (word, textPos) {
         var result = [];
-        this.matches.push(this.root);
+        this.matches.push(new SplitNameMatchElement(this.root, textPos));
         for (var i = this.matches.length - 1; i >= 0; i--) {
-            var child = this.matches[i].children[word];
-            if (child) {
-                if (child.value) {
-                    /* Using unshift to add the match to the array means that
-                     * the longest matches will appear first in the array.
-                     * User can then just use the first array element if only
-                     * the longest match is needed.
-                     */
-                    result.unshift(child.value);
-                    this.matches.splice(i, 1);
+            if (this.matches[i].node.children) {
+                var child = this.matches[i].node.children[word];
+                if (child) {
+                    if (child.value) {
+                        /* Using unshift to add the match to the array means that
+                        * the longest matches will appear first in the array.
+                        * User can then just use the first array element if only
+                        * the longest match is needed.
+                        */
+                        result.unshift(new SplitNameMatchResult(child.value, this.matches[i].textPos));
+                        this.matches.splice(i, 1);
+                    }
+                    else {
+                        this.matches[i] = new SplitNameMatchElement(child, this.matches[i].textPos);
+                    }
                 }
                 else {
-                    this.matches[i] = child;
+                    this.matches.splice(i, 1);
                 }
             }
             else {
                 this.matches.splice(i, 1);
             }
         }
-        if (result = []) {
+        if (result === []) {
             return null;
         }
         else {
@@ -145,7 +165,7 @@ var SplitNameLookup = /** @class */ (function () {
         var currNode = this.root;
         segments.forEach(function (segment, index) {
             var value = "";
-            if (index < (segments.length - 1)) {
+            if (index == (segments.length - 1)) {
                 value = name;
             }
             var childNode = currNode.children[segment];
@@ -161,46 +181,67 @@ var SplitNameLookup = /** @class */ (function () {
 var WordScanner = /** @class */ (function () {
     function WordScanner(text) {
         this.text = text;
-        this.index = -1;
-        this.nextIndex = 0;
+        this.separators = " \n\r\t.;:";
+        this.index = 0;
+        this.nextSeparator = 0;
         this.next();
     }
     WordScanner.prototype.finished = function () {
         return this.index >= this.text.length;
     };
     WordScanner.prototype.next = function () {
-        this.index = this.nextIndex + 1;
-        this.nextIndex = this.text.indexOf(" ", this.index);
-        if (this.nextIndex === -1) {
-            this.nextIndex = this.text.length;
+        this.advanceIndex();
+        this.advanceNextSeparator();
+        this.current = this.text.substring(this.index, this.nextSeparator);
+    };
+    WordScanner.prototype.advanceNextSeparator = function () {
+        for (var i = this.index; i < this.text.length; i++) {
+            if (this.separators.indexOf(this.text[i]) !== -1) {
+                this.nextSeparator = i;
+                return;
+            }
         }
-        this.current = this.text.substring(this.index, this.nextIndex);
+        this.nextSeparator = this.text.length;
+    };
+    WordScanner.prototype.advanceIndex = function () {
+        for (var i = this.nextSeparator; i < this.text.length; i++) {
+            if (this.separators.indexOf(this.text[i]) === -1) {
+                this.index = i;
+                return;
+            }
+        }
+        this.index = this.text.length;
     };
     return WordScanner;
 }());
 function handleLinksInBodyText(aggData, text) {
     var result = [];
     var currTextStart = 0;
-    var matcher = new SplitNameMatcher(aggData.nameLookup);
+    var matcher = new SplitNameMatcher(aggData.nameLookup.root);
     for (var scanner = new WordScanner(text); !scanner.finished(); scanner.next()) {
         var word = scanner.current
             .replace(/'s$/, "")
             .replace(/^[;:,\."']+/g, "")
             .replace(/[;:,\."']+$/g, "");
         var link = resolveTypeLink(aggData, word);
+        var matchStart = void 0;
         if (!link) {
-            var match_1 = matcher.nextWord(word.toLowerCase());
-            if (match_1) {
-                link = resolveTypeLink(aggData, match_1[0]);
+            var match = matcher.nextWord(word.toLowerCase(), scanner.index);
+            if (match && match[0]) {
+                link = resolveTypeLink(aggData, match[0].value);
+                matchStart = match[0].startPos;
             }
         }
+        else {
+            matchStart = scanner.index;
+        }
         if (link) {
-            console.log("Found word link:" + link);
-            var linkNode = unist.makeLink(unist.makeText(scanner.current), link);
-            var prevText = text.substring(currTextStart, scanner.index);
+            var linkText = text.substring(matchStart, scanner.nextSeparator);
+            var linkNode = unist.makeLink(unist.makeText(linkText), link);
+            var prevText = text.substring(currTextStart, matchStart);
             result.push(unist.makeText(prevText));
             result.push(linkNode);
-            currTextStart = scanner.nextIndex;
+            currTextStart = scanner.nextSeparator;
             matcher.reset();
         }
     }

--- a/lib/config/DocProcessor/tools/typeLinker.js
+++ b/lib/config/DocProcessor/tools/typeLinker.js
@@ -14,6 +14,7 @@ var docFolder = path.resolve("..", "docs");
 var adfLibNames = ["core", "content-services", "insights", "process-services"];
 function initPhase(aggData) {
     aggData.docFiles = {};
+    aggData.nameLookup = new SplitNameLookup();
     adfLibNames.forEach(function (libName) {
         var libFolderPath = path.resolve(docFolder, libName);
         var files = fs.readdirSync(libFolderPath);
@@ -25,6 +26,13 @@ function initPhase(aggData) {
             }
         });
     });
+    var classes = aggData.projData.getReflectionsByKind(typedoc_1.ReflectionKind.Class);
+    classes.forEach(function (currClass) {
+        if (currClass.name.match(/(Component|Directive|Interface|Model|Pipe|Service|Widget)$/)) {
+            aggData.nameLookup.addName(currClass.name);
+        }
+    });
+    console.log(JSON.stringify(aggData.nameLookup));
 }
 exports.initPhase = initPhase;
 function readPhase(tree, pathname, aggData) { }
@@ -73,6 +81,83 @@ function updatePhase(tree, pathname, aggData) {
     }
 }
 exports.updatePhase = updatePhase;
+var SplitNameNode = /** @class */ (function () {
+    function SplitNameNode(key, value) {
+        if (key === void 0) { key = ""; }
+        if (value === void 0) { value = ""; }
+        this.key = key;
+        this.value = value;
+        this.children = {};
+    }
+    SplitNameNode.prototype.addChild = function (child) {
+        this.children[child.key] = child;
+    };
+    return SplitNameNode;
+}());
+var SplitNameMatcher = /** @class */ (function () {
+    function SplitNameMatcher(root) {
+        this.root = root;
+        this.reset();
+    }
+    /* Returns all names that match when this word is added. */
+    SplitNameMatcher.prototype.nextWord = function (word) {
+        var result = [];
+        this.matches.push(this.root);
+        for (var i = this.matches.length - 1; i >= 0; i--) {
+            var child = this.matches[i].children[word];
+            if (child) {
+                if (child.value) {
+                    /* Using unshift to add the match to the array means that
+                     * the longest matches will appear first in the array.
+                     * User can then just use the first array element if only
+                     * the longest match is needed.
+                     */
+                    result.unshift(child.value);
+                    this.matches.splice(i, 1);
+                }
+                else {
+                    this.matches[i] = child;
+                }
+            }
+            else {
+                this.matches.splice(i, 1);
+            }
+        }
+        if (result = []) {
+            return null;
+        }
+        else {
+            return result;
+        }
+    };
+    SplitNameMatcher.prototype.reset = function () {
+        this.matches = [];
+    };
+    return SplitNameMatcher;
+}());
+var SplitNameLookup = /** @class */ (function () {
+    function SplitNameLookup() {
+        this.root = new SplitNameNode();
+    }
+    SplitNameLookup.prototype.addName = function (name) {
+        var spacedName = name.replace(/([A-Z])/g, " $1");
+        var segments = spacedName.trim().toLowerCase().split(" ");
+        var currNode = this.root;
+        segments.forEach(function (segment, index) {
+            var value = "";
+            if (index < (segments.length - 1)) {
+                value = name;
+            }
+            var childNode = currNode.children[segment];
+            if (!childNode) {
+                childNode = new SplitNameNode(segment, value);
+                currNode.addChild(childNode);
+            }
+            currNode = childNode;
+        });
+    };
+    return SplitNameLookup;
+}());
 var WordScanner = /** @class */ (function () {
     function WordScanner(text) {
         this.text = text;
@@ -96,18 +181,27 @@ var WordScanner = /** @class */ (function () {
 function handleLinksInBodyText(aggData, text) {
     var result = [];
     var currTextStart = 0;
+    var matcher = new SplitNameMatcher(aggData.nameLookup);
     for (var scanner = new WordScanner(text); !scanner.finished(); scanner.next()) {
         var word = scanner.current
             .replace(/'s$/, "")
             .replace(/^[;:,\."']+/g, "")
             .replace(/[;:,\."']+$/g, "");
         var link = resolveTypeLink(aggData, word);
+        if (!link) {
+            var match_1 = matcher.nextWord(word.toLowerCase());
+            if (match_1) {
+                link = resolveTypeLink(aggData, match_1[0]);
+            }
+        }
         if (link) {
+            console.log("Found word link:" + link);
             var linkNode = unist.makeLink(unist.makeText(scanner.current), link);
             var prevText = text.substring(currTextStart, scanner.index);
             result.push(unist.makeText(prevText));
             result.push(linkNode);
             currTextStart = scanner.nextIndex;
+            matcher.reset();
         }
     }
     var remainingText = text.substring(currTextStart, text.length);
@@ -117,10 +211,10 @@ function handleLinksInBodyText(aggData, text) {
     return result;
 }
 function resolveTypeLink(aggData, text) {
-    var possClassName = cleanClassName(text);
-    var ref = aggData.projData.findReflectionByName(possClassName);
+    var possTypeName = cleanTypeName(text);
+    var ref = aggData.projData.findReflectionByName(possTypeName);
     if (ref && isLinkable(ref.kind)) {
-        var kebabName = ngHelpers.kebabifyClassName(possClassName);
+        var kebabName = ngHelpers.kebabifyClassName(possTypeName);
         var possDocFile = aggData.docFiles[kebabName];
         var url = "../../lib/" + ref.sources[0].fileName;
         if (possDocFile) {
@@ -132,7 +226,7 @@ function resolveTypeLink(aggData, text) {
         return "";
     }
 }
-function cleanClassName(text) {
+function cleanTypeName(text) {
     var matches = text.match(/[a-zA-Z0-9_]+<([a-zA-Z0-9_]+)>/);
     if (matches) {
         return matches[1];

--- a/lib/config/DocProcessor/tools/typeLinker.ts
+++ b/lib/config/DocProcessor/tools/typeLinker.ts
@@ -1,0 +1,140 @@
+import * as path from "path";
+import * as fs from "fs";
+
+import * as remark from "remark";
+import * as stringify from "remark-stringify";
+import * as frontMatter from "remark-frontmatter";
+
+import {
+    Application,
+    ProjectReflection,
+    Reflection,
+    DeclarationReflection,
+    SignatureReflection,
+    ParameterReflection,
+    ReflectionKind,
+    TraverseProperty,
+    Decorator
+ } from "typedoc";
+import { CommentTag } from "typedoc/dist/lib/models";
+
+import * as unist from "../unistHelpers";
+import * as ngHelpers from "../ngHelpers";
+
+
+const includedNodeTypes = [
+    "root", "paragraph", "inlineCode", "list", "listItem",
+    "table", "tableRow", "tableCell", "emphasis", "strong",
+    "link", "text"
+];
+
+const docFolder = path.resolve("..", "docs");
+const adfLibNames = ["core", "content-services", "insights", "process-services"];
+
+
+export function initPhase(aggData) {
+    aggData.docFiles = {};
+
+    adfLibNames.forEach(libName => {
+        let libFolderPath = path.resolve(docFolder, libName);
+
+        let files = fs.readdirSync(libFolderPath);
+
+        files.forEach(file => {
+            if (path.extname(file) === ".md") {
+                let relPath = libFolderPath.substr(libFolderPath.indexOf("docs") + 5).replace(/\\/, "/") + "/" + file;
+                let compName = path.basename(file, ".md");
+                aggData.docFiles[compName] = relPath;
+            }
+        });
+    });
+}
+
+export function readPhase(tree, pathname, aggData) {}
+
+
+export function aggPhase(aggData) {
+
+}
+
+
+export function updatePhase(tree, pathname, aggData) {
+    traverseMDTree(tree);
+    return true;
+
+
+    function traverseMDTree(node) {
+        if (!includedNodeTypes.includes(node.type)) {
+            return;
+        }
+    
+        if (node.type === "inlineCode") {
+            let possClassName = cleanClassName(node.value);
+            let ref: DeclarationReflection = aggData.projData.findReflectionByName(possClassName);
+
+            if (ref && isLinkable(ref.kind)) {
+                let kebabName = ngHelpers.kebabifyClassName(possClassName);
+                console.log(kebabName);
+                let possDocFile = aggData.docFiles[kebabName];
+                let url = "../../lib/" + ref.sources[0].fileName;
+                
+                if (possDocFile) {
+                    url = "../" + possDocFile;
+                }
+
+                convertNodeToTypeLink(node, node.value, url);
+            }
+            
+        } else if (node.type === "link") {
+            if (node.children && (
+                (node.children[0].type === "inlineCode") ||
+                (node.children[0].type === "text")
+            )) {
+                let possClassName = cleanClassName(node.children[0].value);
+                let ref: DeclarationReflection = aggData.projData.findReflectionByName(possClassName);
+
+                if (ref && isLinkable(ref.kind)) {
+                    let kebabName = ngHelpers.kebabifyClassName(possClassName);
+                    console.log(kebabName);
+                    let possDocFile = aggData.docFiles[kebabName];
+                    let url = "../../lib/" + ref.sources[0].fileName;
+                    
+                    if (possDocFile) {
+                        url = "../" + possDocFile;
+                    }
+
+                    convertNodeToTypeLink(node, node.children[0].value, url);
+                }
+            }
+        } else if (node.children) {
+            node.children.forEach(element => {
+                traverseMDTree(element);
+            });
+        }
+    }
+}
+
+
+function cleanClassName(text) {
+    let matches = text.match(/[a-zA-Z0-9_]+<([a-zA-Z0-9_]+)>/);
+
+    if (matches) {
+        return matches[1];
+    } else {
+        return text;
+    }
+}
+
+
+function isLinkable(kind: ReflectionKind) {
+    return (kind === ReflectionKind.Class) ||
+    (kind === ReflectionKind.Interface) ||
+    (kind === ReflectionKind.Enum);
+}
+
+function convertNodeToTypeLink(node, text, url) {
+    let linkDisplayText = unist.makeInlineCode(text);
+    node.type = "link";
+    node.url = url;
+    node.children = [linkDisplayText];
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [x] Documentation
> - [ ] Other... Please describe:

**What is the new behaviour?**

Added a tool to find type names in Markdown files and convert them into links. The links point to the source file where the type is defined or to a doc file if one is available. For components, the tool can also handle English names (eg, "Document List Component" is treated the same as the class name "DocumentListComponent").

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
