### PR TITLE
[ADF-3118] translation support for notification service (snackbars)

### DIFF
--- a/docs/core/notification.service.md
+++ b/docs/core/notification.service.md
@@ -15,12 +15,12 @@ Shows a notification message with optional feedback.
 
 -   **openSnackMessage**(message: `string` = `null`, millisecondsDuration?: `number` = `null`): `MatSnackBarRef<any>`<br/>
     Opens a snackbar notification to show a message.
-    -   _message:_ `string`  - The message to show
+    -   _message:_ `string`  - The message (or resource key) to show.
     -   _millisecondsDuration:_ `number`  - (Optional) Time before notification disappears after being shown
     -   **Returns** `MatSnackBarRef<any>` - Information/control object for the snackbar
 -   **openSnackMessageAction**(message: `string` = `null`, action: `string` = `null`, millisecondsDuration?: `number` = `null`): `MatSnackBarRef<any>`<br/>
     Opens a snackbar notification with a message and a response button.
-    -   _message:_ `string`  - The message to show
+    -   _message:_ `string`  - The message (or resource key) to show.
     -   _action:_ `string`  - Caption for the response button
     -   _millisecondsDuration:_ `number`  - (Optional) Time before the notification disappears (unless the button is clicked)
     -   **Returns** `MatSnackBarRef<any>` - Information/control object for the snackbar
@@ -39,9 +39,12 @@ export class MyComponent implements OnInit {
     }
 
     ngOnInit() {
-          this.notificationService.openSnackMessage('test', 200000).afterDismissed().subscribe(() => {
-                    console.log('The snack-bar was dismissed');
-                });
+        this.notificationService
+            .openSnackMessage('test', 200000)
+            .afterDismissed()
+            .subscribe(() => {
+                console.log('The snack-bar was dismissed');
+            });
     }
 }
 ```
@@ -55,7 +58,10 @@ export class MyComponent implements OnInit {
     }
 
     ngOnInit() {
-         this.notificationService.openSnackMessageAction('Do you want to report this issue?', 'send', 200000).afterDismissed().subscribe(() => {
+        this.notificationService
+            .openSnackMessageAction('Do you want to report this issue?', 'send', 200000)
+            .afterDismissed()
+            .subscribe(() => {
                 console.log('The snack-bar was dismissed');
             });
     }

--- a/lib/core/services/notification.service.spec.ts
+++ b/lib/core/services/notification.service.spec.ts
@@ -23,6 +23,8 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { NotificationService } from './notification.service';
+import { TranslationMock } from '../mock/translation.service.mock';
+import { TranslationService } from './translation.service';
 
 @Component({
     template: '',
@@ -47,6 +49,7 @@ class ProvidesNotificationServiceComponent {
 
 describe('NotificationService', () => {
     let fixture: ComponentFixture<ProvidesNotificationServiceComponent>;
+    let translationService: TranslationService;
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({
@@ -60,15 +63,28 @@ describe('NotificationService', () => {
                 NotificationService,
                 MatSnackBar,
                 OVERLAY_PROVIDERS,
-                LiveAnnouncer
+                LiveAnnouncer,
+                { provide: TranslationService, useClass: TranslationMock }
             ]
         });
 
-        TestBed.compileComponents();
+        translationService = TestBed.get(TranslationService);
     }));
 
     beforeEach(() => {
         fixture = TestBed.createComponent(ProvidesNotificationServiceComponent);
+        fixture.detectChanges();
+    });
+
+    it('should translate messages', (done) => {
+        spyOn(translationService, 'instant').and.callThrough();
+
+        let promise = fixture.componentInstance.sendMessage();
+        promise.afterDismissed().subscribe(() => {
+            expect(translationService.instant).toHaveBeenCalled();
+            done();
+        });
+
         fixture.detectChanges();
     });
 

--- a/lib/core/services/notification.service.ts
+++ b/lib/core/services/notification.service.ts
@@ -17,36 +17,42 @@
 
 import { Injectable } from '@angular/core';
 import { MatSnackBar, MatSnackBarRef } from '@angular/material';
+import { TranslationService } from './translation.service';
 
 @Injectable()
 export class NotificationService {
 
     static DEFAULT_DURATION_MESSAGE: number = 5000;
 
-    constructor(public snackbar: MatSnackBar) {
+    constructor(private snackBar: MatSnackBar,
+                private translationService: TranslationService) {
     }
 
     /**
-     * Opens a snackbar notification to show a message.
-     * @param message The message to show
+     * Opens a SnackBar notification to show a message.
+     * @param message The message (or resource key) to show.
      * @param millisecondsDuration Time before notification disappears after being shown
-     * @returns Information/control object for the snackbar
+     * @returns Information/control object for the SnackBar
      */
-    public openSnackMessage(message: string, millisecondsDuration?: number): MatSnackBarRef<any> {
-        return this.snackbar.open(message, null, {
+    openSnackMessage(message: string, millisecondsDuration?: number): MatSnackBarRef<any> {
+        const translatedMessage = this.translationService.instant(message);
+
+        return this.snackBar.open(translatedMessage, null, {
             duration: millisecondsDuration || NotificationService.DEFAULT_DURATION_MESSAGE
         });
     }
 
     /**
-     * Opens a snackbar notification with a message and a response button.
-     * @param message The message to show
+     * Opens a SnackBar notification with a message and a response button.
+     * @param message The message (or resource key) to show.
      * @param action Caption for the response button
      * @param millisecondsDuration Time before the notification disappears (unless the button is clicked)
-     * @returns Information/control object for the snackbar
+     * @returns Information/control object for the SnackBar
      */
-    public openSnackMessageAction(message: string, action: string, millisecondsDuration?: number): MatSnackBarRef<any> {
-        return this.snackbar.open(message, action, {
+    openSnackMessageAction(message: string, action: string, millisecondsDuration?: number): MatSnackBarRef<any> {
+        const translatedMessage = this.translationService.instant(message);
+
+        return this.snackBar.open(translatedMessage, action, {
             duration: millisecondsDuration || NotificationService.DEFAULT_DURATION_MESSAGE
         });
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

right now developers need to import TranslationService and translate messages in code before sending to NotificationService.

**What is the new behaviour?**

NotificationService provides support for i18n resource keys alongside with plain text

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
