### PR TITLE
[ADF-3133] Fixed inconsistency in doc example

### DIFF
--- a/docs/process-services/process-list.component.md
+++ b/docs/process-services/process-list.component.md
@@ -15,7 +15,7 @@ Renders a list containing all the process instances matched by the parameters sp
 ```html
 <adf-process-instance-list
     [appId]="'1'"
-    [state]="'open'">
+    [state]="'all'">
 </adf-process-instance-list>
 ```
 
@@ -75,7 +75,7 @@ You can define a custom schema for the list in the `app.config.json` file and ac
 ```html
 <adf-process-instance-list
     [appId]="'1'"
-    [state]="'open'"
+    [state]="'all'"
     [presetColumn]="'customSchema'">
 </adf-process-instance-list>
 ```


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [x] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Code samples use an obsolete property value "open".

**What is the new behaviour?**

Samples updated to the valid "all" property value.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
