### PR TITLE
[ADF-3068] ADF Sidenav/Toolbar - Ux background colour review

### DIFF
--- a/lib/core/sidenav-layout/components/layout-container/layout-container.component.scss
+++ b/lib/core/sidenav-layout/components/layout-container/layout-container.component.scss
@@ -1,4 +1,5 @@
 @mixin adf-layout-container-theme($theme) {
+    $background: map-get($theme, background);
     $foreground: map-get($theme, foreground);
 
     adf-layout-container {
@@ -32,6 +33,7 @@
     .mat-sidenav {
         overflow: hidden;
         border-right: 1px solid mat-color($foreground, text, 0.07);
+        background-color: mat-color($background,background);
     }
 
     mat-sidenav-content {

--- a/lib/core/toolbar/toolbar.component.scss
+++ b/lib/core/toolbar/toolbar.component.scss
@@ -18,7 +18,7 @@
         .mat-toolbar {
             min-height: $adf-toolbar-height;
             border: 1px solid mat-color($foreground, text, .07);
-            background-color: mat-color($background, hover, .02);
+            background-color: mat-color($background, app-bar);
         }
 
         .mat-toolbar-row {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
* https://issues.alfresco.com/jira/browse/ADF-3068


**What is the new behaviour?**
* Sidebar background returns fafafa color.
* Toolbar background returns f5f5f5 color.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
