### PR TITLE
remove injectable decorator from non-services

### DIFF
--- a/lib/content-services/content-metadata/services/config/aspect-oriented-config.service.ts
+++ b/lib/content-services/content-metadata/services/config/aspect-oriented-config.service.ts
@@ -15,11 +15,9 @@
  * limitations under the License.
  */
 
-import { Injectable } from '@angular/core';
 import { ContentMetadataConfig, OrganisedPropertyGroup, PropertyGroupContainer } from '../../interfaces/content-metadata.interfaces';
 import { getGroup, getProperty } from './property-group-reader';
 
-@Injectable()
 export class AspectOrientedConfigService implements ContentMetadataConfig {
 
     constructor(private config: any) {}

--- a/lib/content-services/content-metadata/services/config/indifferent-config.service.ts
+++ b/lib/content-services/content-metadata/services/config/indifferent-config.service.ts
@@ -15,12 +15,10 @@
  * limitations under the License.
  */
 
-import { Injectable } from '@angular/core';
 import { ContentMetadataConfig, OrganisedPropertyGroup,
     PropertyGroupContainer
 } from '../../interfaces/content-metadata.interfaces';
 
-@Injectable()
 export class IndifferentConfigService implements ContentMetadataConfig {
 
     constructor(config: any) {}

--- a/lib/content-services/content-metadata/services/config/layout-oriented-config.service.ts
+++ b/lib/content-services/content-metadata/services/config/layout-oriented-config.service.ts
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import { Injectable } from '@angular/core';
 import {
     ContentMetadataConfig,
     LayoutOrientedConfigItem,
@@ -24,7 +23,6 @@ import {
 } from '../../interfaces/content-metadata.interfaces';
 import { getProperty } from './property-group-reader';
 
-@Injectable()
 export class LayoutOrientedConfigService implements ContentMetadataConfig {
 
     constructor(private config: any) {}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

```
Warning: Can't resolve all parameters for IndifferentConfigService in @alfresco/adf-content-services/adf-content-services.d.ts: (?). This will become an error in Angular v6.x
Warning: Can't resolve all parameters for IndifferentConfigService in @alfresco/adf-content-services/adf-content-services.d.ts: (?). This will become an error in Angular v6.x
Warning: Can't resolve all parameters for LayoutOrientedConfigService in @alfresco/adf-content-services/adf-content-services.d.ts: (?). This will become an error in Angular v6.x
Warning: Can't resolve all parameters for LayoutOrientedConfigService in @alfresco/adf-content-services/adf-content-services.d.ts: (?). This will become an error in Angular v6.x
Warning: Can't resolve all parameters for AspectOrientedConfigService in @alfresco/adf-content-services/adf-content-services.d.ts: (?). This will become an error in Angular v6.x
Warning: Can't resolve all parameters for AspectOrientedConfigService in @alfresco/adf-content-services/adf-content-services.d.ts: (?). This will become an error in Angular v6.x
```

**What is the new behaviour?**

Prevent Angular 6 compilation errors by removing Injectable decorator from non-services.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
