### PR TITLE
[ADF-3195] Setting component - Fix default SSO config not filled in

### DIFF
--- a/lib/core/services/user-preferences.service.ts
+++ b/lib/core/services/user-preferences.service.ts
@@ -242,7 +242,7 @@ export class UserPreferencesService {
         if (this.storage.hasItem('authType')) {
             return this.storage.getItem('authType');
         } else {
-            return this.appConfig.get<string>('authType');
+            return this.appConfig.get<string>('authType', 'BASIC');
         }
     }
 

--- a/lib/core/settings/host-settings.component.ts
+++ b/lib/core/settings/host-settings.component.ts
@@ -72,14 +72,9 @@ export class HostSettingsComponent implements OnInit {
 
         let providerSelected = this.userPreference.providers;
 
-        let authType = 'BASIC';
-        if (this.userPreference.authType === 'OAUTH') {
-            authType = this.userPreference.authType;
-        }
-
         this.form = this.formBuilder.group({
             providersControl: [providerSelected, Validators.required],
-            authType: authType
+            authType: this.userPreference.authType
         });
 
         this.addFormGroups();
@@ -132,11 +127,7 @@ export class HostSettingsComponent implements OnInit {
     }
 
     private createOAuthFormGroup(): AbstractControl {
-        let oAuthConfig: any = {};
-        if (this.userPreference.authType === 'OAUTH') {
-            oAuthConfig = this.userPreference.oauthConfig;
-        }
-
+        const oAuthConfig: any = this.userPreference.oauthConfig ? this.userPreference.oauthConfig : {};
         return this.formBuilder.group({
             host: [oAuthConfig.host, [Validators.required, Validators.pattern(this.HOST_REGEX)]],
             clientId: [oAuthConfig.clientId, Validators.required],


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
the sso default setting is not fetched


**What is the new behaviour?**
the sso fields are filled in with the config coming from app.conf.json


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
