### PR TITLE
[ADF-3340] fixed search for adding groups and users for searching con…

### DIFF
--- a/lib/content-services/permission-manager/components/add-permission/search-config-permission.service.ts
+++ b/lib/content-services/permission-manager/components/add-permission/search-config-permission.service.ts
@@ -26,7 +26,7 @@ export class SearchPermissionConfigurationService implements SearchConfiguration
     public generateQueryBody(searchTerm: string, maxResults: number, skipCount: number): QueryBody {
         const defaultQueryBody: QueryBody = {
             query: {
-                query: searchTerm ? `authorityName:${searchTerm}* OR userName:${searchTerm}*` : searchTerm
+                query: searchTerm ? `authorityName:*${searchTerm}* OR userName:*${searchTerm}*` : searchTerm
             },
             include: ['properties', 'aspectNames'],
             paging: {


### PR DESCRIPTION
…taining words into names

**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Search query for user and authorities is done searching not a containing word but starting with the letters typed. A new created group start always with 'GROUP_' so searching for the display name won't show any result


**What is the new behaviour?**
The typed search is checked to be contained into the authority/user name, so a custom group searched by display name will be showed.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-3340