### PR TITLE
[ADF-3283] added minimatch options into the configuration to allow cu…

### DIFF
--- a/demo-shell/src/app.config.json
+++ b/demo-shell/src/app.config.json
@@ -198,7 +198,10 @@
         "supportedPageSizes": [ 5, 10, 15, 20 ]
     },
     "files": {
-        "excluded": [".DS_Store", "desktop.ini", ".git"]
+        "excluded": [".DS_Store", "desktop.ini", ".git"],
+        "match-options": {
+          "nocase": true
+        }
     },
     "logLevel": "trace",
     "activiti": {

--- a/docs/core/upload.service.md
+++ b/docs/core/upload.service.md
@@ -61,6 +61,9 @@ The configuration of this service is saved in the `app.config.json` file
 The example below shows how to filter out the : '.git', '.DS_Store' and 'desktop.ini' files.
 Each element of the ignore list is a glob pattern string, so you could exclude all the `.txt`
 files, for example, by adding a `*.txt` pattern to the list.
+There is also the possibility to add some more option to how perform the check via the `match-options` parameter.
+For example in this case we have added the ignore case so `*.TXT` will match all the txt files ignoring the case for the extension.
+For more information about the options available please check [minimatch](https://www.npmjs.com/package/minimatch#options) documentation.
 
 **app.config.json**
 
@@ -72,7 +75,10 @@ files, for example, by adding a `*.txt` pattern to the list.
         "name": "Alfresco"
     },
     "files": {
-          "excluded": [".DS_Store", "desktop.ini", ".git", "*.txt"]
+          "excluded": [".DS_Store", "desktop.ini", ".git", "*.txt"],
+          "match-options": {
+            "nocase": true
+          }
     }
 }
 ```

--- a/lib/core/app-config/schema.json
+++ b/lib/core/app-config/schema.json
@@ -318,6 +318,56 @@
                     "description": "File exclusions",
                     "type": "array",
                     "items": { "type": "string" }
+                },
+                "match-options": {
+                  "description": "Minimatch plugin option that will be applied for the check. By default all the options are false",
+                  "type": "object",
+                  "properties": {
+                    "debug": {
+                      "description": "Dump a ton of stuff to stderr",
+                      "type": ["boolean", "null"]
+                    },
+                    "nobrace": {
+                      "description": "Do not expand {a,b} and {1..3} brace sets.",
+                      "type": ["boolean", "null"]
+                    },
+                    "noglobstar": {
+                      "description": "Disable ** matching against multiple folder names.",
+                      "type": ["boolean", "null"]
+                    },
+                    "dot": {
+                      "description": "Allow patterns to match filenames starting with a period, even if the pattern does not explicitly have a period in that spot.",
+                      "type": ["boolean", "null"]
+                    },
+                    "noext": {
+                      "description": "Disable 'extglob' style patterns like +(a|b).",
+                      "type": ["boolean", "null"]
+                    },
+                    "nocase": {
+                      "description": "Perform a case-insensitive match.",
+                      "type": ["boolean", "null"]
+                    },
+                    "nonull": {
+                      "description": "When a match is not found by minimatch.match, return a list containing the pattern itself if this option is set. When not set, an empty list is returned if there are no matches.",
+                      "type": ["boolean", "null"]
+                    },
+                    "matchBase": {
+                      "description": "If set, then patterns without slashes will be matched against the basename of the path if it contains slashes.",
+                      "type": ["boolean", "null"]
+                    },
+                    "nocomment": {
+                      "description": "Suppress the behavior of treating # at the start of a pattern as a comment.",
+                      "type": ["boolean", "null"]
+                    },
+                    "nonegate": {
+                      "description": "Suppress the behavior of treating a leading ! character as negation.",
+                      "type": ["boolean", "null"]
+                    },
+                    "flipNegate": {
+                      "description": "Returns from negate expressions the same as if they were not negated.",
+                      "type": ["boolean", "null"]
+                    }
+                  }
                 }
             }
         },

--- a/lib/core/services/upload.service.spec.ts
+++ b/lib/core/services/upload.service.spec.ts
@@ -41,7 +41,10 @@ describe('UploadService', () => {
         appConfig.config = {
             ecmHost: 'http://localhost:9876/ecm',
             files: {
-                excluded: ['.DS_Store', 'desktop.ini', '.git', '*.git']
+                excluded: ['.DS_Store', 'desktop.ini', '.git', '*.git', '*.SWF'],
+                'match-options': {
+                    nocase: true
+                }
             }
         };
 
@@ -77,6 +80,14 @@ describe('UploadService', () => {
 
     it('should skip hidden macOS files', () => {
         const file1 = new FileModel(new File([''], '.git'));
+        const file2 = new FileModel(new File([''], 'readme.md'));
+        const result = service.addToQueue(file1, file2);
+        expect(result.length).toBe(1);
+        expect(result[0]).toBe(file2);
+    });
+
+    it('should match the extension in case insensitive way', () => {
+        const file1 = new FileModel(new File([''], 'test.swf'));
         const file2 = new FileModel(new File([''], 'readme.md'));
         const result = service.addToQueue(file1, file2);
         expect(result.length).toBe(1);

--- a/lib/core/services/upload.service.ts
+++ b/lib/core/services/upload.service.ts
@@ -38,6 +38,7 @@ export class UploadService {
     private totalAborted: number = 0;
     private totalError: number = 0;
     private excludedFileList: String[] = [];
+    private matchingOptions: any = null;
 
     activeTask: Promise<any> = null;
     queue: FileModel[] = [];
@@ -56,6 +57,7 @@ export class UploadService {
     constructor(protected apiService: AlfrescoApiService,
                 appConfigService: AppConfigService) {
         this.excludedFileList = <String[]> appConfigService.get('files.excluded');
+        this.matchingOptions = appConfigService.get('files.match-options');
     }
 
     /**
@@ -90,7 +92,7 @@ export class UploadService {
         let isAllowed = true;
 
         if (this.excludedFileList) {
-            isAllowed = this.excludedFileList.filter(expr => minimatch(file.name, expr)).length === 0;
+            isAllowed = this.excludedFileList.filter(expr => minimatch(file.name, expr, this.matchingOptions)).length === 0;
         }
         return isAllowed;
     }


### PR DESCRIPTION
…stomisation

**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
User has no possibility to add some options to the minimatch plugin used for the excluded files.


**What is the new behaviour?**
Via the app.config.json now user can add options to the match for the excluded files.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-3283