### PR TITLE
[ADF-3645] Rectoring names of e2e for shared link

### DIFF
--- a/e2e/content-services/share-file/share_file.e2e.ts
+++ b/e2e/content-services/share-file/share_file.e2e.ts
@@ -86,14 +86,14 @@ describe('Share file', () => {
             done();
         });
 
-        it('[C286549] Share toggle button is checked automatically', () => {
+        it('[C286549] Should check automatically toggle button in Share dialog', () => {
             contentListPage.clickRowToSelect(pngFileModel.name);
             contentServicesPage.clickShareButton();
             shareDialog.checkDialogIsDisplayed();
             shareDialog.shareToggleButtonIsChecked();
         });
 
-        it('[C286544] Copy shared link button action shows notification', () => {
+        it('[C286544] Should display notification when clicking URL copy button', () => {
             contentListPage.clickRowToSelect(pngFileModel.name);
             contentServicesPage.clickShareButton();
             shareDialog.checkDialogIsDisplayed();
@@ -101,7 +101,7 @@ describe('Share file', () => {
             shareDialog.checkNotificationWithMessage('Link copied to the clipboard');
         });
 
-        it('[C286328] User can close the Share dialog', () => {
+        it('[C286543] Should be possible to close Share dialog', () => {
             contentListPage.clickRowToSelect(pngFileModel.name);
             contentServicesPage.clickShareButton();
             shareDialog.checkDialogIsDisplayed();
@@ -110,7 +110,7 @@ describe('Share file', () => {
             shareDialog.dialogIsClosed();
         });
 
-        it('[C286578] Expiration day calendar should have today day option disabled', () => {
+        it('[C286578] Should disable today option in expiration day calendar', () => {
             contentListPage.clickRowToSelect(pngFileModel.name);
             contentServicesPage.clickShareButton();
             shareDialog.checkDialogIsDisplayed();
@@ -118,7 +118,7 @@ describe('Share file', () => {
             shareDialog.calendarTodayDayIsDisabled();
         });
 
-        it('[C286548] User can set when the shared file link expires', async () => {
+        it('[C286548] Should be possible to set expiry date for link', async () => {
             contentListPage.clickRowToSelect(pngFileModel.name);
             contentServicesPage.clickShareButton();
             shareDialog.checkDialogIsDisplayed();
@@ -143,7 +143,7 @@ describe('Share file', () => {
             done();
         });
 
-        it('[C286565] Logged user can open shared link', async () => {
+        it('[C286565] Should open file when logged user access shared link', async () => {
             contentListPage.clickRowToSelect(pngFileModel.name);
             contentServicesPage.clickShareButton();
             shareDialog.checkDialogIsDisplayed();
@@ -154,7 +154,7 @@ describe('Share file', () => {
             viewerPage.checkFileNameIsDisplayed(pngFileModel.name);
         });
 
-        it('[C286539] A non-logged user should see the shared file in the viewer', async () => {
+        it('[C286539] Should open file when non-logged user access shared link', async () => {
             contentListPage.clickRowToSelect(pngFileModel.name);
             contentServicesPage.clickShareButton();
             shareDialog.checkDialogIsDisplayed();

--- a/e2e/content-services/share-file/unshare_file.e2e.ts
+++ b/e2e/content-services/share-file/unshare_file.e2e.ts
@@ -117,7 +117,7 @@ describe('Unshare file', () => {
             done();
         });
 
-        it('[C286550] Unshare action opens confirmation dialog', () => {
+        it('[C286550] Should display unshare confirmation dialog', () => {
             contentListPage.clickRowToSelect(pngFileModel.name);
             contentServicesPage.clickShareButton();
             shareDialog.checkDialogIsDisplayed();
@@ -125,7 +125,7 @@ describe('Unshare file', () => {
             shareDialog.confirmationDialogIsDisplayed();
         });
 
-        it('[C286551] Cancel unshare file action', () => {
+        it('[C286551] Should be able to cancel unshare action', () => {
             contentListPage.clickRowToSelect(pngFileModel.name);
             contentServicesPage.clickShareButton();
             shareDialog.checkDialogIsDisplayed();
@@ -135,7 +135,7 @@ describe('Unshare file', () => {
             shareDialog.shareToggleButtonIsChecked();
         });
 
-        it('[C286552] Confirm unshare file action', async () => {
+        it('[C286552] Should be able to confirm unshare action', async () => {
             contentListPage.clickRowToSelect(pngFileModel.name);
             contentServicesPage.clickShareButton();
             shareDialog.checkDialogIsDisplayed();
@@ -145,7 +145,7 @@ describe('Unshare file', () => {
             shareDialog.shareToggleButtonIsChecked();
         });
 
-        it('[C280556] Unshared file should show 404 page', async() => {
+        it('[C280556] Should redirect to 404 when trying to access an unshared file', async() => {
             contentListPage.clickRowToSelect(pngFileModel.name);
             contentServicesPage.clickShareButton();
             shareDialog.checkDialogIsDisplayed();
@@ -166,7 +166,7 @@ describe('Unshare file', () => {
             done();
         });
 
-        it('[C286555] User without permission cannot remove shared file', () => {
+        it('[C286555] Should NOT be able to unshare file without permission', () => {
             navBar.goToSite(testSite);
             contentListPage.navigateToFolder('documentLibrary');
             contentListPage.clickRowToSelect(nodeBody.name);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe:
Making sure that automated test introduced for shared link follow ADF specifications (naming, test cases ID etc)

**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
