### PR TITLE
[ADF-3294] fixed drag and drop folder to onto a folder

### DIFF
--- a/lib/content-services/upload/components/upload-drag-area.component.spec.ts
+++ b/lib/content-services/upload/components/upload-drag-area.component.spec.ts
@@ -367,7 +367,36 @@ describe('UploadDragAreaComponent', () => {
 
             addToQueueSpy.and.callFake((fileList) => {
                 expect(fileList.name).toBe('file');
-                expect(fileList.options.path).toBe('/pippo');
+                expect(fileList.options.path).toBe('pippo/');
+            });
+
+            let fakeCustomEvent: CustomEvent = new CustomEvent('CustomEvent', {
+                detail: {
+                    data: getFakeShareDataRow(),
+                    files: [fakeItem]
+                }
+            });
+
+            component.onUploadFiles(fakeCustomEvent);
+        }));
+
+        it('should upload a folder to a specific target folder when dropped onto one', async(() => {
+
+            let fakeItem = {
+                fullPath: '/folder-fake/file-fake.png',
+                isDirectory: false,
+                isFile: true,
+                name: 'file-fake.png',
+                relativeFolder: '/super',
+                file: (callbackFile) => {
+                    let fileFake = new File(['fakefake'], 'file-fake.png', { type: 'image/png' });
+                    callbackFile(fileFake);
+                }
+            };
+
+            addToQueueSpy.and.callFake((fileList) => {
+                expect(fileList.name).toBe('file');
+                expect(fileList.options.path).toBe('pippo/super');
             });
 
             let fakeCustomEvent: CustomEvent = new CustomEvent('CustomEvent', {

--- a/lib/content-services/upload/components/upload-drag-area.component.ts
+++ b/lib/content-services/upload/components/upload-drag-area.component.ts
@@ -121,7 +121,7 @@ export class UploadDragAreaComponent extends UploadBase implements NodePermissio
             let fileInfo: FileInfo[] = event.detail.files;
             if (this.isTargetNodeFolder(event)) {
                 const destinationFolderName = event.detail.data.obj.entry.name;
-                fileInfo.map((file) => file.relativeFolder = file.relativeFolder.concat(destinationFolderName));
+                fileInfo.map((file) => file.relativeFolder = destinationFolderName ? destinationFolderName.concat(file.relativeFolder) : file.relativeFolder);
             }
             if (fileInfo && fileInfo.length > 0) {
                 this.uploadFilesInfo(fileInfo);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Drag and drop a folder onto another folder doesn't upload the folder in the correct location.


**What is the new behaviour?**
Drag and drop a folder onto another folder upload the folder in the correct location.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-3294