### PR TITLE
[ADF-3822] Add Create Library button on mobile view

### DIFF
--- a/demo-shell/resources/i18n/en.json
+++ b/demo-shell/resources/i18n/en.json
@@ -143,7 +143,8 @@
       "THEME": "Select a theme",
       "SHOW_VERSION": "Show version",
       "HIDE_VERSION": "Hide version",
-      "LISTVIEW": "List view mode"
+      "LISTVIEW": "List view mode",
+      "CREATE_LIBRARY": "Create Library"
     },
     "ACTIONS": {
       "VERSIONS": "Manage versions",

--- a/demo-shell/src/app/components/files/files.component.html
+++ b/demo-shell/src/app/components/files/files.component.html
@@ -174,6 +174,11 @@
                         <span>{{ 'DOCUMENT_LIST.TOOLBAR.NEW_FOLDER' | translate }}</span>
                     </button>
                     <button mat-menu-item
+                            (click)="createLibrary()">
+                        <mat-icon>library_add</mat-icon>
+                        <span>{{ 'DOCUMENT_LIST.TOOLBAR.CREATE_LIBRARY' | translate }}</span>
+                    </button>
+                    <button mat-menu-item
                             [disabled]="!canEditFolder(documentList.selection)"
                             (error)="openSnackMessage($event)"
                             [adf-edit-folder]="documentList.selection[0]?.entry">


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-3822


**What is the new behaviour?**
The Create Library Button is now displayed when it's in Mobile View as well.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
