### PR TITLE
[ADF-3203] Fixed doc tools bugs from Linux run and added verbose option

### DIFF
--- a/tools/doc/docProcessor.js
+++ b/tools/doc/docProcessor.js
@@ -53,6 +53,10 @@ function updatePhase(filenames, aggData) {
         errorMessages = [];
         var pathname = filenames[i]; // path.resolve(srcFolder, filenames[i]);
         
+        if (program.verbose) {
+            console.log(pathname);
+        }
+        
         var src = fs.readFileSync(pathname);
         var tree = remark().use(frontMatter, ["yaml"]).parse(src)
 
@@ -132,6 +136,7 @@ program
 .usage("[options] <source>")
 .option("-p, --profile [profileName]", "Select named config profile", "default")
 .option("-j, --json", "Output JSON data for Markdown syntax tree")
+.option("-v, --verbose", "Log doc files as they are processed")
 .parse(process.argv);
 
 var sourcePath;

--- a/tools/doc/mdNav.js
+++ b/tools/doc/mdNav.js
@@ -165,7 +165,7 @@ var MDNav = /** @class */ (function () {
                 return this.item.value;
             }
             else {
-                return undefined;
+                return "";
             }
         },
         enumerable: true,

--- a/tools/doc/mdNav.ts
+++ b/tools/doc/mdNav.ts
@@ -157,7 +157,7 @@ export class MDNav {
         if (this.item && this.item["value"]) {
             return this.item.value;
         } else {
-            return undefined;
+            return "";
         }
     }
 }

--- a/tools/doc/tools/tsInfo.js
+++ b/tools/doc/tools/tsInfo.js
@@ -4,6 +4,8 @@ var fs = require("fs");
 var path = require("path");
 var replaceSection = require("mdast-util-heading-range");
 var remark = require("remark");
+// import * as stringify from "remark-stringify";
+// import * as frontMatter from "remark-frontmatter";
 var ejs = require("ejs");
 var typedoc_1 = require("typedoc");
 var mdNav_1 = require("../mdNav");
@@ -202,8 +204,9 @@ function updatePhase(tree, pathname, aggData, errorMessages) {
         return false;
     }
     var compData = new ComponentInfo(classRef);
-    var classType = compName.match(/component|directive|service/i);
-    if (classType) {
+    var classTypeMatch = compName.match(/component|directive|service/i);
+    if (classTypeMatch) {
+        var classType = classTypeMatch[0].toLowerCase();
         // Copy docs back from the .md file when the JSDocs are empty.
         var inputMD = getPropDocsFromMD(tree, "Properties", 3);
         var outputMD = getPropDocsFromMD(tree, "Events", 2);
@@ -305,7 +308,7 @@ function getMethodDocsFromMD(tree) {
             var methDoc = methItem.childNav
                 .paragraph().childNav
                 .html()
-                .text().item.value;
+                .text().value;
             var params = getMDMethodParams(methItem);
             result[methName] = {
                 "docText": methDoc.replace(/^\n/, ""),
@@ -368,12 +371,12 @@ function updateMethodDocsFromMD(comp, methodDocs, errorMessages) {
     comp.methods.forEach(function (meth) {
         var currMethMD = methodDocs[meth.name];
         // If JSDocs are empty but MD docs aren't then the Markdown is presumably more up-to-date.
-        if (!meth.docText && currMethMD.docText) {
+        if (!meth.docText && currMethMD && currMethMD.docText) {
             meth.docText = currMethMD.docText;
             errorMessages.push("Warning: empty JSDocs for method sig \"" + meth.name + "\" may need sync with the .md file.");
         }
         meth.params.forEach(function (param) {
-            if (!param.docText && currMethMD.params[param.name]) {
+            if (!param.docText && currMethMD && currMethMD.params[param.name]) {
                 param.docText = currMethMD.params[param.name];
                 errorMessages.push("Warning: empty JSDocs for parameter \"" + param.name + " (" + meth.name + ")\" may need sync with the .md file.");
             }

--- a/tools/doc/tools/tsInfo.ts
+++ b/tools/doc/tools/tsInfo.ts
@@ -3,10 +3,9 @@ import * as path from "path";
 
 import * as replaceSection from "mdast-util-heading-range";
 import * as remark from "remark";
-import * as stringify from "remark-stringify";
-import * as frontMatter from "remark-frontmatter";
+// import * as stringify from "remark-stringify";
+// import * as frontMatter from "remark-frontmatter";
 
-import * as combyne from "combyne";
 import * as ejs from "ejs";
 
 import {
@@ -295,9 +294,11 @@ export function updatePhase(tree, pathname, aggData, errorMessages) {
     }
 
     let compData = new ComponentInfo(classRef);
-    let classType = compName.match(/component|directive|service/i);
+    let classTypeMatch = compName.match(/component|directive|service/i);
 
-    if (classType) {
+    if (classTypeMatch) {
+        let classType = classTypeMatch[0].toLowerCase();
+
         // Copy docs back from the .md file when the JSDocs are empty.
         let inputMD = getPropDocsFromMD(tree, "Properties", 3);
         let outputMD = getPropDocsFromMD(tree, "Events", 2);
@@ -440,7 +441,7 @@ function getMethodDocsFromMD(tree) {
             let methDoc = methItem.childNav
             .paragraph().childNav
             .html()
-            .text().item.value;
+            .text().value;
 
             let params = getMDMethodParams(methItem);
 
@@ -523,13 +524,13 @@ function updateMethodDocsFromMD(comp: ComponentInfo, methodDocs, errorMessages) 
         let currMethMD = methodDocs[meth.name]
 
         // If JSDocs are empty but MD docs aren't then the Markdown is presumably more up-to-date.
-        if (!meth.docText && currMethMD.docText) {
+        if (!meth.docText && currMethMD && currMethMD.docText) {
             meth.docText = currMethMD.docText;
             errorMessages.push(`Warning: empty JSDocs for method sig "${meth.name}" may need sync with the .md file.`);
         }
         
         meth.params.forEach(param => {
-            if (!param.docText && currMethMD.params[param.name])
+            if (!param.docText && currMethMD && currMethMD.params[param.name])
             {
                 param.docText = currMethMD.params[param.name];
                 errorMessages.push(`Warning: empty JSDocs for parameter "${param.name} (${meth.name})" may need sync with the .md file.`);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [x] Documentation
> - [ ] Other... Please describe:

**What is the new behaviour?**

Fixed some bugs detected by running the tools with Linux (but unfortunately not the original bug I was looking for). Also added a verbose option to the doc tools that lists the doc files as they are processed. This should help detect which file is being processed when a crash happens.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No

