### PR TITLE
[ADF-2765] Fix for the gallery view in datatable component

### DIFF
--- a/lib/core/datatable/components/datatable/datatable.component.html
+++ b/lib/core/datatable/components/datatable/datatable.component.html
@@ -42,7 +42,6 @@
                 </mat-option>
             </mat-select>
         </mat-form-field>
-
     </div>
 
     <div class="adf-datatable-body">
@@ -190,6 +189,9 @@
                     </ng-template>
                     <ng-content select="adf-empty-list"></ng-content>
                 </div>
+            </div>
+            <div *ngFor="let row of fakeRows"
+                 class="adf-datatable-row adf-datatable-row-empty-card">
             </div>
         </ng-container>
         <div *ngIf="!loading && noPermission"

--- a/lib/core/datatable/components/datatable/datatable.component.scss
+++ b/lib/core/datatable/components/datatable/datatable.component.scss
@@ -29,13 +29,10 @@
             display: flex;
 
             width: 100%;
-            flex-direction: row;
-            justify-content: space-between;
 
-            &:after {
-                content: "";
-                flex: auto;
-            }
+            justify-content: space-evenly;
+            align-content: flex-start;
+            align-items: flex-start;
 
             .adf-datatable-row {
                 transition: all 0.3s ease;
@@ -56,6 +53,14 @@
 
                 @include mat-elevation-transition;
                 @include mat-overridable-elevation(2);
+            }
+
+            .adf-datatable-row-empty-card {
+                height: 0 !important;
+                padding-top: 0;
+                padding-bottom: 0;
+                margin-top: 0;
+                margin-bottom: 0;
             }
 
             .is-selected {

--- a/lib/core/datatable/components/datatable/datatable.component.ts
+++ b/lib/core/datatable/components/datatable/datatable.component.ts
@@ -160,7 +160,7 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck,
 
     isSelectAllChecked: boolean = false;
     selection = new Array<DataRow>();
-    
+
     /** This array of fake rows fix the flex layout for the gallery view */
     fakeRows = [];
 

--- a/lib/core/datatable/components/datatable/datatable.component.ts
+++ b/lib/core/datatable/components/datatable/datatable.component.ts
@@ -664,7 +664,7 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck,
     }
 
     datatableLayoutFix() {
-        const maxGalleryRows = 7;
+        const maxGalleryRows = 25;
 
         if (this.display === 'gallery') {
             for (let i = 0; i < maxGalleryRows; i++) {

--- a/lib/core/datatable/components/datatable/datatable.component.ts
+++ b/lib/core/datatable/components/datatable/datatable.component.ts
@@ -663,12 +663,12 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck,
         }
     }
 
-    datatableLayoutFix() {      
+    datatableLayoutFix() {
         const maxGalleryRows = 7;
 
-        if(this.display === 'gallery') {
+        if (this.display === 'gallery') {
             for (let i = 0; i < maxGalleryRows; i++) {
-               this.fakeRows.push("");  
+               this.fakeRows.push('');
             }
         } else {
             this.fakeRows = [];

--- a/lib/core/datatable/components/datatable/datatable.component.ts
+++ b/lib/core/datatable/components/datatable/datatable.component.ts
@@ -160,6 +160,9 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck,
 
     isSelectAllChecked: boolean = false;
     selection = new Array<DataRow>();
+    
+    /** This array of fake rows fix the flex layout for the gallery view */
+    fakeRows = [];
 
     private clickObserver: Observer<DataRowEvent>;
     private click$: Observable<DataRowEvent>;
@@ -188,6 +191,7 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck,
                 })
             );
         }
+        this.datatableLayoutFix();
         this.setTableSchema();
     }
 
@@ -219,6 +223,10 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck,
 
         if (this.isPropertyChanged(changes['sorting'])) {
             this.setTableSorting(changes['sorting'].currentValue);
+        }
+
+        if (this.isPropertyChanged(changes['display'])) {
+            this.datatableLayoutFix();
         }
     }
 
@@ -652,6 +660,18 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck,
         if (this.dataRowsChanged) {
             this.dataRowsChanged.unsubscribe();
             this.dataRowsChanged = null;
+        }
+    }
+
+    datatableLayoutFix() {      
+        const maxGalleryRows = 7;
+
+        if(this.display === 'gallery') {
+            for (let i = 0; i < maxGalleryRows; i++) {
+               this.fakeRows.push("");  
+            }
+        } else {
+            this.fakeRows = [];
         }
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Gallery view breaks flex layout at the bottom. (Last row).


**What is the new behaviour?**
Now every single row is displayed where it belongs.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-2765