### PR TITLE
[ADF-3028] i18n support for title service

### DIFF
--- a/demo-shell/src/app/app.component.ts
+++ b/demo-shell/src/app/app.component.ts
@@ -16,7 +16,7 @@
  */
 
 import { Component, ViewEncapsulation, OnInit } from '@angular/core';
-import { SettingsService, PageTitleService, StorageService, TranslationService } from '@alfresco/adf-core';
+import { SettingsService, PageTitleService, StorageService } from '@alfresco/adf-core';
 
 @Component({
   selector: 'app-root',

--- a/demo-shell/src/app/app.component.ts
+++ b/demo-shell/src/app/app.component.ts
@@ -15,8 +15,7 @@
  * limitations under the License.
  */
 
-import { Component, ViewEncapsulation } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { Component, ViewEncapsulation, OnInit } from '@angular/core';
 import { SettingsService, PageTitleService, StorageService, TranslationService } from '@alfresco/adf-core';
 
 @Component({
@@ -25,15 +24,17 @@ import { SettingsService, PageTitleService, StorageService, TranslationService }
   styleUrls: ['./app.component.scss'],
   encapsulation: ViewEncapsulation.None
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
 
-  constructor(private settingsService: SettingsService,
-              private storage: StorageService,
-              translationService: TranslationService,
-              pageTitleService: PageTitleService,
-              route: ActivatedRoute) {
+    constructor(private settingsService: SettingsService,
+                private storage: StorageService,
+                private pageTitleService: PageTitleService) {
+    }
+
+  ngOnInit() {
     this.setProvider();
-    pageTitleService.setTitle();
+
+    this.pageTitleService.setTitle('title');
   }
 
   private setProvider() {

--- a/lib/content-services/upload/components/base-upload/upload-base.spec.ts
+++ b/lib/content-services/upload/components/base-upload/upload-base.spec.ts
@@ -26,7 +26,6 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
     selector: 'adf-upload-button-test',
     template: 'test componente'
 })
-
 export class UploadTestComponent extends UploadBase {
 
     constructor(protected uploadService: UploadService,
@@ -234,7 +233,7 @@ describe('UploadBase', () => {
             addToQueueSpy = spyOn(uploadService, 'addToQueue');
         });
 
-        it('should be a mahor version upload if majorVersion is true', () => {
+        it('should be a major version upload if majorVersion is true', () => {
             component.majorVersion = true;
             component.versioning = true;
 
@@ -250,7 +249,7 @@ describe('UploadBase', () => {
             }));
         });
 
-        it('should not  be a mahor version upload if majorVersion is false', () => {
+        it('should not  be a major version upload if majorVersion is false', () => {
             component.majorVersion = false;
             component.versioning = true;
 

--- a/lib/content-services/upload/components/upload-button.component.spec.ts
+++ b/lib/content-services/upload/components/upload-button.component.spec.ts
@@ -20,7 +20,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ContentService, UploadService, TranslationService, setupTestBed, CoreModule } from '@alfresco/adf-core';
 import { Observable } from 'rxjs/Observable';
 import { UploadButtonComponent } from './upload-button.component';
-import { TranslationMock, PermissionsEnum } from '@alfresco/adf-core';
+import { TranslationMock } from '@alfresco/adf-core';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('UploadButtonComponent', () => {

--- a/lib/core/mock/translation.service.mock.ts
+++ b/lib/core/mock/translation.service.mock.ts
@@ -28,9 +28,9 @@ export class TranslationMock {
     defaultLang: string = 'en';
     userLang: string;
     customLoader: any;
-    translate: any;
-
-    onLangChange: EventEmitter<LangChangeEvent> = new EventEmitter<LangChangeEvent>();
+    translate = {
+        onLangChange: new EventEmitter<LangChangeEvent>()
+    };
 
     addTranslationFolder() {
 

--- a/lib/core/services/page-title.service.spec.ts
+++ b/lib/core/services/page-title.service.spec.ts
@@ -117,7 +117,7 @@ describe('AppTitle service', () => {
         appTitleService.setTitle('key');
         expect(titleService.setTitle).toHaveBeenCalledWith('hello - My application');
 
-        (<any>titleService).setTitle.calls.reset();
+        (<any> titleService).setTitle.calls.reset();
 
         translationService.translate.onLangChange.next(<any> {});
         expect(titleService.setTitle).toHaveBeenCalledWith('привет - My application');

--- a/lib/core/services/page-title.service.ts
+++ b/lib/core/services/page-title.service.ts
@@ -18,22 +18,41 @@
 import { Injectable } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { AppConfigService } from '../app-config/app-config.service';
+import { TranslationService } from './translation.service';
 
 @Injectable()
 export class PageTitleService {
 
+    private originalTitle: string = '';
+    private translatedTitle: string = '';
+
     constructor(
         private titleService: Title,
-        private appConfig: AppConfigService) {}
+        private appConfig: AppConfigService,
+        private translationService: TranslationService) {
+        translationService.translate.onLangChange.subscribe(() => this.onLanguageChanged());
+    }
 
     /**
      * Sets the page title.
      * @param value The new title
      */
     setTitle(value: string = '') {
-        const name = this.appConfig.get('application.name') || 'Alfresco ADF Application';
-        const title = value ? `${value} - ${name}` : `${name}`;
+        this.originalTitle = value;
+        this.translatedTitle = this.translationService.instant(value);
 
+        this.updateTitle();
+    }
+
+    private onLanguageChanged() {
+        this.translatedTitle = this.translationService.instant(this.originalTitle);
+        this.updateTitle();
+    }
+
+    private updateTitle() {
+        const name = this.appConfig.get('application.name') || 'Alfresco ADF Application';
+
+        const title = this.translatedTitle ? `${this.translatedTitle} - ${name}` : `${name}`;
         this.titleService.setTitle(title);
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

- allows using i18n resource keys as page titles
- watches and updates page title once language changes

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
