### PR TITLE
delayed document list spinner

### DIFF
--- a/lib/content-services/document-list/components/document-list.component.ts
+++ b/lib/content-services/document-list/components/document-list.component.ts
@@ -239,6 +239,7 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
     private layoutPresets = {};
     private subscriptions: Subscription[] = [];
     private rowMenuCache: { [key: string]: ContentActionModel[] } = {};
+    private loadingTimeout;
 
     constructor(private documentListService: DocumentListService,
                 private ngZone: NgZone,
@@ -571,9 +572,21 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
         }
     }
 
+    private setLoadingState(value: boolean) {
+        if (value) {
+            clearTimeout(this.loadingTimeout);
+            this.loadingTimeout = setTimeout(() => {
+                this.loading = true;
+            }, 1000);
+        } else {
+            clearTimeout(this.loadingTimeout);
+            this.loading = false;
+        }
+    }
+
     loadFolder() {
         if (!this.pagination.getValue().merge) {
-            this.loading = true;
+            this.setLoadingState(true);
         }
 
         if (!this.hasCustomLayout) {
@@ -622,7 +635,7 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
                 .subscribe(
                     nodePaging => {
                         this.data.loadPage(<NodePaging> nodePaging, this.pagination.getValue().merge);
-                        this.loading = false;
+                        this.setLoadingState(false);
                         this.onDataReady(nodePaging);
                         resolve(true);
                     }, err => {
@@ -640,7 +653,7 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
     onPageLoaded(nodePaging: NodePaging) {
         if (nodePaging) {
             this.data.loadPage(nodePaging, this.pagination.getValue().merge);
-            this.loading = false;
+            this.setLoadingState(false);
             this.onDataReady(nodePaging);
         }
     }
@@ -829,7 +842,7 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
     private handleError(err: any) {
         if (err.message) {
             if (JSON.parse(err.message).error.statusCode === 403) {
-                this.loading = false;
+                this.setLoadingState(false);
                 this.noPermission = true;
             }
         }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

delay document list "loading" spinner for 1 second,
if the server response is fast enough the users won't see flickering of UI

testing: enable network throttling  to GPRS to make responses slow.

**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
