### PR TITLE
[ADF-2979] Updated doc tools to avoid erasing MD docs with blank JSDocs in services

### DIFF
--- a/tools/doc/doctool.config.json
+++ b/tools/doc/doctool.config.json
@@ -17,8 +17,7 @@
             "toc"
         ],
         "dev": [
-            "tsInfo",
-            "typeLinker"
+            "tsInfo"
         ]
     }
 }

--- a/tools/doc/mdNav.js
+++ b/tools/doc/mdNav.js
@@ -26,6 +26,13 @@ var MDNav = /** @class */ (function () {
         }
         return new MDNav(this.root, this.root.children.length);
     };
+    MDNav.prototype.emphasis = function (test, index) {
+        if (test === void 0) { test = function () { return true; }; }
+        if (index === void 0) { index = 0; }
+        return this.find(function (h) {
+            return h.type === "emphasis" && test(h);
+        }, index);
+    };
     MDNav.prototype.heading = function (test, index) {
         if (test === void 0) { test = function () { return true; }; }
         if (index === void 0) { index = 0; }
@@ -33,18 +40,46 @@ var MDNav = /** @class */ (function () {
             return h.type === "heading" && test(h);
         }, index);
     };
+    MDNav.prototype.html = function (test, index) {
+        if (test === void 0) { test = function () { return true; }; }
+        if (index === void 0) { index = 0; }
+        return this.find(function (h) {
+            return h.type === "html" && test(h);
+        }, index);
+    };
+    MDNav.prototype.list = function (test, index) {
+        if (test === void 0) { test = function () { return true; }; }
+        if (index === void 0) { index = 0; }
+        return this.find(function (h) {
+            return h.type === "list" && test(h);
+        }, index);
+    };
+    MDNav.prototype.listItem = function (test, index) {
+        if (test === void 0) { test = function () { return true; }; }
+        if (index === void 0) { index = 0; }
+        return this.find(function (h) {
+            return h.type === "listItem" && test(h);
+        }, index);
+    };
+    MDNav.prototype.paragraph = function (test, index) {
+        if (test === void 0) { test = function () { return true; }; }
+        if (index === void 0) { index = 0; }
+        return this.find(function (h) {
+            return h.type === "paragraph" && test(h);
+        }, index);
+    };
+    MDNav.prototype.strong = function (test, index) {
+        if (test === void 0) { test = function () { return true; }; }
+        if (index === void 0) { index = 0; }
+        return this.find(function (h) {
+            return h.type === "strong" && test(h);
+        }, index);
+    };
     MDNav.prototype.table = function (test, index) {
         if (test === void 0) { test = function () { return true; }; }
         if (index === void 0) { index = 0; }
         return this.find(function (h) {
             return h.type === "table" && test(h);
-        }, index);
-    };
-    MDNav.prototype.text = function (test, index) {
-        if (test === void 0) { test = function () { return true; }; }
-        if (index === void 0) { index = 0; }
-        return this.find(function (h) {
-            return h.type === "text" && test(h);
         }, index);
     };
     MDNav.prototype.tableRow = function (test, index) {
@@ -59,6 +94,13 @@ var MDNav = /** @class */ (function () {
         if (index === void 0) { index = 0; }
         return this.find(function (h) {
             return h.type === "tableCell" && test(h);
+        }, index);
+    };
+    MDNav.prototype.text = function (test, index) {
+        if (test === void 0) { test = function () { return true; }; }
+        if (index === void 0) { index = 0; }
+        return this.find(function (h) {
+            return h.type === "text" && test(h);
         }, index);
     };
     Object.defineProperty(MDNav.prototype, "item", {
@@ -85,6 +127,18 @@ var MDNav = /** @class */ (function () {
     Object.defineProperty(MDNav.prototype, "childNav", {
         get: function () {
             return new MDNav(this.item);
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(MDNav.prototype, "value", {
+        get: function () {
+            if (this.item && this.item["value"]) {
+                return this.item.value;
+            }
+            else {
+                return undefined;
+            }
         },
         enumerable: true,
         configurable: true

--- a/tools/doc/mdNav.js
+++ b/tools/doc/mdNav.js
@@ -26,7 +26,28 @@ var MDNav = /** @class */ (function () {
         }
         return new MDNav(this.root, this.root.children.length);
     };
-    MDNav.prototype.emphasis = function (test, index) {
+    MDNav.prototype.findAll = function (test, index) {
+        if (test === void 0) { test = function () { return true; }; }
+        if (index === void 0) { index = 0; }
+        if (!this.root || !this.root.children) {
+            return [];
+        }
+        var result = [];
+        var currIndex = 0;
+        for (var i = this.pos; i < this.root.children.length; i++) {
+            var child = this.root.children[i];
+            if (test(child)) {
+                if (currIndex === index) {
+                    result.push(new MDNav(this.root, i));
+                }
+                else {
+                    currIndex++;
+                }
+            }
+        }
+        return result;
+    };
+    MDNav.prototype.emph = function (test, index) {
         if (test === void 0) { test = function () { return true; }; }
         if (index === void 0) { index = 0; }
         return this.find(function (h) {
@@ -58,6 +79,13 @@ var MDNav = /** @class */ (function () {
         if (test === void 0) { test = function () { return true; }; }
         if (index === void 0) { index = 0; }
         return this.find(function (h) {
+            return h.type === "listItem" && test(h);
+        }, index);
+    };
+    MDNav.prototype.listItems = function (test, index) {
+        if (test === void 0) { test = function () { return true; }; }
+        if (index === void 0) { index = 0; }
+        return this.findAll(function (h) {
             return h.type === "listItem" && test(h);
         }, index);
     };

--- a/tools/doc/mdNav.ts
+++ b/tools/doc/mdNav.ts
@@ -26,7 +26,32 @@ export class MDNav {
     }
 
 
-    emphasis(test: (element: any) => boolean = () => true, index: number = 0): MDNav {
+    findAll(test: (element: any) => boolean = () => true, index: number = 0): MDNav[] {
+        if (!this.root || !this.root.children) {
+            return [];
+        }
+
+        let result = [];
+
+        let currIndex = 0;
+
+        for (let i = this.pos; i < this.root.children.length; i++) {
+            let child = this.root.children[i];
+
+            if (test(child)) {
+                if (currIndex === index) {
+                    result.push(new MDNav(this.root, i));
+                } else {
+                    currIndex++;
+                }
+            }
+        }
+
+        return result;
+    }
+
+
+    emph(test: (element: any) => boolean = () => true, index: number = 0): MDNav {
         return this.find((h) => {
             return h.type === "emphasis" && test(h);
         }, index);
@@ -60,6 +85,11 @@ export class MDNav {
         }, index);
     }
 
+    listItems(test: (element: any) => boolean = () => true, index: number = 0): MDNav[] {
+        return this.findAll((h) => {
+            return h.type === "listItem" && test(h);
+        }, index);
+    }
 
     paragraph(test: (element: any) => boolean = () => true, index: number = 0): MDNav {
         return this.find((h) => {

--- a/tools/doc/mdNav.ts
+++ b/tools/doc/mdNav.ts
@@ -26,6 +26,13 @@ export class MDNav {
     }
 
 
+    emphasis(test: (element: any) => boolean = () => true, index: number = 0): MDNav {
+        return this.find((h) => {
+            return h.type === "emphasis" && test(h);
+        }, index);
+    }
+
+
     heading(test: (element: any) => boolean = () => true, index: number = 0): MDNav {
         return this.find((h) => {
             return h.type === "heading" && test(h);
@@ -33,16 +40,44 @@ export class MDNav {
     }
 
 
-    table(test: (element: any) => boolean = () => true, index: number = 0): MDNav {
+    html(test: (element: any) => boolean = () => true, index: number = 0): MDNav {
         return this.find((h) => {
-            return h.type === "table" && test(h);
+            return h.type === "html" && test(h);
         }, index);
     }
 
 
-    text(test: (element: any) => boolean = () => true, index: number = 0): MDNav {
+    list(test: (element: any) => boolean = () => true, index: number = 0): MDNav {
         return this.find((h) => {
-            return h.type === "text" && test(h);
+            return h.type === "list" && test(h);
+        }, index);
+    }
+
+
+    listItem(test: (element: any) => boolean = () => true, index: number = 0): MDNav {
+        return this.find((h) => {
+            return h.type === "listItem" && test(h);
+        }, index);
+    }
+
+
+    paragraph(test: (element: any) => boolean = () => true, index: number = 0): MDNav {
+        return this.find((h) => {
+            return h.type === "paragraph" && test(h);
+        }, index);
+    }
+
+
+    strong(test: (element: any) => boolean = () => true, index: number = 0): MDNav {
+        return this.find((h) => {
+            return h.type === "strong" && test(h);
+        }, index);
+    }
+
+
+    table(test: (element: any) => boolean = () => true, index: number = 0): MDNav {
+        return this.find((h) => {
+            return h.type === "table" && test(h);
         }, index);
     }
 
@@ -60,6 +95,14 @@ export class MDNav {
         }, index);
     }
 
+
+    text(test: (element: any) => boolean = () => true, index: number = 0): MDNav {
+        return this.find((h) => {
+            return h.type === "text" && test(h);
+        }, index);
+    }
+
+
     get item(): any {
         if (!this.root || !this.root.children) {
             return undefined;
@@ -75,7 +118,16 @@ export class MDNav {
     }
 
     
-    get childNav() {
+    get childNav(): MDNav {
         return new MDNav(this.item);
+    }
+
+
+    get value(): any {
+        if (this.item && this.item["value"]) {
+            return this.item.value;
+        } else {
+            return undefined;
+        }
     }
 }

--- a/tools/doc/templates/service.combyne
+++ b/tools/doc/templates/service.combyne
@@ -2,10 +2,10 @@
 {% if hasMethods %}
 ### Methods
 
-{% each methods as meth %}- `{{meth.name}}{{{meth.signature}}{% if meth.returnsSomething %}: {{{meth.returnType}}}{% endif %}`<br/>
+{% each methods as meth %}- **{{meth.name}}**{{{meth.signature}}}{% if meth.returnsSomething %}: `{{{meth.returnType}}}`{% endif %}<br/>
   {{meth.docText}}
 {% each meth.params as param %}
-   - `{{{param.combined}}}` - {% if param.isOptional %}(Optional){% endif %}{{{param.docText}}}
+   - *{{{param.name}}}:* `{{{param.type}}}`  - {% if param.isOptional %}(Optional){% endif %}{{{param.docText}}}
 {% endeach %}
 {% if meth.returnsSomething %}
    - **Returns** `{{{meth.returnType}}}` - {{{meth.returnDocText}}}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [x] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Blank JSDocs for methods and params will overwrite valid text in the method table in the Markdown file.

**What is the new behaviour?**

The tool now checks the Markdown and will only overwrite it if the JSDocs are valid. Also warns the user if blank JSDocs are detected for an item that has docs in the Markdown.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
