### PR TITLE
[ADF-2764] Fixed union type display glitches in property tables

### DIFF
--- a/docs/content-services/content-action.component.md
+++ b/docs/content-services/content-action.component.md
@@ -93,7 +93,7 @@ export class MyView {
 | permission | `string` |  | The permission type. |
 | target | `string` |  [`ContentActionTarget`](../../lib/content-services/document-list/models/content-action.model.ts).All | Type of item that the action appies to. Can be "document" or "folder" |
 | title | `string` | "Action" | The title of the action as shown in the menu. |
-| visible | `boolean | Function` | true | Visibility state (see examples). |
+| visible | `boolean \| Function` | true | Visibility state (see examples). |
 
 ### Events
 

--- a/docs/content-services/document-list.component.md
+++ b/docs/content-services/document-list.component.md
@@ -70,7 +70,7 @@ Displays the documents from a repository.
 | emptyFolderImageUrl | `string` | "./assets/images/empty_doc_lib.svg" | Custom image for empty folder. Default value: './assets/images/empty_doc_lib.svg' |
 | enableInfiniteScrolling | `boolean` | false | Set document list to work in infinite scrolling mode |
 | folderNode | `MinimalNodeEntryEntity` |  null | Currently displayed folder node |
-| imageResolver | `any | null` |  null | Custom image resolver |
+| imageResolver | `any \| null` |  null | Custom image resolver |
 | includeFields | `string[]` |  | Include additional information about the node in the server request.for example: association, isLink, isLocked and others. |
 | loading | `boolean` | false | Toggles the loading state and animated spinners for the component. Used in combination with `navigate=false` to perform custom navigation and loading state indication. |
 | locationFormat | `string` | "/" | The default route for all the location-based columns (if declared). |
@@ -79,8 +79,8 @@ Displays the documents from a repository.
 | navigate | `boolean` | true | Toggles navigation to folder content or file preview |
 | navigationMode | `string` |  [`DocumentListComponent`](../content-services/document-list.component.md).DOUBLE_CLICK_NAVIGATION | User interaction for folder navigation or file preview. Valid values are "click" and "dblclick". Default value: "dblclick" |
 | node | [`NodePaging`](../../lib/content-services/document-list/models/document-library.model.ts) |  null | The Document list will show all the nodes contained in the [`NodePaging`](../../lib/content-services/document-list/models/document-library.model.ts) entity |
-| permissionsStyle | `PermissionStyleModel[]` |  \[] | Define a set of CSS styles styles to apply depending on the permission of the user on that node. See the [Permission Style model](../../lib/content-services/document-list/models/permissions-style.model.ts) page for further details and examples. |
-| rowFilter | `any | null` |  null | Custom row filter |
+| permissionsStyle | [`PermissionStyleModel[]`](../../lib/content-services/document-list/models/permissions-style.model.ts) |  \[] | Define a set of CSS styles styles to apply depending on the permission of the user on that node. See the [Permission Style model](../../lib/content-services/document-list/models/permissions-style.model.ts) page for further details and examples. |
+| rowFilter | `any \| null` |  null | Custom row filter |
 | rowStyle | `string` |  | The inline style to apply to every row. See the Angular NgStyle docs for more details and usage examples. |
 | rowStyleClass | `string` |  | The CSS class to apply to every row |
 | selectionMode | `string` | "single" | Row selection mode. Can be null, `single` or `multiple`. For `multiple` mode, you can use Cmd (macOS) or Ctrl (Win) modifier key to toggle selection for multiple rows. |

--- a/docs/content-services/search.component.md
+++ b/docs/content-services/search.component.md
@@ -40,12 +40,12 @@ Searches items for supplied search terms.
 
 | Name | Type | Default value | Description |
 | -- | -- | -- | -- |
-| displayWith | `function | null` |  null | Function that maps an option's value to its display value in the trigger. |
+| displayWith | `function \| null` |  null | Function that maps an option's value to its display value in the trigger. |
 | maxResults | `number` | 20 | Maximum number of results to show in the search. |
 | queryBody | `QueryBody` |  | **Deprecated:** in 2.1.0 |
 | searchTerm | `string` | "" | Search term to use when executing the search. Updating this value will run a new search and update the results. |
 | skipResults | `number` | 0 | Number of results to skip from the results pagination. |
-| class | `` |  | CSS class for display. |
+| class |  |  | CSS class for display. |
 
 ### Events
 

--- a/docs/core/info-drawer.component.md
+++ b/docs/core/info-drawer.component.md
@@ -37,7 +37,7 @@ Displays a sidebar-style information panel with tabs.
 | Name | Type | Default value | Description |
 | -- | -- | -- | -- |
 | selectedIndex | `number` | 0 | The selected index tab. |
-| title | `string | null` |  null | The title of the info drawer. |
+| title | `string \| null` |  null | The title of the info drawer. |
 
 ### Events
 
@@ -53,5 +53,5 @@ You can also customize the three regions (title, buttons and content) as with th
 
 ## See also
 
-- [Info drawer layout component](info-drawer-layout.component.md)
-- [Info drawer layout component](info-drawer-tab.component.md)
+-   [Info drawer layout component](info-drawer-layout.component.md)
+-   [Info drawer layout component](info-drawer-tab.component.md)

--- a/tools/doc/tools/tsInfo.js
+++ b/tools/doc/tools/tsInfo.js
@@ -33,6 +33,7 @@ var PropInfo = /** @class */ (function () {
         this.defaultValue = rawProp.defaultValue || "";
         this.defaultValue = this.defaultValue.replace(/\|/, "\\|");
         this.type = rawProp.type ? rawProp.type.toString() : "";
+        this.type = this.type.replace(/\|/, "\\|");
         this.isDeprecated = rawProp.comment && rawProp.comment.hasTag("deprecated");
         if (this.isDeprecated) {
             this.docText = "**Deprecated:** " + rawProp.comment.getTag("deprecated").text.replace(/[\n\r]+/g, " ").trim();

--- a/tools/doc/tools/tsInfo.ts
+++ b/tools/doc/tools/tsInfo.ts
@@ -69,6 +69,7 @@ class PropInfo {
         this.defaultValue = rawProp.defaultValue || "";
         this.defaultValue = this.defaultValue.replace(/\|/, "\\|");
         this.type = rawProp.type ? rawProp.type.toString() : "";
+        this.type = this.type.replace(/\|/, "\\|");
 
         this.isDeprecated = rawProp.comment && rawProp.comment.hasTag("deprecated");
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [x] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Union types (eg, "boolean | Function") are not displayed properly in the property table of the Content Action component. The vertical bar gets treated as a table column.

**What is the new behaviour?**

Vertical bars are now escaped in the type column for Column Action component and three other similar instances. Services with union types in method descriptions *don't* have the same problem (ie, the bar is only handled incorrectly in tables).

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
