### PR TITLE
[ADF-3358][ADF-3359][ADF-3360] Logo link and tooltip and hex colors

### DIFF
--- a/demo-shell/src/app/components/app-layout/app-layout.component.html
+++ b/demo-shell/src/app/components/app-layout/app-layout.component.html
@@ -2,7 +2,7 @@
 
     <adf-sidenav-layout-header>
         <ng-template let-toggleMenu="toggleMenu">
-            <adf-layout-header  id="adf-header" [title]="title | translate" [logoUrl]="['/home']" [logo]="logo" [showSidenavToggle]="showMenu" [color]="color" (clicked)=toggleMenu($event) >
+            <adf-layout-header  id="adf-header" [title]="title | translate" [logoUrl]="['/home']" [logo]="logo" [tooltip]="title | translate" [showSidenavToggle]="showMenu" [color]="color" (clicked)=toggleMenu($event) >
 
             <div class="adf-app-layout-menu-spacer"></div>
 

--- a/demo-shell/src/app/components/app-layout/app-layout.component.html
+++ b/demo-shell/src/app/components/app-layout/app-layout.component.html
@@ -2,7 +2,7 @@
 
     <adf-sidenav-layout-header>
         <ng-template let-toggleMenu="toggleMenu">
-            <adf-layout-header  id="adf-header" [title]="title | translate" [logoUrl]="['/home']" [logo]="logo" [tooltip]="title | translate" [showSidenavToggle]="showMenu" [color]="color" (clicked)=toggleMenu($event) >
+            <adf-layout-header  id="adf-header" [title]="title | translate" [redirectUrl]="['/home']" [logo]="logo" [tooltip]="title | translate" [showSidenavToggle]="showMenu" [color]="color" (clicked)=toggleMenu($event) >
 
             <div class="adf-app-layout-menu-spacer"></div>
 

--- a/demo-shell/src/app/components/app-layout/app-layout.component.html
+++ b/demo-shell/src/app/components/app-layout/app-layout.component.html
@@ -2,7 +2,7 @@
 
     <adf-sidenav-layout-header>
         <ng-template let-toggleMenu="toggleMenu">
-            <adf-layout-header  id="adf-header" [title]="title | translate" [logo]="logo" [showSidenavToggle]="showMenu" [color]="color" (clicked)=toggleMenu($event) >
+            <adf-layout-header  id="adf-header" [title]="title | translate" [logoUrl]="['/home']" [logo]="logo" [showSidenavToggle]="showMenu" [color]="color" (clicked)=toggleMenu($event) >
 
             <div class="adf-app-layout-menu-spacer"></div>
 

--- a/docs/core/header.component.md
+++ b/docs/core/header.component.md
@@ -31,7 +31,7 @@ Reusable header for Alfresco applications
 | logo | string | Path to an image file for the application logo.
 | logoUrl | string\|any[] | The router link for the application logo.
 | tooltip | string | The tooltip text for the application logo.
-| color | string | Primary color for the header
+| color | string | Background color for the header. It can be any hex color code or the Material theme colors: 'primary', 'accent' or 'warn'.
 | showSidenavToggle | boolean | Signals if the sidenav button will be displayed in the header or not. By default is true.
 
 ### Events

--- a/docs/core/header.component.md
+++ b/docs/core/header.component.md
@@ -13,7 +13,7 @@ Reusable header for Alfresco applications
 <adf-layout-header 
     title="title" 
     logo="logo.png" 
-    [logoUrl]="'/home'"
+    [redirectUrl]="'/home'"
     color="primary"
     (toggled)=toggleMenu($event)>
 
@@ -29,7 +29,7 @@ Reusable header for Alfresco applications
 | -- | -- | -- |
 | title | string |  Title of the application
 | logo | string | Path to an image file for the application logo.
-| logoUrl | string\|any[] | The router link for the application logo.
+| redirectUrl | string\|any[] | The router link for the application logo.
 | tooltip | string | The tooltip text for the application logo.
 | color | string | Background color for the header. It can be any hex color code or the Material theme colors: 'primary', 'accent' or 'warn'.
 | showSidenavToggle | boolean | Signals if the sidenav button will be displayed in the header or not. By default is true.

--- a/docs/core/header.component.md
+++ b/docs/core/header.component.md
@@ -5,7 +5,7 @@ Status: Experimental
 
 ## Header component 
 
-Reuseble header for Alfresco applications
+Reusable header for Alfresco applications
 
 ## Basic usage
 
@@ -13,6 +13,7 @@ Reuseble header for Alfresco applications
 <adf-layout-header 
     title="title" 
     logo="logo.png" 
+    [logoUrl]="'/home'"
     color="primary"
     (toggled)=toggleMenu($event)>
 
