### PR TITLE
[ADF-3282] Add maximum length validator to Start Process Form

### DIFF
--- a/lib/process-services/i18n/en.json
+++ b/lib/process-services/i18n/en.json
@@ -286,7 +286,8 @@
       },
       "ERROR": {
         "LOAD_PROCESS_DEFS": "Couldn't load process definitions, check you have access.",
-        "START": "Couldn't start new process instance, check you have access."
+        "START": "Couldn't start new process instance, check you have access.",
+        "MAXIMUM_LENGTH": "Length exceeded, {{characters}} characters max."
       }
     },
     "PROCESS-ATTACHMENT": {

--- a/lib/process-services/process-list/components/start-process.component.html
+++ b/lib/process-services/process-list/components/start-process.component.html
@@ -12,6 +12,9 @@
                 [formControl]="processNameInput"
                 id="processName"
                 required/>
+                <mat-error *ngIf="nameController.hasError('maxlength')">
+                    {{ 'ADF_PROCESS_LIST.START_PROCESS.ERROR.MAXIMUM_LENGTH' | translate : { characters : maxProcessNameLength } }}
+                </mat-error>
         </mat-form-field>
         <mat-form-field class="adf-process-input-container">
             <input

--- a/lib/process-services/process-list/components/start-process.component.ts
+++ b/lib/process-services/process-list/components/start-process.component.ts
@@ -28,7 +28,7 @@ import { ProcessDefinitionRepresentation } from './../models/process-definition.
 import { ProcessInstance } from './../models/process-instance.model';
 import { ProcessService } from './../services/process.service';
 import { AttachFileWidgetComponent, AttachFolderWidgetComponent } from '../../content-widget';
-import { FormControl, Validators } from '@angular/forms';
+import { FormControl, Validators, AbstractControl } from '@angular/forms';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { MatAutocompleteTrigger } from '@angular/material';
@@ -40,6 +40,8 @@ import { MatAutocompleteTrigger } from '@angular/material';
     encapsulation: ViewEncapsulation.None
 })
 export class StartProcessInstanceComponent implements OnChanges, OnInit {
+
+    MAX_LENGTH: number = 255;
 
     /** (optional) Limit the list of processes that can be started to those
      * contained in the specified app.
@@ -92,14 +94,12 @@ export class StartProcessInstanceComponent implements OnChanges, OnInit {
     inputAutocomplete: MatAutocompleteTrigger;
 
     processDefinitions: ProcessDefinitionRepresentation[] = [];
-
     selectedProcessDef: ProcessDefinitionRepresentation = new ProcessDefinitionRepresentation();
-
     errorMessageId: string = '';
-
     processNameInput: FormControl;
     processDefinitionInput: FormControl;
     filteredProcesses: Observable<ProcessDefinitionRepresentation[]>;
+    maxProcessNameLength: number = this.MAX_LENGTH;
 
     constructor(private activitiProcess: ProcessService,
                 private formRenderingService: FormRenderingService,
@@ -110,7 +110,7 @@ export class StartProcessInstanceComponent implements OnChanges, OnInit {
     }
 
     ngOnInit() {
-        this.processNameInput = new FormControl(this.name, Validators.required);
+        this.processNameInput = new FormControl(this.name, [Validators.required, Validators.maxLength(this.maxProcessNameLength)]);
         this.processDefinitionInput = new FormControl();
 
         this.loadStartProcess();
@@ -252,7 +252,7 @@ export class StartProcessInstanceComponent implements OnChanges, OnInit {
     }
 
     validateForm(): boolean {
-        return this.selectedProcessDef && this.selectedProcessDef.id && this.name && this.isStartFormMissingOrValid();
+        return this.selectedProcessDef && this.selectedProcessDef.id && this.processNameInput.valid && this.isStartFormMissingOrValid();
     }
 
     private resetSelectedProcessDefinition() {
@@ -302,5 +302,9 @@ export class StartProcessInstanceComponent implements OnChanges, OnInit {
         } else {
             this.inputAutocomplete.closePanel();
         }
+    }
+
+    get nameController(): AbstractControl {
+        return this.processNameInput;
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-3282
App crashes when the length of the process is longer than 255 characters in the start process form

**What is the new behaviour?**
A new validator has been added to the form so it checks if the process name meets the requirements.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-3282