### PR TITLE
[ADF-3763] fixed subscription for node child and invalid node id

### DIFF
--- a/demo-shell/src/app/components/tree-view/tree-view-sample.component.html
+++ b/demo-shell/src/app/components/tree-view/tree-view-sample.component.html
@@ -1,10 +1,19 @@
 <div>TREE VIEW TEST</div>
 <mat-form-field class="example-full-width">
-    <input matInput placeholder="Node Id" [(ngModel)]="nodeIdSample">
+    <input matInput placeholder="Node Id"
+                [(ngModel)]="nodeIdSample"
+                (ngModelChange)="reset()">
 </mat-form-field>
 <span>
     CLICKED NODE: {{clickedNodeName}}
 </span>
 
-<adf-tree-view-list [nodeId]="nodeIdSample" (nodeClicked)="onClick($event)">
+<adf-tree-view-list *ngIf="!errorMessage; else erroOccurred"
+        [nodeId]="nodeIdSample"
+        (nodeClicked)="onClick($event)"
+        (error)="onErrorOccurred($event)">
 </adf-tree-view-list>
+<ng-template #erroOccurred>
+    <span>An Error Occurred </span>
+    <span>{{errorMessage}}</span>
+</ng-template>

--- a/demo-shell/src/app/components/tree-view/tree-view-sample.component.ts
+++ b/demo-shell/src/app/components/tree-view/tree-view-sample.component.ts
@@ -25,10 +25,21 @@ import { Component } from '@angular/core';
 export class TreeViewSampleComponent {
 
     clickedNodeName: string = '';
+    errorMessage = '';
 
     nodeIdSample: string = '-my-';
 
     onClick(node) {
         this.clickedNodeName = node.entry.name;
+    }
+
+    reset() {
+        this.clickedNodeName = '';
+        this.errorMessage = '';
+    }
+
+    onErrorOccurred(error) {
+        this.clickedNodeName = '';
+        this.errorMessage = error;
     }
 }

--- a/docs/content-services/tree-view.component.md
+++ b/docs/content-services/tree-view.component.md
@@ -30,3 +30,4 @@ Shows the folder and subfolders of a node as a tree view.
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | nodeClicked | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`NodeEntry`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/NodeEntry.md)`>` | Emitted when a node in the tree view is clicked. |
+| error | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<any>` | Emitted when an invalid node id is given. |

--- a/docs/content-services/tree-view.component.md
+++ b/docs/content-services/tree-view.component.md
@@ -29,5 +29,5 @@ Shows the folder and subfolders of a node as a tree view.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| nodeClicked | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`NodeEntry`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/NodeEntry.md)`>` | Emitted when a node in the tree view is clicked. |
 | error | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<any>` | Emitted when an invalid node id is given. |
+| nodeClicked | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`NodeEntry`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/NodeEntry.md)`>` | Emitted when a node in the tree view is clicked. |

--- a/lib/content-services/tree-view/components/tree-view.component.html
+++ b/lib/content-services/tree-view/components/tree-view.component.html
@@ -1,9 +1,12 @@
-<mat-tree class="adf-tree-view-main" [dataSource]="dataSource" [treeControl]="treeControl" *ngIf="nodeId; else missingNodeId">
-    <mat-tree-node class="adf-tree-view-node" *matTreeNodeDef="let treeNode" id="{{treeNode.name + '-tree-node'}}"
+<mat-tree class="adf-tree-view-main" [dataSource]="dataSource"
+          [treeControl]="treeControl" *ngIf="nodeId; else missingNodeId">
+    <mat-tree-node class="adf-tree-view-node"
+        *matTreeNodeDef="let treeNode" id="{{treeNode.name + '-tree-node'}}"
         matTreeNodePadding [matTreeNodePaddingIndent]="15">
         {{treeNode.name}}
     </mat-tree-node>
