### PR TITLE
[ADF-2962] Login Hide/Show icon is not reachable

### DIFF
--- a/lib/core/login/components/login.component.html
+++ b/lib/core/login/components/login.component.html
@@ -61,11 +61,11 @@
                                            data-automation-id="password"
                                            tabindex="2">
                                     <mat-icon *ngIf="isPasswordShow" matSuffix class="adf-login-password-icon"
-                                              data-automation-id="hide_password" (click)="toggleShowPassword($event)" (keyup)="toggleShowPassword($event)" tabindex="3">
+                                              data-automation-id="hide_password" (click)="toggleShowPassword()" (keyup.enter)="toggleShowPassword()" tabindex="3">
                                         visibility
                                     </mat-icon>
                                     <mat-icon *ngIf="!isPasswordShow" matSuffix class="adf-login-password-icon"
-                                              data-automation-id="show_password" (click)="toggleShowPassword($event)" (keyup)="toggleShowPassword($event)" tabindex="3">
+                                              data-automation-id="show_password" (click)="toggleShowPassword()" (keyup.enter)="toggleShowPassword()" tabindex="3">
                                         visibility_off
                                     </mat-icon>
                                 </mat-form-field>

--- a/lib/core/login/components/login.component.html
+++ b/lib/core/login/components/login.component.html
@@ -61,11 +61,11 @@
                                            data-automation-id="password"
                                            tabindex="2">
                                     <mat-icon *ngIf="isPasswordShow" matSuffix class="adf-login-password-icon"
-                                              data-automation-id="hide_password" (click)="toggleShowPassword()">
+                                              data-automation-id="hide_password" (click)="toggleShowPassword($event)" (keyup)="toggleShowPassword($event)" tabindex="3">
                                         visibility
                                     </mat-icon>
                                     <mat-icon *ngIf="!isPasswordShow" matSuffix class="adf-login-password-icon"
-                                              data-automation-id="show_password" (click)="toggleShowPassword()">
+                                              data-automation-id="show_password" (click)="toggleShowPassword($event)" (keyup)="toggleShowPassword($event)" tabindex="3">
                                         visibility_off
                                     </mat-icon>
                                 </mat-form-field>
@@ -79,7 +79,7 @@
                             <ng-content></ng-content>
 
                             <br>
-                            <button type="submit" id="login-button" tabindex="3"
+                            <button type="submit" id="login-button" tabindex="4"
                                     class="adf-login-button"
                                     mat-raised-button color="primary"
                                     [class.isChecking]="actualLoginStep === LoginSteps.Checking"

--- a/lib/core/login/components/login.component.ts
+++ b/lib/core/login/components/login.component.ts
@@ -319,12 +319,14 @@ export class LoginComponent implements OnInit {
     /**
      * Display and hide the password value.
      */
-    toggleShowPassword() {
-        this.isPasswordShow = !this.isPasswordShow;
-        this.elementRef.nativeElement.querySelector('#password').type = this
-            .isPasswordShow
-            ? 'text'
-            : 'password';
+    toggleShowPassword(event) {
+        if (event.type === 'click' || event.key === 'Enter') {
+            this.isPasswordShow = !this.isPasswordShow;
+            this.elementRef.nativeElement.querySelector('#password').type = this
+                .isPasswordShow
+                ? 'text'
+                : 'password';
+        }
     }
 
     /**

--- a/lib/core/login/components/login.component.ts
+++ b/lib/core/login/components/login.component.ts
@@ -319,14 +319,12 @@ export class LoginComponent implements OnInit {
     /**
      * Display and hide the password value.
      */
-    toggleShowPassword(event) {
-        if (event.type === 'click' || event.key === 'Enter') {
-            this.isPasswordShow = !this.isPasswordShow;
-            this.elementRef.nativeElement.querySelector('#password').type = this
-                .isPasswordShow
-                ? 'text'
-                : 'password';
-        }
+    toggleShowPassword() {
+        this.isPasswordShow = !this.isPasswordShow;
+        this.elementRef.nativeElement.querySelector('#password').type = this
+            .isPasswordShow
+            ? 'text'
+            : 'password';
     }
 
     /**


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
 The 'Login' button is focused and 'Hide/Show' is skipped.
https://issues.alfresco.com/jira/browse/ADF-2962

**What is the new behaviour?**
The 'Hide/Show' password icon is focused and can be trigger from enter key or click.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
