### PR TITLE
[ADF-3324] added redirect to 404 page when the shared link is invalid

### DIFF
--- a/demo-shell/src/app/components/shared-link-view/shared-link-view.component.html
+++ b/demo-shell/src/app/components/shared-link-view/shared-link-view.component.html
@@ -1,5 +1,6 @@
 <ng-container *ngIf="sharedLinkId">
     <adf-viewer
+        (invalidSharedLink)="redirectTo404()"
         [sharedLinkId]="sharedLinkId"
         [allowGoBack]="false">
     </adf-viewer>

--- a/demo-shell/src/app/components/shared-link-view/shared-link-view.component.ts
+++ b/demo-shell/src/app/components/shared-link-view/shared-link-view.component.ts
@@ -16,7 +16,7 @@
  */
 
 import { Component, ViewEncapsulation, OnInit } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 
 @Component({
     selector: 'app-shared-link-view',
@@ -30,12 +30,16 @@ export class SharedLinkViewComponent implements OnInit {
 
     sharedLinkId: string = null;
 
-    constructor(private route: ActivatedRoute) {}
+    constructor(private route: ActivatedRoute, private router: Router) {}
 
     ngOnInit() {
         this.route.params.subscribe(params => {
             this.sharedLinkId = params.id;
         });
+    }
+
+    redirectTo404() {
+        this.router.navigate(['error/404']);
     }
 
 }

--- a/docs/core/viewer.component.md
+++ b/docs/core/viewer.component.md
@@ -112,6 +112,7 @@ URL with `urlFile`.
 | print | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`BaseEvent`](../../lib/core/events/base.event.ts)`<any>>` | Emitted when user clicks the 'Print' button. |
 | share | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`BaseEvent`](../../lib/core/events/base.event.ts)`<any>>` | Emitted when user clicks the 'Share' button. |
 | showViewerChange | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<boolean>` | Emitted when the viewer is shown or hidden. |
+| invalidSharedLink | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<Object>` | Emitted when the shared link used is not valid. |
 
 ## Keyboard shortcuts
 

--- a/lib/core/viewer/components/viewer.component.spec.ts
+++ b/lib/core/viewer/components/viewer.component.spec.ts
@@ -118,8 +118,8 @@ class ViewerWithCustomOpenWithComponent {
 })
 class ViewerWithCustomMoreActionsComponent {
 }
-/*tslint:disable*/
-fdescribe('ViewerComponent', () => {
+
+describe('ViewerComponent', () => {
 
     let component: ViewerComponent;
     let fixture: ComponentFixture<ViewerComponent>;

--- a/lib/core/viewer/components/viewer.component.spec.ts
+++ b/lib/core/viewer/components/viewer.component.spec.ts
@@ -118,8 +118,8 @@ class ViewerWithCustomOpenWithComponent {
 })
 class ViewerWithCustomMoreActionsComponent {
 }
-
-describe('ViewerComponent', () => {
+/*tslint:disable*/
+fdescribe('ViewerComponent', () => {
 
     let component: ViewerComponent;
     let fixture: ComponentFixture<ViewerComponent>;
@@ -623,6 +623,21 @@ describe('ViewerComponent', () => {
                 });
 
             }));
+
+            it('should raise an event when the shared link is invalid', (done) => {
+                spyOn(alfrescoApiService.getInstance().core.sharedlinksApi, 'getSharedLink')
+                    .and.returnValue(Promise.reject({}));
+
+                component.invalidSharedLink.subscribe(() => {
+                    done();
+                });
+
+                component.sharedLinkId = 'the-Shared-Link-id';
+                component.urlFile = null;
+                component.mimeType = null;
+
+                component.ngOnChanges(null);
+            });
 
         });
 

--- a/lib/core/viewer/components/viewer.component.ts
+++ b/lib/core/viewer/components/viewer.component.ts
@@ -209,6 +209,9 @@ export class ViewerComponent implements OnChanges, OnInit, OnDestroy {
     @Output()
     navigateNext = new EventEmitter();
 
+    @Output()
+    invalidSharedLink = new EventEmitter();
+
     viewerType = 'unknown';
     isLoading = false;
     node: MinimalNodeEntryEntity;
@@ -307,6 +310,7 @@ export class ViewerComponent implements OnChanges, OnInit, OnDestroy {
                     () => {
                         this.isLoading = false;
                         this.logService.error('This sharedLink does not exist');
+                        this.invalidSharedLink.next();
                     });
             }
         }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
When the shared link is invalid the invalid viewer is showed


**What is the new behaviour?**
When the shared link requested is invalid, the 404 page is showed


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-3324