### PR TITLE
[ADF-3642] moved on the end the arrow

### DIFF
--- a/lib/process-services/process-list/components/start-process.component.scss
+++ b/lib/process-services/process-list/components/start-process.component.scss
@@ -30,7 +30,7 @@
         display: flex;
         button {
             position: absolute;
-            right: 0;
+            right: -14px;
             top: 0;
         }
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Arrow is not displayed at the end of the autocomplete


**What is the new behaviour?**
Arrow is displayed at the end of autocomplete


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
