### PR TITLE
[ADF-2859] fixes for the conditional visibility and disabled states

### DIFF
--- a/demo-shell/src/app/components/files/files.component.html
+++ b/demo-shell/src/app/components/files/files.component.html
@@ -279,13 +279,13 @@
                 </data-columns>
 
                 <content-actions>
+                    <!-- Conditional actions demo -->
                     <content-action
                         target="all"
                         title="Action for 'custom' node"
                         [disabled]="isCustomActionDisabled"
                         (execute)="runCustomAction($event)">
                     </content-action>
-                    <!-- Conditional actions demo -->
                     <content-action
                         icon="get_app"
                         title="Download this file now!"
@@ -297,12 +297,6 @@
                         title="Never see this action again"
                         handler="download"
                         [visible]="false">
-                    </content-action>
-                    <content-action
-                        icon="get_app"
-                        title="This can be toggled"
-                        handler="download"
-                        [visible]="showCustomDownloadAction">
                     </content-action>
                     <!-- common actions -->
                     <content-action
@@ -445,12 +439,6 @@
         <section>
             <mat-slide-toggle color="primary" [(ngModel)]="showNameColumn">
                 Show Name Column
-            </mat-slide-toggle>
-        </section>
-
-        <section>
-            <mat-slide-toggle color="primary" [(ngModel)]="showCustomDownloadAction">
-                Toggle custom download action
             </mat-slide-toggle>
         </section>
 

--- a/demo-shell/src/app/components/files/files.component.ts
+++ b/demo-shell/src/app/components/files/files.component.ts
@@ -170,9 +170,6 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
     @ViewChild(InfinitePaginationComponent)
     infinitePaginationComponent: InfinitePaginationComponent;
 
-    @Input()
-    showCustomDownloadAction = false;
-
     permissionsStyle: PermissionStyleModel[] = [];
     infiniteScrolling: boolean;
     supportedPages: number[];
