### PR TITLE
[ADF-3910] Expose the identityHost as part of the setting component

### DIFF
--- a/lib/core/app-config/app-config.service.ts
+++ b/lib/core/app-config/app-config.service.ts
@@ -29,6 +29,7 @@ export enum AppConfigValues {
     ECMHOST = 'ecmHost',
     BASESHAREURL = 'baseShareUrl',
     BPMHOST = 'bpmHost',
+    IDENTITY_HOST = 'identityHost',
     AUTHTYPE = 'authType',
     CONTEXTROOTECM = 'contextRootEcm',
     CONTEXTROOTBPM = 'contextRootBpm',

--- a/lib/core/settings/host-settings.component.html
+++ b/lib/core/settings/host-settings.component.html
@@ -53,6 +53,17 @@
                             {{ 'CORE.HOST_SETTINGS.REQUIRED'| translate }}
                         </mat-error>
                     </mat-form-field>
+                    <mat-form-field *ngIf="hasIdentity" class="adf-full-width" floatLabel="Identity Host">
+                        <mat-label>Identity Host</mat-label>
+                        <input matInput name="identityHost" id="identityHost" formControlName="identityHost"
+                               placeholder="http(s)://host|ip:port(/path)">
+                        <mat-error *ngIf="identityHost.hasError('pattern')">
+                            {{ 'CORE.HOST_SETTINGS.NOT_VALID'| translate }}
+                        </mat-error>
+                        <mat-error *ngIf="identityHost.hasError('required')">
+                            {{ 'CORE.HOST_SETTINGS.REQUIRED'| translate }}
+                        </mat-error>
+                    </mat-form-field>
                 </mat-card-content>
             </ng-container>
 

--- a/lib/core/settings/host-settings.component.spec.ts
+++ b/lib/core/settings/host-settings.component.spec.ts
@@ -99,6 +99,7 @@ describe('HostSettingsComponent', () => {
 
         beforeEach(() => {
             appConfigService.config.providers = 'BPM';
+            appConfigService.config.authType = 'BASIC';
             appConfigService.load();
             fixture.detectChanges();
             bpmUrlInput = element.querySelector('#bpmHost');
@@ -152,6 +153,7 @@ describe('HostSettingsComponent', () => {
 
         beforeEach(() => {
             appConfigService.config.providers = 'ECM';
+            appConfigService.config.authType = 'BASIC';
             appConfigService.load();
             fixture.detectChanges();
             bpmUrlInput = element.querySelector('#bpmHost');
@@ -200,6 +202,7 @@ describe('HostSettingsComponent', () => {
 
         beforeEach(() => {
             appConfigService.config.providers = 'ALL';
+            appConfigService.config.authType = 'BASIC';
             appConfigService.load();
             fixture.detectChanges();
             bpmUrlInput = element.querySelector('#bpmHost');

--- a/lib/core/settings/host-settings.component.spec.ts
+++ b/lib/core/settings/host-settings.component.spec.ts
@@ -270,10 +270,12 @@ describe('HostSettingsComponent', () => {
 
         let bpmUrlInput;
         let ecmUrlInput;
+        let identityUrlInput;
         let oauthHostUrlInput;
         let clientIdInput;
 
         beforeEach(() => {
+            appConfigService.config.identityHost = 'http://localhost:123';
             appConfigService.config.providers = 'ALL';
             appConfigService.config.authType = 'OAUTH';
             appConfigService.config.oauth2 = {
@@ -289,6 +291,7 @@ describe('HostSettingsComponent', () => {
             fixture.detectChanges();
             bpmUrlInput = element.querySelector('#bpmHost');
             ecmUrlInput = element.querySelector('#ecmHost');
+            identityUrlInput = element.querySelector('#identityHost');
             oauthHostUrlInput = element.querySelector('#oauthHost');
             clientIdInput = element.querySelector('#clientId');
         });
@@ -300,6 +303,7 @@ describe('HostSettingsComponent', () => {
         it('should have a valid form when the urls are correct', (done) => {
             const urlBpm = 'http://localhost:9999/bpm';
             const urlEcm = 'http://localhost:9999/bpm';
+            const urlIdentity = 'http://localhost:9999/identity';
 
             component.form.statusChanges.subscribe((status: string) => {
                 expect(status).toEqual('VALID');
@@ -311,6 +315,9 @@ describe('HostSettingsComponent', () => {
 
             bpmUrlInput.value = urlBpm;
             bpmUrlInput.dispatchEvent(new Event('input'));
+
+            identityUrlInput.value = urlIdentity;
+            identityUrlInput.dispatchEvent(new Event('input'));
         });
 
         it('should have an invalid form when the url inserted is wrong', (done) => {
@@ -324,6 +331,19 @@ describe('HostSettingsComponent', () => {
 
             bpmUrlInput.value = url;
             bpmUrlInput.dispatchEvent(new Event('input'));
+        });
+
+        it('should have an invalid form when the identity url inserted is wrong', (done) => {
+            const url = 'wrong';
+
+            component.form.statusChanges.subscribe((status: string) => {
+                expect(status).toEqual('INVALID');
+                expect(component.identityHost.hasError('pattern')).toBeTruthy();
+                done();
+            });
+
+            identityUrlInput.value = url;
+            identityUrlInput.dispatchEvent(new Event('input'));
         });
 
         it('should have an invalid form when the host is wrong', (done) => {

--- a/lib/core/settings/host-settings.component.ts
+++ b/lib/core/settings/host-settings.component.ts
@@ -43,6 +43,7 @@ export class HostSettingsComponent implements OnInit {
     providers: string[] = ['BPM', 'ECM', 'ALL'];
 
     showSelectProviders = true;
+    hasIdentity = false;
 
     form: FormGroup;
 
@@ -113,11 +114,14 @@ export class HostSettingsComponent implements OnInit {
     private removeFormGroups() {
         this.form.removeControl('bpmHost');
         this.form.removeControl('ecmHost');
+        this.form.removeControl('identityHost');
+        this.hasIdentity = false;
     }
 
     private addFormGroups() {
         this.addBPMFormControl();
         this.addECMFormControl();
+        this.addIdentityHostFormControl();
     }
 
     private addOAuthFormGroup() {
@@ -129,6 +133,14 @@ export class HostSettingsComponent implements OnInit {
         if ((this.isBPM() || this.isALL() || this.isOAUTH()) && !this.bpmHost) {
             const bpmFormControl = this.createBPMFormControl();
             this.form.addControl('bpmHost', bpmFormControl);
+        }
+    }
+
+    private addIdentityHostFormControl() {
+        if ((this.isOAUTH()) && !this.identityHost) {
+            const identityHostFormControl = this.createIdentityFormControl();
+            this.form.addControl('identityHost', identityHostFormControl);
+            this.hasIdentity = true;
         }
     }
 
@@ -156,6 +168,10 @@ export class HostSettingsComponent implements OnInit {
 
     private createBPMFormControl(): AbstractControl {
         return new FormControl(this.appConfig.get<string>(AppConfigValues.BPMHOST), [Validators.required, Validators.pattern(this.HOST_REGEX)]);
+    }
+
+    private createIdentityFormControl(): AbstractControl {
+        return new FormControl(this.appConfig.get<string>(AppConfigValues.IDENTITY_HOST), [Validators.required, Validators.pattern(this.HOST_REGEX)]);
     }
 
     private createECMFormControl(): AbstractControl {
@@ -191,6 +207,7 @@ export class HostSettingsComponent implements OnInit {
 
     private saveOAuthValues(values: any) {
         this.storageService.setItem(AppConfigValues.OAUTHCONFIG, JSON.stringify(values.oauthConfig));
+        this.storageService.setItem(AppConfigValues.IDENTITY_HOST, values.identityHost);
     }
 
     private saveBPMValues(values: any) {
@@ -231,6 +248,10 @@ export class HostSettingsComponent implements OnInit {
 
     get host(): AbstractControl {
         return this.oauthConfig.get('host');
+    }
+
+    get identityHost(): AbstractControl {
+        return this.form.get('identityHost');
     }
 
     get clientId(): AbstractControl {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**
The identityHost is needed to call the API of admin keycloak


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
