### PR TITLE
Markup code headings as code

### DIFF
--- a/docs/core/activiti-alfresco.service.md
+++ b/docs/core/activiti-alfresco.service.md
@@ -36,7 +36,7 @@ export class SomePageComponent implements OnInit {
 
 ## Methods
 
-#### getAlfrescoNodes(accountId: string, folderId: string): Observable&lt;[ExternalContent]>
+#### `getAlfrescoNodes(accountId: string, folderId: string): Observable<ExternalContent>`
 
 Get all the nodes under passed in folder node ID (e.g. 3062d73b-fe47-4040-89d2-79efae63869c) for passed in 
 Alfresco Repository account ID as configured in APS: 
@@ -77,7 +77,7 @@ The response contained in `nodes` is an array with properties for each object li
         simpleType: "folder"
         title: "Event More Stuff"
 
-#### linkAlfrescoNode(accountId: string, node: ExternalContent, siteId: string): Observable<ExternalContentLink>
+#### `linkAlfrescoNode(accountId: string, node: ExternalContent, siteId: string): Observable<ExternalContentLink>`
 
 Link Alfresco content as related content in APS by passing in Alfresco node identifying the content, the Share site
 that contains the content, and the Alfresco Repository account ID as configured in APS:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [x] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Github ignores strings that appear like HTML tags, such as `<ExternalContentLink>`

**What is the new behaviour?**

Wrapping the text in backticks marks it as code, which in turn escapes the `<>` symbols automatically.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
