### PR TITLE
[ADF-3232] fixing retrieving for ecm user via site service

### DIFF
--- a/lib/core/services/sites.service.ts
+++ b/lib/core/services/sites.service.ts
@@ -91,7 +91,7 @@ export class SitesService {
      * @returns Username string
      */
     getEcmCurrentLoggedUserName(): string {
-        return this.apiService.getInstance().ecmAuth.username;
+        return this.apiService.getInstance().getEcmUsername();
     }
 
     private handleError(error: Response): any {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
retrieving of ecm logged username in an incorrect way


**What is the new behaviour?**
using the apposite function to get the currently logged in username


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-3232