### PR TITLE
[ADF-3529] Add permissions fix for IE 11

### DIFF
--- a/lib/content-services/permission-manager/components/add-permission/add-permission-panel.component.html
+++ b/lib/content-services/permission-manager/components/add-permission/add-permission-panel.component.html
@@ -27,7 +27,7 @@
 <adf-search #search [searchTerm]="searchedWord"
         id="adf-add-permission-authority-results"
         class="adf-permission-result-list"
-        *ngIf="searchedWord.length !== 0">
+        [class.adf-permission-result-list-search]="searchedWord.length === 0">
 <ng-template let-data>
     <mat-selection-list class="adf-permission-result-list-elements">
         <mat-list-option

--- a/lib/content-services/permission-manager/components/add-permission/add-permission-panel.component.scss
+++ b/lib/content-services/permission-manager/components/add-permission/add-permission-panel.component.scss
@@ -17,6 +17,10 @@
             &-elements {
                 width: 100%;
             }
+
+            &-search {
+                display: none;
+            }
         }
 
         &-permission-start-message {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
On IE11, the AddPermissionDialogComponent does not allow you to search for users.
When the dialog is opened, an error is thrown:
ERROR TypeError: Unable to get property 'resetResults' of undefined or null reference
https://issues.alfresco.com/jira/browse/ADF-3529

**What is the new behaviour?**
Search component now shows all matching users.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-3529