### PR TITLE
[ADF-3217] reset previous search settings

### DIFF
--- a/demo-shell/src/app/components/search/search-result.component.ts
+++ b/demo-shell/src/app/components/search/search-result.component.ts
@@ -26,7 +26,7 @@ import { Subscription } from 'rxjs/Subscription';
     selector: 'app-search-result-component',
     templateUrl: './search-result.component.html',
     styleUrls: ['./search-result.component.scss'],
-    providers: [SearchService]
+    providers: [SearchService, SearchQueryBuilderService]
 })
 export class SearchResultComponent implements OnInit, OnDestroy {
 

--- a/lib/content-services/search/search-query-builder.service.spec.ts
+++ b/lib/content-services/search/search-query-builder.service.spec.ts
@@ -27,6 +27,31 @@ describe('SearchQueryBuilder', () => {
         return config;
     };
 
+    fit('should reset to defaults', () => {
+        const config: SearchConfiguration = {
+            categories: [
+                <any> { id: 'cat1', enabled: true },
+                <any> { id: 'cat2', enabled: true }
+            ],
+            filterQueries: [
+                { query: 'query1' },
+                { query: 'query2' }
+            ]
+        };
+        const builder = new SearchQueryBuilderService(buildConfig(config), null);
+
+        builder.categories = [];
+        builder.filterQueries = [];
+
+        expect(builder.categories.length).toBe(0);
+        expect(builder.filterQueries.length).toBe(0);
+
+        builder.resetToDefaults();
+
+        expect(builder.categories.length).toBe(2);
+        expect(builder.filterQueries.length).toBe(2);
+    });
+
     it('should have empty user query by default', () => {
         const builder = new SearchQueryBuilderService(buildConfig({}), null);
         expect(builder.userQuery).toBe('');

--- a/lib/content-services/search/search-query-builder.service.spec.ts
+++ b/lib/content-services/search/search-query-builder.service.spec.ts
@@ -27,7 +27,7 @@ describe('SearchQueryBuilder', () => {
         return config;
     };
 
-    fit('should reset to defaults', () => {
+    it('should reset to defaults', () => {
         const config: SearchConfiguration = {
             categories: [
                 <any> { id: 'cat1', enabled: true },

--- a/lib/content-services/search/search-query-builder.service.ts
+++ b/lib/content-services/search/search-query-builder.service.ts
@@ -57,13 +57,24 @@ export class SearchQueryBuilderService {
 
     constructor(appConfig: AppConfigService, private alfrescoApiService: AlfrescoApiService) {
         this.config = appConfig.get<SearchConfiguration>('search');
+        this.resetToDefaults();
+    }
 
+    resetToDefaults() {
         if (this.config) {
-            this.categories = (this.config.categories || []).filter(category => category.enabled);
-            this.filterQueries = this.config.filterQueries || [];
+            this.categories =
+                (this.config.categories || [])
+                    .filter(category => category.enabled)
+                    .map(category => { return { ...category }; });
+
+            this.filterQueries =
+                (this.config.filterQueries || [])
+                    .map(query => { return {...query}; });
 
             if (this.config.sorting) {
-                this.sorting = this.config.sorting.defaults || [];
+                this.sorting =
+                    (this.config.sorting.defaults || [])
+                        .map(sorting => { return { ...sorting }; });
             }
         }
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

If user selects a facet and then leaves the page, the settings are not reset next time the search is performed.

**What is the new behaviour?**

Settings are reset each time user makes a new search and visits new search results

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
