### PR TITLE
[ADF-3095] group uploaded files into single batch, IE fixes

### DIFF
--- a/docs/content-services/file-draggable.directive.md
+++ b/docs/content-services/file-draggable.directive.md
@@ -13,7 +13,6 @@ Provides drag-and-drop features for an element such as a `div`.
 ```html
 <div [file-draggable]="true" id="DragAndDropBorder" class="drag-and-drop-border"
      (filesDropped)="onFilesDropped($event)"
-     (filesEntityDropped)="onFilesEntityDropped($event)"
      (folderEntityDropped)="onFolderEntityDropped($event)"
      dropzone="" webkitdropzone="*" #dragAndDropArea>
   <ng-content></ng-content>
@@ -47,7 +46,7 @@ Some sample CSS to show the drag and drop area:
 | Name | Type | Description |
 | -- | -- | -- |
 | filesDropped | `EventEmitter<File[]>` | Emitted when one or more files are dragged and dropped onto the draggable element. |
-| filesEntityDropped | `EventEmitter<any>` | Emitted when one or more files are dragged and dropped onto the draggable element. |
+| filesEntityDropped | `EventEmitter<any>` | **Deprecated in 2.4.0**: use `filesDropped` instead. Emitted when one or more files are dragged and dropped onto the draggable element. |
 | folderEntityDropped | `EventEmitter<any>` | Emitted when a directory is dragged and dropped onto the draggable element. |
 
 ## Details
@@ -64,11 +63,6 @@ export class SomeComponent implements OnInit {
       // Use for example the uploadService to upload files to ACS
       console.log('# of files dropped: ', files.length);
     }
-  }
-
-  onFilesEntityDropped(item: any): void {
-    // Use for example the uploadService to upload files to ACS
-    console.log('# of files dropped: ', item);
   }
 
   onFolderEntityDropped(folder: any): void {

--- a/lib/content-services/upload/components/upload-drag-area.component.html
+++ b/lib/content-services/upload/components/upload-drag-area.component.html
@@ -1,6 +1,5 @@
 <div [file-draggable]="isDroppable()" class="upload-border"
      (filesDropped)="onFilesDropped($event)"
-     (filesEntityDropped)="onFilesEntityDropped($event)"
      (folderEntityDropped)="onFolderEntityDropped($event)"
      (upload-files)="onUploadFiles($event)"
      dropzone="" webkitdropzone="*" #droparea>

--- a/lib/content-services/upload/components/upload-drag-area.component.ts
+++ b/lib/content-services/upload/components/upload-drag-area.component.ts
@@ -60,6 +60,7 @@ export class UploadDragAreaComponent extends UploadBase implements NodePermissio
     }
 
     /**
+     * @deprecated in 2.4.0: use `onFilesDropped` instead
      * Called when the file are dropped in the drag area
      *
      * @param item - FileEntity


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Right now, if user drops 10 files onto the drop area, there 10 separate single-upload events raised.
It is not possible to effectively intercept the upload in this case.

**What is the new behaviour?**

- All file uploads are grouped into a single batch
- single `filesDropped` event used for single/multiple files used
- it is not possible to intercept upload of multiselection

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
