### PR TITLE
 [ADF-3655] Fix styles on date, date-time and people widgets

### DIFF
--- a/lib/core/form/components/widgets/date-time/date-time.widget.scss
+++ b/lib/core/form/components/widgets/date-time/date-time.widget.scss
@@ -18,6 +18,7 @@
         &-date-widget {
             .mat-form-field-suffix {
                 position: relative;
+                width: auto;
             }
         }
     }

--- a/lib/core/form/components/widgets/date/date.widget.scss
+++ b/lib/core/form/components/widgets/date/date.widget.scss
@@ -36,6 +36,7 @@
         &-date-widget {
             .mat-form-field-suffix {
                 position: relative;
+                width: auto;
             }
         }
     }

--- a/lib/process-services/task-list/components/start-task.component.scss
+++ b/lib/process-services/task-list/components/start-task.component.scss
@@ -62,24 +62,24 @@
         padding-top: 0;
     }
 
-    #people-widget-content {
-        .mat-form-field {
-            width: 100%;
-        }
-        .adf-label {
-            line-height: 0;
-        }
-        .adf-error-text-container {
-            margin-top: -10px;
-        }
-    }
-
     adf-start-task {
 
         people-widget {
             width: 100%;
             .mat-form-field-label-wrapper {
                 top: -14px !important;
+            }
+        }
+
+        #people-widget-content {
+            .mat-form-field {
+                width: 100%;
+            }
+            .adf-label {
+                line-height: 0;
+            }
+            .adf-error-text-container {
+                margin-top: -10px;
             }
         }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-3655
Date and date-time widget inputs don't show on IE 11.
People widget inherits styles from start task component and this affects its own styles when it's displayed on a form.

**What is the new behaviour?**
Date and date-time widgets now show the input on IE 11.
Start task component styles now only affect the people widget within that component.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-3655