### PR TITLE
[ADF-3784] support for browser cultures (i18n)

### DIFF
--- a/docs/user-guide/internationalization.md
+++ b/docs/user-guide/internationalization.md
@@ -248,6 +248,9 @@ The table below illustrates how the selection is made:
 | X | fr | jp | en | fr |
 | it | fr | jp | en | it |
 
+The translation service probes the browser culture first, for example `en-GB`.
+If the `en-GB.json` files does not exist, the service falls back to the language id: `en`.
+
 Once the locale language is determined, it is saved to the user preferences and this saved value
 will be used from that point on, regardless of the `app.config.json` and browser settings.
 

--- a/docs/user-guide/internationalization.md
+++ b/docs/user-guide/internationalization.md
@@ -249,7 +249,7 @@ The table below illustrates how the selection is made:
 | it | fr | jp | en | it |
 
 The translation service probes the browser culture first, for example `en-GB`.
-If the `en-GB.json` files does not exist, the service falls back to the language id: `en`.
+If the `en-GB.json` file does not exist, the service falls back to the language id: `en`.
 
 Once the locale language is determined, it is saved to the user preferences and this saved value
 will be used from that point on, regardless of the `app.config.json` and browser settings.

--- a/lib/core/login/components/login.component.html
+++ b/lib/core/login/components/login.component.html
@@ -46,8 +46,8 @@
                                            tabindex="1">
                                 </mat-form-field>
 
-                                <span class="adf-login-validation" for="username" *ngIf="formError.username">
-                                <span id="username-error" class="adf-login-error" data-automation-id="username-error">{{formError.username | translate }}</span>
+                                <span class="adf-login-validation" for="username" *ngIf="formError['username']">
+                                <span id="username-error" class="adf-login-error" data-automation-id="username-error">{{formError['username'] | translate }}</span>
                             </span>
                             </div>
 
@@ -55,7 +55,7 @@
                             <div class="adf-login__field">
                                 <mat-form-field class="adf-full-width" floatPlaceholder="never" color="primary">
                                     <input matInput placeholder="{{'LOGIN.LABEL.PASSWORD' | translate }}"
-                                           type="password"
+                                           [type]="isPasswordShow ? 'text' : 'password'"
                                            [formControl]="form.controls['password']"
                                            id="password"
                                            data-automation-id="password"
@@ -69,9 +69,9 @@
                                         visibility_off
                                     </mat-icon>
                                 </mat-form-field>
-                                <span class="adf-login-validation" for="password" *ngIf="formError.password">
+                                <span class="adf-login-validation" for="password" *ngIf="formError['password']">
                                 <span id="password-required" class="adf-login-error"
-                                      data-automation-id="password-required">{{formError.password | translate }}</span>
+                                      data-automation-id="password-required">{{formError['password'] | translate }}</span>
                             </span>
                             </div>
 

