### PR TITLE
[ADF-2847] Added class members heading to core docs

### DIFF
--- a/docs/core/accordion-group.component.md
+++ b/docs/core/accordion-group.component.md
@@ -33,6 +33,8 @@ export class MyComponent implements OnInit {
 }
 ```
 
+## Class members
+
 ### Properties
 
 | Name | Type | Default value | Description |

--- a/docs/core/alfresco-content.service.md
+++ b/docs/core/alfresco-content.service.md
@@ -6,7 +6,9 @@ Status: Active
 
 Gets URLs and access info and creates folders in Content Services.
 
-## Methods
+## Class members
+
+### Methods
 
 `getDocumentThumbnailUrl(nodeId: any, attachment?: boolean, ticket?: string): string`<br/>
 Gets a thumbnail URL for a node.

--- a/docs/core/bpm-user.service.md
+++ b/docs/core/bpm-user.service.md
@@ -6,7 +6,9 @@ Status: Active
 
 Gets information about the current Process Services user.
 
-## Methods
+## Class members
+
+### Methods
 
 `getCurrentUserInfo(): Observable<BpmUserModel>`<br/>
 Gets information about the current user.

--- a/docs/core/card-view.component.md
+++ b/docs/core/card-view.component.md
@@ -17,6 +17,8 @@ Displays a configurable property list renderer.
 </adf-card-view>
 ```
 
+## Class members
+
 ### Properties
 
 | Name | Type | Default | Description |

--- a/docs/core/comment-list.component.md
+++ b/docs/core/comment-list.component.md
@@ -56,6 +56,8 @@ In the component template use the comment list component:
 </adf-comment-list>
 ```
 
+## Class members
+
 ### Properties
 
 | Name | Type | Default value | Description |

--- a/docs/core/comments.component.md
+++ b/docs/core/comments.component.md
@@ -26,6 +26,8 @@ Displays comments from users involved in a specified task or content and allows 
 </adf-comments>
 ```
 
+## Class members
+
 ### Properties
 
 | Name | Type | Default value | Description |

--- a/docs/core/content.service.md
+++ b/docs/core/content.service.md
@@ -8,7 +8,9 @@ Last reviewed: 2018-04-13
 
 Accesses app-generated data objects via URLs and file downloads.
 
-## Methods
+## Class members
+
+### Methods
 
 -   `downloadBlob(blob: Blob, fileName: string)`  
     Invokes content download for a Blob with a file name.  

--- a/docs/core/datatable.component.md
+++ b/docs/core/datatable.component.md
@@ -123,6 +123,8 @@ export class DataTableDemo {
 }
 ```
 
+## Class members
+
 ### Properties
 
 | Name | Type | Default value | Description |

--- a/docs/core/favorites-api.service.md
+++ b/docs/core/favorites-api.service.md
@@ -6,7 +6,9 @@ Status: Active
 
 Gets a list of items a user has marked as their favorites.
 
-## Methods
+## Class members
+
+### Methods
 
 `getFavorites(personId: string, options?: any): Observable<NodePaging>`<br/>
 Gets the favorites for a user.

--- a/docs/core/form-field.component.md
+++ b/docs/core/form-field.component.md
@@ -18,6 +18,8 @@ that takes an instance of a `FormFieldModel`:
 This component depends on the `FormRenderingService` to map the `FormFieldModel` to a Form Field UI component
 based on the field type or the metadata information.
 
+## Class members
+
 ### Properties
 
 | Name | Type | Default value | Description |

--- a/docs/core/form-list.component.md
+++ b/docs/core/form-list.component.md
@@ -14,6 +14,8 @@ Shows APS forms as a list.
 </adf-form-list>
 ```
 
+## Class members
+
 ### Properties
 
 | Name | Type | Default value | Description |

--- a/docs/core/form-rendering.service.md
+++ b/docs/core/form-rendering.service.md
@@ -6,7 +6,9 @@ Status: Active
 
 Maps an APS form field type string onto the corresponding form widget component type.
 
-## Methods
+## Class members
+
+### Methods
 
 -   `getComponentTypeResolver(type: string, defaultValue: Type<{}> = this.defaultValue): DynamicComponentResolveFunction`  
     Gets the currently active ComponentTypeResolver function for a field type.  

--- a/docs/core/form.component.md
+++ b/docs/core/form.component.md
@@ -35,6 +35,8 @@ Shows a Form from APS
 </adf-form>
 ```
 
+## Class members
+
 ### Properties
 
 | Name | Type | Default value | Description |

--- a/docs/core/highlight-transform.service.md
+++ b/docs/core/highlight-transform.service.md
@@ -6,7 +6,9 @@ Status: Active
 
 Adds HTML to a string to highlight chosen sections.
 
-## Methods
+## Class members
+
+### Methods
 
 -   `highlight(text: string, search: string, wrapperClass: string = 'highlight'): HightlightTransformResult`  
     Searches for `search` string(s) within `text` and highlights all occurrences.  

--- a/docs/core/host-settings.component.md
+++ b/docs/core/host-settings.component.md
@@ -15,6 +15,8 @@ Validates the URLs for ACS and APS and saves them in the user's local storage
 </adf-breadcrumb>
 ```
 
+## Class members
+
 ### Properties
 
 | Name | Type | Default value | Description |


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [x] Documentation
> - [ ] Other... Please describe:

**What is the new behaviour?**

Another attempt to add the Class Members headings into some of the core docs.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
