### PR TITLE
[ADF-3239] Fixed deprecated property descriptions

### DIFF
--- a/docs/content-services/content-node-selector.component.md
+++ b/docs/content-services/content-node-selector.component.md
@@ -31,13 +31,13 @@ Allows a user to select items from a Content Services repository.
 
 | Name | Type | Default value | Description |
 | -- | -- | -- | -- |
-| currentFolderId | `string` |  null | **Deprecated:** in 2.1.0 |
-| dropdownHideMyFiles | `boolean` | false | **Deprecated:** in 2.1.0 |
-| dropdownSiteList | [`SitePaging`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/SitePaging.md) |  null | **Deprecated:** in 2.1.0 |
-| imageResolver | [`ImageResolver`](../../lib/content-services/document-list/data/image-resolver.model.ts) |  null | **Deprecated:** in 2.1.0 |
-| pageSize | `number` |  | **Deprecated:** in 2.1.0 |
-| rowFilter | [`RowFilter`](../../lib/content-services/document-list/data/row-filter.model.ts) |  null | **Deprecated:** in 2.1.0 |
-| title | `string` |  null | **Deprecated:** in 2.1.0 |
+| currentFolderId | `string` |  null | (**Deprecated:** in 2.1.0)  |
+| dropdownHideMyFiles | `boolean` | false | (**Deprecated:** in 2.1.0)  |
+| dropdownSiteList | [`SitePaging`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/SitePaging.md) |  null | (**Deprecated:** in 2.1.0)  |
+| imageResolver | [`ImageResolver`](../../lib/content-services/document-list/data/image-resolver.model.ts) |  null | (**Deprecated:** in 2.1.0)  |
+| pageSize | `number` |  | (**Deprecated:** in 2.1.0)  |
+| rowFilter | [`RowFilter`](../../lib/content-services/document-list/data/row-filter.model.ts) |  null | (**Deprecated:** in 2.1.0)  |
+| title | `string` |  null | (**Deprecated:** in 2.1.0)  |
 
 ## Details
 

--- a/docs/content-services/file-draggable.directive.md
+++ b/docs/content-services/file-draggable.directive.md
@@ -46,7 +46,7 @@ Some sample CSS to show the drag and drop area:
 | Name | Type | Description |
 | -- | -- | -- |
 | filesDropped | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<File[]>` | Emitted when one or more files are dragged and dropped onto the draggable element. |
-| filesEntityDropped | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<any>` | **Deprecated:** in 2.4.0: use `filesDropped` instead. Emitted when one or more files are dragged and dropped onto the draggable element. |
+| filesEntityDropped | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<any>` | (**Deprecated:** in 2.4.0: use `filesDropped` instead. Emitted when one or more files are dragged and dropped onto the draggable element.)  |
 | folderEntityDropped | `EventEmitter<any>` | Emitted when a directory is dragged and dropped onto the draggable element. |
 
 ## Details

--- a/docs/content-services/search-control.component.md
+++ b/docs/content-services/search-control.component.md
@@ -27,7 +27,7 @@ Displays a input text which shows find-as-you-type suggestions.
 | Name | Type | Default value | Description |
 | -- | -- | -- | -- |
 | autocomplete | `boolean` | false | Toggles auto-completion of the search input field. |
-| customQueryBody | `QueryBody` |  | **Deprecated:** in 2.1.0 |
+| customQueryBody | `QueryBody` |  | (**Deprecated:** in 2.1.0)  |
 | expandable | `boolean` | true | Toggles whether to use an expanding search control. If false then a regular input is used. |
 | highlight | `boolean` | false | Toggles highlighting of the search term in the results. |
 | inputType | `string` | "text" | Type of the input field to render, e.g. "search" or "text" (default). |

--- a/docs/content-services/search.component.md
+++ b/docs/content-services/search.component.md
@@ -42,7 +42,7 @@ Searches items for supplied search terms.
 | -- | -- | -- | -- |
 | displayWith | `function \| null` |  null | Function that maps an option's value to its display value in the trigger. |
 | maxResults | `number` | 20 | Maximum number of results to show in the search. |
-| queryBody | `QueryBody` |  | **Deprecated:** in 2.1.0 |
+| queryBody | `QueryBody` |  | (**Deprecated:** in 2.1.0)  |
 | searchTerm | `string` | "" | Search term to use when executing the search. Updating this value will run a new search and update the results. |
 | skipResults | `number` | 0 | Number of results to skip from the results pagination. |
 | class |  |  | CSS class for display. |

--- a/docs/content-services/version-list.component.md
+++ b/docs/content-services/version-list.component.md
@@ -21,7 +21,7 @@ Displays the version history of a node in a [Version Manager component](../conte
 | Name | Type | Default value | Description |
 | -- | -- | -- | -- |
 | allowDownload | `boolean` | true | Enable/disable downloading a version of the current node. |
-| id | `string` |  | **Deprecated:** in 2.3.0 |
+| id | `string` |  | (**Deprecated:** in 2.3.0)  |
 | node | [`MinimalNodeEntryEntity`](../content-services/document-library.model.md) |  | The target node. |
 | showActions | `boolean` | true | Toggles showing/hiding of version actions |
 | showComments | `boolean` | true | Toggles showing/hiding of comments |

--- a/docs/core/host-settings.component.md
+++ b/docs/core/host-settings.component.md
@@ -25,7 +25,6 @@ Validates the URLs for ACS and APS and saves them in the user's local storage
         { provide: AppConfigService, useClass: DebugAppConfigService },
     ]
 )]
-
 ```
 
 ## Class members
