### PR TITLE
[ADF-3854] Destination picker - restrict site content option

### DIFF
--- a/demo-shell/src/app/components/content-node-selector/content-node-selector.component.html
+++ b/demo-shell/src/app/components/content-node-selector/content-node-selector.component.html
@@ -115,6 +115,39 @@
         <mat-expansion-panel>
                 <mat-expansion-panel-header>
                     <mat-panel-title>
+                        <h2>Restricted Site Content</h2>
+                    </mat-panel-title>
+                    <mat-panel-description>
+                        <label class="adf-content-node-selector-demo-basic-label">
+                            The restricted site content is filtered out from the list
+                        </label>
+                    </mat-panel-description>
+                </mat-expansion-panel-header>
+                <div>
+                    <label>Case when the restrictedSiteContent is set as : <b>{{ restrictedSiteContentList.join(', ') }}</b></label>
+                </div>
+                <div>
+                    <label>Navigate into a site having the top content along the 'documentLibrary' to see that such items are not displayed.</label>
+                </div>
+                <br />
+                <mat-slide-toggle color="primary" [(ngModel)]="showFiles" (click)="recreateRowFilterFunction()">
+                    Show Files
+                </mat-slide-toggle>
+                <mat-slide-toggle color="primary" [(ngModel)]="showFolders" (click)="recreateRowFilterFunction()">
+                    Show Folders
+                </mat-slide-toggle>
+
+                <div class="adf-content-node-selector-demo-basic-table">
+                    <adf-content-node-selector-panel
+                        [rowFilter]="rowFilterFunction"
+                        [restrictedSiteContent]="restrictedSiteContentList"
+                        [currentFolderId]="'-root-'">
+                    </adf-content-node-selector-panel>
+                </div>
+        </mat-expansion-panel>
+        <mat-expansion-panel>
+                <mat-expansion-panel-header>
+                    <mat-panel-title>
                         <h2>Custom Image Resolving</h2>
                     </mat-panel-title>
                     <mat-panel-description>

--- a/demo-shell/src/app/components/content-node-selector/content-node-selector.component.ts
+++ b/demo-shell/src/app/components/content-node-selector/content-node-selector.component.ts
@@ -17,7 +17,7 @@
 
 import { Component, ViewEncapsulation } from '@angular/core';
 import { SitePaging, SiteEntry, MinimalNodeEntryEntity } from '@alfresco/js-api';
