### PR TITLE
[ADF-3587] Fixed doc comment problems

### DIFF
--- a/docs/content-services/document-list.component.md
+++ b/docs/content-services/document-list.component.md
@@ -61,8 +61,8 @@ Displays the documents from a repository.
 | currentFolderId | `string` | null | The ID of the folder node to display or a reserved string alias for special sources |
 | display | `string` | DisplayMode.List | Change the display mode of the table. Can be "list" or "gallery". |
 | emptyFolderImageUrl | `string` |  | Custom image for empty folder. Default value: './assets/images/empty_doc_lib.svg' |
-| enableInfiniteScrolling | `boolean` | false | Set document list to work in infinite scrolling mode |
-| folderNode | [`MinimalNodeEntryEntity`](../content-services/document-library.model.md) | null | Currently displayed folder node |
+| enableInfiniteScrolling | `boolean` | false | (**Deprecated:** 2.3.0) Set document list to work in infinite scrolling mode |
+| folderNode | [`MinimalNodeEntryEntity`](../content-services/document-library.model.md) | null | (**Deprecated:** 2.3.0 - use currentFolderId or node) Currently displayed folder node |
 | imageResolver | `any \| null` | null | Custom image resolver |
 | includeFields | `string[]` |  | Include additional information about the node in the server request.for example: association, isLink, isLocked and others. |
 | loading | `boolean` | false | Toggles the loading state and animated spinners for the component. Used in combination with `navigate=false` to perform custom navigation and loading state indication. |
@@ -78,7 +78,7 @@ Displays the documents from a repository.
 | rowStyleClass | `string` |  | The CSS class to apply to every row |
 | selectionMode | `string` | "single" | Row selection mode. Can be null, `single` or `multiple`. For `multiple` mode, you can use Cmd (macOS) or Ctrl (Win) modifier key to toggle selection for multiple rows. |
 | showHeader | `boolean` | true | Toggles the header |
-| skipCount | `number` | 0 | Number of elements to skip over for pagination purposes |
+| skipCount | `number` | 0 | (**Deprecated:** 2.3.0 - define it in pagination) Number of elements to skip over for pagination purposes |
 | sorting | `string[]` | ['name', 'asc'] | Defines default sorting. The format is an array of 2 strings `[key, direction]` i.e. `['name', 'desc']` or `['name', 'asc']`. Set this value only if you want to override the default sorting detected by the component based on columns. |
 | sortingMode | `string` | "client" | Defines sorting mode. Can be either `client` or `server`. |
 | thumbnails | `boolean` | false | Show document thumbnails rather than icons |
