### PR TITLE
[ADF-3500] added an event to react when a filter is force selected

### DIFF
--- a/demo-shell/src/app/components/process-service/process-service.component.html
+++ b/demo-shell/src/app/components/process-service/process-service.component.html
@@ -124,8 +124,8 @@
                                 #activitiprocessfilter
                                 [filterParam]="filterSelected"
                                 [appId]="appId"
-                                (filterClick)="onProcessFilterClick($event)"
-                                (filterSelected)="onProcessFilterClick($event)"
+                                (filterClick)="onProcessFilterChange($event)"
+                                (filterSelected)="onProcessFilterChange($event)"
                                 (success)="onSuccessProcessFilterList($event)">
                             </adf-process-instance-filters>
                         </adf-accordion-group>

--- a/demo-shell/src/app/components/process-service/process-service.component.html
+++ b/demo-shell/src/app/components/process-service/process-service.component.html
@@ -125,6 +125,7 @@
                                 [filterParam]="filterSelected"
                                 [appId]="appId"
                                 (filterClick)="onProcessFilterClick($event)"
+                                (filterSelected)="onProcessFilterClick($event)"
                                 (success)="onSuccessProcessFilterList($event)">
                             </adf-process-instance-filters>
                         </adf-accordion-group>

--- a/demo-shell/src/app/components/process-service/process-service.component.ts
+++ b/demo-shell/src/app/components/process-service/process-service.component.ts
@@ -292,7 +292,7 @@ export class ProcessServiceComponent implements AfterViewInit, OnDestroy, OnInit
         this.currentTaskId = this.taskList.getCurrentId();
     }
 
-    onProcessFilterClick(event: UserProcessInstanceFilterRepresentation): void {
+    onProcessFilterChange(event: UserProcessInstanceFilterRepresentation): void {
         this.processFilter = event;
         this.resetProcessPaginationPage();
         this.relocateLocationToProcess();

--- a/docs/process-services/process-filters.component.md
+++ b/docs/process-services/process-filters.component.md
@@ -45,6 +45,7 @@ Collection of criteria used to filter process instances, which may be customized
 | error | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<any>` | Emitted when an error occurs. |
 | filterClick | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<ProcessInstanceFilterRepresentation>` | Emitted when the user selects a filter from the list. |
 | success | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<ProcessInstanceFilterRepresentation[]>` | Emitted when the list of filters has been successfully loaded from the server. |
+| filterSelected | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<ProcessInstanceFilterRepresentation>` | Emitted when a process filter is selected. |
 
 ## Details
 

--- a/lib/process-services/process-list/components/process-filters.component.spec.ts
+++ b/lib/process-services/process-list/components/process-filters.component.spec.ts
@@ -96,7 +96,7 @@ describe('ProcessFiltersComponent', () => {
             done();
         });
 
-        filterList.ngOnInit();
+        fixture.detectChanges();
     });
 
     it('should select the Running process filter', (done) => {
@@ -113,7 +113,24 @@ describe('ProcessFiltersComponent', () => {
             done();
         });
 
-        filterList.ngOnInit();
+        fixture.detectChanges();
+    });
+
+    it('should emit an event when a filter is selected', (done) => {
+        spyOn(processFilterService, 'getProcessFilters').and.returnValue(from(fakeGlobalFilterPromise));
+        const appId = '1';
+        let change = new SimpleChange(null, appId, true);
+        filterList.ngOnChanges({ 'appId': change });
+
+        expect(filterList.currentFilter).toBeUndefined();
+
+        filterList.filterSelected.subscribe((filter) => {
+            expect(filter.name).toEqual('FakeInvolvedTasks');
+            done();
+        });
+
+        fixture.detectChanges();
+        filterList.selectRunningFilter();
     });
 
     it('should return the filter task list, filtered By Name', (done) => {
@@ -130,7 +147,7 @@ describe('ProcessFiltersComponent', () => {
             done();
         });
 
-        filterList.ngOnInit();
+        fixture.detectChanges();
     });
 
     it('should emit an error with a bad response', (done) => {
@@ -145,7 +162,7 @@ describe('ProcessFiltersComponent', () => {
             done();
         });
 
-        filterList.ngOnInit();
+        fixture.detectChanges();
     });
 
     it('should emit an error with a bad response', (done) => {
@@ -160,7 +177,7 @@ describe('ProcessFiltersComponent', () => {
             done();
         });
 
-        filterList.ngOnInit();
+        fixture.detectChanges();
     });
 
     it('should emit an event when a filter is selected', (done) => {

--- a/lib/process-services/process-list/components/process-filters.component.ts
+++ b/lib/process-services/process-list/components/process-filters.component.ts
@@ -16,7 +16,7 @@
  */
 
 import { AppsProcessService } from '@alfresco/adf-core';
-import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges } from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
 import { ProcessInstanceFilterRepresentation, UserProcessInstanceFilterRepresentation } from 'alfresco-js-api';
 import { Observable } from 'rxjs';
 import { FilterProcessRepresentationModel } from '../models/filter-process.model';
@@ -27,7 +27,7 @@ import { ProcessFilterService } from './../services/process-filter.service';
     templateUrl: './process-filters.component.html',
     styleUrls: ['process-filters.component.scss']
 })
-export class ProcessFiltersComponent implements OnInit, OnChanges {
+export class ProcessFiltersComponent implements OnChanges {
 
     /** The parameters to filter the task filter. If there is no match then the default one
      * (ie, the first filter in the list) is selected.
@@ -37,7 +37,7 @@ export class ProcessFiltersComponent implements OnInit, OnChanges {
 
     /** Emitted when the user selects a filter from the list. */
     @Output()
-    filterClick: EventEmitter<ProcessInstanceFilterRepresentation> = new EventEmitter<ProcessInstanceFilterRepresentation>();
+    filterClick: EventEmitter<UserProcessInstanceFilterRepresentation> = new EventEmitter<UserProcessInstanceFilterRepresentation>();
 
     /** Emitted when the list of filters has been successfully loaded from the server. */
     @Output()
@@ -59,6 +59,9 @@ export class ProcessFiltersComponent implements OnInit, OnChanges {
     @Input()
     showIcon: boolean = true;
 
+    @Output()
+    filterSelected: EventEmitter<ProcessInstanceFilterRepresentation> = new EventEmitter<ProcessInstanceFilterRepresentation>();
+
     filter$: Observable<ProcessInstanceFilterRepresentation>;
 
     currentFilter: ProcessInstanceFilterRepresentation;
@@ -68,8 +71,6 @@ export class ProcessFiltersComponent implements OnInit, OnChanges {
     constructor(private processFilterService: ProcessFilterService,
                 private appsProcessService: AppsProcessService) {
     }
-
-    ngOnInit() {}
 
     ngOnChanges(changes: SimpleChanges) {
         const appId = changes['appId'];
@@ -151,6 +152,7 @@ export class ProcessFiltersComponent implements OnInit, OnChanges {
                     filterParam.id === processFilter.id ||
                     filterParam.index === index) {
                     this.currentFilter = processFilter;
+                    this.filterSelected.emit(processFilter);
                 }
             });
         }
@@ -172,6 +174,7 @@ export class ProcessFiltersComponent implements OnInit, OnChanges {
     public selectDefaultTaskFilter() {
         if (!this.isFilterListEmpty()) {
             this.currentFilter = this.filters[0];
+            this.filterSelected.emit(this.filters[0]);
         }
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
When a process filter is force selected via the component no event is sent and the process list is not refreshed.


**What is the new behaviour?**
`filterSelected` event is sent when the process filter is force selected.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-3500