### PR TITLE
[ADF-3062] dual api support for Favorites

### DIFF
--- a/lib/core/directives/node-favorite.directive.spec.ts
+++ b/lib/core/directives/node-favorite.directive.spec.ts
@@ -21,11 +21,12 @@ import { NodeFavoriteDirective } from './node-favorite.directive';
 import { AlfrescoApiServiceMock } from '../mock/alfresco-api.service.mock';
 import { AppConfigService } from '../app-config/app-config.service';
 import { StorageService } from '../services/storage.service';
+import { AlfrescoApiService } from '../services/alfresco-api.service';
 
 describe('NodeFavoriteDirective', () => {
 
     let directive;
-    let alfrescoApiService;
+    let alfrescoApiService: AlfrescoApiService;
 
     beforeEach(() => {
         alfrescoApiService = new AlfrescoApiServiceMock(new AppConfigService(null), new StorageService());
@@ -316,6 +317,22 @@ describe('NodeFavoriteDirective', () => {
     });
 
     describe('getFavorite()', () => {
+
+        it('should not hit server when using 6.x api', fakeAsync(() => {
+            spyOn(alfrescoApiService.favoritesApi, 'getFavorite').and.callThrough();
+
+            const selection = [
+                { entry: { id: '1', name: 'name1', isFavorite: true } }
+            ];
+
+            let change = new SimpleChange(null, selection, true);
+            directive.ngOnChanges({'selection': change});
+            tick();
+
+            expect(directive.favorites[0].entry.isFavorite).toBe(true);
+            expect(alfrescoApiService.favoritesApi.getFavorite).not.toHaveBeenCalled();
+        }));
+
         it('should process node as favorite', fakeAsync(() => {
             spyOn(alfrescoApiService.getInstance().core.favoritesApi, 'getFavorite').and.returnValue(Promise.resolve());
 

--- a/lib/core/directives/node-favorite.directive.ts
+++ b/lib/core/directives/node-favorite.directive.ts
@@ -125,9 +125,17 @@ export class NodeFavoriteDirective implements OnChanges {
     }
 
     private getFavorite(selected: MinimalNodeEntity): Observable<any> {
-        const { name, isFile, isFolder } = selected.entry;
+        const node = selected.entry;
+
+        // ACS 6.x with 'isFavorite' include
+        if (node && node.hasOwnProperty('isFavorite')) {
+            return Observable.of(selected);
+        }
+
+        // ACS 5.x and 6.x without 'isFavorite' include
+        const { name, isFile, isFolder } = node;
         // shared files have nodeId
-        const id = (<any> selected).entry.nodeId || selected.entry.id;
+        const id = node.nodeId || node.id;
 
         const promise = this.alfrescoApiService.favoritesApi.getFavorite('-me-', id);
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

- don't fetch data from the server for each check for ACS 6.0 when `isFavorite` include is used

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
