### PR TITLE
[ADF-3792] Added title metadata field to doc files

### DIFF
--- a/docs/content-services/add-permission-dialog.component.md
+++ b/docs/content-services/add-permission-dialog.component.md
@@ -1,4 +1,5 @@
 ---
+Title: Add Permission Dialog Component
 Added: v2.4.0
 Status: Active
 Last reviewed: 2018-11-13

--- a/docs/content-services/add-permission-panel.component.md
+++ b/docs/content-services/add-permission-panel.component.md
@@ -1,4 +1,5 @@
 ---
+Title: Add Permission Panel Component
 Added: v2.4.0
 Status: Active
 Last reviewed: 2018-11-14

--- a/docs/content-services/add-permission.component.md
+++ b/docs/content-services/add-permission.component.md
@@ -1,4 +1,5 @@
 ---
+Title: Add Permission Component
 Added: v2.4.0
 Status: Active
 Last reviewed: 2018-11-19

--- a/docs/content-services/breadcrumb.component.md
+++ b/docs/content-services/breadcrumb.component.md
@@ -1,4 +1,5 @@
 ---
+Title: Breadcrumb Component
 Added: v2.0.0
 Status: Active
 Last reviewed: 2018-06-08

--- a/docs/content-services/content-action.component.md
+++ b/docs/content-services/content-action.component.md
@@ -1,4 +1,5 @@
 ---
+Title: Content Action component
 Added: v2.0.0
 Status: Active
 Last reviewed: 2018-11-20

--- a/docs/content-services/content-metadata-card.component.md
+++ b/docs/content-services/content-metadata-card.component.md
@@ -1,4 +1,5 @@
 ---
+Title: Content Metadata Card component
 Added: v2.1.0
 Status: Active
 Last reviewed: 2018-08-07

--- a/docs/content-services/content-metadata.component.md
+++ b/docs/content-services/content-metadata.component.md
@@ -1,4 +1,5 @@
 ---
+Title: Content Metadata Card component
 Added: v2.1.0
 Status: Active
 Last reviewed: 2018-08-07

--- a/docs/content-services/content-node-dialog.service.md
+++ b/docs/content-services/content-node-dialog.service.md
@@ -1,4 +1,5 @@
 ---
+Title: Content Node Dialog service
 Added: v2.1.0
 Status: Active
 Last reviewed: 2018-11-14

--- a/docs/content-services/content-node-selector-panel.component.md
+++ b/docs/content-services/content-node-selector-panel.component.md
@@ -1,4 +1,5 @@
 ---
+Title: Content Node Selector Panel component
 Added: v2.1.0
 Status: Active
 Last reviewed: 2018-11-19

--- a/docs/content-services/content-node-selector.component.md
+++ b/docs/content-services/content-node-selector.component.md
@@ -1,4 +1,5 @@
 ---
+Title: Content Node Selector component
 Added: v2.0.0
 Status: Active
 Last reviewed: 2018-04-18

--- a/docs/content-services/content-node-share.directive.md
+++ b/docs/content-services/content-node-share.directive.md
@@ -1,4 +1,5 @@
 ---
+Title: Node Public File Share Directive
 Added: v2.3.0
 Status: Active
 Last reviewed: 2018-09-13

--- a/docs/content-services/custom-resources.service.md
+++ b/docs/content-services/custom-resources.service.md
@@ -1,4 +1,5 @@
 ---
+Title: Custom Resources service
 Added: v2.3.0
 Status: Active
 Last reviewed: 2018-11-16

--- a/docs/content-services/document-actions.service.md
+++ b/docs/content-services/document-actions.service.md
@@ -1,4 +1,5 @@
 ---
+Title: Document Actions service
 Added: v2.0.0
 Status: Active
 Last reviewed: 2018-11-13

--- a/docs/content-services/document-library.model.md
+++ b/docs/content-services/document-library.model.md
@@ -1,4 +1,5 @@
 ---
+Title: Document Library model
 Added: v2.0.0
 Status: Active
 ---

