### PR TITLE
[ADF-3614] Fix styling bug in Custom Sources Page

### DIFF
--- a/demo-shell/src/app/components/files/files.component.scss
+++ b/demo-shell/src/app/components/files/files.component.scss
@@ -40,7 +40,7 @@
         fill: #00bcd4 !important;
     }
 
-    .adf-lock-button {
+    .adf-data-table-card .adf-lock-button {
         top: -10px;
     }
 

--- a/lib/core/datatable/components/datatable/datatable.component.scss
+++ b/lib/core/datatable/components/datatable/datatable.component.scss
@@ -411,12 +411,18 @@
             .cell-value {
                 display: block;
                 position: absolute;
-                top: 25px;
                 max-width: calc(100% - 2em);
                 white-space: nowrap;
                 overflow: hidden;
                 text-overflow: ellipsis;
                 line-height: 1.12em;
+            }
+
+            /* query for Microsoft IE 11*/
+            @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none) {
+                .cell-value {
+                    top: 100%;
+                }
             }
 
             /* cell stretching content */


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Cell values on Datatable component in Custom Source Page are unaligned because of a previous fix related to IE.
https://issues.alfresco.com/jira/browse/ADF-3614

**What is the new behaviour?**
The previous fix now only targets IE browsers.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-3614