### PR TITLE
[ADF-2913] search filter now remembers original user query

### DIFF
--- a/demo-shell/src/app/components/search/search-result.component.ts
+++ b/demo-shell/src/app/components/search/search-result.component.ts
@@ -19,7 +19,7 @@ import { Component, OnInit, Optional, ViewChild } from '@angular/core';
 import { Router, ActivatedRoute, Params } from '@angular/router';
 import { NodePaging, Pagination } from 'alfresco-js-api';
 import { SearchComponent, SearchQueryBuilderService } from '@alfresco/adf-content-services';
-import { UserPreferencesService, SearchService } from '@alfresco/adf-core';
+import { UserPreferencesService, SearchService, SearchConfigurationService } from '@alfresco/adf-core';
 
 @Component({
     selector: 'app-search-result-component',
@@ -44,6 +44,7 @@ export class SearchResultComponent implements OnInit {
     constructor(public router: Router,
                 private preferences: UserPreferencesService,
                 private queryBuilder: SearchQueryBuilderService,
+                private searchConfiguration: SearchConfigurationService,
                 @Optional() private route: ActivatedRoute) {
         this.maxItems = this.preferences.paginationSize;
         queryBuilder.paging = {
@@ -63,8 +64,12 @@ export class SearchResultComponent implements OnInit {
         if (this.route) {
             this.route.params.forEach((params: Params) => {
                 this.searchedWord = params.hasOwnProperty(this.queryParamName) ? params[this.queryParamName] : null;
-                this.queryBuilder.queryFragments['queryName'] = `cm:name:'${this.searchedWord}'`;
-                this.queryBuilder.update();
+                if (this.searchedWord) {
+                    const queryBody = this.searchConfiguration.generateQueryBody(this.searchedWord, 0, 100);
+
+                    this.queryBuilder.userQuery = queryBody.query.query;
+                    this.queryBuilder.update();
+                }
             });
         }
     }

--- a/lib/content-services/search/search-query-builder.service.spec.ts
+++ b/lib/content-services/search/search-query-builder.service.spec.ts
@@ -27,6 +27,23 @@ describe('SearchQueryBuilder', () => {
         return config;
     };
 
+    it('should have empty user query by default', () => {
+        const builder = new SearchQueryBuilderService(buildConfig({}), null);
+        expect(builder.userQuery).toBe('');
+    });
+
+    it('should wrap user query with brackets', () => {
+        const builder = new SearchQueryBuilderService(buildConfig({}), null);
+        builder.userQuery = 'my query';
+        expect(builder.userQuery).toEqual('(my query)');
+    });
+
+    it('should trim user query value', () => {
+        const builder = new SearchQueryBuilderService(buildConfig({}), null);
+        builder.userQuery = ' something   ';
+        expect(builder.userQuery).toEqual('(something)');
+    });
+
     it('should use only enabled categories', () => {
         const config: SearchConfiguration = {
             categories: [
@@ -361,6 +378,21 @@ describe('SearchQueryBuilder', () => {
             maxItems: 5,
             skipCount: 5
         });
+    });
+
+    it('should build final request with user and custom queries', () => {
+        const config: SearchConfiguration = {
+            categories: [
+                <any> { id: 'cat1', enabled: true }
+            ]
+        };
+        const builder = new SearchQueryBuilderService(buildConfig(config), null);
+        builder.userQuery = 'my query';
+
+        builder.queryFragments['cat1'] = 'cm:name:test';
+
+        const compiled = builder.buildQuery();
+        expect(compiled.query.query).toBe('(my query) AND (cm:name:test)');
     });
 
 });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

- fixes [ADF-2913](https://issues.alfresco.com/jira/browse/ADF-2913): Search Filter does not preserve original query

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
