### PR TITLE
[ADF-3782] Fixed doc comments for task list cloud component

### DIFF
--- a/docs/process-services-cloud/task-list-cloud.component.md
+++ b/docs/process-services-cloud/task-list-cloud.component.md
@@ -2,7 +2,7 @@
 Title: Task List Cloud component
 Added: v3.0.0
 Status: Active
-Last reviewed: 2018-04-16
+Last reviewed: 2018-11-28
 ---
 
 # Task List Cloud component
@@ -51,22 +51,21 @@ when the task list is empty:
 
 | Name | Type | Default value | Description |
 | ---- | ---- | ------------- | ----------- |
-| applicationName | `string` |  | The name of the application. |
-| assignee | `string` |  | The assigee of the process. Possible values are: "assignee" (the current user is the assignee), candidate (the current user is a task candidate", "group_x" (the task is assigned to a group where the current user is a member, no value(the current user is involved). |
-| createdDate | `Date` |  | filter the tasks for the date when the task should have been created |
-| dueDate | `Date` |  | Filter the tasks. Display only tasks with dueDate equal to the one insterted. |
-| id | `string` |  | Filter the tasks. Display only tasks with id equal to the one insterted. |
-| name | `string` |  | Filter the tasks. Display only tasks with name equal to the one insterted. |
-| parentTaskId | `string` |  | Filter the tasks. Display only tasks with parentTaskId equal to the one insterted. |
-| processDefinitionId | `string` |  | Filter the tasks. Display only tasks with processDefinitionId equal to the one insterted. |
-| processInstanceId | `string` |  | Filter the tasks. Display only tasks with processInstanceId equal to the one insterted. |
-| status | `string` |  | Filter the tasks. Display only tasks with status equal to the one insterted. |
-| processDefinitionId | `string` |  | Filter the tasks. Display only tasks with processDefinitionId equal to the one insterted. |
+| applicationName | `string` | "" | The name of the application. |
+| assignee | `string` | "" | The assignee of the process. Possible values are: "assignee" (the current user is the assignee), "candidate" (the current user is a task candidate", "group_x" (the task is assigned to a group where the current user is a member, no value (the current user is involved). |
+| createdDate | `string` | "" | Filter the tasks. Display only tasks created on the supplied date. |
+| dueDate | `string` | "" | Filter the tasks. Display only tasks with dueDate equal to the supplied date. |
+| id | `string` | "" | Filter the tasks. Display only tasks with id equal to the supplied value. |
 | landingTaskId | `string` |  | Define which task id should be selected after reloading. If the task id doesn't exist or nothing is passed then the first task will be selected. |
-| selectFirstRow | `boolean` | true | Toggles default selection of the first row |
-| selectionMode | `string` | "single" | Row selection mode. Can be none, `single` or `multiple`. For `multiple` mode, you can use Cmd (macOS) or Ctrl (Win) modifier key to toggle selection for multiple rows. |
-| multiselect | `boolean` | false | Toggles multiple row selection, renders checkboxes at the beginning of each row |
-| sorting | `[TaskListCloudSortingModel]` |  | This array of `TaskListCloudSortingModel` specify how the sorting on our table should be provided. This parameters are for BE sorting. |
+| multiselect | `boolean` | false | Toggles multiple row selection, rendering a checkbox at the beginning of each row. |
+| name | `string` | "" | Filter the tasks. Display only tasks with the supplied name. |
+| parentTaskId | `string` | "" | Filter the tasks. Display only tasks with parentTaskId equal to the supplied value. |
+| processDefinitionId | `string` | "" | Filter the tasks. Display only tasks with processDefinitionId equal to the supplied value. |
+| processInstanceId | `string` | "" | Filter the tasks. Display only tasks with processInstanceId equal to the supplied value. |
+| selectFirstRow | `boolean` | true | Toggles default selection of the first row. |
+| selectionMode | `string` | "single" | Row selection mode. Can be none, `single` or `multiple`. For `multiple` mode, you can use the Cmd (macOS) or Ctrl (Win) modifier key to toggle selection for multiple rows. |
+| sorting | [`TaskListCloudSortingModel`](../../lib/process-services-cloud/src/lib/task-list-cloud/models/task-list-sorting.model.ts)`[]` |  | Specifies how the table should be sorted. The parameters are for BE sorting. |
+| status | `string` | "" | Filter the tasks. Display only tasks with status equal to the supplied value. |
 
 ### Events
 
@@ -79,7 +78,7 @@ when the task list is empty:
 
 ## Details
 
-This component displays lists of tasks related to the application name insterted. Extra filtering can be provided by applying extra input parameters
+This component displays lists of tasks related to the application name insterted. Extra filtering can be provided by applying extra input parameters.
 
 ### Setting the column schema
 
@@ -164,7 +163,7 @@ You can use an HTML-based schema and an `app.config.json` custom schema declarat
 
 ### Setting Sorting Order for the list
 
-you can pass sorting order as shown in the example below:
+You can specify a sorting order as shown in the example below:
 
 ```ts
 let sorting = { orderBy: 'created', direction: 'desc' };

--- a/lib/process-services-cloud/src/lib/task-list-cloud/components/task-list-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task-list-cloud/components/task-list-cloud.component.ts
@@ -41,49 +41,76 @@ export class TaskListCloudComponent extends DataTableSchema implements OnChanges
     @ContentChild(EmptyCustomContentDirective)
     emptyCustomContent: EmptyCustomContentDirective;
 
+    /** The name of the application. */
     @Input()
     applicationName: string = '';
 
+    /**
+     * The assignee of the process. Possible values are: "assignee" (the current user is the assignee),
+     * "candidate" (the current user is a task candidate", "group_x" (the task is assigned to a group
+     * where the current user is a member, no value (the current user is involved).
+     */
     @Input()
     assignee: string = '';
 
+    /** Filter the tasks. Display only tasks created on the supplied date. */
     @Input()
     createdDate: string = '';
 
+    /** Filter the tasks. Display only tasks with dueDate equal to the supplied date. */
     @Input()
     dueDate: string = '';
 
+    /** Filter the tasks. Display only tasks with id equal to the supplied value. */
     @Input()
     id: string = '';
 
+    /** Filter the tasks. Display only tasks with the supplied name. */
     @Input()
     name: string = '';
 
+    /** Filter the tasks. Display only tasks with parentTaskId equal to the supplied value. */
     @Input()
     parentTaskId: string = '';
 
+    /** Filter the tasks. Display only tasks with processDefinitionId equal to the supplied value. */
     @Input()
     processDefinitionId: string = '';
 
+    /** Filter the tasks. Display only tasks with processInstanceId equal to the supplied value. */
     @Input()
     processInstanceId: string = '';
 
+    /** Filter the tasks. Display only tasks with status equal to the supplied value. */
     @Input()
     status: string = '';
 
+    /** Toggles default selection of the first row. */
     @Input()
     selectFirstRow: boolean = true;
 
+    /**
+     * Define which task id should be selected after reloading. If the task id doesn't
+     * exist or nothing is passed then the first task will be selected.
+     */
     @Input()
     landingTaskId: string;
 
+    /**
+     * Row selection mode. Can be none, `single` or `multiple`. For `multiple` mode,
+     * you can use the Cmd (macOS) or Ctrl (Win) modifier key to toggle selection for
+     * multiple rows.
+     */
     @Input()
     selectionMode: string = 'single'; // none|single|multiple
 
-    /** Toggles multiple row selection, renders checkboxes at the beginning of each row */
+    /** Toggles multiple row selection, rendering a checkbox at the beginning of each row. */
     @Input()
     multiselect: boolean = false;
 
+    /**
+     * Specifies how the table should be sorted. The parameters are for BE sorting.
+     */
     @Input()
     sorting: TaskListCloudSortingModel[];
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [x] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Task list cloud docs have the processDefinitionId property listed twice. This isn't a script problem - the doc file is new and the property table was copied manually from another file and adapted (presumably the prop description was copied twice by mistake).

**What is the new behaviour?**

Prop descriptions added to the source doc comments and the doc page rebuilt - all seems to be OK now.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
