### PR TITLE
[ADF-3142] Added missing info about 'remember me' in login docs

### DIFF
--- a/docs/core/login.component.md
+++ b/docs/core/login.component.md
@@ -54,7 +54,7 @@ Authenticates to Alfresco Content Services and Alfresco Process Services.
 | providers | `string` |  | Possible valid values are ECM, BPM or ALL. By default, this component will log in only to ECM. If you want to log in in both systems then use ALL. |
 | registerLink | `string` | "" | Sets the URL of the REGISTER link in the footer. |
 | showLoginActions | `boolean` | true | Should the extra actions (`Need Help`, `Register`, etc) be shown? |
-| showRememberMe | `boolean` | true | Should the `Remember me` checkbox be shown? |
+| showRememberMe | `boolean` | true | Should the `Remember me` checkbox be shown? When selected, this option will remember the logged-in user after the browser is closed to avoid logging in repeatedly. |
 | successRoute | `string` |  null | Route to redirect to on successful login. |
 
 ### Events

--- a/lib/core/login/components/login.component.ts
+++ b/lib/core/login/components/login.component.ts
@@ -58,7 +58,11 @@ export class LoginComponent implements OnInit {
 
     isPasswordShow: boolean = false;
 
-    /** Should the `Remember me` checkbox be shown? */
+    /**
+     * Should the `Remember me` checkbox be shown? When selected, this
+     * option will remember the logged-in user after the browser is closed
+     * to avoid logging in repeatedly.
+     */
     @Input()
     showRememberMe: boolean = true;
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [x] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

The docs for the "showRememberMe" property in the login component don't mention what the checkbox actually does.

**What is the new behaviour?**

Added a note to the property description to make it clear that this just remembers the logged-in user between sessions.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
