### PR TITLE
[ADF-3042] Use the custom date adapter from adf-core on Search Date Range widget

### DIFF
--- a/lib/content-services/search/components/search-date-range/search-date-range.component.html
+++ b/lib/content-services/search/components/search-date-range/search-date-range.component.html
@@ -7,13 +7,13 @@
                 (focusout)="onChangedHandler($event, from)">
         <mat-datepicker-toggle matSuffix [for]="fromDatepicker"></mat-datepicker-toggle>
         <mat-datepicker #fromDatepicker></mat-datepicker>
-        <mat-error *ngIf="from.hasError('required') && !from.hasError('matDatepickerParse')">
+        <mat-error *ngIf="from.hasError('required') && !hasParseError(from)">
             {{ 'SEARCH.FILTER.VALIDATION.REQUIRED-VALUE' | translate }}
         </mat-error>
         <mat-error *ngIf="from.hasError('matDatepickerMax')">
             {{ 'SEARCH.FILTER.VALIDATION.BEYOND-MAX-DATE' | translate }}
         </mat-error>
-        <mat-error *ngIf="from.hasError('matDatepickerParse')">
+        <mat-error *ngIf="hasParseError(from)">
             {{ 'SEARCH.FILTER.VALIDATION.INVALID-DATE' | translate: { requiredFormat: datePickerDateFormat } }}
         </mat-error>
     </mat-form-field>
@@ -27,7 +27,7 @@
                 (focusout)="onChangedHandler($event, to)">
         <mat-datepicker-toggle matSuffix [for]="toDatepicker"></mat-datepicker-toggle>
         <mat-datepicker #toDatepicker></mat-datepicker>
-        <mat-error *ngIf="to.hasError('required') && !to.hasError('matDatepickerParse')">
+        <mat-error *ngIf="to.hasError('required') && !hasParseError(to)">
                 {{ 'SEARCH.FILTER.VALIDATION.REQUIRED-VALUE' | translate }}
         </mat-error>
         <mat-error *ngIf="to.hasError('matDatepickerMin')">
@@ -36,7 +36,7 @@
         <mat-error *ngIf="to.hasError('matDatepickerMax')">
             {{ 'SEARCH.FILTER.VALIDATION.BEYOND-MAX-DATE' | translate }}
         </mat-error>
-        <mat-error *ngIf="to.hasError('matDatepickerParse')">
+        <mat-error *ngIf="hasParseError(to)">
             {{ 'SEARCH.FILTER.VALIDATION.INVALID-DATE' | translate: { requiredFormat: datePickerDateFormat } }}
         </mat-error>
     </mat-form-field>

--- a/lib/content-services/search/components/search-date-range/search-date-range.component.spec.ts
+++ b/lib/content-services/search/components/search-date-range/search-date-range.component.spec.ts
@@ -15,11 +15,11 @@
  * limitations under the License.
  */
 
-import { CustomMomentDateAdapter, SearchDateRangeComponent } from './search-date-range.component';
+import { SearchDateRangeComponent } from './search-date-range.component';
 import { Observable } from 'rxjs/Observable';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ContentTestingModule } from '../../../testing/content.testing.module';
-import { setupTestBed } from '@alfresco/adf-core';
+import { setupTestBed, MomentDateAdapter } from '@alfresco/adf-core';
 import { By } from '@angular/platform-browser';
 import { TranslateService } from '@ngx-translate/core';
 
@@ -34,9 +34,9 @@ describe('SearchDateRangeComponent', () => {
         const localeFixture = 'it';
         const dateFormatFixture = 'DD-MMM-YY';
 
-        const buildAdapter = (): CustomMomentDateAdapter => {
-            const dateAdapter = new CustomMomentDateAdapter(null);
-            dateAdapter.customDateFormat = null;
+        const buildAdapter = (): MomentDateAdapter => {
+            const dateAdapter = new MomentDateAdapter();
+            dateAdapter.overrideDisplyaFormat = null;
             return dateAdapter;
         };
 
@@ -72,14 +72,14 @@ describe('SearchDateRangeComponent', () => {
         it('should setup the format of the date from configuration', () => {
             component.settings = {field: 'cm:created', dateFormat: dateFormatFixture};
             component.ngOnInit();
-            expect(theDateAdapter.customDateFormat).toBe(dateFormatFixture);
+            expect(theDateAdapter.overrideDisplyaFormat).toBe(dateFormatFixture);
         });
 
         it('should setup form control with formatted valid date on change', () => {
             component.settings = {field: 'cm:created', dateFormat: dateFormatFixture};
             component.ngOnInit();
 
-            const inputString = '20.feb.18';
+            const inputString = '20-feb-18';
             const momentFromInput = moment(inputString, dateFormatFixture);
             expect(momentFromInput.isValid()).toBeTruthy();
 


### PR DESCRIPTION
-fix localization
-fix tests
-show parse error

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe:
We must use the custom moment data adapter from adf-core because the behavior on date input has to be the same in all ADF.

**What is the current behaviour?** (You can also link to an open issue here)
Please see https://issues.alfresco.com/jira/browse/ADF-3042 
Initially Search Date Widget used the `MomentDateAdapter` from `@angular/material-moment-adapter`.

**What is the new behaviour?**
Use the custom `MomentDateAdapter` from `@alfresco/adf-core`.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
