### PR TITLE
Display icon and label in adf-info-drawer-tab

### DIFF
--- a/lib/core/info-drawer/info-drawer.component.html
+++ b/lib/core/info-drawer/info-drawer.component.html
@@ -8,17 +8,16 @@
 
     <ng-template #tabLayout>
         <mat-tab-group [(selectedIndex)]="selectedIndex" class="adf-info-drawer-tabs" (selectedTabChange)="onTabChange($event)">
-            <ng-container *ngFor="let contentBlock of contentBlocks">
-                <mat-tab [label]="contentBlock.label" class="adf-info-drawer-tab">
-                    <ng-container *ngIf="contentBlock.icon">
-                        <ng-template mat-tab-label>
-                            <mat-icon>{{ contentBlock.icon }}</mat-icon>
-                        </ng-template>
-                    </ng-container>
+            <mat-tab *ngFor="let contentBlock of contentBlocks" [label]="contentBlock.label" class="adf-info-drawer-tab">
+                <ng-container *ngIf="contentBlock.icon">
+                    <ng-template mat-tab-label>
+                        <mat-icon>{{ contentBlock.icon }}</mat-icon>
+                        <span *ngIf="contentBlock.label">{{ contentBlock.label }}</span>
+                    </ng-template>
+                </ng-container>
 
-                    <ng-container *ngTemplateOutlet="contentBlock.content"></ng-container>
-                </mat-tab>
-            </ng-container>
+                <ng-container *ngTemplateOutlet="contentBlock.content"></ng-container>
+            </mat-tab>
         </mat-tab-group>
     </ng-template>
 

--- a/lib/core/info-drawer/info-drawer.component.scss
+++ b/lib/core/info-drawer/info-drawer.component.scss
@@ -28,6 +28,10 @@
 
                     .mat-tab-label {
                         flex-grow: 1;
+
+                        .mat-icon + span {
+                            padding-left: 5px;
+                        }
                     }
 
                     .mat-ink-bar {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

label is not displayed in case there is an icon set on an adf-info-drawer-tab
This is because it is using a mat-tab-label layout instead

**What is the new behaviour?**

label is displayed next to the icon on the right on an adf-info-drawer-tab

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
