### PR TITLE
[ADF-3511] The error message for "Created date" fields is not the correct one when are no inputs - fix

### DIFF
--- a/lib/content-services/search/components/search-date-range/search-date-range.component.ts
+++ b/lib/content-services/search/components/search-date-range/search-date-range.component.ts
@@ -61,14 +61,14 @@ export class SearchDateRangeComponent implements SearchWidget, OnInit {
     }
 
     getFromValidationMessage(): string {
-        return this.from.hasError('matDatepickerParse') ? 'SEARCH.FILTER.VALIDATION.INVALID-DATE' :
+        return this.from.hasError('invalidOnChange') || this.hasParseError(this.from) ? 'SEARCH.FILTER.VALIDATION.INVALID-DATE' :
             this.from.hasError('matDatepickerMax') ? 'SEARCH.FILTER.VALIDATION.BEYOND-MAX-DATE' :
             this.from.hasError('required') ? 'SEARCH.FILTER.VALIDATION.REQUIRED-VALUE' :
             '';
     }
 
     getToValidationMessage(): string {
-        return this.to.hasError('matDatepickerParse') ? 'SEARCH.FILTER.VALIDATION.INVALID-DATE' :
+        return this.to.hasError('invalidOnChange') || this.hasParseError(this.to) ? 'SEARCH.FILTER.VALIDATION.INVALID-DATE' :
             this.to.hasError('matDatepickerMin') ? 'SEARCH.FILTER.VALIDATION.NO-DAYS' :
             this.to.hasError('matDatepickerMax') ? 'SEARCH.FILTER.VALIDATION.BEYOND-MAX-DATE' :
             this.to.hasError('required') ? 'SEARCH.FILTER.VALIDATION.REQUIRED-VALUE' :
@@ -125,21 +125,27 @@ export class SearchDateRangeComponent implements SearchWidget, OnInit {
     onChangedHandler(event: any, formControl: FormControl) {
         const inputValue = event.srcElement.value;
 
-        if (inputValue) {
-            const formatDate = this.dateAdapter.parse(inputValue, this.datePickerDateFormat);
-            if (formatDate && formatDate.isValid()) {
-                formControl.setValue(formatDate);
-            } else {
-                formControl.setErrors({
-                    'matDatepickerParse': true
-                });
-            }
+        const formatDate = this.dateAdapter.parse(inputValue, this.datePickerDateFormat);
+        if (formatDate && formatDate.isValid()) {
+            formControl.setValue(formatDate);
+        } else if (formatDate) {
+            formControl.setErrors({
+                'invalidOnChange': true
+            });
+        } else {
+            formControl.setErrors({
+                'required': true
+            });
         }
     }
 
     setLocale(locale) {
         this.dateAdapter.setLocale(locale);
         moment.locale(locale);
+    }
+
+    hasParseError(formControl) {
+        return formControl.hasError('matDatepickerParse') && formControl.getError('matDatepickerParse').text;
     }
 
     forcePlaceholder(event: any) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Please check Jira issue https://issues.alfresco.com/jira/browse/ADF-3511


**What is the new behaviour?**
Please check Jira issue https://issues.alfresco.com/jira/browse/ADF-3511


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