--- a/docs/content-services/document-list.component.md
+++ b/docs/content-services/document-list.component.md
@@ -1,4 +1,5 @@
 ---
+Title: Document List component
 Added: v2.0.0
 Status: Active
 Last reviewed: 2018-11-12

--- a/docs/content-services/document-list.service.md
+++ b/docs/content-services/document-list.service.md
@@ -1,4 +1,5 @@
 ---
+Title: Document List service
 Added: v2.0.0
 Status: Active
 Last reviewed: 2018-09-13

--- a/docs/content-services/dropdown-breadcrumb.component.md
+++ b/docs/content-services/dropdown-breadcrumb.component.md
@@ -1,4 +1,5 @@
 ---
+Title: Dropdown Breadcrumb Component
 Added: v2.0.0
 Status: Active
 Last reviewed: 2018-06-08

--- a/docs/content-services/file-draggable.directive.md
+++ b/docs/content-services/file-draggable.directive.md
@@ -1,4 +1,5 @@
 ---
+Title: File Draggable directive
 Added: v2.0.0
 Status: Active
 Last reviewed: 2018-04-10

--- a/docs/content-services/file-uploading-dialog.component.md
+++ b/docs/content-services/file-uploading-dialog.component.md
@@ -1,4 +1,5 @@
 ---
+Title: File Uploading Dialog Component
 Added: v2.0.0
 Status: Active
 Last reviewed: 2018-11-20

--- a/docs/content-services/folder-actions.service.md
+++ b/docs/content-services/folder-actions.service.md
@@ -1,4 +1,5 @@
 ---
+Title: Folder Actions service
 Added: v2.0.0
 Status: Active
 Last reviewed: 2018-11-13

--- a/docs/content-services/folder-create.directive.md
+++ b/docs/content-services/folder-create.directive.md
@@ -1,4 +1,5 @@
 ---
+Title: Folder Create directive
 Added: v2.0.0
 Status: Active
 Last reviewed: 2018-11-20

--- a/docs/content-services/folder-edit.directive.md
+++ b/docs/content-services/folder-edit.directive.md
@@ -1,4 +1,5 @@
 ---
+Title: Folder Edit directive
 Added: v2.0.0
 Status: Active
 Last reviewed: 2018-04-10

--- a/docs/content-services/inherited-button.directive.md
+++ b/docs/content-services/inherited-button.directive.md
@@ -1,4 +1,5 @@
 ---
+Title: Inherit Permission directive
 Added: v2.3.0
 Status: Active
 Last reviewed: 2018-11-20

--- a/docs/content-services/like.component.md
+++ b/docs/content-services/like.component.md
@@ -1,4 +1,5 @@
 ---
+Title: Like component
 Added: v2.0.0
 Status: Active
 Last reviewed: 2018-11-14

--- a/docs/content-services/node-download.directive.md
+++ b/docs/content-services/node-download.directive.md
@@ -1,4 +1,5 @@
 ---
+Title: Node Download directive
 Added: v2.2.0
 Status: Active
 Last reviewed: 2018-11-20

--- a/docs/content-services/node-lock.directive.md
+++ b/docs/content-services/node-lock.directive.md
@@ -1,4 +1,5 @@
 ---
+Title: Node Lock directive
 Added: v2.2.0
 Status: Active
 Last reviewed: 2018-11-20

--- a/docs/content-services/node-permission-dialog.service.md
+++ b/docs/content-services/node-permission-dialog.service.md
@@ -1,4 +1,5 @@
 ---
+Title: Node permission dialog service
 Added: v2.4.0
 Status: Active
 Last reviewed: 2018-09-13

--- a/docs/content-services/node-permission.service.md
+++ b/docs/content-services/node-permission.service.md
@@ -1,4 +1,5 @@
 ---
+Title: Node Permission service
 Added: v2.0.0
 Status: Active
 Last reviewed: 2018-11-14

--- a/docs/content-services/permission-list.component.md
+++ b/docs/content-services/permission-list.component.md
@@ -1,4 +1,5 @@
 ---
+Title: Permission List Component
 Added: v2.3.0
 Status: Active
 Last reviewed: 2018-11-20