@@ -514,7 +511,7 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
     }
 
     canDownloadNode = (node: MinimalNodeEntity): boolean => {
-        if (node && node.entry && node.entry.name === 'For Sale.docx') {
+        if (node && node.entry && node.entry.name === 'custom') {
             return true;
         }
         return false;

--- a/docs/content-services/content-action.component.md
+++ b/docs/content-services/content-action.component.md
@@ -324,12 +324,10 @@ allow the item being copied/moved to be the destination if it is itself a folder
 
 ### Conditional visibility
 
-The Content-action component allows you to control visibility with the help of the `visible`
-property which can receive its value in three main ways:
+The `<content-action>` component allows you to control visibility with the help of the `visible` property and supports the following scenarios:
 
--   direct `boolean` value
--   binding to a `boolean` property
--   binding to a `Function` property that evaluates the condition and returns a `boolean` value
+-   direct value of `boolean` type
+-   binding to a property of the `Function` type that evaluates condition and returns `boolean` value
 
 #### Using direct boolean value
 
@@ -342,30 +340,7 @@ property which can receive its value in three main ways:
 </content-action>
 ```
 
-#### Binding to a boolean property
-
-```html
-<content-action
-    icon="get_app"
-    title="This can be toggled"
-    handler="download"
-    [visible]="showCustomDownloadAction">
-</content-action>
-```
-
-The markup above relies on the `showCustomDownloadAction` property declared in your
-component class:
-
-```ts
-export class MyComponent {
-
-    @Input()
-    showCustomDownloadAction = true;
-
-}
-```
-
-#### Binding to a Function property
+#### Using a property of the Function type
 
 ```html
  <content-action
@@ -409,7 +384,6 @@ funcName = (parameters): boolean => {
 Similar to `visible` property, it is possible to control the `disabled` state with the following scenarios:
 
 - direct value of `boolean` type
-- binding to a property of the `boolean` type
 - binding to a property of the `Function` type that evaluates condition and returns `boolean` value
 
 #### Using direct value of boolean type
@@ -421,28 +395,6 @@ Similar to `visible` property, it is possible to control the `disabled` state wi
     [disabled]="true"
     (execute)="runCustomAction($event)">
 </content-action>
-```
-
-#### Using a property of the boolean type
-
-```html
-<content-action
-    target="all"
-    title="Action for 'custom' node"
-    [disabled]="shouldDisableAction"
-    (execute)="runCustomAction($event)">
-</content-action>
-```
-
-The markup above relies on the `shouldDisableAction` property declared at your component class level:
-
-```ts
-export class MyComponent {
-
-    @Input()
-    shouldDisableAction = true;
-
-}
 ```
 
 #### Using a property of the Function type

--- a/lib/content-services/document-list/components/content-action/content-action-list.component.ts
+++ b/lib/content-services/document-list/components/content-action/content-action-list.component.ts
@@ -42,4 +42,15 @@ export class ContentActionListComponent {
         }
         return false;
     }
+
+    unregisterAction(action: ContentActionModel): boolean {
+        if (this.documentList && action) {
+            const idx = this.documentList.actions.indexOf(action);
+            if (idx >= 0) {
+                this.documentList.actions.splice(idx, 1);
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/lib/content-services/document-list/components/content-action/content-action.component.ts
+++ b/lib/content-services/document-list/components/content-action/content-action.component.ts
@@ -132,13 +132,27 @@ export class ContentActionComponent implements OnInit, OnChanges, OnDestroy {
         this.subscriptions.forEach(subscription => subscription.unsubscribe());
         this.subscriptions = [];
 
-        this.documentActionModel = null;
-        this.folderActionModel = null;
+        if (this.documentActionModel) {
+            this.unregister(this.documentActionModel);
+            this.documentActionModel = null;
+        }
+
+        if (this.folderActionModel) {
+            this.unregister(this.folderActionModel);
+            this.folderActionModel = null;
+        }
     }
 
     register(model: ContentActionModel): boolean {
         if (this.list) {
             return this.list.registerAction(model);
+        }
+        return false;
+    }
+
+    unregister(model: ContentActionModel): boolean {
+        if (this.list) {
+            return this.list.unregisterAction(model);
         }
         return false;
     }
@@ -151,7 +165,8 @@ export class ContentActionComponent implements OnInit, OnChanges, OnDestroy {
             disableWithNoPermission: this.disableWithNoPermission,
             target: target,
             disabled: this.disabled,
-            visible: this.visible
+            visible: this.visible,
+            template: this
         });
         if (this.handler) {
             model.handler = this.getSystemHandler(target, this.handler);

--- a/lib/content-services/document-list/components/content-action/content-action.component.ts
+++ b/lib/content-services/document-list/components/content-action/content-action.component.ts
@@ -165,8 +165,7 @@ export class ContentActionComponent implements OnInit, OnChanges, OnDestroy {
             disableWithNoPermission: this.disableWithNoPermission,
             target: target,
             disabled: this.disabled,
-            visible: this.visible,
-            template: this
+            visible: this.visible
         });
         if (this.handler) {
             model.handler = this.getSystemHandler(target, this.handler);

--- a/lib/content-services/document-list/components/document-list.component.html
+++ b/lib/content-services/document-list/components/document-list.component.html
@@ -13,6 +13,7 @@
     [display]="display"
     [noPermission]="noPermission"
     [showHeader]="!isEmpty() && showHeader"
+    [rowMenuCacheEnabled]="false"
     (showRowContextMenu)="onShowRowContextMenu($event)"
     (showRowActionsMenu)="onShowRowActionsMenu($event)"
     (executeRowAction)="onExecuteRowAction($event)"

--- a/lib/content-services/document-list/components/document-list.component.ts
+++ b/lib/content-services/document-list/components/document-list.component.ts
@@ -493,26 +493,23 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
     }
 
     private isActionVisible(action: ContentActionModel, node: MinimalNodeEntity): boolean {
-        const template = action.template;
-        if (typeof template.visible === 'function') {
-            return template.visible(node);
+        if (typeof action.visible === 'function') {
+            return action.visible(node);
         }
 
-        return template.visible;
+        return action.visible;
     }
 
     private isActionDisabled(action: ContentActionModel, node: MinimalNodeEntity): boolean {
-        const template = action.template;
-
-        if (typeof template.disabled === 'function') {
-            return template.disabled(node);
+        if (typeof action.disabled === 'function') {
+            return action.disabled(node);
         }
 
-        if (template.permission && template.disableWithNoPermission && !this.contentService.hasPermission(node.entry, template.permission)) {
+        if (action.permission && action.disableWithNoPermission && !this.contentService.hasPermission(node.entry, action.permission)) {
             return true;
         }
 
-        return template.disabled;
+        return action.disabled;
     }
 
     @HostListener('contextmenu', ['$event'])

--- a/lib/content-services/document-list/models/content-action.model.ts
+++ b/lib/content-services/document-list/models/content-action.model.ts
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-import { ContentActionComponent } from '../components/content-action/content-action.component';
-
 export class ContentActionModel {
     icon: string;
     title: string;

--- a/lib/content-services/document-list/models/content-action.model.ts
+++ b/lib/content-services/document-list/models/content-action.model.ts
@@ -28,8 +28,6 @@ export class ContentActionModel {
     disabled: boolean | Function = false;
     visible: boolean | Function = true;
 
-    template?: ContentActionComponent;
-
     constructor(obj?: any) {
         if (obj) {
             this.icon = obj.icon;
@@ -47,8 +45,6 @@ export class ContentActionModel {
             if (obj.hasOwnProperty('visible')) {
                 this.visible = obj.visible;
             }
-
-            this.template = obj.template;
         }
     }
 }

--- a/lib/content-services/document-list/models/content-action.model.ts
+++ b/lib/content-services/document-list/models/content-action.model.ts
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { ContentActionComponent } from '../components/content-action/content-action.component';
+
 export class ContentActionModel {
     icon: string;
     title: string;
@@ -25,6 +27,8 @@ export class ContentActionModel {
     disableWithNoPermission: boolean = false;
     disabled: boolean | Function = false;
     visible: boolean | Function = true;
+
+    template?: ContentActionComponent;
 
     constructor(obj?: any) {
         if (obj) {
@@ -43,6 +47,8 @@ export class ContentActionModel {
             if (obj.hasOwnProperty('visible')) {
                 this.visible = obj.visible;
             }
+
+            this.template = obj.template;
         }
     }
 }

--- a/lib/core/context-menu/context-menu-holder.component.ts
+++ b/lib/core/context-menu/context-menu-holder.component.ts
@@ -29,13 +29,15 @@ import { ContextMenuService } from './context-menu.service';
     template: `
         <button mat-button [matMenuTriggerFor]="contextMenu"></button>
         <mat-menu #contextMenu="matMenu" class="context-menu">
-            <button *ngFor="let link of links"
-                mat-menu-item
-                [disabled]="link.model?.disabled"
-                (click)="onMenuItemClick($event, link)">
-                <mat-icon *ngIf="showIcons && link.model?.icon">{{ link.model.icon }}</mat-icon>
-                {{ (link.title || link.model?.title) | translate }}
-            </button>
+            <ng-container *ngFor="let link of links">
+                <button *ngIf="link.model?.visible"
+                    mat-menu-item
+                    [disabled]="link.model?.disabled"
+                    (click)="onMenuItemClick($event, link)">
+                    <mat-icon *ngIf="showIcons && link.model?.icon">{{ link.model.icon }}</mat-icon>
+                    {{ (link.title || link.model?.title) | translate }}
+                </button>
+            </ng-container>
         </mat-menu>
     `
 })

--- a/lib/core/datatable/components/datatable/datatable.component.ts
+++ b/lib/core/datatable/components/datatable/datatable.component.ts
@@ -155,6 +155,9 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck,
     @Input()
     noPermission: boolean = false;
 
+    @Input()
+    rowMenuCacheEnabled = true;
+
     noContentTemplate: TemplateRef<any>;
     noPermissionTemplate: TemplateRef<any>;
     loadingTemplate: TemplateRef<any>;
@@ -166,6 +169,8 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck,
     private click$: Observable<DataRowEvent>;
 
     private differ: any;
+    private rowMenuCache: object = {};
+
     private subscriptions: Subscription[] = [];
     private singleClickStreamSub: Subscription;
     private multiClickStreamSub: Subscription;
@@ -297,6 +302,7 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck,
     private initTable() {
         this.data = new ObjectDataTableAdapter(this.rows, this.columns);
         this.setupData(this.data);
+        this.rowMenuCache = {};
     }
 
     private setupData(adapter: DataTableAdapter) {
@@ -553,9 +559,18 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck,
     }
 
     getRowActions(row: DataRow, col: DataColumn): any[] {
-        let event = new DataCellEvent(row, col, []);
-        this.showRowActionsMenu.emit(event);
-        return event.value.actions;
+        const id = row.getValue('id');
+
+        if (!this.rowMenuCache[id]) {
+            let event = new DataCellEvent(row, col, []);
+            this.showRowActionsMenu.emit(event);
+            if (!this.rowMenuCacheEnabled) {
+                return event.value.actions;
+            }
+            this.rowMenuCache[id] = event.value.actions;
+        }
+
+        return this.rowMenuCache[id];
     }
 
     onExecuteRowAction(row: DataRow, action: any) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

This is a set of fixes for the previous updates in the scope of ADF-2859

- fix issues with context menus and action menus
- allow document list have its own cache of action menus
- un-registering content actions on dispose
- remove support for binding to properties (from docs) as it lacks access to the nodes to refresh properly

Testing:

- create a folder with the name `custom`
- right click and then click the row actions button
  - in both cases you should see two actions at the top
- select any other folder and repeat the process
  - you should see only 1 extra action and it should be disabled 

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
