### PR TITLE
[ADF-2675] The string given for 'Extension accepted' is not trim

### DIFF
--- a/lib/content-services/upload/components/base-upload/upload-base.spec.ts
+++ b/lib/content-services/upload/components/base-upload/upload-base.spec.ts
@@ -233,6 +233,59 @@ describe('UploadBase', () => {
             addToQueueSpy = spyOn(uploadService, 'addToQueue');
         });
 
+        it('should filter out file, when file type having white space in the beginning', () => {
+            component.acceptedFilesType = ' .jpg';
+
+            component.uploadFiles(files);
+
+            const filesCalledWith = addToQueueSpy.calls.mostRecent().args;
+            expect(filesCalledWith.length).toBe(1, 'Files should contain only one element');
+            expect(filesCalledWith[0].name).toBe('phobos.jpg', 'png file should be filtered out');
+        });
+
+        it('should filter out file, when file types having white space in the beginning', () => {
+            component.acceptedFilesType = '.jpg, .png';
+
+            component.uploadFiles(files);
+
+            const filesCalledWith = addToQueueSpy.calls.mostRecent().args;
+            expect(filesCalledWith.length).toBe(2, 'Files should contain two elements');
+            expect(filesCalledWith[0].name).toBe('phobos.jpg');
+            expect(filesCalledWith[1].name).toBe('deimos.png');
+        });
+
+        it('should not filter out file, when file type having white space in the middle', () => {
+            component.acceptedFilesType = '.jpg, .p ng';
+
+            component.uploadFiles(files);
+
+            const filesCalledWith = addToQueueSpy.calls.mostRecent().args;
+            expect(filesCalledWith.length).toBe(1, 'Files should contain only one element');
+            expect(filesCalledWith[0].name).toBe('phobos.jpg', 'png file should be filtered out');
+        });
+
+        it('should filter out file, when file types having white space in the end', () => {
+            component.acceptedFilesType = '.jpg ,.png ';
+
+            component.uploadFiles(files);
+
+            const filesCalledWith = addToQueueSpy.calls.mostRecent().args;
+            expect(filesCalledWith.length).toBe(2, 'Files should contain two elements');
+            expect(filesCalledWith[0].name).toBe('phobos.jpg');
+            expect(filesCalledWith[1].name).toBe('deimos.png');
+        });
+
+        it('should filter out file, when file types not having space and dot', () => {
+            component.acceptedFilesType = 'jpg,png';
+
+            component.uploadFiles(files);
+
+            const filesCalledWith = addToQueueSpy.calls.mostRecent().args;
+            expect(filesCalledWith.length).toBe(2, 'Files should contain two elements');
+            expect(filesCalledWith[0].name).toBe('phobos.jpg');
+            expect(filesCalledWith[1].name).toBe('deimos.png');
+        });
+
         it('should filter out file, which is not part of the acceptedFilesType', () => {
             component.acceptedFilesType = '.jpg';
 

--- a/lib/content-services/upload/components/base-upload/upload-base.ts
+++ b/lib/content-services/upload/components/base-upload/upload-base.ts
@@ -156,7 +156,7 @@ export abstract class UploadBase implements OnInit, OnDestroy {
 
         const allowedExtensions = this.acceptedFilesType
             .split(',')
-            .map((ext) => ext.replace(/^\./, ''));
+            .map((ext) => ext.trim().replace(/^\./, ''));
 
         if (allowedExtensions.indexOf(file.extension) !== -1) {
             return true;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://issues.alfresco.com/jira/browse/ADF-2675

**What is the new behaviour?**
Files will be uploaded when file types having white spaces


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
