### PR TITLE
[ADF-3912] Setting Component - Return as default BASIC authType

### DIFF
--- a/lib/core/services/alfresco-api.service.ts
+++ b/lib/core/services/alfresco-api.service.ts
@@ -117,7 +117,6 @@ export class AlfrescoApiService {
     }
 
     protected initAlfrescoApi() {
-        // let oauth: OauthConfigModel = this.appConfig.get<OauthConfigModel>(AppConfigValues.OAUTHCONFIG, null);
         let oauth: OauthConfigModel = Object.assign({}, this.appConfig.get<OauthConfigModel>(AppConfigValues.OAUTHCONFIG, null));
         if (oauth) {
             oauth.redirectUri = window.location.origin + (oauth.redirectUri || '/');

--- a/lib/core/services/alfresco-api.service.ts
+++ b/lib/core/services/alfresco-api.service.ts
@@ -117,8 +117,8 @@ export class AlfrescoApiService {
     }
 
     protected initAlfrescoApi() {
-        let oauth: OauthConfigModel = this.appConfig.get<OauthConfigModel>(AppConfigValues.OAUTHCONFIG, null);
-
+        // let oauth: OauthConfigModel = this.appConfig.get<OauthConfigModel>(AppConfigValues.OAUTHCONFIG, null);
+        let oauth: OauthConfigModel = Object.assign({}, this.appConfig.get<OauthConfigModel>(AppConfigValues.OAUTHCONFIG, null));
         if (oauth) {
             oauth.redirectUri = window.location.origin + (oauth.redirectUri || '/');
             oauth.redirectUriLogout = window.location.origin + (oauth.redirectUriLogout || '/');
@@ -130,7 +130,7 @@ export class AlfrescoApiService {
             ticketBpm: this.storage.getItem('ticket-BPM'),
             hostEcm: this.appConfig.get<string>(AppConfigValues.ECMHOST),
             hostBpm: this.appConfig.get<string>(AppConfigValues.BPMHOST),
-            authType: this.appConfig.get<string>(AppConfigValues.AUTHTYPE),
+            authType: this.appConfig.get<string>(AppConfigValues.AUTHTYPE, 'BASIC'),
             contextRootBpm: this.appConfig.get<string>(AppConfigValues.CONTEXTROOTBPM),
             contextRoot: this.appConfig.get<string>(AppConfigValues.CONTEXTROOTECM),
             disableCsrf: this.storage.getItem('DISABLE_CSRF') === 'true',

--- a/lib/core/settings/host-settings.component.ts
+++ b/lib/core/settings/host-settings.component.ts
@@ -77,14 +77,16 @@ export class HostSettingsComponent implements OnInit {
 
         let providerSelected = this.appConfig.get<string>(AppConfigValues.PROVIDERS);
 
+        const authType = this.appConfig.get<string>(AppConfigValues.AUTHTYPE, 'BASIC');
+
         this.form = this.formBuilder.group({
             providersControl: [providerSelected, Validators.required],
-            authType: this.appConfig.get<string>(AppConfigValues.AUTHTYPE)
+            authType: authType
         });
 
         this.addFormGroups();
 
-        if (this.appConfig.get<string>(AppConfigValues.AUTHTYPE) === 'OAUTH') {
+        if (authType === 'OAUTH') {
             this.addOAuthFormGroup();
         }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
if the app.confi.json file doesn't contain the authType the get return nul


**What is the new behaviour?**
if the app.confi.json file doesn't contain the authType the get return BASIC



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-3219