--- a/docs/content-services/permissions-style.model.md
+++ b/docs/content-services/permissions-style.model.md
@@ -1,4 +1,5 @@
 ---
+Title: Permission Style model
 Added: v2.0.0
 Status: Active
 ---

--- a/docs/content-services/rating.component.md
+++ b/docs/content-services/rating.component.md
@@ -1,4 +1,5 @@
 ---
+Title: Rating component
 Added: v2.0.0
 Status: Active
 ---

--- a/docs/content-services/rating.service.md
+++ b/docs/content-services/rating.service.md
@@ -1,4 +1,5 @@
 ---
+Title: Rating service
 Added: v2.0.0
 Status: Active
 Last reviewed: 2018-05-04

--- a/docs/content-services/search-check-list.component.md
+++ b/docs/content-services/search-check-list.component.md
@@ -1,4 +1,5 @@
 ---
+Title: Search check list component
 Added: v2.4.0
 Status: Active
 Last reviewed: 2018-06-11

--- a/docs/content-services/search-chip-list.component.md
+++ b/docs/content-services/search-chip-list.component.md
@@ -1,4 +1,5 @@
 ---
+Title: Search Chip List Component
 Added: v2.3.0
 Status: Active
 Last reviewed: 2018-09-14

--- a/docs/content-services/search-control.component.md
+++ b/docs/content-services/search-control.component.md
@@ -1,4 +1,5 @@
 ---
+Title: Search control component
 Added: v2.0.0
 Status: Active
 Last reviewed: 2018-11-14

--- a/docs/content-services/search-date-range.component.md
+++ b/docs/content-services/search-date-range.component.md
@@ -1,4 +1,5 @@
 ---
+Title: Search date range component
 Added: v2.4.0
 Status: Active
 Last reviewed: 2018-06-11

--- a/docs/content-services/search-filter.component.md
+++ b/docs/content-services/search-filter.component.md
@@ -1,4 +1,5 @@
 ---
+Title: Search Filter component
 Added: v2.3.0
 Status: Active
 Last reviewed: 2018-06-12

--- a/docs/content-services/search-filter.service.md
+++ b/docs/content-services/search-filter.service.md
@@ -1,4 +1,5 @@
 ---
+Title: Search filter service
 Added: v2.4.0
 Status: Active
 Last reviewed: 2018-06-12

--- a/docs/content-services/search-number-range.component.md
+++ b/docs/content-services/search-number-range.component.md
@@ -1,4 +1,5 @@
 ---
+Title: Search number range component
 Added: v2.4.0
 Status: Active
 Last reviewed: 2018-06-11

--- a/docs/content-services/search-query-builder.service.md
+++ b/docs/content-services/search-query-builder.service.md
@@ -1,4 +1,5 @@
 ---
+Title: Search Query Builder service 
 Added: v2.3.0
 Status: Active
 Last reviewed: 2018-06-12

--- a/docs/content-services/search-radio.component.md
+++ b/docs/content-services/search-radio.component.md
@@ -1,4 +1,5 @@
 ---
+Title: Search radio component
 Added: v2.4.0
 Status: Active
 Last reviewed: 2018-08-10

--- a/docs/content-services/search-slider.component.md
+++ b/docs/content-services/search-slider.component.md
@@ -1,4 +1,5 @@
 ---
+Title: Search slider component
 Added: v2.4.0
 Status: Active
 Last reviewed: 2018-06-11

--- a/docs/content-services/search-sorting-picker.component.md
+++ b/docs/content-services/search-sorting-picker.component.md
@@ -1,4 +1,5 @@
 ---
+Title: Search Sorting Picker Component
 Added: v2.3.0
 Status: Active
 ---

--- a/docs/content-services/search-text.component.md
+++ b/docs/content-services/search-text.component.md
@@ -1,4 +1,5 @@
 ---
+Title: Search text component
 Added: v2.4.0
 Status: Active
 Last reviewed: 2018-06-11

