### PR TITLE
[ADF-3577] Corrected doc filename for content metadata card component

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@ See the [Tutorials index](tutorials/README.md) for the full list.
 -   [Form Extensibility and Customisation](user-guide/extensibility.md)
 -   [Internationalization in ADF](user-guide/internationalization.md)
 -   [Theming](user-guide/theming.md)
+-   [Transclusion](user-guide/transclusion.md)
 -   [Typography](user-guide/typography.md)
 -   [Walkthrough - adding indicators to highlight information about a node](user-guide/metadata-indicators.md)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,7 +38,6 @@ See the [Tutorials index](tutorials/README.md) for the full list.
 -   [Form Extensibility and Customisation](user-guide/extensibility.md)
 -   [Internationalization in ADF](user-guide/internationalization.md)
 -   [Theming](user-guide/theming.md)
--   [Transclusion](user-guide/transclusion.md)
 -   [Typography](user-guide/typography.md)
 -   [Walkthrough - adding indicators to highlight information about a node](user-guide/metadata-indicators.md)
 
@@ -170,6 +169,7 @@ for more information about installing and using the source code.
 | [User preferences service](core/user-preferences.service.md) | Stores preferences for components. | [Source](../lib/core/services/user-preferences.service.ts) |
 | [Bpm user service](core/bpm-user.service.md) | Gets information about the current Process Services user. | [Source](../lib/core/userinfo/services/bpm-user.service.ts) |
 | [Ecm user service](core/ecm-user.service.md) | Gets information about a Content Services user. | [Source](../lib/core/userinfo/services/ecm-user.service.ts) |
+| _View util service_ | _Not currently documented_ | [Source](../lib/core/viewer/services/view-util.service.ts) |
 
 ## Widgets
 
@@ -184,7 +184,7 @@ for more information about installing and using the source code.
 | Name | Description | Source link |
 | ---- | ----------- | ----------- |
 | [Data Table Adapter interface](core/datatable-adapter.interface.md) | Defines how table data is supplied to DataTable and Tasklist components. | [Source](../lib/core/datatable/data/datatable-adapter.ts) |
