### PR TITLE
[ADF-3095] ability to intercept, pause and resume upload process

### DIFF
--- a/demo-shell/resources/i18n/en.json
+++ b/demo-shell/resources/i18n/en.json
@@ -12,7 +12,8 @@
       "ALLOW_DOWNLOAD" :"Enable version download",
       "READ_ONLY" : "Read only"
     },
-    "PERSONAL-FILES": "Personal Files"
+    "PERSONAL-FILES": "Personal Files",
+    "WARN-MULTIPLE-UPLOADS": "Warn on multiple uploads"
   },
     "title": "Welcome",
     "VERSION": {

--- a/demo-shell/src/app/components/files/files.component.html
+++ b/demo-shell/src/app/components/files/files.component.html
@@ -39,7 +39,8 @@
                               [rootFolderId]="getDocumentListCurrentFolderId()"
                               [versioning]="versioning"
                               [adf-node-permission]="'create'"
-                              [adf-nodes]="disableDragArea ? getCurrentDocumentListNode() : []">
+                              [adf-nodes]="disableDragArea ? getCurrentDocumentListNode() : []"
+                              (beginUpload)="onBeginUpload($event)">
             <div *ngIf="errorMessage" class="error-message">
                 <button (click)="resetError()" mat-icon-button>
                     <mat-icon>highlight_off</mat-icon>

--- a/demo-shell/src/app/components/files/files.component.html
+++ b/demo-shell/src/app/components/files/files.component.html
@@ -501,6 +501,12 @@
             </mat-slide-toggle>
         </section>
 
+        <section>
+            <mat-slide-toggle color="primary" [(ngModel)]="warnOnMultipleUploads">
+                {{'APP.WARN-MULTIPLE-UPLOADS' | translate}}
+            </mat-slide-toggle>
+        </section>
+
         <h5>Upload</h5>
         <section *ngIf="acceptedFilesTypeShow">
             <mat-form-field floatPlaceholder="float">

--- a/demo-shell/src/app/components/files/files.component.ts
+++ b/demo-shell/src/app/components/files/files.component.ts
@@ -31,7 +31,7 @@ import {
     PaginationComponent, FormValues, DisplayMode, UserPreferenceValues, InfinitePaginationComponent
 } from '@alfresco/adf-core';
 
-import { DocumentListComponent, PermissionStyleModel, UploadFilesEvent } from '@alfresco/adf-content-services';
+import { DocumentListComponent, PermissionStyleModel, UploadFilesEvent, ConfirmDialogComponent } from '@alfresco/adf-content-services';
 
 import { SelectAppsDialogComponent } from '@alfresco/adf-process-services';
 
@@ -515,6 +515,25 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
     }
 
     onBeginUpload(event: UploadFilesEvent) {
-        console.log(event);
+        if (event) {
+            const files = event.files || [];
+            if (files.length > 2) {
+                event.pauseUpload();
+
+                const dialogRef = this.dialog.open(ConfirmDialogComponent, {
+                    data: {
+                        title: 'Upload',
+                        message: `Are you sure you want to upload ${files.length} file(s)?`
+                    },
+                    minWidth: '250px'
+                });
+
+                dialogRef.afterClosed().subscribe(result => {
+                    if (result === true) {
+                        event.resumeUpload();
+                    }
+                });
+            }
+        }
     }
 }

--- a/demo-shell/src/app/components/files/files.component.ts
+++ b/demo-shell/src/app/components/files/files.component.ts
@@ -31,7 +31,7 @@ import {
     PaginationComponent, FormValues, DisplayMode, UserPreferenceValues, InfinitePaginationComponent
 } from '@alfresco/adf-core';
 
-import { DocumentListComponent, PermissionStyleModel } from '@alfresco/adf-content-services';
+import { DocumentListComponent, PermissionStyleModel, UploadFilesEvent } from '@alfresco/adf-content-services';
 
 import { SelectAppsDialogComponent } from '@alfresco/adf-process-services';
 
@@ -512,5 +512,9 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
             return true;
         }
         return false;
+    }
+
+    onBeginUpload(event: UploadFilesEvent) {
+        console.log(event);
     }
 }

--- a/demo-shell/src/app/components/files/files.component.ts
+++ b/demo-shell/src/app/components/files/files.component.ts
@@ -177,6 +177,7 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
     infiniteScrolling: boolean;
     supportedPages: number[];
     currentSiteid = '';
+    warnOnMultipleUploads = false;
 
     private onCreateFolder: Subscription;
     private onEditFolder: Subscription;