@@ -27,7 +28,9 @@ Reuseble header for Alfresco applications
 | Name | Type | Description |
 | -- | -- | -- |
 | title | string |  Title of the application
-| logo | string| Path to an image file for the application logo.
+| logo | string | Path to an image file for the application logo.
+| logoUrl | string\|any[] | The router link for the application logo.
+| tooltip | string | The tooltip text for the application logo.
 | color | string | Primary color for the header
 | showSidenavToggle | boolean | Signals if the sidenav button will be displayed in the header or not. By default is true.
 

--- a/lib/core/layout/components/header/header.component.html
+++ b/lib/core/layout/components/header/header.component.html
@@ -3,7 +3,7 @@
         <mat-icon class="mat-icon material-icon" role="img" aria-hidden="true">menu</mat-icon>
     </button>
 
-    <a [routerLink]="logoUrl">
+    <a [routerLink]="logoUrl" title="{{ tooltip }}">
         <img src="{{logo}}" class="adf-app-logo" />
     </a>
 

--- a/lib/core/layout/components/header/header.component.html
+++ b/lib/core/layout/components/header/header.component.html
@@ -3,7 +3,9 @@
         <mat-icon class="mat-icon material-icon" role="img" aria-hidden="true">menu</mat-icon>
     </button>
 
-    <img src="{{logo}}" class="adf-app-logo">
+    <a [routerLink]="logoUrl">
+        <img src="{{logo}}" class="adf-app-logo" />
+    </a>
 
     <span fxFlex="1 1 auto" fxShow fxHide.lt-sm="true" class="adf-app-title">{{title}}</span>
     <ng-content></ng-content>

--- a/lib/core/layout/components/header/header.component.html
+++ b/lib/core/layout/components/header/header.component.html
@@ -3,7 +3,7 @@
         <mat-icon class="mat-icon material-icon" role="img" aria-hidden="true">menu</mat-icon>
     </button>
 
-    <a [routerLink]="logoUrl" title="{{ tooltip }}">
+    <a [routerLink]="redirectUrl" title="{{ tooltip }}">
         <img src="{{logo}}" class="adf-app-logo" />
     </a>
 

--- a/lib/core/layout/components/header/header.component.html
+++ b/lib/core/layout/components/header/header.component.html
@@ -1,4 +1,4 @@
-<mat-toolbar color="{{color}}">
+<mat-toolbar color="{{color}}" [style.background-color]="color">
     <button *ngIf="showSidenavToggle" data-automation-id="adf-menu-icon" class="mat-icon-button adf-menu-icon" mat-icon-button (click)="toggleMenu()">
         <mat-icon class="mat-icon material-icon" role="img" aria-hidden="true">menu</mat-icon>
     </button>

--- a/lib/core/layout/components/header/header.component.spec.ts
+++ b/lib/core/layout/components/header/header.component.spec.ts
@@ -87,6 +87,14 @@ describe('HeaderLayoutComponent', () => {
             expect(/\/customHomePage$/.test(logoAnchor.href)).toEqual(true);
         });
 
