### PR TITLE
[ADF-3274] people widget instead of the people list

### DIFF
--- a/docs/process-services/start-task.component.md
+++ b/docs/process-services/start-task.component.md
@@ -31,4 +31,4 @@ Creates/Starts new task for the specified app
 | -- | -- | -- |
 | cancel | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<void>` | Emitted when the cancel button is clicked by the user. |
 | error | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<any>` | Emitted when an error occurs. |
-| success | `EventEmitter<any>` | Emitted when the task is successfully created. |
+| success | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<any>` | Emitted when the task is successfully created. |

--- a/lib/core/form/components/widgets/people/people.widget.spec.ts
+++ b/lib/core/form/components/widgets/people/people.widget.spec.ts
@@ -206,6 +206,22 @@ describe('PeopleWidgetComponent', () => {
                 expect(fixture.debugElement.query(By.css('#adf-people-widget-user-0'))).toBeNull();
             });
         });
+
+        it('should emit peopleSelected if option is selected', () => {
+            let selectEmitSpy = spyOn(widget.peopleSelected, 'emit');
+            let peopleHTMLElement: HTMLInputElement = <HTMLInputElement> element.querySelector('input');
+            peopleHTMLElement.focus();
+            peopleHTMLElement.value = 'T';
+            peopleHTMLElement.dispatchEvent(new Event('keyup'));
+            peopleHTMLElement.dispatchEvent(new Event('input'));
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+                fixture.detectChanges();
+                const optionElement = fixture.debugElement.nativeElement.querySelector('#adf-people-widget-user-0');
+                optionElement.click();
+                expect(selectEmitSpy).toHaveBeenCalledWith(1001);
+            });
+        });
     });
 
 });

--- a/lib/core/form/components/widgets/people/people.widget.ts
+++ b/lib/core/form/components/widgets/people/people.widget.ts
@@ -19,7 +19,7 @@
 
 import { PeopleProcessService } from '../../../../services/people-process.service';
 import { UserProcessModel } from '../../../../models';
-import { Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild, ViewEncapsulation } from '@angular/core';
+import { Component, ElementRef, EventEmitter, OnInit, Output, ViewChild, ViewEncapsulation } from '@angular/core';
 import { FormService } from '../../../services/form.service';
 import { GroupModel } from '../core/group.model';
 import { baseHost, WidgetComponent } from './../widget.component';
@@ -46,11 +46,8 @@ export class PeopleWidgetComponent extends WidgetComponent implements OnInit {
     @ViewChild('inputValue')
     input: ElementRef;
 
-    @Input()
-    peopleId: UserProcessModel;
-
     @Output()
-    peopleIdChange: EventEmitter<number>;
+    peopleSelected: EventEmitter<number>;
 
     groupId: string;
     value: any;
@@ -95,7 +92,7 @@ export class PeopleWidgetComponent extends WidgetComponent implements OnInit {
 
     constructor(public formService: FormService, public peopleProcessService: PeopleProcessService) {
         super(formService);
-        this.peopleIdChange = new EventEmitter();
+        this.peopleSelected = new EventEmitter();
     }
 
     ngOnInit() {
@@ -142,7 +139,7 @@ export class PeopleWidgetComponent extends WidgetComponent implements OnInit {
     onItemSelect(item: UserProcessModel) {
         if (item) {
             this.field.value = item;
-            this.peopleIdChange.emit(item && item.id || undefined);
+            this.peopleSelected.emit(item && item.id || undefined);
             this.value = this.getDisplayName(item);
         }
     }

--- a/lib/core/form/components/widgets/people/people.widget.ts
+++ b/lib/core/form/components/widgets/people/people.widget.ts
@@ -19,7 +19,7 @@
 
 import { PeopleProcessService } from '../../../../services/people-process.service';
 import { UserProcessModel } from '../../../../models';
-import { Component, ElementRef, OnInit, ViewChild, ViewEncapsulation } from '@angular/core';
+import { Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild, ViewEncapsulation } from '@angular/core';
 import { FormService } from '../../../services/form.service';
 import { GroupModel } from '../core/group.model';
 import { baseHost, WidgetComponent } from './../widget.component';
@@ -45,6 +45,12 @@ export class PeopleWidgetComponent extends WidgetComponent implements OnInit {
 
     @ViewChild('inputValue')
     input: ElementRef;
+
+    @Input()
+    peopleId: UserProcessModel;
+
+    @Output()
+    peopleIdChange: EventEmitter<number>;
 
     groupId: string;
     value: any;
@@ -89,6 +95,7 @@ export class PeopleWidgetComponent extends WidgetComponent implements OnInit {
 
     constructor(public formService: FormService, public peopleProcessService: PeopleProcessService) {
         super(formService);
+        this.peopleIdChange = new EventEmitter();
     }
 
     ngOnInit() {
@@ -135,6 +142,7 @@ export class PeopleWidgetComponent extends WidgetComponent implements OnInit {
     onItemSelect(item: UserProcessModel) {
         if (item) {
             this.field.value = item;
+            this.peopleIdChange.emit(item && item.id || undefined);
             this.value = this.getDisplayName(item);
         }
     }

--- a/lib/process-services/task-list/components/start-task.component.html
+++ b/lib/process-services/task-list/components/start-task.component.html
@@ -65,7 +65,7 @@
                 </div>
 
                 <div class="adf-grid-column adf-grid-half-width">
-                    <people-widget [(peopleId)]="assigneeId" [field]="field"></people-widget>
+                    <people-widget (peopleSelected)="getAssigneeId($event)" [field]="field"></people-widget>
                 </div>
             </div>
         </div>

--- a/lib/process-services/task-list/components/start-task.component.html
+++ b/lib/process-services/task-list/components/start-task.component.html
@@ -65,7 +65,7 @@
                 </div>
 
                 <div class="adf-grid-column adf-grid-half-width">
-                    <adf-people-selector [(peopleId)]="assigneeId" id="assignee_id"></adf-people-selector>
+                    <people-widget [(peopleId)]="assigneeId" [field]="field"></people-widget>
                 </div>
             </div>
         </div>

--- a/lib/process-services/task-list/components/start-task.component.scss
+++ b/lib/process-services/task-list/components/start-task.component.scss
@@ -17,10 +17,7 @@
 
     .adf-new-task-layout-card {
         width: 66%;
-        margin-right: auto;
-        margin-left: auto;
-        margin-top: 10px;
-        margin-bottom: 10px;
+        margin: 10px auto;
 
         &-content {
             display: flex;
@@ -61,7 +58,19 @@
     }
 
     .adf-mat-select {
-        padding-top: 0px;
+        padding-top: 0;
+    }
+
+    #people-widget-content {
+        .mat-form-field {
+            width: 100%;
+        }
+        .adf-label {
+            line-height: 0;
+        }
+        .adf-error-text-container {
+            margin-top: -10px;
+        }
     }
 
     adf-start-task {

--- a/lib/process-services/task-list/components/start-task.component.spec.ts
+++ b/lib/process-services/task-list/components/start-task.component.spec.ts
@@ -245,6 +245,23 @@ describe('StartTaskComponent', () => {
                 assignee: null
             });
         });
+
+        it('should assign task with id of selected user assigned', () => {
+            let successSpy = spyOn(component.success, 'emit');
+            component.appId = 42;
+            component.startTaskmodel = new StartTaskModel(startTaskMock);
+            component.formKey = 1204;
+            component.getAssigneeId(testUser.id);
+            fixture.detectChanges();
+            let createTaskButton = <HTMLElement> element.querySelector('#button-start');
+            createTaskButton.click();
+            expect(successSpy).toHaveBeenCalledWith({
+                id: 91,
+                name: 'fakeName',
+                formKey: 1204,
+                assignee: testUser
+            });
+        });
     });
 
     it('should not attach a form when a form id is not slected', () => {

--- a/lib/process-services/task-list/components/start-task.component.ts
+++ b/lib/process-services/task-list/components/start-task.component.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { LogService, UserPreferencesService, UserProcessModel } from '@alfresco/adf-core';
+import { LogService, UserPreferencesService, UserProcessModel, FormFieldModel, FormModel } from '@alfresco/adf-core';
 import { Component, EventEmitter, Input, OnInit, Output, ViewEncapsulation } from '@angular/core';
 import { DateAdapter, MAT_DATE_FORMATS } from '@angular/material/core';
 import { MOMENT_DATE_FORMATS, MomentDateAdapter } from '@alfresco/adf-core';
@@ -26,8 +26,6 @@ import { Form } from '../models/form.model';
 import { StartTaskModel } from '../models/start-task.model';
 import { TaskDetailsModel } from '../models/task-details.model';
 import { TaskListService } from './../services/tasklist.service';
-import { FormFieldModel } from '../../../core/form/components/widgets/core/form-field.model';
-import { FormModel } from '../../../core/form/components/widgets/core/form.model';
 
 @Component({
     selector: 'adf-start-task',

--- a/lib/process-services/task-list/components/start-task.component.ts
+++ b/lib/process-services/task-list/components/start-task.component.ts
@@ -26,6 +26,8 @@ import { Form } from '../models/form.model';
 import { StartTaskModel } from '../models/start-task.model';
 import { TaskDetailsModel } from '../models/task-details.model';
 import { TaskListService } from './../services/tasklist.service';
+import { FormFieldModel } from '../../../core/form/components/widgets/core/form-field.model';
+import { FormModel } from '../../../core/form/components/widgets/core/form.model';
 
 @Component({
     selector: 'adf-start-task',
@@ -68,6 +70,8 @@ export class StartTaskComponent implements OnInit {
 
     dateError: boolean;
 
+    field: FormFieldModel;
+
     /**
      * Constructor
      * @param auth
@@ -81,6 +85,7 @@ export class StartTaskComponent implements OnInit {
     }
 
     ngOnInit() {
+        this.field = new FormFieldModel(new FormModel(), {id: 'fakeId', value: 'fakeValue', placeholder: 'Assignee'});
         this.preferences.locale$.subscribe((locale) => {
             this.dateAdapter.setLocale(locale);
         });

--- a/lib/process-services/task-list/components/start-task.component.ts
+++ b/lib/process-services/task-list/components/start-task.component.ts
@@ -85,7 +85,7 @@ export class StartTaskComponent implements OnInit {
     }
 
     ngOnInit() {
-        this.field = new FormFieldModel(new FormModel(), {id: 'fakeId', value: 'fakeValue', placeholder: 'Assignee'});
+        this.field = new FormFieldModel(new FormModel(), {id: this.assigneeId, value: this.assigneeId, placeholder: 'Assignee'});
         this.preferences.locale$.subscribe((locale) => {
             this.dateAdapter.setLocale(locale);
         });
@@ -113,6 +113,10 @@ export class StartTaskComponent implements OnInit {
                         this.logService.error('An error occurred while creating new task');
                     });
         }
+    }
+
+    getAssigneeId(userId) {
+        this.assigneeId = userId;
     }
 
     private attachForm(taskId: string, formKey: number): Observable<any> {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-3274
Right now, the start form component is using the people list to render the assignee.


**What is the new behaviour?**
We should use the people widget to achieve that as we do for the adf form.




**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