@@ -515,9 +516,9 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
     }
 
     onBeginUpload(event: UploadFilesEvent) {
-        if (event) {
+        if (this.warnOnMultipleUploads && event) {
             const files = event.files || [];
-            if (files.length > 2) {
+            if (files.length > 1) {
                 event.pauseUpload();
 
                 const dialogRef = this.dialog.open(ConfirmDialogComponent, {

--- a/docs/content-services/upload-drag-area.component.md
+++ b/docs/content-services/upload-drag-area.component.md
@@ -51,8 +51,8 @@ export class AppComponent {
 | --- | --- | --- |
 | beginUpload | `EventEmitter<UploadFilesEvent>()` | Raised after files or folders dropped and before the upload process starts. |
 | createFolder | `EventEmitter<Object>` | **Deprecated:** No longer used by the framework |
-| error | `EventEmitter<Object>` | **Deprecated:** 2.4.0 2.4.0 Use UploadService.fileUploadError instead |
-| success | `EventEmitter<Object>` | **Deprecated:** 2.4.0 2.4.0 Use UploadService.fileUploadComplete instead |
+| error | `EventEmitter<Object>` | Emitted when the file is uploaded successfully. |
+| success | `EventEmitter<Object>` | Emitted when an error occurs. |
 
 ## Intercepting uploads
 

--- a/docs/content-services/upload-drag-area.component.md
+++ b/docs/content-services/upload-drag-area.component.md
@@ -48,7 +48,64 @@ export class AppComponent {
 ### Events
 
 | Name | Type | Description |
-| -- | -- | -- |
-| createFolder | `EventEmitter<Object>` | Emitted when a folder is created. |
-| error | `EventEmitter<Object>` | Emitted when an error occurs. |
-| success | `EventEmitter<Object>` | Emitted when the file is uploaded successfully. |
+| --- | --- | --- |
+| beginUpload | `EventEmitter<UploadFilesEvent>()` | Raised after files or folders dropped and before the upload process starts. |
+| createFolder | `EventEmitter<Object>` | **Deprecated:** No longer used by the framework |
+| error | `EventEmitter<Object>` | **Deprecated:** 2.4.0 2.4.0 Use UploadService.fileUploadError instead |
+| success | `EventEmitter<Object>` | **Deprecated:** 2.4.0 2.4.0 Use UploadService.fileUploadComplete instead |
+
+## Intercepting uploads
+
+You can intercept the upload process by utilizing the `beginUpload` event. 
+
+The event has a type of `UploadFilesEvent` and provides the following APIs:
+
+* **files**: get access to the FileInfo objects that are prepared for the upload
+* **pauseUpload**: pause the upload and perform additional tasks, like showing the confirmation dialog
+* **resumeUpload**: resume the upload process
+
+## Example
+
+Wire the `beginUpload` event at the template level
+
+```html
+<adf-upload-drag-area (beginUpload)="onBeginUpload($event)" ...>
+    ...
+</adf-upload-drag-area>
+```
+
+Create the `onBeginUpload` handler that invokes a confirmation dialog
+
+```ts
+import { UploadFilesEvent, ConfirmDialogComponent } from '@alfresco/adf-content-services';
+
+@Component({...})
+export class MyComponent {
+
+    onBeginUpload(event: UploadFilesEvent) {
+        const files = event.files || [];
+
+        if (files.length > 1) {
+            event.pauseUpload();
+
+            const dialogRef = this.dialog.open(ConfirmDialogComponent, {
+                data: {
+                    title: 'Upload',
+                    message: `Are you sure you want to upload ${files.length} file(s)?`
+                },
+                minWidth: '250px'
+            });
+
+            dialogRef.afterClosed().subscribe(result => {
+                if (result === true) {
+                    event.resumeUpload();
+                }
+            });
+        }
+    }
+
+}
+```
+
+The example above is going to raise confirmation dialog every time a user uploads more than 1 file.
+That can be either 2 or more files, or a folder with multiple entries.

--- a/lib/content-services/upload/components/base-upload/upload-base.spec.ts
+++ b/lib/content-services/upload/components/base-upload/upload-base.spec.ts
@@ -16,11 +16,12 @@
  */
 
 import { Component, NgZone } from '@angular/core';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { TranslationService, UploadService, setupTestBed, CoreModule, FileModel } from '@alfresco/adf-core';
 import { UploadBase } from './upload-base';
 import { TranslationMock } from '@alfresco/adf-core';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { UploadFilesEvent } from '../upload-files.event';
 
 @Component({
     selector: 'adf-upload-button-test',
@@ -66,6 +67,66 @@ describe('UploadBase', () => {
     afterEach(() => {
         fixture.destroy();
         TestBed.resetTestingModule();
+    });
+
+    describe('beginUpload', () => {
+
+        it('should raise event', done => {
+            spyOn(uploadService, 'addToQueue').and.stub();
+            spyOn(uploadService, 'uploadFilesInTheQueue').and.stub();
+
+            component.beginUpload.subscribe(() => done());
+            const file = <File> { name: 'bigFile.png', size: 1000 };
+            component.uploadFiles([file]);
+            fixture.detectChanges();
+        });
+
+        it('should pause upload', fakeAsync(() => {
+            spyOn(uploadService, 'addToQueue').and.stub();
+            spyOn(uploadService, 'uploadFilesInTheQueue').and.stub();
+
+            let prevented = false;
+            component.beginUpload.subscribe(event => {
+                event.preventDefault();
+                prevented = true;
+            });
+            const file = <File> { name: 'bigFile.png', size: 1000 };
+            component.uploadFiles([file]);
+
+            tick();
+            expect(prevented).toBeTruthy();
+            expect(uploadService.addToQueue).not.toHaveBeenCalled();
+            expect(uploadService.uploadFilesInTheQueue).not.toHaveBeenCalled();
+        }));
+
+        it('should pause upload', fakeAsync(() => {
+            const addToQueue = spyOn(uploadService, 'addToQueue').and.stub();
+            const uploadFilesInTheQueue = spyOn(uploadService, 'uploadFilesInTheQueue').and.stub();
+
+            let prevented = false;
+            let uploadEvent: UploadFilesEvent;
+            component.beginUpload.subscribe(event => {
+                uploadEvent = event;
+                event.preventDefault();
+                prevented = true;
+            });
+            const file = <File> { name: 'bigFile.png', size: 1000 };
+            component.uploadFiles([file]);
+
+            tick();
+            expect(prevented).toBeTruthy();
+            expect(addToQueue).not.toHaveBeenCalled();
+            expect(uploadFilesInTheQueue).not.toHaveBeenCalled();
+
+            addToQueue.calls.reset();
+            uploadFilesInTheQueue.calls.reset();
+
+            uploadEvent.resumeUpload();
+
+            expect(addToQueue).toHaveBeenCalled();
+            expect(uploadFilesInTheQueue).toHaveBeenCalled();
+        }));
+
     });
 
     describe('filesize', () => {

--- a/lib/content-services/upload/components/base-upload/upload-base.spec.ts
+++ b/lib/content-services/upload/components/base-upload/upload-base.spec.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Component } from '@angular/core';
+import { Component, NgZone } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslationService, UploadService, setupTestBed, CoreModule, FileModel } from '@alfresco/adf-core';
 import { UploadBase } from './upload-base';
@@ -24,13 +24,14 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 @Component({
     selector: 'adf-upload-button-test',
-    template: 'test componente'
+    template: 'test component'
 })
 export class UploadTestComponent extends UploadBase {
 
     constructor(protected uploadService: UploadService,
-                protected translationService: TranslationService) {
-        super(uploadService, translationService);
+                protected translationService: TranslationService,
+                protected ngZone: NgZone) {
+        super(uploadService, translationService, ngZone);
     }
 }
 

--- a/lib/content-services/upload/components/base-upload/upload-base.spec.ts
+++ b/lib/content-services/upload/components/base-upload/upload-base.spec.ts
@@ -99,7 +99,7 @@ describe('UploadBase', () => {
             expect(uploadService.uploadFilesInTheQueue).not.toHaveBeenCalled();
         }));
 
-        it('should pause upload', fakeAsync(() => {
+        it('should resume upload', fakeAsync(() => {
             const addToQueue = spyOn(uploadService, 'addToQueue').and.stub();
             const uploadFilesInTheQueue = spyOn(uploadService, 'uploadFilesInTheQueue').and.stub();
 

--- a/lib/content-services/upload/components/base-upload/upload-base.ts
+++ b/lib/content-services/upload/components/base-upload/upload-base.ts
@@ -59,7 +59,6 @@ export abstract class UploadBase implements OnInit, OnDestroy {
     @Input()
     nodeType: string = 'cm:content';
 
-    /** @deprecated 2.4.0 Use UploadService.fileUploadComplete instead */
     /** Emitted when the file is uploaded successfully. */
     @Output()
     success = new EventEmitter();
@@ -69,7 +68,6 @@ export abstract class UploadBase implements OnInit, OnDestroy {
     @Output()
     createFolder = new EventEmitter();
 
-    /** @deprecated 2.4.0 Use UploadService.fileUploadError instead */
     /** Emitted when an error occurs. */
     @Output()
     error = new EventEmitter();

--- a/lib/content-services/upload/components/upload-button.component.ts
+++ b/lib/content-services/upload/components/upload-button.component.ts
@@ -21,7 +21,7 @@ import {
 } from '@alfresco/adf-core';
 import {
     Component, EventEmitter, forwardRef, Input,
-    OnChanges, OnInit, Output, SimpleChanges, ViewEncapsulation
+    OnChanges, OnInit, Output, SimpleChanges, ViewEncapsulation, NgZone
 } from '@angular/core';
 import { MinimalNodeEntryEntity } from 'alfresco-js-api';
 import { Subject } from 'rxjs/Subject';
@@ -67,8 +67,9 @@ export class UploadButtonComponent extends UploadBase implements OnInit, OnChang
     constructor(protected uploadService: UploadService,
                 private contentService: ContentService,
                 protected translationService: TranslationService,
-                protected logService: LogService) {
-        super(uploadService, translationService);
+                protected logService: LogService,
+                protected ngZone: NgZone) {
+        super(uploadService, translationService, ngZone);
     }
 
     ngOnInit() {

--- a/lib/content-services/upload/components/upload-drag-area.component.ts
+++ b/lib/content-services/upload/components/upload-drag-area.component.ts
@@ -19,7 +19,7 @@ import {
     EXTENDIBLE_COMPONENT, FileInfo, FileModel, FileUtils, NodePermissionSubject,
     NotificationService, TranslationService, UploadService, ContentService, PermissionsEnum
 } from '@alfresco/adf-core';
-import { Component, forwardRef, Input, ViewEncapsulation } from '@angular/core';
+import { Component, forwardRef, Input, ViewEncapsulation, NgZone } from '@angular/core';
 import { UploadBase } from './base-upload/upload-base';
 
 @Component({
@@ -43,8 +43,9 @@ export class UploadDragAreaComponent extends UploadBase implements NodePermissio
     constructor(protected uploadService: UploadService,
                 protected translationService: TranslationService,
                 private notificationService: NotificationService,
-                private contentService: ContentService) {
-        super(uploadService, translationService);
+                private contentService: ContentService,
+                protected ngZone: NgZone) {
+        super(uploadService, translationService, ngZone);
     }
 
     /**

--- a/lib/content-services/upload/components/upload-files.event.ts
+++ b/lib/content-services/upload/components/upload-files.event.ts
@@ -1,0 +1,45 @@
+/*!
+ * @license
+ * Copyright 2016 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FileModel, UploadService } from '@alfresco/adf-core';
+
+export class UploadFilesEvent {
+
+    private isDefaultPrevented: boolean = false;
+
+    get defaultPrevented() {
+        return this.isDefaultPrevented;
+    }
+
+    preventDefault() {
+        this.isDefaultPrevented = true;
+    }
+
+    constructor(public files: Array<FileModel>, private uploadService: UploadService) {
+    }
+
+    pauseUpload() {
+        this.preventDefault();
+    }
+
+    resumeUpload() {
+        if (this.files && this.files.length > 0) {
+            this.uploadService.addToQueue(...this.files);
+            this.uploadService.uploadFilesInTheQueue();
+        }
+    }
+}

--- a/lib/content-services/upload/public-api.ts
+++ b/lib/content-services/upload/public-api.ts
@@ -21,6 +21,7 @@ export * from './components/file-uploading-dialog.component';
 export * from './components/upload-drag-area.component';
 export * from './components/file-uploading-list.component';
 export * from './components/file-uploading-list-row.component';
+export * from './components/upload-files.event';
 
 export * from './directives/file-draggable.directive';
 

--- a/lib/core/services/upload.service.ts
+++ b/lib/core/services/upload.service.ts
@@ -98,7 +98,7 @@ export class UploadService {
      * Finds all the files in the queue that are not yet uploaded and uploads them into the directory folder.
      * @param emitter (Deprecated) Emitter to invoke on file status change
      */
-    uploadFilesInTheQueue(emitter: EventEmitter<any>): void {
+    uploadFilesInTheQueue(emitter?: EventEmitter<any>): void {
         if (!this.activeTask) {
             let file = this.queue.find(currentFile => currentFile.status === FileUploadStatus.Pending);
             if (file) {
@@ -200,15 +200,21 @@ export class UploadService {
         })
             .on('abort', () => {
                 this.onUploadAborted(file);
-                emitter.emit({ value: 'File aborted' });
+                if (emitter) {
+                    emitter.emit({ value: 'File aborted' });
+                }
             })
             .on('error', err => {
                 this.onUploadError(file, err);
-                emitter.emit({ value: 'Error file uploaded' });
+                if (emitter) {
+                    emitter.emit({ value: 'Error file uploaded' });
+                }
             })
             .on('success', data => {
                 this.onUploadComplete(file, data);
-                emitter.emit({ value: data });
+                if (emitter) {
+                    emitter.emit({ value: data });
+                }
             })
             .catch(err => {
                 throw err;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

- [ADF-3095](https://issues.alfresco.com/jira/browse/ADF-3095) Upload and DragArea component events to intercept uploads
- Update demo shell to demonstrate the implementation from the docs

<img width="553" alt="screen shot 2018-05-30 at 16 00 32" src="https://user-images.githubusercontent.com/503991/40736344-b609864a-6435-11e8-839d-62a195aa4611.png">


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
