### PR TITLE
[ADF-3855] Add minimum length to library title

### DIFF
--- a/demo-shell/resources/i18n/en.json
+++ b/demo-shell/resources/i18n/en.json
@@ -1,6 +1,5 @@
 {
   "APP": {
-    "CREATE_LIBRARY": "Create Library",
     "INFO_DRAWER": {
       "TITLE": "Details",
       "COMMENTS": "Comments",

--- a/demo-shell/src/app/components/files/files.component.html
+++ b/demo-shell/src/app/components/files/files.component.html
@@ -87,7 +87,7 @@
                     </button>
                     <button
                         mat-icon-button
-                        matTooltip="{{ 'APP.CREATE_LIBRARY' | translate }}"
+                        matTooltip="{{ 'DOCUMENT_LIST.TOOLBAR.CREATE_LIBRARY' | translate }}"
                         (click)="createLibrary()">
                         <mat-icon>library_add</mat-icon>
                     </button>

--- a/lib/content-services/dialogs/library/library.dialog.html
+++ b/lib/content-services/dialogs/library/library.dialog.html
@@ -19,6 +19,10 @@
         {{ 'LIBRARY.ERRORS.TITLE_TOO_LONG' | translate }}
       </mat-error>
 
+      <mat-error *ngIf="form.controls['title'].hasError('minlength')">
+        {{ 'LIBRARY.ERRORS.TITLE_TOO_SHORT' | translate }}
+      </mat-error>
+
       <mat-error *ngIf="form.controls['title'].errors?.message">
         {{ form.controls['title'].errors?.message | translate }}
       </mat-error>

--- a/lib/content-services/dialogs/library/library.dialog.spec.ts
+++ b/lib/content-services/dialogs/library/library.dialog.spec.ts
@@ -259,4 +259,20 @@ describe('LibraryDialogComponent', () => {
 
         expect(component.form.controls.id.value).toBe('library-title');
     }));
+
+    it('should invalidate library title title if title is too short', fakeAsync(() => {
+        findSitesSpy.and.returnValue(Promise.resolve(findSitesResponse));
+        spyOn(alfrescoApi.sitesApi, 'getSite').and.callFake(() => {
+            return new Promise((resolve, reject) => reject());
+        });
+
+        fixture.detectChanges();
+        component.form.controls.title.setValue('l');
+        tick(500);
+        flush();
+        fixture.detectChanges();
+
+        expect(component.form.controls.title.errors['minlength']).toBeTruthy();
+        expect(component.form.valid).toBe(false);
+    }));
 });

--- a/lib/content-services/dialogs/library/library.dialog.spec.ts
+++ b/lib/content-services/dialogs/library/library.dialog.spec.ts
@@ -260,7 +260,7 @@ describe('LibraryDialogComponent', () => {
         expect(component.form.controls.id.value).toBe('library-title');
     }));
 
-    it('should invalidate library title title if title is too short', fakeAsync(() => {
+    it('should invalidate library title if is too short', fakeAsync(() => {
         findSitesSpy.and.returnValue(Promise.resolve(findSitesResponse));
         spyOn(alfrescoApi.sitesApi, 'getSite').and.callFake(() => {
             return new Promise((resolve, reject) => reject());

--- a/lib/content-services/dialogs/library/library.dialog.ts
+++ b/lib/content-services/dialogs/library/library.dialog.ts
@@ -87,6 +87,7 @@ export class LibraryDialogComponent implements OnInit, OnDestroy {
       title: [
         Validators.required,
         this.forbidOnlySpaces,
+        Validators.minLength(2),
         Validators.maxLength(256)
       ],
       description: [Validators.maxLength(512)]

--- a/lib/content-services/i18n/en.json
+++ b/lib/content-services/i18n/en.json
@@ -328,6 +328,7 @@
       "ID_TOO_LONG": "Use 72 characters or less for the URL name",
       "DESCRIPTION_TOO_LONG": "Use 512 characters or less for description",
       "TITLE_TOO_LONG": "Use 256 characters or less for title",
+      "TITLE_TOO_SHORT": "Title must be at least 2 characters long",
       "ILLEGAL_CHARACTERS": "Use numbers and letters only",
       "ONLY_SPACES": "Library name can't contain only spaces",
       "LIBRARY_UPDATE_ERROR": "There was an error updating library properties"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-3855


**What is the new behaviour?**
A new form validator has been added to ensure that library titles are at least 2 characters long.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-3855