### PR TITLE
[ADF-3785] Move translated strings used in Process Services Cloud

### DIFF
--- a/lib/process-services-cloud/src/lib/app-list-cloud/components/app-list-cloud.component.html
+++ b/lib/process-services-cloud/src/lib/app-list-cloud/components/app-list-cloud.component.html
@@ -24,7 +24,7 @@
         </ng-content>
 
         <ng-template #defaultEmptyTemplate>
-            <adf-empty-content icon="apps" [title]="'ADF_TASK_LIST.APPS.TITLE' | translate" [subtitle]="'ADF_TASK_LIST.APPS.SUBTITLE' | translate">
+            <adf-empty-content icon="apps" [title]="'ADF_CLOUD_TASK_LIST.APPS.TITLE' | translate" [subtitle]="'ADF_CLOUD_TASK_LIST.APPS.SUBTITLE' | translate">
             </adf-empty-content>
         </ng-template>
     </div>

--- a/lib/process-services-cloud/src/lib/app-list-cloud/components/app-list-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/app-list-cloud/components/app-list-cloud.component.spec.ts
@@ -86,8 +86,8 @@ describe('AppListCloudComponent', () => {
         expect(defaultEmptyTemplate).toBeDefined();
         expect(defaultEmptyTemplate).not.toBeNull();
         expect(emptyContent).not.toBeNull();
-        expect(emptyTitle.innerText).toBe('ADF_TASK_LIST.APPS.TITLE');
-        expect(emptySubtitle.innerText).toBe('ADF_TASK_LIST.APPS.SUBTITLE');
+        expect(emptyTitle.innerText).toBe('ADF_CLOUD_TASK_LIST.APPS.TITLE');
+        expect(emptySubtitle.innerText).toBe('ADF_CLOUD_TASK_LIST.APPS.SUBTITLE');
         expect(getAppsSpy).toHaveBeenCalled();
     });
 

--- a/lib/process-services-cloud/src/lib/i18n/en.json
+++ b/lib/process-services-cloud/src/lib/i18n/en.json
@@ -4,6 +4,45 @@
       "TITLE": "No Processes Found",
       "SUBTITLE":"Create a new process that you want to easily find later",
       "NONE": "No process instance filter selected."
