### PR TITLE
[ADF-3119] Document list styles refactored for datatable thumbnails

### DIFF
--- a/lib/content-services/document-list/components/document-list.component.html
+++ b/lib/content-services/document-list/components/document-list.component.html
@@ -20,7 +20,8 @@
     (rowClick)="onNodeClick($event.value?.node)"
     (rowDblClick)="onNodeDblClick($event.value?.node)"
     (row-select)="onNodeSelect($event.detail)"
-    (row-unselect)="onNodeUnselect($event.detail)">
+    (row-unselect)="onNodeUnselect($event.detail)"
+    [class.adf-datatable-gallery-thumbnails]="data.thumbnails">
 
     <div *ngIf="!isEmptyTemplateDefined()">
         <no-content-template>

--- a/lib/content-services/document-list/components/document-list.component.scss
+++ b/lib/content-services/document-list/components/document-list.component.scss
@@ -152,4 +152,28 @@
             }
         }
     }
+
+    .adf-datatable-gallery-thumbnails {
+        .adf-data-table-card .adf-datatable-row {
+            height: 300px !important;
+
+            img {
+                height: 100px;
+            }
+            
+            :first-child .cell-container .cell-value {
+                display: flex;
+                width: 265px;
+                flex: 0 0 auto;
+                justify-content: center;
+            }
+
+            .adf-data-table-cell.adf-datatable-table-cell.adf-data-table-cell--image {
+                flex: 0 0 auto;
+                display: flex;
+                flex-direction: column-reverse;
+                justify-content: space-between;
+            }
+        }
+    }
 }

--- a/lib/core/datatable/components/datatable/datatable.component.scss
+++ b/lib/core/datatable/components/datatable/datatable.component.scss
@@ -45,7 +45,7 @@
                 max-width: 288px !important;
                 min-width: 288px !important;
 
-                height: 200px !important;
+                height: 200px;
 
                 overflow: hidden !important;
                 margin: 6px;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-3119
Datatable component not rendering layout properly when displaying in gallery view mode

**What is the new behaviour?**
Document List component is setting the styles for the gallery view and the thumbnails displaying in the Datatable Component


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-3119