### PR TITLE
 [ADF-3719] added rendition when creating a shared link

### DIFF
--- a/lib/content-services/content-node-share/content-node-share.dialog.spec.ts
+++ b/lib/content-services/content-node-share/content-node-share.dialog.spec.ts
@@ -18,13 +18,14 @@
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TestBed, fakeAsync, async } from '@angular/core/testing';
 import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material';
-import { of } from 'rxjs';
+import { of, empty } from 'rxjs';
 import {
     setupTestBed,
     CoreModule,
     SharedLinksApiService,
     NodesApiService,
-    NotificationService
+    NotificationService,
+    RenditionsService
 } from '@alfresco/adf-core';
 import { ContentNodeShareModule } from './content-node-share.module';
 import { ShareDialogComponent } from './content-node-share.dialog';
@@ -37,6 +38,7 @@ describe('ShareDialogComponent', () => {
         openSnackMessage: jasmine.createSpy('openSnackMessage')
     };
     let sharedLinksApiService: SharedLinksApiService;
+    let renditionService: RenditionsService;
     let nodesApiService: NodesApiService;
     let fixture;
     let component;
@@ -60,6 +62,7 @@ describe('ShareDialogComponent', () => {
         fixture = TestBed.createComponent(ShareDialogComponent);
         matDialog = TestBed.get(MatDialog);
         sharedLinksApiService = TestBed.get(SharedLinksApiService);
+        renditionService = TestBed.get(RenditionsService);
         nodesApiService = TestBed.get(NodesApiService);
         component = fixture.componentInstance;
     });
@@ -83,6 +86,7 @@ describe('ShareDialogComponent', () => {
         spyOn(sharedLinksApiService, 'createSharedLinks').and.returnValue(of({
             entry: { id: 'sharedId', sharedId: 'sharedId' }
         }));
+        spyOn(renditionService, 'generateRenditionForNode').and.returnValue(empty());
 
         component.data = {
             node,
@@ -92,12 +96,14 @@ describe('ShareDialogComponent', () => {
         fixture.detectChanges();
 
         expect(sharedLinksApiService.createSharedLinks).toHaveBeenCalled();
+        expect(renditionService.generateRenditionForNode).toHaveBeenCalled();
         expect(fixture.nativeElement.querySelector('input[formcontrolname="sharedUrl"]').value).toBe('some-url/sharedId');
         expect(fixture.nativeElement.querySelector('.mat-slide-toggle').classList).toContain('mat-checked');
     });
 
     it(`should not toggle share action when file has 'sharedId' property`, async(() => {
         spyOn(sharedLinksApiService, 'createSharedLinks');
+        spyOn(renditionService, 'generateRenditionForNode').and.returnValue(empty());
 
         node.entry.properties['qshare:sharedId'] = 'sharedId';
 

--- a/lib/content-services/content-node-share/content-node-share.dialog.ts
+++ b/lib/content-services/content-node-share/content-node-share.dialog.ts
@@ -31,7 +31,8 @@ import { tap, skip } from 'rxjs/operators';
 import {
     SharedLinksApiService,
     NodesApiService,
-    ContentService
+    ContentService,
+    RenditionsService
 } from '@alfresco/adf-core';
 import { SharedLinkEntry, MinimalNodeEntryEntity } from 'alfresco-js-api';
 import { ConfirmDialogComponent } from '../dialogs/confirm.dialog';
@@ -66,6 +67,7 @@ export class ShareDialogComponent implements OnInit, OnDestroy {
         private dialog: MatDialog,
         private nodesApiService: NodesApiService,
         private contentService: ContentService,
+        private renditionService: RenditionsService,
         @Inject(MAT_DIALOG_DATA) public data: any) {
     }
 
@@ -94,6 +96,7 @@ export class ShareDialogComponent implements OnInit, OnDestroy {
             if (properties && !properties['qshare:sharedId']) {
 
                 this.createSharedLinks(this.data.node.entry.id);
+
             } else {
                 this.sharedId = properties['qshare:sharedId'];
                 this.isFileShared = true;
@@ -157,6 +160,7 @@ export class ShareDialogComponent implements OnInit, OnDestroy {
                     this.data.node.entry.properties['qshare:sharedId'] = this.sharedId;
                     this.isDisabled = false;
                     this.isFileShared = true;
+                    this.renditionService.generateRenditionForNode(this.data.node.entry.id).subscribe();
 
                     this.updateForm();
                 }

--- a/lib/core/mock/renditionsService.mock.ts
+++ b/lib/core/mock/renditionsService.mock.ts
@@ -110,3 +110,77 @@ export let fakeRenditionsList = {
         ]
     }
 };
+
+export let fakeRenditionsListWithACreated = {
+    list: {
+        pagination: {
+            count: 6,
+            hasMoreItems: false,
+            totalItems: 6,
+            skipCount: 0,
+            maxItems: 100
+        },
+        entries: [
+            {
+                entry: {
+                    id: 'avatar',
+                    content: {
+                        mimeType: 'image/png',
+                        mimeTypeName: 'PNG Image'
+                    },
+                    status: 'NOT_CREATED'
+                }
+            },
+            {
+                entry: {
+                    id: 'avatar32',
+                    content: {
+                        mimeType: 'image/png',
+                        mimeTypeName: 'PNG Image'
+                    },
+                    status: 'NOT_CREATED'
+                }
+            },
+            {
+                entry: {
+                    id: 'doclib',
+                    content: {
+                        mimeType: 'image/png',
+                        mimeTypeName: 'PNG Image'
+                    },
+                    status: 'NOT_CREATED'
+                }
+            },
+            {
+                entry: {
+                    id: 'imgpreview',
+                    content: {
+                        mimeType: 'image/jpeg',
+                        mimeTypeName: 'JPEG Image'
+                    },
+                    status: 'NOT_CREATED'
+                }
+            },
+            {
+                entry: {
+                    id: 'medium',
+                    content: {
+                        mimeType: 'image/jpeg',
+                        mimeTypeName: 'JPEG Image'
+                    },
+                    status: 'NOT_CREATED'
+                }
+            },
+            {
+                entry: {
+                    id: 'pdf',
+                    content: {
+                        mimeType: 'application/pdf',
+                        mimeTypeName: 'Adobe PDF Document'
+                    },
+                    status: 'CREATED'
+                }
+            }
+        ]
+    }
+};

--- a/lib/core/services/renditions.service.spec.ts
+++ b/lib/core/services/renditions.service.spec.ts
@@ -16,12 +16,13 @@
  */
 
 import { TestBed } from '@angular/core/testing';
-import { fakeRendition, fakeRenditionCreated, fakeRenditionsList } from '../mock/renditionsService.mock';
+import { fakeRendition, fakeRenditionCreated, fakeRenditionsList, fakeRenditionsListWithACreated } from '../mock/renditionsService.mock';
 import { RenditionsService } from './renditions.service';
 import { setupTestBed } from '../testing/setupTestBed';
 import { CoreModule } from '../core.module';
 import { AlfrescoApiService } from './alfresco-api.service';
 import { AlfrescoApiServiceMock } from '../mock/alfresco-api.service.mock';
+import { RenditionEntry } from 'alfresco-js-api';
 
 declare let jasmine: any;
 
@@ -44,6 +45,34 @@ describe('RenditionsService', () => {
 
     afterEach(() => {
         jasmine.Ajax.uninstall();
+    });
+
+    it('Should return the image rendition for the file if no rendition is already available', (done) => {
+        service.getAvailableRenditionForNode('fake-node-id').subscribe((res: RenditionEntry) => {
+            expect(res.entry.status).toBe('NOT_CREATED');
+            expect(res.entry.id).toBe('imgpreview');
+            done();
+        });
+
+        jasmine.Ajax.requests.mostRecent().respondWith({
+            'status': 200,
+            contentType: 'application/json',
+            responseText: JSON.stringify(fakeRenditionsList)
+        });
+    });
+
+    it('Should return the available rendition for the file', (done) => {
+        service.getAvailableRenditionForNode('fake-node-id').subscribe((res: RenditionEntry) => {
+            expect(res.entry.status).toBe('CREATED');
+            expect(res.entry.id).toBe('pdf');
+            done();
+        });
+
+        jasmine.Ajax.requests.mostRecent().respondWith({
+            'status': 200,
+            contentType: 'application/json',
+            responseText: JSON.stringify(fakeRenditionsListWithACreated)
+        });
     });
 
     it('Get rendition list service should return the list', (done) => {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
No rendition is generated for the file by default so some of the file are not rendered on the viewer when this happen


**What is the new behaviour?**
When user ask for share link of a file a rendition will be generated whenever there's no one available.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-3719