### PR TITLE
[ADF-3266] fixed style for amount widget

### DIFF
--- a/lib/core/form/components/widgets/amount/amount.widget.html
+++ b/lib/core/form/components/widgets/amount/amount.widget.html
@@ -1,5 +1,5 @@
 <div class="adf-amount-widget__container adf-amount-widget {{field.className}}" [class.adf-invalid]="!field.isValid" [class.adf-readonly]="field.readOnly">
-    <mat-form-field floatPlaceholder="never" class="adf-amount-widget__input">
+    <mat-form-field class="adf-amount-widget__input">
         <label class="adf-label" [attr.for]="field.id">{{field.name}}<span *ngIf="isRequired()">*</span></label>
         <span matPrefix class="adf-amount-widget__prefix-spacing"> {{currency }}</span>
         <input matInput
@@ -7,13 +7,12 @@
                 type="text"
                 [id]="field.id"
                 [required]="isRequired()"
+                [placeholder]="field.placeholder"
                 [value]="field.value"
                 [(ngModel)]="field.value"
                 (ngModelChange)="onFieldChanged(field)"
-                [disabled]="field.readOnly"
-                placeholder="{{field.placeholder}}">
+                [disabled]="field.readOnly">
     </mat-form-field>
     <error-widget [error]="field.validationSummary" ></error-widget>
     <error-widget *ngIf="isInvalidFieldRequired()" required="{{ 'FORM.FIELD.REQUIRED' | translate }}"></error-widget>
 </div>
-

--- a/lib/core/form/components/widgets/amount/amount.widget.scss
+++ b/lib/core/form/components/widgets/amount/amount.widget.scss
@@ -5,18 +5,25 @@
         width: 100%;
         vertical-align: baseline !important;
 
-        .mat-input-element {
-            margin-left: 11px;
-        }
-
-        .mat-input-prefix {
-            position: absolute;
-            margin-top: 58px;
-        }
-
         .mat-input-placeholder {
             margin-top: 5px;
             display: none;
+        }
+
+        .mat-form-field-flex{
+            position: relative;
+            padding-top: 18.5px;
+        }
+
+        .mat-form-field-infix{
+            position: static;
+            padding-top: 19px;
+        }
+
+        .adf-label{
+            position: absolute;
+            top: 18.5px;
+            left:0;
         }
 
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
For custom currency input value is overlapped


**What is the new behaviour?**
Custom currency space is now correctly calculated 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-3266