### PR TITLE
[ADF-2739] Long names in breadcrumb fixed

### DIFF
--- a/lib/content-services/breadcrumb/breadcrumb.component.scss
+++ b/lib/content-services/breadcrumb/breadcrumb.component.scss
@@ -38,6 +38,7 @@ $breadcrumb-chevron-spacer: 2px;
             &:hover,
             &.active {
                 opacity: 1;
+                width: 100%;
             }
 
             &.active {
@@ -72,6 +73,11 @@ $breadcrumb-chevron-spacer: 2px;
 
             &.active {
                 display: block;
+            }
+
+            &-current {
+                text-overflow: ellipsis;
+                overflow: hidden;
             }
         }
     }

--- a/lib/core/datatable/components/datatable/datatable.component.scss
+++ b/lib/core/datatable/components/datatable/datatable.component.scss
@@ -394,6 +394,7 @@
         .ellipsis-cell {
             .cell-container {
                 height: 100%;
+                display: inline-grid;
             }
 
             .cell-container > * {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Table not displaying content properly when name of files or folders are too long.


**What is the new behaviour?**
Now all files and folders with long names wrap to keep the table proportions


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
