### PR TITLE
[ADF-3215] Fix Versions dialog height

### DIFF
--- a/lib/content-services/version-manager/version-manager.component.scss
+++ b/lib/content-services/version-manager/version-manager.component.scss
@@ -18,7 +18,7 @@
 }
 
 .adf-new-version-container {
-    height: 800px;
+    height: inherit;
     overflow: hidden;
 }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
The adf-new-version-container CSS class has a fixed 800px height and that provides problems with using it embedded into panels or dialogs.
https://issues.alfresco.com/jira/browse/ADF-3215


**What is the new behaviour?**
The container ow adjusts itself to the parent component to use all the available space.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-3215