### PR TITLE
[ADF-1938] Long names at reports section now fit

### DIFF
--- a/lib/core/form/components/widgets/container/container.widget.scss
+++ b/lib/core/form/components/widgets/container/container.widget.scss
@@ -89,7 +89,6 @@
 
         .mat-grid-tile {
             overflow: visible;
-            width: 80%;
         }
 
     }

--- a/lib/core/form/components/widgets/container/container.widget.scss
+++ b/lib/core/form/components/widgets/container/container.widget.scss
@@ -89,6 +89,7 @@
 
         .mat-grid-tile {
             overflow: visible;
+            width: 80%;
         }
 
     }

--- a/lib/insights/analytics-process/components/analytics-report-list.component.scss
+++ b/lib/insights/analytics-process/components/analytics-report-list.component.scss
@@ -8,6 +8,8 @@
 
         .activiti-filters__entry {
             cursor: pointer;
+            width: inherit;
+            display: grid !important;
         }
 
         .activiti-filters__entry-icon {
@@ -23,6 +25,7 @@
 
         .mat-nav-list .mat-list-item .mat-list-item-content {
             line-height: 48px;
+            overflow: hidden;
         }
 
         .activiti-filters__entry.active {

--- a/lib/insights/analytics-process/components/analytics-report-list.component.scss
+++ b/lib/insights/analytics-process/components/analytics-report-list.component.scss
@@ -18,6 +18,7 @@
         .activiti-filters__label {
             white-space: nowrap;
             overflow: hidden;
+            text-overflow: ellipsis;
         }
 
         .mat-nav-list .mat-list-item .mat-list-item-content {

--- a/lib/insights/analytics-process/components/analytics-report-parameters.component.html
+++ b/lib/insights/analytics-process/components/analytics-report-parameters.component.html
@@ -20,9 +20,10 @@
                                 />
                             </mat-form-field>
                         </div>
-                        <div class="adf-report-title" *ngIf="!isEditable" (click)="editEnable()">
+                        <div class="adf-report-title" *ngIf="!isEditable" (click)="editEnable()" 
+                            fxFlex="600px" fxFlex.xs="300px" fxFlex.sm="350px" fxFlex.md="400px">
                             <mat-icon class="adf-report-icon" >mode_edit</mat-icon>
-                            <h4>{{reportParameters.name}}</h4>
+                            <h4 class="adf-report-title-name">{{reportParameters.name}}</h4>
                         </div>
                     </adf-toolbar-title> 
                     <adf-buttons-action-menu *ngIf="!isEditable"

--- a/lib/insights/analytics-process/components/analytics-report-parameters.component.scss
+++ b/lib/insights/analytics-process/components/analytics-report-parameters.component.scss
@@ -26,15 +26,15 @@
     }
 
     .adf-edit-report-title {
-        float: left;
-        font-size: 20px!important;
+        font-size: 20px !important;
         padding-top: 19px;
+        display: flex;
     }
 
     .adf-report-icon {
-        float: left;
         padding: 5px 5px 0 0;
         visibility: hidden;
+        display: flex;
     }
 
     .adf-report-title-container {
@@ -50,6 +50,12 @@
 
     .adf-report-title {
         padding-top: 10px;
+        display: flex;
+        
+        &-name {
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
     }
 
     .adf-full-width-input {

--- a/lib/insights/analytics-process/components/widgets/checkbox/checkbox.widget.html
+++ b/lib/insights/analytics-process/components/widgets/checkbox/checkbox.widget.html
@@ -1,5 +1,6 @@
 <div [formGroup]="formGroup">
         <mat-checkbox
+        class="adf-checkbox"
         color="primary"
         formControlName="{{controllerName}}"
         [id]="field.id"

--- a/lib/insights/analytics-process/components/widgets/checkbox/checkbox.widget.scss
+++ b/lib/insights/analytics-process/components/widgets/checkbox/checkbox.widget.scss
@@ -1,0 +1,3 @@
+.adf-checkbox .mat-checkbox-layout {
+    white-space: normal;
+}

--- a/lib/insights/analytics-process/components/widgets/checkbox/checkbox.widget.ts
+++ b/lib/insights/analytics-process/components/widgets/checkbox/checkbox.widget.ts
@@ -24,6 +24,7 @@
  @Component({
     selector: 'analytics-checkbox-widget',
     templateUrl: './checkbox.widget.html',
+    styleUrls: ['./checkbox.widget.scss'],
     encapsulation: ViewEncapsulation.None
 })
 export class CheckboxWidgetAanalyticsComponent extends WidgetComponent {

--- a/lib/insights/analytics-process/components/widgets/date-range/date-range.widget.html
+++ b/lib/insights/analytics-process/components/widgets/date-range/date-range.widget.html
@@ -9,9 +9,10 @@
 
             <mat-grid-list cols="2" rowHeight="80px">
                 <mat-grid-tile>
-                    <mat-form-field>
+                    <mat-form-field class="adf-form-field">
                         <input
                             matInput
+                            class="adf-date-input"
                             [min]="minDate"
                             [max]="maxDate"
                             formControlName="startDate"
@@ -30,9 +31,10 @@
                     </mat-datepicker>
                 </mat-grid-tile>
                 <mat-grid-tile>
-                    <mat-form-field>
+                    <mat-form-field class="adf-form-field">
                         <input
                             matInput
+                            class="adf-date-input"
                             [min]="minDate"
                             [max]="maxDate"
                             formControlName="endDate"

--- a/lib/insights/analytics-process/components/widgets/date-range/date-range.widget.scss
+++ b/lib/insights/analytics-process/components/widgets/date-range/date-range.widget.scss
@@ -7,9 +7,9 @@
             color: mat-color($warn);
         }
 
-        &-date-input {
+        &-date-input.mat-input-element{
             text-align: left; 
-            padding-left: 10px;  
+            padding-left: 15px;  
         }
 
         &-form-field {

--- a/lib/insights/analytics-process/components/widgets/date-range/date-range.widget.scss
+++ b/lib/insights/analytics-process/components/widgets/date-range/date-range.widget.scss
@@ -1,7 +1,19 @@
 @mixin adf-analytics-date-range-widget-theme($theme) {
     $warn: map-get($theme, warn);
 
-    .adf-date-range-analytics-text-danger {
-        color: mat-color($warn);
-    }
+    .adf{
+        
+        &-date-range-analytics-text-danger {
+            color: mat-color($warn);
+        }
+
+        &-date-input {
+            text-align: left; 
+            padding-left: 10px;  
+        }
+
+        &-form-field {
+            width: 180px;
+        }
+    }   
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Long names overflow at reports section overflow and push the limits of the layout and the buttons menu


**What is the new behaviour?**
They fit  the available space


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
