### PR TITLE
[ADF-2892] Sidenav now prevents closing itself when ESC key is pressed

### DIFF
--- a/lib/core/sidenav-layout/components/layout-container/layout-container.component.html
+++ b/lib/core/sidenav-layout/components/layout-container/layout-container.component.html
@@ -1,6 +1,6 @@
 <mat-sidenav-container>
     <mat-sidenav
-        [disableClose]="false"
+        [disableClose]="!isMobileScreenSize"
         [ngClass]="{ 'sidenav--hidden': hideSidenav }"
         [@sidenavAnimation]="sidenavAnimationState"
         [opened]="!isMobileScreenSize"

--- a/lib/core/sidenav-layout/components/layout-container/layout-container.component.html
+++ b/lib/core/sidenav-layout/components/layout-container/layout-container.component.html
@@ -1,6 +1,6 @@
 <mat-sidenav-container>
     <mat-sidenav
-        [disableClose]="true"
+        [disableClose]="false"
         [ngClass]="{ 'sidenav--hidden': hideSidenav }"
         [@sidenavAnimation]="sidenavAnimationState"
         [opened]="!isMobileScreenSize"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Sidenav closes on desktop size screen when ESC key is pressed. It also doesn't close when clicking outside the sidenav on Mobile size screen. 

**What is the new behaviour?**
Sidenav does not close on desktop size screen when ESC key is pressed. It also does close when clicking outside the sidenav on Mobile size screen. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
