### PR TITLE
[ADF-3911] Converted GIF image URLs to absolute

### DIFF
--- a/docs/process-services/people.component.md
+++ b/docs/process-services/people.component.md
@@ -65,7 +65,7 @@ This makes it easy to customize the [people component](../process-services/peopl
 </adf-people>
 ```
 
-![involve-people-single-click-and-close-search](../docassets/images/involve-people-single-click-and-close-search.gif)
+![involve-people-single-click-and-close-search](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/docassets/images/involve-people-single-click-and-close-search.gif)
 
 ### Involve People single click without close search
 
@@ -78,7 +78,7 @@ This makes it easy to customize the [people component](../process-services/peopl
 </adf-people>
 ```
 
-![involve-people-single-click-without-close-search](../docassets/images/involve-people-single-click-without-close-search.gif)
+![involve-people-single-click-without-close-search](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/docassets/images/involve-people-single-click-without-close-search.gif)
 
 ### Involve People double click and close search
 
@@ -91,7 +91,7 @@ This makes it easy to customize the [people component](../process-services/peopl
 </adf-people>
 ```
 
-![involve-people-double-click-and-close-search](../docassets/images/involve-people-double-click-and-close-search.gif)
+![involve-people-double-click-and-close-search](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/docassets/images/involve-people-double-click-and-close-search.gif)
 
 ### Involve People double double without close search
 
@@ -104,4 +104,4 @@ This makes it easy to customize the [people component](../process-services/peopl
 </adf-people>
 ```
 
-![involve-people-double-click-without-close-search](../docassets/images/involve-people-double-click-without-close-search.gif)
+![involve-people-double-click-without-close-search](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/docassets/images/involve-people-double-click-without-close-search.gif)

--- a/docs/release-notes/RelNote161.md
+++ b/docs/release-notes/RelNote161.md
@@ -90,7 +90,7 @@ Is now possible define your custom loading template that will be shown during th
 
     </alfresco-datatable>
 
-![](images/Jun-29-2017+11-34-06.gif)
+![](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/Jun-29-2017+11-34-06.gif)
 
 Refer to the [datable documentation](https://github.com/Alfresco/alfresco-ng2-components/tree/master/ng2-components/ng2-alfresco-datatable#loading-content-template) for further details. With this modify also the n2-alfresco-documentlist has gained a loading state.
 
@@ -102,7 +102,7 @@ The ng2-alfresco-viewer is now able to show files with txt extension natively an
 
 We have added more methods in the type definition file of the alfresco-js-api to help you with the autocomplete of your IDE.
 
-![](images/Jun-29-2017+12-34-21.gif)
+![](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/Jun-29-2017+12-34-21.gif)
 
 ### 5. ADF Card View
 
@@ -328,7 +328,7 @@ You get the following settings by default (also applied to the Application setti
 
 ### 14. Login restyling
 
-![](images/Jun-29-2017+13-01-12.gif)
+![](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/Jun-29-2017+13-01-12.gif)
 
 The settings above address most common scenarios for running ACS on port 8080 and APS on port 9999 and allow you to skip the CORS configuration.
 

--- a/docs/release-notes/RelNote170.md
+++ b/docs/release-notes/RelNote170.md
@@ -99,7 +99,7 @@ Two new content actions have been added, the "copy" and the "move" for both fold
         handler="move">
     </content-action>
 
-![](images/copy-move.gif)
+![](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/copy-move.gif)
 
 ### 3. Dropdown Sites/Favorites Component
 
@@ -109,7 +109,7 @@ DocumentList now provides a site dropdown component to show and interact with th
       (change)="getSiteContent($event)">
      </adf-sites-dropdown>
 
-![](images/dropdown-sites.gif)
+![](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/dropdown-sites.gif)
 
 ### 4. Toolbar Component
 
@@ -127,11 +127,11 @@ adf-toolbar is an easy container for headers, titles, actions, breadcrumbs.
         </button>
     </adf-toolbar>
 
-![](images/toobar.gif)
+![](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/toobar.gif)
 
 ### 5. Upload Component New design
 
-![](images/upload.gif)
+![](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/upload.gif)
 
 ### 6. Upload ignore list configuration service
 
@@ -177,19 +177,19 @@ The component is using the **adf-card-view** component to render all the informa
 From now, it is possible to delete files (if you have permission) from within the search results.
 This action will do delete the particular file from your contents and NOT just from the search results.
 
-![](images/search-delete.gif)
+![](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/search-delete.gif)
 
 ### 10. Login new property
 
 You can now customize the copyright text in the adf-login component using the copyrightText property:
 
-![](images/Untitled.gif)
+![](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/Untitled.gif)
 
 ### 11. TaskDetails - DueDate and Description editable
 
 The due date and the description of the task details are now editable and integrate into the adf-task-header component
 
-![](images/description.gif)
+![](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/description.gif)
 
 ### 12. Configuration back end service hostname feature
 
@@ -232,7 +232,7 @@ The [`UserPreferencesService`](../core/user-preferences.service.md) provides an 
 With the current ADF version, we got a Pipe that has the goal to highlight a specific term found in the text. Basically, when the term has been found, a CSS class is added to the HTML code. By doing so it will be easy to customise the colour just overriding the CSS class.
 Note that the Pipe can be used in all the template where this behaviour is needed, but at the moment we are using that only inside the search result.
 
-![Pipe highlight](images/pipe-highlight.gif)
+![Pipe highlight](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/pipe-highlight.gif)
 
 ### 15. Change document list style rows based on permissions
 

--- a/docs/release-notes/RelNote180.md
+++ b/docs/release-notes/RelNote180.md
@@ -74,13 +74,13 @@ Below the most relevant features of this release:
 We have added in ADF several pre-built theme css files. These theme files also include all of the styles for core (styles common to all components), so you only have to include a single css file for Angular Material in your app.
 When you want more customization than a pre-built theme offers, you can create your own theme file. You need to include the packages only what you really use in your application. For more information about theming please refer to the [offiicial documentation.](../user-guide/theming.md)
 
-![](images/theming.gif)
+![](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/theming.gif)
 
 ### 2. Info Drawer component
 
 It is now possible to use the [Info Drawer component,](../core/info-drawer.component.md) which gives you a sidebar like look with tabbing support. For more information about the usage, check the documentation in the core package.
 
-![](images/info-drawer.gif)
+![](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/info-drawer.gif)
 
 ### 3. Form style component enhancements
 
@@ -155,13 +155,13 @@ The major features are:
 
 Further enhancements were implemented for the Copy & move dialog. From now, you can see the path of a selected item, navigate back with the breadcrumbs and select the folder you entered.
 
-![](images/copy-and-move-II.gif)
+![](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/copy-and-move-II.gif)
 
 ### 9. Download as a ZIP functionality
 
 The ADF framework provides support for downloading nodes (Files and Folders) as "ZIP" archives. The **alfresco-js-api** library features new support for the [Downloads](https://api-explorer.alfresco.com/api-explorer/#/downloads) API. In addition, the Core library (ng2-alfresco-core) provides a ["DownloadZipDialogComponent"](../core/download-zip.service.md) that allows invoking "Download as Zip" dialogues from any place in your code.
 
-![](images/download-as-zip.gif)
+![](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/download-as-zip.gif)
 
 You can see a working button handler code in the following [resource](../../demo-shell/src/app/components/files/files.component.ts).
 
@@ -224,7 +224,7 @@ DocumentList now also supports extra data sources. You can now set the "**curren
 
 The component provides reasonable column defaults for each custom source, so you can use an empty **adf-document-list** tag in HTML templates, and the layout will be automatically adopted.
 
-![](images/dl-custom-sources.gif)
+![](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/dl-custom-sources.gif)
 
 You can get more details on the data sources and default presets in the [Data Sources](https://github.com/Alfresco/alfresco-ng2-components/tree/development/ng2-components/ng2-alfresco-documentlist#data-sources) section.
 

--- a/docs/release-notes/RelNote190.md
+++ b/docs/release-notes/RelNote190.md
@@ -62,7 +62,7 @@ Below the most relevant features of this release:
 The document list now provides two different way to paginate the results the normal pagination or the infinite scrolling.
 In order to enable this feature, you need to specify the paginationStrategy properties 'Infinite'. The infinite scrolling is also now used as default in the object picker component
 
-![](images/infinite-scrolling.gif)
+![](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/infinite-scrolling.gif)
 
 ### 2.Requeue option added to adf-task-header
 

--- a/docs/release-notes/RelNote200.md
+++ b/docs/release-notes/RelNote200.md
@@ -164,7 +164,7 @@ For more details please refer to:
 
 Basic content metadata can now be displayed and edited with the new ContentMetadata component. At the moment, only the basic properties are supported, such as title, description, author, etc. As an example it can be injected into the revamped viewer in the sidebar layout.
 
-![content metadata](images/metadata.gif)
+![content metadata](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/metadata.gif)
 
     <adf-content-metadata-card [node]="aMinimalNodeEntryEntity"></adf-content-metadata-card>
 
@@ -172,7 +172,7 @@ Basic content metadata can now be displayed and edited with the new ContentMetad
 
 You can now see and restore previous versions of a file node. This component can also be used in a dialog or in a sidebar layout. Being the first prototype, there are some restrictions applied on this component - check the documentation for details.
 
-![file versions](images/versioning.gif)
+![file versions](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/versioning.gif)
 
     <adf-version-manager [node]="aMinimalNodeEntryEntity"></adf-version-manager>
 
@@ -188,7 +188,7 @@ The adf-search-control provides you with a standard input search with an pre-sty
 
 For example :
 
-![Search Bar Autocomplete](images/GifSearchBar.gif)
+![Search Bar Autocomplete](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/GifSearchBar.gif)
 
 The adf-search component offers a simple way to customize your search results:
 
@@ -214,7 +214,7 @@ You can also associate to your own input/textarea with the search results via th
 
 This allows you to fetch the search result typed from the input/textarea element associated with the adf-search component:
 
-![Custo Input with custom search templates](images/RandoInputWithCustomResult.gif)
+![Custo Input with custom search templates](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/RandoInputWithCustomResult.gif)
 
 For more details please refer to:
 
@@ -233,7 +233,7 @@ For more details please refer to [Upload button documentation](../content-servic
 
 All the ADF MIME type icons are now registered into the MatIconRegistry. This improvement allows you to use all the icons through the mat-icon tag:
 
-![](images/Untitled.gif)
+![](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/Untitled.gif)
 
     <mat-icon svgIcon="video/mp4"></mat-icon>
 
@@ -265,7 +265,7 @@ The NodeFavoriteDirective instance can be bound to a button to retrieve and mana
         </mat-icon>
     </button>
 
-![](images/favorite.gif)
+![](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/favorite.gif)
 
 ### 11. Delete multiple nodes directive
 
@@ -325,7 +325,7 @@ For more information please refer to [host component documentation.](../core/hos
 
 We have added all the [process service](../process-services/process.service.md) related models, class methods and type in the type definition file of the alfresco-js-api to help you with the autocomplete of your IDE.
 
-![](images/type+definition.gif)
+![](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/type+definition.gif)
 
 ### 15. Redirect to original path upon successful login
 

--- a/docs/release-notes/RelNote210.md
+++ b/docs/release-notes/RelNote210.md
@@ -87,7 +87,7 @@ In this release, the [Viewer component](../core/viewer.component.md) got improve
 
 ### 2. Upload file from CS widget
 
-![](images/pastedImage_1.gif)
+![](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/pastedImage_1.gif)
 
 In this release we have re-enabled and improved the upload file widget of our [form component](../core/form.component.md).
 We have added the option to choose the file to upload from a configured ECM repository of APS.
@@ -98,14 +98,14 @@ It is also possible to make it work like a normal local file uploader by configu
 
 ### 3. Attach Folder from CS widget
 
-![](images/pastedImage_3.gif)
+![](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/pastedImage_3.gif)
 
 We have added the attach folder widget which is really useful in processes where you need to create your content in the ECM platform via APS .
 As you can see this widget works like the attach file widget in terms of navigation through the folders and restricting the selection to folders.
 
 ### 4. Content metadata component enhancements
 
-![](images/content-metadata.gif)
+![](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/content-metadata.gif)
 
 The purpose of the [content metadata component](../content-services/content-metadata.component.md) is to display the metadata belonging to a given node. Until now, the component was capable of displaying and making the basic properties editable, but with the latest enhancements, all of the system wide and custom aspects related to a particular node can be displayed and edited.
 
@@ -115,7 +115,7 @@ For more information about the component see its [documentation](https://communi
 
 ### 5. Start process from a file
 
-![](images/new-start-process.gif)
+![](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/new-start-process.gif)
 
 After the repository is created in APS, you can see it in the Alfresco Repositories list. If the ID is set to 1 then all default values are fine. However, if it is set to something else, for example
 _1002_ and the name is _alfresco_, you must set the property alfrescoRepositoryName in your app.config.json file to _alfresco-1002_:

--- a/docs/release-notes/RelNote220.md
+++ b/docs/release-notes/RelNote220.md
@@ -84,7 +84,7 @@ The data table and the document list are now able to render in different formats
     <adf-document-list ...[display]="'gallery'"> </adf-document-list>
     <adf-datatable ... [display]="'gallery'"> </adf-datatable>
 
-![](images/Feb-27-2018+14-36-59.gif)
+![](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/Feb-27-2018+14-36-59.gif)
 
 ### Metadata Component enhancements: layout oriented configurations
 
@@ -167,7 +167,7 @@ With ADF 2.2.0 the processes list result are easy to paginate. You just need to 
 
 With ADF 2.2.0, the app list component is shows the mat-spinner until the apps are loaded.
 
-![app list mat spinner](images/app-list-loader.gif)
+![app list mat spinner](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/app-list-loader.gif)
 
 ### Task Header - Make it customizable from the config file
 
@@ -237,7 +237,7 @@ You can define your custom template in the HTML code:
 We have added the new date time widget provided with APS 1.7.
 This widget lets you choose the date and the time in the format given by the APS form.
 
-![Date Time Widget](images/DataTimeWidget.gif)
+![Date Time Widget](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/DataTimeWidget.gif)
 
 ### Form Upload Widget Actions menu
 
@@ -247,7 +247,7 @@ Clicking on the Show button will trigger the viewer to open with the given docum
 Clicking on the Download button will allow you to download the selected file.
 Clicking on the Remove button will remove the file from the Upload widget value.
 
-![Upload Widget Options](images/UploadWidgetOption.gif)
+![Upload Widget Options](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/UploadWidgetOption.gif)
 
 ### Search custom empty template
 
@@ -263,7 +263,7 @@ We enhanced the [search control component](../content-services/search-control.co
 
 This lets you customize the empty search template as you want.
 
-![Custom Empty Template](images/SearchEmptyTemplate.gif)
+![Custom Empty Template](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/SearchEmptyTemplate.gif)
 
 ### CI changes
 

--- a/docs/release-notes/RelNote230.md
+++ b/docs/release-notes/RelNote230.md
@@ -83,7 +83,7 @@ Creates and manages public shared links for files.
      <mat-icon>share</mat-icon>
     </button>
 
-![](images/share.gif)
+![](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/share.gif)
 
 ### Lock File
 
@@ -97,7 +97,7 @@ When a file is locked it can be locked and unlocked by default only by the user 
      <mat-icon>lock</mat-icon> Lock file
     </button>
 
-![Lock file](images/Apr-15-2018+13-36-31.gif)
+![Lock file](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/Apr-15-2018+13-36-31.gif)
 
 ### Comment a Node
 
@@ -108,7 +108,7 @@ The [comments component](../core/comments.component.md) can now be used also on 
      [readOnly]="YOUR_READ_ONLY_FLAG">
     </adf-comments>
 
-![Comments](images/comments.gif)
+![Comments](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/comments.gif)
 
 ### Inherit Permission Button
 
@@ -121,7 +121,7 @@ Is it now possible add remove inherit permissions to a specific node via ADF add
 
 This directive should be added to a button and when the button is clicked this will add/remove the inherited permission based on the actual node configuration.
 
-![Inherit permissions button](images/InheritButtonPermission.gif)
+![Inherit permissions button](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/InheritButtonPermission.gif)
 
 ### Permission List Component
 
@@ -132,7 +132,7 @@ We have added a new component to show the list of the permission actually presen
 
 Also this component will allow a role change for the locally set permissions using a dropdown.
 
-![Permission List Component](images/PermissionListGIF.gif)
+![Permission List Component](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/PermissionListGIF.gif)
 
 ### Sidenav Layout Component
 
@@ -156,7 +156,7 @@ We have added a new component to make this common layout organisation easier to 
 
     </adf-sidenav-layout>
 
-![Sidenav Layout Component](images/sidenav-layout.gif)
+![Sidenav Layout Component](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/sidenav-layout.gif)
 
 ### Content metadata component enhancement
 
@@ -172,7 +172,7 @@ Two new input parameters have been added to the content-metadata component.
      [readOnly]="true">
     </adf-content-metadata-card>
 
-![Sidenav Layout Component](images/content-metadata-enhancements.gif)
+![Sidenav Layout Component](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/content-metadata-enhancements.gif)
 
 ### Search Enhancements
 

--- a/docs/release-notes/RelNote240.md
+++ b/docs/release-notes/RelNote240.md
@@ -103,7 +103,7 @@ Once the Keycloak login is performed the user is redirected back to the app base
 With ADF 2.4.0, you can now upload minor or major versions of a file. We have also removed the restriction where you were limited to uploading only same file types as new versions.
 For more information about this component please refer to [the official documentation.](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/content-services/version-manager.component.md)
 
-![Verrsioning](images/Jun-24-2018+18-53-43.gif)
+![Verrsioning](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/Jun-24-2018+18-53-43.gif)
 
 ### Empty Page Component
 
@@ -112,7 +112,7 @@ This component needs just 3 inputs: icon, title, and subtitle.
 You can also transclude external content into the component's body.
 For more information about this component please refer to [the official documentation.](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/core/empty-content.component.md) 
 
-![Empty Page State](images/EmptyPage.gif)
+![Empty Page State](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/EmptyPage.gif)
 
 ### TaskList Empty Page
 
@@ -133,7 +133,7 @@ You can still override it from the parent component using `<ng-template>`.
 We have created an error page component that will show buttons and messages relevant to the error that occurred (404, 403, etc...)
 For more information about this component please refer to [the official documentation.](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/core/error-content.component.md) 
 
-![404Example](images/404Error.gif)
+![404Example](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/404Error.gif)
 
 ### Search Improvements
 
@@ -174,7 +174,7 @@ Note that this feature applies to all methods of uploading (drag and drop, butto
 
 You can find more details and examples of how to set up the confirmation dialog on the [Upload drag area page.](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/content-services/upload-drag-area.component.md#intercepting-uploads)
 
-![](images/adf-download-intercept.gif)
+![](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/adf-download-intercept.gif)
 
 ### Conditional Visibility for Data Columns
 
@@ -203,7 +203,7 @@ More details are available on the [Content action component page.](https://githu
 We have added a new component which allows you add a custom list of buttons. The list will automatically collapse into a burger menu choice for small screens so the menu button will always fit inside your page.
 See the [Buttons menu component page](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/core/buttons-menu.component.md) for more information.
 
-![Responsive Button Menu](images/ButtonMenuResponsive.gif)
+![Responsive Button Menu](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/ButtonMenuResponsive.gif)
 
 ## Localization
 

--- a/docs/release-notes/RelNote250.md
+++ b/docs/release-notes/RelNote250.md
@@ -97,7 +97,7 @@ This component is a reusable header for Alfresco applications. It displays a cus
         .......
      </adf-layout-header>
 
-![Empty Page State](images/header.gif)
+![Empty Page State](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/header.gif)
 
 For more information about this component please refer to the 
 [official documentation](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/core/header.component.md).
@@ -110,7 +110,7 @@ In ADF 2.5.0 you can now customize the metadata card with the option of showing 
         [displayEmpty]="false">
     </adf-content-metadata-card>
 
-![Metadata default property](images/metadata.gif)
+![Metadata default property](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/metadata.gif)
 
 ### Card view new property types rendering
 
@@ -132,7 +132,7 @@ Two new property types are now available in the card view:
 
 KeyValuePairs is a map key value that is rendered as shown in the image to the left. It uses a nicely-formatted table that allows also for easy editing.ViewSelectItem is a selectBox that allows you to limit the set of possible values for a property.
 
-![Card view](images/cardview.gif)
+![Card view](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/cardview.gif)
 
 For more information about this component please refer to the 
 [official documentation](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/core/card-view.component.md).
@@ -147,7 +147,7 @@ The NotificationService now exposes a new input parameter to allow a full custom
 -   Vertical Position : The vertical position to place the snack bar.
 -   panelClass :  Extra CSS classes to be added to the snack bar container.
 
-![Notification](images/notification2.gif)
+![Notification](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/notification2.gif)
 
 For more information about this component please refer to the 
 [official documentation](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/core/notification.service.md).
@@ -156,7 +156,7 @@ For more information about this component please refer to the
 
 You can now render DateTime items in the dynamic table of a form.
 
-![Datetime datatable](images/date_time_datatable.gif)
+![Datetime datatable](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/date_time_datatable.gif)
 
 ### Attach a form to a standalone Task
 
@@ -166,7 +166,7 @@ You can now attach a form to a new task that is not part of a Process using the 
         [taskName]= "taskname">
     </adf-task-standalone>
 
-![Standalone task](images/Standalone+task.gif)
+![Standalone task](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/Standalone+task.gif)
 
 For more information about this component please refer to the 
 [official documentation](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/process-services/task-standalone.component.md). 

--- a/docs/release-notes/RelNote260.md
+++ b/docs/release-notes/RelNote260.md
@@ -62,7 +62,7 @@ The **Tag List Component** has two new buttons that allow the user to see more/l
 
     <adf-tag-list></adf-tag-list>
 
-![Show More/Less Tag](images/ShowMoreLessTag.gif)
+![Show More/Less Tag](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/ShowMoreLessTag.gif)
 
 ### Show sidebar on the right option
 
@@ -70,7 +70,7 @@ The **Sidenav Component** now accepts the **position** as an input parameter so 
 
     <adf-sidenav-layout [position]="'end'"></adf-sidenav-layout>
 
-![SideBar Right](images/SideBarMove.gif)
+![SideBar Right](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/SideBarMove.gif)
 
 ### Double sidebar for viewer
 
@@ -89,13 +89,13 @@ An extra sidebar is now available to use within the **Viewer Component**. This h
         [sidebarLeftTemplate]="sidebarLeftTemplate"
         [sidebarTemplate]="sidebarRightTemplate"></adf-viewer>
 
-![double Side bar](images/DoubleSideBar.gif)
+![double Side bar](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/DoubleSideBar.gif)
 
 ### Smart folder icon
 
 The **DocumentList Component** can now show different icons for **Smart Folders** and Standard Folders. No extra action is needed by the user to use this functionality.
 
-![Delete Tag Configurable](images/DeleteTagConfigurable.gif)
+![Delete Tag Configurable](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/DeleteTagConfigurable.gif)
 
 ### Tag node list component has a configurable delete button for tag
 
@@ -103,7 +103,7 @@ A configurable delete button has been added to the **Tag Node List Component** t
 
     <adf-tag-node-list [showDelete]="showDelete" [nodeId]="nodeId"></adf-tag-node-list>
 
-![Smart Folder Icon](images/SmartFolderIcon.gif)
+![Smart Folder Icon](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/SmartFolderIcon.gif)
 
 ### Validation summary support for form component
 
@@ -121,13 +121,13 @@ The **Form Component** will now use the **formError** event to send a validation
      <p *ngFor="let error of errorFields">Error {{ error.name }} {{error.validationSummary.message | translate}}</p>
     </div>
 
-![Form Validation Summary](images/ValidationFormRecap.gif)
+![Form Validation Summary](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/ValidationFormRecap.gif)
 
 ### Share link with expiry date
 
 Some extra information is now available for shared links: expiry date. The earliest date accepted is at least 24h after the time you created it (following the ACS specification : [here](https://docs.alfresco.com/5.2/concepts/repository-properties.html) is the link). This is embedded into the **Share Dialog Component** and will be automatically shown when the share dialog is displayed.
 
-![Expiry Share Link](images/ShareExpiryLink.gif)
+![Expiry Share Link](https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/release-notes/images/ShareExpiryLink.gif)
 
 ### Base extensibility support
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [x] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

GIF images are not handled correctly by the Builder Network tools and so they don't get published in the docs.

**What is the new behaviour?**

GIF image URLs changed to reference Github files with absolute URLs. This works around the issue with the Builder Network image tool.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
