### PR TITLE
[ADF-3087] Clarified section about adding/replacing keys in i18n guide

### DIFF
--- a/docs/core/translation.service.md
+++ b/docs/core/translation.service.md
@@ -70,7 +70,7 @@ general format of the path to this folder will be:
 
 `<app>/src/assets/my-translations/i18n`
 
-If you wanted English and French translations then you would copy the built-in
+If you wanted English and French translations then you would add
 `en.json` and `fr.json` files into the `i18n` folder and add your new keys:
 
     // en.json
@@ -83,6 +83,22 @@ If you wanted English and French translations then you would copy the built-in
         ...
       "WELCOME_MESSAGE": "Bienvenue !"
         ...
+
+The files follow the same hierarchical key:value JSON format as the built-in translations.
+You can add new keys to your local files or redefine existing keys but the built-in definitions
+will be used for any keys you don't explicitly define in your files. For example, `en.json` might
+look like the following:
+
+```json
+{
+  "title": "my app",
+  "LOGIN": {
+     "LABEL": {
+        "LOGIN": "Custom Sign In"
+     }
+  }
+}
+```
 
 To enable the new translations in your app, you also need to register them in your
 `app.module.ts` file. Import `TRANSLATION_PROVIDER` and add the path of your
@@ -127,10 +143,6 @@ ngOnInit() {
   }
   ...
 ```
-
-The new translation files completely replace the built-in ones.
-If you want to continue using the built-in keys then you must add your new
-keys to copies of the existing files.
 
 Note: the `source` property points to the web application root. Ensure you have
 webpack correctly set up to copy all the i18n files at compile time.

--- a/docs/user-guide/internationalization.md
+++ b/docs/user-guide/internationalization.md
@@ -155,14 +155,28 @@ The built-in translations certainly won't cover everything you will need for
 your app but you can easily replace them with your own lists. This enables you
 to add new keys and also replace the text of existing keys with your own.
 
-To override the default translations, you need to copy the existing source files
-(en.json, fr.json, etc) to your application. These local copies will completely
-replace the default files. You can then modify the local files with new keys
-or replace the text of existing keys to suit your needs.
+To modify the default translations, you need to create local translation source files
+(en.json, fr.json, etc) within your application. The local files have the same basic
+hierarchical key:value structure as the built-in translations. You can add new keys to
+your local files to extend the default set or override a default translation by redefining
+an existing key with new message text. The default translations will be used for any keys
+that you don't explicitly override. For example, your local `en.json` might look like the
+following:
+
+```json
+{
+  "title": "my app",
+  "LOGIN": {
+     "LABEL": {
+        "LOGIN": "Custom Sign In"
+     }
+  }
+}
+```
 
 The [Translation service](../core/translation.service.md) page has full details
-of how to do this, including the locations of the required files and code samples
-for enabling your new translations in your app.
+of how to add custom translations, including the locations of the required files
+and code samples for enabling the new translations in your app.
 
 ## Interpolations
 

--- a/docs/user-guide/internationalization.md
+++ b/docs/user-guide/internationalization.md
@@ -14,7 +14,7 @@ fairly straightforward to maintain.
 -   [I18n concepts](#i18n-concepts)
 -   [ADF support for i18n](#adf-support-for-i18n)
 -   [Using the translate pipe](#using-the-translate-pipe)
--   [Adding your own messages](#adding-your-own-messages)
+-   [Adding and replacing messages](#adding-and-replacing-messages)
 -   [Interpolations](#interpolations)
 -   [Selecting the display language](#selecting-the-display-language)
 -   [Support for i18n within ADF components](#support-for-i18n-within-adf-components)
@@ -149,13 +149,20 @@ component's `.ts` file:
 
 <!-- {% endraw %} -->
 
-## Adding your own messages
+## Adding and replacing messages
 
 The built-in translations certainly won't cover everything you will need for
-your app but you can easily replace them with your own lists. This involves
-making copies of the existing lists in your app's folder and adding your
-own keys. See the [Translation service](../core/translation.service.md) page for
-full details and examples.
+your app but you can easily replace them with your own lists. This enables you
+to add new keys and also replace the text of existing keys with your own.
+
+To override the default translations, you need to copy the existing source files
+(en.json, fr.json, etc) to your application. These local copies will completely
+replace the default files. You can then modify the local files with new keys
+or replace the text of existing keys to suit your needs.
+
+The [Translation service](../core/translation.service.md) page has full details
+of how to do this, including the locations of the required files and code samples
+for enabling your new translations in your app.
 
 ## Interpolations
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [x] Documentation
> - [ ] Other... Please describe:

**What is the new behaviour?**

It turned out that the procedure for registering new translation files and keys was quite well explained in the Translation service page already, but the i18n page didn't really draw attention to it properly. I've clarified that section to make it more obvious what the task is and where you can find the information.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
