### PR TITLE
[ADF-2912] group everyone is always visible even for no search result

### DIFF
--- a/lib/content-services/permission-manager/components/add-permission/add-permission-panel.component.html
+++ b/lib/content-services/permission-manager/components/add-permission/add-permission-panel.component.html
@@ -29,7 +29,19 @@
         class="adf-permission-result-list"
         *ngIf="searchedWord.length !== 0">
 <ng-template let-data>
-    <mat-selection-list [class.adf-permission-result-list-elements]="data?.list?.entries.length !== 0">
+    <mat-selection-list class="adf-permission-result-list-elements">
+        <mat-list-option
+            id="adf-add-permission-group-everyone"
+            class="adf-list-option-item"
+            (click)="elementClicked(EVERYONE)">
+            <mat-icon mat-list-icon id="add-group-icon">
+                group_add
+            </mat-icon>
+            <p>
+                {{'PERMISSION_MANAGER.ADD-PERMISSION.EVERYONE' | translate}}
+            </p>
+        </mat-list-option>
+
         <mat-list-option *ngFor="let item of data?.list?.entries; let idx = index"
                             (click)="elementClicked(item)"
                             class="adf-list-option-item"
@@ -46,20 +58,6 @@
                                     item.entry?.properties['cm:authorityName'] :
                                     item.entry?.properties['cm:firstName']}}</p>
         </mat-list-option>
-        <mat-list-option *ngIf="data?.list?.entries.length !== 0"
-                    id="adf-add-permission-group-everyone"
-                    class="adf-list-option-item"
-                    (click)="elementClicked(EVERYONE)">
-            <mat-icon mat-list-icon id="add-group-icon">
-                group_add
-            </mat-icon>
-            <p>
-                {{'PERMISSION_MANAGER.ADD-PERMISSION.EVERYONE' | translate}}
-            </p>
-        </mat-list-option>
     </mat-selection-list>
-    <div *ngIf="data?.list?.entries.length === 0" class="adf-permission-no-result" id="adf-add-permission-no-results">
-        <span>{{'PERMISSION_MANAGER.ADD-PERMISSION.NO-RESULT' | translate}}</span>
-    </div>
 </ng-template>
 </adf-search>

--- a/lib/content-services/permission-manager/components/add-permission/add-permission-panel.component.spec.ts
+++ b/lib/content-services/permission-manager/components/add-permission/add-permission-panel.component.spec.ts
@@ -172,4 +172,19 @@ describe('AddPermissionPanelComponent', () => {
         });
     }));
 
+    it('should show everyone group when search return no result', async(() => {
+        searchApiService = fixture.componentRef.injector.get(SearchService);
+        spyOn(searchApiService, 'search').and.returnValue(Observable.of({ list: { entries: [] } }));
+        component.selectedItems.push(fakeAuthorityListResult.list.entries[0]);
+
+        typeWordIntoSearchInput('a');
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+            fixture.detectChanges();
+            expect(element.querySelector('#adf-add-permission-authority-results')).not.toBeNull();
+            expect(element.querySelector('#adf-add-permission-group-everyone')).toBeDefined();
+            expect(element.querySelector('#adf-add-permission-group-everyone')).not.toBeNull();
+        });
+    }));
+
 });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [X] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Group everyone is showed only when there are result


**What is the new behaviour?**
Group everyone is always showed


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
