### PR TITLE
[ADF-3229] people widget list reseted if empty input

### DIFF
--- a/lib/core/form/components/widgets/people/people.widget.spec.ts
+++ b/lib/core/form/components/widgets/people/people.widget.spec.ts
@@ -169,6 +169,18 @@ describe('PeopleWidgetComponent', () => {
             });
         }));
 
+        it('should hide result list if input is empty', () => {
+            let peopleHTMLElement: HTMLInputElement = <HTMLInputElement> element.querySelector('input');
+            peopleHTMLElement.focus();
+            peopleHTMLElement.value = '';
+            peopleHTMLElement.dispatchEvent(new Event('keyup'));
+            peopleHTMLElement.dispatchEvent(new Event('input'));
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+                fixture.detectChanges();
+                expect(fixture.debugElement.query(By.css('#adf-people-widget-user-0'))).toBeNull();
+            });
+        });
     });
 
 });

--- a/lib/core/form/components/widgets/people/people.widget.ts
+++ b/lib/core/form/components/widgets/people/people.widget.ts
@@ -80,6 +80,7 @@ export class PeopleWidgetComponent extends WidgetComponent implements OnInit {
                 this.checkUserAndValidateForm(list, value);
             } else {
                 this.field.value = null;
+                list = [];
             }
 
             return list;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-3229
The result box is still displayed.


**What is the new behaviour?**
The result box isn't displayed anymore.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
