### PR TITLE
[ADF-3065] TaskList component - Deprecate the processDefinitionKey

### DIFF
--- a/demo-shell/src/app/components/process-service/process-service.component.ts
+++ b/demo-shell/src/app/components/process-service/process-service.component.ts
@@ -50,8 +50,7 @@ import {
     TaskDetailsComponent,
     TaskDetailsEvent,
     TaskFiltersComponent,
-    TaskListComponent,
-    TaskListService
+    TaskListComponent
 } from '@alfresco/adf-process-services';
 import { LogService } from '@alfresco/adf-core';
 import { AlfrescoApiService, UserPreferencesService } from '@alfresco/adf-core';
@@ -157,7 +156,6 @@ export class ProcessServiceComponent implements AfterViewInit, OnDestroy, OnInit
     constructor(private elementRef: ElementRef,
                 private route: ActivatedRoute,
                 private router: Router,
-                private taskListService: TaskListService,
                 private apiService: AlfrescoApiService,
                 private logService: LogService,
                 private appConfig: AppConfigService,
@@ -234,7 +232,6 @@ export class ProcessServiceComponent implements AfterViewInit, OnDestroy, OnInit
 
     ngOnDestroy() {
         this.sub.unsubscribe();
-        this.taskListService.tasksList$.subscribe();
     }
 
     onTaskFilterClick(filter: FilterRepresentationModel): void {

--- a/docs/process-services/task-list.component.md
+++ b/docs/process-services/task-list.component.md
@@ -26,7 +26,7 @@ Renders a list containing all the tasks matched by the parameters specified.
 | ---- | ---- | ------------- | ----------- |
 | appId | `number` |  | The id of the app.  |
 | processInstanceId | `string` |  | The Instance Id of the process.  |
-| processDefinitionKey | `string` |  | The Definition Key of the process.  |
+| processDefinitionKey | `string` |  | The Definition Key of the process.  **Deprecated:** in 2.3.0   |
 | state | `string` |  | Current state of the process. Possible values are: `completed`, `active`.  |
 | assignment | `string` |  | The assignment of the process. Possible values are: "assignee" (the current user is the assignee), candidate (the current user is a task candidate", "group_x" (the task is assigned to a group where the current user is a member, no value(the current user is involved). |
 | sort | `string` |  | Define the sort order of the processes. Possible values are : `created-desc`, `created-asc`, `due-desc`, `due-asc` |

--- a/docs/process-services/task-list.component.md
+++ b/docs/process-services/task-list.component.md
@@ -26,7 +26,7 @@ Renders a list containing all the tasks matched by the parameters specified.
 | ---- | ---- | ------------- | ----------- |
 | appId | `number` |  | The id of the app.  |
 | processInstanceId | `string` |  | The Instance Id of the process.  |
-| processDefinitionKey | `string` |  | The Definition Key of the process.  **Deprecated:** in 2.3.0   |
+| processDefinitionKey | `string` |  | The Definition Key of the process.  **Deprecated:** in 2.4.0   |
 | state | `string` |  | Current state of the process. Possible values are: `completed`, `active`.  |
 | assignment | `string` |  | The assignment of the process. Possible values are: "assignee" (the current user is the assignee), candidate (the current user is a task candidate", "group_x" (the task is assigned to a group where the current user is a member, no value(the current user is involved). |
 | sort | `string` |  | Define the sort order of the processes. Possible values are : `created-desc`, `created-asc`, `due-desc`, `due-asc` |

--- a/lib/process-services/task-list/components/task-list.component.ts
+++ b/lib/process-services/task-list/components/task-list.component.ts
@@ -30,7 +30,6 @@ import { TaskQueryRequestRepresentationModel } from '../models/filter.model';
 import { TaskListModel } from '../models/task-list.model';
 import { taskPresetsDefaultModel } from '../models/task-preset.model';
 import { TaskListService } from './../services/tasklist.service';
-import { deprecate } from 'util';
 
 @Component({
     selector: 'adf-tasklist',

--- a/lib/process-services/task-list/components/task-list.component.ts
+++ b/lib/process-services/task-list/components/task-list.component.ts
@@ -51,7 +51,7 @@ export class TaskListComponent implements OnChanges, AfterContentInit, Paginated
     processInstanceId: string;
 
     /** The Definition Key of the process.
-     * @deprecated
+     * @deprecated 2.4.0
      */
     @Input()
     processDefinitionKey: string;

--- a/lib/process-services/task-list/components/task-list.component.ts
+++ b/lib/process-services/task-list/components/task-list.component.ts
@@ -30,6 +30,7 @@ import { TaskQueryRequestRepresentationModel } from '../models/filter.model';
 import { TaskListModel } from '../models/task-list.model';
 import { taskPresetsDefaultModel } from '../models/task-preset.model';
 import { TaskListService } from './../services/tasklist.service';
+import { deprecate } from 'util';
 
 @Component({
     selector: 'adf-tasklist',
@@ -50,7 +51,9 @@ export class TaskListComponent implements OnChanges, AfterContentInit, Paginated
     @Input()
     processInstanceId: string;
 
-    /** The Definition Key of the process. */
+    /** The Definition Key of the process.
+     * @deprecated
+     */
     @Input()
     processDefinitionKey: string;
 

--- a/lib/process-services/task-list/services/task-filter.service.ts
+++ b/lib/process-services/task-list/services/task-filter.service.ts
@@ -18,20 +18,14 @@
 import { AlfrescoApiService, LogService } from '@alfresco/adf-core';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
-import { Subject } from 'rxjs/Subject';
 import { FilterRepresentationModel } from '../models/filter.model';
-import { TaskListModel } from '../models/task-list.model';
 import 'rxjs/add/observable/throw';
 
 @Injectable()
 export class TaskFilterService {
-    private tasksListSubject = new Subject<TaskListModel>();
-
-    public tasksList$: Observable<TaskListModel>;
 
     constructor(private apiService: AlfrescoApiService,
                 private logService: LogService) {
-        this.tasksList$ = this.tasksListSubject.asObservable();
     }
 
     /**
@@ -216,7 +210,6 @@ export class TaskFilterService {
 
     private handleError(error: any) {
         this.logService.error(error);
-        this.tasksListSubject.error(error);
         return Observable.throw(error || 'Server error');
     }
 

--- a/lib/process-services/task-list/services/tasklist.service.spec.ts
+++ b/lib/process-services/task-list/services/tasklist.service.spec.ts
@@ -76,27 +76,6 @@ describe('Activiti TaskList Service', () => {
             });
         });
 
-        it('should return the task list filtered by processDefinitionKey', (done) => {
-            service.getTasks(<TaskQueryRequestRepresentationModel> fakeFilter).subscribe(res => {
-                expect(res).toBeDefined();
-                expect(res.size).toEqual(2);
-                expect(res.start).toEqual(0);
-                expect(res.data).toBeDefined();
-                expect(res.data.length).toEqual(2);
-                expect(res.data[0].name).toEqual('FakeNameTask');
-                expect(res.data[0].assignee.email).toEqual('fake-email@dom.com');
-                expect(res.data[0].assignee.firstName).toEqual('firstName');
-                expect(res.data[0].assignee.lastName).toEqual('lastName');
-                done();
-            });
-
-            jasmine.Ajax.requests.mostRecent().respondWith({
-                'status': 200,
-                contentType: 'application/json',
-                responseText: JSON.stringify(fakeTaskListDifferentProcessDefinitionKey)
-            });
-        });
-
         it('should return the task list with all tasks filtered by state', (done) => {
             spyOn(service, 'getTasks').and.returnValue(Observable.of(fakeTaskList));
             spyOn(service, 'getTotalTasks').and.returnValue(Observable.of(fakeTaskList));

--- a/lib/process-services/task-list/services/tasklist.service.ts
+++ b/lib/process-services/task-list/services/tasklist.service.ts
@@ -18,7 +18,6 @@
 import { AlfrescoApiService, LogService } from '@alfresco/adf-core';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
-import { Subject } from 'rxjs/Subject';
 import { FilterRepresentationModel, TaskQueryRequestRepresentationModel } from '../models/filter.model';
 import { Form } from '../models/form.model';
 import { TaskDetailsModel } from '../models/task-details.model';
@@ -31,13 +30,9 @@ import 'rxjs/add/observable/from';
 
 @Injectable()
 export class TaskListService {
-    private tasksListSubject = new Subject<TaskListModel>();
-
-    public tasksList$: Observable<TaskListModel>;
 
     constructor(private apiService: AlfrescoApiService,
                 private logService: LogService) {
-        this.tasksList$ = this.tasksListSubject.asObservable();
     }
 
     /**
@@ -88,8 +83,7 @@ export class TaskListService {
      */
     getTasks(requestNode: TaskQueryRequestRepresentationModel): Observable<TaskListModel> {
         return Observable.fromPromise(this.callApiTasksFiltered(requestNode))
-            .map((res: any) => {
-                this.tasksListSubject.next(res);
+            .map((res: TaskListModel) => {
                 return res;
             }).catch(err => this.handleError(err));
     }
@@ -136,7 +130,6 @@ export class TaskListService {
                     const tasks = Object.assign({}, activeTasks);
                     tasks.total += completedTasks.total;
                     tasks.data = tasks.data.concat(completedTasks.data);
-                    this.tasksListSubject.next(tasks);
                     return tasks;
                 }
             );
@@ -374,7 +367,6 @@ export class TaskListService {
 
     private handleError(error: any) {
         this.logService.error(error);
-        this.tasksListSubject.error(error);
         return Observable.throw(error || 'Server error');
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
We have a processDefinitionKey filter property but no code that is filtering the result


**What is the new behaviour?**
processDefinitionKey deprecated


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-3065