+    },
+    "PROPERTIES": {
+      "NAME": "Name",
+      "CREATED": "Created"
+    }
+  },
+  "ADF_CLOUD_TASK_LIST": {
+    "APPS": {
+      "TITLE": "No Applications Found",
+      "SUBTITLE":"Create a new application that you want to easily find later"
+    },
+    "START_TASK": {
+      "FORM": {
+        "TITLE": "Start Task",
+        "LABEL": {
+          "NAME": "Name",
+          "DESCRIPTION": "Description",
+          "ATTACHFORM": "Attach Form",
+          "ASSIGNEE": "Assignee",
+          "FORM": "Form",
+          "DATE": "Choose Date"
+        },
+        "ACTION": {
+          "START": "Start",
+          "CANCEL": "Cancel"
+        }
+      }
+    },
+    "PROPERTIES": {
+      "NAME": "Name",
+      "ASSIGNEE": "Assignee",
+      "CREATED": "Created"
+    },
+    "LIST": {
+      "MESSAGES": {
+        "TITLE": "No Tasks Found",
+        "SUBTITLE":"Create a new task that you want to easily find later",
+        "NONE": "No task lists found"
+      }
     }
   },
   "ADF_CLOUD_TASK_FILTERS": {

--- a/lib/process-services-cloud/src/lib/process-list-cloud/components/process-list-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/process-list-cloud/components/process-list-cloud.component.spec.ts
@@ -30,9 +30,9 @@ import { ProcessListCloudModule } from '../process-list-cloud.module';
     template: `
     <adf-cloud-process-list #processListCloud>
         <data-columns>
-            <data-column key="name" title="ADF_TASK_LIST.PROPERTIES.NAME" class="adf-full-width adf-name-column"></data-column>
-            <data-column key="created" title="ADF_TASK_LIST.PROPERTIES.CREATED" class="adf-hidden"></data-column>
-            <data-column key="startedBy" title="ADF_TASK_LIST.PROPERTIES.CREATED" class="adf-desktop-only dw-dt-col-3 adf-ellipsis-cell">
+            <data-column key="name" title="ADF_CLOUD_TASK_LIST.PROPERTIES.NAME" class="adf-full-width adf-name-column"></data-column>
+            <data-column key="created" title="ADF_CLOUD_TASK_LIST.PROPERTIES.CREATED" class="adf-hidden"></data-column>
+            <data-column key="startedBy" title="ADF_CLOUD_TASK_LIST.PROPERTIES.CREATED" class="adf-desktop-only dw-dt-col-3 adf-ellipsis-cell">
                 <ng-template let-entry="$implicit">
                     <div>{{getFullName(entry.row.obj.startedBy)}}</div>
                 </ng-template>
@@ -83,13 +83,13 @@ describe('ProcessListCloudComponent', () => {
                         {
                             'key': 'fakeName',
                             'type': 'text',
-                            'title': 'ADF_TASK_LIST.PROPERTIES.FAKE',
+                            'title': 'ADF_CLOUD_TASK_LIST.PROPERTIES.FAKE',
                             'sortable': true
                         },
                         {
                             'key': 'fakeTaskName',
                             'type': 'text',
-                            'title': 'ADF_TASK_LIST.PROPERTIES.TASK_FAKE',
+                            'title': 'ADF_CLOUD_TASK_LIST.PROPERTIES.TASK_FAKE',
                             'sortable': true
                         }
                     ]
@@ -244,8 +244,8 @@ describe('ProcessListCloudComponent', () => {
         it('should fetch custom schemaColumn from html', () => {
             fixture.detectChanges();
             expect(componentCustom.processListCloud.columnList).toBeDefined();
-            expect(componentCustom.processListCloud.columns[0]['title']).toEqual('ADF_TASK_LIST.PROPERTIES.NAME');
-            expect(componentCustom.processListCloud.columns[1]['title']).toEqual('ADF_TASK_LIST.PROPERTIES.CREATED');
+            expect(componentCustom.processListCloud.columns[0]['title']).toEqual('ADF_CLOUD_TASK_LIST.PROPERTIES.NAME');
+            expect(componentCustom.processListCloud.columns[1]['title']).toEqual('ADF_CLOUD_TASK_LIST.PROPERTIES.CREATED');
             expect(componentCustom.processListCloud.columns.length).toEqual(3);
         });
     });

--- a/lib/process-services-cloud/src/lib/process-list-cloud/mock/process-list-service.mock.ts
+++ b/lib/process-services-cloud/src/lib/process-list-cloud/mock/process-list-service.mock.ts
@@ -102,13 +102,13 @@ export let fakeCustomSchema =
         new ObjectDataColumn({
             'key': 'fakeName',
             'type': 'text',
-            'title': 'ADF_TASK_LIST.PROPERTIES.FAKE',
+            'title': 'ADF_CLOUD_TASK_LIST.PROPERTIES.FAKE',
             'sortable': true
         }),
         new ObjectDataColumn({
             'key': 'fakeTaskName',
             'type': 'text',
-            'title': 'ADF_TASK_LIST.PROPERTIES.TASK_FAKE',
+            'title': 'ADF_CLOUD_TASK_LIST.PROPERTIES.TASK_FAKE',
             'sortable': true
         })
     ];

--- a/lib/process-services-cloud/src/lib/process-list-cloud/models/process-cloud-preset.model.ts
+++ b/lib/process-services-cloud/src/lib/process-list-cloud/models/process-cloud-preset.model.ts
@@ -20,13 +20,13 @@ export let processCloudPresetsDefaultModel = {
         {
             'key': 'name',
             'type': 'text',
-            'title': 'ADF_PROCESS_LIST.PROPERTIES.NAME',
+            'title': 'ADF_CLOUD_PROCESS_LIST.PROPERTIES.NAME',
             'sortable': true
         },
         {
             'key': 'created',
             'type': 'text',
-            'title': 'ADF_PROCESS_LIST.PROPERTIES.CREATED',
+            'title': 'ADF_CLOUD_PROCESS_LIST.PROPERTIES.CREATED',
             'cssClass': 'hidden',
             'sortable': true
         }

--- a/lib/process-services-cloud/src/lib/start-task-cloud/components/people-cloud/people-cloud.component.html
+++ b/lib/process-services-cloud/src/lib/start-task-cloud/components/people-cloud/people-cloud.component.html
@@ -1,6 +1,6 @@
 <form>
 <mat-form-field class="adf-people-cloud">
-    <mat-label id="assignee-id">{{'ADF_TASK_LIST.START_TASK.FORM.LABEL.ASSIGNEE' | translate}}</mat-label>
+    <mat-label id="assignee-id">{{'ADF_CLOUD_TASK_LIST.START_TASK.FORM.LABEL.ASSIGNEE' | translate}}</mat-label>
     <input #inputValue
            matInput
            class="adf-cloud-input"

--- a/lib/process-services-cloud/src/lib/start-task-cloud/components/start-task-cloud.component.html
+++ b/lib/process-services-cloud/src/lib/start-task-cloud/components/start-task-cloud.component.html
@@ -1,13 +1,13 @@
 <mat-card>
     <mat-card-header fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="10px" class="adf-cloud-start-task-heading">
-        <mat-card-title>{{'ADF_TASK_LIST.START_TASK.FORM.TITLE' | translate}}</mat-card-title>
+        <mat-card-title>{{'ADF_CLOUD_TASK_LIST.START_TASK.FORM.TITLE' | translate}}</mat-card-title>
     </mat-card-header>
     <form [formGroup]="taskForm" fxLayout="column" (ngSubmit)="saveTask()">
 
     <mat-card-content>
             <div class="adf-task-name">
                 <mat-form-field fxFlex>
-                    <mat-label>{{'ADF_TASK_LIST.START_TASK.FORM.LABEL.NAME' | translate }}</mat-label>
+                    <mat-label>{{'ADF_CLOUD_TASK_LIST.START_TASK.FORM.LABEL.NAME' | translate }}</mat-label>
                     <input
                         matInput
                         id="name_id"
@@ -23,7 +23,7 @@
             </div>
             <div class="input-row" fxLayout="row" fxLayout.lt-md="column" fxLayoutGap="20px" fxLayoutGap.lt-md="0px">
                 <mat-form-field fxFlex>
-                    <mat-label>{{'ADF_TASK_LIST.START_TASK.FORM.LABEL.DESCRIPTION' | translate}}</mat-label>
+                    <mat-label>{{'ADF_CLOUD_TASK_LIST.START_TASK.FORM.LABEL.DESCRIPTION' | translate}}</mat-label>
                     <textarea
                         matInput
                         class="form-control"
@@ -44,7 +44,7 @@
                         [matDatepicker]="taskDatePicker"
                         (keydown)="true"
                         (focusout)="onDateChanged($event.srcElement.value)"
-                        placeholder="{{'ADF_TASK_LIST.START_TASK.FORM.LABEL.DATE'|translate}}"
+                        placeholder="{{'ADF_CLOUD_TASK_LIST.START_TASK.FORM.LABEL.DATE'|translate}}"
                         [(ngModel)]="dueDate"
                         [ngModelOptions]="{standalone: true}"
                         id="date_id">
@@ -74,14 +74,14 @@
                 type="button"
                 (click)="onCancel()"
                 id="button-cancel">
-                {{'ADF_TASK_LIST.START_TASK.FORM.ACTION.CANCEL'|translate}}
+                {{'ADF_CLOUD_TASK_LIST.START_TASK.FORM.ACTION.CANCEL'|translate}}
             </button>
             <button
                 color="primary"
                 type="submit" [disabled]="dateError || !taskForm.valid || submitted"
                 mat-button
                 id="button-start">
-                {{'ADF_TASK_LIST.START_TASK.FORM.ACTION.START'|translate}}
+                {{'ADF_CLOUD_TASK_LIST.START_TASK.FORM.ACTION.START'|translate}}
             </button>
         </div>
     </mat-card-actions>

--- a/lib/process-services-cloud/src/lib/start-task-cloud/components/start-task-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/start-task-cloud/components/start-task-cloud.component.spec.ts
@@ -178,7 +178,7 @@ describe('StartTaskCloudComponent', () => {
         fixture.detectChanges();
         expect(element.querySelector('#button-start')).toBeDefined();
         expect(element.querySelector('#button-start')).not.toBeNull();
-        expect(element.querySelector('#button-start').textContent).toContain('ADF_TASK_LIST.START_TASK.FORM.ACTION.START');
+        expect(element.querySelector('#button-start').textContent).toContain('ADF_CLOUD_TASK_LIST.START_TASK.FORM.ACTION.START');
     });
 
     it('should disable start button if name is empty', () => {

--- a/lib/process-services-cloud/src/lib/task-list-cloud/components/task-list-cloud.component.html
+++ b/lib/process-services-cloud/src/lib/task-list-cloud/components/task-list-cloud.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="!rows">{{ 'ADF_TASK_LIST.FILTERS.MESSAGES.NONE' | translate }}</div>
+<div *ngIf="!rows">{{ 'ADF_CLOUD_TASK_LIST.FILTERS.MESSAGES.NONE' | translate }}</div>
 <ng-container *ngIf="rows">
         <adf-datatable
             [rows]="rows"
@@ -23,8 +23,8 @@
                 <ng-template>
                     <adf-empty-content *ngIf="!emptyCustomContent"
                                        icon="assignment"
-                                       [title]="'ADF_TASK_LIST.LIST.MESSAGES.TITLE' | translate"
-                                       [subtitle]="'ADF_TASK_LIST.LIST.MESSAGES.SUBTITLE' | translate">
+                                       [title]="'ADF_CLOUD_TASK_LIST.LIST.MESSAGES.TITLE' | translate"
+                                       [subtitle]="'ADF_CLOUD_TASK_LIST.LIST.MESSAGES.SUBTITLE' | translate">
                     </adf-empty-content>
                     <ng-content select="adf-empty-custom-content"></ng-content>
                 </ng-template>

--- a/lib/process-services-cloud/src/lib/task-list-cloud/components/task-list-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/task-list-cloud/components/task-list-cloud.component.spec.ts
@@ -30,9 +30,9 @@ import { TaskListCloudModule } from '../task-list-cloud.module';
     template: `
     <adf-cloud-task-list #taskListCloud>
         <data-columns>
-            <data-column key="name" title="ADF_TASK_LIST.PROPERTIES.NAME" class="adf-full-width adf-name-column"></data-column>
-            <data-column key="created" title="ADF_TASK_LIST.PROPERTIES.CREATED" class="adf-hidden"></data-column>
-            <data-column key="startedBy" title="ADF_TASK_LIST.PROPERTIES.CREATED" class="adf-desktop-only dw-dt-col-3 adf-ellipsis-cell">
+            <data-column key="name" title="ADF_CLOUD_TASK_LIST.PROPERTIES.NAME" class="adf-full-width adf-name-column"></data-column>
+            <data-column key="created" title="ADF_CLOUD_TASK_LIST.PROPERTIES.CREATED" class="adf-hidden"></data-column>
+            <data-column key="startedBy" title="ADF_CLOUD_TASK_LIST.PROPERTIES.CREATED" class="adf-desktop-only dw-dt-col-3 adf-ellipsis-cell">
                 <ng-template let-entry="$implicit">
                     <div>{{getFullName(entry.row.obj.startedBy)}}</div>
                 </ng-template>
@@ -80,13 +80,13 @@ describe('TaskListCloudComponent', () => {
                         {
                             'key': 'fakeName',
                             'type': 'text',
-                            'title': 'ADF_TASK_LIST.PROPERTIES.FAKE',
+                            'title': 'ADF_CLOUD_TASK_LIST.PROPERTIES.FAKE',
                             'sortable': true
                         },
                         {
                             'key': 'fakeTaskName',
                             'type': 'text',
-                            'title': 'ADF_TASK_LIST.PROPERTIES.TASK_FAKE',
+                            'title': 'ADF_CLOUD_TASK_LIST.PROPERTIES.TASK_FAKE',
                             'sortable': true
                         }
                     ]
@@ -276,8 +276,8 @@ describe('TaskListCloudComponent', () => {
         it('should fetch custom schemaColumn from html', () => {
             fixture.detectChanges();
             expect(componentCustom.taskList.columnList).toBeDefined();
-            expect(componentCustom.taskList.columns[0]['title']).toEqual('ADF_TASK_LIST.PROPERTIES.NAME');
-            expect(componentCustom.taskList.columns[1]['title']).toEqual('ADF_TASK_LIST.PROPERTIES.CREATED');
+            expect(componentCustom.taskList.columns[0]['title']).toEqual('ADF_CLOUD_TASK_LIST.PROPERTIES.NAME');
+            expect(componentCustom.taskList.columns[1]['title']).toEqual('ADF_CLOUD_TASK_LIST.PROPERTIES.CREATED');
             expect(componentCustom.taskList.columns.length).toEqual(3);
         });
 

--- a/lib/process-services-cloud/src/lib/task-list-cloud/mock/fakeTaskResponseMock.ts
+++ b/lib/process-services-cloud/src/lib/task-list-cloud/mock/fakeTaskResponseMock.ts
@@ -134,13 +134,13 @@ export let fakeCustomSchema =
         new ObjectDataColumn({
             'key': 'fakeName',
             'type': 'text',
-            'title': 'ADF_TASK_LIST.PROPERTIES.FAKE',
+            'title': 'ADF_CLOUD_TASK_LIST.PROPERTIES.FAKE',
             'sortable': true
         }),
         new ObjectDataColumn({
             'key': 'fakeTaskName',
             'type': 'text',
-            'title': 'ADF_TASK_LIST.PROPERTIES.TASK_FAKE',
+            'title': 'ADF_CLOUD_TASK_LIST.PROPERTIES.TASK_FAKE',
             'sortable': true
         })
     ];

--- a/lib/process-services-cloud/src/lib/task-list-cloud/models/task-preset-cloud.model.ts
+++ b/lib/process-services-cloud/src/lib/task-list-cloud/models/task-preset-cloud.model.ts
@@ -20,20 +20,20 @@ export let taskPresetsCloudDefaultModel = {
         {
             'key': 'name',
             'type': 'text',
-            'title': 'ADF_TASK_LIST.PROPERTIES.NAME',
+            'title': 'ADF_CLOUD_TASK_LIST.PROPERTIES.NAME',
             'sortable': true
         },
         {
             'key': 'created',
             'type': 'text',
-            'title': 'ADF_TASK_LIST.PROPERTIES.CREATED',
+            'title': 'ADF_CLOUD_TASK_LIST.PROPERTIES.CREATED',
             'cssClass': 'hidden',
             'sortable': true
         },
         {
             'key': 'assignee',
             'type': 'text',
-            'title': 'ADF_TASK_LIST.PROPERTIES.ASSIGNEE',
+            'title': 'ADF_CLOUD_TASK_LIST.PROPERTIES.ASSIGNEE',
             'cssClass': 'hidden',
             'sortable': true
         }


### PR DESCRIPTION
… to its own translation file

**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-3785
There are some strings that get the translation from the Process Services folder.

**What is the new behaviour?**
All strings found inside the Process Service Cloud get their respective translations from the file located inside the folder


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-3785