### PR TITLE
[ADF-2788] Task filter input preselect

### DIFF
--- a/demo-shell/src/app/components/process-service/process-service.component.html
+++ b/demo-shell/src/app/components/process-service/process-service.component.html
@@ -20,6 +20,7 @@
                                 [filterParam]="{name:'MY tasks'}"
                                 [appId]="appId"
                                 [hasIcon]="false"
+                                [landingFilterId]="7"
                                 (filterClick)="onTaskFilterClick($event)"
                                 (success)="onSuccessTaskFilterList($event)"
                                 #activitifilter>

--- a/docs/process-services/task-filters.component.md
+++ b/docs/process-services/task-filters.component.md
@@ -20,6 +20,7 @@ Shows all available filters.
 | appId | `number` |  | Display filters available to the current user for the application with the specified ID.  |
 | appName | `string` |  | Display filters available to the current user for the application with the specified name.  |
 | hasIcon | `boolean` | `true` | Toggles display of the filter's icon.  |
+| landingFilterId | `number` | | Define which filter id should be selected after reloading. If the filter id doesn't exist or nothing is passed then the first filter will be selected.  |
 
 ### Events
 

--- a/lib/process-services/task-list/components/task-filters.component.spec.ts
+++ b/lib/process-services/task-list/components/task-filters.component.spec.ts
@@ -48,6 +48,8 @@ describe('TaskFiltersComponent', () => {
         filter: { state: 'open', assignment: 'fake-assignee' }
     }));
 
+    let fakeLandingFilterId = 11;
+
     let fakeGlobalFilterPromise = new Promise(function (resolve, reject) {
         resolve(fakeGlobalFilter);
     });
@@ -293,6 +295,14 @@ describe('TaskFiltersComponent', () => {
         component.ngOnChanges({ 'appName': change });
 
         expect(component.getFiltersByAppId).toHaveBeenCalled();
+    });
+
+    fit('should select the current task filter comes from @Input', () => {
+        component.landingFilterId = fakeLandingFilterId;
+        component.filters = fakeGlobalFilter;
+        component.selectDefaultTaskFilter();
+
+        expect(component.getCurrentFilter()).toBe(fakeGlobalFilter[1]);
     });
 
     it('should not change the current filter if no filter with taskid is found', async(() => {

--- a/lib/process-services/task-list/components/task-filters.component.spec.ts
+++ b/lib/process-services/task-list/components/task-filters.component.spec.ts
@@ -297,7 +297,7 @@ describe('TaskFiltersComponent', () => {
         expect(component.getFiltersByAppId).toHaveBeenCalled();
     });
 
-    fit('should select the current task filter comes from @Input', () => {
+    it('should select the current task filter comes from @Input', () => {
         component.landingFilterId = fakeLandingFilterId;
         component.filters = fakeGlobalFilter;
         component.selectDefaultTaskFilter();

--- a/lib/process-services/task-list/components/task-filters.component.ts
+++ b/lib/process-services/task-list/components/task-filters.component.ts
@@ -56,6 +56,12 @@ export class TaskFiltersComponent implements OnInit, OnChanges {
     @Input()
     appName: string;
 
+    /** Define which filter id should be selected after reloading. If the filter id doesn't
+     * exist or nothing is passed then the first filter will be selected.
+     */
+    @Input()
+    landingFilterId: number;
+
     /** Toggles display of the filter's icon. */
     @Input()
     hasIcon: boolean = true;
@@ -74,6 +80,10 @@ export class TaskFiltersComponent implements OnInit, OnChanges {
     ngOnInit() {
         this.filter$.subscribe((filter: FilterRepresentationModel) => {
             this.filters.push(filter);
+            if (filter.id === this.landingFilterId) {
+                console.log(filter);
+                this.currentFilter = filter;
+            }
         });
     }
 
@@ -132,8 +142,9 @@ export class TaskFiltersComponent implements OnInit, OnChanges {
                     res.forEach((filter) => {
                         this.filterObserver.next(filter);
                     });
-
-                    this.selectTaskFilter(this.filterParam, this.filters);
+                    if (!this.currentFilter) {
+                        this.selectTaskFilter(this.filterParam, this.filters);
+                    }
                     this.success.emit(res);
                 }
             },
@@ -210,7 +221,7 @@ export class TaskFiltersComponent implements OnInit, OnChanges {
      */
     public selectDefaultTaskFilter(filteredFilterList: FilterRepresentationModel[]) {
         if (!this.isFilterListEmpty()) {
-            this.currentFilter = this.filters[0];
+            this.currentFilter = this.filters.find((filter) => filter.id === this.landingFilterId );
         }
     }
 

--- a/lib/process-services/task-list/components/task-filters.component.ts
+++ b/lib/process-services/task-list/components/task-filters.component.ts
@@ -81,7 +81,6 @@ export class TaskFiltersComponent implements OnInit, OnChanges {
         this.filter$.subscribe((filter: FilterRepresentationModel) => {
             this.filters.push(filter);
             if (filter.id === this.landingFilterId) {
-                console.log(filter);
                 this.currentFilter = filter;
             }
         });
@@ -212,16 +211,16 @@ export class TaskFiltersComponent implements OnInit, OnChanges {
         if (findTaskFilter) {
             this.currentFilter = findTaskFilter;
         } else {
-             this.selectDefaultTaskFilter(filteredFilterList);
+             this.selectDefaultTaskFilter();
         }
     }
 
     /**
      * Select as default task filter the first in the list
      */
-    public selectDefaultTaskFilter(filteredFilterList: FilterRepresentationModel[]) {
+    public selectDefaultTaskFilter() {
         if (!this.isFilterListEmpty()) {
-            this.currentFilter = this.filters.find((filter) => filter.id === this.landingFilterId );
+            this.currentFilter = this.landingFilterId ? this.filters.find((filter) => filter.id === this.landingFilterId ) : this.filters[0];
         }
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [X] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [X] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
The task filter doesn't provide any way to preselect a filterId.
https://issues.alfresco.com/jira/browse/ADF-2788


**What is the new behaviour?**
Now, the task filter can be preselect by a filterId.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