@@ -34,12 +33,14 @@ Validates the URLs for ACS and APS and saves them in the user's local storage
 
 | Name | Type | Default value | Description |
 | -- | -- | -- | -- |
-| providers | `array` |  | Tells the component which provider option are available. Possible valid values are "ECM" (Content), "BPM" (Process) , "ALL" (Content and Process), 'OAUTH2' SSO . |
+| providers | `string[]` |  ['BPM', 'ECM', 'ALL'] | Tells the component which provider option are available. Possible valid values are "ECM" (Content), "BPM" (Process) , "ALL" (Content and Process), 'OAUTH2' SSO . |
 
 ### Events
 
 | Name | Type | Description |
 | -- | -- | -- |
-| bpmHostChange | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<string>` | Emitted when the bpm host URL is changed. **Deprecated:** in 2.4.0 |
-| ecmHostChange | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<string>` | Emitted when the ecm host URL is changed. **Deprecated:** in 2.4.0 |
-| error | `EventEmitter<string>` | Emitted when the URL is invalid. |
+| bpmHostChange | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<string>` | (**Deprecated:** in 2.4.0) Emitted when the bpm host URL is changed. |
+| cancel | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<boolean>` |  |
+| ecmHostChange | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<string>` | (**Deprecated:** in 2.4.0) Emitted when the ecm host URL is changed. |
+| error | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<string>` | Emitted when the URL is invalid. |
+| success | `EventEmitter<boolean>` |  |

--- a/docs/core/infinite-pagination.component.md
+++ b/docs/core/infinite-pagination.component.md
@@ -39,7 +39,7 @@ Adds "infinite" pagination to the component it is used with.
 | -- | -- | -- | -- |
 | loading | `boolean` | false | Is a new page loading? |
 | pageSize | `number` |  [`InfinitePaginationComponent`](../core/infinite-pagination.component.md).DEFAULT_PAGE_SIZE | Number of items that are added with each "load more" event. |
-| pagination | [`PaginationModel`](../../lib/core/models/pagination.model.ts) |  | **Deprecated:** 2.3.0  [Pagination](../../lib/content-services/document-list/models/document-library.model.ts) object. |
+| pagination | [`PaginationModel`](../../lib/core/models/pagination.model.ts) |  | (**Deprecated:** 2.3.0  [Pagination](../../lib/content-services/document-list/models/document-library.model.ts) object.)  |
 | target | `PaginatedComponent` |  | Component that provides custom pagination support. |
 
 ### Events

--- a/docs/core/node-restore.directive.md
+++ b/docs/core/node-restore.directive.md
@@ -50,7 +50,7 @@ Restores deleted nodes to their original location.
 
 | Name | Type | Default value | Description |
 | -- | -- | -- | -- |
