### PR TITLE
[ADF-2599] Share button disabled after clicking it fixed

### DIFF
--- a/demo-shell/src/app/components/files/files.component.html
+++ b/demo-shell/src/app/components/files/files.component.html
@@ -116,7 +116,7 @@
                         </mat-icon>
                     </button>
                     <button mat-icon-button
-                            [disabled]="!documentList.selection.length"
+                            disabled
                             [baseShareUrl]="baseShareUrl"
                             [adf-share]="documentList.selection[0]"
                             matTooltip="{{ 'DOCUMENT_LIST.TOOLBAR.SHARE' | translate }}">

--- a/lib/content-services/dialogs/share.dialog.ts
+++ b/lib/content-services/dialogs/share.dialog.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Component, Inject, OnInit, ViewEncapsulation, ElementRef } from '@angular/core';
+import { Component, Inject, OnInit, ViewEncapsulation } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material';
 import { SharedLinksApiService } from '@alfresco/adf-core';
 import { SharedLinkEntry } from 'alfresco-js-api';
@@ -33,7 +33,6 @@ export class ShareDialogComponent implements OnInit {
 
     fileName: string;
     baseShareUrl: string;
-    elementRef: ElementRef;
 
     isFileShared: boolean = false;
     isDisabled: boolean = false;
@@ -48,7 +47,6 @@ export class ShareDialogComponent implements OnInit {
         if (this.data.node && this.data.node.entry) {
             this.fileName = this.data.node.entry.name;
             this.baseShareUrl = this.data.baseShareUrl;
-            this.elementRef = this.data.elementRef;
 
             if (this.data.node.entry.properties && this.data.node.entry.properties['qshare:sharedId']) {
                 this.sharedId = this.data.node.entry.properties['qshare:sharedId'];
@@ -62,7 +60,6 @@ export class ShareDialogComponent implements OnInit {
 
     cancelShare() {
         this.dialogRef.close(false);
-        this.elementRef.nativeElement.disabled = false;
     }
 
     onSlideShareChange(event: any) {

--- a/lib/content-services/dialogs/share.dialog.ts
+++ b/lib/content-services/dialogs/share.dialog.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Component, Inject, OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, Inject, OnInit, ViewEncapsulation, ElementRef } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material';
 import { SharedLinksApiService } from '@alfresco/adf-core';
 import { SharedLinkEntry } from 'alfresco-js-api';
@@ -33,6 +33,7 @@ export class ShareDialogComponent implements OnInit {
 
     fileName: string;
     baseShareUrl: string;
+    elementRef: ElementRef;
 
     isFileShared: boolean = false;
     isDisabled: boolean = false;
@@ -47,6 +48,7 @@ export class ShareDialogComponent implements OnInit {
         if (this.data.node && this.data.node.entry) {
             this.fileName = this.data.node.entry.name;
             this.baseShareUrl = this.data.baseShareUrl;
+            this.elementRef = this.data.elementRef;
 
             if (this.data.node.entry.properties && this.data.node.entry.properties['qshare:sharedId']) {
                 this.sharedId = this.data.node.entry.properties['qshare:sharedId'];
@@ -60,6 +62,7 @@ export class ShareDialogComponent implements OnInit {
 
     cancelShare() {
         this.dialogRef.close(false);
+        this.elementRef.nativeElement.disabled = false;
     }
 
     onSlideShareChange(event: any) {

--- a/lib/content-services/directives/node-share.directive.ts
+++ b/lib/content-services/directives/node-share.directive.ts
@@ -51,7 +51,8 @@ export class NodeSharedDirective implements OnChanges {
                 disableClose: true,
                 data: {
                     node: node,
-                    baseShareUrl: this.baseShareUrl
+                    baseShareUrl: this.baseShareUrl,
+                    elementRef: this.elementRef
                 }
             });
         } else {

--- a/lib/content-services/directives/node-share.directive.ts
+++ b/lib/content-services/directives/node-share.directive.ts
@@ -25,7 +25,6 @@ import { ShareDialogComponent } from '../dialogs/share.dialog';
     selector: '[adf-share]'
 })
 export class NodeSharedDirective implements OnChanges {
-    
 
     /** Node to share. */
     // tslint:disable-next-line:no-input-rename

--- a/lib/content-services/directives/node-share.directive.ts
+++ b/lib/content-services/directives/node-share.directive.ts
@@ -25,6 +25,7 @@ import { ShareDialogComponent } from '../dialogs/share.dialog';
     selector: '[adf-share]'
 })
 export class NodeSharedDirective implements OnChanges {
+    
 
     /** Node to share. */
     // tslint:disable-next-line:no-input-rename
@@ -45,14 +46,12 @@ export class NodeSharedDirective implements OnChanges {
 
     shareNode(node: MinimalNodeEntity) {
         if (node.entry && node.entry.isFile) {
-            this.setDisableAttribute(true);
             this.dialog.open(ShareDialogComponent, {
                 width: '600px',
                 disableClose: true,
                 data: {
                     node: node,
-                    baseShareUrl: this.baseShareUrl,
-                    elementRef: this.elementRef
+                    baseShareUrl: this.baseShareUrl
                 }
             });
         } else {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Share button gets disabled once it's clicked and never comes back to enabled again
https://issues.alfresco.com/jira/browse/ADF-2599?workflowName=ADF&stepId=1

**What is the new behaviour?**
After closing share dialog, this re-enables the share button.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-2599?workflowName=ADF&stepId=1