### PR TITLE
[ADF-3288] Removed restrictions from upload version button docs

### DIFF
--- a/docs/content-services/upload-version-button.component.md
+++ b/docs/content-services/upload-version-button.component.md
@@ -24,11 +24,6 @@ to enrich the features and decrease the restrictions currently applied to node v
 </adf-upload-version-button>
 ```
 
-This component extends the [Upload Button component](upload-button.component.md). The
-properties and events are the same except for the `node` property that specifies the node
-to be versioned (this is a _required_ input parameter). However, some properties don't make
-sense when applied to the [Upload Version Button component,](../content-services/upload-version-button.component.md) so they are simply ignored.
-
 ## Class members
 
 ### Properties
@@ -61,19 +56,10 @@ sense when applied to the [Upload Version Button component,](../content-services
 
 ## Details
 
-### Restrictions
-
-Currently, the API only allows new version uploads for a node where the name
-(and most importantly the _extension_) of the new version
-is exactly the same as the old version. As a result, this workaround component uploads the
-chosen file with the same name that the original file had. This is the reason why the `node`
-is a mandatory dependency for this component.
-
-So, to sum up, this component:
-
--   **Can** upload a new version from the same file extension regardless of the file name.
--   **Cannot** upload a new version that has a different file extension, to the file that was
-    originally uploaded (an error message will be emitted by the `error` [`EventEmitter`](https://angular.io/api/core/EventEmitter) of the component.
+This component extends the [Upload Button component](upload-button.component.md). The
+properties and events are the same except for the `node` property that specifies the node
+to be versioned (this is a _required_ input parameter). However, some properties don't make
+sense when applied to the [Upload Version Button component,](../content-services/upload-version-button.component.md) so they are simply ignored.
 
 ## See also
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [x] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Upload version button docs contain a section about upload restrictions. These restrictions no longer apply and so the docs are incorrect.

**What is the new behaviour?**

Removed the incorrect restrictions section.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No

