### PR TITLE
[ADF-2710] removed default shared link creation at the opening

### DIFF
--- a/lib/content-services/dialogs/share.dialog.ts
+++ b/lib/content-services/dialogs/share.dialog.ts
@@ -52,7 +52,8 @@ export class ShareDialogComponent implements OnInit {
                 this.sharedId = this.data.node.entry.properties['qshare:sharedId'];
                 this.isFileShared = true;
             } else {
-                this.createSharedLinks(this.data.node.entry.id);
+                this.isFileShared = false;
+                this.isDisabled = false;
             }
         }
     }
@@ -87,6 +88,7 @@ export class ShareDialogComponent implements OnInit {
 
     deleteSharedLink(sharedId: string) {
         this.sharedLinksApiService.deleteSharedLink(sharedId).subscribe(() => {
+                this.data.node.entry.properties['qshare:sharedId'] = null;
                 this.isFileShared = false;
                 this.isDisabled = false;
             },


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

When clicked on 'share' toolbar a new shared link is created if there's none.

**What is the new behaviour?**
No new link is created unless the user clearly enable the toggle 'Shared link'


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-2710