### PR TITLE
[ADF-3455] Show more/less buttons in Search Radio Component hide when…

### DIFF
--- a/lib/content-services/search/components/search-radio/search-radio.component.html
+++ b/lib/content-services/search/components/search-radio/search-radio.component.html
@@ -10,13 +10,13 @@
 
 <div class="facet-buttons" *ngIf="!options.fitsPage">
     <button mat-icon-button
-        [disabled]="!options.canShowLessItems"
+        *ngIf="options.canShowLessItems"
         title="{{ 'SEARCH.FILTER.ACTIONS.SHOW-LESS' | translate }}"
         (click)="options.showLessItems()">
         <mat-icon>keyboard_arrow_up</mat-icon>
     </button>
     <button mat-icon-button
-        [disabled]="!options.canShowMoreItems"
+        *ngIf="options.canShowMoreItems"
         title="{{ 'SEARCH.FILTER.ACTIONS.SHOW-MORE' | translate }}"
         (click)="options.showMoreItems()">
         <mat-icon>keyboard_arrow_down</mat-icon>


### PR DESCRIPTION
… they are not necessary

**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-3455
Show More and show less button are disabled when necessary but not hidden.

**What is the new behaviour?**
When there are no more elements, show more/less buttons are hidden.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-3455
