### PR TITLE
[ADF-2669] fixed style for confim buttons

### DIFF
--- a/lib/content-services/dialogs/confirm.dialog.ts
+++ b/lib/content-services/dialogs/confirm.dialog.ts
@@ -27,8 +27,8 @@ import { MAT_DIALOG_DATA } from '@angular/material';
         </mat-dialog-content>
         <mat-dialog-actions>
             <span class="spacer"></span>
-            <button id="adf-confirm-accept" mat-button [mat-dialog-close]="true">{{ yesLabel | translate }}</button>
-            <button id="adf-confirm-cancel" mat-button color="primary" [mat-dialog-close]="false" cdkFocusInitial>{{ noLabel | translate }}</button>
+            <button id="adf-confirm-accept" mat-button color="primary" [mat-dialog-close]="true">{{ yesLabel | translate }}</button>
+            <button id="adf-confirm-cancel" mat-button [mat-dialog-close]="false" cdkFocusInitial>{{ noLabel | translate }}</button>
         </mat-dialog-actions>
     `,
     styles: [`


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
The styles for the delete version confirm popup are not correct


**What is the new behaviour?**
The styles for the delete version confirm popup are now correct


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-2669