@@ -371,7 +371,6 @@ export class FilesComponent implements OnInit {
     [currentFolderId]="currentFolderId">
 </adf-document-list>
 ```
-
 
 The `console.log(node)` for the `getNodeInfo` callback is just for study and debug purposes. 
 It is useful for examining other information that you can access if necessary:

--- a/docs/content-services/document-list.service.md
+++ b/docs/content-services/document-list.service.md
@@ -40,7 +40,7 @@ Implements node operations used by the [Document List component](../content-serv
     -   _includeFields:_ `string[]`  - Extra information to include (available options are "aspectNames", "isLink" and "association")
     -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`NodePaging`](../../lib/content-services/document-list/models/document-library.model.ts)`>` - Details of the folder
 -   **getFolderNode**(nodeId: `string`, includeFields: `string[]` = `[]`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`MinimalNodeEntryEntity`](../content-services/document-library.model.md)`>`<br/>
-    (**Deprecated:** 2.3.0. Gets a folder node via its node ID.) 
+    (**Deprecated:** 2.3.0) Gets a folder node via its node ID.
     -   _nodeId:_ `string`  - ID of the folder node
     -   _includeFields:_ `string[]`  - Extra information to include (available options are "aspectNames", "isLink" and "association")
     -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`MinimalNodeEntryEntity`](../content-services/document-library.model.md)`>` - Details of the folder
@@ -54,7 +54,7 @@ Implements node operations used by the [Document List component](../content-serv
     -   _includeFields:_ `string[]`  - Extra information to include (available options are "aspectNames", "isLink" and "association")
     -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`NodeEntry`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/NodeEntry.md)`>` - Details of the folder
 -   **hasPermission**(node: `any`, permission: [`PermissionsEnum`](../../lib/core/models/permissions.enum.ts)`|string`): `boolean`<br/>
-    (**Deprecated:** 2.3.0 - use the equivalent in the content service. Checks if a node has the specified permission.) 
+    (**Deprecated:** 2.3.0 - use the equivalent in the content service) Checks if a node has the specified permission.
     -   _node:_ `any`  - Target node
     -   _permission:_ [`PermissionsEnum`](../../lib/core/models/permissions.enum.ts)`|string`  - Permission level to query
     -   **Returns** `boolean` - True if the node has the permission, false otherwise

--- a/docs/content-services/file-draggable.directive.md
+++ b/docs/content-services/file-draggable.directive.md
@@ -46,7 +46,7 @@ Some sample CSS to show the drag and drop area:
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | filesDropped | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<File[]>` | Emitted when one or more files are dragged and dropped onto the draggable element. |
-| filesEntityDropped | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<any>` | (**Deprecated:** in 2.4.0: use `filesDropped` instead. Emitted when one or more files are dragged and dropped onto the draggable element.) |
+| filesEntityDropped | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<any>` | (**Deprecated:** in 2.4.0: use `filesDropped` instead) Emitted when one or more files are dragged and dropped onto the draggable element. |
 | folderEntityDropped | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<any>` | Emitted when a directory is dragged and dropped onto the draggable element. |
 
 ## Details

--- a/docs/content-services/upload-drag-area.component.md
+++ b/docs/content-services/upload-drag-area.component.md
@@ -67,13 +67,14 @@ as the drag/drop target:
 | nodeType | `string` | "cm:content" | Custom node type for uploaded file |
 | rootFolderId | `string` | "-root-" | The ID of the root. Use the nodeId for Content Services or the taskId/processId for Process Services. |
 | versioning | `boolean` | false | Toggles versioning. |
+| parentId | `void` |  | (**Deprecated:** 2.4.0 - use rootFolderId ID of parent folder node) ID of parent folder node |
 
 ### Events
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | beginUpload | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`UploadFilesEvent`](../../lib/content-services/upload/components/upload-files.event.ts)`>` | Emitted when the upload begins. |
-| createFolder | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<Object>` | Emitted when a folder is created. |
+| createFolder | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<Object>` | (**Deprecated:** 2.4.0 No longer used by the framework) Emitted when a folder is created. |
 | error | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<Object>` | Emitted when an error occurs. |
 | success | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<Object>` | Emitted when the file is uploaded successfully. |
 

--- a/docs/core/accordion-group.component.md
+++ b/docs/core/accordion-group.component.md
@@ -50,6 +50,8 @@ define a section in a surrounding [Accordion component](accordion.component.md).
 | heading | `string` |  | Title heading for the group. |
 | headingIcon | `string` |  | The material design icon. |
 | headingIconTooltip | `string` |  | Tooltip message to be shown for headingIcon |
+| isOpen | `boolean` |  | Is this group currently open? |
+| isSelected | `boolean` |  | Is this group currently selected? |
 
 ### Events
 

--- a/docs/core/form.component.md
+++ b/docs/core/form.component.md
@@ -83,7 +83,7 @@ Any content in the body of `<adf-form>` will be shown when no form definition is
 | formError | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`FormFieldModel`](../core/form-field.model.md)`[]>` | Emitted when form validations has validation error. |
 | formLoaded | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`FormModel`](../../lib/core/form/components/widgets/core/form.model.ts)`>` | Emitted when the form is loaded or reloaded. |
 | formSaved | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`FormModel`](../../lib/core/form/components/widgets/core/form.model.ts)`>` | Emitted when the form is submitted with the `Save` or custom outcomes. |
-| onError | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<any>` | Emitted when any error occurs. |
+| onError | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<any>` | (**Deprecated:** in 2.4.0, will be renamed as "error" in 3.x.x) Emitted when any error occurs. |
 
 ## Details
 

--- a/docs/core/infinite-pagination.component.md
+++ b/docs/core/infinite-pagination.component.md
@@ -39,7 +39,7 @@ Adds "infinite" pagination to the component it is used with.
 | ---- | ---- | ------------- | ----------- |
 | isLoading | `boolean` | false | Is a new page loading? |
 | pageSize | `number` |  | Number of items that are added with each "load more" event. |
-| pagination | [`PaginationModel`](../../lib/core/models/pagination.model.ts) |  | (**Deprecated:** 2.3.0  [Pagination](../../lib/content-services/document-list/models/document-library.model.ts) object.) |
+| pagination | [`PaginationModel`](../../lib/core/models/pagination.model.ts) |  | (**Deprecated:** 2.3.0) [Pagination](../../lib/content-services/document-list/models/document-library.model.ts) object. |
 | target | `PaginatedComponent` |  | Component that provides custom pagination support. |
 
 ### Events

--- a/docs/core/node-restore.directive.md
+++ b/docs/core/node-restore.directive.md
@@ -50,7 +50,7 @@ Restores deleted nodes to their original location.
 
 | Name | Type | Default value | Description |
 | ---- | ---- | ------------- | ----------- |
-| location | `string` | "" | (**Deprecated:** 2.4.0 Path to restored node.) |
+| location | `string` | "" | (**Deprecated:** 2.4.0) Path to restored node. |
 | selection | `DeletedNodeEntry[]` |  | Array of deleted nodes to restore. |
 
 ### Events

--- a/docs/core/viewer.component.md
+++ b/docs/core/viewer.component.md
@@ -79,7 +79,7 @@ See the [Custom layout](#custom-layout) section for full details of all availabl
 | allowGoBack | `boolean` | true | Allows `back` navigation |
 | allowNavigate | `boolean` | false | Toggles before/next navigation. You can use the arrow buttons to navigate between documents in the collection. |
 | allowPrint | `boolean` | false | Toggles printing. |
-| allowShare | `boolean` | false | Toggles sharing. |
+| allowShare | `boolean` | false | (**Deprecated:** 2.5.0 - inject the share button directive as custom button) Toggles sharing. |
 | allowSidebar | `boolean` | false | Toggles the sidebar. |
 | allowThumbnails | `boolean` | true | Toggles PDF thumbnails. |
 | blobFile | [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob) |  | Loads a [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob) File |
@@ -94,15 +94,16 @@ See the [Custom layout](#custom-layout) section for full details of all availabl
 | overlayMode | `boolean` | false | If `true` then show the Viewer as a full page over the current content. Otherwise fit inside the parent div. |
 | sharedLinkId | `string` | null | Shared link id (to display shared file). |
 | showLeftSidebar | `boolean` | false | Toggles left sidebar visibility. Requires `allowSidebar` to be set to `true`. |
-| showSidebar | `boolean` | false | Toggles sidebar visibility. Requires `allowSidebar` to be set to `true`. |
+| showSidebar | `boolean` | false | (**Deprecated:** 2.5.0 - will be renamed showRightSidebar in 3.0.0) Toggles sidebar visibility. Requires `allowSidebar` to be set to `true`. |
 | showToolbar | `boolean` | true | Hide or show the toolbar |
 | showViewer | `boolean` | true | Hide or show the viewer |
 | sidebarLeftTemplate | [`TemplateRef`](https://angular.io/api/core/TemplateRef)`<any>` | null | The template for the left sidebar. The template context contains the loaded node data. |
-| sidebarPosition | `string` | "right" | The position of the sidebar. Can be `left` or `right`. |
-| sidebarTemplate | [`TemplateRef`](https://angular.io/api/core/TemplateRef)`<any>` | null | The template for the sidebar. The template context contains the loaded node data. |
+| sidebarPosition | `string` | "right" | (**Deprecated:** 2.5.0 use sidebarTemplateLeft) The position of the sidebar. Can be `left` or `right`. |
+| sidebarTemplate | [`TemplateRef`](https://angular.io/api/core/TemplateRef)`<any>` | null | (**Deprecated:** 2.5.0 renamed as sidebarRight) The template for the sidebar. The template context contains the loaded node data. |
 | thumbnailsTemplate | [`TemplateRef`](https://angular.io/api/core/TemplateRef)`<any>` | null | The template for the pdf thumbnails. |
 | urlFile | `string` | "" | If you want to load an external file that does not come from ACS you can use this URL to specify where to load the file from. |
 | urlFileViewer | `string` | null | Viewer to use with the `urlFile` address (`pdf`, `image`, `media`, `text`). Used when `urlFile` has no filename and extension. |
+| fileNodeId | `void` |  | (**Deprecated:** 2.4.0 use nodeId) Node Id of the file to load. |
 
 ### Events
 

--- a/docs/process-services/task-list.component.md
+++ b/docs/process-services/task-list.component.md
@@ -55,7 +55,7 @@ when the task list is empty:
 | appId | `number` |  | The id of the app. |
 | assignment | `string` |  | The assignment of the process. Possible values are: "assignee" (the current user is the assignee), candidate (the current user is a task candidate", "group_x" (the task is assigned to a group where the current user is a member, no value(the current user is involved). |
 | data | `DataTableAdapter` |  | (**Deprecated:** 2.4.0) Data source object that represents the number and the type of the columns that you want to show. |
-| dueAfter | `string` |  | Filter the tasks. Display only tasks with created_date before dueAfter.. |
+| dueAfter | `string` |  | Filter the tasks. Display only tasks with created_date after dueAfter. |
 | dueBefore | `string` |  | Filter the tasks. Display only tasks with created_date before dueBefore. |
 | includeProcessInstance | `boolean` |  | Toggles inclusion of Process Instances |
 | landingTaskId | `string` |  | Define which task id should be selected after reloading. If the task id doesn't exist or nothing is passed then the first task will be selected. |

--- a/lib/content-services/document-list/components/document-list.component.ts
+++ b/lib/content-services/document-list/components/document-list.component.ts
@@ -166,8 +166,10 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
     @Input()
     currentFolderId: string = null;
 
-    /** @deprecated 2.3.0 use currentFolderId or node */
-    /** Currently displayed folder node */
+    /**
+     * Currently displayed folder node
+     * @deprecated 2.3.0 - use currentFolderId or node
+     */
     @Input()
     folderNode: MinimalNodeEntryEntity = null;
 
@@ -179,13 +181,17 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
     @Input()
     maxItems: number;
 
-    /** @deprecated 2.3.0 define it in pagination */
-    /** Number of elements to skip over for pagination purposes */
+    /**
+     * Number of elements to skip over for pagination purposes
+     * @deprecated 2.3.0 - define it in pagination
+     */
     @Input()
     skipCount: number = 0;
 
-    /** @deprecated 2.3.0 */
-    /** Set document list to work in infinite scrolling mode */
+    /**
+     * Set document list to work in infinite scrolling mode
+     * @deprecated 2.3.0
+     */
     @Input()
     enableInfiniteScrolling: boolean = false;
 

--- a/lib/content-services/document-list/services/document-list.service.ts
+++ b/lib/content-services/document-list/services/document-list.service.ts
@@ -150,7 +150,8 @@ export class DocumentListService {
     }
 
     /**
-     * @deprecated 2.3.0. Gets a folder node via its node ID.
+     * Gets a folder node via its node ID.
+     * @deprecated 2.3.0
      * @param nodeId ID of the folder node
      * @param includeFields Extra information to include (available options are "aspectNames", "isLink" and "association")
      * @returns Details of the folder
@@ -194,7 +195,8 @@ export class DocumentListService {
     }
 
     /**
-     * @Deprecated 2.3.0 - use the equivalent in the content service. Checks if a node has the specified permission.
+     * Checks if a node has the specified permission.
+     * @deprecated 2.3.0 - use the equivalent in the content service
      * @param node Target node
      * @param permission Permission level to query
      * @returns True if the node has the permission, false otherwise

--- a/lib/content-services/upload/components/base-upload/upload-base.ts
+++ b/lib/content-services/upload/components/base-upload/upload-base.ts
@@ -63,8 +63,10 @@ export abstract class UploadBase implements OnInit, OnDestroy {
     @Output()
     success = new EventEmitter();
 
-    /** @deprecated 2.4.0 No longer used by the framework */
-    /** Emitted when a folder is created. */
+    /**
+     * Emitted when a folder is created.
+     * @deprecated 2.4.0 No longer used by the framework
+     */
     @Output()
     createFolder = new EventEmitter();
 

--- a/lib/content-services/upload/components/upload-drag-area.component.ts
+++ b/lib/content-services/upload/components/upload-drag-area.component.ts
@@ -34,7 +34,10 @@ import { UploadBase } from './base-upload/upload-base';
 })
 export class UploadDragAreaComponent extends UploadBase implements NodePermissionSubject {
 
-    /** @deprecated 2.4.0  use rootFolderId ID of parent folder node. */
+    /**
+     * ID of parent folder node
+     * @deprecated 2.4.0 - use rootFolderId ID of parent folder node
+     */
     @Input()
     set parentId(nodeId: string) {
         this.rootFolderId = nodeId;
@@ -60,9 +63,8 @@ export class UploadDragAreaComponent extends UploadBase implements NodePermissio
     }
 
     /**
+     * Called when the file are dropped in the drag area.
      * @deprecated in 2.4.0: use `onFilesDropped` instead
-     * Called when the file are dropped in the drag area
-     *
      * @param item - FileEntity
      */
     onFilesEntityDropped(item: any): void {

--- a/lib/content-services/upload/directives/file-draggable.directive.ts
+++ b/lib/content-services/upload/directives/file-draggable.directive.ts
@@ -35,8 +35,9 @@ export class FileDraggableDirective implements OnInit, OnDestroy {
     @Output()
     filesDropped: EventEmitter<File[]> = new EventEmitter<File[]>();
 
-    /** @deprecated in 2.4.0: use `filesDropped` instead.
+    /**
      * Emitted when one or more files are dragged and dropped onto the draggable element.
+     * @deprecated in 2.4.0: use `filesDropped` instead
      */
     @Output()
     filesEntityDropped: EventEmitter<any> = new EventEmitter();

--- a/lib/core/directives/node-restore.directive.ts
+++ b/lib/core/directives/node-restore.directive.ts
@@ -40,7 +40,10 @@ export class NodeRestoreDirective {
     @Input('adf-restore')
     selection: DeletedNodeEntry[];
 
-    /** @deprecated 2.4.0 Path to restored node. */
+    /**
+     * Path to restored node.
+     * @deprecated 2.4.0
+     */
     @Input()
     location: string = '';
 

--- a/lib/core/form/components/form.component.ts
+++ b/lib/core/form/components/form.component.ts
@@ -156,8 +156,10 @@ export class FormComponent implements OnInit, OnChanges, OnDestroy {
     @Output()
     executeOutcome: EventEmitter<FormOutcomeEvent> = new EventEmitter<FormOutcomeEvent>();
 
-    /** @deprecated in 2.4.0, will be renamed in error in 3.x.x */
-    /** Emitted when any error occurs. */
+    /**
+     * Emitted when any error occurs.
+     * @deprecated in 2.4.0, will be renamed as "error" in 3.x.x
+     */
     @Output()
     onError: EventEmitter<any> = new EventEmitter<any>();
 

--- a/lib/core/form/components/widgets/widget.component.ts
+++ b/lib/core/form/components/widgets/widget.component.ts
@@ -55,7 +55,10 @@ export class WidgetComponent implements AfterViewInit {
     @Input()
     field: FormFieldModel;
 
-    /** @deprecated Used only to trigger visibility engine; components should do that internally if needed */
+    /**
+     * Emitted when a field value changes.
+     * @deprecated Used only to trigger visibility engine; components should do that internally if needed.
+     */
     @Output()
     fieldChanged: EventEmitter<FormFieldModel> = new EventEmitter<FormFieldModel>();
 

--- a/lib/core/form/services/form.service.ts
+++ b/lib/core/form/services/form.service.ts
@@ -164,8 +164,8 @@ export class FormService {
     }
 
     /**
+     * Add Fields to a form
      * @deprecated in 1.7.0, use saveForm API instead
-     * Add Fields to A form
      * @param formId ID of the form
      * @param formModel Form definition
      */

--- a/lib/core/pagination/infinite-pagination.component.ts
+++ b/lib/core/pagination/infinite-pagination.component.ts
@@ -47,7 +47,10 @@ export class InfinitePaginationComponent implements OnInit, OnDestroy, Paginatio
         merge: true
     };
 
-    /**  @deprecated 2.3.0  Pagination object. */
+    /**
+     * Pagination object.
+     * @deprecated 2.3.0
+     */
     @Input()
     pagination: PaginationModel;
 

--- a/lib/core/viewer/components/viewer.component.ts
+++ b/lib/core/viewer/components/viewer.component.ts
@@ -170,7 +170,7 @@ export class ViewerComponent implements OnChanges, OnInit, OnDestroy {
     /**
      * The template for the sidebar. The template context contains the loaded node data.
      * @deprecated 2.5.0 renamed as sidebarRight
-     * */
+     */
     @Input()
     sidebarTemplate: TemplateRef<any> = null;
 

--- a/lib/core/viewer/components/viewer.component.ts
+++ b/lib/core/viewer/components/viewer.component.ts
@@ -69,8 +69,10 @@ export class ViewerComponent implements OnChanges, OnInit, OnDestroy {
     @Input()
     blobFile: Blob;
 
-    /** @deprecated 2.4.0 use nodeId */
-    /** Node Id of the file to load. */
+    /**
+     * Node Id of the file to load.
+     * @deprecated 2.4.0 use nodeId
+     */
     @Input()
     set fileNodeId(nodeId: string) {
         this.nodeId = nodeId;
@@ -114,8 +116,10 @@ export class ViewerComponent implements OnChanges, OnInit, OnDestroy {
     @Input()
     allowPrint = false;
 
-    /**  @deprecated 2.5.0 inkect the share button directive as custom button */
-    /** Toggles sharing. */
+    /**
+     * Toggles sharing.
+     * @deprecated 2.5.0 - inject the share button directive as custom button
+     */
     @Input()
     allowShare = false;
 
@@ -145,8 +149,10 @@ export class ViewerComponent implements OnChanges, OnInit, OnDestroy {
     @Input()
     allowThumbnails = true;
 
-    /** @deprecated 2.5.0 will be renamed showRightSidebar in 3.0.0  */
-    /** Toggles sidebar visibility. Requires `allowSidebar` to be set to `true`. */
+    /**
+     * Toggles sidebar visibility. Requires `allowSidebar` to be set to `true`.
+     * @deprecated 2.5.0 - will be renamed showRightSidebar in 3.0.0
+     */
     @Input()
     showSidebar = false;
 
@@ -154,13 +160,17 @@ export class ViewerComponent implements OnChanges, OnInit, OnDestroy {
     @Input()
     showLeftSidebar = false;
 
-    /** @deprecated 2.5.0 use sidebarTemplateLeft */
-    /** The position of the sidebar. Can be `left` or `right`. */
+    /**
+     * The position of the sidebar. Can be `left` or `right`.
+     * @deprecated 2.5.0 use sidebarTemplateLeft
+     */
     @Input()
     sidebarPosition = 'right';
 
-    /**  @deprecated 2.5.0 rename sidebarRight */
-    /** The template for the sidebar. The template context contains the loaded node data. */
+    /**
+     * The template for the sidebar. The template context contains the loaded node data.
+     * @deprecated 2.5.0 renamed as sidebarRight
+     * */
     @Input()
     sidebarTemplate: TemplateRef<any> = null;
 

--- a/lib/process-services/task-list/components/task-list.component.ts
+++ b/lib/process-services/task-list/components/task-list.component.ts
@@ -55,7 +55,8 @@ export class TaskListComponent extends DataTableSchema implements OnChanges, Aft
     @Input()
     processDefinitionId: string;
 
-    /** The Definition Key of the process.
+    /**
+     * The Definition Key of the process.
      * @deprecated 2.4.0
      */
     @Input()
@@ -89,7 +90,8 @@ export class TaskListComponent extends DataTableSchema implements OnChanges, Aft
     @Input()
     landingTaskId: string;
 
-    /** Data source object that represents the number and the type of the columns that
+    /**
+     * Data source object that represents the number and the type of the columns that
      * you want to show.
      * @deprecated 2.4.0
      */

--- a/tools/doc/SourceInfoClasses.js
+++ b/tools/doc/SourceInfoClasses.js
@@ -294,6 +294,7 @@ var ComponentInfo = /** @class */ (function () {
         sourceData.items.forEach(function (item) {
             switch (item.type) {
                 case "property":
+                case "accessor":
                     var prop = new PropInfo(item);
                     _this.properties.push(prop);
                     if (prop.isInput) {

--- a/tools/doc/SourceInfoClasses.ts
+++ b/tools/doc/SourceInfoClasses.ts
@@ -370,6 +370,7 @@ export class ComponentInfo {
         sourceData.items.forEach(item => {
             switch(item.type) {
                 case "property":
+                case "accessor":
                     var prop = new PropInfo(item);
                     this.properties.push(prop);
 

--- a/tools/doc/yamlTemplates/propSyntaxSection.ejs
+++ b/tools/doc/yamlTemplates/propSyntaxSection.ejs
@@ -1,0 +1,6 @@
+    syntax:
+      return:
+        type: >-
+          <%- include("type", {type: child.type}).trim() %>
+        defaultValue: >-
+          <%- (child.defaultValue || "").length < 20 ? child.defaultValue : "" %>

--- a/tools/doc/yamlTemplates/property.ejs
+++ b/tools/doc/yamlTemplates/property.ejs
@@ -21,9 +21,3 @@
 <% } -%>
 <%_ }) -%>
 <% } -%>
-    syntax:
-      return:
-        type: >-
-          <%- include("type", {type: child.type}).trim() %>
-        defaultValue: >-
-          <%- (child.defaultValue || "").length < 20 ? child.defaultValue : "" %>

--- a/tools/doc/yamlTemplates/template.ejs
+++ b/tools/doc/yamlTemplates/template.ejs
@@ -29,16 +29,20 @@ items:
 <% } -%>
 <%- include("methodSig", {sig: sig}); -%>
 <% }); %>
-<% } else if (child.kindString === "Property") { -%>
+<% } else if ((child.kindString === "Property") || (child.kindString === "Accessor")) { -%>
   - uid: <%= name %>.<%= child.name %>
     name: <%= child.name %>
     type: <%= child.kindString.toLowerCase() %>
 <%- include("property", {child: child}); -%>
-<% } else if ((child.kindString === "Accessor") && (typeof child.getSignature !== "undefined")) { -%>
-  - uid: <%= name %>.<%= child.name %>
-    name: <%= child.name %>
-    type: <%= child.kindString.toLowerCase() %>
-<%- include("property", {child: child.getSignature}); -%>
+<% if (child.kindString === "Accessor") { -%>
+<% if (typeof child.getSignature !== "undefined") { -%>
+<%- include("propSyntaxSection", {child: child.getSignature}); -%>
+<% } else if (typeof child.setSignature !== "undefined") { -%>
+<%- include("propSyntaxSection", {child: child.setSignature}); -%>
+<% } -%>
+<% } else { -%>
+<%- include("propSyntaxSection", {child: child}); -%>
+<% } -%>
 <% } -%>
 <% }) -%>
 <% } -%>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [x] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Accessor properties were not always shown correctly in doc file property tables. Some deprecated tags in doc comments were not being recognised.

**What is the new behaviour?**

Doc tools modified to deal with accessors correctly in all cases. Deprecated tag feature works but is limited by the source comment format - badly formed comments are now fixed and doc files are updated with the correct deprecation warnings.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
