### PR TITLE
[ADF-3592] remove web-animation-js not needed anymore in angular 6

### DIFF
--- a/demo-shell/src/polyfills.ts
+++ b/demo-shell/src/polyfills.ts
@@ -53,9 +53,6 @@ import 'core-js/es6/set';
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 import 'classlist.js';  // Run `npm install --save classlist.js`.
 
-/** IE10 and IE11 requires the following to support `@angular/animation`. */
-import 'web-animations-js';  // Run `npm install --save web-animations-js`.
-
 /** Evergreen browsers require these. */
 import 'core-js/es6/reflect';
 import 'core-js/es7/reflect';

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "rxjs": "^6.2.2",
     "rxjs-compat": "^6.1.0",
     "systemjs": "0.19.27",
-    "web-animations-js": "2.3.1",
     "zone.js": "~0.8.26"
   },
   "devDependencies": {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [X] Build related changes
> - [ ] Documentation
> - [X] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-3592