### PR TITLE
[ADF-2764] Added new type linker features and applied them to core docs

### DIFF
--- a/docs/core/accordion-group.component.md
+++ b/docs/core/accordion-group.component.md
@@ -52,7 +52,7 @@ export class MyComponent implements OnInit {
 
 | Name | Type | Description |
 | -- | -- | -- |
-| headingClick | `EventEmitter<any>` | Emitted when the heading is clicked. |
+| headingClick | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<any>` | Emitted when the heading is clicked. |
 
 ## Details
 

--- a/docs/core/alfresco-content.service.md
+++ b/docs/core/alfresco-content.service.md
@@ -17,13 +17,13 @@ Gets a thumbnail URL for a node.
 `getContentUrl(nodeId: any, attachment?: boolean, ticket?: string): string`<br/>
 Gets the URL for a node's content.
 
-`getNodeContent(nodeId: string): Observable<any>`<br/>
+`getNodeContent(nodeId: string):`[`Observable`](http://reactivex.io/documentation/observable.html)`<any>`<br/>
 Gets a node's content.
 
 [`createFolder(relativePath: string, name: string, parentId?: string): Observable<FolderCreatedEvent>`](../../lib/core/events/folder-created.event.ts)<br/>
 Creates a folder.
 
-`hasPermission(node: any, permission: PermissionsEnum|string): boolean`<br/>
+`hasPermission(node: any, permission:`[`PermissionsEnum`](../../lib/core/models/permissions.enum.ts)`|string): boolean`<br/>
 Checks if the user has the specified permissions for `node`.
 
 `hasAllowableOperations(node: any): boolean`<br/>

--- a/docs/core/app-config.service.md
+++ b/docs/core/app-config.service.md
@@ -29,10 +29,10 @@ Supports app configuration settings, stored server side.
 -   **load**(): `Promise<any>`<br/>
     Loads the config file.
     -   **Returns** `Promise<any>` - Notification when loading is complete
--   **select**(property: `string` = `null`): `Observable<any>`<br/>
+-   **select**(property: `string` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<any>`<br/>
     Requests notification of a property value when it is loaded.
     -   _property:_ `string`  - The desired property value
-    -   **Returns** `Observable<any>` - [Property](../../lib/content-services/content-metadata/interfaces/property.interface.ts) value, when loaded
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<any>` - Property value, when loaded
 
 ## Details
 

--- a/docs/core/apps-process.service.md
+++ b/docs/core/apps-process.service.md
@@ -12,23 +12,23 @@ Gets details of the Process Services apps that are deployed for the user.
 
 ### Methods
 
--   **getApplicationDetailsById**(appId: `number` = `null`): `Observable<AppDefinitionRepresentation>`<br/>
+-   **getApplicationDetailsById**(appId: `number` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`AppDefinitionRepresentation`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-activiti-rest-api/docs/AppDefinitionRepresentation.md)`>`<br/>
     Gets the details for a specific app ID number.
     -   _appId:_ `number`  - ID of the target app
-    -   **Returns** `Observable<AppDefinitionRepresentation>` - Details of the app
--   **getDeployedApplications**(): `Observable<AppDefinitionRepresentation[]>`<br/>
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`AppDefinitionRepresentation`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-activiti-rest-api/docs/AppDefinitionRepresentation.md)`>` - Details of the app
+-   **getDeployedApplications**(): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`AppDefinitionRepresentation`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-activiti-rest-api/docs/AppDefinitionRepresentation.md)`[]>`<br/>
     Gets a list of deployed apps for this user.
-    -   **Returns** `Observable<AppDefinitionRepresentation[]>` - The list of deployed apps
--   **getDeployedApplicationsByName**(name: `string` = `null`): `Observable<AppDefinitionRepresentation>`<br/>
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`AppDefinitionRepresentation`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-activiti-rest-api/docs/AppDefinitionRepresentation.md)`[]>` - The list of deployed apps
+-   **getDeployedApplicationsByName**(name: `string` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`AppDefinitionRepresentation`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-activiti-rest-api/docs/AppDefinitionRepresentation.md)`>`<br/>
     Gets a list of deployed apps for this user, where the app name is `name`.
     -   _name:_ `string`  - Name of the app
-    -   **Returns** `Observable<AppDefinitionRepresentation>` - The list of deployed apps
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`AppDefinitionRepresentation`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-activiti-rest-api/docs/AppDefinitionRepresentation.md)`>` - The list of deployed apps
 
 ## Details
 
 This service can be used to access the Process Services apps that are available
 to the current user. You can find more information about the
-returned `AppDefinitionRepresentation` class in the
+returned [`AppDefinitionRepresentation`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-activiti-rest-api/docs/AppDefinitionRepresentation.md) class in the
 [Filter model page](../process-services/filter.model.md)
 and in the
 [Process Services Apps API](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-activiti-rest-api/docs/AppsApi.md#getAppDefinitions).

--- a/docs/core/authentication.service.md
+++ b/docs/core/authentication.service.md
@@ -31,10 +31,10 @@ Provides authentication to ACS and APS.
 -   **getTicketEcmBase64**(): `string | null`<br/>
     Gets the BPM ticket from the Storage in Base 64 format.
     -   **Returns** `string | null` - The ticket or `null` if none was found
--   **handleError**(error: `any` = `null`): `Observable<any>`<br/>
+-   **handleError**(error: `any` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<any>`<br/>
     Prints an error message in the console browser
     -   _error:_ `any`  - Error message
-    -   **Returns** `Observable<any>` - Object representing the error message
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<any>` - Object representing the error message
 -   **isBpmLoggedIn**(): `boolean`<br/>
     Checks if the user is logged in on a BPM provider.
     -   **Returns** `boolean` - True if logged in, false otherwise
@@ -47,15 +47,15 @@ Provides authentication to ACS and APS.
 -   **isRememberMeSet**(): `boolean`<br/>
     Checks whether the "remember me" cookie was set or not.
     -   **Returns** `boolean` - True if set, false otherwise
--   **login**(username: `string` = `null`, password: `string` = `null`, rememberMe: `boolean` = `false`): `Observable<object>`<br/>
+-   **login**(username: `string` = `null`, password: `string` = `null`, rememberMe: `boolean` = `false`): [`Observable`](http://reactivex.io/documentation/observable.html)`<object>`<br/>
     Logs the user in.
     -   _username:_ `string`  - Username for the login
     -   _password:_ `string`  - Password for the login
     -   _rememberMe:_ `boolean`  - Stores the user's login details if true
-    -   **Returns** `Observable<object>` - Object with auth type ("ECM", "BPM" or "ALL") and auth ticket
--   **logout**(): `Observable<any>`<br/>
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<object>` - Object with auth type ("ECM", "BPM" or "ALL") and auth ticket
+-   **logout**(): [`Observable`](http://reactivex.io/documentation/observable.html)`<any>`<br/>
     Logs the user out.
-    -   **Returns** `Observable<any>` - Response event called when logout is complete
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<any>` - Response event called when logout is complete
 -   **removeTicket**()<br/>
     Removes the login ticket from Storage.
 -   **saveTicketAuth**()<br/>

--- a/docs/core/bpm-user.service.md
+++ b/docs/core/bpm-user.service.md
@@ -12,9 +12,9 @@ Gets information about the current Process Services user.
 
 ### Methods
 
--   **getCurrentUserInfo**(): [`Observable<BpmUserModel>`](../core/bpm-user.model.md)<br/>
+-   **getCurrentUserInfo**(): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`BpmUserModel`](../core/bpm-user.model.md)`>`<br/>
     Gets information about the current user.
-    -   **Returns** [`Observable<BpmUserModel>`](../core/bpm-user.model.md) - User information object
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`BpmUserModel`](../core/bpm-user.model.md)`>` - User information object
 -   **getCurrentUserProfileImage**(): `string`<br/>
     Gets the current user's profile image as a URL.
     -   **Returns** `string` - URL string

--- a/docs/core/buttons-menu.component.md
+++ b/docs/core/buttons-menu.component.md
@@ -24,7 +24,7 @@ Displays buttons on a responsive menu.
 
 | Name | Type | Default value | Description |
 | -- | -- | -- | -- |
-| buttons | [`MenuButton[]`](../../lib/core/buttons-menu/menu-button.model.ts) |  | Array of buttons that defines the menu. |
+| buttons | [`MenuButton`](../../lib/core/buttons-menu/menu-button.model.ts)`[]` |  | Array of buttons that defines the menu. |
 
 ## Details
 
@@ -39,7 +39,7 @@ Mobile view of the menu
 
 ![adf-buttons-menu-mobile](../docassets/images/adf-buttons-menu-mobile.png)
 
-The `buttons` property contains an array of [MenuButton](../../lib/core/buttons-menu/menu-button.model.ts) instances that define
+The `buttons` property contains an array of [`MenuButton`](../../lib/core/buttons-menu/menu-button.model.ts) instances that define
 the label and appearance of each button along with a handler function to
 implement its action:
 

--- a/docs/core/card-item-types.service.md
+++ b/docs/core/card-item-types.service.md
@@ -12,20 +12,20 @@ Maps type names to field component types for the [Card View component](../core/c
 
 ### Methods
 
--   **getComponentTypeResolver**(type: `string` = `null`, defaultValue: `Type<__type>` = `this.defaultValue`): `DynamicComponentResolveFunction`<br/>
+-   **getComponentTypeResolver**(type: `string` = `null`, defaultValue: `Type<__type>` = `this.defaultValue`): [`DynamicComponentResolveFunction`](../../lib/core/services/dynamic-component-mapper.service.ts)<br/>
     Gets the currently active ComponentTypeResolver function for a field type.
     -   _type:_ `string`  - The type whose resolver you want
     -   _defaultValue:_ `Type<__type>`  - Default type returned for types that are not yet mapped
-    -   **Returns** `DynamicComponentResolveFunction` - Resolver function
+    -   **Returns** [`DynamicComponentResolveFunction`](../../lib/core/services/dynamic-component-mapper.service.ts) - Resolver function
 -   **resolveComponentType**(model: [`DynamicComponentModel`](../../lib/core/services/dynamic-component-mapper.service.ts) = `null`, defaultValue: `Type<__type>` = `this.defaultValue`): `Type<__type>`<br/>
     Finds the component type that is needed to render a form field.
-    -   _model:_ [`DynamicComponentModel`](../../lib/core/services/dynamic-component-mapper.service.ts)  - (form-field.model.md) for the field to render
+    -   _model:_ [`DynamicComponentModel`](../../lib/core/services/dynamic-component-mapper.service.ts)  - [Form](../../lib/process-services/task-list/models/form.model.ts) field model for the field to render
     -   _defaultValue:_ `Type<__type>`  - Default type returned for field types that are not yet mapped.
     -   **Returns** `Type<__type>` - Component type
--   **setComponentTypeResolver**(type: `string` = `null`, resolver: `DynamicComponentResolveFunction` = `null`, override: `boolean` = `true`)<br/>
+-   **setComponentTypeResolver**(type: `string` = `null`, resolver: [`DynamicComponentResolveFunction`](../../lib/core/services/dynamic-component-mapper.service.ts) = `null`, override: `boolean` = `true`)<br/>
     Sets or optionally replaces a ComponentTypeResolver function for a field type.
     -   _type:_ `string`  - The type whose resolver you want to set
-    -   _resolver:_ `DynamicComponentResolveFunction`  - The new resolver function
+    -   _resolver:_ [`DynamicComponentResolveFunction`](../../lib/core/services/dynamic-component-mapper.service.ts)  - The new resolver function
     -   _override:_ `boolean`  - The new resolver will only replace an existing one if this parameter is true
 
 ## Details

--- a/docs/core/card-view-item.interface.md
+++ b/docs/core/card-view-item.interface.md
@@ -26,17 +26,17 @@ export interface CardViewItem {
 
 ### Properties
 
-| Name         | Type    | Default | Description                                                                                                                                                                                                  |
-| ------------ | ------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| label        | string  | ""      | Item label                                                                                                                                                                                                   |
-| value        | any     |         | The original data value for the item                                                                                                                                                                         |
-| key          | string  | ""      | Identifying key (important when editing the item)                                                                                                                                                            |
-| default      | any     |         | The default value to display if the value is empty                                                                                                                                                           |
-| displayValue | string  | ""      | The value to display                                                                                                                                                                                         |
-| editable     | boolean | false   | Toggles whether the item is editable                                                                                                                                                                         |
-| clickable    | boolean | false   | Toggles whether the item is clickable                                                                                                                                                                        |
-| icon         | string  |         | The material icon to show beside clickable items                                                                                                                                                             |
-| data         | any     | null    | Any custom data which is needed to be provided and stored in the model for any reason. During an update or a click event this can be a container of any custom data which can be useful for 3rd party codes. |
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| label | string | "" | Item label |
+| value | any |  | The original data value for the item |
+| key | string | "" | Identifying key (important when editing the item) |
+| default | any |  | The default value to display if the value is empty |
+| displayValue | string | "" | The value to display |
+| editable | boolean | false | Toggles whether the item is editable |
+| clickable | boolean | false | Toggles whether the item is clickable |
+| icon | string |  | The material icon to show beside clickable items |
+| data | any | null | Any custom data which is needed to be provided and stored in the model for any reason. During an update or a click event this can be a container of any custom data which can be useful for 3rd party codes. |
 
 ## Details
 
@@ -147,5 +147,5 @@ Picard's birthday (47457.1):
 
 ## See also
 
-*   [Card View component](card-view.component.md)
-*   [Card Item Types service](card-item-types.service.md)
+-   [Card View component](card-view.component.md)
+-   [Card Item Types service](card-item-types.service.md)

--- a/docs/core/card-view.component.md
+++ b/docs/core/card-view.component.md
@@ -86,7 +86,7 @@ Defining properties from Typescript:
 | -- | -- | -- | -- |
 | displayEmpty | `boolean` | true | Toggles whether or not to show empty items in non-editable mode. |
 | editable | `boolean` |  | Toggles whether or not the items can be edited. |
-| properties | [`CardViewItem[]`](../../lib/core/card-view/interfaces/card-view-item.interface.ts) |  | (**required**) Items to show in the card view. |
+| properties | [`CardViewItem`](../../lib/core/card-view/interfaces/card-view-item.interface.ts)`[]` |  | (**required**) Items to show in the card view. |
 
 ## Details
 

--- a/docs/core/comment-content.service.md
+++ b/docs/core/comment-content.service.md
@@ -12,15 +12,15 @@ Adds and retrieves comments for nodes in Content Services.
 
 ### Methods
 
--   **addNodeComment**(nodeId: `string` = `null`, message: `string` = `null`): [`Observable<CommentModel>`](../../lib/core/models/comment.model.ts)<br/>
+-   **addNodeComment**(nodeId: `string` = `null`, message: `string` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`CommentModel`](../../lib/core/models/comment.model.ts)`>`<br/>
     Adds a comment to a node.
     -   _nodeId:_ `string`  - ID of the target node
     -   _message:_ `string`  - Text for the comment
-    -   **Returns** [`Observable<CommentModel>`](../../lib/core/models/comment.model.ts) - Details of the comment added
--   **getNodeComments**(nodeId: `string` = `null`): [`Observable<CommentModel[]>`](../../lib/core/models/comment.model.ts)<br/>
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`CommentModel`](../../lib/core/models/comment.model.ts)`>` - Details of the comment added
+-   **getNodeComments**(nodeId: `string` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`CommentModel`](../../lib/core/models/comment.model.ts)`[]>`<br/>
     Gets all comments that have been added to a node.
     -   _nodeId:_ `string`  - ID of the target node
-    -   **Returns** [`Observable<CommentModel[]>`](../../lib/core/models/comment.model.ts) - Details for each comment
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`CommentModel`](../../lib/core/models/comment.model.ts)`[]>` - Details for each comment
 
 ## Details
 

--- a/docs/core/comment-list.component.md
+++ b/docs/core/comment-list.component.md
@@ -63,10 +63,10 @@ In the component template use the [comment list component](../core/comment-list.
 
 | Name | Type | Default value | Description |
 | -- | -- | -- | -- |
-| comments | [`CommentModel[]`](../../lib/core/models/comment.model.ts) |  | The comments data used to populate the list. |
+| comments | [`CommentModel`](../../lib/core/models/comment.model.ts)`[]` |  | The comments data used to populate the list. |
 
 ### Events
 
 | Name | Type | Description |
 | -- | -- | -- |
-| clickRow | [`EventEmitter<CommentModel>`](../../lib/core/models/comment.model.ts) | Emitted when the user clicks on one of the comment rows. |
+| clickRow | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`CommentModel`](../../lib/core/models/comment.model.ts)`>` | Emitted when the user clicks on one of the comment rows. |

--- a/docs/core/comment-process.service.md
+++ b/docs/core/comment-process.service.md
@@ -12,24 +12,24 @@ Adds and retrieves comments for task and process instances in Process Services.
 
 ### Methods
 
--   **addProcessInstanceComment**(processInstanceId: `string` = `null`, message: `string` = `null`): [`Observable<CommentModel>`](../../lib/core/models/comment.model.ts)<br/>
+-   **addProcessInstanceComment**(processInstanceId: `string` = `null`, message: `string` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`CommentModel`](../../lib/core/models/comment.model.ts)`>`<br/>
     Adds a comment to a process instance.
     -   _processInstanceId:_ `string`  - ID of the target process instance
     -   _message:_ `string`  - Text for the comment
-    -   **Returns** [`Observable<CommentModel>`](../../lib/core/models/comment.model.ts) - Details of the comment added
--   **addTaskComment**(taskId: `string` = `null`, message: `string` = `null`): [`Observable<CommentModel>`](../../lib/core/models/comment.model.ts)<br/>
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`CommentModel`](../../lib/core/models/comment.model.ts)`>` - Details of the comment added
+-   **addTaskComment**(taskId: `string` = `null`, message: `string` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`CommentModel`](../../lib/core/models/comment.model.ts)`>`<br/>
     Adds a comment to a task.
     -   _taskId:_ `string`  - ID of the target task
     -   _message:_ `string`  - Text for the comment
-    -   **Returns** [`Observable<CommentModel>`](../../lib/core/models/comment.model.ts) - Details about the comment
--   **getProcessInstanceComments**(processInstanceId: `string` = `null`): [`Observable<CommentModel[]>`](../../lib/core/models/comment.model.ts)<br/>
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`CommentModel`](../../lib/core/models/comment.model.ts)`>` - Details about the comment
+-   **getProcessInstanceComments**(processInstanceId: `string` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`CommentModel`](../../lib/core/models/comment.model.ts)`[]>`<br/>
     Gets all comments that have been added to a process instance.
     -   _processInstanceId:_ `string`  - ID of the target process instance
-    -   **Returns** [`Observable<CommentModel[]>`](../../lib/core/models/comment.model.ts) - Details for each comment
--   **getTaskComments**(taskId: `string` = `null`): [`Observable<CommentModel[]>`](../../lib/core/models/comment.model.ts)<br/>
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`CommentModel`](../../lib/core/models/comment.model.ts)`[]>` - Details for each comment
+-   **getTaskComments**(taskId: `string` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`CommentModel`](../../lib/core/models/comment.model.ts)`[]>`<br/>
     Gets all comments that have been added to a task.
     -   _taskId:_ `string`  - ID of the target task
-    -   **Returns** [`Observable<CommentModel[]>`](../../lib/core/models/comment.model.ts) - Details for each comment
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`CommentModel`](../../lib/core/models/comment.model.ts)`[]>` - Details for each comment
 
 ## Details
 

--- a/docs/core/comments.component.md
+++ b/docs/core/comments.component.md
@@ -41,4 +41,4 @@ Displays comments from users involved in a specified task or content and allows 
 
 | Name | Type | Description |
 | -- | -- | -- |
-| error | `EventEmitter<any>` | Emitted when an error occurs while displaying/adding a comment. |
+| error | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<any>` | Emitted when an error occurs while displaying/adding a comment. |

--- a/docs/core/content.service.md
+++ b/docs/core/content.service.md
@@ -12,19 +12,19 @@ Accesses app-generated data objects via URLs and file downloads.
 
 ### Methods
 
--   **createFolder**(relativePath: `string` = `null`, name: `string` = `null`, parentId?: `string` = `null`): [`Observable<FolderCreatedEvent>`](../../lib/core/events/folder-created.event.ts)<br/>
+-   **createFolder**(relativePath: `string` = `null`, name: `string` = `null`, parentId?: `string` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`FolderCreatedEvent`](../../lib/core/events/folder-created.event.ts)`>`<br/>
     Creates a folder.
     -   _relativePath:_ `string`  - Location to create the folder
     -   _name:_ `string`  - Folder name
     -   _parentId:_ `string`  - (Optional) Node ID of parent folder
-    -   **Returns** [`Observable<FolderCreatedEvent>`](../../lib/core/events/folder-created.event.ts) - Information about the new folder
--   **createTrustedUrl**(blob: `Blob` = `null`): `string`<br/>
-    Creates a trusted object URL from the Blob. WARNING: calling this method with untrusted user data exposes your application to XSS security risks!
-    -   _blob:_ `Blob`  - Data to wrap into object URL
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`FolderCreatedEvent`](../../lib/core/events/folder-created.event.ts)`>` - Information about the new folder
+-   **createTrustedUrl**(blob: [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob) = `null`): `string`<br/>
+    Creates a trusted object URL from the [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob). WARNING: calling this method with untrusted user data exposes your application to XSS security risks!
+    -   _blob:_ [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob)  - Data to wrap into object URL
     -   **Returns** `string` - URL string
--   **downloadBlob**(blob: `Blob` = `null`, fileName: `string` = `null`)<br/>
-    Invokes content download for a Blob with a file name.
-    -   _blob:_ `Blob`  - Content to download.
+-   **downloadBlob**(blob: [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob) = `null`, fileName: `string` = `null`)<br/>
+    Invokes content download for a [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob) with a file name.
+    -   _blob:_ [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob)  - Content to download.
     -   _fileName:_ `string`  - Name of the resulting file.
 -   **downloadData**(data: `any` = `null`, fileName: `string` = `null`)<br/>
     Invokes content download for a data array with a file name.
@@ -46,48 +46,48 @@ Accesses app-generated data objects via URLs and file downloads.
     -   _attachment:_ `boolean`  - (Optional) Toggles whether to retrieve content as an attachment for download
     -   _ticket:_ `string`  - (Optional) Custom ticket to use for authentication
     -   **Returns** `string` - URL string
--   **getNode**(nodeId: `string` = `null`, opts?: `any` = `null`): `Observable<NodeEntry>`<br/>
+-   **getNode**(nodeId: `string` = `null`, opts?: `any` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`NodeEntry`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/NodeEntry.md)`>`<br/>
     Gets a Node via its node ID.
     -   _nodeId:_ `string`  - ID of the target node
     -   _opts:_ `any`  - (Optional) Options supported by JSAPI
-    -   **Returns** `Observable<NodeEntry>` - Details of the folder
--   **getNodeContent**(nodeId: `string` = `null`): `Observable<any>`<br/>
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`NodeEntry`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/NodeEntry.md)`>` - Details of the folder
+-   **getNodeContent**(nodeId: `string` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<any>`<br/>
     Gets content for the given node.
     -   _nodeId:_ `string`  - ID of the target node
-    -   **Returns** `Observable<any>` - Content data
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<any>` - Content data
 -   **hasAllowableOperations**(node: `any` = `null`): `boolean`<br/>
     Checks if the node has the properties allowableOperations
     -   _node:_ `any`  - Node to check allowableOperations
     -   **Returns** `boolean` - True if the node has the property, false otherwise
--   **hasPermission**(node: `Node` = `null`, permission: `PermissionsEnum | string` = `null`): `boolean`<br/>
+-   **hasPermission**(node: `Node` = `null`, permission: [`PermissionsEnum`](../../lib/core/models/permissions.enum.ts)` | string` = `null`): `boolean`<br/>
     Checks if the user has permissions on that node
     -   _node:_ `Node`  - Node to check allowableOperations
-    -   _permission:_ `PermissionsEnum | string`  - Create, delete, update, updatePermissions, !create, !delete, !update, !updatePermissions
+    -   _permission:_ [`PermissionsEnum`](../../lib/core/models/permissions.enum.ts)` | string`  - Create, delete, update, updatePermissions, !create, !delete, !update, !updatePermissions
     -   **Returns** `boolean` - True if the user has the required permissions, false otherwise
 
 ## Details
 
-Use the [Content service](../core/content.service.md) to deliver data to the user from `Blob` objects.
+Use the [Content service](../core/content.service.md) to deliver data to the user from [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob) objects.
 
-The [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob) class
+The [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob) class
 (implemented in the browser, not ADF) represents an array of bytes that you can
 use to construct and store data in any binary format you choose.
-The user can access a Blob either by downloading the byte array as a file or in
+The user can access a [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob) either by downloading the byte array as a file or in
 some cases by viewing it directly in the browser via a special URL that references
-the Blob. For example, you could use the Blob interface to construct an image in the
+the [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob). For example, you could use the [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob) interface to construct an image in the
 [PNG format](https://en.wikipedia.org/wiki/Portable_Network_Graphics). Since
-PNG is a format the browser can display, you could use the Blob's URL in an
+PNG is a format the browser can display, you could use the [Blob's](https://developer.mozilla.org/en-US/docs/Web/API/Blob) URL in an
 &lt;img> element to view the image within the page. Alternatively, you could let
 the user download it as a PNG file.
 
-The `downloadBlob` method starts a download of the Blob data to the `filename`
+The `downloadBlob` method starts a download of the [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob) data to the `filename`
 within the user's downloads folder. The other `downloadXXX` methods do the same
-but first convert the supplied data to a Blob before downloading; see the
+but first convert the supplied data to a [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob) before downloading; see the
 [Blob reference page](https://developer.mozilla.org/en-US/docs/Web/API/Blob)
-for details of how a Blob's contents are assembled from the constructor arguments.
+for details of how a [Blob's](https://developer.mozilla.org/en-US/docs/Web/API/Blob) contents are assembled from the constructor arguments.
 
-Use `createdTrustedUrl` to generate a URL string for a Blob. The URL refers to
-the Blob as though it were a file but it is actually an object stored in memory,
+Use `createdTrustedUrl` to generate a URL string for a [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob). The URL refers to
+the [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob) as though it were a file but it is actually an object stored in memory,
 so it does not persist across browser sessions. This URL can be used much like any
 other, so you could use it for the `src` attribute of an &lt;img> element or the
 `href` of a download link. Note that while the URL is 'trusted', the data it contains

--- a/docs/core/datatable-adapter.interface.md
+++ b/docs/core/datatable-adapter.interface.md
@@ -18,7 +18,7 @@ and [Tasklist](../process-services/task-list.component.md) components.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| rowsChanged | `Subject<Array<DataRow>>` | Raised when data adapter gets new rows. |
+| rowsChanged | [`Subject<Array<DataRow>>`](../../lib/core/datatable/data/data-row.model.ts) | Raised when data adapter gets new rows. |
 
 ## Methods
 
@@ -30,10 +30,10 @@ Get/set the values for display in the table using an array of rows.
 [`setColumns(columns: Array<DataColumn>): void;`](../../lib/core/datatable/data/data-column.model.ts)<br/>
 Get/set an array of column specifications.
 
-`getValue(row: DataRow, col: DataColumn): any;`<br/>
+`getValue(row: `[`DataRow,`](../../lib/core/datatable/data/data-row.model.ts)` col: DataColumn): any;`<br/>
 Get the data value from a specific table cell.
 
-`getSorting(): DataSorting;`<br/>
+`getSorting(): `[`DataSorting`](../../lib/core/datatable/data/data-sorting.model.ts)`;`<br/>
 `setSorting(sorting: DataSorting): void;`<br/>
 Get/set the sorting key and direction (ascending or descending).
 

--- a/docs/core/datatable.component.md
+++ b/docs/core/datatable.component.md
@@ -16,6 +16,8 @@ See it live: [DataTable Quickstart](https://embed.plnkr.co/80qr4YFBeHjLMdAV0F6l/
 
 -   [Basic usage](#basic-usage)
 
+    -   [Setting the rows and column schema](#setting-the-rows-and-column-schema)
+
 -   [Class members](#class-members)
 
     -   [Properties](#properties)
@@ -82,7 +84,7 @@ export class DataTableDemo {
 
 ### Setting the rows and column schema
 
-You can set rows and columns to the ObjectDataTableAdapter like shown below:
+You can set rows and columns to the [ObjectDataTableAdapter](../../lib/core/datatable/data/object-datatable-adapter.ts) like shown below:
 
 ```ts
 import { ObjectDataTableAdapter }  from '@alfresco/adf-core';
@@ -159,7 +161,7 @@ export class DataTableDemo {
 </adf-datatable>
 ```
 
-You can also set rows to the ObjectDataTableAdapter and set columns as an input like shown below :
+You can also set rows to the [ObjectDataTableAdapter](../../lib/core/datatable/data/object-datatable-adapter.ts) and set columns as an input like shown below :
 
 ```ts
 import { ObjectDataTableAdapter }  from '@alfresco/adf-core';
@@ -258,7 +260,7 @@ export class DataTableDemo {
 | actions | `boolean` | false | Toggles the data actions column. |
 | actionsPosition | `string` | "right" | Position of the actions dropdown menu. Can be "left" or "right". |
 | allowDropFiles | `boolean` | false | Toggles file drop support for rows (see [Upload directive](upload.directive.md) for further details). |
-| columns | `any[]` | `[]` | The columns that the datatable will show.  |
+| columns | `any[]` |  \[] | The columns that the datatable will show. |
 | contextMenu | `boolean` | false | Toggles custom context menu for the component. |
 | data | [`DataTableAdapter`](../../lib/core/datatable/data/datatable-adapter.ts) |  | Data source for the table |
 | display | `string` |  [`DisplayMode`](../../lib/core/datatable/components/datatable/datatable.component.ts).List | Selects the display mode of the table. Can be "list" or "gallery". |
@@ -269,19 +271,20 @@ export class DataTableDemo {
 | rowStyle | `string` |  | The inline style to apply to every row. See [NgStyle](https://angular.io/docs/ts/latest/api/common/index/NgStyle-directive.html) docs for more details and usage examples. |
 | rowStyleClass | `string` | "" | The CSS class to apply to every row. |
 | rows | `any[]` |  \[] | The rows that the datatable will show. |
+| selectFirstRow | `boolean` | true | Toggles the first row selection. |
 | selectionMode | `string` | "single" | Row selection mode. Can be none, `single` or `multiple`. For `multiple` mode, you can use Cmd (macOS) or Ctrl (Win) modifier key to toggle selection for multiple rows. |
-| selectFirstRow | `boolean` | `true` | Toggles the first row selection. |
 | showHeader | `boolean` | true | Toggles the header. |
+| sorting | `any[]` |  \[] | Define the sort order of the datatable. Possible values are : [`created`, `desc`], [`created`, `asc`], [`due`, `desc`], [`due`, `asc`] |
 
 ### Events
 
 | Name | Type | Description |
 | -- | -- | -- |
-| executeRowAction | [`EventEmitter<DataRowActionEvent>`](../../lib/core/datatable/components/datatable/data-row-action.event.ts) | Emitted when the user executes a row action. |
-| rowClick | [`EventEmitter<DataRowEvent>`](../../lib/core/datatable/data/data-row-event.model.ts) | Emitted when the user clicks a row. |
-| rowDblClick | [`EventEmitter<DataRowEvent>`](../../lib/core/datatable/data/data-row-event.model.ts) | Emitted when the user double-clicks a row. |
-| showRowActionsMenu | [`EventEmitter<DataCellEvent>`](../../lib/core/datatable/components/datatable/data-cell.event.ts) | Emitted before the actions menu is displayed for a row. |
-| showRowContextMenu | [`EventEmitter<DataCellEvent>`](../../lib/core/datatable/components/datatable/data-cell.event.ts) | Emitted before the context menu is displayed for a row. |
+| executeRowAction | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`DataRowActionEvent`](../../lib/core/datatable/components/datatable/data-row-action.event.ts)`>` | Emitted when the user executes a row action. |
+| rowClick | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`DataRowEvent`](../../lib/core/datatable/data/data-row-event.model.ts)`>` | Emitted when the user clicks a row. |
+| rowDblClick | `EventEmitter<DataRowEvent>` | Emitted when the user double-clicks a row. |
+| showRowActionsMenu | `EventEmitter<DataCellEvent>` | Emitted before the actions menu is displayed for a row. |
+| showRowContextMenu | `EventEmitter<DataCellEvent>` | Emitted before the context menu is displayed for a row. |
 
 ## Details
 

--- a/docs/core/deleted-nodes-api.service.md
+++ b/docs/core/deleted-nodes-api.service.md
@@ -12,10 +12,10 @@ Gets a list of Content Services nodes currently in the trash.
 
 ### Methods
 
--   **getDeletedNodes**(options?: `Object` = `null`): [`Observable<NodePaging>`](../../lib/content-services/document-list/models/document-library.model.ts)<br/>
+-   **getDeletedNodes**(options?: `Object` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`NodePaging`](../../lib/content-services/document-list/models/document-library.model.ts)`>`<br/>
     Gets a list of nodes in the trash.
     -   _options:_ `Object`  - (Optional) Options for JSAPI call
-    -   **Returns** [`Observable<NodePaging>`](../../lib/content-services/document-list/models/document-library.model.ts) - List of nodes in the trash
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`NodePaging`](../../lib/content-services/document-list/models/document-library.model.ts)`>` - List of nodes in the trash
 
 ## Details
 

--- a/docs/core/discovery-api.service.md
+++ b/docs/core/discovery-api.service.md
@@ -12,12 +12,12 @@ Gets version and license information for Process Services and Content Services.
 
 ### Methods
 
--   **getBpmProductInfo**(): `Observable<any>`<br/>
+-   **getBpmProductInfo**(): [`Observable`](http://reactivex.io/documentation/observable.html)`<any>`<br/>
     Gets product information for Process Services.
-    -   **Returns** `Observable<any>` - ProductVersionModel containing product details
--   **getEcmProductInfo**(): `Observable<any>`<br/>
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<any>` - ProductVersionModel containing product details
+-   **getEcmProductInfo**(): [`Observable`](http://reactivex.io/documentation/observable.html)`<any>`<br/>
     Gets product information for Content Services.
-    -   **Returns** `Observable<any>` - ProductVersionModel containing product details
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<any>` - ProductVersionModel containing product details
 
 ## Details
 

--- a/docs/core/ecm-user.service.md
+++ b/docs/core/ecm-user.service.md
@@ -12,13 +12,13 @@ Gets information about a Content Services user.
 
 ### Methods
 
--   **getCurrentUserInfo**(): [`Observable<EcmUserModel>`](../core/ecm-user.model.md)<br/>
+-   **getCurrentUserInfo**(): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`EcmUserModel`](../core/ecm-user.model.md)`>`<br/>
     Gets information about the user who is currently logged-in.
-    -   **Returns** [`Observable<EcmUserModel>`](../core/ecm-user.model.md) - User information as for getUserInfo
--   **getUserInfo**(userName: `string` = `null`): [`Observable<EcmUserModel>`](../core/ecm-user.model.md)<br/>
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`EcmUserModel`](../core/ecm-user.model.md)`>` - User information as for getUserInfo
+-   **getUserInfo**(userName: `string` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`EcmUserModel`](../core/ecm-user.model.md)`>`<br/>
     Gets information about a user identified by their username.
     -   _userName:_ `string`  - Target username
-    -   **Returns** [`Observable<EcmUserModel>`](../core/ecm-user.model.md) - User information
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`EcmUserModel`](../core/ecm-user.model.md)`>` - User information
 -   **getUserProfileImage**(avatarId: `string` = `null`): `string`<br/>
     Returns a profile image as a URL.
     -   _avatarId:_ `string`  - Target avatar

--- a/docs/core/favorites-api.service.md
+++ b/docs/core/favorites-api.service.md
@@ -12,11 +12,11 @@ Gets a list of items a user has marked as their favorites.
 
 ### Methods
 
--   **getFavorites**(personId: `string` = `null`, options?: `any` = `null`): [`Observable<NodePaging>`](../../lib/content-services/document-list/models/document-library.model.ts)<br/>
+-   **getFavorites**(personId: `string` = `null`, options?: `any` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`NodePaging`](../../lib/content-services/document-list/models/document-library.model.ts)`>`<br/>
     Gets the favorites for a user.
     -   _personId:_ `string`  - ID of the user
     -   _options:_ `any`  - (Optional) Options supported by JSAPI
-    -   **Returns** [`Observable<NodePaging>`](../../lib/content-services/document-list/models/document-library.model.ts) - List of favorites
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`NodePaging`](../../lib/content-services/document-list/models/document-library.model.ts)`>` - List of favorites
 -   **remapFavoriteEntries**(entries: `any[]` = `null`): `any[]`<br/>
 
     -   _entries:_ `any[]`  - 

--- a/docs/core/form-rendering.service.md
+++ b/docs/core/form-rendering.service.md
@@ -12,20 +12,20 @@ Maps an APS form field type string onto the corresponding form [widget component
 
 ### Methods
 
--   **getComponentTypeResolver**(type: `string` = `null`, defaultValue: `Type<__type>` = `this.defaultValue`): `DynamicComponentResolveFunction`<br/>
+-   **getComponentTypeResolver**(type: `string` = `null`, defaultValue: `Type<__type>` = `this.defaultValue`): [`DynamicComponentResolveFunction`](../../lib/core/services/dynamic-component-mapper.service.ts)<br/>
     Gets the currently active ComponentTypeResolver function for a field type.
     -   _type:_ `string`  - The type whose resolver you want
     -   _defaultValue:_ `Type<__type>`  - Default type returned for types that are not yet mapped
-    -   **Returns** `DynamicComponentResolveFunction` - Resolver function
+    -   **Returns** [`DynamicComponentResolveFunction`](../../lib/core/services/dynamic-component-mapper.service.ts) - Resolver function
 -   **resolveComponentType**(model: [`DynamicComponentModel`](../../lib/core/services/dynamic-component-mapper.service.ts) = `null`, defaultValue: `Type<__type>` = `this.defaultValue`): `Type<__type>`<br/>
     Finds the component type that is needed to render a form field.
-    -   _model:_ [`DynamicComponentModel`](../../lib/core/services/dynamic-component-mapper.service.ts)  - (form-field.model.md) for the field to render
+    -   _model:_ [`DynamicComponentModel`](../../lib/core/services/dynamic-component-mapper.service.ts)  - [Form](../../lib/process-services/task-list/models/form.model.ts) field model for the field to render
     -   _defaultValue:_ `Type<__type>`  - Default type returned for field types that are not yet mapped.
     -   **Returns** `Type<__type>` - Component type
--   **setComponentTypeResolver**(type: `string` = `null`, resolver: `DynamicComponentResolveFunction` = `null`, override: `boolean` = `true`)<br/>
+-   **setComponentTypeResolver**(type: `string` = `null`, resolver: [`DynamicComponentResolveFunction`](../../lib/core/services/dynamic-component-mapper.service.ts) = `null`, override: `boolean` = `true`)<br/>
     Sets or optionally replaces a ComponentTypeResolver function for a field type.
     -   _type:_ `string`  - The type whose resolver you want to set
-    -   _resolver:_ `DynamicComponentResolveFunction`  - The new resolver function
+    -   _resolver:_ [`DynamicComponentResolveFunction`](../../lib/core/services/dynamic-component-mapper.service.ts)  - The new resolver function
     -   _override:_ `boolean`  - The new resolver will only replace an existing one if this parameter is true
 
 ## Details

--- a/docs/core/form.component.md
+++ b/docs/core/form.component.md
@@ -46,7 +46,7 @@ Shows a [`Form`](../../lib/process-services/task-list/models/form.model.ts) from
 | data | [`FormValues`](../../lib/core/form/components/widgets/core/form-values.ts) |  | Custom form values map to be used with the rendered form. |
 | disableCompleteButton | `boolean` | false | If true then the `Complete` outcome button is shown but it will be disabled. |
 | disableStartProcessButton | `boolean` | false | If true then the `Start Process` outcome button is shown but it will be disabled. |
-| fieldValidators | [`FormFieldValidator[]`](../../lib/core/form/components/widgets/core/form-field-validator.ts) |  \[] | Contains a list of form field validator instances. |
+| fieldValidators | [`FormFieldValidator`](../../lib/core/form/components/widgets/core/form-field-validator.ts)`[]` |  \[] | Contains a list of form field validator instances. |
 | form | [`FormModel`](../../lib/core/form/components/widgets/core/form.model.ts) |  | Underlying [form model](../../lib/core/form/components/widgets/core/form.model.ts) instance. |
 | formId | `string` |  | The id of the form definition to load and display with custom values. |
 | formName | `string` |  | Name of the form definition to load and display with custom values. |
@@ -67,12 +67,12 @@ Shows a [`Form`](../../lib/process-services/task-list/models/form.model.ts) from
 
 | Name | Type | Description |
 | -- | -- | -- |
-| executeOutcome | [`EventEmitter<FormOutcomeEvent>`](../../lib/core/form/components/widgets/core/form-outcome-event.model.ts) | Emitted when any outcome is executed. Default behaviour can be prevented via `event.preventDefault()`. |
-| formCompleted | [`EventEmitter<FormModel>`](../../lib/core/form/components/widgets/core/form.model.ts) | Emitted when the form is submitted with the `Complete` outcome. |
-| formContentClicked | [`EventEmitter<ContentLinkModel>`](../../lib/core/form/components/widgets/core/content-link.model.ts) | Emitted when form content is clicked. |
-| formDataRefreshed | [`EventEmitter<FormModel>`](../../lib/core/form/components/widgets/core/form.model.ts) | Emitted when form values are refreshed due to a data property change. |
-| formLoaded | [`EventEmitter<FormModel>`](../../lib/core/form/components/widgets/core/form.model.ts) | Emitted when the form is loaded or reloaded. |
-| formSaved | [`EventEmitter<FormModel>`](../../lib/core/form/components/widgets/core/form.model.ts) | Emitted when the form is submitted with the `Save` or custom outcomes. |
+| executeOutcome | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`FormOutcomeEvent`](../../lib/core/form/components/widgets/core/form-outcome-event.model.ts)`>` | Emitted when any outcome is executed. Default behaviour can be prevented via `event.preventDefault()`. |
+| formCompleted | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`FormModel`](../../lib/core/form/components/widgets/core/form.model.ts)`>` | Emitted when the form is submitted with the `Complete` outcome. |
+| formContentClicked | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`ContentLinkModel`](../../lib/core/form/components/widgets/core/content-link.model.ts)`>` | Emitted when form content is clicked. |
+| formDataRefreshed | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`FormModel`](../../lib/core/form/components/widgets/core/form.model.ts)`>` | Emitted when form values are refreshed due to a data property change. |
+| formLoaded | `EventEmitter<FormModel>` | Emitted when the form is loaded or reloaded. |
+| formSaved | `EventEmitter<FormModel>` | Emitted when the form is submitted with the `Save` or custom outcomes. |
 | onError | `EventEmitter<any>` | Emitted when any error occurs. |
 
 ## Details

--- a/docs/core/form.service.md
+++ b/docs/core/form.service.md
@@ -51,83 +51,83 @@ class MyComponent {
 
 ### Methods
 
--   `parseForm(json: any, data?: FormValues, readOnly: boolean = false): FormModel`  
+-   `parseForm(json: any, data?: `[`FormValues,`](../../lib/core/form/components/widgets/core/form-values.ts)` readOnly: boolean = false): `[`FormModel`](../../lib/core/form/components/widgets/core/form.model.ts)  
     Parses JSON data to create a corresponding [`Form`](../../lib/process-services/task-list/models/form.model.ts) model.  
     -   `json` - JSON to create the form
     -   `data` - (Optional) Values for the form fields
     -   `readOnly` - Should the form fields be read-only?
--   `createFormFromANode(formName: string): Observable<any>`  
+-   `createFormFromANode(formName: string): `[`Observable`](http://reactivex.io/documentation/observable.html)`<any>`  
     Create a [`Form`](../../lib/process-services/task-list/models/form.model.ts) with a field for each metadata property.  
     -   `formName` - Name of the new form
--   `createForm(formName: string): Observable<any>`  
+-   `createForm(formName: string): `[`Observable`](http://reactivex.io/documentation/observable.html)`<any>`  
     Create a [`Form`](../../lib/process-services/task-list/models/form.model.ts).  
     -   `formName` - Name of the new form
--   `saveForm(formId: string, formModel: FormDefinitionModel): Observable<any>`  
+-   `saveForm(formId: string, formModel: FormDefinitionModel): `[`Observable`](http://reactivex.io/documentation/observable.html)`<any>`  
     Saves a form.  
     -   `formId` - ID of the form to save 
     -   `formModel` - Model data for the form
--   `addFieldsToAForm(formId: string, formModel: FormDefinitionModel): Observable<any>`  
+-   `addFieldsToAForm(formId: string, formModel: FormDefinitionModel): `[`Observable`](http://reactivex.io/documentation/observable.html)`<any>`  
     -   `formId` - ID of the form
     -   `formModel` - [`Form`](../../lib/process-services/task-list/models/form.model.ts) definition
--   `searchFrom(name: string): Observable<any>`  
+-   `searchFrom(name: string): `[`Observable`](http://reactivex.io/documentation/observable.html)`<any>`  
     Search for a form by name.  
     -   `name` - The form name to search for
--   `getForms(): Observable<any>`  
+-   `getForms(): `[`Observable`](http://reactivex.io/documentation/observable.html)`<any>`  
     Gets all the forms.  
 
--   `getProcessDefinitions(): Observable<any>`  
+-   `getProcessDefinitions(): `[`Observable`](http://reactivex.io/documentation/observable.html)`<any>`  
     Get Process Definitions  
 
--   `getProcessVarablesById(processInstanceId: string): Observable<any[]>`  
+-   `getProcessVarablesById(processInstanceId: string): `[`Observable`](http://reactivex.io/documentation/observable.html)`<any[]>`  
     Get instance variables for a process.  
     -   `processInstanceId` - ID of the target process
--   `getTasks(): Observable<any>`  
+-   `getTasks(): `[`Observable`](http://reactivex.io/documentation/observable.html)`<any>`  
     Gets all the tasks.  
 
--   `getTask(taskId: string): Observable<any>`  
+-   `getTask(taskId: string): `[`Observable`](http://reactivex.io/documentation/observable.html)`<any>`  
     Gets a task.  
     -   `taskId` - Task Id
--   `saveTaskForm(taskId: string, formValues: FormValues): Observable<any>`  
+-   `saveTaskForm(taskId: string, formValues: FormValues): `[`Observable`](http://reactivex.io/documentation/observable.html)`<any>`  
     Save Task [`Form`](../../lib/process-services/task-list/models/form.model.ts).  
     -   `taskId` - Task Id
     -   `formValues` - [`Form`](../../lib/process-services/task-list/models/form.model.ts) Values
--   `completeTaskForm(taskId: string, formValues: FormValues, outcome?: string): Observable<any>`  
+-   `completeTaskForm(taskId: string, formValues: `[`FormValues,`](../../lib/core/form/components/widgets/core/form-values.ts)` outcome?: string): `[`Observable`](http://reactivex.io/documentation/observable.html)`<any>`  
     Complete Task [`Form`](../../lib/process-services/task-list/models/form.model.ts)  
     -   `taskId` - Task Id
     -   `formValues` - [`Form`](../../lib/process-services/task-list/models/form.model.ts) Values
     -   `outcome` - (Optional) [`Form`](../../lib/process-services/task-list/models/form.model.ts) Outcome
--   `getTaskForm(taskId: string): Observable<any>`  
+-   `getTaskForm(taskId: string): `[`Observable`](http://reactivex.io/documentation/observable.html)`<any>`  
     Get [`Form`](../../lib/process-services/task-list/models/form.model.ts) related to a taskId  
     -   `taskId` - Task Id
--   `getFormDefinitionById(formId: string): Observable<any>`  
+-   `getFormDefinitionById(formId: string): `[`Observable`](http://reactivex.io/documentation/observable.html)`<any>`  
     Get [`Form`](../../lib/process-services/task-list/models/form.model.ts) Definition  
     -   `formId` - [`Form`](../../lib/process-services/task-list/models/form.model.ts) Id
--   `getFormDefinitionByName(name: string): Observable<any>`  
+-   `getFormDefinitionByName(name: string): `[`Observable`](http://reactivex.io/documentation/observable.html)`<any>`  
     Returns form definition with a given name.  
     -   `name` - The form name
--   `getStartFormInstance(processId: string): Observable<any>`  
+-   `getStartFormInstance(processId: string): `[`Observable`](http://reactivex.io/documentation/observable.html)`<any>`  
     Get start form instance for a given processId  
     -   `processId` - Process definition ID
--   `getProcessIntance(processId: string): Observable<any>`  
+-   `getProcessIntance(processId: string): `[`Observable`](http://reactivex.io/documentation/observable.html)`<any>`  
     Gets a process instance.  
     -   `processId` - ID of the process to get
--   `getStartFormDefinition(processId: string): Observable<any>`  
+-   `getStartFormDefinition(processId: string): `[`Observable`](http://reactivex.io/documentation/observable.html)`<any>`  
     Get start form definition for a given process  
     -   `processId` - Process definition ID
--   `getRestFieldValues(taskId: string, field: string): Observable<any>`  
+-   `getRestFieldValues(taskId: string, field: string): `[`Observable`](http://reactivex.io/documentation/observable.html)`<any>`  
     Gets values of fields populated by a REST backend.  
     -   `taskId` - Task identifier
     -   `field` - Field identifier
--   `getRestFieldValuesByProcessId(processDefinitionId: string, field: string): Observable<any>`  
+-   `getRestFieldValuesByProcessId(processDefinitionId: string, field: string): `[`Observable`](http://reactivex.io/documentation/observable.html)`<any>`  
     Gets values of fields populated by a REST backend using a process ID.  
     -   `processDefinitionId` - Process identifier
     -   `field` - Field identifier
--   `getRestFieldValuesColumnByProcessId(processDefinitionId: string, field: string, column?: string): Observable<any>`  
+-   `getRestFieldValuesColumnByProcessId(processDefinitionId: string, field: string, column?: string): `[`Observable`](http://reactivex.io/documentation/observable.html)`<any>`  
     Gets column values of fields populated by a REST backend using a process ID.  
     -   `processDefinitionId` - Process identifier
     -   `field` - Field identifier
     -   `column` - (Optional) Column identifier
--   `getRestFieldValuesColumn(taskId: string, field: string, column?: string): Observable<any>`  
+-   `getRestFieldValuesColumn(taskId: string, field: string, column?: string): `[`Observable`](http://reactivex.io/documentation/observable.html)`<any>`  
     Gets column values of fields populated by a REST backend.  
     -   `taskId` - Task identifier
     -   `field` - Field identifier
@@ -152,6 +152,6 @@ class MyComponent {
 -   `toJsonArray(res: any): any`  
     Creates a JSON array representation of form data.  
     -   `res` - Object representing form data
--   `handleError(error: any): Observable<any>`  
+-   `handleError(error: any): `[`Observable`](http://reactivex.io/documentation/observable.html)`<any>`  
     Reports an error message.  
     -   `error` - Data object with optional \`message\` and \`status\` fields for the error

--- a/docs/core/host-settings.component.md
+++ b/docs/core/host-settings.component.md
@@ -28,6 +28,6 @@ Validates the URLs for ACS and APS and saves them in the user's local storage
 
 | Name | Type | Description |
 | -- | -- | -- |
-| bpmHostChange | `EventEmitter<string>` | Emitted when the bpm host URL is changed. |
-| ecmHostChange | `EventEmitter<string>` | Emitted when the ecm host URL is changed. |
+| bpmHostChange | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<string>` | Emitted when the bpm host URL is changed. |
+| ecmHostChange | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<string>` | Emitted when the ecm host URL is changed. |
 | error | `EventEmitter<string>` | Emitted when the URL is invalid. |

--- a/docs/core/infinite-pagination.component.md
+++ b/docs/core/infinite-pagination.component.md
@@ -46,7 +46,7 @@ Adds "infinite" pagination to the component it is used with.
 
 | Name | Type | Description |
 | -- | -- | -- |
-| loadMore | [`EventEmitter<Pagination>`](../../lib/content-services/document-list/models/document-library.model.ts) | Emitted when the "Load More" button is clicked. |
+| loadMore | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`Pagination`](../../lib/content-services/document-list/models/document-library.model.ts)`>` | Emitted when the "Load More" button is clicked. |
 
 ## Details
 

--- a/docs/core/info-drawer-tab.md
+++ b/docs/core/info-drawer-tab.md
@@ -42,10 +42,10 @@ Render tab with icon instead of labels:
 ### Properties
 
 | Name | Type | Default value | Description |
-| -- | -- | -- | -- |
+| ---- | ---- | ------------- | ----------- |
 | label | `string` | '' | Tab label. |
-| icon | `string` |  null | The material design icon. |
+| icon | `string` | null | The material design icon. |
 
 ## See also
 
-- [Info drawer layout component](info-drawer.component.md)
+-   [Info drawer layout component](info-drawer.component.md)

--- a/docs/core/info-drawer.component.md
+++ b/docs/core/info-drawer.component.md
@@ -43,7 +43,7 @@ Displays a sidebar-style information panel with tabs.
 
 | Name | Type | Description |
 | -- | -- | -- |
-| currentTab | `EventEmitter<number>` | Emitted when the currently active tab changes. |
+| currentTab | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<number>` | Emitted when the currently active tab changes. |
 
 ## Details
 

--- a/docs/core/log.service.md
+++ b/docs/core/log.service.md
@@ -58,7 +58,7 @@ If you want set for example the log to warning:
 
 ### Log message bus
 
-The logservice provide also an Observable **_onMessage_**  where you can subscribe and recive all the logs: 
+The logservice provide also an [`Observable`](http://reactivex.io/documentation/observable.html) **_onMessage_**  where you can subscribe and recive all the logs: 
 
 The messagge object recived form the bus is composed:
 

--- a/docs/core/login.component.md
+++ b/docs/core/login.component.md
@@ -61,9 +61,9 @@ Authenticates to Alfresco Content Services and Alfresco Process Services.
 
 | Name | Type | Description |
 | -- | -- | -- |
-| error | [`EventEmitter<LoginErrorEvent>`](../../lib/core/login/models/login-error.event.ts) | Emitted when the login fails. |
-| executeSubmit | [`EventEmitter<LoginSubmitEvent>`](../../lib/core/login/models/login-submit.event.ts) | Emitted when the login form is submitted. |
-| success | [`EventEmitter<LoginSuccessEvent>`](../../lib/core/login/models/login-success.event.ts) | Emitted when the login is successful. |
+| error | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`LoginErrorEvent`](../../lib/core/login/models/login-error.event.ts)`>` | Emitted when the login fails. |
+| executeSubmit | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`LoginSubmitEvent`](../../lib/core/login/models/login-submit.event.ts)`>` | Emitted when the login form is submitted. |
+| success | `EventEmitter<LoginSuccessEvent>` | Emitted when the login is successful. |
 
 ## Details
 

--- a/docs/core/menu-button.model.md
+++ b/docs/core/menu-button.model.md
@@ -34,7 +34,7 @@ let button = new MenuButton({
 ## Details
 
 An array of [`MenuButton`](../../lib/core/buttons-menu/menu-button.model.ts) instances is passed to the Button Menu component via its
-`buttons` property. See the Buttons Menu component page for a code sample and
+`buttons` property. See the [Buttons Menu component](../core/buttons-menu.component.md) page for a code sample and
 further details about setting up the menu.
 
 ## See also

--- a/docs/core/node-delete.directive.md
+++ b/docs/core/node-delete.directive.md
@@ -30,13 +30,13 @@ Deletes multiple files and folders.
 | Name | Type | Default value | Description |
 | -- | -- | -- | -- |
 | permanent | `boolean` | false | If true then the nodes are deleted immediately rather than being put in the trash |
-| adf-delete | `MinimalNodeEntity[] | DeletedNodeEntity[]` |  | Array of nodes to delete. |
+| adf-delete | `MinimalNodeEntity[] \| DeletedNodeEntity[]` |  | Array of nodes to delete. |
 
 ### Events
 
 | Name | Type | Description |
 | -- | -- | -- |
-| delete | `EventEmitter<any>` | Emitted when the nodes have been deleted. |
+| delete | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<any>` | Emitted when the nodes have been deleted. |
 
 ## Details
 

--- a/docs/core/node-favorite.directive.md
+++ b/docs/core/node-favorite.directive.md
@@ -48,8 +48,8 @@ export class MyComponent {
 
 | Name | Type | Description |
 | -- | -- | -- |
-| error | `EventEmitter<any>` | Emitted when the favorite setting has fail. |
-| toggle | `EventEmitter<any>` | Emitted when the favorite setting is complete. |
+| error | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<any>` | Emitted when the favorite setting has fail. |
+| toggle | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<any>` | Emitted when the favorite setting is complete. |
 
 ## Details
 

--- a/docs/core/node-restore.directive.md
+++ b/docs/core/node-restore.directive.md
@@ -39,7 +39,7 @@ Restores deleted nodes to their original location.
 
 | Name | Type | Description |
 | -- | -- | -- |
-| restore | `EventEmitter<any>` | Emitted when restoration is complete. |
+| restore | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<any>` | Emitted when restoration is complete. |
 
 ## Details
 

--- a/docs/core/nodes-api.service.md
+++ b/docs/core/nodes-api.service.md
@@ -27,47 +27,47 @@ Accesses and manipulates ACS document nodes using their node IDs.
 
 ### Methods
 
--   **createFolder**(parentNodeId: `string` = `null`, nodeBody: `any` = `null`, options: `any` = `{}`): `Observable<MinimalNodeEntryEntity>`<br/>
+-   **createFolder**(parentNodeId: `string` = `null`, nodeBody: `any` = `null`, options: `any` = `{}`): [`Observable`](http://reactivex.io/documentation/observable.html)`<MinimalNodeEntryEntity>`<br/>
     Creates a new folder node inside a parent folder.
     -   _parentNodeId:_ `string`  - ID of the parent folder node
     -   _nodeBody:_ `any`  - Data for the new folder
     -   _options:_ `any`  - Optional parameters supported by JSAPI
-    -   **Returns** `Observable<MinimalNodeEntryEntity>` - Details of the new folder
--   **createNode**(parentNodeId: `string` = `null`, nodeBody: `any` = `null`, options: `any` = `{}`): `Observable<MinimalNodeEntryEntity>`<br/>
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<MinimalNodeEntryEntity>` - Details of the new folder
+-   **createNode**(parentNodeId: `string` = `null`, nodeBody: `any` = `null`, options: `any` = `{}`): [`Observable`](http://reactivex.io/documentation/observable.html)`<MinimalNodeEntryEntity>`<br/>
     Creates a new document node inside a folder.
     -   _parentNodeId:_ `string`  - ID of the parent folder node
     -   _nodeBody:_ `any`  - Data for the new node
     -   _options:_ `any`  - Optional parameters supported by JSAPI
-    -   **Returns** `Observable<MinimalNodeEntryEntity>` - Details of the new node
--   **deleteNode**(nodeId: `string` = `null`, options: `any` = `{}`): `Observable<void>`<br/>
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<MinimalNodeEntryEntity>` - Details of the new node
+-   **deleteNode**(nodeId: `string` = `null`, options: `any` = `{}`): [`Observable`](http://reactivex.io/documentation/observable.html)`<void>`<br/>
     Moves a node to the trashcan.
     -   _nodeId:_ `string`  - ID of the target node
     -   _options:_ `any`  - Optional parameters supported by JSAPI
-    -   **Returns** `Observable<void>` - Empty result that notifies when the deletion is complete
--   **getNode**(nodeId: `string` = `null`, options: `any` = `{}`): `Observable<MinimalNodeEntryEntity>`<br/>
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<void>` - Empty result that notifies when the deletion is complete
+-   **getNode**(nodeId: `string` = `null`, options: `any` = `{}`): [`Observable`](http://reactivex.io/documentation/observable.html)`<MinimalNodeEntryEntity>`<br/>
     Gets the stored information about a node.
     -   _nodeId:_ `string`  - ID of the target node
     -   _options:_ `any`  - Optional parameters supported by JSAPI
-    -   **Returns** `Observable<MinimalNodeEntryEntity>` - Node information
--   **getNodeChildren**(nodeId: `string` = `null`, options: `any` = `{}`): [`Observable<NodePaging>`](../../lib/content-services/document-list/models/document-library.model.ts)<br/>
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<MinimalNodeEntryEntity>` - Node information
+-   **getNodeChildren**(nodeId: `string` = `null`, options: `any` = `{}`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`NodePaging`](../../lib/content-services/document-list/models/document-library.model.ts)`>`<br/>
     Gets the items contained in a folder node.
     -   _nodeId:_ `string`  - ID of the target node
     -   _options:_ `any`  - Optional parameters supported by JSAPI
-    -   **Returns** [`Observable<NodePaging>`](../../lib/content-services/document-list/models/document-library.model.ts) - List of child items from the folder
--   **handleError**(error: `any` = `null`): `Observable<any>`<br/>
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`NodePaging`](../../lib/content-services/document-list/models/document-library.model.ts)`>` - List of child items from the folder
+-   **handleError**(error: `any` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<any>`<br/>
     Reports an error.
     -   _error:_ `any`  - Object representing the error
-    -   **Returns** `Observable<any>` - Error information
--   **restoreNode**(nodeId: `string` = `null`): `Observable<MinimalNodeEntryEntity>`<br/>
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<any>` - Error information
+-   **restoreNode**(nodeId: `string` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<MinimalNodeEntryEntity>`<br/>
     Restores a node previously moved to the trashcan.
     -   _nodeId:_ `string`  - ID of the node to restore
-    -   **Returns** `Observable<MinimalNodeEntryEntity>` - Details of the restored node
--   **updateNode**(nodeId: `string` = `null`, nodeBody: `any` = `null`, options: `any` = `{}`): `Observable<MinimalNodeEntryEntity>`<br/>
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<MinimalNodeEntryEntity>` - Details of the restored node
+-   **updateNode**(nodeId: `string` = `null`, nodeBody: `any` = `null`, options: `any` = `{}`): [`Observable`](http://reactivex.io/documentation/observable.html)`<MinimalNodeEntryEntity>`<br/>
     Updates the information about a node.
     -   _nodeId:_ `string`  - ID of the target node
     -   _nodeBody:_ `any`  - New data for the node
     -   _options:_ `any`  - Optional parameters supported by JSAPI
-    -   **Returns** `Observable<MinimalNodeEntryEntity>` - Updated node information
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<MinimalNodeEntryEntity>` - Updated node information
 
 ## Details
 

--- a/docs/core/notification.service.md
+++ b/docs/core/notification.service.md
@@ -13,17 +13,17 @@ Shows a notification message with optional feedback.
 
 ### Methods
 
--   **openSnackMessage**(message: `string` = `null`, millisecondsDuration?: `number` = `null`): `MatSnackBarRef<any>`<br/>
-    Opens a snackbar notification to show a message.
+-   **openSnackMessage**(message: `string` = `null`, millisecondsDuration?: `number` = `null`): [`MatSnackBarRef`](https://material.angular.io/components/snack-bar/overview)`<any>`<br/>
+    Opens a SnackBar notification to show a message.
     -   _message:_ `string`  - The message (or resource key) to show.
     -   _millisecondsDuration:_ `number`  - (Optional) Time before notification disappears after being shown
-    -   **Returns** `MatSnackBarRef<any>` - Information/control object for the snackbar
--   **openSnackMessageAction**(message: `string` = `null`, action: `string` = `null`, millisecondsDuration?: `number` = `null`): `MatSnackBarRef<any>`<br/>
-    Opens a snackbar notification with a message and a response button.
+    -   **Returns** [`MatSnackBarRef`](https://material.angular.io/components/snack-bar/overview)`<any>` - Information/control object for the SnackBar
+-   **openSnackMessageAction**(message: `string` = `null`, action: `string` = `null`, millisecondsDuration?: `number` = `null`): [`MatSnackBarRef`](https://material.angular.io/components/snack-bar/overview)`<any>`<br/>
+    Opens a SnackBar notification with a message and a response button.
     -   _message:_ `string`  - The message (or resource key) to show.
     -   _action:_ `string`  - Caption for the response button
     -   _millisecondsDuration:_ `number`  - (Optional) Time before the notification disappears (unless the button is clicked)
-    -   **Returns** `MatSnackBarRef<any>` - Information/control object for the snackbar
+    -   **Returns** [`MatSnackBarRef`](https://material.angular.io/components/snack-bar/overview)`<any>` - Information/control object for the SnackBar
 
 ## Details
 

--- a/docs/core/pagination.component.md
+++ b/docs/core/pagination.component.md
@@ -54,11 +54,11 @@ Adds pagination to the component it is used with.
 
 | Name | Type | Description |
 | -- | -- | -- |
-| change | [`EventEmitter<PaginationModel>`](../../lib/core/models/pagination.model.ts) | Emitted when pagination changes in any way. |
-| changePageNumber | [`EventEmitter<PaginationModel>`](../../lib/core/models/pagination.model.ts) | Emitted when the page number changes. |
-| changePageSize | [`EventEmitter<PaginationModel>`](../../lib/core/models/pagination.model.ts) | Emitted when the page size changes. |
-| nextPage | [`EventEmitter<PaginationModel>`](../../lib/core/models/pagination.model.ts) | Emitted when the next page is requested. |
-| prevPage | [`EventEmitter<PaginationModel>`](../../lib/core/models/pagination.model.ts) | Emitted when the previous page is requested. |
+| change | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`PaginationModel`](../../lib/core/models/pagination.model.ts)`>` | Emitted when pagination changes in any way. |
+| changePageNumber | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`PaginationModel`](../../lib/core/models/pagination.model.ts)`>` | Emitted when the page number changes. |
+| changePageSize | `EventEmitter<PaginationModel>` | Emitted when the page size changes. |
+| nextPage | `EventEmitter<PaginationModel>` | Emitted when the next page is requested. |
+| prevPage | `EventEmitter<PaginationModel>` | Emitted when the previous page is requested. |
 
 ## Details
 

--- a/docs/core/people-content.service.md
+++ b/docs/core/people-content.service.md
@@ -12,13 +12,13 @@ Gets information about a Content Services user.
 
 ### Methods
 
--   **getCurrentPerson**(): `Observable<any>`<br/>
+-   **getCurrentPerson**(): [`Observable`](http://reactivex.io/documentation/observable.html)`<any>`<br/>
     Gets information about the user who is currently logged in.
-    -   **Returns** `Observable<any>` - User information
--   **getPerson**(personId: `string` = `null`): `Observable<any>`<br/>
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<any>` - User information
+-   **getPerson**(personId: `string` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<any>`<br/>
     Gets information about a user identified by their username.
     -   _personId:_ `string`  - ID of the target user
-    -   **Returns** `Observable<any>` - User information
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<any>` - User information
 
 ## Details
 

--- a/docs/core/people-process.service.md
+++ b/docs/core/people-process.service.md
@@ -16,21 +16,21 @@ Gets information about Process Services users.
     Gets the profile picture URL for the specified user.
     -   _user:_ [`UserProcessModel`](../core/user-process.model.md)  - The target user
     -   **Returns** `string` - Profile picture URL
--   **getWorkflowUsers**(taskId?: `string` = `null`, searchWord?: `string` = `null`): [`Observable<UserProcessModel[]>`](../core/user-process.model.md)<br/>
+-   **getWorkflowUsers**(taskId?: `string` = `null`, searchWord?: `string` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`UserProcessModel`](../core/user-process.model.md)`[]>`<br/>
     Gets information about users across all tasks.
     -   _taskId:_ `string`  - (Optional) ID of the task
     -   _searchWord:_ `string`  - (Optional) Filter text to search for
-    -   **Returns** [`Observable<UserProcessModel[]>`](../core/user-process.model.md) - Array of user information objects
--   **involveUserWithTask**(taskId: `string` = `null`, idToInvolve: `string` = `null`): [`Observable<UserProcessModel[]>`](../core/user-process.model.md)<br/>
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`UserProcessModel`](../core/user-process.model.md)`[]>` - Array of user information objects
+-   **involveUserWithTask**(taskId: `string` = `null`, idToInvolve: `string` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`UserProcessModel`](../core/user-process.model.md)`[]>`<br/>
     Sets a user to be involved with a task.
     -   _taskId:_ `string`  - ID of the target task
     -   _idToInvolve:_ `string`  - ID of the user to involve
-    -   **Returns** [`Observable<UserProcessModel[]>`](../core/user-process.model.md) - Empty response when the update completes
--   **removeInvolvedUser**(taskId: `string` = `null`, idToRemove: `string` = `null`): [`Observable<UserProcessModel[]>`](../core/user-process.model.md)<br/>
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`UserProcessModel`](../core/user-process.model.md)`[]>` - Empty response when the update completes
+-   **removeInvolvedUser**(taskId: `string` = `null`, idToRemove: `string` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`UserProcessModel`](../core/user-process.model.md)`[]>`<br/>
     Removes a user who is currently involved with a task.
     -   _taskId:_ `string`  - ID of the target task
     -   _idToRemove:_ `string`  - ID of the user to remove
-    -   **Returns** [`Observable<UserProcessModel[]>`](../core/user-process.model.md) - Empty response when the update completes
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`UserProcessModel`](../core/user-process.model.md)`[]>` - Empty response when the update completes
 
 ## Details
 

--- a/docs/core/process-content.service.md
+++ b/docs/core/process-content.service.md
@@ -11,58 +11,58 @@ Manipulates content related to a Process Instance or Task Instance in APS.
 
 ### Methods
 
--   **createProcessRelatedContent**(processInstanceId: `string` = `null`, content: `any` = `null`, opts?: `any` = `null`): `Observable<any>`<br/>
+-   **createProcessRelatedContent**(processInstanceId: `string` = `null`, content: `any` = `null`, opts?: `any` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<any>`<br/>
     Associates an uploaded file with a process instance.
     -   _processInstanceId:_ `string`  - ID of the target process instance
     -   _content:_ `any`  - File to associate
     -   _opts:_ `any`  - (Optional) Options supported by JSAPI
-    -   **Returns** `Observable<any>` - Details of created content
--   **createTaskRelatedContent**(taskId: `string` = `null`, file: `any` = `null`, opts?: `any` = `null`): `Observable<any>`<br/>
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<any>` - Details of created content
+-   **createTaskRelatedContent**(taskId: `string` = `null`, file: `any` = `null`, opts?: `any` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<any>`<br/>
     Associates an uploaded file with a task instance.
     -   _taskId:_ `string`  - ID of the target task
     -   _file:_ `any`  - File to associate
     -   _opts:_ `any`  - (Optional) Options supported by JSAPI
-    -   **Returns** `Observable<any>` - Details of created content
--   **createTemporaryRawRelatedContent**(file: `any` = `null`): `Observable<RelatedContentRepresentation>`<br/>
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<any>` - Details of created content
+-   **createTemporaryRawRelatedContent**(file: `any` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`RelatedContentRepresentation`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-activiti-rest-api/docs/RelatedContentRepresentation.md)`>`<br/>
     Create temporary related content from an uploaded file.
     -   _file:_ `any`  - File to use for content
-    -   **Returns** `Observable<RelatedContentRepresentation>` - The created content data
--   **deleteRelatedContent**(contentId: `number` = `null`): `Observable<any>`<br/>
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`RelatedContentRepresentation`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-activiti-rest-api/docs/RelatedContentRepresentation.md)`>` - The created content data
+-   **deleteRelatedContent**(contentId: `number` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<any>`<br/>
     Deletes related content.
     -   _contentId:_ `number`  - Identifier of the content to delete
-    -   **Returns** `Observable<any>` - Null response that notifies when the deletion is complete
--   **getContentPreview**(contentId: `number` = `null`): `Observable<Blob>`<br/>
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<any>` - Null response that notifies when the deletion is complete
+-   **getContentPreview**(contentId: `number` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob)`>`<br/>
     Gets the preview for a related content file.
     -   _contentId:_ `number`  - ID of the related content
-    -   **Returns** `Observable<Blob>` - Binary data of the content preview
--   **getContentThumbnail**(contentId: `number` = `null`): `Observable<Blob>`<br/>
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob)`>` - Binary data of the content preview
+-   **getContentThumbnail**(contentId: `number` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob)`>`<br/>
     Gets the thumbnail for a related content file.
     -   _contentId:_ `number`  - ID of the related content
-    -   **Returns** `Observable<Blob>` - Binary data of the thumbnail image
--   **getFileContent**(contentId: `number` = `null`): `Observable<RelatedContentRepresentation>`<br/>
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob)`>` - Binary data of the thumbnail image
+-   **getFileContent**(contentId: `number` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`RelatedContentRepresentation`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-activiti-rest-api/docs/RelatedContentRepresentation.md)`>`<br/>
     Gets the metadata for a related content item.
     -   _contentId:_ `number`  - ID of the content item
-    -   **Returns** `Observable<RelatedContentRepresentation>` - Metadata for the content
--   **getFileRawContent**(contentId: `number` = `null`): `Observable<Blob>`<br/>
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`RelatedContentRepresentation`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-activiti-rest-api/docs/RelatedContentRepresentation.md)`>` - Metadata for the content
+-   **getFileRawContent**(contentId: `number` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob)`>`<br/>
     Gets raw binary content data for a related content file.
     -   _contentId:_ `number`  - ID of the related content
-    -   **Returns** `Observable<Blob>` - Binary data of the related content
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob)`>` - Binary data of the related content
 -   **getFileRawContentUrl**(contentId: `number` = `null`): `string`<br/>
     Gets a URL for direct access to a related content file.
     -   _contentId:_ `number`  - ID of the related content
     -   **Returns** `string` - URL to access the content
--   **getProcessRelatedContent**(processId: `string` = `null`): `Observable<any>`<br/>
+-   **getProcessRelatedContent**(processId: `string` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<any>`<br/>
     Gets related content items for a process instance.
     -   _processId:_ `string`  - ID of the target process
-    -   **Returns** `Observable<any>` - Metadata for the content
--   **getTaskRelatedContent**(taskId: `string` = `null`): `Observable<any>`<br/>
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<any>` - Metadata for the content
+-   **getTaskRelatedContent**(taskId: `string` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<any>`<br/>
     Gets related content items for a task instance.
     -   _taskId:_ `string`  - ID of the target task
-    -   **Returns** `Observable<any>` - Metadata for the content
--   **handleError**(error: `any` = `null`): `Observable<any>`<br/>
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<any>` - Metadata for the content
+-   **handleError**(error: `any` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<any>`<br/>
     Reports an error message.
     -   _error:_ `any`  - Data object with optional `message` and `status` fields for the error
-    -   **Returns** `Observable<any>` - Callback when an error occurs
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<any>` - Callback when an error occurs
 -   **toJson**(res: `any` = `null`): `any`<br/>
     Creates a JSON representation of data.
     -   _res:_ `any`  - Object representing data
@@ -206,7 +206,7 @@ See `getProcessRelatedContent` and `getTaskRelatedContent` for how to get to the
 
 #### getFileContent(contentId: number): Observable`<RelatedContentRepresentation>`
 
-Get the metadata for a related content item in the format of a `RelatedContentRepresentation` object: 
+Get the metadata for a related content item in the format of a [`RelatedContentRepresentation`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-activiti-rest-api/docs/RelatedContentRepresentation.md) object: 
 
 ```ts
 const contentId = 6008;

--- a/docs/core/renditions.service.md
+++ b/docs/core/renditions.service.md
@@ -9,16 +9,16 @@ Manages prearranged conversions of content to different formats.
 
 ## Methods
 
-`isRenditionAvailable(nodeId: string, encoding: string): Observable<boolean>`<br/>
+`isRenditionAvailable(nodeId: string, encoding: string): `[`Observable`](http://reactivex.io/documentation/observable.html)`<boolean>`<br/>
 Has the specified rendition been set up for this item?
 
-`isConversionPossible(nodeId: string, encoding: string): Observable<boolean>`<br/>
+`isConversionPossible(nodeId: string, encoding: string): `[`Observable`](http://reactivex.io/documentation/observable.html)`<boolean>`<br/>
 Is it possible to convert this item to the specified format?
 
 `getRenditionUrl(nodeId: string, encoding: string): string`<br/>
 Gets a URL linking to a rendition.
 
-`getRenditionsListByNodeId(nodeId: string): Observable<RenditionPaging>`<br/>
+`getRenditionsListByNodeId(nodeId: string): `[`Observable`](http://reactivex.io/documentation/observable.html)`<RenditionPaging>`<br/>
 Gets all available renditions for an item.
 
 `convert(nodeId: string, encoding: string, pollingInterval: number = 1000)`<br/>

--- a/docs/core/shared-links-api.service.md
+++ b/docs/core/shared-links-api.service.md
@@ -11,19 +11,19 @@ Finds shared links to Content Services items.
 
 ### Methods
 
--   **createSharedLinks**(nodeId: `string` = `null`, options: `any` = `{}`): `Observable<SharedLinkEntry>`<br/>
+-   **createSharedLinks**(nodeId: `string` = `null`, options: `any` = `{}`): [`Observable`](http://reactivex.io/documentation/observable.html)`<SharedLinkEntry>`<br/>
     Creates a shared link available to the current user.
     -   _nodeId:_ `string`  - ID of the node to link to
     -   _options:_ `any`  - Options supported by JSAPI
-    -   **Returns** `Observable<SharedLinkEntry>` - The shared link just created
--   **deleteSharedLink**(sharedId: `string` = `null`): `Observable<SharedLinkEntry>`<br/>
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<SharedLinkEntry>` - The shared link just created
+-   **deleteSharedLink**(sharedId: `string` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<SharedLinkEntry>`<br/>
     Deletes a shared link.
     -   _sharedId:_ `string`  - ID of the link to delete
-    -   **Returns** `Observable<SharedLinkEntry>` - Null response notifying when the operation is complete
--   **getSharedLinks**(options: `any` = `{}`): [`Observable<NodePaging>`](../../lib/content-services/document-list/models/document-library.model.ts)<br/>
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<SharedLinkEntry>` - Null response notifying when the operation is complete
+-   **getSharedLinks**(options: `any` = `{}`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`NodePaging`](../../lib/content-services/document-list/models/document-library.model.ts)`>`<br/>
     Gets shared links available to the current user.
     -   _options:_ `any`  - Options supported by JSAPI
-    -   **Returns** [`Observable<NodePaging>`](../../lib/content-services/document-list/models/document-library.model.ts) - List of shared links
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`NodePaging`](../../lib/content-services/document-list/models/document-library.model.ts)`>` - List of shared links
 
 ## Details
 

--- a/docs/core/sidenav-layout.component.md
+++ b/docs/core/sidenav-layout.component.md
@@ -78,7 +78,7 @@ Displays the standard three-region ADF application layout.
 
 | Name | Type | Description |
 | -- | -- | -- |
-| expanded | `EventEmitter<boolean>` |  |
+| expanded | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<boolean>` |  |
 
 ## Details
 
@@ -115,8 +115,8 @@ Mobile layout (screen width less than the `stepOver` value):
 ### Events
 
 | Name | Type | Description |
-| -- | -- | -- |
-| expanded | `EventEmitter<boolean>` | Emmitted when the menu toggle and the collapsed/expanded state of the sideNav changes
+| ---- | ---- | ----------- |
+| expanded | `EventEmitter<boolean>` | Emmitted when the menu toggle and the collapsed/expanded state of the sideNav changes |
 
 ### Template context
 

--- a/docs/core/sites.service.md
+++ b/docs/core/sites.service.md
@@ -12,36 +12,36 @@ Accesses and manipulates sites from a Content Services repository.
 
 ### Methods
 
--   **deleteSite**(siteId: `string` = `null`, permanentFlag: `boolean` = `true`): `Observable<any>`<br/>
+-   **deleteSite**(siteId: `string` = `null`, permanentFlag: `boolean` = `true`): [`Observable`](http://reactivex.io/documentation/observable.html)`<any>`<br/>
     Deletes a site.
     -   _siteId:_ `string`  - Site to delete
     -   _permanentFlag:_ `boolean`  - True: deletion is permanent; False: site is moved to the trash
-    -   **Returns** `Observable<any>` - Null response notifying when the operation is complete
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<any>` - Null response notifying when the operation is complete
 -   **getEcmCurrentLoggedUserName**(): `string`<br/>
     Gets the username of the user currently logged into ACS.
     -   **Returns** `string` - Username string
--   **getSite**(siteId: `string` = `null`, opts?: `any` = `null`): `Observable<SiteEntry>`<br/>
+-   **getSite**(siteId: `string` = `null`, opts?: `any` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`SiteEntry`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/SiteEntry.md)`>`<br/>
     Gets the details for a site.
     -   _siteId:_ `string`  - ID of the target site
     -   _opts:_ `any`  - (Optional) Options supported by JSAPI
-    -   **Returns** `Observable<SiteEntry>` - Information about the site
--   **getSiteContent**(siteId: `string` = `null`): `Observable<SiteEntry>`<br/>
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`SiteEntry`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/SiteEntry.md)`>` - Information about the site
+-   **getSiteContent**(siteId: `string` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`SiteEntry`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/SiteEntry.md)`>`<br/>
     Gets a site's content.
     -   _siteId:_ `string`  - ID of the target site
-    -   **Returns** `Observable<SiteEntry>` - Site content
--   **getSiteMembers**(siteId: `string` = `null`): `Observable<SiteEntry>`<br/>
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`SiteEntry`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/SiteEntry.md)`>` - Site content
+-   **getSiteMembers**(siteId: `string` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`SiteEntry`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/SiteEntry.md)`>`<br/>
     Gets a list of all a site's members.
     -   _siteId:_ `string`  - ID of the target site
-    -   **Returns** `Observable<SiteEntry>` - Site members
--   **getSites**(opts: `any` = `{}`): `Observable<SitePaging>`<br/>
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`SiteEntry`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/SiteEntry.md)`>` - Site members
+-   **getSites**(opts: `any` = `{}`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`SitePaging`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/SitePaging.md)`>`<br/>
     Gets a list of all sites in the repository.
     -   _opts:_ `any`  - Options supported by JSAPI
-    -   **Returns** `Observable<SitePaging>` - List of sites
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`SitePaging`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/SitePaging.md)`>` - List of sites
 
 ## Details
 
 You can use `getSites` to get a list of all sites in the repository.
-The sites are returned as `Observable<SiteModel[]>` (see
+The sites are returned as [`Observable`](http://reactivex.io/documentation/observable.html)`<SiteModel[]>` (see
 [Site Model](site.model.md) for more information about this class).
 If you are only interested in a single site and you have its ID, you
 can use `getSite` to access it. Alternatively, you can use `getSiteContent`

--- a/docs/core/start-form.component.md
+++ b/docs/core/start-form.component.md
@@ -27,7 +27,7 @@ Displays the Start [`Form`](../../lib/process-services/task-list/models/form.mod
 | data | [`FormValues`](../../lib/core/form/components/widgets/core/form-values.ts) |  | Custom form values map to be used with the rendered form. |
 | disableCompleteButton | `boolean` | false | If true then the `Complete` outcome button is shown but it will be disabled. |
 | disableStartProcessButton | `boolean` | false | If true then the `Start Process` outcome button is shown but it will be disabled. |
-| fieldValidators | [`FormFieldValidator[]`](../../lib/core/form/components/widgets/core/form-field-validator.ts) |  \[] | Contains a list of form field validator instances. |
+| fieldValidators | [`FormFieldValidator`](../../lib/core/form/components/widgets/core/form-field-validator.ts)`[]` |  \[] | Contains a list of form field validator instances. |
 | form | [`FormModel`](../../lib/core/form/components/widgets/core/form.model.ts) |  | Underlying [form model](../../lib/core/form/components/widgets/core/form.model.ts) instance. |
 | formId | `string` |  | The id of the form definition to load and display with custom values. |
 | formName | `string` |  | Name of the form definition to load and display with custom values. |
@@ -52,12 +52,12 @@ Displays the Start [`Form`](../../lib/process-services/task-list/models/form.mod
 
 | Name | Type | Description |
 | -- | -- | -- |
-| executeOutcome | [`EventEmitter<FormOutcomeEvent>`](../../lib/core/form/components/widgets/core/form-outcome-event.model.ts) | Emitted when any outcome is executed. Default behaviour can be prevented via `event.preventDefault()`. |
-| formCompleted | [`EventEmitter<FormModel>`](../../lib/core/form/components/widgets/core/form.model.ts) | Emitted when the form is submitted with the `Complete` outcome. |
-| formContentClicked | [`EventEmitter<ContentLinkModel>`](../../lib/core/form/components/widgets/core/content-link.model.ts) | Emitted when a field of the form is clicked. |
-| formDataRefreshed | [`EventEmitter<FormModel>`](../../lib/core/form/components/widgets/core/form.model.ts) | Emitted when form values are refreshed due to a data property change. |
-| formLoaded | [`EventEmitter<FormModel>`](../../lib/core/form/components/widgets/core/form.model.ts) | Emitted when the form is loaded or reloaded. |
-| formSaved | [`EventEmitter<FormModel>`](../../lib/core/form/components/widgets/core/form.model.ts) | Emitted when the form is submitted with the `Save` or custom outcomes. |
+| executeOutcome | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`FormOutcomeEvent`](../../lib/core/form/components/widgets/core/form-outcome-event.model.ts)`>` | Emitted when any outcome is executed. Default behaviour can be prevented via `event.preventDefault()`. |
+| formCompleted | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`FormModel`](../../lib/core/form/components/widgets/core/form.model.ts)`>` | Emitted when the form is submitted with the `Complete` outcome. |
+| formContentClicked | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`ContentLinkModel`](../../lib/core/form/components/widgets/core/content-link.model.ts)`>` | Emitted when a field of the form is clicked. |
+| formDataRefreshed | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`FormModel`](../../lib/core/form/components/widgets/core/form.model.ts)`>` | Emitted when form values are refreshed due to a data property change. |
+| formLoaded | `EventEmitter<FormModel>` | Emitted when the form is loaded or reloaded. |
+| formSaved | `EventEmitter<FormModel>` | Emitted when the form is submitted with the `Save` or custom outcomes. |
 | onError | `EventEmitter<any>` | Emitted when any error occurs. |
 | outcomeClick | `EventEmitter<any>` | Emitted when the user clicks one of the outcome buttons that completes the form. |
 

--- a/docs/core/toolbar.component.md
+++ b/docs/core/toolbar.component.md
@@ -21,6 +21,7 @@ Simple container for headers, titles, actions and breadcrumbs.
 
     -   [Custom title](#custom-title)
     -   [Divider](#divider)
+    -   [Spacer](#spacer)
     -   [Dropdown menu](#dropdown-menu)
     -   [Custom color](#custom-color)
 

--- a/docs/core/translation.service.md
+++ b/docs/core/translation.service.md
@@ -15,11 +15,11 @@ Supports localisation.
     Adds a new folder of translation source files.
     -   _name:_ `string`  - Name for the translation provider
     -   _path:_ `string`  - Path to the folder
--   **get**(key: `string | Array<string>` = `null`, interpolateParams?: `Object` = `null`): `Observable<string | any>`<br/>
+-   **get**(key: `string | Array<string>` = `null`, interpolateParams?: `Object` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<string | any>`<br/>
     Gets the translation for the supplied key.
     -   _key:_ `string | Array<string>`  - Key to translate
     -   _interpolateParams:_ `Object`  - (Optional) String(s) to be interpolated into the main message
-    -   **Returns** `Observable<string | any>` - Translated text
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<string | any>` - Translated text
 -   **instant**(key: `string | Array<string>` = `null`, interpolateParams?: `Object` = `null`): `string | any`<br/>
     Directly returns the translation for the supplied key.
     -   _key:_ `string | Array<string>`  - Key to translate
@@ -28,10 +28,10 @@ Supports localisation.
 -   **onTranslationChanged**(lang: `string` = `null`)<br/>
     Triggers a notification callback when the translation language changes.
     -   _lang:_ `string`  - The new language code
--   **use**(lang: `string` = `null`): `Observable<any>`<br/>
+-   **use**(lang: `string` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<any>`<br/>
     Sets the target language for translations.
     -   _lang:_ `string`  - Code name for the language
-    -   **Returns** `Observable<any>` - Translations available for the language
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<any>` - Translations available for the language
 
 ## Details
 

--- a/docs/core/upload.service.md
+++ b/docs/core/upload.service.md
@@ -12,18 +12,18 @@ Provides access to various APIs related to file upload features.
 
 ### Methods
 
--   **addToQueue**(files: [`FileModel[]`](../../lib/core/models/file.model.ts) = `null`): [`FileModel[]`](../../lib/core/models/file.model.ts)<br/>
+-   **addToQueue**(files: [`FileModel`](../../lib/core/models/file.model.ts)`[]` = `null`): [`FileModel`](../../lib/core/models/file.model.ts)`[]`<br/>
     Adds files to the uploading queue to be uploaded
-    -   _files:_ [`FileModel[]`](../../lib/core/models/file.model.ts)  - One or more separate parameters or an array of files to queue
-    -   **Returns** [`FileModel[]`](../../lib/core/models/file.model.ts) - Array of files that were not blocked from upload by the ignore list
--   **cancelUpload**(files: [`FileModel[]`](../../lib/core/models/file.model.ts) = `null`)<br/>
+    -   _files:_ [`FileModel`](../../lib/core/models/file.model.ts)`[]`  - One or more separate parameters or an array of files to queue
+    -   **Returns** [`FileModel`](../../lib/core/models/file.model.ts)`[]` - Array of files that were not blocked from upload by the ignore list
+-   **cancelUpload**(files: [`FileModel`](../../lib/core/models/file.model.ts)`[]` = `null`)<br/>
     Cancels uploading of files.
-    -   _files:_ [`FileModel[]`](../../lib/core/models/file.model.ts)  - One or more separate parameters or an array of files specifying uploads to cancel
+    -   _files:_ [`FileModel`](../../lib/core/models/file.model.ts)`[]`  - One or more separate parameters or an array of files specifying uploads to cancel
 -   **clearQueue**()<br/>
     Clears the upload queue
--   **getQueue**(): [`FileModel[]`](../../lib/core/models/file.model.ts)<br/>
+-   **getQueue**(): [`FileModel`](../../lib/core/models/file.model.ts)`[]`<br/>
     Gets the file Queue
-    -   **Returns** [`FileModel[]`](../../lib/core/models/file.model.ts) - Array of files that form the queue
+    -   **Returns** [`FileModel`](../../lib/core/models/file.model.ts)`[]` - Array of files that form the queue
 -   **getUploadPromise**(file: [`FileModel`](../../lib/core/models/file.model.ts) = `null`): `any`<br/>
     Gets an upload promise for a file.
     -   _file:_ [`FileModel`](../../lib/core/models/file.model.ts)  - The target file
@@ -31,9 +31,9 @@ Provides access to various APIs related to file upload features.
 -   **isUploading**(): `boolean`<br/>
     Checks whether the service is uploading a file.
     -   **Returns** `boolean` - True if a file is uploading, false otherwise
--   **uploadFilesInTheQueue**(emitter: `EventEmitter<any>` = `null`)<br/>
+-   **uploadFilesInTheQueue**(emitter?: [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<any>` = `null`)<br/>
     Finds all the files in the queue that are not yet uploaded and uploads them into the directory folder.
-    -   _emitter:_ `EventEmitter<any>`  - (Deprecated) Emitter to invoke on file status change
+    -   _emitter:_ [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<any>`  - (Optional) (Deprecated) Emitter to invoke on file status change
 
 ## Events
 

--- a/docs/core/user-preferences.service.md
+++ b/docs/core/user-preferences.service.md
@@ -30,10 +30,10 @@ Stores preferences for components.
 -   **getStoragePrefix**(): `string`<br/>
     Gets the active storage prefix for preferences.
     -   **Returns** `string` - Storage prefix
--   **select**(property: `string` = `null`): `Observable<any>`<br/>
+-   **select**(property: `string` = `null`): [`Observable`](http://reactivex.io/documentation/observable.html)`<any>`<br/>
     Sets up a callback to notify when a property has changed.
     -   _property:_ `string`  - The property to watch
-    -   **Returns** `Observable<any>` - Notification callback
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<any>` - Notification callback
 -   **set**(property: `string` = `null`, value: `any` = `null`)<br/>
     Sets a preference property.
     -   _property:_ `string`  - Name of the property

--- a/docs/core/viewer.component.md
+++ b/docs/core/viewer.component.md
@@ -86,7 +86,7 @@ URL with `urlFile`.
 | allowShare | `boolean` | false | Toggles sharing. |
 | allowSidebar | `boolean` | false | Toggles the sidebar. |
 | allowThumbnails | `boolean` | true | Toggles PDF thumbnails. |
-| blobFile | `Blob` |  | Loads a Blob File |
+| blobFile | [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob) |  | Loads a [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob) File |
 | canNavigateBefore | `boolean` | true | Toggles the "before" ("&lt;") button. Requires `allowNavigate` to be enabled. |
 | canNavigateNext | `boolean` | true | Toggles the next (">") button. Requires `allowNavigate` to be enabled. |
 | displayName | `string` |  | Specifies the name of the file when it is not available from the URL. |
@@ -101,8 +101,8 @@ URL with `urlFile`.
 | showToolbar | `boolean` | true | Hide or show the toolbar |
 | showViewer | `boolean` | true | Hide or show the viewer |
 | sidebarPosition | `string` | "right" | The position of the sidebar. Can be `left` or `right`. |
-| sidebarTemplate | `TemplateRef<any>` |  null | The template for the sidebar. The template context contains the loaded node data. |
-| thumbnailsTemplate | `TemplateRef<any>` |  null | The template for the pdf thumbnails. |
+| sidebarTemplate | [`TemplateRef`](https://angular.io/api/core/TemplateRef)`<any>` |  null | The template for the sidebar. The template context contains the loaded node data. |
+| thumbnailsTemplate | [`TemplateRef`](https://angular.io/api/core/TemplateRef)`<any>` |  null | The template for the pdf thumbnails. |
 | urlFile | `string` | "" | If you want to load an external file that does not come from ACS you can use this URL to specify where to load the file from. |
 | urlFileViewer | `string` |  null | Viewer to use with the `urlFile` address (`pdf`, `image`, `media`, `text`). Used when `urlFile` has no filename and extension. |
 | fileNodeId |  |  | Node Id of the file to load. |
@@ -111,10 +111,10 @@ URL with `urlFile`.
 
 | Name | Type | Description |
 | -- | -- | -- |
-| download | `EventEmitter<BaseEvent<any>>` | Emitted when user clicks the 'Download' button. |
-| extensionChange | `EventEmitter<string>` | Emitted when the filename extension changes. |
-| goBack | `EventEmitter<BaseEvent<any>>` | Emitted when user clicks the 'Back' button. |
-| navigateBefore | `EventEmitter<Object>` | Emitted when user clicks 'Navigate Before' ("&lt;") button. |
+| download | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`BaseEvent`](../../lib/core/events/base.event.ts)`<any>>` | Emitted when user clicks the 'Download' button. |
+| extensionChange | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<string>` | Emitted when the filename extension changes. |
+| goBack | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`BaseEvent`](../../lib/core/events/base.event.ts)`<any>>` | Emitted when user clicks the 'Back' button. |
+| navigateBefore | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<Object>` | Emitted when user clicks 'Navigate Before' ("&lt;") button. |
 | navigateNext | `EventEmitter<Object>` | Emitted when user clicks 'Navigate Next' (">") button. |
 | print | `EventEmitter<BaseEvent<any>>` | Emitted when user clicks the 'Print' button. |
 | share | `EventEmitter<BaseEvent<any>>` | Emitted when user clicks the 'Share' button. |

--- a/lib/core/services/dynamic-component-mapper.service.ts
+++ b/lib/core/services/dynamic-component-mapper.service.ts
@@ -69,7 +69,7 @@ export abstract class DynamicComponentMapper {
 
     /**
      * Finds the component type that is needed to render a form field.
-     * @param model [Form field model](form-field.model.md) for the field to render
+     * @param model Form field model for the field to render
      * @param defaultValue Default type returned for field types that are not yet mapped.
      * @returns Component type
      */

--- a/tools/doc/docProcessor.js
+++ b/tools/doc/docProcessor.js
@@ -66,10 +66,13 @@ function updatePhase(filenames, aggData) {
             showErrors(pathname, errorMessages);
         }
 
-        if (modified)
+        if (program.json) {
+            console.log(JSON.stringify(tree));
+        }
+
+        if (modified) {
             fs.writeFileSync(filenames[i], remark().use(frontMatter, {type: 'yaml', fence: '---'}).data("settings", {paddedTable: false, gfm: false}).stringify(tree));
-        
-        //console.log(JSON.stringify(tree));
+        }
     }
 }
 
@@ -128,6 +131,7 @@ function getAllDocFilePaths(docFolder, files) {
 program
 .usage("[options] <source>")
 .option("-p, --profile [profileName]", "Select named config profile", "default")
+.option("-j, --json", "Output JSON data for Markdown syntax tree")
 .parse(process.argv);
 
 var sourcePath;

--- a/tools/doc/doctool.config.json
+++ b/tools/doc/doctool.config.json
@@ -19,7 +19,8 @@
             "toc"
         ],
         "dev": [
-            "versionIndex"
+            "tsInfo",
+            "typeLinker"
         ]
     }
 }

--- a/tools/doc/tools/typeLinker.js
+++ b/tools/doc/tools/typeLinker.js
@@ -13,9 +13,15 @@ var includedNodeTypes = [
 var docFolder = path.resolve("docs");
 var adfLibNames = ["core", "content-services", "insights", "process-services"];
 var externalTypes = {
+    'Blob': 'https://developer.mozilla.org/en-US/docs/Web/API/Blob',
     'EventEmitter': 'https://angular.io/api/core/EventEmitter',
     'MatSnackBarRef': 'https://material.angular.io/components/snack-bar/overview',
-    'Observable': 'http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html',
+    'TemplateRef': 'https://angular.io/api/core/TemplateRef',
+    'Observable': 'http://reactivex.io/documentation/observable.html',
+    'Subject': 'http://reactivex.io/documentation/subject.html',
+    'AppDefinitionRepresentation': 'https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-activiti-rest-api/docs/AppDefinitionRepresentation.md',
+    'NodeEntry': 'https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/NodeEntry.md',
+    'RelatedContentRepresentation': 'https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-activiti-rest-api/docs/RelatedContentRepresentation.md',
     'SiteEntry': 'https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/SiteEntry.md',
     'SitePaging': 'https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/SitePaging.md'
 };
@@ -188,7 +194,7 @@ var SplitNameLookup = /** @class */ (function () {
 var WordScanner = /** @class */ (function () {
     function WordScanner(text) {
         this.text = text;
-        this.separators = " \n\r\t.;:<>[]";
+        this.separators = " \n\r\t.;:<>[]&|";
         this.index = 0;
         this.nextSeparator = 0;
         this.next();
@@ -280,6 +286,9 @@ function handleLinksInBodyText(aggData, text, wrapInlineCode) {
 }
 function resolveTypeLink(aggData, text) {
     var possTypeName = cleanTypeName(text);
+    if (possTypeName === 'constructor') {
+        return "";
+    }
     var ref = aggData.projData.findReflectionByName(possTypeName);
     if (ref && isLinkable(ref.kind)) {
         var kebabName = ngHelpers.kebabifyClassName(possTypeName);
@@ -309,7 +318,8 @@ function cleanTypeName(text) {
 function isLinkable(kind) {
     return (kind === typedoc_1.ReflectionKind.Class) ||
         (kind === typedoc_1.ReflectionKind.Interface) ||
-        (kind === typedoc_1.ReflectionKind.Enum);
+        (kind === typedoc_1.ReflectionKind.Enum) ||
+        (kind === typedoc_1.ReflectionKind.TypeAlias);
 }
 function convertNodeToTypeLink(node, text, url) {
     var linkDisplayText = unist.makeInlineCode(text);

--- a/tools/doc/tools/typeLinker.ts
+++ b/tools/doc/tools/typeLinker.ts
@@ -34,9 +34,15 @@ const adfLibNames = ["core", "content-services", "insights", "process-services"]
 
 
 const externalTypes = {
+    'Blob': 'https://developer.mozilla.org/en-US/docs/Web/API/Blob',
     'EventEmitter': 'https://angular.io/api/core/EventEmitter',
     'MatSnackBarRef': 'https://material.angular.io/components/snack-bar/overview',
-    'Observable': 'http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html',
+    'TemplateRef': 'https://angular.io/api/core/TemplateRef',
+    'Observable': 'http://reactivex.io/documentation/observable.html',
+    'Subject': 'http://reactivex.io/documentation/subject.html',
+    'AppDefinitionRepresentation': 'https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-activiti-rest-api/docs/AppDefinitionRepresentation.md',
+    'NodeEntry': 'https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/NodeEntry.md',
+    'RelatedContentRepresentation': 'https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-activiti-rest-api/docs/RelatedContentRepresentation.md',
     'SiteEntry': 'https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/SiteEntry.md',
     'SitePaging': 'https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/SitePaging.md'
 };
@@ -238,7 +244,7 @@ class WordScanner {
     current: string;
 
     constructor(public text: string) {
-        this.separators = " \n\r\t.;:<>[]";
+        this.separators = " \n\r\t.;:<>[]&|";
         this.index = 0;
         this.nextSeparator = 0;
         this.next();
@@ -346,6 +352,11 @@ function handleLinksInBodyText(aggData, text: string, wrapInlineCode: boolean = 
 
 function resolveTypeLink(aggData, text): string {
     let possTypeName = cleanTypeName(text);
+
+    if (possTypeName === 'constructor') {
+        return "";
+    }
+
     let ref: Reflection = aggData.projData.findReflectionByName(possTypeName);
 
     if (ref && isLinkable(ref.kind)) {
@@ -380,7 +391,8 @@ function cleanTypeName(text) {
 function isLinkable(kind: ReflectionKind) {
     return (kind === ReflectionKind.Class) ||
     (kind === ReflectionKind.Interface) ||
-    (kind === ReflectionKind.Enum);
+    (kind === ReflectionKind.Enum) ||
+    (kind === ReflectionKind.TypeAlias);
 }
 
 function convertNodeToTypeLink(node, text, url) {

--- a/tools/doc/unistHelpers.js
+++ b/tools/doc/unistHelpers.js
@@ -132,5 +132,9 @@ module.exports = {
 
     isText: function (node) {
         return node.type === "text";
+    },
+
+    isLink: function (node) {
+        return node.type === "inlineCode";
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [x] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Type links are not generated for externally defined types (eg, MatSnackBarRef) and composite types are only supported in a very basic way (eg, the whole type Observable<xxx> has only a single link to the xxx type without a separate link to Observable).

**What is the new behaviour?**

External and composite types are now supported. It would take a long time to scan for all externally defined types, so the tool just uses a list of the most important ones. The composite types seem to work correctly but the template types are displayed a bit strangely on Github (eg, "Observable<xxx>" is displayed with spaces like "Observable < xxx >". I'm not sure if there is any way to get around this because the spaces are introduced by Github and are not present in the Markdown.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
