### PR TITLE
[ADF-3408] Tasklist Component - presetColumn input change is not handled

### DIFF
--- a/demo-shell/src/app.config.json
+++ b/demo-shell/src/app.config.json
@@ -482,14 +482,44 @@
     },
     "adf-task-list": {
         "presets": {
-            "default": [
+            "minimal": [
                 {
                     "key": "name",
                     "type": "text",
                     "title": "ADF_TASK_LIST.PROPERTIES.NAME",
                     "sortable": true
                 }
+            ],
+            "detailed": [
+                {
+                    "key": "name",
+                    "type": "text",
+                    "title": "ADF_TASK_LIST.PROPERTIES.NAME",
+                    "cssClass": "full-width ellipsis-cell",
+                    "sortable": true
+                },
+                {
+                    "key": "created",
+                    "type": "date",
+                    "title": "ADF_TASK_LIST.PROPERTIES.CREATED",
+                    "format": "timeAgo",
+                    "sortable": true
+                },
+                {
+                    "key": "processDefinitionName",
+                    "type": "text",
+                    "title": "ADF_PROCESS_LIST.PROPERTIES.PROCESS_NAME",
+                    "cssClass": "desktop-only",
+                    "sortable": true
+                },
+                {
+                    "key": "priority",
+                    "type": "text",
+                    "title": "ADF_TASK_LIST.PROPERTIES.PRIORITY",
+                    "sortable": true
+                }
             ]
+
         }
     },
     "adf-start-process": {
@@ -504,6 +534,7 @@
                     "key": "name",
                     "type": "text",
                     "title": "ADF_PROCESS_LIST.PROPERTIES.NAME",
+                    "cssClass": "full-width ellipsis-cell",
                     "sortable": true
                 },
                 {

--- a/demo-shell/src/app.config.json
+++ b/demo-shell/src/app.config.json
@@ -487,15 +487,35 @@
                     "key": "name",
                     "type": "text",
                     "title": "ADF_TASK_LIST.PROPERTIES.NAME",
+                    "cssClass": "full-width ellipsis-cell",
+                    "sortable": true
+                },
+                {
+                    "key": "created",
+                    "type": "date",
+                    "title": "ADF_TASK_LIST.PROPERTIES.CREATED",
+                    "format": "timeAgo",
                     "sortable": true
                 }
             ],
             "detailed": [
                 {
+                    "key": "id",
+                    "type": "text",
+                    "title": "ADF_TASK_LIST.PROPERTIES.ID",
+                    "sortable": true
+                },
+                {
                     "key": "name",
                     "type": "text",
                     "title": "ADF_TASK_LIST.PROPERTIES.NAME",
                     "cssClass": "full-width ellipsis-cell",
+                    "sortable": true
+                },
+                {
+                    "key": "description",
+                    "type": "text",
+                    "title": "ADF_TASK_LIST.PROPERTIES.DESCRIPTION",
                     "sortable": true
                 },
                 {

--- a/demo-shell/src/app/components/task-list-demo/task-list-demo.component.html
+++ b/demo-shell/src/app/components/task-list-demo/task-list-demo.component.html
@@ -132,6 +132,13 @@
                 </mat-option>
             </mat-select>
         </mat-form-field>
+
+        <div class="adf-reset-button">
+            <mat-slide-toggle [checked]="true" [formControl]="detailedView">
+              {{isDetailedView ? 'Detailed View' : 'Minimal View'}}
+            </mat-slide-toggle>
+            <button mat-raised-button (click)="resetTaskForm()">Reset</button>
+        </div>
     </form>
 </div>
 <div class="adf-reset-button">
@@ -154,6 +161,7 @@
         [dueAfter]="dueAfter"
         [dueBefore]="dueBefore"
         [includeProcessInstance]="includeProcessInstance"
+        [presetColumn]="getPresetColumn()"
         #taskList>
         <data-columns>
             <data-column key="id" title="Id"></data-column>

--- a/demo-shell/src/app/components/task-list-demo/task-list-demo.component.html
+++ b/demo-shell/src/app/components/task-list-demo/task-list-demo.component.html
@@ -141,9 +141,6 @@
         </div>
     </form>
 </div>
-<div class="adf-reset-button">
-    <button mat-raised-button (click)="resetTaskForm()">Reset</button>
-</div>
 
 <div>
     <adf-tasklist
@@ -163,15 +160,6 @@
         [includeProcessInstance]="includeProcessInstance"
         [presetColumn]="getPresetColumn()"
         #taskList>
-        <data-columns>
-            <data-column key="id" title="Id"></data-column>
-            <data-column key="name" title="Name"></data-column>
-            <data-column key="description" title="Description"></data-column>
-            <data-column key="created" title="Created"></data-column>
-            <data-column key="dueDate" title="Due Date"></data-column>
-            <data-column key="processInstanceId" title="Process Instance Id"></data-column>
-            <data-column key="processDefinitionId" title="Process Definition Id"></data-column>
-        </data-columns>
     </adf-tasklist>
 
     <adf-pagination

--- a/demo-shell/src/app/components/task-list-demo/task-list-demo.component.scss
+++ b/demo-shell/src/app/components/task-list-demo/task-list-demo.component.scss
@@ -12,6 +12,9 @@
     margin-bottom: 50px;
     display: flex;
     justify-content: center;
+    button {
+        margin-left: 10px; 
+    }
 }
 
 .task-list-demo-error-message {

--- a/demo-shell/src/app/components/task-list-demo/task-list-demo.component.ts
+++ b/demo-shell/src/app/components/task-list-demo/task-list-demo.component.ts
@@ -49,6 +49,8 @@ export class TaskListDemoComponent implements OnInit {
 
     includeProcessInstance: boolean;
 
+    isDetailedView: boolean;
+
     assignmentOptions = [
         {value: 'assignee', title: 'Assignee'},
         {value: 'candidate', title: 'Candidate'}
@@ -106,8 +108,11 @@ export class TaskListDemoComponent implements OnInit {
             taskDueAfter: new FormControl(''),
             taskDueBefore: new FormControl(''),
             taskStart: new FormControl('', [Validators.pattern('^[0-9]*$')]),
-            taskIncludeProcessInstance: new FormControl('')
+            taskIncludeProcessInstance: new FormControl(''),
+            detailedView: new FormControl(true)
         });
+
+        this.filterTasks(this.taskListForm.value);
 
         this.taskListForm.valueChanges
             .pipe(
@@ -143,6 +148,7 @@ export class TaskListDemoComponent implements OnInit {
         this.dueBefore = taskFilter.taskDueBefore;
 
         this.includeProcessInstance = taskFilter.taskIncludeProcessInstance === 'include';
+        this.isDetailedView = taskFilter.detailedView;
     }
 
     resetTaskForm() {
@@ -168,6 +174,10 @@ export class TaskListDemoComponent implements OnInit {
 
     isFormValid() {
         return this.taskListForm && this.taskListForm.dirty && this.taskListForm.valid;
+    }
+
+    getPresetColumn() {
+        return this.isDetailedView ? 'detailed' : 'minimal';
     }
 
     get taskAppId(): AbstractControl {
@@ -224,5 +234,9 @@ export class TaskListDemoComponent implements OnInit {
 
     get taskDueBefore(): AbstractControl {
         return this.taskListForm.get('taskDueBefore');
+    }
+
+    get detailedView(): AbstractControl {
+        return this.taskListForm.get('detailedView');
     }
 }

--- a/lib/core/datatable/components/datatable/datatable.component.spec.ts
+++ b/lib/core/datatable/components/datatable/datatable.component.spec.ts
@@ -261,6 +261,35 @@ describe('DataTable', () => {
         expect(rows[1].getValue('name')).toEqual('test2');
     });
 
+    it('should set columns to the data when columns input changes', () => {
+        const dataColumns =
+            [
+                { title: 'Name', key: 'name' },
+                { title: 'Age',  key: 'age' },
+                { title: 'Group', key: 'group' }
+            ];
+        dataTable.data = new ObjectDataTableAdapter([{ name: 'test1', age: 11, group: 'A' }],
+            [new ObjectDataColumn({ key: 'name' })]
+        );
+
+        dataTable.columns = dataColumns;
+
+        dataTable.ngOnChanges({
+            columns: new SimpleChange(null, dataColumns, false)
+        });
+        fixture.detectChanges();
+
+        const columns = dataTable.data.getColumns();
+
+        expect(columns.length).toBe(3);
+        expect(columns[0].key).toBe('name');
+        expect(columns[0].title).toBe('Name');
+        expect(columns[1].key).toBe('age');
+        expect(columns[1].title).toBe('Age');
+        expect(columns[2].key).toBe('group');
+        expect(columns[2].title).toBe('Group');
+    });
+
     it('should set custom sort order', () => {
         const dataSortObj = new DataSorting('dummayName', 'asc');
         const dataRows =

--- a/lib/core/datatable/components/datatable/datatable.component.ts
+++ b/lib/core/datatable/components/datatable/datatable.component.ts
@@ -210,6 +210,10 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck,
             return;
         }
 
+        if (this.isPropertyChanged(changes['columns'])) {
+            this.setTableSchema();
+        }
+
         if (this.isPropertyChanged(changes['rows'])) {
             if (this.isTableEmpty()) {
                 this.initTable();

--- a/lib/process-services/task-list/components/task-list.component.spec.ts
+++ b/lib/process-services/task-list/components/task-list.component.spec.ts
@@ -61,6 +61,14 @@ describe('TaskListComponent', () => {
                             'title': 'ADF_TASK_LIST.PROPERTIES.TASK_FAKE',
                             'sortable': true
                         }
+                    ],
+                    'minimalSchema': [
+                        {
+                            'key': 'name',
+                            'type': 'text',
+                            'title': 'ADF_TASK_LIST.PROPERTIES.FAKE',
+                            'sortable': true
+                        }
                     ]
                 }
             }
@@ -77,14 +85,13 @@ describe('TaskListComponent', () => {
     });
 
     it('should use the default schemaColumn as default', () => {
-        component.ngAfterContentInit();
+        fixture.detectChanges();
         expect(component.columns).toBeDefined();
         expect(component.columns.length).toEqual(3);
     });
 
     it('should use the custom schemaColumn from app.config.json', () => {
         component.presetColumn = 'fakeCutomSchema';
-        component.ngAfterContentInit();
         fixture.detectChanges();
         expect(component.columns).toEqual(fakeCutomSchema);
     });
@@ -96,8 +103,21 @@ describe('TaskListComponent', () => {
         expect(component.columns.length).toEqual(2);
     });
 
+    it('should change the schema when the presetColumn input changes', () => {
+        component.presetColumn = 'fakeCutomSchema';
+        fixture.detectChanges();
+        expect(component.columns).toEqual(fakeCutomSchema);
+
+        const presetColumnChange = new SimpleChange(fakeCutomSchema, 'minimalSchema', false);
+        component.presetColumn = 'minimalSchema';
+        component.ngOnChanges({'presetColumn' : presetColumnChange });
+        fixture.detectChanges();
+        expect(component.columns.length).toEqual(1);
+        expect(component.columns[0].key).toEqual('name');
+    });
+
     it('should return an empty task list when no input parameters are passed', () => {
-        component.ngAfterContentInit();
+        fixture.detectChanges();
         expect(component.rows).toBeDefined();
         expect(component.isListEmpty()).toBeTruthy();
     });
@@ -112,30 +132,29 @@ describe('TaskListComponent', () => {
             expect(component.rows).toBeDefined();
             expect(component.isListEmpty()).not.toBeTruthy();
             expect(component.rows.length).toEqual(2);
-            expect(component.rows[0]['name']).toEqual('nameFake1');
-            expect(component.rows[0]['description']).toEqual('descriptionFake1');
-            expect(component.rows[0]['category']).toEqual('categoryFake1');
-            expect(component.rows[0]['assignee'].id).toEqual(2);
-            expect(component.rows[0]['assignee'].firstName).toEqual('firstNameFake1');
-            expect(component.rows[0]['assignee'].lastName).toEqual('lastNameFake1');
-            expect(component.rows[0][('assignee')].email).toEqual('emailFake1');
-            expect(component.rows[0]['created']).toEqual('2017-03-01T12:25:17.189+0000');
-            expect(component.rows[0]['dueDate']).toEqual('2017-04-02T12:25:17.189+0000');
-            expect(component.rows[0]['endDate']).toEqual('2017-05-03T12:25:31.129+0000');
-            expect(component.rows[0]['duration']).toEqual(13940);
-            expect(component.rows[0]['priority']).toEqual(50);
-            expect(component.rows[0]['parentTaskId']).toEqual(1);
-            expect(component.rows[0]['parentTaskName']).toEqual('parentTaskNameFake');
-            expect(component.rows[0]['processInstanceId']).toEqual(2511);
-            expect(component.rows[0]['processInstanceName']).toEqual('processInstanceNameFake');
-            expect(component.rows[0]['processDefinitionId']).toEqual('myprocess:1:4');
-            expect(component.rows[0]['processDefinitionName']).toEqual('processDefinitionNameFake');
-            expect(component.rows[0]['processDefinitionDescription']).toEqual('processDefinitionDescriptionFake');
-            expect(component.rows[0]['processDefinitionKey']).toEqual('myprocess');
-            expect(component.rows[0]['processDefinitionCategory']).toEqual('http://www.activiti.org/processdef');
+            expect(component.rows[0].name).toEqual('nameFake1');
+            expect(component.rows[0].description).toEqual('descriptionFake1');
+            expect(component.rows[0].category).toEqual('categoryFake1');
+            expect(component.rows[0].assignee.id).toEqual(2);
+            expect(component.rows[0].assignee.firstName).toEqual('firstNameFake1');
+            expect(component.rows[0].assignee.lastName).toEqual('lastNameFake1');
+            expect(component.rows[0].assignee.email).toEqual('emailFake1');
+            expect(component.rows[0].created).toEqual('2017-03-01T12:25:17.189+0000');
+            expect(component.rows[0].dueDate).toEqual('2017-04-02T12:25:17.189+0000');
+            expect(component.rows[0].endDate).toEqual('2017-05-03T12:25:31.129+0000');
+            expect(component.rows[0].duration).toEqual(13940);
+            expect(component.rows[0].priority).toEqual(50);
+            expect(component.rows[0].parentTaskId).toEqual(1);
+            expect(component.rows[0].parentTaskName).toEqual('parentTaskNameFake');
+            expect(component.rows[0].processInstanceId).toEqual(2511);
+            expect(component.rows[0].processInstanceName).toEqual('processInstanceNameFake');
+            expect(component.rows[0].processDefinitionId).toEqual('myprocess:1:4');
+            expect(component.rows[0].processDefinitionName).toEqual('processDefinitionNameFake');
+            expect(component.rows[0].processDefinitionDescription).toEqual('processDefinitionDescriptionFake');
+            expect(component.rows[0].processDefinitionKey).toEqual('myprocess');
+            expect(component.rows[0].processDefinitionCategory).toEqual('http://www.activiti.org/processdef');
             done();
         });
-        component.ngAfterContentInit();
         component.ngOnChanges({ 'state': state, 'processDefinitionKey': processDefinitionKey, 'assignment': assignment });
         fixture.detectChanges();
 
@@ -156,11 +175,10 @@ describe('TaskListComponent', () => {
             expect(component.rows).toBeDefined();
             expect(component.isListEmpty()).not.toBeTruthy();
             expect(component.rows.length).toEqual(2);
-            expect(component.rows[0]['name']).toEqual('nameFake1');
+            expect(component.rows[0].name).toEqual('nameFake1');
             done();
         });
 
-        component.ngAfterContentInit();
         component.ngOnChanges({ 'state': state, 'processDefinitionKey': processDefinitionKey, 'assignment': assignment });
         fixture.detectChanges();
 
@@ -181,12 +199,11 @@ describe('TaskListComponent', () => {
             expect(component.rows).toBeDefined();
             expect(component.isListEmpty()).not.toBeTruthy();
             expect(component.rows.length).toEqual(2);
-            expect(component.rows[0]['name']).toEqual('nameFake1');
-            expect(component.rows[0]['processInstanceId']).toEqual(2511);
+            expect(component.rows[0].name).toEqual('nameFake1');
+            expect(component.rows[0].processInstanceId).toEqual(2511);
             done();
         });
 
-        component.ngAfterContentInit();
         component.ngOnChanges({ 'state': state, 'processInstanceId': processInstanceId, 'assignment': assignment });
         fixture.detectChanges();
 
@@ -207,12 +224,11 @@ describe('TaskListComponent', () => {
             expect(component.rows).toBeDefined();
             expect(component.isListEmpty()).not.toBeTruthy();
             expect(component.rows.length).toEqual(2);
-            expect(component.rows[0]['name']).toEqual('nameFake1');
-            expect(component.rows[0]['processDefinitionId']).toEqual('myprocess:1:4');
+            expect(component.rows[0].name).toEqual('nameFake1');
+            expect(component.rows[0].processDefinitionId).toEqual('myprocess:1:4');
             done();
         });
 
-        component.ngAfterContentInit();
         component.ngOnChanges({ 'state': state, 'processDefinitionId': processDefinitionId, 'assignment': assignment });
         fixture.detectChanges();
 
@@ -254,15 +270,14 @@ describe('TaskListComponent', () => {
             expect(component.rows).toBeDefined();
             expect(component.isListEmpty()).not.toBeTruthy();
             expect(component.rows.length).toEqual(2);
-            expect(component.rows[0]['name']).toEqual('nameFake1');
-            expect(component.rows[0]['processInstanceId']).toEqual(2511);
-            expect(component.rows[0]['endDate']).toBeDefined();
-            expect(component.rows[1]['name']).toEqual('No name');
-            expect(component.rows[1]['endDate']).toBeNull();
+            expect(component.rows[0].name).toEqual('nameFake1');
+            expect(component.rows[0].processInstanceId).toEqual(2511);
+            expect(component.rows[0].endDate).toBeDefined();
+            expect(component.rows[1].name).toEqual('No name');
+            expect(component.rows[1].endDate).toBeNull();
             done();
         });
 
-        component.ngAfterContentInit();
         component.ngOnChanges({ 'state': state, 'processInstanceId': processInstanceId });
         fixture.detectChanges();
 
@@ -291,13 +306,12 @@ describe('TaskListComponent', () => {
     it('should reload tasks when reload() is called', (done) => {
         component.state = 'open';
         component.assignment = 'fake-assignee';
-        component.ngAfterContentInit();
         component.success.subscribe((res) => {
             expect(res).toBeDefined();
             expect(component.rows).toBeDefined();
             expect(component.isListEmpty()).not.toBeTruthy();
             expect(component.rows.length).toEqual(2);
-            expect(component.rows[0]['name']).toEqual('nameFake1');
+            expect(component.rows[0].name).toEqual('nameFake1');
             done();
         });
         fixture.detectChanges();
@@ -382,7 +396,7 @@ describe('TaskListComponent', () => {
                 expect(component.rows).toBeDefined();
                 expect(component.isListEmpty()).not.toBeTruthy();
                 expect(component.rows.length).toEqual(2);
-                expect(component.rows[1]['name']).toEqual('No name');
+                expect(component.rows[1].name).toEqual('No name');
                 done();
             });
             component.ngOnChanges({ 'appId': change });
@@ -403,7 +417,7 @@ describe('TaskListComponent', () => {
                 expect(component.rows).toBeDefined();
                 expect(component.isListEmpty()).not.toBeTruthy();
                 expect(component.rows.length).toEqual(2);
-                expect(component.rows[1]['name']).toEqual('No name');
+                expect(component.rows[1].name).toEqual('No name');
                 done();
             });
 
@@ -425,7 +439,7 @@ describe('TaskListComponent', () => {
                 expect(component.rows).toBeDefined();
                 expect(component.isListEmpty()).not.toBeTruthy();
                 expect(component.rows.length).toEqual(2);
-                expect(component.rows[1]['name']).toEqual('No name');
+                expect(component.rows[1].name).toEqual('No name');
                 done();
             });
 
@@ -439,7 +453,7 @@ describe('TaskListComponent', () => {
         });
 
         it('should reload the list when the sort parameter changes', (done) => {
-            const sort = 'desc';
+            const sort = 'created-asc';
             let change = new SimpleChange(null, sort, true);
 
             component.success.subscribe((res) => {
@@ -447,7 +461,7 @@ describe('TaskListComponent', () => {
                 expect(component.rows).toBeDefined();
                 expect(component.isListEmpty()).not.toBeTruthy();
                 expect(component.rows.length).toEqual(2);
-                expect(component.rows[1]['name']).toEqual('No name');
+                expect(component.rows[1].name).toEqual('No name');
                 done();
             });
 
@@ -469,7 +483,7 @@ describe('TaskListComponent', () => {
                 expect(component.rows).toBeDefined();
                 expect(component.isListEmpty()).not.toBeTruthy();
                 expect(component.rows.length).toEqual(2);
-                expect(component.rows[1]['name']).toEqual('No name');
+                expect(component.rows[1].name).toEqual('No name');
                 done();
             });
 
@@ -491,11 +505,67 @@ describe('TaskListComponent', () => {
                 expect(component.rows).toBeDefined();
                 expect(component.isListEmpty()).not.toBeTruthy();
                 expect(component.rows.length).toEqual(2);
-                expect(component.rows[1]['name']).toEqual('No name');
+                expect(component.rows[1].name).toEqual('No name');
                 done();
             });
 
             component.ngOnChanges({ 'assignment': change });
+
+            jasmine.Ajax.requests.mostRecent().respondWith({
+                'status': 200,
+                contentType: 'application/json',
+                responseText: JSON.stringify(fakeGlobalTask)
+            });
+        });
+
+        it('should NOT reload the tasks when presetColumn input changes', () => {
+            spyOn(component, 'reload').and.stub();
+            component.rows = [{ id: '999', name: 'Fake-name' }];
+            let change = new SimpleChange(null, 'minimalSchema', false);
+            component.presetColumn = 'minimalSchema';
+            component.ngOnChanges({'presetColumn': change});
+            expect(component.reload).not.toHaveBeenCalled();
+            expect(component.rows.length).toEqual(1);
+        });
+
+        it('should reload the list when the processInstanceId input changes', (done) => {
+            const processInstanceId = '1111';
+            let change = new SimpleChange(null, processInstanceId, true);
+
+            component.success.subscribe((res) => {
+                expect(res).toBeDefined();
+                expect(component.rows).toBeDefined();
+                expect(component.isListEmpty()).not.toBeTruthy();
+                expect(component.rows.length).toEqual(2);
+                expect(component.rows[1].name).toEqual('No name');
+                done();
+            });
+
+            component.processInstanceId = processInstanceId;
+            component.ngOnChanges({ 'processInstanceId': change });
+
+            jasmine.Ajax.requests.mostRecent().respondWith({
+                'status': 200,
+                contentType: 'application/json',
+                responseText: JSON.stringify(fakeGlobalTask)
+            });
+        });
+
+        it('should reload the list when the processDefinitionId input changes', (done) => {
+            const processDefinitionId = 'SimpleProcess:5:204';
+            let change = new SimpleChange(null, processDefinitionId, true);
+
+            component.success.subscribe((res) => {
+                expect(res).toBeDefined();
+                expect(component.rows).toBeDefined();
+                expect(component.isListEmpty()).not.toBeTruthy();
+                expect(component.rows.length).toEqual(2);
+                expect(component.rows[1].name).toEqual('No name');
+                done();
+            });
+
+            component.processDefinitionId = processDefinitionId;
+            component.ngOnChanges({ 'processDefinitionId': change });
 
             jasmine.Ajax.requests.mostRecent().respondWith({
                 'status': 200,
@@ -550,8 +620,8 @@ describe('CustomTaskListComponent', () => {
     it('should fetch custom schemaColumn from html', () => {
         fixture.detectChanges();
         expect(component.taskList.columnList).toBeDefined();
-        expect(component.taskList.columns[0]['title']).toEqual('ADF_TASK_LIST.PROPERTIES.NAME');
-        expect(component.taskList.columns[1]['title']).toEqual('ADF_TASK_LIST.PROPERTIES.CREATED');
+        expect(component.taskList.columns[0].title).toEqual('ADF_TASK_LIST.PROPERTIES.NAME');
+        expect(component.taskList.columns[1].title).toEqual('ADF_TASK_LIST.PROPERTIES.CREATED');
         expect(component.taskList.columns.length).toEqual(3);
     });
 });

--- a/lib/process-services/task-list/components/task-list.component.ts
+++ b/lib/process-services/task-list/components/task-list.component.ts
@@ -213,7 +213,7 @@ export class TaskListComponent extends DataTableSchema implements OnChanges, Aft
         }
 
         if (this.isPresetColumnChanged(changes)) {
-            this.createDatatableSchema();
+            this.columns = this.mergeJsonAndHtmlSchema();
             if (this.hasDataWithoutSchema) {
                 this.data.setColumns(this.columns);
             }

--- a/lib/process-services/task-list/components/task-list.component.ts
+++ b/lib/process-services/task-list/components/task-list.component.ts
@@ -21,7 +21,7 @@ import {
     UserPreferencesService, UserPreferenceValues, PaginationModel } from '@alfresco/adf-core';
 import {
     AfterContentInit, Component, ContentChild, EventEmitter,
-    Input, OnChanges, Output, SimpleChanges } from '@angular/core';
+    Input, OnChanges, Output, SimpleChanges, SimpleChange } from '@angular/core';
 
 import { Observable, BehaviorSubject } from 'rxjs';
 import { TaskQueryRequestRepresentationModel } from '../models/filter.model';
@@ -205,7 +205,7 @@ export class TaskListComponent extends DataTableSchema implements OnChanges, Aft
     }
 
     ngOnChanges(changes: SimpleChanges) {
-        if (this.isPropertyChanged(changes)) {
+        if (this.isInputChanged(changes)) {
             if (this.isSortChanged(changes)) {
                 this.sorting = this.sort ? this.sort.split('-') : this.sorting;
             }
@@ -220,53 +220,65 @@ export class TaskListComponent extends DataTableSchema implements OnChanges, Aft
         }
     }
 
-    private isSortChanged(changes: SimpleChanges): boolean {
-        const actualSort = changes['sort'];
-        return actualSort && actualSort.currentValue && actualSort.currentValue !== actualSort.previousValue;
-    }
-
-    private isPropertyChanged(changes: SimpleChanges): boolean {
-        let changed = false;
-
-        const appId = changes['appId'];
-        const processInstanceId = changes['processInstanceId'];
-        const processDefinitionId = changes['processDefinitionId'];
-        const processDefinitionKey = changes['processDefinitionKey'];
-        const state = changes['state'];
-        const assignment = changes['assignment'];
-        const name = changes['name'];
-        const landingTaskId = changes['landingTaskId'];
-        const page = changes['page'];
-        const size = changes['size'];
-
-        if (appId && appId.currentValue) {
-            changed = true;
-        } else if (processInstanceId) {
-            changed = true;
-        } else if (processDefinitionId) {
-            changed = true;
-        } else if (processDefinitionKey) {
-            changed = true;
-        } else if (state) {
-            changed = true;
-        }  else if (assignment) {
-            changed = true;
-        }  else if (name) {
-            changed = true;
-        }  else if (landingTaskId && landingTaskId.currentValue && !this.isEqualToCurrentId(landingTaskId.currentValue)) {
-            changed = true;
-        } else if (page && page.currentValue !== page.previousValue) {
-            changed = true;
-        } else if (size && size.currentValue !== size.previousValue) {
-            changed = true;
-        }
-
-        return changed;
+    private isInputChanged(changes: SimpleChanges): boolean {
+        return this.isAppIdChanged(changes) || this.isProcessInstanceIdChanged(changes) ||
+                this.isProcessDefinitionKeyChanged(changes) || this.isProcessDefinitionIdChanged(changes) ||
+                this.isStateChanged(changes) || this.isAssignmentChanged(changes) ||
+                this.isNameChanged(changes) || this.isLandingTaskIdChanged(changes) ||
+                this.isPageChanged(changes) || this.isSizeChanged(changes) || this.isSortChanged(changes);
     }
 
     private isPresetColumnChanged(changes: SimpleChanges): boolean {
-        const presetColumn = changes['presetColumn'];
-        return presetColumn && !presetColumn.firstChange;
+        return this.isChanged(changes.presetColumn) && !changes.presetColumn.firstChange;
+    }
+
+    private isAppIdChanged(changes: SimpleChanges): boolean {
+        return this.isChanged(changes.appId) && changes.appId.currentValue;
+    }
+
+    private isProcessInstanceIdChanged(changes: SimpleChanges): boolean {
+        return this.isChanged(changes.processInstanceId);
+    }
+
+    private isProcessDefinitionKeyChanged(changes: SimpleChanges): boolean {
+        return this.isChanged(changes.processDefinitionKey);
+    }
+
+    private isProcessDefinitionIdChanged(changes: SimpleChanges): boolean {
+        return this.isChanged(changes.processDefinitionId);
+    }
+
+    private isStateChanged(changes: SimpleChanges): boolean {
+        return this.isChanged(changes.state);
+    }
+
+    private isAssignmentChanged(changes: SimpleChanges): boolean {
+        return this.isChanged(changes.assignment);
+    }
+
+    private isNameChanged(changes: SimpleChanges): boolean {
+        return this.isChanged(changes.name);
+    }
+
+    private isLandingTaskIdChanged(changes: SimpleChanges): boolean {
+        const landingTaskId = changes.landingTaskId;
+        return landingTaskId && landingTaskId.currentValue && !this.isEqualToCurrentId(landingTaskId.currentValue);
+    }
+
+    private isPageChanged(changes: SimpleChanges): boolean {
+        return this.isChanged(changes.page);
+    }
+
+    private isSizeChanged(changes: SimpleChanges): boolean {
+        return this.isChanged(changes.size);
+    }
+
+    private isSortChanged(changes: SimpleChanges): boolean {
+        return this.isChanged(changes.sort) && changes.sort.currentValue;
+    }
+
+    private isChanged(change: SimpleChange): boolean {
+        return change && change.currentValue !== change.previousValue;
     }
 
     reload(): void {

--- a/lib/process-services/task-list/components/task-list.component.ts
+++ b/lib/process-services/task-list/components/task-list.component.ts
@@ -281,6 +281,10 @@ export class TaskListComponent extends DataTableSchema implements OnChanges, Aft
         return change && change.currentValue !== change.previousValue;
     }
 
+    private checkDataHasSchema(): void {
+        this.hasDataWithoutSchema = this.data && this.data.getColumns().length === 0;
+    }
+
     reload(): void {
         if (!this.hasCustomDataSource) {
             this.requestNode = this.createRequestNode();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [x] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

* Tasklist component doesn't detect presetColumn input change. When the presetColumn value changes, same set of columns are shown after reloading the data https://issues.alfresco.com/jira/browse/ADF-3408

**What is the new behaviour?**

* New schema is rendered when presetColumn input changes without reloading the data

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
