### PR TITLE
[ADF-2978] added a check when locally set permission is undefined

### DIFF
--- a/lib/content-services/permission-manager/services/node-permission.service.ts
+++ b/lib/content-services/permission-manager/services/node-permission.service.ts
@@ -94,12 +94,14 @@ export class NodePermissionService {
 
     private getDuplicatedPermissions(nodeLocallySet: PermissionElement[], permissionListAdded: PermissionElement[]): PermissionElement[] {
         let duplicatePermissions: PermissionElement[] = [];
-        permissionListAdded.forEach((permission: PermissionElement) => {
-            const duplicate = nodeLocallySet.find((localPermission) => this.isEqualPermission(localPermission, permission));
-            if (duplicate) {
-                duplicatePermissions.push(duplicate);
-            }
-        });
+        if (nodeLocallySet) {
+            permissionListAdded.forEach((permission: PermissionElement) => {
+                const duplicate = nodeLocallySet.find((localPermission) => this.isEqualPermission(localPermission, permission));
+                if (duplicate) {
+                    duplicatePermissions.push(duplicate);
+                }
+            });
+        }
         return duplicatePermissions;
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
It is not possibile add a new locally set permission


**What is the new behaviour?**
Is possibile again.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
