### PR TITLE
Fix pageSize value fetch for infinite pagination

### DIFF
--- a/lib/core/pagination/infinite-pagination.component.spec.ts
+++ b/lib/core/pagination/infinite-pagination.component.spec.ts
@@ -139,7 +139,17 @@ describe('InfinitePaginationComponent', () => {
 
             component.onLoadMore();
 
-            expect(testTarget.updatePagination).toHaveBeenCalledWith({ maxItems: 469, skipCount: 0, totalItems: 888, hasMoreItems: true, merge: true });
+            expect(testTarget.updatePagination).toHaveBeenCalledWith({ maxItems: 444 + 25, skipCount: 0, totalItems: 888, hasMoreItems: true, merge: true });
+        });
+
+        it('should call the target\'s updatePagination on invoking the onLoadMore with a specific pageSize', () => {
+            component.target = testTarget;
+            component.pageSize = 7;
+            fixture.detectChanges();
+
+            component.onLoadMore();
+
+            expect(testTarget.updatePagination).toHaveBeenCalledWith({ maxItems: 444 + component.pageSize, skipCount: 0, totalItems: 888, hasMoreItems: true, merge: true });
         });
 
         it('should unsubscribe from the target\'s pagination on onDestroy', () => {

--- a/lib/core/pagination/infinite-pagination.component.ts
+++ b/lib/core/pagination/infinite-pagination.component.ts
@@ -40,6 +40,9 @@ import { UserPreferencesService } from '../services/user-preferences.service';
 })
 export class InfinitePaginationComponent implements OnInit, OnDestroy, PaginationComponentInterface {
 
+    /**
+     * @deprecated 3.0.0 - uses paginationSize's default in UserPreferencesService
+     */
     static DEFAULT_PAGE_SIZE: number = 25;
 
     static DEFAULT_PAGINATION: PaginationModel = {
@@ -61,7 +64,7 @@ export class InfinitePaginationComponent implements OnInit, OnDestroy, Paginatio
 
     /** Number of items that are added with each "load more" event. */
     @Input()
-    pageSize: number = InfinitePaginationComponent.DEFAULT_PAGE_SIZE;
+    pageSize: number;
 
     /** Is a new page loading? */
     @Input('loading')
@@ -81,7 +84,7 @@ export class InfinitePaginationComponent implements OnInit, OnDestroy, Paginatio
             this.paginationSubscription = this.target.pagination.subscribe((pagination) => {
                 this.isLoading = false;
                 this.pagination = pagination;
-                this.pageSize = this.userPreferencesService.paginationSize || this.pageSize;
+                this.pageSize = this.pageSize || this.userPreferencesService.paginationSize;
                 this.cdr.detectChanges();
             });
         }


### PR DESCRIPTION
> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
pageSize of 25 is always used


**What is the new behaviour?**
uses pageSize defined on the component or by the UserPreferencesService
if not defined

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-3843