-| [Form Field Validator interface](core/form-field-validator.interface.md) | Defines how the input fields of Form and Task Details components are validated. | [Source](../lib/core/form/components/widgets/core/form-field-validator.ts) |
+| [Form Field Validator interface](core/form-field-validator.interface.md) | Defines how the input fields of [Form](../../lib/process-services/task-list/models/form.model.ts) and Task Details components are validated. | [Source](../lib/core/form/components/widgets/core/form-field-validator.ts) |
 | [Search Configuration interface](core/search-configuration.interface.md) | Provides fine control of parameters to a search. | [Source](../lib/core/services/search-configuration.service.ts) |
 
 [(Back to Contents)](#contents)
@@ -204,7 +204,7 @@ for more information about installing and using the source code.
 | ---- | ----------- | ----------- |
 | [Breadcrumb component](content-services/breadcrumb.component.md) | Indicates the current position within a navigation hierarchy. | [Source](../lib/content-services/breadcrumb/breadcrumb.component.ts) |
 | [Dropdown breadcrumb component](content-services/dropdown-breadcrumb.component.md) | Indicates the current position within a navigation hierarchy using a dropdown menu. | [Source](../lib/content-services/breadcrumb/dropdown-breadcrumb.component.ts) |
-| [Content metadata component](content-services/content-metadata.component.md) | Displays and edits metadata related to a node. | [Source](../lib/content-services/content-metadata/components/content-metadata/content-metadata.component.ts) |
+| [Content metadata card component](content-services/content-metadata-card.component.md) | Displays and edits metadata related to a node. | [Source](../lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.ts) |
 | [Content node selector panel component](content-services/content-node-selector-panel.component.md) | Opens a Content Node Selector in its own dialog window. | [Source](../lib/content-services/content-node-selector/content-node-selector-panel.component.ts) |
 | [Content node selector component](content-services/content-node-selector.component.md) | Allows a user to select items from a Content Services repository. | [Source](../lib/content-services/content-node-selector/content-node-selector.component.ts) |
 | [Content action component](content-services/content-action.component.md) | Adds options to a Document List actions menu for a particular content type. | [Source](../lib/content-services/document-list/components/content-action/content-action.component.ts) |
@@ -279,7 +279,7 @@ for more information about installing and using the source code.
 
 | Name | Description | Source link |
 | ---- | ----------- | ----------- |
-| [Search Widget interface](content-services/search-widget.interface.md) | Specifies required properties for Search filter component widgets. | [Source](../lib/content-services/search/search-widget.interface.ts) |
+| [Search Widget interface](content-services/search-widget.interface.md) | Specifies required properties for [Search filter component](../content-services/search-filter.component.md) widgets. | [Source](../lib/content-services/search/search-widget.interface.ts) |
 
 [(Back to Contents)](#contents)
 

--- a/docs/content-services/README.md
+++ b/docs/content-services/README.md
@@ -13,7 +13,7 @@ for more information about installing and using the source code.
 | ---- | ----------- | ----------- |
 | [Breadcrumb component](breadcrumb.component.md) | Indicates the current position within a navigation hierarchy. | [Source](../../lib/content-services/breadcrumb/breadcrumb.component.ts) |
 | [Dropdown breadcrumb component](dropdown-breadcrumb.component.md) | Indicates the current position within a navigation hierarchy using a dropdown menu. | [Source](../../lib/content-services/breadcrumb/dropdown-breadcrumb.component.ts) |
-| [Content metadata component](content-metadata.component.md) | Displays and edits metadata related to a node. | [Source](../../lib/content-services/content-metadata/components/content-metadata/content-metadata.component.ts) |
+| [Content metadata card component](content-metadata-card.component.md) | Displays and edits metadata related to a node. | [Source](../../lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.ts) |
 | [Content node selector panel component](content-node-selector-panel.component.md) | Opens a Content Node Selector in its own dialog window. | [Source](../../lib/content-services/content-node-selector/content-node-selector-panel.component.ts) |
 | [Content node selector component](content-node-selector.component.md) | Allows a user to select items from a Content Services repository. | [Source](../../lib/content-services/content-node-selector/content-node-selector.component.ts) |
 | [Content action component](content-action.component.md) | Adds options to a Document List actions menu for a particular content type. | [Source](../../lib/content-services/document-list/components/content-action/content-action.component.ts) |
@@ -88,4 +88,4 @@ for more information about installing and using the source code.
 
 | Name | Description | Source link |
 | ---- | ----------- | ----------- |
-| [Search Widget interface](search-widget.interface.md) | Specifies required properties for Search filter component widgets. | [Source](../../lib/content-services/search/search-widget.interface.ts) |
+| [Search Widget interface](search-widget.interface.md) | Specifies required properties for [Search filter component](../content-services/search-filter.component.md) widgets. | [Source](../../lib/content-services/search/search-widget.interface.ts) |

--- a/docs/content-services/content-metadata-card.component.md
+++ b/docs/content-services/content-metadata-card.component.md
@@ -1,0 +1,217 @@
+---
+Added: v2.1.0
+Status: Active
+Last reviewed: 2018-08-07
+---
+
+# Content Metadata Card component
+
+Displays and edits metadata related to a node.
+
+![Content metadata screenshot](../docassets/images/ContentMetadata.png)
+
+## Basic Usage
+
+```html
+<adf-content-metadata-card
+    [displayEmpty]="false"
+    [toggleDisplayProperties]="displayDefaultProperties"
+    [preset]="'*'"
+    [node]="node">
+</adf-content-metadata-card>
+```
+
+## Class members
+
+### Properties
+
+| Name | Type | Default value | Description |
+| ---- | ---- | ------------- | ----------- |
+| displayEmpty | `boolean` | false | (optional) This flag displays/hides empty metadata fields. |
+| multi | `boolean` | false | (optional) This flag allows the component to display more than one accordion at a time. |
+| node | [`MinimalNodeEntryEntity`](../content-services/document-library.model.md) |  | (required) The node entity to fetch metadata about |
+| preset | `string` |  | (required) Name of the metadata preset, which defines aspects and their properties. |
+| readOnly | `boolean` | false | (optional) This flag sets the metadata in read only mode preventing changes. |
+
+## Details
+
+The component shows metadata related to a given node. It uses the
+[Card View component](../core/card-view.component.md) to render the properties of metadata aspects.
+The different aspects and their properties to be shown can be configured as application config
+presets (see below). By default the component only shows the basic properties of the node.
+The user can click on the pencil icon at the bottom of the component to edit the metadata
+properties.
+
+### Application config presets
+
+You can define different presets for the metadata component or override the default presets in
+the `app.config.json` file. The **default** preset is "\*" if not set, meaning the component
+will display every aspect and property of a node without filtering. 
+
+You can define as many extra presets as you need for your components.
+
+The example configurations below show the options in detail.
+
+#### Indifferent config
+
+The default configuration behaves like the following:
+
+```json
+...
+"content-metadata": {
+    "presets": {
+        "default": "*"
+    }
+}
+...
+```
+
+#### Aspect oriented config
+
+With this type of configuration you can "whitelist" aspects and properties for a preset, but everything will be grouped by aspects and there is no further way to group properties. Use a
+[layout oriented configuration](#layout-oriented-config) if you want to define your own
+custom groups.
+
+The default configuration shows every aspect but you can restrict it to just a small selection
+of aspects by "whitelisting" the ones you want in the `default` section. In the example below,
+just the `exif:exif` and `custom:aspect` aspects are whitelisted:
+
+```json
+...
+"content-metadata": {
+    "presets": {
+        "default": {
+            "custom:aspect": "*",
+            "exif:exif": "*"
+        }
+    }
+}
+...
+```
+
+You can further restrict the whitelist to specific properties of one or more aspects by using
+an array of property names in place of the "\*" filter:
+
+```json
+...
+"content-metadata": {
+    "presets": {
+        "default": {
+            "custom:aspect": "*",
+            "exif:exif": [ "exif:pixelXDimension", "exif:pixelYDimension"]
+        }
+    }
+}
+...
+```
+
+A final example shows the same process applied to a custom preset called "kitten-images":
+
+```json
+...
+"content-metadata": {
+    "presets": {
+        "default": "*",
+        "kitten-images": {
+            "custom:aspect": "*",
+            "exif:exif": [ "exif:pixelXDimension", "exif:pixelYDimension"]
+        }
+    }
+}
+...
+```
+
+### Layout oriented config
+
+You can also go beyond the aspect oriented configuration if you need to configure the groups and properties in a more detailed way. With this type of configuration any property of any aspect/type
+can be "cherry picked" and grouped into an accordion drawer, along with a translatable title
+defined in the preset configuration.
+
+#### Basic elements
+
+The following config will produce one accordion group named "TRANSLATABLE_TITLE_FOR_GROUP_1",
+with all the properties from `custom:aspect` followed by the two properties (`exif:pixelXDimension`
+and `exif:pixelYDimension`) from the `exif:exif` aspect and then one property (`custom:myPropertyName`) from `custom:type`:
+
+```json
+...
+"content-metadata": {
+    "presets": {
+        "kitten-images": [{
+            "title": "TRANSLATABLE_TITLE_FOR_GROUP_1",
+            "items": [
+                { "aspect": "custom:aspect", "properties": "*" },
+                { "aspect": "exif:exif", "properties": [ "exif:pixelXDimension", "exif:pixelYDimension"] },
+                { "type": "custom:type", "properties": [ "custom:myPropertyName" ] },
+            ] 
+        }]
+    }
+}
+...
+```
+
+#### More complex example
+
+A more complex config is shown in the example below:
+
+```json
+  "content-metadata": {
+    "presets": {
+      "kittens": [
+      {
+        "title": "GROUP-TITLE1-TRANSLATION-KEY",
+        "items": [
+          { 
+            "aspect": "exif:exif",
+            "properties": "*"
+          },
+          { 
+            "aspect": "kitten:vet-records", 
+            "properties": [ "kitten:custom1", "kitten:custom3" ]
+          },
+          { 
+            "aspect": "owner:parameters", 
+            "properties": [ "owner:name" ]
+          },
+          { 
+            "type": "kitten:kitten", 
+            "properties": [ "kitten:name", "kitten:color" ]
+          }
+        ]
+      },
+      {
+        "title": "GROUP-TITLE2-TRANSLATION-KEY",
+        "items": [
+          {
+            "aspect": "kitten:food", 
+            "properties": [ "kitten:favourite-food", "kitten:recommended-food" ] 
+          }
+        ]
+      }
+    ]
+  }
+```
+
+The result of this config would be two accordion groups with the following properties:
+
+| GROUP-TITLE1-TRANSLATION-KEY |
+| ---------------------------- |
+| exif:param1 |
+| exif:param2 |
+| ... |
+| exif:paramN |
+| kitten:custom1 |
+| kitten:custom3 |
+| owner:name |
+| kitten:name |
+| kitten:color |
+
+| GROUP-TITLE2-TRANSLATION-KEY |
+| ---------------------------- |
+| kitten:favourite-food |
+| kitten:recommended-food |
+
+## What happens when there is a whitelisted aspect in the config but the given node doesn't relate to that aspect
+
+Nothing - since this aspect is not related to the node, it will simply be ignored and not
+displayed. The aspects to be displayed are calculated as an intersection of the preset's aspects and the aspects related to the node.

--- a/docs/user-guide/summary.json
+++ b/docs/user-guide/summary.json
@@ -3,6 +3,7 @@
     { "title": "Form Extensibility and Customisation", "file": "extensibility.md" },
     { "title": "Internationalization in ADF", "file": "internationalization.md" },
     { "title": "Theming", "file": "theming.md" },
+    { "title": "Transclusion", "file": "transclusion.md" },
     { "title": "Typography", "file": "typography.md" },
     { "title": "Walkthrough - adding indicators to highlight information about a node", "file": "metadata-indicators.md" },
     { "title": "Tutorials", "file": "tutorialIndex.md",

--- a/docs/versionIndex.md
+++ b/docs/versionIndex.md
@@ -13,7 +13,6 @@ of components organized by ADF libraries.
 -   [v2.1.0](#v210)
 -   [v2.0.0](#v200)
 
-
 ## v2.5.0
 
 **Released:** 2018-08-14 ([Release notes](release-notes/RelNote250.md))<br/>
@@ -109,7 +108,7 @@ No new components added.
 
 <!--v210 start-->
 
--   [Content metadata component](content-services/content-metadata.component.md)
+-   [Content metadata card component](content-services/content-metadata-card.component.md)
 -   [Content node dialog service](content-services/content-node-dialog.service.md)
 -   [Content node selector panel component](content-services/content-node-selector-panel.component.md)
 -   [Search configuration service](core/search-configuration.service.md)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [x] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Content metadata card component docs use the wrong class to get the property table because the filename is wrong (content-metadata.component.md instead of content-metatdata-card.component.md).

**What is the new behaviour?**

Filename is now correct. Property tables and index files updated with the new info.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