--- a/lib/core/services/translate-loader.service.ts
+++ b/lib/core/services/translate-loader.service.ts
@@ -33,8 +33,13 @@ export class TranslateLoaderService implements TranslateLoader {
     private suffix: string = '.json';
     private providers: ComponentTranslationModel[] = [];
     private queue: string [][] = [];
+    private defaultLang: string = 'en';
 
     constructor(private http: HttpClient) {
+    }
+
+    setDefaultLang(value: string) {
+        this.defaultLang = value || 'en';
     }
 
     registerProvider(name: string, path: string) {
@@ -50,6 +55,27 @@ export class TranslateLoaderService implements TranslateLoader {
         return this.providers.find((x) => x.name === name) ? true : false;
     }
 
+    fetchLanguageFile(lang: string, component: ComponentTranslationModel): Observable<void> {
+        const translationUrl = `${component.path}/${this.prefix}/${lang}${this.suffix}?v=${Date.now()}`;
+
+        return this.http.get(translationUrl).pipe(
+            map((res: Response) => {
+                component.json[lang] = res;
+            }),
+            retry(3),
+            catchError(() => {
+                if (lang.includes('-')) {
+                    const [langId] = lang.split('-');
+
+                    if (langId && langId !== this.defaultLang) {
+                        return this.fetchLanguageFile(langId, component);
+                    }
+                }
+                return throwError(`Failed to load ${translationUrl}`);
+            })
+        );
+    }
+
     getComponentToFetch(lang: string): Array<Observable<any>> {
         const observableBatch = [];
         if (!this.queue[lang]) {
@@ -59,16 +85,8 @@ export class TranslateLoaderService implements TranslateLoader {
             if (!this.isComponentInQueue(lang, component.name)) {
                 this.queue[lang].push(component.name);
 
-                const translationUrl = `${component.path}/${this.prefix}/${lang}${this.suffix}?v=${Date.now()}`;
-
                 observableBatch.push(
-                    this.http.get(translationUrl).pipe(
-                        map((res: Response) => {
-                            component.json[lang] = res;
-                        }),
-                        retry(3),
-                        catchError(() => throwError(`Failed to load ${translationUrl}`))
-                    )
+                    this.fetchLanguageFile(lang, component)
                 );
             }
         });

--- a/lib/core/services/translation.service.ts
+++ b/lib/core/services/translation.service.ts
@@ -43,6 +43,7 @@ export class TranslationService {
 
         this.defaultLang = 'en';
         translate.setDefaultLang(this.defaultLang);
+        this.customLoader.setDefaultLang(this.defaultLang);
 
         if (providers && providers.length > 0) {
             for (let provider of providers) {

--- a/lib/core/services/user-preferences.service.spec.ts
+++ b/lib/core/services/user-preferences.service.spec.ts
@@ -117,24 +117,24 @@ describe('UserPreferencesService', () => {
 
     it('should return as default locale the app.config locate as first', () => {
         appConfig.config.locale = 'fake-locate-config';
-        spyOn(translate, 'getBrowserLang').and.returnValue('fake-locate-browser');
+        spyOn(translate, 'getBrowserCultureLang').and.returnValue('fake-locate-browser');
         expect(preferences.getDefaultLocale()).toBe('fake-locate-config');
     });
 
     it('should return as default locale the browser locale as second', () => {
-        spyOn(translate, 'getBrowserLang').and.returnValue('fake-locate-browser');
+        spyOn(translate, 'getBrowserCultureLang').and.returnValue('fake-locate-browser');
         expect(preferences.getDefaultLocale()).toBe('fake-locate-browser');
     });
 
     it('should return as default locale the component property as third ', () => {
-        spyOn(translate, 'getBrowserLang').and.stub();
+        spyOn(translate, 'getBrowserCultureLang').and.stub();
         expect(preferences.getDefaultLocale()).toBe('en');
     });
 
     it('should return as locale the store locate', () => {
         preferences.locale = 'fake-store-locate';
         appConfig.config.locale = 'fake-locate-config';
-        spyOn(translate, 'getBrowserLang').and.returnValue('fake-locate-browser');
+        spyOn(translate, 'getBrowserCultureLang').and.returnValue('fake-locate-browser');
         expect(preferences.locale).toBe('fake-store-locate');
     });
 

--- a/lib/core/services/user-preferences.service.ts
+++ b/lib/core/services/user-preferences.service.ts
@@ -183,7 +183,7 @@ export class UserPreferencesService {
      * @returns Default locale language code
      */
     public getDefaultLocale(): string {
-        return this.appConfig.get<string>('locale') || this.translate.getBrowserLang() || 'en';
+        return this.appConfig.get<string>('locale') || this.translate.getBrowserCultureLang() || 'en';
     }
 
 }

--- a/lib/core/templates/error-content/error-content.component.spec.ts
+++ b/lib/core/templates/error-content/error-content.component.spec.ts
@@ -31,16 +31,6 @@ describe('ErrorContentComponent', () => {
     let element: HTMLElement;
     let translateService: TranslationService;
 
-    setupTestBed({
-        imports: [
-            CoreTestingModule
-        ],
-        providers: [
-            { provide: TranslationService, useClass: TranslationMock },
-            { provide: ActivatedRoute, useValue: { params: of({id: '404'})}}
-        ]
-    });
-
     beforeEach(() => {
         fixture = TestBed.createComponent(ErrorContentComponent);
         element = fixture.nativeElement;
@@ -53,84 +43,109 @@ describe('ErrorContentComponent', () => {
         TestBed.resetTestingModule();
     });
 
-    it('should create error component', async(() => {
-        fixture.detectChanges();
-        expect(errorContentComponent).toBeTruthy();
-    }));
+    describe(' with an undefined error', () => {
 
-    it('should render error code', async(() => {
-        fixture.detectChanges();
-        const errorContentElement = element.querySelector('.adf-error-content-code');
-        expect(errorContentElement).not.toBeNull();
-        expect(errorContentElement).toBeDefined();
-    }));
-
-    it('should render error title', async(() => {
-        fixture.detectChanges();
-        const errorContentElement = element.querySelector('.adf-error-content-title');
-        expect(errorContentElement).not.toBeNull();
-        expect(errorContentElement).toBeDefined();
-    }));
-
-    it('should render error description', async(() => {
-        fixture.detectChanges();
-        const errorContentElement = element.querySelector('.adf-error-content-description');
-        expect(errorContentElement).not.toBeNull();
-        expect(errorContentElement).toBeDefined();
-    }));
-
-    it('should render error description', async(() => {
-        fixture.detectChanges();
-        const errorContentElement = element.querySelector('.adf-error-content-description');
-        expect(errorContentElement).not.toBeNull();
-        expect(errorContentElement).toBeDefined();
-    }));
-
-    it('should hide secondary button if this one has no value', async(() => {
-        spyOn(translateService, 'instant').and.callFake((inputString) => {
-            return '';
+        setupTestBed({
+            imports: [
+                CoreTestingModule
+            ],
+            providers: [
+                { provide: TranslationService, useClass: TranslationMock },
+                { provide: ActivatedRoute, useValue: { params: of() } }
+            ]
         });
-        fixture.detectChanges();
-        fixture.whenStable().then(() => {
-            const errorContentElement = element.querySelector('.adf-error-content-description-link');
-            expect(errorContentElement).toBeNull();
-        });
-    }));
 
-    it('should render secondary button with its value from the translate file', async(() => {
-        spyOn(translateService, 'instant').and.callFake((inputString) => {
-            return 'Secondary Button';
-        });
-        fixture.detectChanges();
-        fixture.whenStable().then(() => {
-            const errorContentElement = element.querySelector('#adf-secondary-button');
+        it('should create error component', async(() => {
+            fixture.detectChanges();
+            expect(errorContentComponent).toBeTruthy();
+        }));
+
+        it('should render error code', async(() => {
+            fixture.detectChanges();
+            const errorContentElement = element.querySelector('.adf-error-content-code');
             expect(errorContentElement).not.toBeNull();
             expect(errorContentElement).toBeDefined();
-            expect(errorContentElement.textContent).toContain('ERROR_CONTENT.UNKNOWN.SECONDARY_BUTTON.TEXT');
+        }));
 
+        it('should render error title', async(() => {
+            fixture.detectChanges();
+            const errorContentElement = element.querySelector('.adf-error-content-title');
+            expect(errorContentElement).not.toBeNull();
+            expect(errorContentElement).toBeDefined();
+        }));
+
+        it('should render error description', async(() => {
+            fixture.detectChanges();
+            const errorContentElement = element.querySelector('.adf-error-content-description');
+            expect(errorContentElement).not.toBeNull();
+            expect(errorContentElement).toBeDefined();
+        }));
+
+        it('should render error description', async(() => {
+            fixture.detectChanges();
+            const errorContentElement = element.querySelector('.adf-error-content-description');
+            expect(errorContentElement).not.toBeNull();
+            expect(errorContentElement).toBeDefined();
+        }));
+
+        it('should hide secondary button if this one has no value', async(() => {
+            spyOn(translateService, 'instant').and.callFake((inputString) => {
+                return '';
+            });
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+                const errorContentElement = element.querySelector('.adf-error-content-description-link');
+                expect(errorContentElement).toBeNull();
+            });
+        }));
+
+        it('should render secondary button with its value from the translate file', async(() => {
+            spyOn(translateService, 'instant').and.callFake((inputString) => {
+                return 'Secondary Button';
+            });
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+                const errorContentElement = element.querySelector('#adf-secondary-button');
+                expect(errorContentElement).not.toBeNull();
+                expect(errorContentElement).toBeDefined();
+                expect(errorContentElement.textContent).toContain('ERROR_CONTENT.UNKNOWN.SECONDARY_BUTTON.TEXT');
+
+            });
+        }));
+
+        it('should the default value of return button be /', async(() => {
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+                expect(errorContentComponent.returnButtonUrl).toBe('/');
+            });
+        }));
+
+        it('should navigate to the default error UNKNOWN if it does not find the error', async(() => {
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+                expect(errorContentComponent.errorCode).toBe('UNKNOWN');
+            });
+        }));
+    });
+
+    describe(' with a specific error', () => {
+
+        setupTestBed({
+            imports: [
+                CoreTestingModule
+            ],
+            providers: [
+                { provide: TranslationService, useClass: TranslationMock },
+                { provide: ActivatedRoute, useValue: { params: of({ id: '404' }) } }
+            ]
         });
-    }));
 
-    it('should the default value of return button be /', async(() => {
-        fixture.detectChanges();
-        fixture.whenStable().then(() => {
-            expect(errorContentComponent.returnButtonUrl).toBe('/');
-        });
-    }));
-
-    it('should navigate to an error given by the route params', async(() => {
-        spyOn(translateService, 'get').and.returnValue(of('404'));
-        fixture.detectChanges();
-        fixture.whenStable().then(() => {
-            expect(errorContentComponent.errorCode).toBe('404');
-        });
-    }));
-
-    it('should navigate to the default error UNKNOWN if it does not find the error', async(() => {
-        fixture.detectChanges();
-        fixture.whenStable().then(() => {
-            expect(errorContentComponent.errorCode).toBe('UNKNOWN');
-        });
-    }));
-
+        it('should navigate to an error given by the route params', async(() => {
+            spyOn(translateService, 'get').and.returnValue(of('404'));
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+                expect(errorContentComponent.errorCode).toBe('404');
+            });
+        }));
+    });
 });

--- a/lib/core/templates/error-content/error-content.component.ts
+++ b/lib/core/templates/error-content/error-content.component.ts
@@ -46,7 +46,7 @@ export class ErrorContentComponent implements OnInit, AfterContentChecked {
 
     /** Error code associated with this error. */
     @Input()
-    errorCode: string;
+    errorCode: string = 'UNKNOWN';
 
     hasSecondButton: boolean;
 
@@ -58,15 +58,8 @@ export class ErrorContentComponent implements OnInit, AfterContentChecked {
     ngOnInit() {
         if (this.route) {
             this.route.params.forEach((params: Params) => {
-                if (params['id'] && !this.errorCode) {
+                if (params['id']) {
                     this.errorCode = params['id'];
-                    let unknown = '';
-                    this.translateService.get('ERROR_CONTENT.' + this.errorCode + '.TITLE').subscribe((errorTranslation: string) => {
-                        unknown = errorTranslation;
-                    });
-                    if (unknown === 'ERROR_CONTENT.' + this.errorCode + '.TITLE') {
-                        this.errorCode = 'UNKNOWN';
-                    }
                 }
             });
         }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Browser cultures are not supported (i.e. `pt-BR` or `zh-CN`)

**What is the new behaviour?**

- support browser cultures
- fallback to the language ids when missing culture-based translations

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
