### PR TITLE
[ADF-2888] UX doesn't respect the Sidenav specifiactions

### DIFF
--- a/demo-shell/src/app/components/process-service/process-service.component.html
+++ b/demo-shell/src/app/components/process-service/process-service.component.html
@@ -4,7 +4,7 @@
             <div class="adf-grid" fxLayout="row" fxLayout.lt-lg="column" fxLayoutAlign="stretch">
                 <div class="adf-grid-item adf-tasks-menu" fxFlex.gt-md="225px">
                     <div class="adf-list-buttons">
-                        <adf-sidebar-action-menu [expanded]="true" [width]="202" title="{{'ADF_SIDEBAR_ACTION_MENU.BUTTON.CREATE' | translate}}">
+                        <adf-sidebar-action-menu [expanded]="true" [width]="205" title="{{'ADF_SIDEBAR_ACTION_MENU.BUTTON.CREATE' | translate}}">
                             <mat-icon sidebar-menu-title-icon >arrow_drop_down</mat-icon>
                                 <div sidebar-menu-options>
                                     <button mat-menu-item data-automation-id="btn-start-task" (click)="navigateStartTask()">

--- a/demo-shell/src/app/components/process-service/process-service.component.html
+++ b/demo-shell/src/app/components/process-service/process-service.component.html
@@ -4,7 +4,7 @@
             <div class="adf-grid" fxLayout="row" fxLayout.lt-lg="column" fxLayoutAlign="stretch">
                 <div class="adf-grid-item adf-tasks-menu" fxFlex.gt-md="225px">
                     <div class="adf-list-buttons">
-                        <adf-sidebar-action-menu [expanded]="true" title="{{'ADF_SIDEBAR_ACTION_MENU.BUTTON.CREATE' | translate}}">
+                        <adf-sidebar-action-menu [expanded]="true" [width]="202" title="{{'ADF_SIDEBAR_ACTION_MENU.BUTTON.CREATE' | translate}}">
                             <mat-icon sidebar-menu-title-icon >arrow_drop_down</mat-icon>
                                 <div sidebar-menu-options>
                                     <button mat-menu-item data-automation-id="btn-start-task" (click)="navigateStartTask()">

--- a/docs/core/sidebar-action-menu.component.md
+++ b/docs/core/sidebar-action-menu.component.md
@@ -34,6 +34,7 @@ Displays a sidebar-action menu information panel.
 | ---- | ---- | ------------- | ----------- |
 | title | `string` |  | The title of the sidebar action.  |
 | expanded | `boolean` |  | Toggle the sidebar action menu on expand.  |
+| width | `number` |  | Width in pixels for sidebar action menu options  |
 
 ## Details
 

--- a/docs/core/sidebar-action-menu.component.md
+++ b/docs/core/sidebar-action-menu.component.md
@@ -34,7 +34,7 @@ Displays a sidebar-action menu information panel.
 | ---- | ---- | ------------- | ----------- |
 | title | `string` |  | The title of the sidebar action.  |
 | expanded | `boolean` |  | Toggle the sidebar action menu on expand.  |
-| width | `number` |  | Width in pixels for sidebar action menu options  |
+| width | `number` | 272 | Width in pixels for sidebar action menu options  |
 
 ## Details
 

--- a/lib/core/sidebar/sidebar-action-menu.component.html
+++ b/lib/core/sidebar/sidebar-action-menu.component.html
@@ -9,7 +9,7 @@
     </div>
 
     <mat-menu #adfSidebarMenu="matMenu" class="adf-sidebar-action-menu-panel" [overlapTrigger]="false" yPosition="below">
-        <div class="adf-sidebar-action-menu-options">
+        <div class="adf-sidebar-action-menu-options" [style.width.px]="width">
             <ng-content select="[sidebar-menu-options]"></ng-content>
         </div>
     </mat-menu>

--- a/lib/core/sidebar/sidebar-action-menu.component.scss
+++ b/lib/core/sidebar/sidebar-action-menu.component.scss
@@ -4,7 +4,6 @@
     $foreground: map-get($theme, foreground);
 
     $adf-sidebar-action-menu-button-height: 37.5px;
-    $adf-sidebar-action-menu-panel-width: 202px;
     $adf-sidebar-action-menu-button-border-radius: 4px;
     $adf-sidebar-action-menu-opacity: 0.54;
     $adf-sidebar-action-menu-item-opacity: 0.87;
@@ -59,7 +58,6 @@
             margin-top: 7.5px;
             border-radius: 2px;
             box-shadow: #{map-get($_umbra-elevation-map, 2)}, #{map-get($_penumbra-elevation-map, 2)},#{map-get($_ambient-elevation-map, 2)};
-            min-width: $adf-sidebar-action-menu-panel-width !important;
         }
     }
 }

--- a/lib/core/sidebar/sidebar-action-menu.component.scss
+++ b/lib/core/sidebar/sidebar-action-menu.component.scss
@@ -8,6 +8,7 @@
     $adf-sidebar-action-menu-opacity: 0.54;
     $adf-sidebar-action-menu-item-opacity: 0.87;
     $adf-sidebar-action-menu-item-line-spacing: -0.4px;
+    $adf-sidebar-action-menu-item-font-size: 14px;
 
     .adf {
         &-sidebar-action-menu {
@@ -44,6 +45,7 @@
             text-align: left;
             letter-spacing: $adf-sidebar-action-menu-item-line-spacing;
             .mat-menu-item {
+                font-size: $adf-sidebar-action-menu-item-font-size;
                 color: mat-color($foreground, text, $adf-sidebar-action-menu-item-opacity);
                 text-align: left;
                 line-height: 1.5;

--- a/lib/core/sidebar/sidebar-action-menu.component.ts
+++ b/lib/core/sidebar/sidebar-action-menu.component.ts
@@ -37,7 +37,7 @@ export class SidebarActionMenuComponent {
     expanded: boolean;
 
     @Input()
-    width: number;
+    width: number = 272;
 
     isExpanded(): boolean {
         return this.expanded;

--- a/lib/core/sidebar/sidebar-action-menu.component.ts
+++ b/lib/core/sidebar/sidebar-action-menu.component.ts
@@ -36,6 +36,9 @@ export class SidebarActionMenuComponent {
     @Input()
     expanded: boolean;
 
+    @Input()
+    width: number;
+
     isExpanded(): boolean {
         return this.expanded;
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

* https://issues.alfresco.com/jira/browse/ADF-2888
* Width for sidebar-action-menu-options was hardcoded.

**What is the new behaviour?**

 * Now the width for sidebar-action-menu-options is passed as an Input property to adf-sidebar-action-menu component.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
