### PR TITLE
[ADF-2985] Login - Only the username form control should be emitted by executeSubmit event

### DIFF
--- a/lib/core/login/components/login.component.spec.ts
+++ b/lib/core/login/components/login.component.spec.ts
@@ -571,4 +571,16 @@ describe('LoginComponent', () => {
 
         loginWithCredentials('fake-username', 'fake-password', null);
     }));
+
+    it('should emit only the username and not the password as part of the executeSubmit', async(() => {
+        component.executeSubmit.subscribe((res) => {
+            fixture.detectChanges();
+
+            expect(res.values.controls.username).toBeDefined('username mandatory');
+            expect(res.values.controls.username.value).toEqual('fake-username');
+            expect(res.values.controls.password).toBeUndefined('The password not not be part of the emitted values');
+        });
+
+        loginWithCredentials('fake-username', 'fake-password');
+    }));
 });

--- a/lib/core/login/components/login.component.ts
+++ b/lib/core/login/components/login.component.ts
@@ -174,8 +174,7 @@ export class LoginComponent implements OnInit {
         this.settingsService.csrfDisabled = this.disableCsrf;
 
         this.disableError();
-
-        const args = new LoginSubmitEvent(this.form);
+        const args = new LoginSubmitEvent({controls : { username : this.form.controls.username} });
         this.executeSubmit.emit(args);
 
         if (args.defaultPrevented) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
the event emit the password value too


**What is the new behaviour?**
only the username is emitted


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-2985