### PR TITLE
[ADF-3410] Form Preview - remove validators on read-only

### DIFF
--- a/lib/core/form/components/form.component.spec.ts
+++ b/lib/core/form/components/form.component.spec.ts
@@ -856,4 +856,17 @@ describe('FormComponent', () => {
         radioFieldById = formFields.find(field => field.id === 'radio');
         expect(radioFieldById.value).toBe('option_3');
     });
+
+    it('should remove fieldsValidators if form is read-only', () => {
+        formComponent.readOnly = true;
+
+        let parsedForm = formComponent.parseForm({
+            id: '<id>',
+            fields: [
+                { id: 'field1', type: FormFieldTypes.CONTAINER }
+            ]
+        });
+
+        expect(parsedForm.fieldValidators.length).toBe(0);
+    });
 });

--- a/lib/core/form/components/form.component.ts
+++ b/lib/core/form/components/form.component.ts
@@ -438,7 +438,9 @@ export class FormComponent implements OnInit, OnChanges {
             if (!json.fields) {
                 form.outcomes = this.getFormDefinitionOutcomes(form);
             }
-            if (this.fieldValidators && this.fieldValidators.length > 0) {
+            if (this.readOnly) {
+                form.fieldValidators = [];
+            } else if (this.fieldValidators && this.fieldValidators.length > 0) {
                 form.fieldValidators = this.fieldValidators;
             }
             return form;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Required fields are not displayed on a read-only mode.
https://issues.alfresco.com/jira/browse/ADF-3410


**What is the new behaviour?**
Validators are not displayed when form is read-only.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
