### PR TITLE
[ADF-3816] Clarified misleading property description in Document List docs

### DIFF
--- a/docs/content-services/document-list.component.md
+++ b/docs/content-services/document-list.component.md
@@ -71,7 +71,7 @@ Displays the documents from a repository.
 | maxItems | `number` |  | Default value is stored into user preference settings use it only if you are not using the pagination |
 | multiselect | `boolean` | false | Toggles multiselect mode |
 | navigate | `boolean` | true | Toggles navigation to folder content or file preview |
-| navigationMode | `string` |  | User interaction for folder navigation or file preview. Valid values are "click" and "dblclick". Default value: "dblclick" |
+| navigationMode | `string` |  | [User](../../e2e/models/APS/User.ts) interaction for folder navigation or file preview. Valid values are "click" and "dblclick". Default value: "dblclick" |
 | node | [`NodePaging`](../../lib/content-services/document-list/models/document-library.model.ts) | null | The Document list will show all the nodes contained in the [NodePaging](../../lib/content-services/document-list/models/document-library.model.ts) entity |
 | permissionsStyle | [`PermissionStyleModel`](../../lib/content-services/document-list/models/permissions-style.model.ts)`[]` | \[] | Define a set of CSS styles to apply depending on the permission of the user on that node. See the [Permission Style model](../../lib/content-services/document-list/models/permissions-style.model.ts) page for further details and examples. |
 | rowFilter | `any \| null` | null | Custom row filter |
@@ -81,7 +81,7 @@ Displays the documents from a repository.
 | showHeader | `boolean` | true | Toggles the header |
 | skipCount | `number` | 0 | (**Deprecated:** 2.3.0 - define it in pagination) Number of elements to skip over for pagination purposes |
 | sorting | `string[]` | ['name', 'asc'] | Defines default sorting. The format is an array of 2 strings `[key, direction]` i.e. `['name', 'desc']` or `['name', 'asc']`. Set this value only if you want to override the default sorting detected by the component based on columns. |
-| sortingMode | `string` | "client" | Defines sorting mode. Can be either `client` or `server`. |
+| sortingMode | `string` | "client" | Defines sorting mode. Can be either `client` (items in the list are sorted client-side) or `server` (the ordering supplied by the server is used without further client-side sorting). Note that the `server` option _does not_ request the server to sort the data before delivering it. |
 | thumbnails | `boolean` | false | Show document thumbnails rather than icons |
 
 ### Events

--- a/docs/content-services/document-list.component.md
+++ b/docs/content-services/document-list.component.md
@@ -71,7 +71,7 @@ Displays the documents from a repository.
 | maxItems | `number` |  | Default value is stored into user preference settings use it only if you are not using the pagination |
 | multiselect | `boolean` | false | Toggles multiselect mode |
 | navigate | `boolean` | true | Toggles navigation to folder content or file preview |
-| navigationMode | `string` |  | [User](../../e2e/models/APS/User.ts) interaction for folder navigation or file preview. Valid values are "click" and "dblclick". Default value: "dblclick" |
+| navigationMode | `string` |  | User interaction for folder navigation or file preview. Valid values are "click" and "dblclick". Default value: "dblclick" |
 | node | [`NodePaging`](../../lib/content-services/document-list/models/document-library.model.ts) | null | The Document list will show all the nodes contained in the [NodePaging](../../lib/content-services/document-list/models/document-library.model.ts) entity |
 | permissionsStyle | [`PermissionStyleModel`](../../lib/content-services/document-list/models/permissions-style.model.ts)`[]` | \[] | Define a set of CSS styles to apply depending on the permission of the user on that node. See the [Permission Style model](../../lib/content-services/document-list/models/permissions-style.model.ts) page for further details and examples. |
 | rowFilter | `any \| null` | null | Custom row filter |

--- a/lib/content-services/document-list/components/document-list.component.ts
+++ b/lib/content-services/document-list/components/document-list.component.ts
@@ -134,7 +134,12 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
     @Input()
     sorting = ['name', 'asc'];
 
-    /** Defines sorting mode. Can be either `client` or `server`. */
+    /** Defines sorting mode. Can be either `client` (items in the list
+     * are sorted client-side) or `server` (the ordering supplied by the
+     * server is used without further client-side sorting).
+     * Note that the `server` option *does not* request the server to sort the data
+     * before delivering it.
+     */
     @Input()
     sortingMode = 'client';
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [x] Documentation
> - [ ] Other... Please describe:

**What is the new behaviour?**

Updated the unclear `sortingMode` property description for the document list based on the reply to a Gitter question.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
