### PR TITLE
[ADF-3854] destination picker - exclude site content after rowFilter reset

### DIFF
--- a/demo-shell/src/app/components/content-node-selector/content-node-selector.component.ts
+++ b/demo-shell/src/app/components/content-node-selector/content-node-selector.component.ts
@@ -18,7 +18,7 @@
 import { Component, ViewEncapsulation } from '@angular/core';
 import { SitePaging, SiteEntry, MinimalNodeEntryEntity } from '@alfresco/js-api';
 import { ContentNodeDialogService, ShareDataRow, RowFilter } from '@alfresco/adf-content-services';
-import { DataRow, DataColumn, ThumbnailService,  } from '@alfresco/adf-core';
+import { DataRow, DataColumn, ThumbnailService } from '@alfresco/adf-core';
 
 @Component({
     templateUrl: './content-node-selector.component.html',

--- a/demo-shell/src/app/components/content-node-selector/content-node-selector.component.ts
+++ b/demo-shell/src/app/components/content-node-selector/content-node-selector.component.ts
@@ -17,8 +17,8 @@
 
 import { Component, ViewEncapsulation } from '@angular/core';
 import { SitePaging, SiteEntry, MinimalNodeEntryEntity } from '@alfresco/js-api';
-import { ContentNodeDialogService, ShareDataRow } from '@alfresco/adf-content-services';
-import { DataRow, DataColumn, ThumbnailService } from '@alfresco/adf-core';
+import { ContentNodeDialogService, ShareDataRow, RowFilter } from '@alfresco/adf-content-services';
+import { DataRow, DataColumn, ThumbnailService,  } from '@alfresco/adf-core';
 
 @Component({
     templateUrl: './content-node-selector.component.html',
@@ -40,7 +40,7 @@ export class ContentNodeSelectorComponent {
     customSideTitle = '';
     actualPageSize = 2;
 
-    rowFilterFunction: any = null;
+    rowFilterFunction: RowFilter = null;
     excludeSiteContentList: string[] = ContentNodeDialogService.nonDocumentSiteContent;
     customImageResolver: any = null;
 

--- a/e2e/pages/adf/contentServicesPage.ts
+++ b/e2e/pages/adf/contentServicesPage.ts
@@ -190,8 +190,15 @@ export class ContentServicesPage {
     checkElementsSortedAsc(elements) {
         let sorted = true;
         let i = 0;
+        let compareNumbers = false;
+
+        if (elements && elements[0] && typeof elements[0] === 'number') {
+            compareNumbers = true;
+        }
         while (elements.length > 1 && sorted === true && i < (elements.length - 1)) {
-            if (JSON.stringify(elements[i]) > JSON.stringify(elements[i + 1])) {
+            const left = compareNumbers ? elements[i] : JSON.stringify(elements[i]);
+            const right = compareNumbers ? elements[i + 1] : JSON.stringify(elements[i + 1]);
+            if (left > right) {
                 sorted = false;
             }
             i++;

--- a/lib/content-services/content-node-selector/content-node-selector-panel.component.html
+++ b/lib/content-services/content-node-selector/content-node-selector-panel.component.html
@@ -58,7 +58,7 @@
             [showHeader]="false"
             [node]="nodes"
             [maxItems]="pageSize"
-            [rowFilter]="rowFilter"
+            [rowFilter]="_rowFilter"
             [imageResolver]="imageResolver"
             [currentFolderId]="folderIdToShow"
             selectionMode="single"

--- a/lib/content-services/content-node-selector/content-node-selector-panel.component.spec.ts
+++ b/lib/content-services/content-node-selector/content-node-selector-panel.component.spec.ts
@@ -112,7 +112,6 @@ describe('ContentNodeSelectorComponent', () => {
                             <SiteEntry> { entry: { guid: 'blog', id: 'blog' } }]
                     }
                 }));
-                spyOn(component.documentList, 'loadFolderNodesByFolderNodeId').and.returnValue(Promise.resolve());
                 component.currentFolderId = 'cat-girl-nuku-nuku';
                 fixture.detectChanges();
             });
@@ -624,6 +623,20 @@ describe('ContentNodeSelectorComponent', () => {
                             })
                         }
                     }));
