### PR TITLE
[ADF-3644] Automated test for search filters collapse

### DIFF
--- a/e2e/content-services/search/search_filters.e2e.ts
+++ b/e2e/content-services/search/search_filters.e2e.ts
@@ -100,4 +100,18 @@ describe('Search Filters', () => {
         searchFiltersPage.clickSizeShowLessButtonUntilIsNotDisplayed();
     });
 
+    it('[C286556] Search categories should preserve their collapsed/expanded state after the search', () => {
+        browser.get(TestConfig.adf.url + '/search;q=*');
+
+        searchFiltersPage.clickFileTypeFilterHeader();
+        searchFiltersPage.checkFileTypeFilterIsCollapsed();
+        searchFiltersPage.clickFileSizeFilterHeader();
+        searchFiltersPage.checkFileSizeFilterIsCollapsed();
+
+        searchFiltersPage.selectCreator('Administrator');
+
+        searchFiltersPage.checkFileTypeFilterIsCollapsed();
+        searchFiltersPage.checkFileSizeFilterIsCollapsed();
+    });
+
 });

--- a/e2e/content-services/search/search_filters.e2e.ts
+++ b/e2e/content-services/search/search_filters.e2e.ts
@@ -91,13 +91,13 @@ describe('Search Filters', () => {
     it('[C277146] Should Show more/less buttons be hidden when inactive', () => {
         browser.get(TestConfig.adf.url + '/search;q=*');
 
-        searchFiltersPage.checkShowLessButtonIsNotDisplayed();
-        searchFiltersPage.checkSizeShowMoreButtonIsDisplayed();
+        searchFiltersPage.checkCreatedShowLessButtonIsNotDisplayed();
+        searchFiltersPage.checkCreatedShowMoreButtonIsDisplayed();
 
-        searchFiltersPage.clickSizeShowMoreButtonUntilIsNotDisplayed();
-        searchFiltersPage.checkShowLessButtonIsDisplayed();
+        searchFiltersPage.clickCreatedShowMoreButtonUntilIsNotDisplayed();
+        searchFiltersPage.checkCreatedShowLessButtonIsDisplayed();
 
-        searchFiltersPage.clickSizeShowLessButtonUntilIsNotDisplayed();
+        searchFiltersPage.clickCreatedShowLessButtonUntilIsNotDisplayed();
     });
 
     it('[C286556] Search categories should preserve their collapsed/expanded state after the search', () => {

--- a/e2e/pages/adf/searchFiltersPage.ts
+++ b/e2e/pages/adf/searchFiltersPage.ts
@@ -74,6 +74,30 @@ export class SearchFiltersPage {
         result.click();
     }
 
+    clickFileSizeFilterHeader() {
+        let fileSizeFilterHeader = this.fileSizeFilter.element(by.css('mat-expansion-panel-header'));
+        Util.waitUntilElementIsClickable(fileSizeFilterHeader);
+        return fileSizeFilterHeader.click();
+    }
+
+    clickFileTypeFilterHeader() {
+        let fileTypeFilterHeader = this.fileTypeFilter.element(by.css('mat-expansion-panel-header'));
+        Util.waitUntilElementIsClickable(fileTypeFilterHeader);
+        return fileTypeFilterHeader.click();
+    }
+
+    checkFileTypeFilterIsCollapsed() {
+        this.fileTypeFilter.getAttribute('class').then((elementClass) => {
+            expect(elementClass).not.toContain('mat-expanded');
+        });
+    }
+
+    checkFileSizeFilterIsCollapsed() {
+        this.fileSizeFilter.getAttribute('class').then((elementClass) => {
+            expect(elementClass).not.toContain('mat-expanded');
+        });
+    }
+
     filterByFileType(fileType) {
         this.checkFileTypeFilterIsDisplayed();
 

--- a/e2e/pages/adf/searchFiltersPage.ts
+++ b/e2e/pages/adf/searchFiltersPage.ts
@@ -26,9 +26,9 @@ export class SearchFiltersPage {
     creatorFilter = element(by.css('mat-expansion-panel[data-automation-id="expansion-panel-SEARCH.FACET_FIELDS.CREATOR"]'));
     searchCreatorFilter = element(by.css('input[data-automation-id="facet-result-filter-SEARCH.FACET_FIELDS.CREATOR"]'));
     fileSizeFilter = element(by.css('mat-expansion-panel[data-automation-id="expansion-panel-SEARCH.FACET_FIELDS.SIZE"]'));
-    showMoreButtonForSize = element(by.css('mat-expansion-panel[data-automation-id="expansion-panel-SEARCH.FACET_FIELDS.SIZE"] button[title="Show more"]'));
-    showLessButtonForSize = element(by.css('mat-expansion-panel[data-automation-id="expansion-panel-SEARCH.FACET_FIELDS.SIZE"] button[title="Show less"]'));
-    numberOfCheckboxesForSize = element.all(by.css('mat-checkbox[data-automation-id*="checkbox-SEARCH.FACET_FIELDS.SIZE"]'));
+    createdFilter = element(by.css('mat-expansion-panel[data-automation-id="expansion-panel-SEARCH.FACET_FIELDS.CREATED"'));
+    showMoreButtonForCreated = this.createdFilter.element(by.css('button[title="Show more"]'));
+    showLessButtonForCreated = this.createdFilter.element(by.css('button[title="Show less"]'));
 
     checkSearchFiltersIsDisplayed() {
         Util.waitUntilElementIsVisible(this.searchFilters);
@@ -128,53 +128,42 @@ export class SearchFiltersPage {
         return Util.waitUntilElementIsNotOnPage(element(by.cssContainingText('mat-chip', ` ${creatorFirstName} ${creatorLastName} `)).element(by.css('mat-icon')));
     }
 
-    clickSizeShowMoreButtonUntilIsNotDisplayed() {
-        Util.waitUntilElementIsVisible(this.fileSizeFilter);
+    clickCreatedShowMoreButtonUntilIsNotDisplayed() {
+        Util.waitUntilElementIsVisible(this.createdFilter);
 
-        this.showMoreButtonForSize.isDisplayed().then(async (visible) => {
+        this.showMoreButtonForCreated.isDisplayed().then(async (visible) => {
             if (visible) {
-                for (let checkboxes = 5; checkboxes <= totalNumberOfCheckboxes; checkboxes + 5) {
-                    let totalNumberOfCheckboxes = await numberOfCheckboxesForSize.count();
+                this.showMoreButtonForCreated.click();
 
-                    expect(totalNumberOfCheckboxes).toEqual(checkboxes);
-                }
-                this.showMoreButtonForSize.click();
-
-                this.clickSizeShowMoreButtonUntilIsNotDisplayed();
+                this.clickCreatedShowMoreButtonUntilIsNotDisplayed();
             }
         }, err => {
         });
     }
 
-    checkSizeShowMoreButtonIsDisplayed() {
-        Util.waitUntilElementIsVisible(this.showMoreButtonForSize);
+    checkCreatedShowMoreButtonIsDisplayed() {
+        Util.waitUntilElementIsVisible(this.showMoreButtonForCreated);
     }
 
-    clickSizeShowLessButtonUntilIsNotDisplayed() {
-        Util.waitUntilElementIsVisible(this.fileSizeFilter);
+    clickCreatedShowLessButtonUntilIsNotDisplayed() {
+        Util.waitUntilElementIsVisible(this.createdFilter);
 
-        this.showLessButtonForSize.isDisplayed().then(async (visible) => {
+        this.showLessButtonForCreated.isDisplayed().then(async (visible) => {
             if (visible) {
-                let totalNumberOfCheckboxes = await this.numberOfCheckboxesForSize.count();
+                this.showLessButtonForCreated.click();
 
-                for (let checkboxes = totalNumberOfCheckboxes; checkboxes > 10; checkboxes = totalNumberOfCheckboxes - checkboxes) {
-                    expect(totalNumberOfCheckboxes).toEqual(checkboxes);
-                }
-
-                this.showLessButtonForSize.click();
-
-                this.clickSizeShowLessButtonUntilIsNotDisplayed();
+                this.clickCreatedShowLessButtonUntilIsNotDisplayed();
             }
         }, err => {
         });
     }
 
-    checkShowLessButtonIsNotDisplayed() {
-        Util.waitUntilElementIsNotVisible(this.showLessButtonForSize);
+    checkCreatedShowLessButtonIsNotDisplayed() {
+        Util.waitUntilElementIsNotVisible(this.showLessButtonForCreated);
     }
 
-    checkShowLessButtonIsDisplayed() {
-        Util.waitUntilElementIsVisible(this.showLessButtonForSize);
+    checkCreatedShowLessButtonIsDisplayed() {
+        Util.waitUntilElementIsVisible(this.showLessButtonForCreated);
     }
 
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe:
Automated test to check that collapsed search filters stay collapsed after search.

**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
Bug : https://issues.alfresco.com/jira/browse/ADF-3536