### PR TITLE
[ADF-2760] Toolbar and datatable background colours fixed

### DIFF
--- a/demo-shell/src/custom-style.scss
+++ b/demo-shell/src/custom-style.scss
@@ -24,7 +24,6 @@ $theme:   mat-light-theme($primary, $accent, $warn);
 @include adf-login-component-theme($theme);
 @include adf-process-service-component-theme($theme);
 
-
 @include adf-content-services-theme($theme);
 @include adf-process-services-theme($theme);
 @include adf-insights-theme($theme);

--- a/lib/core/datatable/components/datatable/datatable.component.scss
+++ b/lib/core/datatable/components/datatable/datatable.component.scss
@@ -170,6 +170,7 @@
         border-collapse: collapse;
         white-space: nowrap;
         font-size: $data-table-font-size;
+        background-color: mat-color($background, card);
 
         /* Firefox fixes */
         border-collapse: unset;

--- a/lib/core/datatable/components/datatable/datatable.component.scss
+++ b/lib/core/datatable/components/datatable/datatable.component.scss
@@ -1,7 +1,6 @@
 @mixin adf-datatable-theme($theme) {
     $foreground: map-get($theme, foreground);
     $background: map-get($theme, background);
-    //$custom-background: map-get($theme, custom-background);
     $primary: map-get($theme, primary);
 
     $data-table-font-size: 14px !default;

--- a/lib/core/datatable/components/datatable/datatable.component.scss
+++ b/lib/core/datatable/components/datatable/datatable.component.scss
@@ -170,7 +170,7 @@
         border-collapse: collapse;
         white-space: nowrap;
         font-size: $data-table-font-size;
-        background-color: $datatable-background;
+        background-color: mat-color($background, card);
 
         /* Firefox fixes */
         border-collapse: unset;

--- a/lib/core/datatable/components/datatable/datatable.component.scss
+++ b/lib/core/datatable/components/datatable/datatable.component.scss
@@ -1,6 +1,7 @@
 @mixin adf-datatable-theme($theme) {
     $foreground: map-get($theme, foreground);
     $background: map-get($theme, background);
+    //$custom-background: map-get($theme, custom-background);
     $primary: map-get($theme, primary);
 
     $data-table-font-size: 14px !default;
@@ -170,7 +171,7 @@
         border-collapse: collapse;
         white-space: nowrap;
         font-size: $data-table-font-size;
-        background-color: mat-color($background, card);
+        background-color: $datatable-background;
 
         /* Firefox fixes */
         border-collapse: unset;

--- a/lib/core/styles/_variables.scss
+++ b/lib/core/styles/_variables.scss
@@ -6,3 +6,6 @@ $animation-curve-default: $animation-curve-fast-out-slow-in !default;
 
 $swift-ease-in-duration: 300ms !default;
 $swift-ease-in-timing-function: cubic-bezier(0.55, 0, 0.55, 0.2) !default;
+
+$datatable-background: #ffffff;
+$toolbar-background: #f5f5f5;

--- a/lib/core/styles/_variables.scss
+++ b/lib/core/styles/_variables.scss
@@ -6,6 +6,3 @@ $animation-curve-default: $animation-curve-fast-out-slow-in !default;
 
 $swift-ease-in-duration: 300ms !default;
 $swift-ease-in-timing-function: cubic-bezier(0.55, 0, 0.55, 0.2) !default;
-
-$datatable-background: #ffffff;
-$toolbar-background: #f5f5f5;

--- a/lib/core/toolbar/toolbar.component.scss
+++ b/lib/core/toolbar/toolbar.component.scss
@@ -1,6 +1,7 @@
 
 @mixin adf-toolbar-theme($theme) {
     $foreground: map-get($theme, foreground);
+    $background: map-get($theme, background);
     $adf-toolbar-height: 48px;
     $adf-toolbar-font-size: 14px;
 
@@ -17,6 +18,7 @@
         .mat-toolbar {
             min-height: $adf-toolbar-height;
             border: 1px solid mat-color($foreground, text, .07);
+            background-color: mat-color($background, 'hover')
         }
 
         .mat-toolbar-row {

--- a/lib/core/toolbar/toolbar.component.scss
+++ b/lib/core/toolbar/toolbar.component.scss
@@ -1,7 +1,6 @@
 
 @mixin adf-toolbar-theme($theme) {
     $foreground: map-get($theme, foreground);
-    $background: map-get($theme, background);
     $adf-toolbar-height: 48px;
     $adf-toolbar-font-size: 14px;
 
@@ -18,7 +17,7 @@
         .mat-toolbar {
             min-height: $adf-toolbar-height;
             border: 1px solid mat-color($foreground, text, .07);
-            background-color: mat-color($background, 'hover')
+            background-color: $toolbar-background;
         }
 
         .mat-toolbar-row {

--- a/lib/core/toolbar/toolbar.component.scss
+++ b/lib/core/toolbar/toolbar.component.scss
@@ -1,6 +1,7 @@
 
 @mixin adf-toolbar-theme($theme) {
     $foreground: map-get($theme, foreground);
+    $background: map-get($theme, background);
     $adf-toolbar-height: 48px;
     $adf-toolbar-font-size: 14px;
 
@@ -17,7 +18,7 @@
         .mat-toolbar {
             min-height: $adf-toolbar-height;
             border: 1px solid mat-color($foreground, text, .07);
-            background-color: $toolbar-background;
+            background-color: mat-color($background, hover, .02);
         }
 
         .mat-toolbar-row {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
These components had a wrong background colour.


**What is the new behaviour?**
Following UI instructions these components have got new colours using Material Theming


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
