### PR TITLE
[ADF-3864] Create library - no error is displayed when name contains white spaces only

### DIFF
--- a/lib/content-services/dialogs/library/library.dialog.html
+++ b/lib/content-services/dialogs/library/library.dialog.html
@@ -18,6 +18,10 @@
       <mat-error *ngIf="form.controls['title'].hasError('maxlength')">
         {{ 'LIBRARY.ERRORS.TITLE_TOO_LONG' | translate }}
       </mat-error>
+
+      <mat-error *ngIf="form.controls['title'].errors?.message">
+        {{ form.controls['title'].errors?.message | translate }}
+      </mat-error>
     </mat-form-field>
 
     <mat-form-field>

--- a/lib/content-services/dialogs/library/library.dialog.spec.ts
+++ b/lib/content-services/dialogs/library/library.dialog.spec.ts
@@ -195,4 +195,46 @@ describe('LibraryDialogComponent', () => {
       message: 'LIBRARY.ERRORS.CONFLICT'
     });
   }));
+
+  it('should not translate library title if value is not a valid id', fakeAsync(() => {
+    spyOn(alfrescoApi.sitesApi, 'getSite').and.callFake(() => {
+      return new Promise((resolve, reject) => reject());
+    });
+
+    fixture.detectChanges();
+    component.form.controls.title.setValue('@@@####');
+    tick(500);
+    flush();
+    fixture.detectChanges();
+
+    expect(component.form.controls.id.value).toBe(null);
+  }));
+
+  it('should translate library title partially for library id', fakeAsync(() => {
+    spyOn(alfrescoApi.sitesApi, 'getSite').and.callFake(() => {
+      return new Promise((resolve, reject) => reject());
+    });
+
+    fixture.detectChanges();
+    component.form.controls.title.setValue('@@@####library');
+    tick(500);
+    flush();
+    fixture.detectChanges();
+
+    expect(component.form.controls.id.value).toBe('library');
+  }));
+
+  it('should translate library title multiple space character to one dash for library id', fakeAsync(() => {
+    spyOn(alfrescoApi.sitesApi, 'getSite').and.callFake(() => {
+      return new Promise((resolve, reject) => reject());
+    });
+
+    fixture.detectChanges();
+    component.form.controls.title.setValue('library     title');
+    tick(500);
+    flush();
+    fixture.detectChanges();
+
+    expect(component.form.controls.id.value).toBe('library-title');
+  }));
 });

--- a/lib/content-services/dialogs/library/library.dialog.ts
+++ b/lib/content-services/dialogs/library/library.dialog.ts
@@ -110,11 +110,7 @@ export class LibraryDialogComponent implements OnInit, OnDestroy {
         takeUntil(this.onDestroy$)
       )
       .subscribe((title: string) => {
-        if (!title.trim().length) {
-          return;
-        }
-
-        if (!this.form.controls['id'].dirty) {
+        if (!this.form.controls['id'].dirty && this.canGenerateId(title)) {
           this.form.patchValue({ id: this.sanitize(title.trim()) });
           this.form.controls['id'].markAsTouched();
         }
@@ -181,7 +177,11 @@ export class LibraryDialogComponent implements OnInit, OnDestroy {
   }
 
   private sanitize(input: string) {
-    return input.replace(/[\s]/g, '-').replace(/[^A-Za-z0-9-]/g, '');
+    return input.replace(/[\s\s]+/g, '-').replace(/[^A-Za-z0-9-]/g, '');
+  }
+
+  private canGenerateId(title) {
+    return Boolean(title.replace(/[^A-Za-z0-9-]/g, '').length);
   }
 
   private handleError(error: any): any {
@@ -219,6 +219,10 @@ export class LibraryDialogComponent implements OnInit, OnDestroy {
   }
 
   private forbidSpecialCharacters({ value }: FormControl) {
+    if (value === null || value.length === 0) {
+      return null;
+    }
+
     const validCharacters: RegExp = /[^A-Za-z0-9-]/;
     const isValid: boolean = !validCharacters.test(value);
 

--- a/lib/content-services/dialogs/library/library.dialog.ts
+++ b/lib/content-services/dialogs/library/library.dialog.ts
@@ -84,13 +84,17 @@ export class LibraryDialogComponent implements OnInit, OnDestroy {
         Validators.maxLength(72),
         this.forbidSpecialCharacters
       ],
-      title: [Validators.required, Validators.maxLength(256)],
+      title: [
+        Validators.required,
+        this.forbidOnlySpaces,
+        Validators.maxLength(256)
+      ],
       description: [Validators.maxLength(512)]
     };
 
     this.form = this.formBuilder.group({
-      title: ['', validators.title],
-      id: ['', validators.id, this.createSiteIdValidator()],
+      title: [null, validators.title],
+      id: [null, validators.id, this.createSiteIdValidator()],
       description: ['', validators.description]
     });
 
@@ -222,6 +226,20 @@ export class LibraryDialogComponent implements OnInit, OnDestroy {
       ? null
       : {
           message: 'LIBRARY.ERRORS.ILLEGAL_CHARACTERS'
+        };
+  }
+
+  private forbidOnlySpaces({ value }: FormControl) {
+    if (value === null || value.length === 0) {
+      return null;
+    }
+
+    const isValid: boolean = !!(value || '').trim();
+
+    return isValid
+      ? null
+      : {
+          message: 'LIBRARY.ERRORS.ONLY_SPACES'
         };
   }
 

--- a/lib/content-services/i18n/en.json
+++ b/lib/content-services/i18n/en.json
@@ -323,6 +323,7 @@
       "DESCRIPTION_TOO_LONG": "Use 512 characters or less for description",
       "TITLE_TOO_LONG": "Use 256 characters or less for title",
       "ILLEGAL_CHARACTERS": "Use numbers and letters only",
+      "ONLY_SPACES": "Library name can't contain only spaces",
       "LIBRARY_UPDATE_ERROR": "There was an error updating library properties"
     },
     "SUCCESS": {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://issues.alfresco.com/jira/browse/ADF-3864

**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