+            });
+
+            it('should pass through the excludeSiteContent to the rowFilter of the documentList', () => {
+                component.excludeSiteContent = ['blog'];
+
+                fixture.detectChanges();
+
+                let documentList = fixture.debugElement.query(By.directive(DocumentListComponent));
+                expect(documentList).not.toBeNull('Document list should be shown');
+                expect(documentList.componentInstance.rowFilter).toBeTruthy('Document list should have had a rowFilter');
+
+                const testSiteContent = new Node({ id: 'blog-id', properties: { 'st:componentId': 'blog' } });
+                expect(documentList.componentInstance.rowFilter(<any> { node: { entry: testSiteContent } }, null, null))
+                    .toBe(false);
             });
 
             it('should pass through the imageResolver to the documentList', () => {

--- a/lib/content-services/content-node-selector/content-node-selector-panel.component.ts
+++ b/lib/content-services/content-node-selector/content-node-selector-panel.component.ts
@@ -165,7 +165,9 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
         this.breadcrumbTransform = this.breadcrumbTransform ? this.breadcrumbTransform : null;
         this.isSelectionValid = this.isSelectionValid ? this.isSelectionValid : defaultValidation;
         this.excludeSiteContent = this.excludeSiteContent ? this.excludeSiteContent : [];
-        this.rowFilter = this.getRowFilter(this.rowFilter);
+        if (!this.rowFilter) {
+            this.rowFilter = this.getRowFilter(this.rowFilter);
+        }
     }
 
     ngOnChanges(changes: SimpleChanges) {

--- a/lib/content-services/content-node-selector/content-node-selector-panel.component.ts
+++ b/lib/content-services/content-node-selector/content-node-selector-panel.component.ts
@@ -60,7 +60,7 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
     @Input()
     dropdownSiteList: SitePaging = null;
 
-    _rowFilter: RowFilter;
+    _rowFilter: RowFilter = defaultValidation;
 
     /** Custom row filter function. See the
      * [Document List component](document-list.component.md#custom-row-filter)
@@ -68,18 +68,27 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
      */
     @Input()
     set rowFilter(rowFilter: RowFilter) {
-        this._rowFilter = this.getRowFilter(rowFilter);
+        this.createRowFilter(rowFilter);
     }
 
     get rowFilter(): RowFilter {
-        return this._rowFilter || this.getRowFilter();
+        return this._rowFilter;
     }
+
+    _excludeSiteContent: string[] = [];
 
     /** Custom list of site content componentIds.
      * Used to filter out the corresponding items from the displayed nodes
      */
     @Input()
-    excludeSiteContent: string[] = [];
+    set excludeSiteContent(excludeSiteContent: string[]) {
+        this._excludeSiteContent = excludeSiteContent;
+        this.createRowFilter(this._rowFilter);
+    }
+
+    get excludeSiteContent(): string[] {
+        return this._excludeSiteContent;
+    }
 
     /** Custom image resolver function. See the
      * [Document List component](document-list.component.md#custom-row-filter)
@@ -172,14 +181,13 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
 
         this.breadcrumbTransform = this.breadcrumbTransform ? this.breadcrumbTransform : null;
         this.isSelectionValid = this.isSelectionValid ? this.isSelectionValid : defaultValidation;
-        this.excludeSiteContent = this.excludeSiteContent ? this.excludeSiteContent : [];
     }
 
-    private getRowFilter(filter?: RowFilter): RowFilter {
+    private createRowFilter(filter?: RowFilter) {
         if (!filter) {
             filter = () => true;
         }
-        return (value: ShareDataRow, index: number, array: ShareDataRow[]) => {
+        this._rowFilter = (value: ShareDataRow, index: number, array: ShareDataRow[]) => {
             return filter(value, index, array) &&
                 !this.isExcludedSiteContent(value);
         };
@@ -187,11 +195,11 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
 
     private isExcludedSiteContent(row: ShareDataRow): boolean {
         const entry = row.node.entry;
-        if (this.excludeSiteContent.length &&
+        if (this._excludeSiteContent.length &&
             entry &&
             entry.properties &&
             entry.properties['st:componentId']) {
-            const excludedItem = this.excludeSiteContent.find(
+            const excludedItem = this._excludeSiteContent.find(
                 (id: string) => entry.properties['st:componentId'] === id
             );
             return !!excludedItem;

--- a/lib/content-services/content-node-selector/content-node-selector-panel.component.ts
+++ b/lib/content-services/content-node-selector/content-node-selector-panel.component.ts
@@ -60,12 +60,20 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
     @Input()
     dropdownSiteList: SitePaging = null;
 
+    _rowFilter: RowFilter;
+
     /** Custom row filter function. See the
      * [Document List component](document-list.component.md#custom-row-filter)
      * for more information.
      */
     @Input()
-    rowFilter: RowFilter = null;
+    set rowFilter(rowFilter: RowFilter) {
+        this._rowFilter = this.getRowFilter(rowFilter);
+    }
+
+    get rowFilter(): RowFilter {
+        return this._rowFilter || this.getRowFilter();
+    }
 
     /** Custom list of site content componentIds.
      * Used to filter out the corresponding items from the displayed nodes
@@ -165,23 +173,14 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
         this.breadcrumbTransform = this.breadcrumbTransform ? this.breadcrumbTransform : null;
         this.isSelectionValid = this.isSelectionValid ? this.isSelectionValid : defaultValidation;
         this.excludeSiteContent = this.excludeSiteContent ? this.excludeSiteContent : [];
-        if (!this.rowFilter) {
-            this.rowFilter = this.getRowFilter(this.rowFilter);
-        }
     }
 
-    ngOnChanges(changes: SimpleChanges) {
-        if (changes.rowFilter) {
-            this.rowFilter = this.getRowFilter(this.rowFilter);
-        }
-    }
-
-    private getRowFilter(initialFilterFunction): RowFilter {
-        if (!initialFilterFunction) {
-            initialFilterFunction = () => true;
+    private getRowFilter(filter?: RowFilter): RowFilter {
+        if (!filter) {
+            filter = () => true;
         }
         return (value: ShareDataRow, index: number, array: ShareDataRow[]) => {
-            return initialFilterFunction(value, index, array) &&
+            return filter(value, index, array) &&
                 !this.isExcludedSiteContent(value);
         };
     }

--- a/lib/content-services/content-node-selector/content-node-selector-panel.component.ts
+++ b/lib/content-services/content-node-selector/content-node-selector-panel.component.ts
@@ -168,6 +168,12 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
         this.rowFilter = this.getRowFilter(this.rowFilter);
     }
 
+    ngOnChanges(changes: SimpleChanges) {
+        if (changes.rowFilter) {
+            this.rowFilter = this.getRowFilter(this.rowFilter);
+        }
+    }
+
     private getRowFilter(initialFilterFunction): RowFilter {
         if (!initialFilterFunction) {
             initialFilterFunction = () => true;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
If the rowFilter parameter is changed, then the excludeSiteContent is ignored


**What is the new behaviour?**
Exclude the specified site content even after rowFilter param changes.
please check comment on https://issues.alfresco.com/jira/browse/ADF-3854


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