+        it('should have custom tooltip text set on logo when the tooltip parameter is set', () => {
+            component.tooltip = 'logo title';
+            fixture.detectChanges();
+
+            const logoAnchor = fixture.nativeElement.querySelector('mat-toolbar>a');
+            expect(logoAnchor.title).toEqual('logo title');
+        });
+
         it('test click on sidenav button', () => {
             component.showSidenavToggle = true;
             fixture.detectChanges();

--- a/lib/core/layout/components/header/header.component.spec.ts
+++ b/lib/core/layout/components/header/header.component.spec.ts
@@ -79,8 +79,8 @@ describe('HeaderLayoutComponent', () => {
             expect(src).toEqual('logo.png');
         });
 
-        it('should have custom url link set on logo when the logoUrl is set', () => {
-            component.logoUrl = '/customHomePage';
+        it('should have custom url link set on logo when the redirectUrl is set', () => {
+            component.redirectUrl = '/customHomePage';
             fixture.detectChanges();
 
             const logoAnchor = fixture.nativeElement.querySelector('mat-toolbar>a');

--- a/lib/core/layout/components/header/header.component.spec.ts
+++ b/lib/core/layout/components/header/header.component.spec.ts
@@ -22,6 +22,7 @@ import { CoreTestingModule } from '../../../testing/core.testing.module';
 import { By } from '@angular/platform-browser';
 import { LayoutModule } from '../..';
 import { Component } from '@angular/core';
+import { RouterTestingModule } from '@angular/router/testing';
 import { MaterialModule } from './../../../material.module';
 
 describe('HeaderLayoutComponent', () => {
@@ -78,6 +79,14 @@ describe('HeaderLayoutComponent', () => {
             expect(src).toEqual('logo.png');
         });
 
+        it('should have custom url link set on logo when the logoUrl is set', () => {
+            component.logoUrl = '/customHomePage';
+            fixture.detectChanges();
+
+            const logoAnchor = fixture.nativeElement.querySelector('mat-toolbar>a');
+            expect(/\/customHomePage$/.test(logoAnchor.href)).toEqual(true);
+        });
+
         it('test click on sidenav button', () => {
             component.showSidenavToggle = true;
             fixture.detectChanges();
@@ -117,7 +126,7 @@ describe('HeaderLayoutComponent', () => {
         beforeEach(async(() => {
             TestBed.configureTestingModule({
               declarations: [HeaderLayoutTesterComponent],
-              imports: [ LayoutModule, MaterialModule ]
+              imports: [ LayoutModule, MaterialModule, RouterTestingModule ]
             })
             .compileComponents();
           }));

--- a/lib/core/layout/components/header/header.component.ts
+++ b/lib/core/layout/components/header/header.component.ts
@@ -26,7 +26,7 @@ import { Component, Input, Output, EventEmitter, ViewEncapsulation, OnInit } fro
 export class HeaderLayoutComponent implements OnInit {
     @Input() title: string;
     @Input() logo: string;
-    @Input() logoUrl: string | any[] = '/';
+    @Input() redirectUrl: string | any[] = '/';
     @Input() tooltip: string;
     @Input() color: string;
     @Input() showSidenavToggle: boolean = true;

--- a/lib/core/layout/components/header/header.component.ts
+++ b/lib/core/layout/components/header/header.component.ts
@@ -26,7 +26,7 @@ import { Component, Input, Output, EventEmitter, ViewEncapsulation, OnInit } fro
 export class HeaderLayoutComponent implements OnInit {
     @Input() title: string;
     @Input() logo: string;
-    @Input() logoUrl: any = '/';
+    @Input() logoUrl: string | any[] = '/';
     @Input() tooltip: string;
     @Input() color: string;
     @Input() showSidenavToggle: boolean = true;

--- a/lib/core/layout/components/header/header.component.ts
+++ b/lib/core/layout/components/header/header.component.ts
@@ -27,6 +27,7 @@ export class HeaderLayoutComponent implements OnInit {
     @Input() title: string;
     @Input() logo: string;
     @Input() logoUrl: any = '/';
+    @Input() tooltip: string;
     @Input() color: string;
     @Input() showSidenavToggle: boolean = true;
     @Output() clicked = new EventEmitter<any>();

--- a/lib/core/layout/components/header/header.component.ts
+++ b/lib/core/layout/components/header/header.component.ts
@@ -26,6 +26,7 @@ import { Component, Input, Output, EventEmitter, ViewEncapsulation, OnInit } fro
 export class HeaderLayoutComponent implements OnInit {
     @Input() title: string;
     @Input() logo: string;
+    @Input() logoUrl: string = '/';
     @Input() color: string;
     @Input() showSidenavToggle: boolean = true;
     @Output() clicked = new EventEmitter<any>();

--- a/lib/core/layout/components/header/header.component.ts
+++ b/lib/core/layout/components/header/header.component.ts
@@ -26,7 +26,7 @@ import { Component, Input, Output, EventEmitter, ViewEncapsulation, OnInit } fro
 export class HeaderLayoutComponent implements OnInit {
     @Input() title: string;
     @Input() logo: string;
-    @Input() logoUrl: string = '/';
+    @Input() logoUrl: any = '/';
     @Input() color: string;
     @Input() showSidenavToggle: boolean = true;
     @Output() clicked = new EventEmitter<any>();

--- a/lib/core/layout/layout.module.ts
+++ b/lib/core/layout/layout.module.ts
@@ -17,6 +17,7 @@
 
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
 import { MaterialModule } from '../material.module';
 import { SidenavLayoutContentDirective } from './directives/sidenav-layout-content.directive';
 import { SidenavLayoutHeaderDirective } from './directives/sidenav-layout-header.directive';
@@ -29,7 +30,8 @@ import { HeaderLayoutComponent } from './components/header/header.component';
 @NgModule({
     imports: [
         CommonModule,
-        MaterialModule
+        MaterialModule,
+        RouterModule
     ],
     exports: [
         SidenavLayoutHeaderDirective,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Please see https://issues.alfresco.com/jira/browse/ADF-3360, https://issues.alfresco.com/jira/browse/ADF-3359 and https://issues.alfresco.com/jira/browse/ADF-3358


**What is the new behaviour?**
Link and tooltip can be set on the application logo.
Background color allows also hex color codes besides the theme colors: 'primary', 'accent', 'warn'.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
