### PR TITLE
[ADF-2661] disabling comments when user doesn't have permissions

### DIFF
--- a/demo-shell/src/app/components/file-view/file-view.component.html
+++ b/demo-shell/src/app/components/file-view/file-view.component.html
@@ -4,7 +4,7 @@
         <adf-info-drawer [title]="'APP.INFO_DRAWER.TITLE' | translate">
 
             <adf-info-drawer-tab [label]="'APP.INFO_DRAWER.COMMENTS' | translate">
-                <adf-comments [nodeId]="nodeId"></adf-comments>
+                <adf-comments [nodeId]="nodeId" [readOnly]="isCommentEnabled"></adf-comments>
             </adf-info-drawer-tab>
 
             <adf-info-drawer-tab [label]="'APP.INFO_DRAWER.PROPERTIES' | translate">

--- a/demo-shell/src/app/components/file-view/file-view.component.ts
+++ b/demo-shell/src/app/components/file-view/file-view.component.ts
@@ -17,7 +17,7 @@
 
 import { Component, OnInit, ViewEncapsulation } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { AlfrescoApiService } from '@alfresco/adf-core';
+import { ContentService, PermissionsEnum, NodesApiService } from '@alfresco/adf-core';
 import { MatSnackBar } from '@angular/material';
 
 @Component({
@@ -52,20 +52,23 @@ export class FileViewComponent implements OnInit {
     showLeftSidebar = null;
     showRightSidebar = false;
     customToolbar = false;
+    isCommentEnabled = true;
 
     constructor(private router: Router,
                 private route: ActivatedRoute,
                 private snackBar: MatSnackBar,
-                private apiService: AlfrescoApiService) {
+                private nodeApiService: NodesApiService,
+                private contentServices: ContentService) {
     }
 
     ngOnInit() {
         this.route.params.subscribe(params => {
             const id = params.nodeId;
             if (id) {
-                this.apiService.getInstance().nodes.getNodeInfo(id).then(
+                this.nodeApiService.getNode(id).subscribe(
                     (node) => {
                         if (node && node.isFile) {
+                            this.isCommentEnabled = !this.contentServices.hasPermission(node, PermissionsEnum.UPDATE);
                             this.nodeId = id;
                             return;
                         }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
User with no permission can attempt to put a comment on a file.


**What is the new behaviour?**
Comments are now disabled when user doesn t have permissions.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-2661