-| location | `string` | "" | **Deprecated:** 2.4.0 Path to restored node. |
+| location | `string` | "" | (**Deprecated:** 2.4.0 Path to restored node.)  |
 | adf-restore | `DeletedNodeEntry[]` |  | Array of deleted nodes to restore. |
 
 ### Events

--- a/docs/insights/widget.component.md
+++ b/docs/insights/widget.component.md
@@ -28,19 +28,19 @@ export class CustomEditorComponent extends WidgetComponent {}
 ### Properties
 
 | Name | Type | Default value | Description |
-| ---- | ---- | ------------- | ----------- |
-| field | `FormFieldModel` |  | Data to be displayed in the field |
+| -- | -- | -- | -- |
+| field | [`FormFieldModel`](../core/form-field.model.md) |  | Data to be displayed in the field |
 | readOnly | `boolean` | false | Does the widget show a read-only value? (ie, can't be edited) |
 
 ### Events
 
 | Name | Type | Description |
-| ---- | ---- | ----------- |
-| fieldChanged | `EventEmitter<FormFieldModel>` | **Deprecated:** Used only to trigger visibility engine; components should do that internally if needed |
+| -- | -- | -- |
+| fieldChanged | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`FormFieldModel`](../core/form-field.model.md)`>` | (**Deprecated:** Used only to trigger visibility engine; components should do that internally if needed)  |
 
 ## Details
 
-The Widget component is the base class for all standard and custom form widgets. See the
+The [Widget component](../insights/widget.component.md) is the base class for all standard and custom form widgets. See the
 [Form Extensibility and Customisation](../user-guide/extensibility.md) page for full details about
 implementing custom widgets.
 

