### PR TITLE
[ADF-2876] retrieving user from APS api and not from js-api

### DIFF
--- a/lib/core/models/user-process.model.ts
+++ b/lib/core/models/user-process.model.ts
@@ -27,6 +27,7 @@ export class UserProcessModel implements LightUserRepresentation {
     firstName?: string;
     lastName?: string;
     pictureId?: number = null;
+    externalId?: string;
 
     constructor(obj?: any) {
         if (obj) {
@@ -35,6 +36,7 @@ export class UserProcessModel implements LightUserRepresentation {
             this.firstName = obj.firstName || null;
             this.lastName = obj.lastName || null;
             this.pictureId = obj.pictureId || null;
+            this.externalId = obj.externalId || null;
         }
     }
 

--- a/lib/core/services/authentication.service.spec.ts
+++ b/lib/core/services/authentication.service.spec.ts
@@ -22,6 +22,7 @@ import { CookieService } from './cookie.service';
 import { AppConfigService } from '../app-config/app-config.service';
 import { setupTestBed } from '../testing/setupTestBed';
 import { CoreTestingModule } from '../testing/core.testing.module';
+import { UserRepresentation } from 'alfresco-js-api';
 
 declare let jasmine: any;
 
@@ -348,6 +349,18 @@ describe('AuthenticationService', () => {
 
         it('[BPM] should return isALLProvider false', () => {
             expect(authService.isALLProvider()).toBe(false);
+        });
+
+        it('[BPM] should be able to retrieve current logged in user', (done) => {
+            spyOn(apiService.getInstance().activiti.profileApi, 'getProfile').and.returnValue(
+                Promise.resolve((<UserRepresentation> {
+                    email: 'fake-email'
+                })));
+
+            authService.getBpmLoggedUser().subscribe((fakeUser) => {
+                expect(fakeUser.email).toBe('fake-email');
+                done();
+            });
         });
     });
 

--- a/lib/core/services/authentication.service.ts
+++ b/lib/core/services/authentication.service.ts
@@ -21,12 +21,11 @@ import { Subject } from 'rxjs/Subject';
 import { AlfrescoApiService } from './alfresco-api.service';
 import { CookieService } from './cookie.service';
 import { LogService } from './log.service';
-import { StorageService } from './storage.service';
-import { UserPreferencesService } from './user-preferences.service';
+import { RedirectionModel } from '../models/redirection.model';
+import { AppConfigService, AppConfigValues } from '../app-config/app-config.service';
 import 'rxjs/add/observable/fromPromise';
 import 'rxjs/add/operator/catch';
 import 'rxjs/add/observable/throw';
-import { RedirectionModel } from '../models/redirection.model';
 import { UserRepresentation } from 'alfresco-js-api';
 
 const REMEMBER_ME_COOKIE_KEY = 'ALFRESCO_REMEMBER_ME';
@@ -34,15 +33,14 @@ const REMEMBER_ME_UNTIL = 1000 * 60 * 60 * 24 * 30 ;
 
 @Injectable()
 export class AuthenticationService {
-    private redirect: RedirectionModel = null;
+    private redirectUrl: RedirectionModel = null;
 
     onLogin: Subject<any> = new Subject<any>();
     onLogout: Subject<any> = new Subject<any>();
 
     constructor(
-        private preferences: UserPreferencesService,
+        private appConfig: AppConfigService,
         private alfrescoApi: AlfrescoApiService,
-        private storage: StorageService,
         private cookie: CookieService,
         private logService: LogService) {
     }
@@ -59,6 +57,18 @@ export class AuthenticationService {
         return this.alfrescoApi.getInstance().isOauthConfiguration();
     }
 
+    isECMProvider(): boolean {
+        return this.alfrescoApi.getInstance().isEcmConfiguration();
+    }
+
+    isBPMProvider(): boolean {
+        return this.alfrescoApi.getInstance().isBpmConfiguration();
+    }
+
+    isALLProvider(): boolean {
+        return this.alfrescoApi.getInstance().isEcmBpmConfiguration();
+    }
+
     /**
      * Logs the user in.
      * @param username Username for the login
@@ -67,14 +77,12 @@ export class AuthenticationService {
      * @returns Object with auth type ("ECM", "BPM" or "ALL") and auth ticket
      */
     login(username: string, password: string, rememberMe: boolean = false): Observable<{ type: string, ticket: any }> {
-        this.removeTicket();
         return Observable.fromPromise(this.alfrescoApi.getInstance().login(username, password))
             .map((response: any) => {
                 this.saveRememberMeCookie(rememberMe);
-                this.saveTickets();
                 this.onLogin.next(response);
                 return {
-                    type: this.preferences.providers,
+                    type: this.appConfig.get(AppConfigValues.PROVIDERS),
                     ticket: response
                 };
             })
@@ -84,7 +92,7 @@ export class AuthenticationService {
     /**
      * Logs the user in with SSO
      */
-    ssoImplictiLogin() {
+    ssoImplicitLogin() {
         this.alfrescoApi.getInstance().implicitLogin();
     }
 
@@ -119,7 +127,6 @@ export class AuthenticationService {
     logout() {
         return Observable.fromPromise(this.callApiLogout())
             .do(response => {
-                this.removeTicket();
                 this.onLogout.next(response);
                 return response;
             })
@@ -136,20 +143,11 @@ export class AuthenticationService {
     }
 
     /**
-     * Removes the login ticket from Storage.
-     */
-    removeTicket(): void {
-        this.storage.removeItem('ticket-ECM');
-        this.storage.removeItem('ticket-BPM');
-        this.alfrescoApi.getInstance().setTicket(undefined, undefined);
-    }
-
-    /**
      * Gets the ECM ticket stored in the Storage.
      * @returns The ticket or `null` if none was found
      */
     getTicketEcm(): string | null {
-        return this.storage.getItem('ticket-ECM');
+        return this.alfrescoApi.getInstance().getTicketEcm();
     }
 
     /**
@@ -157,7 +155,7 @@ export class AuthenticationService {
      * @returns The ticket or `null` if none was found
      */
     getTicketBpm(): string | null {
-        return this.storage.getItem('ticket-BPM');
+        return this.alfrescoApi.getInstance().getTicketBpm();
     }
 
     /**
@@ -165,7 +163,7 @@ export class AuthenticationService {
      * @returns The ticket or `null` if none was found
      */
     getTicketEcmBase64(): string | null {
-        let ticket = this.storage.getItem('ticket-ECM');
+        let ticket = this.alfrescoApi.getInstance().getTicketEcm();
         if (ticket) {
             return 'Basic ' + btoa(ticket);
         }
@@ -173,50 +171,17 @@ export class AuthenticationService {
     }
 
     /**
-     * Saves the ECM and BPM ticket in the Storage.
-     */
-    saveTickets(): void {
-        this.saveTicketEcm();
-        this.saveTicketBpm();
-        this.saveTicketAuth();
-    }
-
-    /**
-     * Saves the ECM ticket in the Storage.
-     */
-    saveTicketEcm(): void {
-        if (this.alfrescoApi.getInstance() && this.alfrescoApi.getInstance().getTicketEcm()) {
-            this.storage.setItem('ticket-ECM', this.alfrescoApi.getInstance().getTicketEcm());
-        }
-    }
-
-    /**
-     * Saves the BPM ticket in the Storage.
-     */
-    saveTicketBpm(): void {
-        if (this.alfrescoApi.getInstance() && this.alfrescoApi.getInstance().getTicketBpm()) {
-            this.storage.setItem('ticket-BPM', this.alfrescoApi.getInstance().getTicketBpm());
-        }
-    }
-
-    /**
-     * Saves the AUTH ticket in the Storage.
-     */
-    saveTicketAuth(): void {
-        if (this.alfrescoApi.getInstance() && (<any> this.alfrescoApi.getInstance()).getTicketAuth()) {
-            this.storage.setItem('ticket-AUTH', (<any> this.alfrescoApi.getInstance()).getTicketAuth());
-        }
-    }
-
-    /**
      * Checks if the user is logged in on an ECM provider.
      * @returns True if logged in, false otherwise
      */
     isEcmLoggedIn(): boolean {
-        if (this.cookie.isEnabled() && !this.isRememberMeSet()) {
-            return false;
+        if (this.isECMProvider() || this.isALLProvider()) {
+            if (!this.isOauth() && this.cookie.isEnabled() && !this.isRememberMeSet()) {
+                return false;
+            }
+            return this.alfrescoApi.getInstance().isEcmLoggedIn();
         }
-        return this.alfrescoApi.getInstance().isEcmLoggedIn();
+        return false;
     }
 
     /**
@@ -224,10 +189,13 @@ export class AuthenticationService {
      * @returns True if logged in, false otherwise
      */
     isBpmLoggedIn(): boolean {
-        if (this.cookie.isEnabled() && !this.isRememberMeSet()) {
-            return false;
+        if (this.isBPMProvider() || this.isALLProvider()) {
+            if (!this.isOauth() && this.cookie.isEnabled() && !this.isRememberMeSet()) {
+                return false;
+            }
+            return this.alfrescoApi.getInstance().isBpmLoggedIn();
         }
-        return this.alfrescoApi.getInstance().isBpmLoggedIn();
+        return false;
     }
 
     /**
@@ -246,31 +214,31 @@ export class AuthenticationService {
         return this.alfrescoApi.getInstance().getBpmUsername();
     }
 
-    getBpmLoggedUser(): Observable<UserRepresentation> {
-        return Observable.fromPromise(this.alfrescoApi.getInstance().activiti.profileApi.getProfile());
-    }
-
     /** Sets the URL to redirect to after login.
      * @param url URL to redirect to
      */
     setRedirect(url: RedirectionModel) {
-        this.redirect = url;
+        this.redirectUrl = url;
     }
 
     /** Gets the URL to redirect to after login.
      * @param provider Service provider. Can be "ECM", "BPM" or "ALL".
      * @returns The redirect URL
      */
-    getRedirect(provider: string): any[] {
-        return this.hasValidRedirection(provider) ? this.redirect.navigation : null;
+    getRedirect(provider: string): string {
+        return this.hasValidRedirection(provider) ? this.redirectUrl.url : null;
+    }
+
+    getBpmLoggedUser(): Observable<UserRepresentation> {
+        return Observable.fromPromise(this.alfrescoApi.getInstance().activiti.profileApi.getProfile());
     }
 
     private hasValidRedirection(provider: string): boolean {
-        return this.redirect && (this.redirect.provider === provider || this.hasSelectedProviderAll(provider));
+        return this.redirectUrl && (this.redirectUrl.provider === provider || this.hasSelectedProviderAll(provider));
     }
 
     private hasSelectedProviderAll(provider: string): boolean {
-        return this.redirect && (this.redirect.provider === 'ALL' || provider === 'ALL');
+        return this.redirectUrl && (this.redirectUrl.provider === 'ALL' || provider === 'ALL');
     }
 
     /**

--- a/lib/process-services/task-list/components/task-details.component.spec.ts
+++ b/lib/process-services/task-list/components/task-details.component.spec.ts
@@ -21,7 +21,7 @@ import { By } from '@angular/platform-browser';
 import { Observable } from 'rxjs/Observable';
 
 import { FormModel, FormOutcomeEvent, FormOutcomeModel, FormService, setupTestBed, BpmUserService } from '@alfresco/adf-core';
-import { CommentProcessService, LogService } from '@alfresco/adf-core';
+import { CommentProcessService, LogService, AuthenticationService } from '@alfresco/adf-core';
 
 import { UserProcessModel } from '@alfresco/adf-core';
 import { TaskDetailsModel } from '../models/task-details.model';
@@ -51,6 +51,7 @@ describe('TaskDetailsComponent', () => {
     let logService: LogService;
     let commentProcessService: CommentProcessService;
     let peopleProcessService: PeopleProcessService;
+    let authService: AuthenticationService;
 
     setupTestBed({
         imports: [
@@ -79,6 +80,9 @@ describe('TaskDetailsComponent', () => {
         assignTaskSpy = spyOn(service, 'assignTask').and.returnValue(Observable.of(fakeUser));
         completeTaskSpy = spyOn(service, 'completeTask').and.returnValue(Observable.of({}));
         commentProcessService = TestBed.get(CommentProcessService);
+
+        authService = TestBed.get(AuthenticationService);
+        spyOn(authService, 'getBpmLoggedUser').and.returnValue(Observable.of({ email: 'fake-email'}));
 
         spyOn(commentProcessService, 'getTaskComments').and.returnValue(Observable.of([
             {message: 'Test1', created: Date.now(), createdBy: {firstName: 'Admin', lastName: 'User'}},

--- a/lib/process-services/task-list/components/task-details.component.ts
+++ b/lib/process-services/task-list/components/task-details.component.ts
@@ -44,6 +44,7 @@ import { TaskQueryRequestRepresentationModel } from '../models/filter.model';
 import { TaskDetailsModel } from '../models/task-details.model';
 import { TaskListService } from './../services/tasklist.service';
 import { AttachFileWidgetComponent, AttachFolderWidgetComponent } from '../../content-widget';
+import { UserRepresentation } from 'alfresco-js-api';
 
 @Component({
     selector: 'adf-task-details',
@@ -179,6 +180,8 @@ export class TaskDetailsComponent implements OnInit, OnChanges {
 
     peopleSearch: Observable<UserProcessModel[]>;
 
+    currentLoggedUser: UserRepresentation;
+
     constructor(private taskListService: TaskListService,
                 private authService: AuthenticationService,
                 private peopleProcessService: PeopleProcessService,
@@ -199,6 +202,10 @@ export class TaskDetailsComponent implements OnInit, OnChanges {
 
         this.cardViewUpdateService.itemUpdated$.subscribe(this.updateTaskDetails.bind(this));
         this.cardViewUpdateService.itemClicked$.subscribe(this.clickTaskDetails.bind(this));
+
+        this.authService.getBpmLoggedUser().subscribe((user: UserRepresentation) => {
+            this.currentLoggedUser = user;
+        });
     }
 
     ngOnChanges(changes: SimpleChanges): void {
@@ -286,7 +293,7 @@ export class TaskDetailsComponent implements OnInit, OnChanges {
     }
 
     isAssignedToMe(): boolean {
-        return this.isAssigned() ? this.taskDetails.assignee.email === this.authService.getBpmUsername() : false;
+        return this.isAssigned() ? this.taskDetails.assignee.email.toLocaleLowerCase() === this.currentLoggedUser.email.toLocaleLowerCase() : false;
     }
 
     isCompleteButtonEnabled(): boolean {

--- a/lib/process-services/task-list/components/task-details.component.ts
+++ b/lib/process-services/task-list/components/task-details.component.ts
@@ -292,8 +292,22 @@ export class TaskDetailsComponent implements OnInit, OnChanges {
         return this.taskDetails.assignee ? true : false;
     }
 
+    private hasEmailAddress(): boolean {
+        return this.taskDetails.assignee.email ? true : false;
+    }
+
     isAssignedToMe(): boolean {
-        return this.isAssigned() ? this.taskDetails.assignee.email.toLocaleLowerCase() === this.currentLoggedUser.email.toLocaleLowerCase() : false;
+        return this.isAssigned() && this.hasEmailAddress() ?
+                    this.isEmailEqual(this.taskDetails.assignee.email, this.currentLoggedUser.email) :
+                    this.isExternalIdEqual(this.taskDetails.assignee.externalId, this.currentLoggedUser.externalId);
+    }
+
+    private isEmailEqual(assigneeMail, currentLoggedEmail): boolean {
+        return assigneeMail.toLocaleLowerCase() === currentLoggedEmail.toLocaleLowerCase();
+    }
+
+    private isExternalIdEqual(assigneeExternalId, currentUserExternalId): boolean {
+        return assigneeExternalId.toLocaleLowerCase() === currentUserExternalId.toLocaleLowerCase();
     }
 
     isCompleteButtonEnabled(): boolean {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Current logged in user for APS is taken from js-api instead of calling the proper API


**What is the new behaviour?**
We will use the APS API to get the current logged in user.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-2876