### PR TITLE
[ADF-3510] Search facets date-range goes invalid when empty - fix

### DIFF
--- a/lib/content-services/search/forms/live-error-state-matcher.ts
+++ b/lib/content-services/search/forms/live-error-state-matcher.ts
@@ -22,7 +22,7 @@ export class LiveErrorStateMatcher implements ErrorStateMatcher {
 
     isErrorState(control: FormControl | null, form: FormGroupDirective | NgForm | null): boolean {
         const isSubmitted = form && form.submitted;
-        return !!(control && control.invalid && (control.dirty || control.touched || isSubmitted));
+        return !!(control && control.invalid && (control.dirty || control.touched || (!control.pristine && isSubmitted)));
     }
 
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Please check https://github.com/Alfresco/alfresco-ng2-components/issues/3736 and corresponding Jira ticket https://issues.alfresco.com/jira/browse/ADF-3510

**What is the new behaviour?**
Please check https://github.com/Alfresco/alfresco-ng2-components/issues/3736 and corresponding Jira ticket https://issues.alfresco.com/jira/browse/ADF-3510

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