--- a/docs/content-services/search-widget.interface.md
+++ b/docs/content-services/search-widget.interface.md
@@ -1,4 +1,5 @@
 ---
+Title: Search widget interface
 Added: v2.4.0
 Status: Active
 Last reviewed: 2018-06-12

--- a/docs/content-services/search.component.md
+++ b/docs/content-services/search.component.md
@@ -1,4 +1,5 @@
 ---
+Title: Search component
 Added: v2.0.0
 Status: Active
 Last reviewed: 2018-04-13

--- a/docs/content-services/sites-dropdown.component.md
+++ b/docs/content-services/sites-dropdown.component.md
@@ -1,4 +1,5 @@
 ---
+Title: Sites Dropdown component
 Added: v2.0.0
 Status: Active
 Last reviewed: 2018-11-19

--- a/docs/content-services/tag-actions.component.md
+++ b/docs/content-services/tag-actions.component.md
@@ -1,4 +1,5 @@
 ---
+Title: Tag Node Actions List component
 Added: v2.0.0
 Status: Active
 Last reviewed: 2018-11-19

--- a/docs/content-services/tag-list.component.md
+++ b/docs/content-services/tag-list.component.md
@@ -1,4 +1,5 @@
 ---
+Title: Tag List component
 Added: v2.0.0
 Status: Active
 Last reviewed: 2018-11-14

--- a/docs/content-services/tag-node-list.component.md
+++ b/docs/content-services/tag-node-list.component.md
@@ -1,4 +1,5 @@
 ---
+Title: Tag Node List component
 Added: v2.0.0
 Status: Active
 Last reviewed: 2018-11-19

--- a/docs/content-services/tag.service.md
+++ b/docs/content-services/tag.service.md
@@ -1,4 +1,5 @@
 ---
+Title: Tag service
 Added: v2.0.0
 Status: Active
 Last reviewed: 2018-11-13

--- a/docs/content-services/tree-view.component.md
+++ b/docs/content-services/tree-view.component.md
@@ -1,4 +1,5 @@
 ---
+Title: Tree View component
 Added: v3.0.0
 Status: Active
 Last reviewed: 2018-11-19

--- a/docs/content-services/upload-button.component.md
+++ b/docs/content-services/upload-button.component.md
@@ -1,4 +1,5 @@
 ---
+Title: Upload Button Component
 Added: v2.0.0
 Status: Active
 Last reviewed: 2018-09-13

--- a/docs/content-services/upload-drag-area.component.md
+++ b/docs/content-services/upload-drag-area.component.md
@@ -1,4 +1,5 @@
 ---
+Title: Upload Drag Area Component
 Added: v2.0.0
 Status: Active
 Last reviewed: 2018-09-13

--- a/docs/content-services/upload-version-button.component.md
+++ b/docs/content-services/upload-version-button.component.md
@@ -1,4 +1,5 @@
 ---
+Title: Upload Version Button Component (Workaround)
 Added: v2.3.0
 Status: Experimental
 Last reviewed: 2018-03-23

--- a/docs/content-services/version-list.component.md
+++ b/docs/content-services/version-list.component.md
@@ -1,4 +1,5 @@
 ---
+Title: Version List component
 Added: v2.0.0
 Status: Experimental
 Last reviewed: 2018-05-08

--- a/docs/content-services/version-manager.component.md
+++ b/docs/content-services/version-manager.component.md
@@ -1,4 +1,5 @@
 ---
+Title: Version Manager Component
 Added: v2.0.0
 Status: Experimental
 Last reviewed: 2018-04-13

--- a/docs/content-services/webscript.component.md
+++ b/docs/content-services/webscript.component.md
@@ -1,4 +1,5 @@
 ---
+Title: Webscript component
 Added: v2.0.0
 Status: Active
 Last reviewed: 2018-11-14


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [x] Documentation
> - [ ] Other... Please describe:

**What is the new behaviour?**

Added a Title metadata field to the content services docs (other libraries to follow). This is to simplify an issue with the Builder Network publishing. Hopefully, we will be able to remove this field in future and just query the Markdown title directly but this solves the problem quickly for now.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
