### PR TITLE
[ADF-3175] renabling upload on single target folder row

### DIFF
--- a/lib/content-services/upload/components/upload-drag-area.component.spec.ts
+++ b/lib/content-services/upload/components/upload-drag-area.component.spec.ts
@@ -62,6 +62,40 @@ function getFakeShareDataRow(allowableOperations = ['delete', 'update', 'create'
     };
 }
 
+function getFakeFileShareRow(allowableOperations = ['delete', 'update', 'create']) {
+    return {
+        obj: {
+            entry: {
+                createdAt: '2017-06-04T04:32:15.597Z',
+                path: {
+                    name: '/Company Home/User Homes/Test',
+                    isComplete: true,
+                    elements: [
+                        {
+                            id: '94acfc73-7014-4475-9bd9-93a2162f0f8c',
+                            name: 'Company Home'
+                        },
+                        {
+                            id: '55052317-7e59-4058-8e07-769f41e615e1',
+                            name: 'User Homes'
+                        },
+                        {
+                            id: '70e1cc6a-6918-468a-b84a-1048093b06fd',
+                            name: 'Test'
+                        }
+                    ]
+                },
+                isFolder: false,
+                isFile: true,
+                name: 'pippo',
+                id: '7462d28e-bd43-4b91-9e7b-0d71598680ac',
+                nodeType: 'cm:folder',
+                allowableOperations
+            }
+        }
+    };
+}
+
 describe('UploadDragAreaComponent', () => {
 
     let component: UploadDragAreaComponent;
@@ -120,6 +154,7 @@ describe('UploadDragAreaComponent', () => {
                 fullPath: '/folder-fake/file-fake.png',
                 isDirectory: false,
                 isFile: true,
+                relativeFolder: '/',
                 name: 'file-fake.png',
                 file: (callbackFile) => {
                     let fileFake = new File(['fakefake'], 'file-fake.png', { type: 'image/png' });
@@ -166,6 +201,7 @@ describe('UploadDragAreaComponent', () => {
                 fullPath: '/folder-fake/file-fake.png',
                 isDirectory: false,
                 isFile: true,
+                relativeFolder: '/',
                 name: 'file-fake.png',
                 file: (callbackFile) => {
                     let fileFake = new File(['fakefake'], 'file-fake.png', { type: 'image/png' });
@@ -236,6 +272,7 @@ describe('UploadDragAreaComponent', () => {
                 isDirectory: false,
                 isFile: true,
                 name: 'file-fake.png',
+                relativeFolder: '/',
                 file: (callbackFile) => {
                     let fileFake = new File(['fakefake'], 'file-fake.png', { type: 'image/png' });
                     callbackFile(fileFake);
@@ -257,6 +294,7 @@ describe('UploadDragAreaComponent', () => {
                 fullPath: '/folder-fake/file-fake.png',
                 isDirectory: false,
                 isFile: true,
+                relativeFolder: '/',
                 name: 'file-fake.png',
                 file: (callbackFile) => {
                     let fileFake = new File(['fakefake'], 'file-fake.png', { type: 'image/png' });
@@ -279,6 +317,7 @@ describe('UploadDragAreaComponent', () => {
                 isDirectory: false,
                 isFile: true,
                 name: 'file-fake.png',
+                relativeFolder: '/',
                 file: (callbackFile) => {
                     let fileFake = new File(['fakefake'], 'file-fake.png', { type: 'image/png' });
                     callbackFile(fileFake);
@@ -294,6 +333,7 @@ describe('UploadDragAreaComponent', () => {
                 isDirectory: false,
                 isFile: true,
                 name: 'file-fake.png',
+                relativeFolder: '/',
                 file: (callbackFile) => {
                     let fileFake = new File(['fakefake'], 'file-fake.png', { type: 'image/png' });
                     callbackFile(fileFake);
@@ -303,6 +343,65 @@ describe('UploadDragAreaComponent', () => {
             let fakeCustomEvent: CustomEvent = new CustomEvent('CustomEvent', {
                 detail: {
                     data: getFakeShareDataRow(),
+                    files: [fakeItem]
+                }
+            });
+
+            component.onUploadFiles(fakeCustomEvent);
+            expect(uploadService.addToQueue).toHaveBeenCalled();
+        }));
+
+        it('should upload a file to a specific target folder when dropped onto one', async(() => {
+
+            let fakeItem = {
+                fullPath: '/folder-fake/file-fake.png',
+                isDirectory: false,
+                isFile: true,
+                name: 'file-fake.png',
+                relativeFolder: '/',
+                file: (callbackFile) => {
+                    let fileFake = new File(['fakefake'], 'file-fake.png', { type: 'image/png' });
+                    callbackFile(fileFake);
+                }
+            };
+
+            addToQueueSpy.and.callFake((fileList) => {
+                expect(fileList.name).toBe('file');
+                expect(fileList.options.path).toBe('/pippo');
+            });
+
+            let fakeCustomEvent: CustomEvent = new CustomEvent('CustomEvent', {
+                detail: {
+                    data: getFakeShareDataRow(),
+                    files: [fakeItem]
+                }
+            });
+
+            component.onUploadFiles(fakeCustomEvent);
+        }));
+
+        it('should upload the file in the current folder when the target is file', async(() => {
+
+            let fakeItem = {
+                fullPath: '/folder-fake/file-fake.png',
+                isDirectory: false,
+                isFile: true,
+                name: 'file-fake.png',
+                relativeFolder: '/',
+                file: (callbackFile) => {
+                    let fileFake = new File(['fakefake'], 'file-fake.png', { type: 'image/png' });
+                    callbackFile(fileFake);
+                }
+            };
+
+            addToQueueSpy.and.callFake((fileList) => {
+                expect(fileList.name).toBe('file');
+                expect(fileList.options.path).toBe('/');
+            });
+
+            let fakeCustomEvent: CustomEvent = new CustomEvent('CustomEvent', {
+                detail: {
+                    data: getFakeFileShareRow(),
                     files: [fakeItem]
                 }
             });
@@ -320,6 +419,7 @@ describe('UploadDragAreaComponent', () => {
                 fullPath: '/folder-fake/file-fake.png',
                 isDirectory: false,
                 isFile: true,
+                relativeFolder: '/',
                 name: 'file-fake.png',
                 file: (callbackFile) => {
                     let fileFake = new File(['fakefake'], 'file-fake.png', { type: 'image/png' });

--- a/lib/content-services/upload/components/upload-drag-area.component.ts
+++ b/lib/content-services/upload/components/upload-drag-area.component.ts
@@ -119,10 +119,18 @@ export class UploadDragAreaComponent extends UploadBase implements NodePermissio
         let isAllowed: boolean = this.contentService.hasPermission(event.detail.data.obj.entry, PermissionsEnum.CREATE);
         if (isAllowed) {
             let fileInfo: FileInfo[] = event.detail.files;
+            if (this.isTargetNodeFolder(event)) {
+                const destinationFolderName = event.detail.data.obj.entry.name;
+                fileInfo.map((file) => file.relativeFolder = file.relativeFolder.concat(destinationFolderName));
+            }
             if (fileInfo && fileInfo.length > 0) {
                 this.uploadFilesInfo(fileInfo);
             }
         }
+    }
+
+    private isTargetNodeFolder(event: CustomEvent): boolean {
+        return event.detail.data.obj && event.detail.data.obj.entry.isFolder;
     }
 
 }

--- a/lib/core/datatable/components/datatable/datatable.component.scss
+++ b/lib/core/datatable/components/datatable/datatable.component.scss
@@ -456,16 +456,19 @@
     }
 
     .adf-upload__dragging {
-        & > td {
-            border-top: $data-table-drag-border;
-            border-bottom: $data-table-drag-border;
+        & > div {
+            border-top: $data-table-drag-border !important;
+            border-bottom: $data-table-drag-border !important;
+            border-color: $data-table-drag-border;
 
             &:first-child {
                 border-left: $data-table-drag-border;
+                border-color: $data-table-drag-border;
             }
 
             &:last-child {
-                border-right: $data-table-drag-border;
+                border-right: $data-table-drag-border !important;
+                border-color: $data-table-drag-border;
             }
         }
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
It is not possible to upload a file when on not opened folders


**What is the new behaviour?**
we renabled this possibility for the subfolder where we have permission on.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-3175