### PR TITLE
[ADF-3745] Fixed broken links in docs

### DIFF
--- a/docs/core/form-field.component.md
+++ b/docs/core/form-field.component.md
@@ -27,7 +27,7 @@ based on the field type or the metadata information.
 
 | Name | Type | Default value | Description |
 | ---- | ---- | ------------- | ----------- |
-| field | [`FormFieldModel`](../core/form-field.model.md) | null | Contains all the necessary data needed to determine what UI [`Widget`](../../e2e/pages/adf/process_services/widgets/widget.ts) to use when rendering the field in the form. You would typically not create this data manually but instead create the form in APS and export it to get to all the `FormFieldModel` definitions. |
+| field | [`FormFieldModel`](../core/form-field.model.md) | null | Contains all the necessary data needed to determine what UI `Widget` to use when rendering the field in the form. You would typically not create this data manually but instead create the form in APS and export it to get to all the `FormFieldModel` definitions. |
 
 ## Details
 
@@ -38,7 +38,7 @@ uses `<adf-form-field>` components to render the form fields.
 
 Forms defined in APS have the following default mappings for the form fields:
 
-| _APS [`Form`](../../lib/process-services/task-list/models/form.model.ts) Designer_ [`Widget`](../../e2e/pages/adf/process_services/widgets/widget.ts) | Field Type | Component Type |
+| _APS Form Designer_ Widget | Field Type | Component Type |
 | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- | -------------- |
 | Text | text | [`TextWidgetComponent`](../../lib/core/form/components/widgets/text/text.widget.ts) |
 | Multi-line text | multi-line-text | [`MultilineTextWidgetComponentComponent`](../../lib/core/form/components/widgets/multiline-text/multiline-text.widget.ts) |