--- a/docs/process-services/task-list.component.md
+++ b/docs/process-services/task-list.component.md
@@ -46,14 +46,14 @@ Renders a list containing all the tasks matched by the parameters specified.
 | -- | -- | -- | -- |
 | appId | `number` |  | The id of the app. |
 | assignment | `string` |  | The assignment of the process. Possible values are: "assignee" (the current user is the assignee), candidate (the current user is a task candidate", "group_x" (the task is assigned to a group where the current user is a member, no value(the current user is involved). |
-| data | [`DataTableAdapter`](../../lib/core/datatable/data/datatable-adapter.ts) |  | (**Deprecated:** 2.4.0)  |
+| data | [`DataTableAdapter`](../../lib/core/datatable/data/datatable-adapter.ts) |  | (**Deprecated:** 2.4.0) Data source object that represents the number and the type of the columns that you want to show. |
 | landingTaskId | `string` |  | Define which task id should be selected after reloading. If the task id doesn't exist or nothing is passed then the first task will be selected. |
 | multiselect | `boolean` | false | Toggles multiple row selection, renders checkboxes at the beginning of each row |
 | name | `string` |  | Name of the tasklist. |
 | page | `number` | 0 | The page number of the tasks to fetch. |
 | processDefinitionKey | `string` |  | (**Deprecated:** 2.4.0) The Definition Key of the process. |
 | processInstanceId | `string` |  | The Instance Id of the process. |
-| selectFirstRow | `boolean` | true | Automatically tries to select the first row if a landingTaskId is not given |
+| selectFirstRow | `boolean` | true | Toggles default selection of the first row |
 | selectionMode | `string` | "single" | Row selection mode. Can be none, `single` or `multiple`. For `multiple` mode, you can use Cmd (macOS) or Ctrl (Win) modifier key to toggle selection for multiple rows. |
 | size | `number` |  [`PaginationComponent`](../core/pagination.component.md).DEFAULT_PAGINATION.maxItems | The number of tasks to fetch. Default value: 25. |
 | sort | `string` |  | Define the sort order of the tasks. Possible values are : `created-desc`, `created-asc`, `due-desc`, `due-asc` |

--- a/docs/process-services/task-list.component.md
+++ b/docs/process-services/task-list.component.md
@@ -46,12 +46,12 @@ Renders a list containing all the tasks matched by the parameters specified.
 | -- | -- | -- | -- |
 | appId | `number` |  | The id of the app. |
 | assignment | `string` |  | The assignment of the process. Possible values are: "assignee" (the current user is the assignee), candidate (the current user is a task candidate", "group_x" (the task is assigned to a group where the current user is a member, no value(the current user is involved). |
-| data | [`DataTableAdapter`](../../lib/core/datatable/data/datatable-adapter.ts) |  | **Deprecated:** 2.4.0 |
+| data | [`DataTableAdapter`](../../lib/core/datatable/data/datatable-adapter.ts) |  | (**Deprecated:** 2.4.0)  |
 | landingTaskId | `string` |  | Define which task id should be selected after reloading. If the task id doesn't exist or nothing is passed then the first task will be selected. |
 | multiselect | `boolean` | false | Toggles multiple row selection, renders checkboxes at the beginning of each row |
 | name | `string` |  | Name of the tasklist. |
 | page | `number` | 0 | The page number of the tasks to fetch. |
-| processDefinitionKey | `string` |  | **Deprecated:** 2.4.0 |
+| processDefinitionKey | `string` |  | (**Deprecated:** 2.4.0) The Definition Key of the process. |
 | processInstanceId | `string` |  | The Instance Id of the process. |
 | selectFirstRow | `boolean` | true | Automatically tries to select the first row if a landingTaskId is not given |
 | selectionMode | `string` | "single" | Row selection mode. Can be none, `single` or `multiple`. For `multiple` mode, you can use Cmd (macOS) or Ctrl (Win) modifier key to toggle selection for multiple rows. |

--- a/lib/process-services/task-list/components/task-list.component.ts
+++ b/lib/process-services/task-list/components/task-list.component.ts
@@ -87,8 +87,8 @@ export class TaskListComponent extends DataTableSchema implements OnChanges, Aft
 
     /** Data source object that represents the number and the type of the columns that
      * you want to show.
+     * @deprecated 2.4.0
      */
-    /** @deprecated 2.4.0 */
     @Input()
     data: DataTableAdapter;
 
@@ -103,7 +103,7 @@ export class TaskListComponent extends DataTableSchema implements OnChanges, Aft
     @Input()
     multiselect: boolean = false;
 
-    /* Toggles default selection of the first row */
+    /** Toggles default selection of the first row */
     @Input()
     selectFirstRow: boolean = true;
 

--- a/tools/doc/tools/tsInfo.js
+++ b/tools/doc/tools/tsInfo.js
@@ -31,7 +31,7 @@ var PropInfo = /** @class */ (function () {
         this.type = this.type.replace(/\|/, "\\|");
         this.isDeprecated = rawProp.comment && rawProp.comment.hasTag("deprecated");
         if (this.isDeprecated) {
-            this.docText = "**Deprecated:** " + rawProp.comment.getTag("deprecated").text.replace(/[\n\r]+/g, " ").trim();
+            this.docText = "(**Deprecated:** " + rawProp.comment.getTag("deprecated").text.replace(/[\n\r]+/g, " ").trim() + ") " + this.docText;
         }
         if (rawProp.decorators) {
             rawProp.decorators.forEach(function (dec) {

--- a/tools/doc/tools/tsInfo.ts
+++ b/tools/doc/tools/tsInfo.ts
@@ -65,7 +65,7 @@ class PropInfo {
         this.isDeprecated = rawProp.comment && rawProp.comment.hasTag("deprecated");
 
         if (this.isDeprecated) {
-            this.docText = "**Deprecated:** " + rawProp.comment.getTag("deprecated").text.replace(/[\n\r]+/g, " ").trim();
+            this.docText = "(**Deprecated:** " + rawProp.comment.getTag("deprecated").text.replace(/[\n\r]+/g, " ").trim() + ") " + this.docText;
         }
 
         if (rawProp.decorators) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [x] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Some deprecated property descriptions don't show the full comment text.

**What is the new behaviour?**

Updated the tools to show both the text from the deprecated tag line and the main comment. Note that in some cases, the original description has been removed from the comment by the developers so the prop table will just say "Deprecated in 2.10", etc.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