-import { ShareDataRow } from '@alfresco/adf-content-services';
+import { ContentNodeDialogService, ShareDataRow } from '@alfresco/adf-content-services';
 import { DataRow, DataColumn, ThumbnailService } from '@alfresco/adf-core';
 
 @Component({
@@ -41,6 +41,7 @@ export class ContentNodeSelectorComponent {
     actualPageSize = 2;
 
     rowFilterFunction: any = null;
+    restrictedSiteContentList: string[] = ContentNodeDialogService.copyMoveRestrictedSiteContent;
     customImageResolver: any = null;
 
     defaultSites: SiteEntry[] = [

--- a/docs/content-services/content-node-selector-panel.component.md
+++ b/docs/content-services/content-node-selector-panel.component.md
@@ -38,6 +38,7 @@ Opens a Content Node Selector in its own dialog window.
 | isSelectionValid | `ValidationFunction` | defaultValidation | Function used to decide if the selected node has permission to be selected. Default value is a function that always returns true. |
 | pageSize | `number` |  | Number of items shown per page in the list. |
 | rowFilter | `RowFilter` | null | Custom row filter function. See the [Document List component](document-list.component.md#custom-row-filter) for more information. |
+| restrictedSiteContent | string[] | [] | Custom list of restricted site content that should be hidden from displayed nodes. |
 
 ### Events
 

--- a/lib/content-services/content-node-selector/content-node-dialog.service.ts
+++ b/lib/content-services/content-node-selector/content-node-dialog.service.ts
@@ -32,6 +32,14 @@ import { switchMap } from 'rxjs/operators';
     providedIn: 'root'
 })
 export class ContentNodeDialogService {
+    static copyMoveRestrictedSiteContent = [
+        'blog',
+        'calendar',
+        'dataLists',
+        'discussions',
+        'links',
+        'wiki'
+    ];
 
     /** Emitted when an error occurs. */
     @Output()
@@ -117,9 +125,10 @@ export class ContentNodeDialogService {
      * @param action Name of the action (eg, "Copy" or "Move") to show in the title
      * @param contentEntry Item to be copied or moved
      * @param permission Permission for the operation
+     * @param restrictedSiteContent The site content that should be filtered out
      * @returns Information about files that were copied/moved
      */
-    openCopyMoveDialog(action: string, contentEntry: Node, permission?: string): Observable<Node[]> {
+    openCopyMoveDialog(action: string, contentEntry: Node, permission?: string, restrictedSiteContent?: string[]): Observable<Node[]> {
         if (this.contentService.hasPermission(contentEntry, permission)) {
 
             const select = new Subject<Node[]>();
@@ -136,6 +145,7 @@ export class ContentNodeDialogService {
                 imageResolver: this.imageResolver.bind(this),
                 rowFilter: this.rowFilter.bind(this, contentEntry.id),
                 isSelectionValid: this.isCopyMoveSelectionValid.bind(this),
+                restrictedSiteContent: restrictedSiteContent || ContentNodeDialogService.copyMoveRestrictedSiteContent,
                 select: select
             };
 

--- a/lib/content-services/content-node-selector/content-node-selector-panel.component.spec.ts
+++ b/lib/content-services/content-node-selector/content-node-selector-panel.component.spec.ts
@@ -107,6 +107,21 @@ describe('ContentNodeSelectorComponent', () => {
 
                 component.chosenNode = expectedNode;
             });
+
+            it('should be able to filter out the restricted site content', () => {
+                component.restrictedSiteContent = ['blog'];
+                fixture.detectChanges();
+
+                const testSiteContent = new Node({id: 'blog-id', properties: { 'st:componentId': 'blog' }});
+                expect(component.rowFilter(<any> {node: {entry: testSiteContent}}, null, null)).toBe(false);
+            });
+
+            it('should NOT filter out any site content by default', () => {
+                fixture.detectChanges();
+
+                const testSiteContent = new Node({id: 'blog-id', properties: { 'st:componentId': 'blog' }});
+                expect(component.rowFilter(<any> {node: {entry: testSiteContent}}, null, null)).toBe(true);
+            });
         });
 
         describe('Breadcrumbs', () => {

--- a/lib/content-services/content-node-selector/content-node-selector.component-data.interface.ts
+++ b/lib/content-services/content-node-selector/content-node-selector.component-data.interface.ts
@@ -28,5 +28,6 @@ export interface ContentNodeSelectorComponentData {
     imageResolver?: any;
     isSelectionValid?: (entry: Node) => boolean;
     breadcrumbTransform?: (node) => any;
+    restrictedSiteContent?: string[];
     select: Subject<Node[]>;
 }

--- a/lib/content-services/content-node-selector/content-node-selector.component.html
+++ b/lib/content-services/content-node-selector/content-node-selector.component.html
@@ -12,6 +12,7 @@
         [imageResolver]="imageResolver || data?.imageResolver"
         [isSelectionValid]="data?.isSelectionValid"
         [breadcrumbTransform]="data?.breadcrumbTransform"
+        [restrictedSiteContent]="data?.restrictedSiteContent"
         (select)="onSelect($event)">
     </adf-content-node-selector-panel>
 </mat-dialog-content>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe: new option to hide the unwanted site content from destination picker list


**What is the current behaviour?** (You can also link to an open issue here)
Users can select non-document library content as destination when performing a copy/move action.


**What is the new behaviour?**
Only the 'documentList' can be selected as destination node for a copy/move action.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
