### PR TITLE
[ADF-2891] decoupled search service love

### DIFF
--- a/demo-shell/src/app/components/search/search-result.component.html
+++ b/demo-shell/src/app/components/search/search-result.component.html
@@ -3,7 +3,7 @@
             [maxResults]="maxItems"
             [skipResults]="skipCount"
             (resultLoaded)="onSearchResultLoaded($event)"
-            #search>
+            #searchResult>
 </adf-search>
 
 <div class="adf-search-results__facets">

--- a/demo-shell/src/app/components/search/search-result.component.ts
+++ b/demo-shell/src/app/components/search/search-result.component.ts
@@ -19,17 +19,18 @@ import { Component, OnInit, Optional, ViewChild } from '@angular/core';
 import { Router, ActivatedRoute, Params } from '@angular/router';
 import { NodePaging, Pagination } from 'alfresco-js-api';
 import { SearchComponent, SearchQueryBuilderService } from '@alfresco/adf-content-services';
-import { UserPreferencesService } from '@alfresco/adf-core';
+import { UserPreferencesService, SearchService } from '@alfresco/adf-core';
 
 @Component({
     selector: 'app-search-result-component',
     templateUrl: './search-result.component.html',
-    styleUrls: ['./search-result.component.scss']
+    styleUrls: ['./search-result.component.scss'],
+    providers: [SearchService]
 })
 export class SearchResultComponent implements OnInit {
 
-    @ViewChild('search')
-    search: SearchComponent;
+    @ViewChild('searchResult')
+    searchResult: SearchComponent;
 
     queryParamName = 'q';
     searchedWord = '';
@@ -76,6 +77,6 @@ export class SearchResultComponent implements OnInit {
     }
 
     onDeleteElementSuccess(element: any) {
-        this.search.reload();
+        this.searchResult.reload();
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Search service mess up with the new search result page


**What is the new behaviour?**
search-result has it's own instance of search service.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