--- a/docs/core/form-rendering.service.md
+++ b/docs/core/form-rendering.service.md
@@ -31,13 +31,13 @@ Maps a form field type string onto the corresponding form [widget component](../
 
 ## Details
 
-The [`Form`](../../lib/process-services/task-list/models/form.model.ts) Field component uses this service to choose which [widget](../../e2e/pages/adf/process_services/widgets/widget.ts) to use to render an instance of a
+The [`Form`](../../lib/process-services/task-list/models/form.model.ts) Field component uses this service to choose which widget to use to render an instance of a
 form field. The [`Form`](../../lib/process-services/task-list/models/form.model.ts) Field model stores the field type name as a string (see the table below).
 The [`Form`](../../lib/process-services/task-list/models/form.model.ts) Rendering service maintains a mapping between each type name and
 a corresponding `DynamicComponentResolveFunction`. The function takes a [`FormFieldModel`](../core/form-field.model.md) object as its argument and
-uses the data from the object to determine which [widget](../../e2e/pages/adf/process_services/widgets/widget.ts) should be used to render the field.
+uses the data from the object to determine which widget should be used to render the field.
 
-In some cases, the field type string alone is enough to determine the [widget](../../e2e/pages/adf/process_services/widgets/widget.ts) type and so the function
+In some cases, the field type string alone is enough to determine the widget type and so the function
 just returns the type directly:
 
 ```ts
@@ -45,7 +45,7 @@ let customResolver: DynamicComponentResolveFunction = () => CustomWidgetComponen
 formRenderingService.setComponentTypeResolver('text', customResolver, true);
 ```
 
-In other cases, the function may need to choose the [widget](../../e2e/pages/adf/process_services/widgets/widget.ts) dynamically based on
+In other cases, the function may need to choose the widget dynamically based on
 specific values in the form data:
 
 ```ts
@@ -95,7 +95,7 @@ if you set the `override` parameter to 'true':
 formRenderingService.setComponentTypeResolver('text', newResolver, true);
 ```
 
-You would typically use this to replace an existing [widget](../../e2e/pages/adf/process_services/widgets/widget.ts) with your own custom version that
+You would typically use this to replace an existing widget with your own custom version that
 implements a modified layout or responds differently when the data is entered. See the
 [Form Extensibility and Customisation](../user-guide/extensibility.md) guide for further details and examples
 of this technique.

--- a/docs/core/form.component.md
+++ b/docs/core/form.component.md
@@ -278,7 +278,7 @@ could use this, say, to provide two alternative ways of entering the same inform
 up default values that can be edited.
 
 You can implement this in ADF using the `formFieldValueChanged` event of the
-[Form service](form.service.md). For example, if you had a form with a [dropdown widget](../../e2e/pages/adf/process_services/widgets/dropdownWidget.ts) (id: `type`)
+[Form service](form.service.md). For example, if you had a form with a dropdown widget (id: `type`)
 and a multiline text (id:`description`), you could synchronize their values as follows:
 
 ```ts
@@ -295,7 +295,7 @@ formService.formFieldValueChanged.subscribe((e: FormFieldEvent) => {
 ```
 
 The code shown above subscribes to the `formFieldValueChanged` event to check whether an event
-is emitted for the `type` [widget](../../e2e/pages/adf/process_services/widgets/widget.ts). Then it finds the `description` [widget](../../e2e/pages/adf/process_services/widgets/widget.ts) and assigns some text
+is emitted for the `type` widget. Then it finds the `description` widget and assigns some text
 to its `value` property.
 
 The result should look like the following:

--- a/docs/insights/README.md
+++ b/docs/insights/README.md
@@ -16,7 +16,7 @@ for more information about installing and using the source code.
 
 | Name | Description | Source link |
 | ---- | ----------- | ----------- |
-| [Widget component](widget.component.md) | Base class for standard and custom [widget](../../e2e/pages/adf/process_services/widgets/widget.ts) classes. | [Source](../../lib/insights/analytics-process/components/widgets/widget.component.ts) |
+| [Widget component](widget.component.md) | Base class for standard and custom widget classes. | [Source](../../lib/insights/analytics-process/components/widgets/widget.component.ts) |
 | [Analytics generator component](analytics-generator.component.md) | Generates and shows charts | [Source](../../lib/insights/analytics-process/components/analytics-generator.component.ts) |
 | [Analytics report list component](analytics-report-list.component.md) | Shows a list of all available reports | [Source](../../lib/insights/analytics-process/components/analytics-report-list.component.ts) |
 | [Analytics component](analytics.component.md) | Shows the charts related to the reportId passed as input | [Source](../../lib/insights/analytics-process/components/analytics.component.ts) |

--- a/docs/insights/widget.component.md
+++ b/docs/insights/widget.component.md
@@ -7,7 +7,7 @@ Last reviewed: 2018-03-29
 
 # [Widget component](../../lib/insights/analytics-process/components/widgets/widget.component.ts "Defined in widget.component.ts")
 
-Base class for standard and custom [widget](../../e2e/pages/adf/process_services/widgets/widget.ts) classes.
+Base class for standard and custom widget classes.
 
 ## Basic Usage
 

--- a/docs/release-notes/RelNote161.md
+++ b/docs/release-notes/RelNote161.md
@@ -4,9 +4,9 @@ Title: Release notes v1.6.1
 
 # Alfresco Application Development Framework, version 1.6.1 Release Note
 
-These release notes provide information for the **1.6.1 release** of Alfresco Application Development Framework.
-This is the next **Limited Available** release of Application Development Framework, containing the Angular components to build a Web Application on top of the Alfresco Services.
-The release can be found on GitHub at [this link.](https://github.com/Alfresco/alfresco-ng2-components/releases/tag/1.6.1)
+These release notes provide information for the **1.6.1 release** of Alfresco Application Development Framework.
+This is the next **Limited Available** release of Application Development Framework, containing the Angular components to build a Web Application on top of the Alfresco Services.
+The release can be found on GitHub at [this link.](https://github.com/Alfresco/alfresco-ng2-components/releases/tag/1.6.1)
 
 ## Contents
 
@@ -38,11 +38,11 @@ The release can be found on GitHub at [this link.](https://github.com/Alfresc
 
 The roadmap for ADF is taking form, and we have a high focus on bringing in engaging design and UX, as well as add more and more content capabilities into ADF.
 
-Our focus while developing ADF 1.6.1 has been improving the Document List, Improved Preview, Finalize the design of the [Login component,](../core/login.component.md) External configuration, Performance enhancements for development, improvements in forms as well as paving the way for editing metadata and using forms for content.
+Our focus while developing ADF 1.6.1 has been improving the Document List, Improved Preview, Finalize the design of the [Login component,](../core/login.component.md) External configuration, Performance enhancements for development, improvements in forms as well as paving the way for editing metadata and using forms for content.
 
 This release builds on last month's contains bug fixes and new feature. See the list below for major details.
 
-Please report issues with this release in the [issue tracker](https://github.com/Alfresco/alfresco-ng2-components/issues). You can collaborate on this release or share feedback by using the discussion tools on [gitter](https://gitter.im/Alfresco/alfresco-ng2-components).
+Please report issues with this release in the [issue tracker](https://github.com/Alfresco/alfresco-ng2-components/issues). You can collaborate on this release or share feedback by using the discussion tools on [gitter](https://gitter.im/Alfresco/alfresco-ng2-components).
 
 ## Notable new features
 
@@ -71,32 +71,32 @@ _The ng2-alfresco-viewer if the [renditions service](../core/renditions.service.
 
 ### 2. Datatable loading state
 
-Is now possible define your custom loading template that will be shown during the loading of your data in the datatable:
+Is now possible define your custom loading template that will be shown during the loading of your data in the datatable:
 
     <alfresco-datatable
-        [data]="data"
-        [loading]=isLoading()">
+        [data]="data"
+        [loading]=isLoading()">
 
-            <loading-content-template>
-                <ng-template>
-                   <!--Add your custom loading template here-->
-                    <md-progress-spinner
-                        class="adf-document-list-loading-margin"
-                        [color]="'primary'"
-                        [mode]="'indeterminate'">
-                    </md-progress-spinner>
-                </ng-template>
-            </loading-content-template>
+            <loading-content-template>
+                <ng-template>
+                   <!--Add your custom loading template here-->
+                    <md-progress-spinner
+                        class="adf-document-list-loading-margin"
+                        [color]="'primary'"
+                        [mode]="'indeterminate'">
+                    </md-progress-spinner>
+                </ng-template>
+            </loading-content-template>
 
     </alfresco-datatable>
 
 ![](images/Jun-29-2017+11-34-06.gif)
 
-Refer to the [datable documentation](https://github.com/Alfresco/alfresco-ng2-components/tree/master/ng2-components/ng2-alfresco-datatable#loading-content-template) for further details. With this modify also the n2-alfresco-documentlist has gained a loading state.
+Refer to the [datable documentation](https://github.com/Alfresco/alfresco-ng2-components/tree/master/ng2-components/ng2-alfresco-datatable#loading-content-template) for further details. With this modify also the n2-alfresco-documentlist has gained a loading state.
 
 ### 3. New extension support in viewer
 
-The ng2-alfresco-viewer is now able to show files with txt extension natively and play wav and Mp3 files.
+The ng2-alfresco-viewer is now able to show files with txt extension natively and play wav and Mp3 files.
 
 ### 4. Extend TypeScript definitions for JS-API
 
@@ -106,33 +106,33 @@ We have added more methods in the type definition file of the alfresco-js-api to
 
 ### 5. ADF Card View
 
-The ADF Card is a generic component, which shows the properties received in input as a material design card.  The main idea was to create a component that can be shared among different components.
+The ADF Card is a generic component, which shows the properties received in input as a material design card.  The main idea was to create a component that can be shared among different components.
 
     <adf-card-view
-        [properties]="[{label: 'My Label', value: 'My value'}]">
+        [properties]="[{label: 'My Label', value: 'My value'}]">
     </adf-card-view>
 
 The properties are an array of CardViewModel
 
     export class CardViewModel {
-        label: string;
-        value: any;
-        key: any;
-        format: string;
-        default: string;
+        label: string;
+        value: any;
+        key: any;
+        format: string;
+        default: string;
 
-        constructor(obj?: any) {
-            this.label = obj.label || '';
-            this.value = obj.value;
-            this.key = obj.key;
-            this.format = obj.format;
-            this.default = obj.default;
-        }
+        constructor(obj?: any) {
+            this.label = obj.label || '';
+            this.value = obj.value;
+            this.key = obj.key;
+            this.format = obj.format;
+            this.default = obj.default;
+        }
     }
 
 As properties you can set the label, the value and other optional fields, such as the format and the default values.
 Specifically, the **format** propriety is useful to show a value in a custom format, for example, the date in DD/MM/YYYY or MM/DD/YYYY
-The **default** values allow initializing some properties as defined, in case the value provided is empty.
+The **default** values allow initializing some properties as defined, in case the value provided is empty.
 
 ### 6. Task Header Component
 
@@ -140,9 +140,9 @@ This component was already present in the previous ADF versions but we changed t
 The Task Header shows all the information related to the task.
 
     <div *ngIf="taskDetails">
-        <div class="mdl-grid mdl-shadow--2dp">
-            <adf-card-view [properties]="properties"></adf-card-view>
-        </div>
+        <div class="mdl-grid mdl-shadow--2dp">
+            <adf-card-view [properties]="properties"></adf-card-view>
+        </div>
     </div>
 
 Result:
@@ -151,19 +151,19 @@ Result:
 
 ### 7. Process and Task attachment list component
 
-This component shows all the attachments added to a task/process as a list. The component is using the [data table component](../../lib/core/datatable/components/datatable/datatable.component.ts) to show the list and the context menu with the actions. At the moment, you can open the attachment doing the double click on the row or select the action view from the menu actions. There is also the ability to download the attachment or remove it.
+This component shows all the attachments added to a task/process as a list. The component is using the [data table component](../../lib/core/datatable/components/datatable/datatable.component.ts) to show the list and the context menu with the actions. At the moment, you can open the attachment doing the double click on the row or select the action view from the menu actions. There is also the ability to download the attachment or remove it.
 
     <alfresco-datatable *ngIf="!isEmpty()"
-        [rows]="attachments"
-        [actions]="true"
-        (rowDblClick)="openContent($event)"
-        (showRowActionsMenu)="onShowRowActionsMenu($event)"
-        (executeRowAction)="onExecuteRowAction($event)">
-        <data-columns>
-            <data-column key="icon" type="icon" srTitle="Thumbnail" [sortable]="false"></data-column>
-            <data-column key="name" type="text" title="Name" class="full-width ellipsis-cell" [sortable]="true"></data-column>
-            <data-column key="created" type="date" format="shortDate" title="Date"></data-column>
-        </data-columns>
+        [rows]="attachments"
+        [actions]="true"
+        (rowDblClick)="openContent($event)"
+        (showRowActionsMenu)="onShowRowActionsMenu($event)"
+        (executeRowAction)="onExecuteRowAction($event)">
+        <data-columns>
+            <data-column key="icon" type="icon" srTitle="Thumbnail" [sortable]="false"></data-column>
+            <data-column key="name" type="text" title="Name" class="full-width ellipsis-cell" [sortable]="true"></data-column>
+            <data-column key="created" type="date" format="shortDate" title="Date"></data-column>
+        </data-columns>
     </alfresco-datatable>
 
 Result:
@@ -180,33 +180,33 @@ The [search component](../content-services/search.component.md) has the goal to 
 
 The [people list component](../process-services/people-list.component.md) shows all the people involved in a task in a list.
 
-The component is a wrapper of the data-table component with a custom action i.e. Remove the person from the list.
+The component is a wrapper of the data-table component with a custom action i.e. Remove the person from the list.
 
     <div class="assignment-container" *ngIf="showAssignment">
-        <activiti-people-search
-            (searchPeople)="searchUser($event)"
-            (success)="involveUser($event)"
-            (closeSearch)="onCloseSearch()"
-            [results]="peopleSearch$">
-            </activiti-people-search>
+        <activiti-people-search
+            (searchPeople)="searchUser($event)"
+            (success)="involveUser($event)"
+            (closeSearch)="onCloseSearch()"
+            [results]="peopleSearch$">
+            </activiti-people-search>
     </div>
     <div class="assignment-list-container" id="assignment-people-list" *ngIf="hasPeople()">
-       <adf-people-list [users]="people">
-          <data-columns>
-            <data-column key="firstName">
-              <ng-template let-entry="$implicit">
-                <div class="people-pic">{{getInitialUserName(entry.row.obj.firstName, entry.row.obj.lastName)}}</div>
-              </ng-template>
-            </data-column>
-            <data-column key="email" class="full-width">
-              <ng-template let-entry="$implicit">
-                <div class="adf-people-full-name">{{ getDisplayUser(entry.row.obj.firstName, entry.row.obj.lastName, ' ') }}</div>
-                <div class="adf-people-email">{{ entry.row.obj.email }}</div>
-                <div class="adf-people-edit-label">can edit</div>
-              </ng-template>
-            </data-column>
-          </data-columns>
-       </adf-people-list>
+       <adf-people-list [users]="people">
+          <data-columns>
+            <data-column key="firstName">
+              <ng-template let-entry="$implicit">
+                <div class="people-pic">{{getInitialUserName(entry.row.obj.firstName, entry.row.obj.lastName)}}</div>
+              </ng-template>
+            </data-column>
+            <data-column key="email" class="full-width">
+              <ng-template let-entry="$implicit">
+                <div class="adf-people-full-name">{{ getDisplayUser(entry.row.obj.firstName, entry.row.obj.lastName, ' ') }}</div>
+                <div class="adf-people-email">{{ entry.row.obj.email }}</div>
+                <div class="adf-people-edit-label">can edit</div>
+              </ng-template>
+            </data-column>
+          </data-columns>
+       </adf-people-list>
     </div>
 
 Add people search person result:
@@ -223,14 +223,14 @@ The Breadcrumbs has received a little cosmetic upgrade plus we have added also a
 
 ![](images/Screen+Shot+2017-06-29+at+01.06.36.png)
 
-The new property is **root**. You can specify in the root property the name of the folder where you want to tart the breadcrumb. Note: The root will always be shown as first element and it will continue to be displayed until you are not in a subfolder of it.
+The new property is **root**. You can specify in the root property the name of the folder where you want to tart the breadcrumb. Note: The root will always be shown as first element and it will continue to be displayed until you are not in a subfolder of it.
 
 Example:
 
     <adf-breadcrumb
-         [target]="documentList"
-         [root]="'New-Root'"
-         [folderNode]="newRootId">
+         [target]="documentList"
+         [root]="'New-Root'"
+         [folderNode]="newRootId">
     </adf-breadcrumb>
 
 Result:
@@ -239,18 +239,18 @@ Result:
 
 Note: The root will always be showed as first element and it will continue to be displayed until you are not in a subfolder of it.
 
-Refer to the [document list documentation](https://github.com/Alfresco/alfresco-ng2-components/tree/master/ng2-components/ng2-alfresco-documentlist#properties-1) for further details.
+Refer to the [document list documentation](https://github.com/Alfresco/alfresco-ng2-components/tree/master/ng2-components/ng2-alfresco-documentlist#properties-1) for further details.
 
 ### 10. Form events bus
 
-If you want to listen to all the events fired from the form you can subscribe to this [`Subject`](http://reactivex.io/documentation/subject.html):
+If you want to listen to all the events fired from the form you can subscribe to this [`Subject`](http://reactivex.io/documentation/subject.html):
 
     formService.formEvents.subscribe((event: Event) => {
-      console.log('Event fired:' + event.type);
-      console.log('Event Target:' + event.target);
+      console.log('Event fired:' + event.type);
+      console.log('Event Target:' + event.target);
     });
 
-Refer to the [form documentation](https://github.com/Alfresco/alfresco-ng2-components/tree/master/ng2-components/ng2-activiti-form#listen-all-form-events)
+Refer to the [form documentation](https://github.com/Alfresco/alfresco-ng2-components/tree/master/ng2-components/ng2-activiti-form#listen-all-form-events)
 for further details.
 
 ### 11. Form render independent from APS
@@ -268,13 +268,13 @@ And the underlying component controller code can be as follows:
 
     export class FormDemoComponent implements OnInit {
 
-      form: FormModel;
+      form: FormModel;
 
-      ngOnInit() {
-        let formDefinitionJSON: any = DemoForm.getDefinition();
-        let form = this.formService.parseForm(formDefinitionJSON);
-        this.form = form;
-      }
+      ngOnInit() {
+        let formDefinitionJSON: any = DemoForm.getDefinition();
+        let form = this.formService.parseForm(formDefinitionJSON);
+        this.form = form;
+      }
     }
 
 #### Parsing form definitions
@@ -289,12 +289,12 @@ It is now possible to control what happens when end users click the form outcome
 
     export class FormDemoComponent implements OnInit {
 
-      constructor(private formService: FormService) {
-        formService.executeOutcome.subscribe(e => {
-          e.preventDefault();
-          console.log(e.outcome);
-        });
-      }
+      constructor(private formService: FormService) {
+        formService.executeOutcome.subscribe(e => {
+          e.preventDefault();
+          console.log(e.outcome);
+        });
+      }
 
     }
 
@@ -305,17 +305,17 @@ It is now possible to have global (server-side) settings that enable or disable 
 By default, all application settings are stored in the "app.config.json" file in the root of your web application and have the following defaults:
 
     {
-        "ecmHost": "http://localhost:3000/ecm",
-        "bpmHost": "http://localhost:3000/bpm",
-        "application": {
-            "name": "Alfresco"
-        }
+        "ecmHost": "http://localhost:3000/ecm",
+        "bpmHost": "http://localhost:3000/bpm",
+        "application": {
+            "name": "Alfresco"
+        }
     }
 
 You can get more details on application configuration in the following articles:
 
--   [Demo App Readme](https://github.com/Alfresco/alfresco-ng2-components/blob/development/demo-shell-ng2/README.md#application-settings-server-side)
--   [AppConfigService Readme](https://github.com/Alfresco/alfresco-ng2-components/tree/development/ng2-components/ng2-alfresco-core#appconfigservice)
+-   [Demo App Readme](../..//demo-shell/README.md#application-settings-server-side)
+-   [AppConfigService Readme](../core/app-config.service.md)
 
 ### 13. Proxy settings and CORS
 
@@ -323,8 +323,8 @@ To greatly simplify development process the demo and generated applications now 
 
 You get the following settings by default (also applied to the Application settings)
 
--   <http://localhost:3000/ecm> is mapped to <http://localhost:8080>
--   <http://localhost:3000/bpm> is mapped to <http://localhost:9999>
+-   <http://localhost:3000/ecm> is mapped to <http://localhost:8080>
+-   <http://localhost:3000/bpm> is mapped to <http://localhost:9999>
 
 ### 14. Login restyling
 
@@ -336,13 +336,13 @@ If you would like to change default proxy settings, please edit the "**config/we
 
 ## References
 
-Below you can find a brief list of references to help you starting to use the new release.
+Below you can find a brief list of references to help you starting to use the new release.
 
-[Official GitHub Project - alfresco-ng2-components](https://github.com/Alfresco/alfresco-ng2-components)
+[Official GitHub Project - alfresco-ng2-components](https://github.com/Alfresco/alfresco-ng2-components)
 
 [Getting started guides with Alfresco Application Development Framework](https://community.alfresco.com/community/application-development-framework/pages/get-started)
 
-[Component catalog](http://devproducts.alfresco.com/)
+[Component catalog](http://devproducts.alfresco.com/)
 
 [Gitter chat supporting Alfresco ADF](https://gitter.im/Alfresco/alfresco-ng2-components)
 
@@ -352,13 +352,13 @@ Below you can find a brief list of references to help you starting to use the 
 
 [Alfresco-JS-API](https://github.com/Alfresco/alfresco-js-api)
 
-[ADF App Generator ](https://github.com/Alfresco/generator-ng2-alfresco-app)
+[ADF App Generator ](https://github.com/Alfresco/generator-ng2-alfresco-app)
 
-Please refer to the [official documentation](http://docs.alfresco.com/) for further details and suggestions.
+Please refer to the [official documentation](http://docs.alfresco.com/) for further details and suggestions.
 
 ## Issues addressed
 
-Below you can find a detailed list of tickets addressed in the new release. For a better understanding, the list is grouped by topic.
+Below you can find a detailed list of tickets addressed in the new release. For a better understanding, the list is grouped by topic.
 
 ## Feature
 
@@ -439,7 +439,7 @@ Below you can find a detailed list of tickets addressed in the new release. Fo
 ## Documentation
 
 -   \[[ADF-78](https://issues.alfresco.com/jira/browse/ADF-78)] - Update Activiti CORS setup guide - 1438 Github
--   \[[ADF-602](https://issues.alfresco.com/jira/browse/ADF-602)] - [Accordion Component](../core/accordion.component.md) - Documentation
+-   \[[ADF-602](https://issues.alfresco.com/jira/browse/ADF-602)] - Accordion Component - Documentation
 -   \[[ADF-776](https://issues.alfresco.com/jira/browse/ADF-776)] - Update ADF project from 1.4.0 to 1.5. 
 
-Please refer to [the Alfresco issue tracker](https://issues.alfresco.com/jira/projects/ADF/issues/ADF-581?filter=allopenissues) for other known issues in this release. If you have more questions, please reply here or contact us using [gitter](https://gitter.im/Alfresco/alfresco-ng2-components).
+Please refer to [the Alfresco issue tracker](https://issues.alfresco.com/jira/projects/ADF/issues/ADF-581?filter=allopenissues) for other known issues in this release. If you have more questions, please reply here or contact us using [gitter](https://gitter.im/Alfresco/alfresco-ng2-components).

--- a/docs/release-notes/RelNote170.md
+++ b/docs/release-notes/RelNote170.md
@@ -4,10 +4,10 @@ Title: Release notes v1.7.0
 
 # Alfresco Application Development Framework, version 1.7.0 Release Note
 
-These release notes provide information for the **1.7.0 release** of Alfresco Application Development Framework.
+These release notes provide information for the **1.7.0 release** of Alfresco Application Development Framework.
 
-This is the next **Limited Available** release of Application Development Framework, containing the Angular components to build a Web Application on top of the Alfresco Services.
-The release can be found on GitHub at [this link.](https://github.com/Alfresco/alfresco-ng2-components/releases/tag/1.7.0)
+This is the next **Limited Available** release of Application Development Framework, containing the Angular components to build a Web Application on top of the Alfresco Services.
+The release can be found on GitHub at [this link.](https://github.com/Alfresco/alfresco-ng2-components/releases/tag/1.7.0)
 
 ## Contents
 
@@ -19,12 +19,12 @@ The release can be found on GitHub at [this link.](https://github.com/Alfresc
     -   [4. Toolbar Component](#4-toolbar-component)
     -   [5. Upload Component New design](#5-upload-component-new-design)
     -   [6. Upload ignore list configuration service](#6-upload-ignore-list-configuration-service)
-    -   [7. Process Service Start Task New design]\(#7-process-service-start-task new-design)
+    -   [7. Process Service Start Task New design](#7-process-service-start-task-new-design)
     -   [8. Process Header Component](#8-process-header-component)
-    -   [9. Search list Component new delete file feature]\(#9-search-list-component new-delete-file-feature)
+    -   [9. Search list Component new delete file feature](#9-search-list-component-new-delete-file-feature)
     -   [10. Login new property](#10-login-new-property)
-    -   [11. TaskDetails - DueDate and Description editable](#11-taskDetails---duedate-and-description-editable)
-    -   [12. Configuration back end service hostname feature]\(#12-configuration-back-end-service hostname feature)
+    -   [11. TaskDetails - DueDate and Description editable](#11-taskdetails---duedate-and-description-editable)
+    -   [12. Configuration back end service hostname feature](#12-configuration-back-end-service-hostname-feature)
     -   [13. User Preferences Service](#13-user-preferences-service)
     -   [14. Search results highlighting properties](#14-search-results-highlighting-properties)
     -   [15. Change document list style rows based on permissions](#15-change-document-list-style-rows-based-on-permissions)
@@ -48,7 +48,7 @@ We have introduced a "Copy and Move" component that integrates into the document
 
 This release builds on last month's contains bug fixes and new feature. See the list below for major details.
 
-Please report issues with this release in the [issue tracker](https://github.com/Alfresco/alfresco-ng2-components/issues). You can collaborate on this release or share feedback by using the discussion tools on [gitter](https://gitter.im/Alfresco/alfresco-ng2-components).
+Please report issues with this release in the [issue tracker](https://github.com/Alfresco/alfresco-ng2-components/issues). You can collaborate on this release or share feedback by using the discussion tools on [gitter](https://gitter.im/Alfresco/alfresco-ng2-components).
 
 ## Notable new features
 
@@ -62,10 +62,10 @@ Below the most relevant features of this release:
 -   Upload ignore list configuration service
 -   Start Task New design
 -   Process Header Component
--   Search list Component new delete file feature
--   Login new property
+-   Search list Component new delete file feature
+-   Login new property
 -   TaskDetails - DueDate and Description editable
--   Configuration back end service hostname feature
+-   Configuration back end service hostname feature
 -   [User Preferences Service](../core/user-preferences.service.md)
 -   Search results highlighting properties
 -   Change document list style rows based on permissions
@@ -75,7 +75,7 @@ Below the most relevant features of this release:
 
 ### 1. ADF Prefix
 
-In the previous release, there was a mixing usage of TAG prefix for all the components ("alfresco-", "activiti-", "adf-" ) . We find out that this approach was quite cumbersome. Now all the component using only the  TAG adf- prefix.
+In the previous release, there was a mixing usage of TAG prefix for all the components ("alfresco-", "activiti-", "adf-" ) . We find out that this approach was quite cumbersome. Now all the component using only the  TAG adf- prefix.
 The good news is that you don't need to rename your old component because the old name also if are not suggested anymore to use will be still supported. If you want see the complete list of all our components please follow [this link.](https://github.com/Alfresco/alfresco-ng2-components/tree/master/ng2-components)
 
 ### 2. Copy and Move component
@@ -83,30 +83,30 @@ The good news is that you don't need to rename your old component because the ol
 Two new content actions have been added, the "copy" and the "move" for both folders and files. You can define them the same way as you can do it for the existing content actions.
 
     <content-action
-        icon="content_copy"
-        target="folder"
-        title="{{'DOCUMENT_LIST.ACTIONS.FOLDER.COPY' | translate}}"
-        permission="update"
-        [disableWithNoPermission]="true"
-        handler="copy">
+        icon="content_copy"
+        target="folder"
+        title="{{'DOCUMENT_LIST.ACTIONS.FOLDER.COPY' | translate}}"
+        permission="update"
+        [disableWithNoPermission]="true"
+        handler="copy">
     </content-action>
     <content-action
-        icon="redo"
-        target="folder"
-        title="{{'DOCUMENT_LIST.ACTIONS.FOLDER.MOVE' | translate}}"
-        permission="update"
-        [disableWithNoPermission]="true"
-        handler="move">
+        icon="redo"
+        target="folder"
+        title="{{'DOCUMENT_LIST.ACTIONS.FOLDER.MOVE' | translate}}"
+        permission="update"
+        [disableWithNoPermission]="true"
+        handler="move">
     </content-action>
 
 ![](images/copy-move.gif)
 
 ### 3. Dropdown Sites/Favorites Component
 
-DocumentList now provides a site dropdown component to show and interact with the sites of the current user.
+DocumentList now provides a site dropdown component to show and interact with the sites of the current user.
 
      <adf-sites-dropdown
-      (change)="getSiteContent($event)">
+      (change)="getSiteContent($event)">
      </adf-sites-dropdown>
 
 ![](images/dropdown-sites.gif)
@@ -116,15 +116,15 @@ DocumentList now provides a site dropdown component to show and interact with t
 adf-toolbar is an easy container for headers, titles, actions, breadcrumbs.
 
     <adf-toolbar title="Toolbar">
-        <adf-toolbar-title>
-            <adf-breadcrumb ...></adf-breadcrumb>
-        </adf-toolbar-title>
-        <button md-icon-button>
-            <md-icon>create_new_folder</md-icon>
-        </button>
-        <button md-icon-button>
-            <md-icon>delete</md-icon>
-        </button>
+        <adf-toolbar-title>
+            <adf-breadcrumb ...></adf-breadcrumb>
+        </adf-toolbar-title>
+        <button md-icon-button>
+            <md-icon>create_new_folder</md-icon>
+        </button>
+        <button md-icon-button>
+            <md-icon>delete</md-icon>
+        </button>
     </adf-toolbar>
 
 ![](images/toobar.gif)
@@ -135,26 +135,26 @@ adf-toolbar is an easy container for headers, titles, actions, breadcrumbs.
 
 ### 6. Upload ignore list configuration service
 
-Is now possible add an ignore list for files that you don't want to allow upload on your CS. The configuration of this service is made through the [config service](https://github.com/Alfresco/alfresco-ng2-components/tree/master/ng2-components/ng2-alfresco-core#appconfigservice)
+Is now possible add an ignore list for files that you don't want to allow upload on your CS. The configuration of this service is made through the [config service](https://github.com/Alfresco/alfresco-ng2-components/tree/master/ng2-components/ng2-alfresco-core#appconfigservice)
 In the example below, you can see how filtered out the: '.git', '.DS_Store' and 'desktop.ini'.
 
 ```json
 {
-    "ecmHost": "[http://localhost:3000/ecm](http://localhost:3000/ecm)",
-    "bpmHost": "[http://localhost:3000/bpm](http://localhost:3000/bpm)",
-    "application": {
-        "name": "Alfresco"
-    },
-    "files": {
-          "excluded": [".DS_Store", "desktop.ini", ".git"]
-    }
+    "ecmHost": "[http://localhost:3000/ecm](http://localhost:3000/ecm)",
+    "bpmHost": "[http://localhost:3000/bpm](http://localhost:3000/bpm)",
+    "application": {
+        "name": "Alfresco"
+    },
+    "files": {
+          "excluded": [".DS_Store", "desktop.ini", ".git"]
+    }
 }
 ```
 
 -   Standard glob patterns work.
 -   You can end patterns with a forward slash / to specify a directory.
 
-### 7. Process Service Start Task New design
+### 7. Process Service Start Task New design
 
 Start Process task form has been redesigned:
 
@@ -165,14 +165,14 @@ Start Process task form has been redesigned:
 This component shows all the basic information of a process.
 
     <adf-process-instance-header
-        processInstance="localProcessDetails">
+        processInstance="localProcessDetails">
     </adf-process-instance-details>
 
-The component is using the **adf-card-view** component to render all the information like a card.
+The component is using the **adf-card-view** component to render all the information like a card.
 
 ![adf process header component](images/adf-process-instance-header-attachment.png)
 
-### 9. Search list Component new delete file feature
+### 9. Search list Component new delete file feature
 
 From now, it is possible to delete files (if you have permission) from within the search results.
 This action will do delete the particular file from your contents and NOT just from the search results.
@@ -181,7 +181,7 @@ This action will do delete the particular file from your contents and NOT just f
 
 ### 10. Login new property
 
-You can now customize the copyright text in the adf-login component using the copyrightText property:
+You can now customize the copyright text in the adf-login component using the copyrightText property:
 
 ![](images/Untitled.gif)
 
@@ -191,17 +191,17 @@ The due date and the description of the task details are now editable and integr
 
 ![](images/description.gif)
 
-### 12. Configuration back end service hostname feature
+### 12. Configuration back end service hostname feature
 
 [Application Configuration Service](https://github.com/Alfresco/alfresco-ng2-components/tree/development/ng2-components/ng2-alfresco-core#appconfigservice) (AppConfigService) gets support for dynamic variable substitution for APS and ACS endpoint settings.
 It is now possible having a configuration like given below:
 
     {
-        "ecmHost": "http://{hostname}:{port}/ecm",
-        "bpmHost": "http://{hostname}:{port}/bpm",
-        "application": {
-            "name": "Alfresco"
-        }
+        "ecmHost": "http://{hostname}:{port}/ecm",
+        "bpmHost": "http://{hostname}:{port}/bpm",
+        "application": {
+            "name": "Alfresco"
+        }
     }
 
 At runtime, the "hostname" and "port" variables will be automatically replaced with the actual values taken from the client machine. This helps reducing overhead with having multiple CI and E2E environments, all environments can use the same config file.
@@ -214,22 +214,22 @@ Developers have now a possibility storing and retrieving user preferences for ei
 
     @Component({...})
     class AppComponent {
-        constructor(userPreferences: UserPreferencesService) {
+        constructor(userPreferences: UserPreferencesService) {
 
-            userPreferences.set('myProperty1', 'value1');
-            userPreferences.set('myProperty2', 'value2');
+            userPreferences.set('myProperty1', 'value1');
+            userPreferences.set('myProperty2', 'value2');
 
-            console.log(
-                userPreferences.get('myProperty1')
-            );
-        }
+            console.log(
+                userPreferences.get('myProperty1')
+            );
+        }
     }
 
-The [`UserPreferencesService`](../core/user-preferences.service.md) provides an API needed to store preferences based on different profiles. You can now have multiple users on the same machine with different set of preferences (like pagination size, authentication type, etc).
+The [`UserPreferencesService`](../core/user-preferences.service.md) provides an API needed to store preferences based on different profiles. You can now have multiple users on the same machine with different set of preferences (like pagination size, authentication type, etc).
 
 ### 14. Search results highlighting properties
 
-With the current ADF version, we got a Pipe that has the goal to highlight a specific term found in the text. Basically, when the term has been found, a CSS class is added to the HTML code. By doing so it will be easy to customise the colour just overriding the CSS class.
+With the current ADF version, we got a Pipe that has the goal to highlight a specific term found in the text. Basically, when the term has been found, a CSS class is added to the HTML code. By doing so it will be easy to customise the colour just overriding the CSS class.
 Note that the Pipe can be used in all the template where this behaviour is needed, but at the moment we are using that only inside the search result.
 
 ![Pipe highlight](images/pipe-highlight.gif)
@@ -242,12 +242,12 @@ You can now customize the document list style row based on the permissions of th
 
 ### 16. APS Audit REST API in the JS API
 
-Two new methods has been added into the alfresco-js-api to support retrieve the audit informations inside the [process service](../process-services/process.service.md):
+Two new methods has been added into the alfresco-js-api to support retrieve the audit informations inside the [process service](../process-services/process.service.md):
 
 | API | Name | HTTP method | URL | Description |
 | --- | ---- | ----------- | --- | ----------- |
-| _ActivitiPublicRestApi.TaskApi_ | [**getTaskAuditJson**](https://github.com/Alfresco/alfresco-js-api/blob/a82ce3bbe56cb0944f8771d14193704b571adf96/src/alfresco-activiti-rest-api/docs/TaskApi.md#getTaskAuditJson) | **GET**  | /api/enterprise/tasks/{taskId}/audit | Retrieve audit infromation in json format |
-| _ActivitiPublicRestApi.TaskApi_ | [**getTaskAuditPdf**](https://github.com/Alfresco/alfresco-js-api/blob/a82ce3bbe56cb0944f8771d14193704b571adf96/src/alfresco-activiti-rest-api/docs/TaskApi.md#getTaskAuditPdf) | **GET**  | /app/rest/tasks/{taskId}/audit | Retrieve the task audit infromation in pdf format |
+| _ActivitiPublicRestApi.TaskApi_ | [**getTaskAuditJson**](https://github.com/Alfresco/alfresco-js-api/blob/a82ce3bbe56cb0944f8771d14193704b571adf96/src/alfresco-activiti-rest-api/docs/TaskApi.md#getTaskAuditJson) | **GET**  | /api/enterprise/tasks/{taskId}/audit | Retrieve audit infromation in json format |
+| _ActivitiPublicRestApi.TaskApi_ | [**getTaskAuditPdf**](https://github.com/Alfresco/alfresco-js-api/blob/a82ce3bbe56cb0944f8771d14193704b571adf96/src/alfresco-activiti-rest-api/docs/TaskApi.md#getTaskAuditPdf) | **GET**  | /app/rest/tasks/{taskId}/audit | Retrieve the task audit infromation in pdf format |
 
 For further details about those endepoints please refer to the [official documentation](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-activiti-rest-api/docs/TaskApi.md) 
 
@@ -268,20 +268,20 @@ The list below is the list of the new services added in 1.7.0:
 
 ### 18. Code Contribution Guide and CLA
 
-With the goal to make even easy contribute to our project, we have created a new [Contribution guide](https://github.com/Alfresco/alfresco-ng2-components/blob/master/CONTRIBUTING.md) to help all the people the community to contribute to the ADF code.
+With the goal to make even easy contribute to our project, we have created a new [Contribution guide](https://github.com/Alfresco/alfresco-ng2-components/blob/master/CONTRIBUTING.md) to help all the people the community to contribute to the ADF code.
 To make the contribution process smooth we have also added an automatic CLA (Contributor License Agreement) in our GitHub CI.
 
 ![](images/Screen+Shot+2017-07-31+at+20.16.25.png)
 
 ## References
 
-Below you can find a brief list of references to help you starting to use the new release.
+Below you can find a brief list of references to help you starting to use the new release.
 
-[Official GitHub Project - alfresco-ng2-components](https://github.com/Alfresco/alfresco-ng2-components)
+[Official GitHub Project - alfresco-ng2-components](https://github.com/Alfresco/alfresco-ng2-components)
 
 [Getting started guides with Alfresco Application Development Framework](https://community.alfresco.com/community/application-development-framework/pages/get-started)
 
-[Component catalog](http://devproducts.alfresco.com/)
+[Component catalog](http://devproducts.alfresco.com/)
 
 [Gitter chat supporting Alfresco ADF](https://gitter.im/Alfresco/alfresco-ng2-components)
 
@@ -291,13 +291,13 @@ Below you can find a brief list of references to help you starting to use the 
 
 [Alfresco-JS-API](https://github.com/Alfresco/alfresco-js-api)
 
-[ADF App Generator ](https://github.com/Alfresco/generator-ng2-alfresco-app)
+[ADF App Generator ](https://github.com/Alfresco/generator-ng2-alfresco-app)
 
-Please refer to the [official documentation](http://docs.alfresco.com/) for further details and suggestions.
+Please refer to the [official documentation](http://docs.alfresco.com/) for further details and suggestions.
 
 ## Issues addressed
 
-Below you can find a detailed list of tickets addressed in the new release. For a better understanding, the list is grouped by topic.
+Below you can find a detailed list of tickets addressed in the new release. For a better understanding, the list is grouped by topic.
 
 Release Notes - Apps Development Framework - Version 1.7. 
 
@@ -436,4 +436,4 @@ Release Notes - Apps Development Framework - Version 1.7.
 -   \[[ADF-1120](https://issues.alfresco.com/jira/browse/ADF-1120)] - Remove MDL button wrapper from ADF core
 -   \[[ADF-1144](https://issues.alfresco.com/jira/browse/ADF-1144)] - Deprecate MDL sidebar in demo shell
 
-Please refer to [the Alfresco issue tracker](https://issues.alfresco.com/jira/projects/ADF/issues/ADF-581?filter=allopenissues) for other known issues in this release. If you have more questions, please reply here or contact us using [gitter](https://gitter.im/Alfresco/alfresco-ng2-components).
+Please refer to [the Alfresco issue tracker](https://issues.alfresco.com/jira/projects/ADF/issues/ADF-581?filter=allopenissues) for other known issues in this release. If you have more questions, please reply here or contact us using [gitter](https://gitter.im/Alfresco/alfresco-ng2-components).

--- a/docs/release-notes/RelNote180.md
+++ b/docs/release-notes/RelNote180.md
@@ -4,10 +4,10 @@ Title: Release notes v1.8.0
 
 # Alfresco Application Development Framework, version 1.8.0 Release Note
 
-These release notes provide information for the **1.8.0 release** of Alfresco Application Development Framework.
+These release notes provide information for the **1.8.0 release** of Alfresco Application Development Framework.
 
-This is the next **Limited Available** release of Application Development Framework, containing the Angular components to build a Web Application on top of the Alfresco Services.
-The release can be found on GitHub at [this link.](https://github.com/Alfresco/alfresco-ng2-components/releases/tag/1.7.0)
+This is the next **Limited Available** release of Application Development Framework, containing the Angular components to build a Web Application on top of the Alfresco Services.
+The release can be found on GitHub at [this link.](https://github.com/Alfresco/alfresco-ng2-components/releases/tag/1.7.0)
 
 ## Contents
 
@@ -15,11 +15,11 @@ The release can be found on GitHub at [this link.](https://github.com/Alfresc
 -   [Notable new features](#notable-new-features)
     -   [1. Theming ADF component](#1-theming-adf-component)
     -   [2. Info Drawer component](#2-info-drawer-component)
-    -   [3. Form style component enhancements]\(#3-form-style-component enhancements)
+    -   [3. Form style component enhancements](#3-form-style-component-enhancements)
     -   [4. Empty form template](#4-empty-form-template)
     -   [5. Form Validation Enhancements](#5-form-validation-enhancements)
     -   [6. FormFieldModel/FormModel improvements](#6-formfieldmodelformmodel-improvements)
-    -   [7. DataTable Accessibility Improvements]\(#7-datatable accessibility-improvements)
+    -   [7. DataTable Accessibility Improvements](#7-datatable-accessibility-improvements)
     -   [8. Copy and move component enhancements](#8-copy-and-move-component-enhancements)
     -   [9. Download as a ZIP functionality](#9-download-as-a-zip-functionality)
     -   [10. Tooltips for DataTable/DocumentList cells](#10-tooltips-for-datatabledocumentlist-cells)
@@ -44,7 +44,7 @@ We continue the effort to migrate to @angular/material, it will be a few more re
 
 This release builds on last month's contains bug fixes and new feature. See the list below for major details.
 
-Please report issues with this release in the [issue tracker](https://github.com/Alfresco/alfresco-ng2-components/issues). You can collaborate on this release or share feedback by using the discussion tools on [gitter](https://gitter.im/Alfresco/alfresco-ng2-components).
+Please report issues with this release in the [issue tracker](https://github.com/Alfresco/alfresco-ng2-components/issues). You can collaborate on this release or share feedback by using the discussion tools on [gitter](https://gitter.im/Alfresco/alfresco-ng2-components).
 
 ## Notable new features
 
@@ -52,12 +52,12 @@ Below the most relevant features of this release:
 
 -   Theming ADF component
 -   [Info Drawer component](../core/info-drawer.component.md)
--   [`Form`](../../lib/process-services/task-list/models/form.model.ts) style component enhancements
+-   [`Form`](../../lib/process-services/task-list/models/form.model.ts) style component enhancements
 -   Empty form template
 -   Additional data sources input for Document List
 -   [`Form`](../../lib/process-services/task-list/models/form.model.ts) validation enhancements
 -   FormFieldModel/FormModelimprovements
--   DataTable\*\* \*\*Accessibility Improvements
+-   DataTable\*\* \*\*Accessibility Improvements
 -   Copy and move component enhancements
 -   Download as a ZIP functionality
 -   Tooltips for DataTable/DocumentList cells
@@ -72,7 +72,7 @@ Below the most relevant features of this release:
 ### 1. Theming ADF component
 
 We have added in ADF several pre-built theme css files. These theme files also include all of the styles for core (styles common to all components), so you only have to include a single css file for Angular Material in your app.
-When you want more customization than a pre-built theme offers, you can create your own theme file. You need to include the packages only what you really use in your application. For more information about theming please refer to the [offiicial documentation.](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/theming.md)
+When you want more customization than a pre-built theme offers, you can create your own theme file. You need to include the packages only what you really use in your application. For more information about theming please refer to the [offiicial documentation.](../user-guide/theming.md)
 
 ![](images/theming.gif)
 
@@ -82,7 +82,7 @@ It is now possible to use the [Info Drawer component,](../core/info-drawer.compo
 
 ![](images/info-drawer.gif)
 
-### 3. Form style component enhancements
+### 3. Form style component enhancements
 
 We have completed the transition from mdl to material2 for the form components. In addition we have also improved the style of some form components.
 
@@ -93,9 +93,9 @@ We have completed the transition from mdl to material2 for the form components. 
 You can now add an empty template that will be shown if no form definition are present
 
     <adf-form .... >
-       <div empty-form >
-           <h2>Empty form</h2>
-        </div>
+       <div empty-form >
+           <h2>Empty form</h2>
+        </div>
     </adf-form>
 
 ### 5. Form Validation Enhancements
@@ -105,22 +105,22 @@ New events that allow taking control over the [`Form`](../../lib/process-service
     validateForm: Subject<ValidateFormEvent>
     validateFormField: Subject<ValidateFormFieldEvent>()
 
-The [validateForm](https://github.com/Alfresco/alfresco-ng2-components/blob/development/ng2-components/ng2-activiti-form/src/events/validate-form.event.ts) event is raised every time the entire [`Form`](../../lib/process-services/task-list/models/form.model.ts) is re-validated. This happens also every time a field value or some of the properties is changed (for example the "required" property). The [validateFormField](https://github.com/Alfresco/alfresco-ng2-components/blob/development/ng2-components/ng2-activiti-form/src/events/validate-form-field.event.ts) event is raised every time a single [`Form`](../../lib/process-services/task-list/models/form.model.ts) Field is re-validated.
+The [validateForm](../core/form.service.md) event is raised every time the entire [`Form`](../../lib/process-services/task-list/models/form.model.ts) is re-validated. This happens also every time a field value or some of the properties is changed (for example the "required" property). The [validateFormField](../core/form.service.md) event is raised every time a single [`Form`](../../lib/process-services/task-list/models/form.model.ts) Field is re-validated.
 
 Both events are "cancellable", that means you can apply your own validation rules, change corresponding field validation state, or even prevent the default behaviour if needed.
 
 Example:
 
     this.formService.validateFormField.subscribe(
-      (event: ValidateFormFieldEvent) => {
-        const field = event.field;
-        const form = event.form;
-        // do some custom validation based on field or form
+      (event: ValidateFormFieldEvent) => {
+        const field = event.field;
+        const form = event.form;
+        // do some custom validation based on field or form
 
-        // set validation as "failed" and prevent any further checks
-        event.isValid = false;
-        event.preventDefault();
-      }
+        // set validation as "failed" and prevent any further checks
+        event.isValid = false;
+        event.preventDefault();
+      }
     );
 
 ### 6. FormFieldModel/FormModel improvements
@@ -131,25 +131,25 @@ The "required" property now re-validates the corresponding Field and entire [`Fo
 
 #### FormModel
 
-New "getFieldById" method to simplify certain scenarios when accessing multiple fields by id
+New "getFieldById" method to simplify certain scenarios when accessing multiple fields by id
 
     getFieldById(fieldId: string): FormFieldModel
 
 The [`Form`](../../lib/process-services/task-list/models/form.model.ts) now controls all Field validators. It becomes possible managing existing validator instances, replacing them, or extending form validation with custom rules and error messages. The "adf-form" component now also supports binding custom validator sets to the underlying [FormModel,](../../lib/core/form/components/widgets/core/form.model.ts) that allows defining validation sets in your code and binding via HTML.
 
-You can read more details on the new Validation layer in the [`Form`](../../lib/process-services/task-list/models/form.model.ts) readme: [Form Field Validators](https://github.com/Alfresco/alfresco-ng2-components/tree/development/ng2-components/ng2-activiti-form#form-field-validators). The "demo shell" application has been also extended to demonstrate custom validators in action. You can check the code here: [Demo Field Validator](https://github.com/Alfresco/alfresco-ng2-components/blob/development/demo-shell-ng2/app/components/activiti/demo-field-validator.ts).
+You can read more details on the new Validation layer in the [`Form`](../../lib/process-services/task-list/models/form.model.ts) readme: [Form Field Validators](../core/form-field-validator.interface.md). The "demo shell" application has been also extended to demonstrate custom validators in action. You can check the code here: [Demo Field Validator](../core/form-field-validator.interface.md).
 
-### 7. DataTable Accessibility Improvements
+### 7. DataTable Accessibility Improvements
 
-The "**DataTable**" component has got multiple accessibility improvements. That means all derived components (Document List, Tas/Process List, etc) get the same set of features automatically.
+The "**DataTable**" component has got multiple accessibility improvements. That means all derived components (Document List, Tas/Process List, etc) get the same set of features automatically.
 
-The major features are:
+The major features are:
 
 -   tabbing through the column headers (including Shift-Tab to tab backwards)
--   tabbing through the individual row cells (including Shift-Tab to tab backwards)
+-   tabbing through the individual row cells (including Shift-Tab to tab backwards)
 -   focus rings for row cells and column headers
 -   keyboard (Enter key) support for column headers: sorting order change
--   keyboard (Enter key) support for rows: navigate to a folder or initiate a file preview
+-   keyboard (Enter key) support for rows: navigate to a folder or initiate a file preview
 
 ### 8. Copy and move component enhancements
 
@@ -159,21 +159,21 @@ Further enhancements were implemented for the Copy & move dialog. From now, you 
 
 ### 9. Download as a ZIP functionality
 
-The ADF framework provides support for downloading nodes (Files and Folders) as "ZIP" archives. The **alfresco-js-api** library features new support for the [Downloads](https://api-explorer.alfresco.com/api-explorer/#/downloads) API. In addition, the Core library (ng2-alfresco-core) provides a ["DownloadZipDialogComponent"](../../lib/content-services/dialogs/download-zip.dialog.ts) that allows invoking "Download as Zip" dialogues from any place in your code.
+The ADF framework provides support for downloading nodes (Files and Folders) as "ZIP" archives. The **alfresco-js-api** library features new support for the [Downloads](https://api-explorer.alfresco.com/api-explorer/#/downloads) API. In addition, the Core library (ng2-alfresco-core) provides a ["DownloadZipDialogComponent"](../core/download-zip.service.md) that allows invoking "Download as Zip" dialogues from any place in your code.
 
 ![](images/download-as-zip.gif)
 
-You can see a working button handler code in the following [resource](https://github.com/Alfresco/alfresco-ng2-components/blob/development/demo-shell-ng2/app/components/files/files.component.ts#L234).
+You can see a working button handler code in the following [resource](../../demo-shell/src/app/components/files/files.component.ts).
 
 ### 10. Tooltips for DataTable/DocumentList cells
 
 It is now possible to provide a custom tooltip for every column in the DataTable and derived components.
 
     <data-column
-        title="Name"
-        key="name"
-        [formatTooltip]="getNodeNameTooltip"
-        class="full-width ellipsis-cell">
+        title="Name"
+        key="name"
+        [formatTooltip]="getNodeNameTooltip"
+        class="full-width ellipsis-cell">
     </data-column>
 
 And the code behind in this case can be as follows:
@@ -182,14 +182,14 @@ And the code behind in this case can be as follows:
 
     @Component({...})
     export class MyComponent {
-        ...
+        ...
 
-        getNodeNameTooltip(row: DataRow, col: DataColumn): string {
-            if (row) {
-                return row.getValue('name');
-            }
-            return null;
-        }
+        getNodeNameTooltip(row: DataRow, col: DataColumn): string {
+            if (row) {
+                return row.getValue('name');
+            }
+            return null;
+        }
     }
 
 ### 11. Profile picture in Comments and Involved people
@@ -232,14 +232,14 @@ You can get more details on the data sources and default presets in the [Data So
 
 The Core ADF library (ng2-alfresco-core) features a new **adf-node-permission** directive that allows you to selectively disable or enable an HTML element or an Angular component based on the node permissions. You can bind one or multiple nodes by means of the **adf-nodes** property that becomes available for each element.
 
-For example toggling the state of the toolbar button based on the DocumentList selection state (selected nodes):
+For example toggling the state of the toolbar button based on the DocumentList selection state (selected nodes):
 
     <adf-toolbar title="toolbar example">
-        <button md-icon-button
-                adf-node-permission="delete"
-                [adf-nodes]="documentList.selection">
-            <md-icon>delete</md-icon>
-        </button>
+        <button md-icon-button
+                adf-node-permission="delete"
+                [adf-nodes]="documentList.selection">
+            <md-icon>delete</md-icon>
+        </button>
     </adf-toolbar>
 
     <adf-document-list #documentList ...>
@@ -250,8 +250,8 @@ You can find all the details and usage examples in the directive documentation: 
 
 ### 14. Task/Process Audit Log Directive
 
-With the latest ADF release, we got two new directives **adf-process-audit** and **adf-task-audit**. Using these directives is very easily create a button to download the Task Audit or the Process Audit pdf.
-In the case you are using the **adf-process-audit**  the only parameters that are needed are:
+With the latest ADF release, we got two new directives **adf-process-audit** and **adf-task-audit**. Using these directives is very easily create a button to download the Task Audit or the Process Audit pdf.
+In the case you are using the **adf-process-audit**  the only parameters that are needed are:
 
 -   process-id
 -   fileName
@@ -259,11 +259,11 @@ In the case you are using the **adf-process-audit**  the only parameters that 
 
 
     <button
-       md-icon-button
-       adf-process-audit
-       [process-id]="processInstanceDetails.id"
-       [fileName]="'Process Audit - ' + processInstanceDetails.id"
-       (error)="onAuditError($event)">
+       md-icon-button
+       adf-process-audit
+       [process-id]="processInstanceDetails.id"
+       [fileName]="'Process Audit - ' + processInstanceDetails.id"
+       (error)="onAuditError($event)">
     <md-icon mdTooltip="Process Audit">assignment_ind</md-icon>
     </button>
 
@@ -275,19 +275,19 @@ On the click process audit pdf will be downloaded:
 
 ![download process audit ](images/Screen+Shot+2017-09-04+at+12.10.25.png)
 
-In the case you are using the **adf-task-audit**  the only parameters that are needed are:
+In the case you are using the **adf-task-audit**  the only parameters that are needed are:
 
 -   task-id
 -   fileName
--   format (pdf or json)
+-   format (pdf or json)
 
 
     <button
-       md-icon-button
-       adf-task-audit
-       [task-id]="taskId"
-       [fileName]="'Task Audit - ' + taskId"
-       (error)="onAuditError($event)">
+       md-icon-button
+       adf-task-audit
+       [task-id]="taskId"
+       [fileName]="'Task Audit - ' + taskId"
+       (error)="onAuditError($event)">
     <md-icon mdTooltip="Task Audit">assignment_ind</md-icon>
     </button>
 
@@ -301,7 +301,7 @@ On the click the task audit pdf will be downloaded:
 
 ### 15. Task List Pagination
 
-With the latest ADF release, the adf-tasklist is fully compatible with the adf-pagination component. Although ADF doesn't provide a  single component that includes the adf-tasklist and the adf-pagination in a single component, is not so difficult create your custom component that binds the adf-tasklist and the adf-pagination.
+With the latest ADF release, the adf-tasklist is fully compatible with the adf-pagination component. Although ADF doesn't provide a  single component that includes the adf-tasklist and the adf-pagination in a single component, is not so difficult create your custom component that binds the adf-tasklist and the adf-pagination.
 
 This is how the pagination looks like:
 
@@ -310,22 +310,22 @@ This is how the pagination looks like:
 tasklist-pagination.html
 
     <activiti-tasklist
-        [appId]="'2002'"
-        [assignment]="'assignee'"
-        [state]="'open'"
-        [sort]="'created-desc'"
-        [page]="page"
-        [size]="pagination.maxItems"
-        #activititasklist>
+        [appId]="'2002'"
+        [assignment]="'assignee'"
+        [state]="'open'"
+        [sort]="'created-desc'"
+        [page]="page"
+        [size]="pagination.maxItems"
+        #activititasklist>
     </activiti-tasklist>
 
     <adf-pagination
-        [pagination]="pagination"
-        [supportedPageSizes]="[5, 10, 15, 20]"
-        (changePageNumber)="onChangePageNumber($event)"
-        (changePageSize)="onChangePageSize($event)"
-        (nextPage)="onNextPage($event)"
-        (prevPage)="onPrevPage($event)">
+        [pagination]="pagination"
+        [supportedPageSizes]="[5, 10, 15, 20]"
+        (changePageNumber)="onChangePageNumber($event)"
+        (changePageSize)="onChangePageSize($event)"
+        (nextPage)="onNextPage($event)"
+        (prevPage)="onPrevPage($event)">
     </adf-pagination>
 
 tasklist-pagination.ts
@@ -335,53 +335,53 @@ tasklist-pagination.ts
     import { TaskListService } from 'ng2-activiti-tasklist';
 
     @Component({
-        selector: 'tasklist-paginator',
-        templateUrl: './activiti-tasklist-paginator.component.html'
+        selector: 'tasklist-paginator',
+        templateUrl: './activiti-tasklist-paginator.component.html'
     })
     export class TasklistPaginatorComponent implements OnInit {
 
-        pagination: Pagination = {
-            skipCount: 0,
-            maxItems: 5,
-            totalItems:  
-        };
+        pagination: Pagination = {
+            skipCount: 0,
+            maxItems: 5,
+            totalItems:  
+        };
 
-        page: number = 0;
+        page: number = 0;
 
-        constructor(private taskListService: TaskListService) {
-        }
+        constructor(private taskListService: TaskListService) {
+        }
 
-        ngOnInit() {
-            this.taskListService.tasksList$.subscribe(
-                (tasks) => {
-                    this.pagination = {count: tasks.data.length, maxItems: this.pagination.maxItems, skipCount: this.pagination.skipCount, totalItems: tasks.total};
-                }, (err) => {
-                console.log('err');
-            });
+        ngOnInit() {
+            this.taskListService.tasksList$.subscribe(
+                (tasks) => {
+                    this.pagination = {count: tasks.data.length, maxItems: this.pagination.maxItems, skipCount: this.pagination.skipCount, totalItems: tasks.total};
+                }, (err) => {
+                console.log('err');
+            });
 
-        }
+        }
 
-        onPrevPage(pagination: Pagination): void {
-            this.pagination.skipCount = pagination.skipCount;
-            this.page--;
-        }
+        onPrevPage(pagination: Pagination): void {
+            this.pagination.skipCount = pagination.skipCount;
+            this.page--;
+        }
 
-        onNextPage(pagination: Pagination): void {
-            this.pagination.skipCount = pagination.skipCount;
-            this.page++;
-        }
+        onNextPage(pagination: Pagination): void {
+            this.pagination.skipCount = pagination.skipCount;
+            this.page++;
+        }
 
-        onChangePageSize(pagination: Pagination): void {
-            const { maxItems, skipCount } = pagination;
-            this.page = (skipCount && maxItems) ? Math.floor(skipCount / maxItems) : 0;
-            this.pagination.maxItems = maxItems;
-            this.pagination.skipCount = skipCount;
-        }
+        onChangePageSize(pagination: Pagination): void {
+            const { maxItems, skipCount } = pagination;
+            this.page = (skipCount && maxItems) ? Math.floor(skipCount / maxItems) : 0;
+            this.pagination.maxItems = maxItems;
+            this.pagination.skipCount = skipCount;
+        }
 
-        onChangePageNumber(pagination: Pagination): void {
-            this.pagination.skipCount = pagination.skipCount;
-            this.page = Math.floor(pagination.skipCount / pagination.maxItems);
-        }
+        onChangePageNumber(pagination: Pagination): void {
+            this.pagination.skipCount = pagination.skipCount;
+            this.page = Math.floor(pagination.skipCount / pagination.maxItems);
+        }
 
     }
 
@@ -400,23 +400,23 @@ In the current release, you can test a basic implementation of the Viewer Dialog
 
 ![](images/Screenshot+2017-09-05+14.00.57.png)
 
-This dialogue does not require extra HTML elements in your templates and can be opened from any place in your code using Viewer Service:
+This dialogue does not require extra HTML elements in your templates and can be opened from any place in your code using Viewer Service:
 
     if (node.isFile) {
-      this.viewerService.showViewerForNode(node);
+      this.viewerService.showViewerForNode(node);
     }
 
 Note that the dialog component and the underlying service are in the early preview and APIs are subject to change in the future releases.
 
 ## References
 
-Below you can find a brief list of references to help you start to use the new release.
+Below you can find a brief list of references to help you start to use the new release.
 
-[Official GitHub Project - alfresco-ng2-components](https://github.com/Alfresco/alfresco-ng2-components)
+[Official GitHub Project - alfresco-ng2-components](https://github.com/Alfresco/alfresco-ng2-components)
 
 [Getting started guides with Alfresco Application Development Framework](https://community.alfresco.com/community/application-development-framework/pages/get-started)
 
-[Component catalog](http://devproducts.alfresco.com/)
+[Component catalog](http://devproducts.alfresco.com/)
 
 [Gitter chat supporting Alfresco ADF](https://gitter.im/Alfresco/alfresco-ng2-components)
 
@@ -426,13 +426,13 @@ Below you can find a brief list of references to help you start to use the new
 
 [Alfresco-JS-API](https://github.com/Alfresco/alfresco-js-api)
 
-[ADF App Generator ](https://github.com/Alfresco/generator-ng2-alfresco-app)
+[ADF App Generator ](https://github.com/Alfresco/generator-ng2-alfresco-app)
 
-Please refer to the [official documentation](http://docs.alfresco.com/) for further details and suggestions.
+Please refer to the [official documentation](http://docs.alfresco.com/) for further details and suggestions.
 
 ## Issues addressed
 
-Below you can find a detailed list of tickets addressed in the new release. For a better understanding, the list is grouped by topic.
+Below you can find a detailed list of tickets addressed in the new release. For a better understanding, the list is grouped by topic.
 
 Release Notes - Apps Development Framework - Version 1.8. 
 
@@ -571,4 +571,4 @@ Release Notes - Apps Development Framework - Version 1.8.
 -   \[[ADF-1457](https://issues.alfresco.com/jira/browse/ADF-1457)] - Upload Dialog - Cancel all confirmation dialog
 -   \[[ADF-1468](https://issues.alfresco.com/jira/browse/ADF-1468)] - Upload Dialog - Remove color import
 
-Please refer to [the Alfresco issue tracker](https://issues.alfresco.com/jira/projects/ADF/issues/ADF-581?filter=allopenissues) for other known issues in this release. If you have more questions, please reply here or contact us using [gitter](https://gitter.im/Alfresco/alfresco-ng2-components).
+Please refer to [the Alfresco issue tracker](https://issues.alfresco.com/jira/projects/ADF/issues/ADF-581?filter=allopenissues) for other known issues in this release. If you have more questions, please reply here or contact us using [gitter](https://gitter.im/Alfresco/alfresco-ng2-components).

--- a/docs/release-notes/RelNote190.md
+++ b/docs/release-notes/RelNote190.md
@@ -4,20 +4,20 @@ Title: Release notes v1.9.0
 
 # Alfresco Application Development Framework, version 1.9.0 Release Note
 
-These release notes provide information for the **1.9.0 release** of Alfresco Application Development Framework.
+These release notes provide information for the **1.9.0 release** of Alfresco Application Development Framework.
 
-This is the next **Limited Available** release of Application Development Framework, containing the Angular components to build a Web Application on top of the Alfresco Services.
-The release can be found on GitHub at [this link.](https://github.com/Alfresco/alfresco-ng2-components/releases/tag/1.7.0)
+This is the next **Limited Available** release of Application Development Framework, containing the Angular components to build a Web Application on top of the Alfresco Services.
+The release can be found on GitHub at [this link.](https://github.com/Alfresco/alfresco-ng2-components/releases/tag/1.7.0)
 
 ## Contents
 
 -   [Goals for this release](#goals-for-this-release)
 -   [Notable new features](#notable-new-features)
     -   [1.Infinite scrolling](#1infinite-scrolling)
-    -   [2.Requeue option added to adf-task-header]\(#2requeue-option-added-to adf-task-header)
+    -   [2.Requeue option added to adf-task-header](#2requeue-option-added-to-adf-task-header)
     -   [3.Tasklist multi-selection support](#3tasklist-multi-selection-support)
     -   [4.Page Title Service](#4page-title-service)
-    -   [5.Viewer Enhancements]\(#5viewer enhancements)
+    -   [5.Viewer Enhancements](#5viewer-enhancements)
     -   [6.Document List Presets](#6document-list-presets)
     -   [7.Login redirect options](#7login-redirect-options)
     -   [8.Logout directive](#8logout-directive)
@@ -34,13 +34,13 @@ The release can be found on GitHub at [this link.](https://github.com/Alfresc
 
 ## Goals for this release
 
-In the ADF 1.9 release we've enhanced a number of components, such as Document List, Viewer and Breadcrumbs. We continue the effort to migrate to @angular/material, only a few more components remain until we are fully switched to Angular Material Design. Again in this release we have enhanced the accessibility and we have started to consolidate, streamline and enhance our documentation. Before everything was inside the individual README.md files, this has now been pulled out into a [separate directory](https://github.com/Alfresco/alfresco-ng2-components/tree/master/docs), and a new [Doc Index](https://github.com/Alfresco/alfresco-ng2-components/blob/master/docs/README.md) to help navigate it.
+In the ADF 1.9 release we've enhanced a number of components, such as Document List, Viewer and Breadcrumbs. We continue the effort to migrate to @angular/material, only a few more components remain until we are fully switched to Angular Material Design. Again in this release we have enhanced the accessibility and we have started to consolidate, streamline and enhance our documentation. Before everything was inside the individual README.md files, this has now been pulled out into a [separate directory](https://github.com/Alfresco/alfresco-ng2-components/tree/master/docs), and a new [Doc Index](https://github.com/Alfresco/alfresco-ng2-components/blob/master/docs/README.md) to help navigate it.
 
-This is the last LA release, we are targeting ADF 2.0 by the end of November at which point it will become **General Available** and **fully supported** by Alfresco. As part of this effort we have increased the efforts on resolving bugs and stabilisation.
+This is the last LA release, we are targeting ADF 2.0 by the end of November at which point it will become **General Available** and **fully supported** by Alfresco. As part of this effort we have increased the efforts on resolving bugs and stabilisation.
 
 This release builds on last month's contains bug fixes and the new features. See the list below for major details.
 
-Please report issues with this release in the [issue tracker](https://github.com/Alfresco/alfresco-ng2-components/issues). You can collaborate on this release or share feedback by using the discussion tools on [gitter](https://gitter.im/Alfresco/alfresco-ng2-components).
+Please report issues with this release in the [issue tracker](https://github.com/Alfresco/alfresco-ng2-components/issues). You can collaborate on this release or share feedback by using the discussion tools on [gitter](https://gitter.im/Alfresco/alfresco-ng2-components).
 
 ## Notable new features
 
@@ -50,7 +50,7 @@ Below the most relevant features of this release:
 -   Requeue option added to adf-task-header
 -   Tasklist now support multi-select
 -   [Page title service](../core/page-title.service.md)
--   Viewer enhancements
+-   Viewer enhancements
 -   Document List presets
 -   Login redirect options
 -   [Logout directive](../core/logout.directive.md)
@@ -60,11 +60,11 @@ Below the most relevant features of this release:
 ### 1.Infinite scrolling
 
 The document list now provides two different way to paginate the results the normal pagination or the infinite scrolling.
-In order to enable this feature, you need to specify the paginationStrategy properties 'Infinite'. The infinite scrolling is also now used as default in the object picker component
+In order to enable this feature, you need to specify the paginationStrategy properties 'Infinite'. The infinite scrolling is also now used as default in the object picker component
 
 ![](images/infinite-scrolling.gif)
 
-### 2.Requeue option added to adf-task-header
+### 2.Requeue option added to adf-task-header
 
 The requeue feature has been added into the ADF 1.9.0. This means that after a task has been claimed by the user, the user will see a button Requeue to un-claim the task.
 
@@ -75,10 +75,10 @@ The requeue feature has been added into the ADF 1.9.0. This means that after a t
 With the latest code, the tasklist component exposes the **multiselect** property. If the value is true a checkbox is rendered at the beginning of each row. In this way, the user can select more than one row.
 
     <adf-tasklist
-        [multiselect]="true"
-        [appId]="'1'"
-        [state]="'open'"
-        [assignment]="'assignee'">
+        [multiselect]="true"
+        [appId]="'1'"
+        [state]="'open'"
+        [assignment]="'assignee'">
     </adf-tasklist>
 
 ### 
@@ -87,28 +87,28 @@ This is the result:
 
 ![Tasklist multiselection](images/Screen+Shot+2017-10-09+at+15.51.31.png)
 
-The component also provides a new event **rowSelected** that contains all the selected rows:
+The component also provides a new event **rowSelected** that contains all the selected rows:
 
     <adf-tasklist
-        [appId]="'1'"
-        [state]="'open'"
-        [assignment]="'assignee'"
-        (rowsSelected)="console.log($event)">
+        [appId]="'1'"
+        [state]="'open'"
+        [assignment]="'assignee'"
+        (rowsSelected)="console.log($event)">
     </adf-tasklist>
 
 ![task list rowsSelected ](images/Screen+Shot+2017-10-09+at+16.01.46.png)
 
 ### 4.Page Title Service
 
-The 1.9.0 version features a new service ["PageTitleService"](../core/page-title.service.md) in the "ng2-alfresco-core" package. This service allows changing the title of the page (browser tab) on demand from the code. The format of the title is always "&lt;Application Name> - &lt;Title>" where "&lt;Application Name>" is taken from the application configuration file:
+The 1.9.0 version features a new service ["PageTitleService"](../core/page-title.service.md) in the "ng2-alfresco-core" package. This service allows changing the title of the page (browser tab) on demand from the code. The format of the title is always "&lt;Application Name> - &lt;Title>" where "&lt;Application Name>" is taken from the application configuration file:
 
     {
-      "application": {
-        "name": "Alfresco ADF Appplication"
-      }
+      "application": {
+        "name": "Alfresco ADF Appplication"
+      }
     }
 
-### 5.Viewer Enhancements
+### 5.Viewer Enhancements
 
 [Viewer component](../core/viewer.component.md) has been updated with improved UI and support for integration with Angular Router.
 The major features and improvements are:
@@ -122,58 +122,58 @@ The major features and improvements are:
 It is now possible to store layouts for Document List in the global application configuration file ("app.config.json") for default mode or special aliases like "-trashcan-", "-favorites-", etc. The DocumentList component automatically falls back to the defaults if no customizations are present.
 
     {
-        ...,
+        ...,
 
-        "document-list": {
-            "supportedPageSizes": [5, 10, 15, 20],
-            "presets": {
-                "-trashcan-": [
-                    {
-                        "key": "$thumbnail",
-                        "type": "image",
-                        "srTitle": "ADF-DOCUMENT-LIST.LAYOUT.THUMBNAIL",
-                        "sortable": false
-                    },
-                    {
-                        "key": "name",
-                        "type": "text",
-                        "title": "ADF-DOCUMENT-LIST.LAYOUT.NAME",
-                        "cssClass": "full-width ellipsis-cell",
-                        "sortable": true
-                    },
-                    {
-                        "key": "path",
-                        "type": "location",
-                        "title": "ADF-DOCUMENT-LIST.LAYOUT.LOCATION",
-                        "format": "/files",
-                        "sortable": true
-                    },
-                    {
-                        "key": "content.sizeInBytes",
-                        "type": "fileSize",
-                        "title": "ADF-DOCUMENT-LIST.LAYOUT.SIZE",
-                        "sortable": true
-                    },
-                    {
-                        "key": "archivedAt",
-                        "type": "date",
-                        "title": "ADF-DOCUMENT-LIST.LAYOUT.DELETED_ON",
-                        "format": "timeAgo",
-                        "sortable": true
-                    },
-                    {
-                        "key": "archivedByUser.displayName",
-                        "type": "text",
-                        "title": "ADF-DOCUMENT-LIST.LAYOUT.DELETED_BY",
-                        "sortable": true
-                    }
-                ],
+        "document-list": {
+            "supportedPageSizes": [5, 10, 15, 20],
+            "presets": {
+                "-trashcan-": [
+                    {
+                        "key": "$thumbnail",
+                        "type": "image",
+                        "srTitle": "ADF-DOCUMENT-LIST.LAYOUT.THUMBNAIL",
+                        "sortable": false
+                    },
+                    {
+                        "key": "name",
+                        "type": "text",
+                        "title": "ADF-DOCUMENT-LIST.LAYOUT.NAME",
+                        "cssClass": "full-width ellipsis-cell",
+                        "sortable": true
+                    },
+                    {
+                        "key": "path",
+                        "type": "location",
+                        "title": "ADF-DOCUMENT-LIST.LAYOUT.LOCATION",
+                        "format": "/files",
+                        "sortable": true
+                    },
+                    {
+                        "key": "content.sizeInBytes",
+                        "type": "fileSize",
+                        "title": "ADF-DOCUMENT-LIST.LAYOUT.SIZE",
+                        "sortable": true
+                    },
+                    {
+                        "key": "archivedAt",
+                        "type": "date",
+                        "title": "ADF-DOCUMENT-LIST.LAYOUT.DELETED_ON",
+                        "format": "timeAgo",
+                        "sortable": true
+                    },
+                    {
+                        "key": "archivedByUser.displayName",
+                        "type": "text",
+                        "title": "ADF-DOCUMENT-LIST.LAYOUT.DELETED_BY",
+                        "sortable": true
+                    }
+                ],
 
-                "default": [
-                    ...
-                ]
-            }
-        }
+                "default": [
+                    ...
+                ]
+            }
+        }
     }
 
 ### 7.Login redirect options
@@ -190,7 +190,7 @@ You can turn any clickable HTML element or other Angular Component into a Logout
 
 ### 9.Breadcrumb enhancements
 
-The [Breadcrumb component](../content-services/breadcrumb.component.md) exposes a new **rootId** property to allow you restricting the root element to a particular node. Component automatically trims the elements if full node path needs to be cut. You can use this together with the **root** property that allows renaming the root (first) element of the path.
+The [Breadcrumb component](../content-services/breadcrumb.component.md) exposes a new **rootId** property to allow you restricting the root element to a particular node. Component automatically trims the elements if full node path needs to be cut. You can use this together with the **root** property that allows renaming the root (first) element of the path.
 
     <adf-breadcrumb root="Personal Files" rootId="<GUID>" ...></adf-breadcrumb>
 
@@ -200,13 +200,13 @@ All the documentation was inside the individual README.md files of any component
 
 ## References
 
-Below you can find a brief list of references to help you start to use the new release.
+Below you can find a brief list of references to help you start to use the new release.
 
-[Official GitHub Project - alfresco-ng2-components](https://github.com/Alfresco/alfresco-ng2-components)
+[Official GitHub Project - alfresco-ng2-components](https://github.com/Alfresco/alfresco-ng2-components)
 
 [Getting started guides with Alfresco Application Development Framework](https://community.alfresco.com/community/application-development-framework/pages/get-started)
 
-[Component catalog](http://devproducts.alfresco.com/)
+[Component catalog](http://devproducts.alfresco.com/)
 
 [Gitter chat supporting Alfresco ADF](https://gitter.im/Alfresco/alfresco-ng2-components)
 
@@ -216,13 +216,13 @@ Below you can find a brief list of references to help you start to use the new
 
 [Alfresco-JS-API](https://github.com/Alfresco/alfresco-js-api)
 
-[ADF App Generator ](https://github.com/Alfresco/generator-ng2-alfresco-app)
+[ADF App Generator ](https://github.com/Alfresco/generator-ng2-alfresco-app)
 
-Please refer to the [official documentation](http://docs.alfresco.com/) for further details and suggestions.
+Please refer to the [official documentation](http://docs.alfresco.com/) for further details and suggestions.
 
 ## Issues addressed
 
-Below you can find a detailed list of tickets addressed in the new release. For a better understanding, the list is grouped by topic.
+Below you can find a detailed list of tickets addressed in the new release. For a better understanding, the list is grouped by topic.
 
 Release Notes - Apps Development Framework - Version 1.9. 
 
@@ -369,4 +369,4 @@ Release Notes - Apps Development Framework - Version 1.9.
 -   \[[ADF-1534](https://issues.alfresco.com/jira/browse/ADF-1534)] - Automatic PDF rendition loading for Viewer Dialog
 -   \[[ADF-1542](https://issues.alfresco.com/jira/browse/ADF-1542)] - Toggle all toolbar elements in the Viewer Dialog from code
 
-Please refer to [the Alfresco issue tracker](https://issues.alfresco.com/jira/projects/ADF/issues/ADF-581?filter=allopenissues) for other known issues in this release. If you have more questions, please reply here or contact us using [gitter](https://gitter.im/Alfresco/alfresco-ng2-components).
+Please refer to [the Alfresco issue tracker](https://issues.alfresco.com/jira/projects/ADF/issues/ADF-581?filter=allopenissues) for other known issues in this release. If you have more questions, please reply here or contact us using [gitter](https://gitter.im/Alfresco/alfresco-ng2-components).

--- a/docs/release-notes/RelNote200.md
+++ b/docs/release-notes/RelNote200.md
@@ -4,32 +4,32 @@ Title: Release notes v2.0.0
 
 # Alfresco Application Development Framework, version 2.0.0 Release Note
 
-These release notes provide information for the **2.0.0 release** of the Alfresco Application Development Framework.
+These release notes provide information for the **2.0.0 release** of the Alfresco Application Development Framework.
 
-This is the first **General Available** release of the Application Development Framework, which contains the Angular components to build a Web Application on top of the Alfresco Services.
-The release can be found on GitHub at [this link.](https://github.com/Alfresco/alfresco-ng2-components/releases/tag/1.7.0)
+This is the first **General Available** release of the Application Development Framework, which contains the Angular components to build a Web Application on top of the Alfresco Services.
+The release can be found on GitHub at [this link.](https://github.com/Alfresco/alfresco-ng2-components/releases/tag/1.7.0)
 
 ## Contents
 
 -   [New name packages](#new-name-packages)
 -   [Goals for this release](#goals-for-this-release)
 -   [Notable new features](#notable-new-features)
-    -   [1. Viewer Enhancements]\(#1 viewer-enhancements)
+    -   [1. Viewer Enhancements](#1-viewer-enhancements)
     -   [2. Pagination Component and DocumentList integration](#2-pagination-component-and-documentlist-integration)
     -   [3. Create Folder and Edit Folder dialogs](#3-create-folder-and-edit-folder-dialogs)
     -   [4. Editable file metadata](#4-editable-file-metadata)
     -   [5. File versioning](#5-file-versioning)
     -   [6. Search Component refactoring](#6-search-component-refactoring)
-    -   [7. Max file size constraints properties in Upload Button]\(#7-max-file-size-constraints properties-in-upload-button)
+    -   [7. Max file size constraints properties in Upload Button](#7-max-file-size-constraints-properties-in-upload-button)
     -   [8. Register Alfresco file type icons within the mat-icon](#8-register-alfresco-file-type-icons-within-the-mat-icon)
     -   [9. LogService configuration](#9-logservice-configuration)
     -   [10. Favorite node directive](#10-favorite-node-directive)
     -   [11. Delete multiple nodes directive](#11-delete-multiple-nodes-directive)
-    -   [12. Task Attachment List customizable template]\(#12-task attachment-list-customizable-template)
-    -   [13. CS and PS setting host component]\(#13 cs-and-ps-setting-host-component)
-    -   [14. Complete process service type definition in the alfresco-js-api]\(#14-complete-process-service-type definition-in-the-alfresco-js-api)
+    -   [12. Task Attachment List customizable template](#12-task-attachment-list-customizable-template)
+    -   [13. CS and PS setting host component](#13-cs-and-ps-setting-host-component)
+    -   [14. Complete process service type definition in the alfresco-js-api](#14-complete-process-service-type-definition-in-the-alfresco-js-api)
     -   [15. Redirect to original path upon successful login](#15-redirect-to-original-path-upon-successful-login)
-    -   [16. Task List override the columns]\(#16-task-list override-the-columns)
+    -   [16. Task List override the columns](#16-task-list-override-the-columns)
     -   [17. Internationalization support](#17-internationalization-support)
     -   [18. Document List enhancements](#18-document-list-enhancements)
 -   [Breaking changes](#breaking-changes)
@@ -39,10 +39,10 @@ The release can be found on GitHub at [this link.](https://github.com/Alfresc
     -   [Rename 'extension-viewer' component to 'adf-viewer-extension'](#rename-extension-viewer-component-to-adf-viewer-extension)
     -   [Deprecated Upload button and Drag area properties have been removed](#deprecated-upload-button-and-drag-area-properties-have-been-removed)
     -   [Internal pagination has been removed from the DocumentList](#internal-pagination-has-been-removed-from-the-documentlist)
-    -   [Internal search documentlist has been removed from the search component]\(#internal-search documentlist has-been-removed-from-the-search-component)
+    -   [Internal search documentlist has been removed from the search component](#internal-search-documentlist-has-been-removed-from-the-search-component)
 -   [CI changes](#ci-changes)
     -   [Bundle size checker](#bundle-size-checker)
-    -   [Security checker Snyk]\(#security checker-snyk)
+    -   [Security checker Snyk](#security-checker-snyk)
     -   [Application generators (Yeoman)](#application-generators-yeoman)
 -   [References](#references)
 -   [Issues addressed](#issues-addressed)
@@ -55,14 +55,14 @@ The release can be found on GitHub at [this link.](https://github.com/Alfresc
 
 ## New name packages
 
-From ADF 2.0 we split everything into four main packages:
+From ADF 2.0 we split everything into four main packages:
 
     "@alfresco/adf-content-services" : "2.0.0"
     "@alfresco/adf-process-services" : "2.0.0"
     "@alfresco/adf-core" : "2.0.0"
     "@alfresco/adf-insights" : "2.0.1"
 
-Please note the only major version valid for the package @alfresco/adf-insights is 2.0.1
+Please note the only major version valid for the package @alfresco/adf-insights is 2.0.1
 
 ## Goals for this release
 
@@ -74,7 +74,7 @@ We have continued to expand and rewrite our documentation. We now have a [new co
 The Yeoman generators have been updated. We now ship three small [Angular CLI](https://cli.angular.io)
 based applications to help get you started.
 
-Please report issues with this release in the [issue tracker](https://github.com/Alfresco/alfresco-ng2-components/issues). Enterprise customers can now submit issues in the support portal. You can collaborate on this release or share feedback by using the discussion tools on [gitter](https://gitter.im/Alfresco/alfresco-ng2-components).
+Please report issues with this release in the [issue tracker](https://github.com/Alfresco/alfresco-ng2-components/issues). Enterprise customers can now submit issues in the support portal. You can collaborate on this release or share feedback by using the discussion tools on [gitter](https://gitter.im/Alfresco/alfresco-ng2-components).
 
 The entire team has been working hard to make this release a reality and we're excited to share all the details!
 
@@ -88,19 +88,19 @@ Below the most relevant features of this release:
 -   Editable file metadata
 -   File versioning
 -   [Search Component](../content-services/search.component.md) refatoring
--   Max file size constraints properties in Upload Button
+-   Max file size constraints properties in Upload Button
 -   Register Alfresco file type icons within the mat-icon
 -   [`LogService`](../core/log.service.md) configuration
 -   Favorite node Directive
 -   Delete multiple nodes directive
 -   Task Attachment list customizable template
 -   CS and PS setting host component
--   Complete [process service](../process-services/process.service.md) type definition in the alfresco-js-api
+-   Complete [process service](../process-services/process.service.md) type definition in the alfresco-js-api
 -   Redirect to original path upon successful login
 -   Task List override the default columns
 -   Internationalization support
 
-### 1. Viewer Enhancements
+### 1. Viewer Enhancements
 
 The [Viewer component](../core/viewer.component.md) has been enhanced with the following features:
 
@@ -114,7 +114,7 @@ The [Viewer component](../core/viewer.component.md) has been enhanced with the f
 -   Custom "traffic light" menu that you can fill with your own content
 -   Ability to download the file previewed
 -   Ability to hide/show any button on the toolbar
--   Ability to hide, show or even replace entire [toolbar component](../core/toolbar.component.md)
+-   Ability to hide, show or even replace entire [toolbar component](../core/toolbar.component.md)
 
 ![](images/pastedImage_1.png)
 
@@ -123,7 +123,7 @@ This allows you to have separate URLs for previewing content and later revisitin
 
 In addition, the "Overlay" mode has been stabilised. It now handles subsequent reopenings correctly.
 
-You can find more details in the corresponding documentation: [Viewer Component](https://github.com/Alfresco/alfresco-ng2-components/blob/master/docs/viewer.component.md).
+You can find more details in the corresponding documentation: [Viewer Component](../core/viewer.component.md).
 
 ### 2. Pagination Component and DocumentList integration
 
@@ -136,7 +136,7 @@ ADF provides a lightweight integration with the DocumentList component out of th
     <adf-pagination [target]="documentList" ...>
     </adf-pagination>
 
-For more details on custom pagination features see the following article: [Pagination Component](https://github.com/Alfresco/alfresco-ng2-components/blob/master/docs/pagination.component.md)
+For more details on custom pagination features see the following article: [Pagination Component](../core/pagination.component.md)
 
 ### 3. Create Folder and Edit Folder dialogs
 
@@ -145,10 +145,10 @@ You can now use "Create Folder" and "Edit Folder" dialogs with your ACS-enabled 
 In order to greatly simplify your development experience, two extra Angular directives were introduced: "adf-create-folder" and "adf-edit-folder". These allow you to invoke dialogs from any clickable element, including other Angular components:
 
     <adf-toolbar>
-        <button mat-icon-button
-                [adf-create-folder]="documentList.currentFolderId">
-                <mat-icon>create_new_folder</mat-icon>
-        </button>
+        <button mat-icon-button
+                [adf-create-folder]="documentList.currentFolderId">
+                <mat-icon>create_new_folder</mat-icon>
+        </button>
     </adf-toolbar>
 
     <adf-document-list #documentList ...>
@@ -157,8 +157,8 @@ In order to greatly simplify your development experience, two extra Angular dire
 
 For more details please refer to:
 
--   [Folder Create directive](https://github.com/Alfresco/alfresco-ng2-components/blob/master/docs/folder-create.directive.md)
--   [Folder Edit directive](https://github.com/Alfresco/alfresco-ng2-components/blob/master/docs/folder-edit.directive.md)
+-   [Folder Create directive](../content-services/folder-create.directive.md)
+-   [Folder Edit directive](../content-services/folder-edit.directive.md)
 
 ### 4. Editable file metadata
 
@@ -170,7 +170,7 @@ Basic content metadata can now be displayed and edited with the new ContentMetad
 
 ### 5. File versioning
 
-You can now see and restore previous versions of a file node. This component can also be used in a dialog or in a sidebar layout. Being the first prototype, there are some restrictions applied on this component - check the documentation for details.
+You can now see and restore previous versions of a file node. This component can also be used in a dialog or in a sidebar layout. Being the first prototype, there are some restrictions applied on this component - check the documentation for details.
 
 ![file versions](images/versioning.gif)
 
@@ -193,13 +193,13 @@ For example :
 The adf-search component offers a simple way to customize your search results:
 
     <adf-search [searchTerm]="searchedWord">
-      <ng-template let-data>
-       <ul>
-          <li *ngFor="let item of data?.list?.entries; let idx = index">
-             ...
-          </li>
-       </ul>
-      </ng-template>
+      <ng-template let-data>
+       <ul>
+          <li *ngFor="let item of data?.list?.entries; let idx = index">
+             ...
+          </li>
+       </ul>
+      </ng-template>
     </adf-search>
 
 With this, you have access to the search results objects, so you can modify them as you like :
@@ -218,16 +218,16 @@ This allows you to fetch the search result typed from the input/textarea element
 
 For more details please refer to:
 
--   [Search Control Component](https://github.com/Alfresco/alfresco-ng2-components/blob/master/docs/search-control.component.md)
--   [Search Component](https://github.com/Alfresco/alfresco-ng2-components/blob/master/docs/search.component.md)
+-   [Search Control Component](../content-services/search-control.component.md)
+-   [Search Component](../content-services/search.component.md)
 
-### 7. Max file size constraints properties in Upload Button
+### 7. Max file size constraints properties in Upload Button
 
-The [upload button component](../content-services/upload-button.component.md) now provides a new parameter to disallow uploading files larger than a certain size (in bytes):
+The [upload button component](../content-services/upload-button.component.md) now provides a new parameter to disallow uploading files larger than a certain size (in bytes):
 
     <adf-upload-button [maxFilesSize]="20"></adf-upload-button>
 
-For more details please refer to [Upload button documentation](https://github.com/Alfresco/alfresco-ng2-components/blob/master/docs/upload-button.component.md)
+For more details please refer to [Upload button documentation](../content-services/upload-button.component.md)
 
 ### 8. Register Alfresco file type icons within the mat-icon
 
@@ -240,29 +240,29 @@ All the ADF MIME type icons are now registered into the MatIconRegistry. This im
     constructor(public thumbnailService: ThumbnailService) {
     }
 
-To see the list of all supported MIME types please refer to [Thumbnail service documentation](https://github.com/Alfresco/alfresco-ng2-components/blob/master/docs/thumbnail.service.md).
+To see the list of all supported MIME types please refer to [Thumbnail service documentation](../core/thumbnail.service.md).
 
 ### 9. LogService configuration
 
-The new logservice provides logging functionality for your ADF application. You can configure **_logLevel_** in **app.config.json**.
+The new logservice provides logging functionality for your ADF application. You can configure **_logLevel_** in **app.config.json**.
 By default the level is TRACE. If you want to silence all log output in ADF you can set it to SILENT:
 
     {
-        "logLevel": " SILENT"
+        "logLevel": " SILENT"
     }
 
-The [log service](../core/log.service.md) provides 6 level of logs: TRACE, DEBUG, INFO, WARN, ERROR, SILENT. For more information please refer to [log service documentation.](https://github.com/Alfresco/alfresco-ng2-components/blob/master/docs/log.service.md)
+The [log service](../core/log.service.md) provides 6 level of logs: TRACE, DEBUG, INFO, WARN, ERROR, SILENT. For more information please refer to [log service documentation.](../core/log.service.md)
 
 ### 10. Favorite node directive
 
-The NodeFavoriteDirective instance can be bound to a button to retrieve and manage a favorites node list:
+The NodeFavoriteDirective instance can be bound to a button to retrieve and manage a favorites node list:
 
     <button mat-icon-button
-            #favorite="adfFavorite"
-            [adf-node-favorite]="nodeSelection">
-        <mat-icon>
-            {{ favorite.hasFavorites() ? 'star' :'star_border' }}
-        </mat-icon>
+            #favorite="adfFavorite"
+            [adf-node-favorite]="nodeSelection">
+        <mat-icon>
+            {{ favorite.hasFavorites() ? 'star' :'star_border' }}
+        </mat-icon>
     </button>
 
 ![](images/favorite.gif)
@@ -272,12 +272,12 @@ The NodeFavoriteDirective instance can be bound to a button to retrieve and m
 Deletes multiple files and folders.
 
     <button mat-icon-button
-            (delete)="onDelete()"
-            [adf-delete]="nodeSelection">
-        <mat-icon>delete</mat-icon>
+            (delete)="onDelete()"
+            [adf-delete]="nodeSelection">
+        <mat-icon>delete</mat-icon>
     </button>
 
-### 12. Task Attachment List customizable template
+### 12. Task Attachment List customizable template
 
 If there are no attachments for the selected task the [Task Attachment List component](../process-services/task-attachment-list.component.md) shows a basic empty template.
 
@@ -286,42 +286,42 @@ If there are no attachments for the selected task the [Task Attachment List comp
 If you want to customize and render a custom template, you can inject the **adf-empty-list** tag
 
     <adf-task-attachment-list
-        [taskId]="YOUR_TASK_ID">
-        <adf-empty-list>
-            <div adf-empty-list-header>This is the header of my empty list</div>
-            <div adf-empty-list-body>This is the body</div>
-            <div adf-empty-list-footer>>This is the footer</div>
-        </adf-empty-list>
+        [taskId]="YOUR_TASK_ID">
+        <adf-empty-list>
+            <div adf-empty-list-header>This is the header of my empty list</div>
+            <div adf-empty-list-body>This is the body</div>
+            <div adf-empty-list-footer>>This is the footer</div>
+        </adf-empty-list>
     </adf-task-attachment-list>
 
 Note that the [Task Attachment List component](../process-services/task-attachment-list.component.md) doesn't provide the Drag & Drop feature out-of-the-box. To add it, you must use an **adf-upload-drag-area** as the parent of this component. You can also specify a custom template:
 
     <adf-upload-drag-area
-        [parentId]="YOUR_TASK_ID">
-        <adf-task-attachment-list
-            [taskId]="YOUR_TASK_ID">
-            <adf-empty-list>
-                <div adf-empty-list-header>This List is empty</div>
-                <div adf-empty-list-body>Drag and drop to upload</div>
-                <div adf-empty-list-footer>
-                    <img [src]="Your custom image URL"></div>
-            </adf-empty-list>
-        </adf-task-attachment-list>
+        [parentId]="YOUR_TASK_ID">
+        <adf-task-attachment-list
+            [taskId]="YOUR_TASK_ID">
+            <adf-empty-list>
+                <div adf-empty-list-header>This List is empty</div>
+                <div adf-empty-list-body>Drag and drop to upload</div>
+                <div adf-empty-list-footer>
+                    <img [src]="Your custom image URL"></div>
+            </adf-empty-list>
+        </adf-task-attachment-list>
     </adf-upload-drag-area>
 
 This is the result:
 
 ![Task Attachment List drag & drop template](images/Screen+Shot+2017-11-29+at+12.50.22+copy.png)
 
-### 13. CS and PS setting host component
+### 13. CS and PS setting host component
 
 This component is a form that allows you to validate and set the URL of your CS and PS, saving it in the user's local storage
 
 ![](images/host-settings-component.png)
 
-For more information please refer to [host component documentation.](https://github.com/Alfresco/alfresco-ng2-components/blob/master/docs/host-settings.component.md)
+For more information please refer to [host component documentation.](../core/host-settings.component.md)
 
-### 14. Complete process service type definition in the alfresco-js-api
+### 14. Complete process service type definition in the alfresco-js-api
 
 We have added all the [process service](../process-services/process.service.md) related models, class methods and type in the type definition file of the alfresco-js-api to help you with the autocomplete of your IDE.
 
@@ -331,41 +331,41 @@ We have added all the [process service](../process-services/process.service.md) 
 
 The [Login component](../core/login.component.md) now redirects users back to the originally requested URLs.
 
-For example, if you have a route "/my-files" protected by the **[`AuthGuardEcm`](../../lib/core/services/auth-guard-ecm.service.ts)** (for ACS-related content) or **[`AuthGuardBpm`](../../lib/core/services/auth-guard-bpm.service.ts)** (for APS-related content), users may be redirected to a "/login" route if they are not authenticated. Upon successful login, the user is then redirected back to the "/my-files" page.
+For example, if you have a route "/my-files" protected by the **[`AuthGuardEcm`](../../lib/core/services/auth-guard-ecm.service.ts)** (for ACS-related content) or **[`AuthGuardBpm`](../../lib/core/services/auth-guard-bpm.service.ts)** (for APS-related content), users may be redirected to a "/login" route if they are not authenticated. Upon successful login, the user is then redirected back to the "/my-files" page.
 
-### 16. Task List override the columns
+### 16. Task List override the columns
 
-With the current ADF release, you can override the Task List columns from the **app.config.json** file.
+With the current ADF release, you can override the Task List columns from the **app.config.json** file.
 
     "adf-task-list": {
-            "presets": {
-                "default": [
-                    {
-                        "key": "name",
-                        "type": "text",
-                        "title": "ADF_TASK_LIST.PROPERTIES.NAME",
-                        "sortable": true
-                    },
-                    {
-                        "key": "created",
-                        "type": "date",
-                        "title": "ADF_TASK_LIST.PROPERTIES.CREATED",
-                        "sortable": true
-                    },
-                    {
-                        "key": "priority",
-                        "type": "text",
-                        "title": "ADF_TASK_LIST.PROPERTIES.PRIORITY",
-                        "sortable": true
-                    },
-                    {
-                        "key": "assignee",
-                        "type": "text",
-                        "title": "ADF_TASK_LIST.PROPERTIES.ASSIGNEE",
-                        "sortable": true
-                    }
-                ]
-            }
+            "presets": {
+                "default": [
+                    {
+                        "key": "name",
+                        "type": "text",
+                        "title": "ADF_TASK_LIST.PROPERTIES.NAME",
+                        "sortable": true
+                    },
+                    {
+                        "key": "created",
+                        "type": "date",
+                        "title": "ADF_TASK_LIST.PROPERTIES.CREATED",
+                        "sortable": true
+                    },
+                    {
+                        "key": "priority",
+                        "type": "text",
+                        "title": "ADF_TASK_LIST.PROPERTIES.PRIORITY",
+                        "sortable": true
+                    },
+                    {
+                        "key": "assignee",
+                        "type": "text",
+                        "title": "ADF_TASK_LIST.PROPERTIES.ASSIGNEE",
+                        "sortable": true
+                    }
+                ]
+            }
     }
 
 This is the result:
@@ -390,9 +390,9 @@ From the version 2.0.0, all the components in ADF are natively translated into 1
 
 ### 18. Document List enhancements
 
-It is now possible to display the Sites (from ACS) that the currently logged-in user is a member of. You can do this by assigning the "**-mysites-**" alias to the "**currentFolderId**" property. The Document List automatically displays the required content.  If you want to display all available Sites use the "**-sites-**" alias, which is still supported.
+It is now possible to display the Sites (from ACS) that the currently logged-in user is a member of. You can do this by assigning the "**-mysites-**" alias to the "**currentFolderId**" property. The Document List automatically displays the required content.  If you want to display all available Sites use the "**-sites-**" alias, which is still supported.
 
-Also, the Document List now provides a customizable screen for permission errors. The users will see your custom content if they are trying to access any restricted content. The default permission screen is shown in the picture below:
+Also, the Document List now provides a customizable screen for permission errors. The users will see your custom content if they are trying to access any restricted content. The default permission screen is shown in the picture below:
 
 ![](images/pastedImage_2.png)
 
@@ -403,14 +403,14 @@ Also, the Document List now provides a customizable screen for permission errors
 -   Clean old prefix TAG name support
 -   Rename 'extension-viewer' component to 'adf-viewer-extension'
 -   Upload button and Drag area deprecated properties has been removed
--   DocumentList has been separated from the [search component](../content-services/search.component.md)
+-   DocumentList has been separated from the [search component](../content-services/search.component.md)
 -   'md' prefix is not supported anymore
--   Internal pagination has been removed from the  DocumentList
--   Internal search documentlist has been separated from the [search component](../content-services/search.component.md)
+-   Internal pagination has been removed from the  DocumentList
+-   Internal search documentlist has been separated from the [search component](../content-services/search.component.md)
 
 ### New name packages
 
-From ADF 2.0 we split everything into four main packages:
+From ADF 2.0 we split everything into four main packages:
 
     @alfresco/adf-content-services
     @alfresco/adf-process-services
@@ -418,12 +418,12 @@ From ADF 2.0 we split everything into four main packages:
     @alfresco/adf-insights
 
 The Alfresco Javascript API remains the same and will be deployed as previously.
-The structure of the Github repository has been rearranged to reflect these changes.
-The impact for developers using ADF is that the dependencies need to be adjusted (and simplified) in package.json, and all import statements in typescript files need to be changed.
+The structure of the Github repository has been rearranged to reflect these changes.
+The impact for developers using ADF is that the dependencies need to be adjusted (and simplified) in package.json, and all import statements in typescript files need to be changed.
 
 ### Clean all the events that start with "on"
 
-If you want to know more about why this modification was necessary, please see this [link](https://angular.io/guide/styleguide#dont-prefix-output-properties). Full details about the events that have been renamed are given below:
+If you want to know more about why this modification was necessary, please see this [link](https://angular.io/guide/styleguide#dont-prefix-output-properties). Full details about the events that have been renamed are given below:
 
 adf-analytics-generator, adf-analytics-report-list, adf-diagram, adf-login, adf-process-instance-filters, adf-process-instance-list, adf-filters:
 
@@ -463,11 +463,11 @@ adf-analytics:
 
 ### Remove old prefix TAG name support
 
-In the previous release, there was a mixed usage of TAG prefixes for all the components ("alfresco-", "activiti","adf-") We found this approach was quite cumbersome in 1.7.0 and so we renamed all of them using only the TAG **adf-** prefix. However, we still had backward compatibility for the old tags. **The compatibility with "alfresco-" and "activiti-" prefix is now discontinued from 2.0.0**
+In the previous release, there was a mixed usage of TAG prefixes for all the components ("alfresco-", "activiti","adf-") We found this approach was quite cumbersome in 1.7.0 and so we renamed all of them using only the TAG **adf-** prefix. However, we still had backward compatibility for the old tags. **The compatibility with "alfresco-" and "activiti-" prefix is now discontinued from 2.0.0**
 
 ### Rename 'extension-viewer' component to 'adf-viewer-extension'
 
-The **extension-viewer** tag (used to extend the viewer behavior to open extensions not supported by the standard viewer) has been renamed to **adf-viewer-extension**.
+The **extension-viewer** tag (used to extend the viewer behavior to open extensions not supported by the standard viewer) has been renamed to **adf-viewer-extension**.
 
 ### Deprecated Upload button and Drag area properties have been removed
 
@@ -475,38 +475,38 @@ The **extension-viewer** tag (used to extend the viewer behavior to open exten
 
 | Properties | Description |
 | ---------- | ----------- |
-| enabled |  Deprecated in 1.6.0 in favor of disabled input property |
-| showNotificationBar  | Deprecated in 1.6.0 you can use [`UploadService`](../core/upload.service.md) events and [`NotificationService`](../core/notification.service.md) api instead. |
-| currentFolderPath  | Deprecated in 1.6.0, this property is not used for couple of releases already. Use rootFolderId instead. |
-| rootFolderId  | Deprecated in 1.6.0, this property is not used for couple of releases already. Use parentId instead |
+| enabled |  Deprecated in 1.6.0 in favor of disabled input property |
+| showNotificationBar  | Deprecated in 1.6.0 you can use [`UploadService`](../core/upload.service.md) events and [`NotificationService`](../core/notification.service.md) api instead. |
+| currentFolderPath  | Deprecated in 1.6.0, this property is not used for couple of releases already. Use rootFolderId instead. |
+| rootFolderId  | Deprecated in 1.6.0, this property is not used for couple of releases already. Use parentId instead |
 
 **adf-upload-button :**
 
 | Properties | Description |
 | ---------- | ----------- |
-| showNotificationBar  | Deprecated in 1.6.0 you can use [`UploadService`](../core/upload.service.md) events and NotificationService api instead. |
-| currentFolderPath  | Deprecated in 1.6.0, this property is not used for couple of releases already. Use rootFolderId instead. |
-| disableWithNoPermission  | Deprecated in 1.8.0, use the button with combination of adf-node-permission directive |
+| showNotificationBar  | Deprecated in 1.6.0 you can use [`UploadService`](../core/upload.service.md) events and NotificationService api instead. |
+| currentFolderPath  | Deprecated in 1.6.0, this property is not used for couple of releases already. Use rootFolderId instead. |
+| disableWithNoPermission  | Deprecated in 1.8.0, use the button with combination of adf-node-permission directive |
 
 ### Internal pagination has been removed from the DocumentList
 
 The [search component](../content-services/search.component.md) has received a big refactor in this release in order to use the new search API. This gives better configurability as described above. The decoupling of the internal documentlist from the search allows you to customize the search result as you wish.
-Learn how to show the search result in a document list [here](https://github.com/Alfresco/alfresco-ng2-components/tree/master/demo-shell/src/app/components/search).
+Learn how to show the search result in a document list [here](https://github.com/Alfresco/alfresco-ng2-components/tree/master/demo-shell/src/app/components/search).
 
-### Internal search documentlist has been removed from the search component
+### Internal search documentlist has been removed from the search component
 
-Because is now possible to select between two different pagination strategies (**classic pagination** and** infinite scrolling**) we moved these options into separate components:
+Because is now possible to select between two different pagination strategies (**classic pagination** and** infinite scrolling**) we moved these options into separate components:
 
     <adf-document-list
-        .....>
+        .....>
     </adf-document-list>
     <adf-pagination
-        *ngIf="!infiniteScrolling"
-        .....>
+        *ngIf="!infiniteScrolling"
+        .....>
     </adf-pagination>
     <adf-infinite-pagination
-        *ngIf="infiniteScrolling"
-        .....>
+        *ngIf="infiniteScrolling"
+        .....>
     </adf-infinite-pagination>
 
 This modification will even allow you to write your own pagination if you need to or use our pagination system to paginate your own list.
@@ -521,9 +521,9 @@ In our constant commitment to improving the quality of ADF we have also introduc
 
 ![](images/bundle+size+check.png)
 
-### Security checker Snyk
+### Security checker Snyk
 
-[Snyk](https://snyk.io) is an open source tool that helps us to find and  fix known vulnerabilities in our dependencies
+[Snyk](https://snyk.io) is an open source tool that helps us to find and  fix known vulnerabilities in our dependencies
 
 ![](images/security+check.png)
 
@@ -533,7 +533,7 @@ This release features brand new application generators powered by Yeoman. All ou
 
     npm install -g generator-alfresco-adf-app
 
-In addition, the application generator provides support for "blueprints". The 2.0 release includes the following blueprints:
+In addition, the application generator provides support for "blueprints". The 2.0 release includes the following blueprints:
 
 -   Content Services Application
 -   Process Services Application
@@ -549,13 +549,13 @@ The tests run for all modifications to either the generator the underlying bluep
 
 ## References
 
-Below you can find a brief list of references to help you start to use the new release.
+Below you can find a brief list of references to help you start to use the new release.
 
-[Official GitHub Project - alfresco-ng2-components](https://github.com/Alfresco/alfresco-ng2-components)
+[Official GitHub Project - alfresco-ng2-components](https://github.com/Alfresco/alfresco-ng2-components)
 
 [Getting started guides with Alfresco Application Development Framework](https://community.alfresco.com/community/application-development-framework/pages/get-started)
 
-[Component catalog](https://alfresco.github.io/adf-component-catalog/)
+[Component catalog](https://alfresco.github.io/adf-component-catalog/)
 
 [Gitter chat supporting Alfresco ADF](https://gitter.im/Alfresco/alfresco-ng2-components)
 
@@ -565,9 +565,9 @@ Below you can find a brief list of references to help you start to use the new
 
 [Alfresco-JS-API](https://github.com/Alfresco/alfresco-js-api)
 
-[ADF App Generator ](https://github.com/Alfresco/generator-ng2-alfresco-app)
+[ADF App Generator ](https://github.com/Alfresco/generator-ng2-alfresco-app)
 
-Please refer to the [official documentation](http://docs.alfresco.com/) for further details and suggestions.
+Please refer to the [official documentation](http://docs.alfresco.com/) for further details and suggestions.
 
 ## Issues addressed
 
@@ -749,7 +749,7 @@ Release Notes - Apps Development Framework - Version 2.0.
 -   \[[ADF-1861](https://issues.alfresco.com/jira/browse/ADF-1861)] - Line breaks not displayed in "Display Text" widget in forms
 -   \[[ADF-1862](https://issues.alfresco.com/jira/browse/ADF-1862)] - Adf toolbar should get the background color from the theme
 -   \[[ADF-1865](https://issues.alfresco.com/jira/browse/ADF-1865)] - [Document List] "Empty View" does not wrap long text
--   \[[ADF-1866](https://issues.alfresco.com/jira/browse/ADF-1866)] - [Accordion Component](../core/accordion.component.md) - Doesn't allow to close the menu
+-   \[[ADF-1866](https://issues.alfresco.com/jira/browse/ADF-1866)] - Accordion Component - Doesn't allow to close the menu
 -   \[[ADF-1871](https://issues.alfresco.com/jira/browse/ADF-1871)] - Tasklist IE 11 crash
 -   \[[ADF-1872](https://issues.alfresco.com/jira/browse/ADF-1872)] - TaskList Component - Doesn't show the currentTaskId highlited
 -   \[[ADF-1875](https://issues.alfresco.com/jira/browse/ADF-1875)] - [`ProcessList`](../../lib/process-services/mock/process/process.model.mock.ts) Component - Doesn't show the currentProcessId highlighted
@@ -833,4 +833,4 @@ Release Notes - Apps Development Framework - Version 2.0.
 -   \[[ADF-2040](https://issues.alfresco.com/jira/browse/ADF-2040)] - Date picker is not working when changing language.
 -   \[[ADF-2045](https://issues.alfresco.com/jira/browse/ADF-2045)] - [Demo-Shell][pagination](../../lib/content-services/document-list/models/document-library.model.ts) is not working properly on Search Results Page
 
-Please refer to [the Alfresco issue tracker](https://issues.alfresco.com/jira/projects/ADF/issues/ADF-581?filter=allopenissues) for other known issues in this release. If you have more questions, please reply here or contact us using [gitter](https://gitter.im/Alfresco/alfresco-ng2-components).
+Please refer to [the Alfresco issue tracker](https://issues.alfresco.com/jira/projects/ADF/issues/ADF-581?filter=allopenissues) for other known issues in this release. If you have more questions, please reply here or contact us using [gitter](https://gitter.im/Alfresco/alfresco-ng2-components).

--- a/docs/release-notes/RelNote210.md
+++ b/docs/release-notes/RelNote210.md
@@ -111,7 +111,7 @@ The purpose of the [content metadata component](../content-services/content-meta
 
 The component can be configured from the application configuration. This way, you can easily restrict the displayed metadata to a list of aspects or even further, to just a subset or properties belonging to an aspect.
 
-For more information about the component see its [documentation](https://community.alfresco.com/docs/DOC-7301-introduction-to-the-new-content-metadata-component) or [this article](https://github.com/Alfresco/alfresco-ng2-components/blob/master/docs/content-metadata.component.md).
+For more information about the component see its [documentation](https://community.alfresco.com/docs/DOC-7301-introduction-to-the-new-content-metadata-component) or [this article](../content-services/content-metadata.component.md).
 
 ### 5. Start process from a file
 
@@ -146,7 +146,7 @@ Note that in the object above, the key file is the name of the attach file fie
 
 For more information about this functionality see the documentation section linked below:
 
--   [Attaching a File to the start form of the process](https://github.com/Alfresco/alfresco-ng2-components/blob/master/docs/start-process.component.md#attaching-a-file-to-the-start-form-of-the-process)
+-   [Attaching a File to the start form of the process](../process-services/start-process.component.md#attaching-a-file-to-the-start-form-of-the-process)
 
 ### 6. Start form process prefilling values
 
@@ -169,7 +169,7 @@ Here is an example of how to pass in form field values to initialize the start f
 With these settings, the start form will appear with the values above already filled in.
 For more information about this functionality see the following link:
 
--   [Custom data form example](https://github.com/Alfresco/alfresco-ng2-components/blob/master/docs/start-process.component.md#custom-data-example)
+-   [Custom data form example](../process-services/start-process.component.md#custom-data-example)
 
 ### 7. Task List - Support custom HTML template and static columns
 
@@ -258,7 +258,7 @@ You can use the same component also to create a [Content Service](../core/conten
 
 For more information about this functionality see the following link:
 
--   [Sidebar component](https://github.com/Alfresco/alfresco-ng2-components/blob/master/docs/sidebar-action-menu.component.md)
+-   [Sidebar component](../core/sidebar-action-menu.component.md)
 
 ### 9. Infinite pagination component enhancement
 
@@ -271,8 +271,8 @@ We have added the [target] property in the [infinite pagination component](../co
 
 For more information about the infinite pagination see the following links:
 
--   [Infinite pagination component](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/infinite-pagination.component.md)
--   [Paginated component interface](https://github.com/Alfresco/alfresco-ng2-components/blob/18dc0711f93ebad7fbcadc50cd5a6e50c7667be9/lib/core/pagination/paginated-component.interface.ts)
+-   [Infinite pagination component](../core/infinite-pagination.component.md)
+-   [Paginated component interface](../../lib/core/pagination/paginated-component.interface.ts)
 
 ### 10. App drop-down dialog selector
 

--- a/docs/release-notes/RelNote210.md
+++ b/docs/release-notes/RelNote210.md
@@ -4,28 +4,28 @@ Title: Release notes v2.1.0
 
 # Alfresco Application Development Framework, version 2.1.0 Release Note
 
-These release notes provide information for the **2.1.0 release** of the Alfresco Application Development Framework.
+These release notes provide information for the **2.1.0 release** of the Alfresco Application Development Framework.
 
-This is the first **General Available** release of the Application Development Framework, which contains the Angular components to build a Web Application on top of the Alfresco Services.
-The release can be found on GitHub at [this link.](https://github.com/Alfresco/alfresco-ng2-components/releases/tag/1.7.0)
+This is the first **General Available** release of the Application Development Framework, which contains the Angular components to build a Web Application on top of the Alfresco Services.
+The release can be found on GitHub at [this link.](https://github.com/Alfresco/alfresco-ng2-components/releases/tag/1.7.0)
 
 ## Contents
 
 -   [New name packages](#new-name-packages)
 -   [Goals for this release](#goals-for-this-release)
 -   [Notable new features](#notable-new-features)
-    -   [1. Viewer Enhancements]\(#1 viewer-enhancements)
-    -   [2. Upload file from CS widget]\(#2 upload-file-from cs-widget)
-    -   [3. Attach Folder from CS widget]\(#3 attach-folder-from-cs-widget)
-    -   [4. Content metadata component enhancements]\(#4 content-metadata-component-enhancements)
+    -   [1. Viewer Enhancements](#1-viewer-enhancements)
+    -   [2. Upload file from CS widget](#2-upload-file-from-cs-widget)
+    -   [3. Attach Folder from CS widget](#3-attach-folder-from-cs-widget)
+    -   [4. Content metadata component enhancements](#4-content-metadata-component-enhancements)
     -   [5. Start process from a file](#5-start-process-from-a-file)
     -   [6. Start form process prefilling values](#6-start-form-process-prefilling-values)
-    -   [7. Task List - Support custom HTML template and static columns]\(#7 task-list-- support-custom-html-template-and-static-columns)
+    -   [7. Task List - Support custom HTML template and static columns](#7-task-list---support-custom-html-template-and-static-columns)
     -   [8. Sidebar action menu](#8-sidebar-action-menu)
-    -   [9. Infinite pagination component enhancement]\(#9 infinite pagination-component-enhancement)
+    -   [9. Infinite pagination component enhancement](#9-infinite-pagination-component-enhancement)
     -   [10. App drop-down dialog selector](#10-app-drop-down-dialog-selector)
-    -   [11. JS-API Governance]\(#11 js-api-governance)
-    -   [12. Documentation]\(#12 documentation)
+    -   [11. JS-API Governance](#11-js-api-governance)
+    -   [12. Documentation](#12-documentation)
 -   [CI changes](#ci-changes)
 -   [References](#references)
 -   [Issues addressed](#issues-addressed)
@@ -56,7 +56,7 @@ Continuing on our journey for ADF, this release had a big focus on enhancing the
 
 The [Content Metadata component](../content-services/content-metadata.component.md) also got a lot of new features: It now has full support for custom metadata and aspects. It's dynamic and has complex configuration to enable exactly which aspects and properties you want to show in your app. These are just a few highlights for this release. See the full details below.
 
-This release builds on the one from last month and contains bug fixes and new features as listed below.
+This release builds on the one from last month and contains bug fixes and new features as listed below.
 Please report issues with this release in the [issue tracker](https://github.com/Alfresco/alfresco-ng2-components/issues). You can collaborate on this release or share feedback by using the discussion tools on [Gitter](https://gitter.im/Alfresco/alfresco-ng2-components).
 
 ## Notable new features
@@ -68,15 +68,15 @@ Below are the most important new features of this release:
 -   Attach Folder from CS Widget
 -   [Content metadata component](../content-services/content-metadata.component.md) enhancements
 -   Start process from a file
--   Start form process pre-filling value
--   Task List - Support custom HTML template and static columns
+-   Start form process pre-filling value
+-   Task List - Support custom HTML template and static columns
 -   Sidebar action menu
--   Infinite pagination component enhancement
+-   Infinite pagination component enhancement
 -   App drop-down dialog selector
 -   JS-API Governance
--   Documentation enhancements
+-   Documentation enhancements
 
-### 1. Viewer Enhancements
+### 1. Viewer Enhancements
 
 In this release, the [Viewer component](../core/viewer.component.md) got improved styles and document processing enhancements:
 
@@ -85,40 +85,40 @@ In this release, the [Viewer component](../core/viewer.component.md) got improve
 -   automatic fallback to Thumbnail when PDF rendition is not available (for example when viewing Apple Keynote/Pages/Numbers files)
 -   support for viewing Shared links with a new "sharedLinkId" property that allows the Viewer to display shared content (does not require authentication)
 
-### 2. Upload file from CS widget
+### 2. Upload file from CS widget
 
 ![](images/pastedImage_1.gif)
 
 In this release we have re-enabled and improved the upload file widget of our [form component](../core/form.component.md).
 We have added the option to choose the file to upload from a configured ECM repository of APS.
 
-This allows you to start the navigation of ECM folders starting from a configured folder or just from the root. It also has an option to restrict the selection to files.
+This allows you to start the navigation of ECM folders starting from a configured folder or just from the root. It also has an option to restrict the selection to files.
 Sometimes you might want to allow the user to choose from all the sources. The new upload widget will show all the options in the menu when clicked.
 It is also possible to make it work like a normal local file uploader by configuring it to allow only local files.
 
-### 3. Attach Folder from CS widget
+### 3. Attach Folder from CS widget
 
 ![](images/pastedImage_3.gif)
 
 We have added the attach folder widget which is really useful in processes where you need to create your content in the ECM platform via APS .
-As you can see this widget works like the attach file widget in terms of navigation through the folders and restricting the selection to folders.
+As you can see this widget works like the attach file widget in terms of navigation through the folders and restricting the selection to folders.
 
-### 4. Content metadata component enhancements
+### 4. Content metadata component enhancements
 
 ![](images/content-metadata.gif)
 
 The purpose of the [content metadata component](../content-services/content-metadata.component.md) is to display the metadata belonging to a given node. Until now, the component was capable of displaying and making the basic properties editable, but with the latest enhancements, all of the system wide and custom aspects related to a particular node can be displayed and edited.
 
-The component can be configured from the application configuration. This way, you can easily restrict the displayed metadata to a list of aspects or even further, to just a subset or properties belonging to an aspect.
+The component can be configured from the application configuration. This way, you can easily restrict the displayed metadata to a list of aspects or even further, to just a subset or properties belonging to an aspect.
 
-For more information about the component see its [documentation](https://community.alfresco.com/docs/DOC-7301-introduction-to-the-new-content-metadata-component) or [this article](../content-services/content-metadata.component.md).
+For more information about the component see its [documentation](https://community.alfresco.com/docs/DOC-7301-introduction-to-the-new-content-metadata-component) or [this article](../content-services/content-metadata.component.md).
 
 ### 5. Start process from a file
 
 ![](images/new-start-process.gif)
 
 After the repository is created in APS, you can see it in the Alfresco Repositories list. If the ID is set to 1 then all default values are fine. However, if it is set to something else, for example
-_1002_ and the name is _alfresco_, you must set the property alfrescoRepositoryName in your app.config.json file to _alfresco-1002_:
+_1002_ and the name is _alfresco_, you must set the property alfrescoRepositoryName in your app.config.json file to _alfresco-1002_:
 
     {
         name: 'Alfresco ADF Application'
@@ -128,23 +128,23 @@ _1002_ and the name is _alfresco_, you must set the property alfrescoReposito
     logLevel: 'silent',
     alfrescoRepositoryName : 'alfresco-1002'
 
-You then need to pass the node via the input values object along with the other properties:
+You then need to pass the node via the input values object along with the other properties:
 
     let node: MinimalNodeEntryEntity = this.nodesApiService.getNode(NODE_ID);
 
-    const formValues: FormValues  = {
-        'file' : node
-        'field_one': 'example text'
+    const formValues: FormValues  = {
+        'file' : node
+        'field_one': 'example text'
     };
 
-Note that in the object above, the key file is the name of the attach file field in the start form of the process. The value of the file property must be a [`MinimalNodeEntryEntity`](../content-services/document-library.model.md):
+Note that in the object above, the key file is the name of the attach file field in the start form of the process. The value of the file property must be a [`MinimalNodeEntryEntity`](../content-services/document-library.model.md):
 
     <adf-start-process
-        [values]="formValues"
-        [appId]="YOUR_APP_ID" >
+        [values]="formValues"
+        [appId]="YOUR_APP_ID" >
     </adf-start-process>
 
-For more information about this functionality see the documentation section linked below:
+For more information about this functionality see the documentation section linked below:
 
 -   [Attaching a File to the start form of the process](../process-services/start-process.component.md#attaching-a-file-to-the-start-form-of-the-process)
 
@@ -152,56 +152,56 @@ For more information about this functionality see the documentation section li
 
 Here is an example of how to pass in form field values to initialize the start form that has been defined for the process:
 
-    const formValues: FormValues  = {
-        'test_1': 'value_1',
-        'test_2': 'value_2',
-        'test_3': 'value_1',
-        'test_4': 'dropdown_id',
-        'test_5': 'dropdown_label',
-        'dropdown': {'id': 'dropdown_id', 'name': 'dropdown_label'}
+    const formValues: FormValues  = {
+        'test_1': 'value_1',
+        'test_2': 'value_2',
+        'test_3': 'value_1',
+        'test_4': 'dropdown_id',
+        'test_5': 'dropdown_label',
+        'dropdown': {'id': 'dropdown_id', 'name': 'dropdown_label'}
     };
 
     <adf-start-process
-        [values]="formValues"
-        [appId]="YOUR_APP_ID" >
+        [values]="formValues"
+        [appId]="YOUR_APP_ID" >
     </adf-start-process>
 
-With these settings, the start form will appear with the values above already filled in.
-For more information about this functionality see the following link:
+With these settings, the start form will appear with the values above already filled in.
+For more information about this functionality see the following link:
 
 -   [Custom data form example](../process-services/start-process.component.md#custom-data-example)
 
-### 7. Task List - Support custom HTML template and static columns
+### 7. Task List - Support custom HTML template and static columns
 
-With the previous ADF version, there was no way to combine a custom HTML template and static columns (configured in the **app.config.**json file, for example). With ADF 2.1.0 you can have both of them at the same time.
+With the previous ADF version, there was no way to combine a custom HTML template and static columns (configured in the **app.config.**json file, for example). With ADF 2.1.0 you can have both of them at the same time.
 
 For instance, we can display the Assignee (custom HTML template) and Task Name (Static column)
 
 The HTML contains a custom HTML template column
 
     <adf-tasklist>
-        <data-columns>
-            <data-column key="assignee" title="ASSIGNEE">
-                <ng-template let-entry="$implicit">
-                    <div>{{getFullName(entry.row.obj.assignee)}}</div>
-                </ng-template>
-            </data-column>
-        <data-columns>
+        <data-columns>
+            <data-column key="assignee" title="ASSIGNEE">
+                <ng-template let-entry="$implicit">
+                    <div>{{getFullName(entry.row.obj.assignee)}}</div>
+                </ng-template>
+            </data-column>
+        <data-columns>
     </adf-tasklist>
 
 app.config.json (contains a static column)
 
     "adf-task-list": {
-        "presets": {
-            "default": [
-                {
-                    "key": "name",
-                    "type": "text",
-                    "title": "NAME",
-                    "sortable": true
-                }
-            ]
-        }
+        "presets": {
+            "default": [
+                {
+                    "key": "name",
+                    "type": "text",
+                    "title": "NAME",
+                    "sortable": true
+                }
+            ]
+        }
     }
 
 This is the result:
@@ -210,7 +210,7 @@ This is the result:
 
 ### 8. Sidebar action menu
 
-This component displays a sidebar-action menu information panel. It is basically just a layout with CSS styling.
+This component displays a sidebar-action menu information panel. It is basically just a layout with CSS styling.
 There are three regions where you can add your own content, as shown in the example:
 
 -   sidebar-menu-title-icon
@@ -219,33 +219,33 @@ There are three regions where you can add your own content, as shown in the exam
 
 
     <adf-sidebar-action-menu title="Create">
-        <mat-icon sidebar-menu-title-icon>arrow_drop_down</mat-icon>
-        <div sidebar-menu-options>
-            <button mat-menu-item>
-                <span>New Task</span>
-            </button>
-            <button mat-menu-item>
-                <span>New Process</span>
-            </button>
-        </div>
+        <mat-icon sidebar-menu-title-icon>arrow_drop_down</mat-icon>
+        <div sidebar-menu-options>
+            <button mat-menu-item>
+                <span>New Task</span>
+            </button>
+            <button mat-menu-item>
+                <span>New Process</span>
+            </button>
+        </div>
     </adf-sidebar-action-menu>
 
 This is the result:
 
 ![Sidebar action menu](images/Screen+Shot+2018-01-26+at+16.06.41.png)
 
-You can also use the same component for mobile content
+You can also use the same component for mobile content
 
     <adf-sidebar-action-menu [expanded]="false">
-        <mat-icon sidebar-menu-expand-icon matTooltip="Create">queue</mat-icon>
-        <div sidebar-menu-options>
-            <button mat-menu-item (click)="onCreateClick('tasks')">
-                <span>New Task</span>
-            </button>
-            <button mat-menu-item (click)="onCreateClick('processes')">
-                <span>New Process</span>
-            </button>
-        </div>
+        <mat-icon sidebar-menu-expand-icon matTooltip="Create">queue</mat-icon>
+        <div sidebar-menu-options>
+            <button mat-menu-item (click)="onCreateClick('tasks')">
+                <span>New Task</span>
+            </button>
+            <button mat-menu-item (click)="onCreateClick('processes')">
+                <span>New Process</span>
+            </button>
+        </div>
     </adf-sidebar-action-menu>
 
 This is the result:
@@ -256,17 +256,17 @@ You can use the same component also to create a [Content Service](../core/conten
 
 ![Sidebar action menu content service](images/Screen+Shot+2018-01-26+at+16.28.15.png)
 
-For more information about this functionality see the following link:
+For more information about this functionality see the following link:
 
 -   [Sidebar component](../core/sidebar-action-menu.component.md)
 
-### 9. Infinite pagination component enhancement
+### 9. Infinite pagination component enhancement
 
-We have added the [target] property in the [infinite pagination component](../core/infinite-pagination.component.md) to bring it in line with the [pagination component](../core/pagination.component.md). With this, the link between the infinite pagination and its target is simpler:
+We have added the [target] property in the [infinite pagination component](../core/infinite-pagination.component.md) to bring it in line with the [pagination component](../core/pagination.component.md). With this, the link between the infinite pagination and its target is simpler:
 
     <adf-infinite-pagination
-        [target]="documentList"
-        [loading="documentList.infiniteLoading">
+        [target]="documentList"
+        [loading="documentList.infiniteLoading">
     </adf-infinite-pagination>
 
 For more information about the infinite pagination see the following links:
@@ -280,42 +280,42 @@ For more information about the infinite pagination see the following links:
 
 ### 
 
-### 11. JS-API Governance
+### 11. JS-API Governance
 
-In order to enable the creation of new ADF component based on Alfresco Governance Services, we have updated the alfresco-js-api with all the governance core and classification API.
-For more information about this functionality see the following links:
+In order to enable the creation of new ADF component based on Alfresco Governance Services, we have updated the alfresco-js-api with all the governance core and classification API.
+For more information about this functionality see the following links:
 
 -   [Governance Core](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-gs-core-rest-api)
 -   [Governance Classification](https://github.com/Alfresco/alfresco-js-api/tree/master/src/alfresco-gs-classification-rest-api)
 
-### 12. Documentation
+### 12. Documentation
 
-The Properties tables in the [documentation](https://alfresco.github.io/adf-component-catalog/) are now updated with the type and the default value of any property.
+The Properties tables in the [documentation](https://alfresco.github.io/adf-component-catalog/) are now updated with the type and the default value of any property.
 
 ## CI changes
 
-In our constant commitment to improving the quality of ADF we have also introduced one new automatic check over all the PRs:
+In our constant commitment to improving the quality of ADF we have also introduced one new automatic check over all the PRs:
 
 ![](images/Screen+Shot+2018-01-26+at+10.59.39.png)
 
-Codacy is a tool that checks the code style, security, duplication and complexity of any pull request. If you want more information on Codacy please visit their [website](https://community.alfresco.com/docs/DOC-7292/codacy.com)
+Codacy is a tool that checks the code style, security, duplication and complexity of any pull request. If you want more information on Codacy please visit their [website](https://community.alfresco.com/docs/DOC-7292/codacy.com)
 
 Application generators (Yeoman)
 Below are the most noteworthy changes in the generator:
 
--   Support for silent mode ton enable generators to be used in shell scripts and automated scenarios
+-   Support for silent mode ton enable generators to be used in shell scripts and automated scenarios
 -   All blueprints now also contain a basic Dockerfile to build docker images
--   All blueprints are updated to the latest angular cli 1.6.5 dependencies
+-   All blueprints are updated to the latest angular cli 1.6.5 dependencies
 
 ## References
 
-Below you can find a brief list of references to help you start to use the new release.
+Below you can find a brief list of references to help you start to use the new release.
 
-[Official GitHub Project - alfresco-ng2-components](https://github.com/Alfresco/alfresco-ng2-components)
+[Official GitHub Project - alfresco-ng2-components](https://github.com/Alfresco/alfresco-ng2-components)
 
 [Getting started guides with Alfresco Application Development Framework](https://community.alfresco.com/community/application-development-framework/pages/get-started)
 
-[Component catalog](https://alfresco.github.io/adf-component-catalog/)
+[Component catalog](https://alfresco.github.io/adf-component-catalog/)
 
 [Gitter chat supporting Alfresco ADF](https://gitter.im/Alfresco/alfresco-ng2-components)
 
@@ -325,9 +325,9 @@ Below you can find a brief list of references to help you start to use the new
 
 [Alfresco-JS-API](https://github.com/Alfresco/alfresco-js-api)
 
-[ADF App Generator ](https://github.com/Alfresco/generator-ng2-alfresco-app)
+[ADF App Generator ](https://github.com/Alfresco/generator-ng2-alfresco-app)
 
-Please refer to the [official documentation](http://docs.alfresco.com/) for further details and suggestions.
+Please refer to the [official documentation](http://docs.alfresco.com/) for further details and suggestions.
 
 ## Issues addressed
 
@@ -443,4 +443,4 @@ Release Notes - Apps Development Framework - Version 2.1.
 -   \[[ADF-2172](https://issues.alfresco.com/jira/browse/ADF-2172)] - Adding of data-automation-id tag for 'Create' process/task button.
 -   \[[ADF-2188](https://issues.alfresco.com/jira/browse/ADF-2188)] - Provide a workaround to change the processName without changing the code.
 
-Please refer to [the Alfresco issue tracker](https://issues.alfresco.com/jira/projects/ADF/issues/ADF-581?filter=allopenissues) for other known issues in this release. If you have more questions, please reply here or contact us using [gitter](https://gitter.im/Alfresco/alfresco-ng2-components).
+Please refer to [the Alfresco issue tracker](https://issues.alfresco.com/jira/projects/ADF/issues/ADF-581?filter=allopenissues) for other known issues in this release. If you have more questions, please reply here or contact us using [gitter](https://gitter.im/Alfresco/alfresco-ng2-components).

--- a/docs/release-notes/RelNote220.md
+++ b/docs/release-notes/RelNote220.md
@@ -126,7 +126,7 @@ In this release, the [Viewer component](../core/viewer.component.md) has receive
 -   Image view now supports panning of the images. Hardware-accelerated styles were used to enable panning of zoomed in or large images with the highest performance and efficiency
 -   The viewer has greatly improved maintenance of the Renditions (see possible conversion options here: [File types that support preview and thumbnail generation | Alfresco Documentation](https://docs.alfresco.com/5.2/references/valid-transformations-preview.html) )
 -   Support for "carousel" modes and document navigation options (extra buttons you can enable and provide handlers for). This feature will be fully demonstrated in the upcoming "Alfresco Content Application" release.
--   It is now possible to provide custom menu buttons for the Viewer toolbar. See more details in the docs: [alfresco-ng2-components/viewer.component.md at development · Alfresco/alfresco-ng2-components · GitHub ](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/viewer.component.md#custom-toolbar-buttons)
+-   It is now possible to provide custom menu buttons for the Viewer toolbar. See more details in the docs: [alfresco-ng2-components/viewer.component.md at development · Alfresco/alfresco-ng2-components · GitHub ](../core/viewer.component.md#custom-toolbar-buttons)
 
 ![PDF thumbnails](images/pdf-thumbnails.png)
 

--- a/docs/release-notes/RelNote240.md
+++ b/docs/release-notes/RelNote240.md
@@ -5,7 +5,7 @@ Title: Release notes v2.4.0
 # Alfresco Application Development Framework, version 2.4.0 Release Note
 
 These release notes provide information about the **2.4.0 release** of the Alfresco Application Development Framework.
-This is the latest **General Available** release of the Application Development Framework, which contains the Angular components to build a Web Application on top of the Alfresco Platform.
+This is the latest **General Available** release of the Application Development Framework, which contains the Angular components to build a Web Application on top of the Alfresco Platform.
 The release can be found on GitHub at [this location.](https://github.com/Alfresco/alfresco-ng2-components/releases/tag/1.7.0)
 
 ## Contents
@@ -14,7 +14,7 @@ The release can be found on GitHub at [this location.](https://github.com/Alfres
 -   [Goals for this release](#goals-for-this-release)
 -   [Notable new features](#notable-new-features)
     -   [SSO Login support](#sso-login-support)
-    -   [SSO Implicit Flow with Keycloak Login page]\(#sso implicit-flow-with-keycloak-login-page)
+    -   [SSO Implicit Flow with Keycloak Login page](#sso-implicit-flow-with-keycloak-login-page)
     -   [File versioning enhancement](#file-versioning-enhancement)
     -   [Empty Page Component](#empty-page-component)
     -   [TaskList Empty Page](#tasklist-empty-page)
@@ -46,7 +46,7 @@ The release can be found on GitHub at [this location.](https://github.com/Alfres
 
 ## Goals for this release
 
-This release introduces native support for OpenID Connect and oAuth2 implicit flows. This enables complex Single Sign-On configurations using JWT and OpenID Connect and aligns with the new authentication features in Alfresco Process Services (powered by Activiti) 1.9 and Alfresco Content Services 6.0 which both include native support for using Keycloak. If you have SSO requirements for your project then this release (along with APS 1.9, ACS 6.0, and Keycloak) will be useful to you. 
+This release introduces native support for OpenID Connect and oAuth2 implicit flows. This enables complex Single Sign-On configurations using JWT and OpenID Connect and aligns with the new authentication features in Alfresco Process Services (powered by Activiti) 1.9 and Alfresco Content Services 6.0 which both include native support for using Keycloak. If you have SSO requirements for your project then this release (along with APS 1.9, ACS 6.0, and Keycloak) will be useful to you. 
 
 The release also contains new components such as Error Pages and Empty Page. Searchs continues to be improved and the Upload component has new features to customize the upload flow by providing new events and configuration properties to enable providing metadata and nodeType as part of the upload. See all the new features and bug fixes below.
 
@@ -55,13 +55,13 @@ The release also contains new components such as Error Pages and Empty Page. Sea
 Below are the most important new features of this release:
 
 -   SSO Login support
--   SSO Implicit flow Keycloak login page
+-   SSO Implicit flow Keycloak login page
 -   File Versioning enhancements
 -   Empty Page Component
 -   TaskList Empty Page
 -   [`ProcessList`](../../lib/process-services/mock/process/process.model.mock.ts) Empty Page
 -   Error Page Component
--   Search Improvements 
+-   Search Improvements 
 -   [App config pipe](../core/app-config.pipe.md)
 -   Intercepting and Resuming Upload
 -   Conditional Visibility for Data Columns
@@ -78,17 +78,17 @@ For more information about how to configure SSO on ADF please refer to:
 
 ![Empty Page State](images/Screen+Shot+2018-06-24+at+18.40.41.png)
 
-### SSO Implicit Flow with Keycloak Login page
+### SSO Implicit Flow with Keycloak Login page
 
-You can configure the app.config.json file to redirect the user to the Keycloak login page to fetch the JWT token if you need this functionality.
+You can configure the app.config.json file to redirect the user to the Keycloak login page to fetch the JWT token if you need this functionality.
 
-As you can see from the configuration we are pointing to an Alfresco Process Services _(powered by Activiti)_ [_1.9.0_ ](https://www.alfresco.com/platform/process-services-bpm/trial/download) instance with Keycloak enabled ([http://myactivitikeycloak.com](https://community.alfresco.com/myactivitikeycloak.com)). 
+As you can see from the configuration we are pointing to an Alfresco Process Services _(powered by Activiti)_ [_1.9.0_ ](https://www.alfresco.com/platform/process-services-bpm/trial/download) instance with Keycloak enabled ([http://myactivitikeycloak.com](https://community.alfresco.com/myactivitikeycloak.com)). 
 AuthType is **OAuth**, which means that the JS API will add the JWT token as part of the header when an API call is performed. In addition, we provide all the necessary configuration for the Keycloak,
 **host, clientId, scope and redirectUri**.
 
 When the app is bootstrapped, the user is redirected to the Keycloak login if they are not logged in. 
-As a prerequisite, the user must be known to Keycloak and Activiti.
-Once the Keycloak login is performed the user is redirected back to the app based on the **redirectUri** that has been specified. From now on every time we do a call a JWT token is added to the header.
+As a prerequisite, the user must be known to Keycloak and Activiti.
+Once the Keycloak login is performed the user is redirected back to the app based on the **redirectUri** that has been specified. From now on every time we do a call a JWT token is added to the header.
 
 ![ADF SSO implicit flow with redirect](images/Screen+Shot+2018-06-25+at+11.14.34.png)
 
@@ -100,8 +100,8 @@ Once the Keycloak login is performed the user is redirected back to the app bas
 
 ### File versioning enhancement
 
-With ADF 2.4.0, you can now upload minor or major versions of a file. We have also removed the restriction where you were limited to uploading only same file types as new versions.
-For more information about this component please refer to [the official documentation.](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/content-services/version-manager.component.md)
+With ADF 2.4.0, you can now upload minor or major versions of a file. We have also removed the restriction where you were limited to uploading only same file types as new versions.
+For more information about this component please refer to [the official documentation.](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/content-services/version-manager.component.md)
 
 ![Verrsioning](images/Jun-24-2018+18-53-43.gif)
 
@@ -109,21 +109,21 @@ For more information about this component please refer to [the official documen
 
 We have created a general-purpose Empty Page Component to allow you to have a consistent empty state for your tables.
 This component needs just 3 inputs: icon, title, and subtitle.
-You can also transclude external content into the component's body.
-For more information about this component please refer to [the official documentation.](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/core/empty-content.component.md) 
+You can also transclude external content into the component's body.
+For more information about this component please refer to [the official documentation.](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/core/empty-content.component.md) 
 
 ![Empty Page State](images/EmptyPage.gif)
 
 ### TaskList Empty Page
 
-In the version 2.4, the TaskList uses the empty state component if there are no available tasks.
+In the version 2.4, the TaskList uses the empty state component if there are no available tasks.
 You can still override it from the parent component using `<ng-template>`.
 
 ![Task list Empty Page](images/Screen+Shot+2018-06-25+at+11.16.45.png)
 
 ### ProcessList Empty Page
 
-In the version 2.4, the [`ProcessList`](../../lib/process-services/mock/process/process.model.mock.ts) uses the empty state component if there are no available processes.   
+In the version 2.4, the [`ProcessList`](../../lib/process-services/mock/process/process.model.mock.ts) uses the empty state component if there are no available processes.   
 You can still override it from the parent component using `<ng-template>`.
 
 ![Process list Empty Page](images/Screen+Shot+2018-06-25+at+11.16.57.png)
@@ -131,7 +131,7 @@ You can still override it from the parent component using `<ng-template>`.
 ### Error Page Component
 
 We have created an error page component that will show buttons and messages relevant to the error that occurred (404, 403, etc...)
-For more information about this component please refer to [the official documentation.](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/core/error-content.component.md) 
+For more information about this component please refer to [the official documentation.](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/core/error-content.component.md) 
 
 ![404Example](images/404Error.gif)
 
@@ -144,8 +144,8 @@ In this release we have provided a great number of Search enhancements.
 -   Configuration schema for "app.config.json" updates that provide you with validation and code completion
 -   Server-side sorting with full customization support
 -   Support for custom widgets in the Search Filter
--   Multi-select facet, Date range facet, Number range facet,  Slider range facet
-    A full list of details and examples is available in the [Search filter component documentation.](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/content-services/search-filter.component.md)
+-   Multi-select facet, Date range facet, Number range facet,  Slider range facet
+    A full list of details and examples is available in the [Search filter component documentation.](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/content-services/search-filter.component.md)
 
 ![](images/pastedImage_1.png)
 
@@ -154,16 +154,16 @@ In this release we have provided a great number of Search enhancements.
 In 2.4.0 we provide a special Angular Pipe to deal with application configuration without coding overhead. You can now extract a value from the configuration directly into the component property or content:
 
     <adf-login
-        copyrightText="{{ 'application.copyright' | adfAppConfig }}">
+        copyrightText="{{ 'application.copyright' | adfAppConfig }}">
     </adf-login>
 
 Developers can also provide fallback values and chain the pipe with other pipes, such as Translate.
 
-You can find details and examples on the [App config pipe page.](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/core/app-config.pipe.md)
+You can find details and examples on the [App config pipe page.](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/core/app-config.pipe.md)
 
 ### Intercepting and Resuming Upload
 
-You can now intercept a file or folder upload to perform additional actions. With the current release you can:
+You can now intercept a file or folder upload to perform additional actions. With the current release you can:
 
 -   pause the upload process and get access to the array of file models prepared for upload
 -   show dialogs (confirmation or custom)
@@ -172,7 +172,7 @@ You can now intercept a file or folder upload to perform additional actions. Wi
 
 Note that this feature applies to all methods of uploading (drag and drop, buttons, etc).
 
-You can find more details and examples of how to set up the confirmation dialog on the [Upload drag area page.](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/content-services/upload-drag-area.component.md#intercepting-uploads)
+You can find more details and examples of how to set up the confirmation dialog on the [Upload drag area page.](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/content-services/upload-drag-area.component.md#intercepting-uploads)
 
 ![](images/adf-download-intercept.gif)
 
@@ -181,27 +181,27 @@ You can find more details and examples of how to set up the confirmation dialog�
 You can now toggle Data Column visibility based on a static value or expression.
 
     <data-column
-        *nfIg="showNameColumn"
-        key="name"
-        title="MY.RESOURCE.KEY">
+        *nfIg="showNameColumn"
+        key="name"
+        title="MY.RESOURCE.KEY">
     </data-column>
 
-Find more details and examples on the [Document list component page.](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/content-services/document-list.component.md#conditional-visibility)
+Find more details and examples on the [Document list component page.](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/content-services/document-list.component.md#conditional-visibility)
 
 ### Conditional States for Content Actions
 
-You can now control the visibility and disabled state of the Content Actions.
+You can now control the visibility and disabled state of the Content Actions.
 Specifically, you can:
 
 -   Set static values
 -   Bind to functions that take the corresponding node and evaluate the state
 
-More details are available on the [Content action component page.](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/content-services/content-action.component.md#conditional-visibility)
+More details are available on the [Content action component page.](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/content-services/content-action.component.md#conditional-visibility)
 
 ### Responsive Button Menu
 
-We have added a new component which allows you add a custom list of buttons. The list will automatically collapse into a burger menu choice for small screens so the menu button will always fit inside your page.
-See the [Buttons menu component page](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/core/buttons-menu.component.md) for more information.
+We have added a new component which allows you add a custom list of buttons. The list will automatically collapse into a burger menu choice for small screens so the menu button will always fit inside your page.
+See the [Buttons menu component page](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/core/buttons-menu.component.md) for more information.
 
 ![Responsive Button Menu](images/ButtonMenuResponsive.gif)
 
@@ -211,16 +211,16 @@ This release includes: French, German, Italian, Spanish, Japanese, Dutch, Norweg
 
 ## References
 
-Below you can find a brief list of references to help you start using the new release.
+Below you can find a brief list of references to help you start using the new release.
 
--   [Official GitHub Project - alfresco-ng2-components](https://github.com/Alfresco/alfresco-ng2-components)
+-   [Official GitHub Project - alfresco-ng2-components](https://github.com/Alfresco/alfresco-ng2-components)
 -   [Getting started guides with Alfresco Application Development Framework](https://community.alfresco.com/community/application-development-framework/pages/get-started)
 -   [Component catalog](https://alfresco.github.io/adf-component-catalog/)
 -   [Gitter chat supporting Alfresco ADF](https://gitter.im/Alfresco/alfresco-ng2-components)
 -   [ADF examples](https://github.com/Alfresco/adf-examples)
 -   [List of all components](https://github.com/Alfresco/alfresco-ng2-components/tree/master/ng2-components)
 -   [Alfresco-JS-API](https://github.com/Alfresco/alfresco-js-api)
--   [ADF App Generator ](https://github.com/Alfresco/generator-ng2-alfresco-app)
+-   [ADF App Generator ](https://github.com/Alfresco/generator-ng2-alfresco-app)
 
 Please refer to the [official documentation](http://docs.alfresco.com/) for further details and suggestions.
 
@@ -460,4 +460,4 @@ Release Notes - Apps Development Framework - Version 2.4.0
 -   \[[ADF-3055](https://issues.alfresco.com/jira/browse/ADF-3055)] - pageSize not working for facetField
 -   \[[ADF-3060](https://issues.alfresco.com/jira/browse/ADF-3060)] - Multi-select facet basic (P2)
 
-Please refer to [the Alfresco issue tracker](https://issues.alfresco.com/jira/projects/ADF/issues/ADF-581?filter=allopenissues) for other known issues in this release. If you have any questions about the release,please contact us using [gitter](https://gitter.im/Alfresco/alfresco-ng2-components) . 
+Please refer to [the Alfresco issue tracker](https://issues.alfresco.com/jira/projects/ADF/issues/ADF-581?filter=allopenissues) for other known issues in this release. If you have any questions about the release,please contact us using [gitter](https://gitter.im/Alfresco/alfresco-ng2-components) . 

--- a/docs/release-notes/RelNote250.md
+++ b/docs/release-notes/RelNote250.md
@@ -4,11 +4,11 @@ Title: Release notes v2.5.0
 
 # Alfresco Application Development Framework, version 2.5.0 Release Note
 
-These release notes provide information about the **2.5.0 release**
+These release notes provide information about the **2.5.0 release**
 of the Alfresco Application Development Framework.
-This is the latest **General Available**
-release of the Application Development Framework, which contains the Angular components to build a Web Application on top of the Alfresco Platform.
-The release can be found on GitHub at
+This is the latest **General Available**
+release of the Application Development Framework, which contains the Angular components to build a Web Application on top of the Alfresco Platform.
+The release can be found on GitHub at
 [this location.](https://github.com/Alfresco/alfresco-ng2-components/releases/tag/1.7.0)
 
 ### New name packages
@@ -31,7 +31,7 @@ The release can be found on GitHub at
     -   [NotificationService customizability improvement](#notificationservice-customizability-improvement)
     -   [Dynamic Table - Datetime widget](#dynamic-table---datetime-widget)
     -   [Attach a form to a standalone Task](#attach-a-form-to-a-standalone-task)
-    -   [Task list/Process list processDefinitionId filter]\(#task-listprocess-list processdefinitionid-filter)
+    -   [Task list/Process list processDefinitionId filter](#task-listprocess-list-processdefinitionid-filter)
     -   [Lazy loading improvements](#lazy-loading-improvements)
     -   [Localization](#localization)
 -   [References](#references)
@@ -49,11 +49,11 @@ The release can be found on GitHub at
 
 In this release we have focused on updating the version of the Angular and Material libraries from 5 to 6. The team has also spent part of the sprints improving the e2e test coverage.
 
-We truly believe in TDD and the whole library has a unit test coverage of 90%. The e2e coverage is still partly achieved with manual work but this is due to a technical debt that we want to fix. The commitment of the team to increasing the coverage of the automatic e2e tests is an added guarantee of the quality and stability that we want delivery in ADF.
+We truly believe in TDD and the whole library has a unit test coverage of 90%. The e2e coverage is still partly achieved with manual work but this is due to a technical debt that we want to fix. The commitment of the team to increasing the coverage of the automatic e2e tests is an added guarantee of the quality and stability that we want delivery in ADF.
 
-Amongst all this hard work, we also found a little time to add some new functionality and fix bugs.
+Amongst all this hard work, we also found a little time to add some new functionality and fix bugs.
 
-Please report issues with this release in the 
+Please report issues with this release in the 
 [issue tracker](https://github.com/Alfresco/alfresco-ng2-components/issues/new).
 You can collaborate on this release or share feedback by using the discussion tools on
 [Gitter](http://gitter.im/Alfresco/alfresco-ng2-components).
@@ -80,31 +80,31 @@ In this release, we have updated our direct dependency on the Angular and Materi
 
 ### Search Improvements
 
--   You can now select multiple buckets for the facet result. All buckets from the same facet are combined with logical "OR", so you can select "JPEG" and "PNG" for the "content.mimetype" for example.
--   Facet fields and queries now respect the order of declaration in the application configuration file. When rendering query results, the Search Filter uses the order of declaration.
+-   You can now select multiple buckets for the facet result. All buckets from the same facet are combined with logical "OR", so you can select "JPEG" and "PNG" for the "content.mimetype" for example.
+-   Facet fields and queries now respect the order of declaration in the application configuration file. When rendering query results, the Search Filter uses the order of declaration.
 -   Facet buckets get the numbers automatically updated based on user interaction.
 
 ### General Header component
 
-This component is a reusable header for Alfresco applications. It displays a customizable header that can be reused. Use the input properties to configure the left side (title, button) and the primary color of the header. The right side of the header can contain other components which are transcluded in the header component.
+This component is a reusable header for Alfresco applications. It displays a customizable header that can be reused. Use the input properties to configure the left side (title, button) and the primary color of the header. The right side of the header can contain other components which are transcluded in the header component.
 
     <adf-layout-header
-        title="title"
-        logo="logo.png"
-        [redirectUrl]="'/home'"
-        color="primary"
-        (toggled)=toggleMenu($event)>
-        .......
+        title="title"
+        logo="logo.png"
+        [redirectUrl]="'/home'"
+        color="primary"
+        (toggled)=toggleMenu($event)>
+        .......
      </adf-layout-header>
 
 ![Empty Page State](images/header.gif)
 
-For more information about this component please refer to the 
+For more information about this component please refer to the 
 [official documentation](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/core/header.component.md).
 
 ### Default metadata properties hide/show
 
-In ADF 2.5.0 you can now customize the metadata card with the option of showing or hiding the default properties of the file.
+In ADF 2.5.0 you can now customize the metadata card with the option of showing or hiding the default properties of the file.
 
     <adf-content-metadata-card .......
         [displayEmpty]="false">
@@ -117,63 +117,63 @@ In ADF 2.5.0 you can now customize the metadata card with the option of showin
 Two new property types are now available in the card view:
 
     new CardViewKeyValuePairsItemModel({
-        label: 'CardView Key-Value Pairs Item',
-        value: [],
-        key: 'key-value-pairs',
-        editable: this.isEditable
+        label: 'CardView Key-Value Pairs Item',
+        value: [],
+        key: 'key-value-pairs',
+        editable: this.isEditable
     }),
     new CardViewSelectItemModel({
-        label: 'CardView Select Item',
-        value: 'one',
-        options$: of([{ key: 'one', label: 'One' }, { key: 'two', label: 'Two' }]),
-        key: 'select',
-        editable: this.isEditable
+        label: 'CardView Select Item',
+        value: 'one',
+        options$: of([{ key: 'one', label: 'One' }, { key: 'two', label: 'Two' }]),
+        key: 'select',
+        editable: this.isEditable
     }),
 
-KeyValuePairs is a map key value that is rendered as shown in the image to the left. It uses a nicely-formatted table that allows also for easy editing.ViewSelectItem is a selectBox that allows you to limit the set of possible values for a property.
+KeyValuePairs is a map key value that is rendered as shown in the image to the left. It uses a nicely-formatted table that allows also for easy editing.ViewSelectItem is a selectBox that allows you to limit the set of possible values for a property.
 
 ![Card view](images/cardview.gif)
 
-For more information about this component please refer to the 
+For more information about this component please refer to the 
 [official documentation](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/core/card-view.component.md).
 
 ### NotificationService customizability improvement
 
-The NotificationService now exposes a new input parameter to allow a full customization of the notification message: 
+The NotificationService now exposes a new input parameter to allow a full customization of the notification message: 
 
--   Direction : Text layout direction for the snack bar.
--   Duration : The length of time in milliseconds to wait before automatically dismissing the snack bar.
--   Horizontal Position : The horizontal position to place the snack bar.
--   Vertical Position : The vertical position to place the snack bar.
--   panelClass :  Extra CSS classes to be added to the snack bar container.
+-   Direction : Text layout direction for the snack bar.
+-   Duration : The length of time in milliseconds to wait before automatically dismissing the snack bar.
+-   Horizontal Position : The horizontal position to place the snack bar.
+-   Vertical Position : The vertical position to place the snack bar.
+-   panelClass :  Extra CSS classes to be added to the snack bar container.
 
 ![Notification](images/notification2.gif)
 
-For more information about this component please refer to the 
+For more information about this component please refer to the 
 [official documentation](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/core/notification.service.md).
 
 ### Dynamic Table - Datetime widget
 
-You can now render DateTime items in the dynamic table of a form.
+You can now render DateTime items in the dynamic table of a form.
 
 ![Datetime datatable](images/date_time_datatable.gif)
 
 ### Attach a form to a standalone Task
 
-You can now attach a form to a new task that is not part of a Process using the task-standalone component 
+You can now attach a form to a new task that is not part of a Process using the task-standalone component 
 
     <adf-task-standalone
-        [taskName]= "taskname">
+        [taskName]= "taskname">
     </adf-task-standalone>
 
 ![Standalone task](images/Standalone+task.gif)
 
-For more information about this component please refer to the 
-[official documentation](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/process-services/task-standalone.component.md). 
+For more information about this component please refer to the 
+[official documentation](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/process-services/task-standalone.component.md). 
 
-### Task list/Process list processDefinitionId filter
+### Task list/Process list processDefinitionId filter
 
-A new input parameter processDefinitionId has been added to the Tasklist and the Processlist to allow you to filter the list by processDefinitionId.
+A new input parameter processDefinitionId has been added to the Tasklist and the Processlist to allow you to filter the list by processDefinitionId.
 
 ![Task List new processDefinitionId The Definition Id of the process](images/Screen+Shot+2018-08-12+at+15.51.18.png)
 
@@ -188,9 +188,9 @@ This release includes: French, German, Italian, Spanish, Japanese, Dutch, Norweg
 
 ## References
 
-Below you can find a brief list of references to help you start using the new release:
+Below you can find a brief list of references to help you start using the new release:
 
-[Official GitHub Project - alfresco-ng2-components](https://github.com/Alfresco/alfresco-ng2-components)
+[Official GitHub Project - alfresco-ng2-components](https://github.com/Alfresco/alfresco-ng2-components)
 
 [Getting started guides with Alfresco Application Development Framework](https://community.alfresco.com/community/application-development-framework/pages/get-started)
 
@@ -204,9 +204,9 @@ Below you can find a brief list of references to help you start using the new
 
 [Alfresco-JS-API](https://github.com/Alfresco/alfresco-js-api)
 
-[ADF App Generator ](https://github.com/Alfresco/generator-ng2-alfresco-app)
+[ADF App Generator ](https://github.com/Alfresco/generator-ng2-alfresco-app)
 
-Please refer to the 
+Please refer to the 
 [official documentation](http://docs.alfresco.com/)
 for further details and suggestions.
 
@@ -565,8 +565,8 @@ Release Notes - Apps Development Framework - Version 2.5.0
     [ADF-3369](https://issues.alfresco.com/jira/browse/ADF-3369)
     ] - Add 'showHeaderContent' property of adf-task-details set on false on Demo-Shell
 
-Please refer to 
+Please refer to 
 [the Alfresco issue tracker](https://issues.alfresco.com/jira/projects/ADF/issues/ADF-581?filter=allopenissues)
-for other known issues in this release. If you have any questions about the release, please contact us
+for other known issues in this release. If you have any questions about the release, please contact us
 using
 [gitter](https://gitter.im/Alfresco/alfresco-ng2-components).

--- a/docs/release-notes/RelNote260.md
+++ b/docs/release-notes/RelNote260.md
@@ -4,9 +4,9 @@ Title: Release notes v2.6.0
 
 # Alfresco Application Development Framework, version 2.6.0 Release Note
 
-These release notes provide information about the **2.6.0 release** of the Alfresco Application Development Framework.
-This is the latest **General Available** release of the Application Development Framework, which contains the Angular components to build a Web Application on top of the Alfresco Platform.
-The release can be found on GitHub at [this location.](https://github.com/Alfresco/alfresco-ng2-components/releases/tag/1.7.0)
+These release notes provide information about the **2.6.0 release** of the Alfresco Application Development Framework.
+This is the latest **General Available** release of the Application Development Framework, which contains the Angular components to build a Web Application on top of the Alfresco Platform.
+The release can be found on GitHub at [this location.](https://github.com/Alfresco/alfresco-ng2-components/releases/tag/1.7.0)
 
 ## Contents
 
@@ -16,7 +16,7 @@ The release can be found on GitHub at [this location.](https://github.com/Alf
     -   [Show sidebar on the right option](#show-sidebar-on-the-right-option)
     -   [Double sidebar for viewer](#double-sidebar-for-viewer)
     -   [Smart folder icon](#smart-folder-icon)
-    -   [Tag node list component has a configurable delete button for tag](#tag-node-list-component has-a-configurable-delete-button-for-tag)
+    -   [Tag node list component has a configurable delete button for tag](#tag-node-list-component-has-a-configurable-delete-button-for-tag)
     -   [Validation summary support for form component](#validation-summary-support-for-form-component)
     -   [Share link with expiry date](#share-link-with-expiry-date)
     -   [Base extensibility support](#base-extensibility-support)
@@ -42,7 +42,7 @@ The release can be found on GitHub at [this location.](https://github.com/Alf
 
 In this release we added some new minor features such as validation summary for forms, filter support in the process list and setting an expiry date for the public sharing features. The team also worked on the extensibility features for applications, which we will talk much more about in the following months. As usual the team closed a lot of bugs and minor enhancements to provide an even better experience when using ADF - check out the full list below.
 
-Please report issues with this release in the [issue tracker](https://github.com/Alfresco/alfresco-ng2-components/issues/new). You can collaborate on this release or share feedback by using the discussion tools on [Gitter](http://gitter.im/Alfresco/alfresco-ng2-components).
+Please report issues with this release in the [issue tracker](https://github.com/Alfresco/alfresco-ng2-components/issues/new). You can collaborate on this release or share feedback by using the discussion tools on [Gitter](http://gitter.im/Alfresco/alfresco-ng2-components).
 
 Notable new features
 Below are the most important new features of this release:
@@ -58,7 +58,7 @@ Below are the most important new features of this release:
 
 ### Show more/less tag
 
-The **Tag List Component** has two new buttons that allow the user to see more/less tags. This turns out to be more useful than showing the whole list of tags related to a node. This functionality is already embedded into the component and the user doesn't have to do anything to make it work.
+The **Tag List Component** has two new buttons that allow the user to see more/less tags. This turns out to be more useful than showing the whole list of tags related to a node. This functionality is already embedded into the component and the user doesn't have to do anything to make it work.
 
     <adf-tag-list></adf-tag-list>
 
@@ -66,7 +66,7 @@ The **Tag List Component** has two new buttons that allow the user to see more
 
 ### Show sidebar on the right option
 
-The **Sidenav Component** now accepts the **position** as an input parameter so you can decide where to show the sidebar. The possible values are **start** for the left of the screen and **end** for the right of the screen.
+The **Sidenav Component** now accepts the **position** as an input parameter so you can decide where to show the sidebar. The possible values are **start** for the left of the screen and **end** for the right of the screen.
 
     <adf-sidenav-layout [position]="'end'"></adf-sidenav-layout>
 
@@ -74,32 +74,32 @@ The **Sidenav Component** now accepts the **position** as an input parameter so 
 
 ### Double sidebar for viewer
 
-An extra sidebar is now available to use within the **Viewer Component**. This helps the user to organise the information related to the node in a better way.
+An extra sidebar is now available to use within the **Viewer Component**. This helps the user to organise the information related to the node in a better way.
 
      <ng-template #sidebarRightTemplate>
-       //your right sidebar content here
+       //your right sidebar content here
      </ng-template>
      <ng-template #sidebarLeftTemplate>
-      //your left sidebar content here
+      //your left sidebar content here
     </ng-template>
      <adf-viewer
-        [nodeId]="nodeId"
-        [showSidebar]="showRightSidebar"
-        [showLeftSidebar]="showLeftSidebar"
-        [sidebarLeftTemplate]="sidebarLeftTemplate"
-        [sidebarTemplate]="sidebarRightTemplate"></adf-viewer>
+        [nodeId]="nodeId"
+        [showSidebar]="showRightSidebar"
+        [showLeftSidebar]="showLeftSidebar"
+        [sidebarLeftTemplate]="sidebarLeftTemplate"
+        [sidebarTemplate]="sidebarRightTemplate"></adf-viewer>
 
 ![double Side bar](images/DoubleSideBar.gif)
 
 ### Smart folder icon
 
-The **DocumentList Component** can now show different icons for **Smart Folders** and Standard Folders. No extra action is needed by the user to use this functionality.
+The **DocumentList Component** can now show different icons for **Smart Folders** and Standard Folders. No extra action is needed by the user to use this functionality.
 
 ![Delete Tag Configurable](images/DeleteTagConfigurable.gif)
 
-### Tag node list component has a configurable delete button for tag
+### Tag node list component has a configurable delete button for tag
 
-A configurable delete button has been added to the **Tag Node List Component** to let you show it only when user has permissions.
+A configurable delete button has been added to the **Tag Node List Component** to let you show it only when user has permissions.
 
     <adf-tag-node-list [showDelete]="showDelete" [nodeId]="nodeId"></adf-tag-node-list>
 
@@ -107,13 +107,13 @@ A configurable delete button has been added to the **Tag Node List Component** 
 
 ### Validation summary support for form component
 
-The **Form Component** will now use the **formError** event to send a validation summary for all the fields with errors. This will be useful particularly with big forms for showing which fields are in error without scrolling the whole form by creating a summary.
+The **Form Component** will now use the **formError** event to send a validation summary for all the fields with errors. This will be useful particularly with big forms for showing which fields are in error without scrolling the whole form by creating a summary.
 
     <div class="form-container">
     <adf-form
-        [showRefreshButton]="false"
-        [form]="form"
-        (formError)="logErrors($event)">
+        [showRefreshButton]="false"
+        [form]="form"
+        (formError)="logErrors($event)">
     </adf-form>
     </div>
      <div class="console" #console>
@@ -125,15 +125,15 @@ The **Form Component** will now use the **formError** event to send a validat
 
 ### Share link with expiry date
 
-Some extra information is now available for shared links: expiry date. The earliest date accepted is at least 24h after the time you created it (following the ACS specification : [here](https://docs.alfresco.com/5.2/concepts/repository-properties.html) is the link). This is embedded into the **Share Dialog Component** and will be automatically shown when the share dialog is displayed.
+Some extra information is now available for shared links: expiry date. The earliest date accepted is at least 24h after the time you created it (following the ACS specification : [here](https://docs.alfresco.com/5.2/concepts/repository-properties.html) is the link). This is embedded into the **Share Dialog Component** and will be automatically shown when the share dialog is displayed.
 
 ![Expiry Share Link](images/ShareExpiryLink.gif)
 
 ### Base extensibility support
 
-With this release, we also add basic extensibility support in the scope of the **@alfresco/adf-extensions** library.
-This library powers the extensibility layer in the Alfresco Content Application, and you can find more details about the features it supports here: [Alfresco Content App](https://alfresco.github.io/alfresco-content-app/#/extending)
-In the following releases we will provide more documentation and examples of how to use this library and how to build your own extension points.
+With this release, we also add basic extensibility support in the scope of the **@alfresco/adf-extensions** library.
+This library powers the extensibility layer in the Alfresco Content Application, and you can find more details about the features it supports here: [Alfresco Content App](https://alfresco.github.io/alfresco-content-app/#/extending)
+In the following releases we will provide more documentation and examples of how to use this library and how to build your own extension points.
 
 ## Localization
 
@@ -141,9 +141,9 @@ This release includes: French, German, Italian, Spanish, Japanese, Dutch, Norweg
 
 ## References
 
-Below you can find a brief list of references to help you start using the new release.
+Below you can find a brief list of references to help you start using the new release.
 
-[Official GitHub Project - alfresco-ng2-components](https://github.com/Alfresco/alfresco-ng2-components)
+[Official GitHub Project - alfresco-ng2-components](https://github.com/Alfresco/alfresco-ng2-components)
 
 [Getting started guides with Alfresco Application Development Framework](https://community.alfresco.com/community/application-development-framework/pages/get-started)
 
@@ -157,9 +157,9 @@ Below you can find a brief list of references to help you start using the new
 
 [Alfresco-JS-API](https://github.com/Alfresco/alfresco-js-api)
 
-[ADF App Generator ](https://github.com/Alfresco/generator-ng2-alfresco-app)
+[ADF App Generator ](https://github.com/Alfresco/generator-ng2-alfresco-app)
 
-Please refer to the [official documentation](http://docs.alfresco.com/) for further details and suggestions.
+Please refer to the [official documentation](http://docs.alfresco.com/) for further details and suggestions.
 
 ## Issues addressed
 
@@ -296,4 +296,4 @@ Release Notes - Apps Development Framework - Version 2.6.
 -   \[[ADF-3596](https://issues.alfresco.com/jira/browse/ADF-3596)] - Automated tests for start a process
 -   \[[ADF-3597](https://issues.alfresco.com/jira/browse/ADF-3597)] - Create automated test to cover Error Log on Form component
 
-Please refer to [the Alfresco issue tracker](https://issues.alfresco.com/jira/projects/ADF/issues/ADF-581?filter=allopenissues) for other known issues in this release. If you have any questions about the release, please contact us using [gitter](https://gitter.im/Alfresco/alfresco-ng2-components).
+Please refer to [the Alfresco issue tracker](https://issues.alfresco.com/jira/projects/ADF/issues/ADF-581?filter=allopenissues) for other known issues in this release. If you have any questions about the release, please contact us using [gitter](https://gitter.im/Alfresco/alfresco-ng2-components).

--- a/docs/user-guide/app-extensions.md
+++ b/docs/user-guide/app-extensions.md
@@ -231,7 +231,7 @@ A more complex rule can take other rules as parameters:
 This is mainly useful for creating "metarules" that require certain
 relationships to hold among the parameter rules. A few useful metarules
 are defined in the
-[core.evaluators.ts](../lib/extensions/evaluators/core.evaluators.ts) file:
+[core.evaluators.ts](../../lib/extensions/src/lib/evaluators/core.evaluators.ts) file:
 
 -   `every`: Returns true only if all the parameter rules return true
 -   `some`: Returns true if one or more of the parameter rules return true

--- a/docs/user-guide/transclusion.md
+++ b/docs/user-guide/transclusion.md
@@ -11,7 +11,7 @@ most cases, this is used to make small customizations (for example, the various
 list components let you supply custom content to show when the list is empty).
 However, there are also a few "containers" whose entire content is set by the user
 with the container itself being mainly for convenient display and formatting
-(for example, the [Accordion component](../core/accordion.component.md)).
+(for example, the [Info drawer component](../core/info-drawer.component.md)).
 
 You supply the content you want to transclude between the opening and closing tags of
 the main component. In a few cases, this content can be completely free-form as with


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [x] Documentation
> - [ ] Other... Please describe:

**What is the new behaviour?**

Fixed broken links in docs. These were mostly in the release notes, mainly old links where the paths have since changed. There were also a few incorrect type links (the problem that caused those links in the first place was fixed separately and should not happen again now).

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
