### PR TITLE
[ADF-3513] - removed wrong slide from task-detail component

### DIFF
--- a/demo-shell/src/app/components/process-service/process-service.component.html
+++ b/demo-shell/src/app/components/process-service/process-service.component.html
@@ -30,6 +30,14 @@
                 </div>
                 <div class="adf-grid-item adf-tasks-list" fxFlex.gt-md="380px" [ngClass.gt-md]="{'small-pagination': true}"
                      *ngIf="taskFilter && !isStartTaskMode()">
+                     <mat-slide-toggle
+                        class="adf-task-details-toggle"
+                        id="showHeaderToggle"
+                        [color]="'primary'"
+                        (change)="toggleHeaderContent()"
+                        [checked]="showHeaderContent">
+                        {{ 'PS-TAB.TASK-SHOW-HEADER'| translate }}
+                    </mat-slide-toggle>
                     <adf-tasklist
                         [appId]="taskFilter?.appId"
                         [presetColumn]="presetColumn"
@@ -67,6 +75,7 @@
                                            [debugMode]="true"
                                            [taskId]="currentTaskId"
                                            [fieldValidators]="fieldValidators"
+                                           [showHeaderContent]="showHeaderContent"
                                            (formCompleted)="onFormCompleted($event)"
                                            (formContentClicked)="onContentClick($event)"
                                            (taskCreated)="onTaskCreated($event)"

--- a/demo-shell/src/app/components/process-service/process-service.component.ts
+++ b/demo-shell/src/app/components/process-service/process-service.component.ts
@@ -126,6 +126,7 @@ export class ProcessServiceComponent implements AfterViewInit, OnDestroy, OnInit
     processPage = 0;
     paginationPageSize = 0;
     processSchemaColumns: any[] = [];
+    showHeaderContent = true;
 
     defaultProcessDefinitionName: string;
     defaultProcessName: string;
@@ -241,6 +242,10 @@ export class ProcessServiceComponent implements AfterViewInit, OnDestroy, OnInit
 
     resetTaskPaginationPage() {
         this.taskPage = 0;
+    }
+
+    toggleHeaderContent(): void {
+        this.showHeaderContent = !this.showHeaderContent;
     }
 
     onTabChange(event: any): void {

--- a/lib/process-services/task-list/components/task-details.component.html
+++ b/lib/process-services/task-list/components/task-details.component.html
@@ -15,15 +15,6 @@
         </h2>
     </div>
 
-    <mat-slide-toggle
-        class="adf-task-details-toggle"
-        id="showHeaderToggle"
-        [color]="'primary'"
-        (change)="toggleHeaderContent()"
-        [checked]="showHeaderContent">
-        {{ 'PS-TAB.TASK-SHOW-HEADER'| translate }}
-    </mat-slide-toggle>
-
     <div class="adf-task-details-core"
         fxLayout="column"
         fxLayoutGap="8px"

--- a/lib/process-services/task-list/components/task-details.component.ts
+++ b/lib/process-services/task-list/components/task-details.component.ts
@@ -455,10 +455,6 @@ export class TaskDetailsComponent implements OnInit, OnChanges {
         this.loadDetails(taskId);
     }
 
-    toggleHeaderContent(): void {
-        this.showHeaderContent = !this.showHeaderContent;
-    }
-
     isCompletedTask(): boolean {
         return this.taskDetails && this.taskDetails.endDate ? true : undefined;
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
a wrong slide property was inserted in task-details.


**What is the new behaviour?**
the slider for e2e is moved into demo-shell component.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-3513