### PR TITLE
[ADF-3263] added extra options to upload file for upload service

### DIFF
--- a/lib/core/models/file.model.ts
+++ b/lib/core/models/file.model.ts
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { AssocChildBody, AssocTargetBody } from 'alfresco-js-api';
+
 export interface FileUploadProgress {
     loaded: number;
     total: number;
@@ -28,6 +30,10 @@ export interface FileUploadOptions {
     parentId?: string;
     path?: string;
     nodeType?: string;
+    properties?: any;
+    association?: any;
+    secondaryChildren?: AssocChildBody[];
+    targets?: AssocTargetBody[];
 }
 
 export enum FileUploadStatus {

--- a/lib/core/services/upload.service.spec.ts
+++ b/lib/core/services/upload.service.spec.ts
@@ -175,7 +175,7 @@ describe('UploadService', () => {
         expect(uploadFileSpy).toHaveBeenCalledWith({
             name: 'fake-name',
             size: 10
-        }, undefined, undefined, null, {
+        }, undefined, undefined, { newVersion: true }, {
             renditions: 'doclib',
             include: [ 'allowableOperations' ],
             overwrite: true,
@@ -209,6 +209,39 @@ describe('UploadService', () => {
             contentType: 'text/plain',
             responseText: 'File uploaded'
         });
+    });
+
+    it('should append to the request the extra upload options', () => {
+        let uploadFileSpy = spyOn(alfrescoApiService.getInstance().upload, 'uploadFile').and.callThrough();
+        let emitter = new EventEmitter();
+
+        let filesFake = new FileModel(
+            <File> { name: 'fake-name', size: 10 },
+            <FileUploadOptions> { parentId: '123', path: 'fake-dir',
+                                    secondaryChildren: [{ assocType: 'assoc-1', childId: 'child-id' }],
+                                    association: { assocType: 'fake-assoc' },
+                                    targets: [{ assocType: 'target-assoc', targetId: 'fake-target-id' }]
+                                }
+        );
+        service.addToQueue(filesFake);
+        service.uploadFilesInTheQueue(emitter);
+
+        expect(uploadFileSpy).toHaveBeenCalledWith({
+            name: 'fake-name',
+            size: 10
+        }, 'fake-dir', '123', {
+            newVersion: false,
+                parentId: '123',
+                path: 'fake-dir',
+                secondaryChildren: [
+                    { assocType: 'assoc-1', childId: 'child-id' }],
+                    association: { assocType: 'fake-assoc' },
+                    targets: [{ assocType: 'target-assoc', targetId: 'fake-target-id' }]
+            }, {
+                renditions: 'doclib',
+                include: ['allowableOperations'],
+                autoRename: true
+            });
     });
 
     it('should start downloading the next one if a file of the list is aborted', (done) => {

--- a/lib/core/services/upload.service.ts
+++ b/lib/core/services/upload.service.ts
@@ -187,7 +187,7 @@ export class UploadService {
                 file.file,
                 file.options.path,
                 file.options.parentId,
-                null,
+                file.options,
                 opts
             );
         }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [X] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
extra options where not added to addNode request performed


**What is the new behaviour?**
extra options are now correctly added to the addNode request


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-3263