### PR TITLE
[APM-520] Fixing typescript compilation error to work together with AMA

### DIFF
--- a/lib/core/viewer/components/txtViewer.component.ts
+++ b/lib/core/viewer/components/txtViewer.component.ts
@@ -34,7 +34,7 @@ export class TxtViewerComponent implements OnChanges {
     @Input()
     blobFile: Blob;
 
-    content: string;
+    content: string | ArrayBuffer;
 
     constructor(private http: HttpClient) {
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [x] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Typescript error is thrown when using local copy of ng2-components from AMA:

```
ERROR in ../alfresco-ng2-components/lib/core/viewer/components/txtViewer.component.ts(75,17): error TS2322: Type 'string | ArrayBuffer' is not assignable to type 'string'.
  Type 'ArrayBuffer' is not assignable to type 'string'.
```


**What is the new behaviour?**
Fixed


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
