### PR TITLE
[ADF-3814] Fix PDF file not centered on PDF Viewer

### DIFF
--- a/lib/core/viewer/components/pdfViewerHost.component.scss
+++ b/lib/core/viewer/components/pdfViewerHost.component.scss
@@ -143,7 +143,7 @@
             overflow: hidden;
         }
 
-        .adf-page {
+        .page {
             direction: ltr;
             width: 816px;
             height: 1056px;

--- a/stylelint-config.json
+++ b/stylelint-config.json
@@ -81,7 +81,7 @@
     "max-line-length": 100,
     "linebreaks": "unix",
     "selector-class-pattern": [
-      "^_?(adf|adf-|cdk-|example-|demo-|mat-|material-|textLayer|canvasWrapper)",
+      "^_?(adf|adf-|cdk-|example-|demo-|mat-|material-|textLayer|canvasWrapper|page)",
       {
         "resolveNestedSelectors": true
       }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-3814


**What is the new behaviour?**
Page Host class had the `adf-` prefix and it was assigning a wrong class to the viewer element


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-3814