-    <mat-tree-node class="adf-tree-view-node" id="{{treeNode.name + '-tree-child-node'}}" *matTreeNodeDef="let treeNode; when: hasChild"
+    <mat-tree-node class="adf-tree-view-node"
+        id="{{treeNode.name + '-tree-child-node'}}" *matTreeNodeDef="let treeNode; when: hasChild"
         matTreeNodePadding [matTreeNodePaddingIndent]="15">
         <button id="{{'button-'+treeNode.name}}" (click)="onNodeClicked(treeNode.node)"
                 mat-icon-button [attr.aria-label]="'toggle ' + treeNode.filename" matTreeNodeToggle>

--- a/lib/content-services/tree-view/components/tree-view.component.spec.ts
+++ b/lib/content-services/tree-view/components/tree-view.component.spec.ts
@@ -24,8 +24,8 @@ import { of, throwError } from 'rxjs';
 import { TreeBaseNode } from '../models/tree-view.model';
 import { NodeEntry } from 'alfresco-js-api';
 import { SimpleChange } from '@angular/core';
-/*tslint:disable*/
-fdescribe('TreeViewComponent', () => {
+
+describe('TreeViewComponent', () => {
 
     let fixture: ComponentFixture<TreeViewComponent>;
     let element: HTMLElement;

--- a/lib/content-services/tree-view/components/tree-view.component.ts
+++ b/lib/content-services/tree-view/components/tree-view.component.ts
@@ -16,7 +16,7 @@
  */
 
 import { FlatTreeControl } from '@angular/cdk/tree';
-import { Component, Input, OnInit, OnChanges, SimpleChanges, Output, EventEmitter } from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges, Output, EventEmitter } from '@angular/core';
 import { TreeBaseNode } from '../models/tree-view.model';
 import { TreeViewDataSource } from '../data/tree-view-datasource';
 import { TreeViewService } from '../services/tree-view.service';
@@ -28,7 +28,7 @@ import { NodeEntry } from 'alfresco-js-api';
     styleUrls: ['tree-view.component.scss']
 })
 
-export class TreeViewComponent implements OnInit, OnChanges {
+export class TreeViewComponent implements OnChanges {
 
     /** Identifier of the node to display. */
     @Input()
@@ -38,6 +38,9 @@ export class TreeViewComponent implements OnInit, OnChanges {
     @Output()
     nodeClicked: EventEmitter<NodeEntry> = new EventEmitter();
 
+    @Output()
+    error: EventEmitter<any> = new EventEmitter();
+
     treeControl: FlatTreeControl<TreeBaseNode>;
     dataSource: TreeViewDataSource;
 
@@ -46,16 +49,12 @@ export class TreeViewComponent implements OnInit, OnChanges {
         this.dataSource = new TreeViewDataSource(this.treeControl, this.treeViewService);
     }
 
-    ngOnInit() {
-        if (this.nodeId) {
-            this.loadTreeNode();
-        }
-    }
-
     ngOnChanges(changes: SimpleChanges) {
-        if (changes['nodeId'].currentValue &&
+        if (changes['nodeId'] && changes['nodeId'].currentValue &&
             changes['nodeId'].currentValue !== changes['nodeId'].previousValue) {
             this.loadTreeNode();
+        } else {
+            this.dataSource.data = [];
         }
     }
 
@@ -74,6 +73,8 @@ export class TreeViewComponent implements OnInit, OnChanges {
             .subscribe(
                 (treeNode: TreeBaseNode[]) => {
                     this.dataSource.data = treeNode;
-                });
+                },
+                (error) => this.error.emit(error)
+            );
     }
 }

--- a/lib/content-services/tree-view/components/tree-view.component.ts
+++ b/lib/content-services/tree-view/components/tree-view.component.ts
@@ -38,6 +38,7 @@ export class TreeViewComponent implements OnChanges {
     @Output()
     nodeClicked: EventEmitter<NodeEntry> = new EventEmitter();
 
+    /** Emitted when an invalid node id is given. */
     @Output()
     error: EventEmitter<any> = new EventEmitter();
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Changing node id will append subscription and trigger several times the children queries.
Invalid node id fails silently


**What is the new behaviour?**
Change node will disconnect and unsubscribe the datasource.
Invalid node trigger an error event.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-3763
https://issues.alfresco.com/jira/browse/ADF-3765