### PR TITLE
[ADF-3934] People Cloud Component - Removed value is not emitted in single mode

### DIFF
--- a/docs/process-services-cloud/people-cloud.component.md
+++ b/docs/process-services-cloud/people-cloud.component.md
@@ -28,7 +28,7 @@ Allows one or more users to be selected (with auto-suggestion) based on the inpu
 | mode | `string` |  | User selection mode (single/multiple). |
 | preSelectUsers | [`IdentityUserModel`](../../lib/core/userinfo/models/identity-user.model.ts)`[]` |  | Array of users to be pre-selected. All users in the array are pre-selected in multi selection mode, but only the first user is pre-selected in single selection mode. |
 | roles | `string[]` |  | Role names of the users to be listed. |
-| title | `string` |  | Title for input control. |
+| title | `string` |  | Title for the input control. |
 
 ### Events
 

--- a/docs/process-services-cloud/people-cloud.component.md
+++ b/docs/process-services-cloud/people-cloud.component.md
@@ -28,6 +28,7 @@ Allows one or more users to be selected (with auto-suggestion) based on the inpu
 | mode | `string` |  | User selection mode (single/multiple). |
 | preSelectUsers | [`IdentityUserModel`](../../lib/core/userinfo/models/identity-user.model.ts)`[]` |  | Array of users to be pre-selected. All users in the array are pre-selected in multi selection mode, but only the first user is pre-selected in single selection mode. |
 | roles | `string[]` |  | Role names of the users to be listed. |
+| title | `string` |  | Title for input control. |
 
 ### Events
 

--- a/lib/process-services-cloud/src/lib/task/start-task/components/people-cloud/people-cloud.component.html
+++ b/lib/process-services-cloud/src/lib/task/start-task/components/people-cloud/people-cloud.component.html
@@ -1,6 +1,6 @@
 <form>
 <mat-form-field class="adf-people-cloud">
-    <mat-label id="assignee-id">{{'ADF_TASK_LIST.START_TASK.FORM.LABEL.ASSIGNEE' | translate}}</mat-label>
+    <mat-label id="assignee-id">{{ (title || 'ADF_TASK_LIST.START_TASK.FORM.LABEL.ASSIGNEE') | translate}}</mat-label>
     <mat-chip-list #userChipList *ngIf="isMultipleMode(); else singleSelection">
       <mat-chip
         *ngFor="let user of selectedUsers$ | async"

--- a/lib/process-services-cloud/src/lib/task/start-task/components/people-cloud/people-cloud.component.html
+++ b/lib/process-services-cloud/src/lib/task/start-task/components/people-cloud/people-cloud.component.html
@@ -1,7 +1,7 @@
 <form>
 <mat-form-field class="adf-people-cloud">
     <mat-label id="assignee-id">{{ (title || 'ADF_TASK_LIST.START_TASK.FORM.LABEL.ASSIGNEE') | translate}}</mat-label>
-    <mat-chip-list #userChipList *ngIf="isMultipleMode(); else singleSelection">
+    <mat-chip-list #userChipList [disabled]="isDisabled" *ngIf="isMultipleMode(); else singleSelection">
       <mat-chip
         *ngFor="let user of selectedUsers$ | async"
         (removed)="onRemove(user)">
@@ -11,6 +11,7 @@
       <input
         #userInput
         matInput
+        [disabled]="isDisabled"
         [formControl]="searchUserCtrl"
         [matAutocomplete]="auto"
         [matChipInputFor]="userChipList"

--- a/lib/process-services-cloud/src/lib/task/start-task/components/people-cloud/people-cloud.component.scss
+++ b/lib/process-services-cloud/src/lib/task/start-task/components/people-cloud/people-cloud.component.scss
@@ -8,7 +8,6 @@
 
         &-people-cloud {
             width: 100%;
-            padding-top: 8px;
         }
 
         &-people-cloud-list {

--- a/lib/process-services-cloud/src/lib/task/start-task/components/people-cloud/people-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/task/start-task/components/people-cloud/people-cloud.component.spec.ts
@@ -51,6 +51,23 @@ describe('PeopleCloudComponent', () => {
         expect(component instanceof PeopleCloudComponent).toBeTruthy();
     });
 
+    it('should show default title when title is not given', async(() => {
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+            const labelElement = element.querySelector('label');
+            expect(labelElement.innerText).toBe('ADF_TASK_LIST.START_TASK.FORM.LABEL.ASSIGNEE');
+        });
+    }));
+
+    it('should show the title instead of default title when title is given', async(() => {
+        component.title = 'Mock Title';
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+            const labelElement = element.querySelector('label');
+            expect(labelElement.innerText).toBe('Mock Title');
+        });
+    }));
+
     it('should show the users if the typed result match', async(() => {
         component.searchUsers$ = of(<IdentityUserModel[]> mockUsers);
         fixture.detectChanges();
@@ -62,7 +79,6 @@ describe('PeopleCloudComponent', () => {
         inputHTMLElement.value = 'M';
         fixture.detectChanges();
         fixture.whenStable().then(() => {
-            fixture.detectChanges();
             expect(fixture.debugElement.query(By.css('mat-option'))).toBeDefined();
         });
     }));
@@ -101,7 +117,6 @@ describe('PeopleCloudComponent', () => {
         fixture.detectChanges();
         fixture.whenStable().then(() => {
             inputHTMLElement.blur();
-            fixture.detectChanges();
             const errorMessage = element.querySelector('.adf-start-task-cloud-error-message');
             expect(errorMessage).not.toBeNull();
             expect(errorMessage.textContent).toContain('ADF_CLOUD_START_TASK.ERROR.MESSAGE');
@@ -129,7 +144,7 @@ describe('PeopleCloudComponent', () => {
     it('should pre-select all preSelectUsers when mode=multiple', async(() => {
         spyOn(identityService, 'getUsersByRolesWithCurrentUser').and.returnValue(Promise.resolve(mockUsers));
         component.mode = 'multiple';
-        component.preSelectUsers = <any> [{id: mockUsers[1].id}, {id: mockUsers[2].id}];
+        component.preSelectUsers = <any> [mockUsers[1], mockUsers[2]];
         fixture.detectChanges();
         fixture.whenStable().then(() => {
             fixture.detectChanges();
@@ -168,6 +183,48 @@ describe('PeopleCloudComponent', () => {
             const selectedUser = component.searchUserCtrl.value;
             expect(selectedUser).toBeNull();
         });
+    }));
+
+    it('should emit select event for all preSelectUsers when mode=multiple', async(() => {
+        spyOn(identityService, 'getUsersByRolesWithCurrentUser').and.returnValue(Promise.resolve(mockUsers));
+        const selectUserSpy = spyOn(component.selectUser, 'emit');
+        component.mode = 'multiple';
+        component.preSelectUsers = <any> [mockUsers[1], mockUsers[2]];
+
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+            expect(selectUserSpy).toHaveBeenCalledTimes(2);
+        });
+    }));
+
+    it('should emit select event for first preSelectUser when mode=single', async(() => {
+        spyOn(identityService, 'getUsersByRolesWithCurrentUser').and.returnValue(Promise.resolve(mockUsers));
+        const selectUserSpy = spyOn(component.selectUser, 'emit');
+        component.preSelectUsers = <any> [mockUsers[1], mockUsers[2]];
+
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+            expect(selectUserSpy).toHaveBeenCalledTimes(1);
+        });
+    }));
+
+    it('should emit removeUser when a selected user is removed if mode=single', async(() => {
+        spyOn(identityService, 'getUsersByRolesWithCurrentUser').and.returnValue(Promise.resolve(mockUsers));
+        const removeUserSpy = spyOn(component.removeUser, 'emit');
+
+        component.preSelectUsers = <any> [mockUsers[1], mockUsers[2]];
+        fixture.detectChanges();
+
+        fixture.whenStable().then(() => {
+            let inputHTMLElement: HTMLInputElement = <HTMLInputElement> element.querySelector('input');
+            inputHTMLElement.focus();
+            inputHTMLElement.value = '';
+            inputHTMLElement.dispatchEvent(new Event('input'));
+
+            fixture.detectChanges();
+            expect(removeUserSpy).toHaveBeenCalledWith(mockUsers[1]);
+        });
+
     }));
 
     it('should emit removeUser when a selected user is removed if mode=multiple', async(() => {

--- a/lib/process-services-cloud/src/lib/task/start-task/components/people-cloud/people-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/start-task/components/people-cloud/people-cloud.component.ts
@@ -66,7 +66,7 @@ export class PeopleCloudComponent implements OnInit, AfterViewInit {
 
     /** Title for input control.  */
     @Input()
-    title: string
+    title: string;
 
     /** Emitted when a user is selected. */
     @Output()
@@ -97,6 +97,8 @@ export class PeopleCloudComponent implements OnInit, AfterViewInit {
     clientId: string;
 
     isFocused: boolean;
+
+    isDisabled: boolean;
 
     constructor(private identityUserService: IdentityUserService) {
         this.searchUsersSubject = new BehaviorSubject<IdentityUserModel[]>(this.searchUsers);
@@ -130,11 +132,12 @@ export class PeopleCloudComponent implements OnInit, AfterViewInit {
             tap((value) => {
                 if (value) {
                     this.setError();
-                    if (this.isSingleMode() && this.hasSelectedUsers()) {
-                        this.resetSingleModeSelection();
-                    }
                 } else {
                     this.clearError();
+                }
+
+                if (this.isSingleMode() && this.hasSelectedUsers()) {
+                    this.resetSingleModeSelection();
                 }
              }),
             debounceTime(500),
@@ -225,7 +228,7 @@ export class PeopleCloudComponent implements OnInit, AfterViewInit {
 
     onRemove(user: IdentityUserModel) {
         this.removeUser.emit(user);
-        const indexToRemove = this.selectedUsers.findIndex((selectedUser) => { return selectedUser.id === user.id; });
+        const indexToRemove = this.selectedUsers.findIndex((selectedUser) => { return selectedUser.id === user.id || selectedUser.email === user.email; });
         this.selectedUsers.splice(indexToRemove, 1);
         this.selectedUsersSubject.next(this.selectedUsers);
     }
@@ -273,16 +276,18 @@ export class PeopleCloudComponent implements OnInit, AfterViewInit {
 
     private disableSearch() {
         this.searchUserCtrl.disable();
+        this.isDisabled = true;
     }
 
     private enableSearch() {
         this.searchUserCtrl.enable();
+        this.isDisabled = false;
     }
 
     private resetSingleModeSelection() {
         if (this.hasSelectedUsers()) {
-            this.onRemove(this.searchUsers[0]);
-        } 
+            this.onRemove(this.selectedUsers[0]);
+        }
     }
 
     private hasSelectedUsers(): boolean {

--- a/lib/process-services-cloud/src/lib/task/start-task/components/people-cloud/people-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/start-task/components/people-cloud/people-cloud.component.ts
@@ -64,7 +64,7 @@ export class PeopleCloudComponent implements OnInit, AfterViewInit {
     @Input()
     preSelectUsers: IdentityUserModel[];
 
-    /** Title for input control.  */
+    /** Title for the input control.  */
     @Input()
     title: string;
 
@@ -285,9 +285,7 @@ export class PeopleCloudComponent implements OnInit, AfterViewInit {
     }
 
     private resetSingleModeSelection() {
-        if (this.hasSelectedUsers()) {
-            this.onRemove(this.selectedUsers[0]);
-        }
+        this.onRemove(this.selectedUsers[0]);
     }
 
     private hasSelectedUsers(): boolean {

--- a/lib/process-services-cloud/src/lib/task/start-task/components/people-cloud/people-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/start-task/components/people-cloud/people-cloud.component.ts
@@ -16,7 +16,7 @@
  */
 
 import { FormControl } from '@angular/forms';
-import { Component, OnInit, Output, EventEmitter, ViewEncapsulation, Input, ViewChild, ElementRef } from '@angular/core';
+import { Component, OnInit, Output, EventEmitter, ViewEncapsulation, Input, ViewChild, ElementRef, AfterViewInit } from '@angular/core';
 import { Observable, of, BehaviorSubject } from 'rxjs';
 import { switchMap, debounceTime, distinctUntilChanged, mergeMap, tap, filter } from 'rxjs/operators';
 import { FullNamePipe, IdentityUserModel, IdentityUserService } from '@alfresco/adf-core';
@@ -39,7 +39,7 @@ import { trigger, state, style, transition, animate } from '@angular/animations'
     encapsulation: ViewEncapsulation.None
 })
 
-export class PeopleCloudComponent implements OnInit {
+export class PeopleCloudComponent implements OnInit, AfterViewInit {
 
     static MODE_SINGLE = 'single';
     static MODE_MULTIPLE = 'multiple';
@@ -64,6 +64,10 @@ export class PeopleCloudComponent implements OnInit {
     @Input()
     preSelectUsers: IdentityUserModel[];
 
+    /** Title for input control.  */
+    @Input()
+    title: string
+
     /** Emitted when a user is selected. */
     @Output()
     selectUser: EventEmitter<IdentityUserModel> = new EventEmitter<IdentityUserModel>();
@@ -79,7 +83,8 @@ export class PeopleCloudComponent implements OnInit {
     @ViewChild('userInput')
     private userInput: ElementRef<HTMLInputElement>;
 
-    private _searchUsers: IdentityUserModel[] = [];
+    private selectedUsers: IdentityUserModel[] = [];
+    private searchUsers: IdentityUserModel[] = [];
     private selectedUsersSubject: BehaviorSubject<IdentityUserModel[]>;
     private searchUsersSubject: BehaviorSubject<IdentityUserModel[]>;
     selectedUsers$: Observable<IdentityUserModel[]>;
@@ -94,23 +99,26 @@ export class PeopleCloudComponent implements OnInit {
     isFocused: boolean;
 
     constructor(private identityUserService: IdentityUserService) {
-        this.searchUsersSubject = new BehaviorSubject<IdentityUserModel[]>(this._searchUsers);
+        this.searchUsersSubject = new BehaviorSubject<IdentityUserModel[]>(this.searchUsers);
         this.searchUsers$ = this.searchUsersSubject.asObservable();
+        this.selectedUsersSubject = new BehaviorSubject<IdentityUserModel[]>(this.selectedUsers);
+        this.selectedUsers$ = this.selectedUsersSubject.asObservable();
     }
 
     ngOnInit() {
-        this.selectedUsersSubject = new BehaviorSubject<IdentityUserModel[]>(this.preSelectUsers);
-        this.selectedUsers$ = this.selectedUsersSubject.asObservable();
-
-        if (this.hasPreSelectUsers()) {
-            this.loadPreSelectUsers();
-        }
-
         this.initSearch();
 
         if (this.appName) {
             this.disableSearch();
             this.loadClientId();
+        }
+    }
+
+    ngAfterViewInit() {
+        if (this.hasPreSelectUsers()) {
+            setTimeout(() => {
+                this.loadPreSelectUsers();
+            });
         }
     }
 
@@ -122,6 +130,9 @@ export class PeopleCloudComponent implements OnInit {
             tap((value) => {
                 if (value) {
                     this.setError();
+                    if (this.isSingleMode() && this.hasSelectedUsers()) {
+                        this.resetSingleModeSelection();
+                    }
                 } else {
                     this.clearError();
                 }
@@ -150,8 +161,8 @@ export class PeopleCloudComponent implements OnInit {
                 }
             })
         ).subscribe((user) => {
-            this._searchUsers.push(user);
-            this.searchUsersSubject.next(this._searchUsers);
+            this.searchUsers.push(user);
+            this.searchUsersSubject.next(this.searchUsers);
         });
     }
 
@@ -168,8 +179,8 @@ export class PeopleCloudComponent implements OnInit {
     }
 
     private isUserAlreadySelected(user: IdentityUserModel): boolean {
-        if (this.preSelectUsers && this.preSelectUsers.length > 0) {
-            const result = this.preSelectUsers.find((selectedUser) => {
+        if (this.selectedUsers && this.selectedUsers.length > 0) {
+            const result = this.selectedUsers.find((selectedUser) => {
                 return selectedUser.id === user.id || selectedUser.email  === user.email;
             });
 
@@ -179,9 +190,11 @@ export class PeopleCloudComponent implements OnInit {
     }
 
     private loadPreSelectUsers() {
-        if (!this.isMultipleMode()) {
+        if (this.isSingleMode()) {
             this.searchUserCtrl.setValue(this.preSelectUsers[0]);
-            this.preSelectUsers = [];
+            this.onSelect(this.preSelectUsers[0]);
+        } else {
+            this.preSelectUsers.forEach((user) => this.onSelect(user));
         }
     }
 
@@ -194,18 +207,16 @@ export class PeopleCloudComponent implements OnInit {
     }
 
     onSelect(user: IdentityUserModel) {
+
+        if (!this.isUserAlreadySelected(user)) {
+            this.selectedUsers.push(user);
+            this.selectedUsersSubject.next(this.selectedUsers);
+            this.selectUser.emit(user);
+        }
+
         if (this.isMultipleMode()) {
-
-            if (!this.isUserAlreadySelected(user)) {
-                this.preSelectUsers.push(user);
-                this.selectedUsersSubject.next(this.preSelectUsers);
-                this.selectUser.emit(user);
-            }
-
             this.userInput.nativeElement.value = '';
             this.searchUserCtrl.setValue('');
-        } else {
-            this.selectUser.emit(user);
         }
 
         this.clearError();
@@ -214,9 +225,9 @@ export class PeopleCloudComponent implements OnInit {
 
     onRemove(user: IdentityUserModel) {
         this.removeUser.emit(user);
-        const indexToRemove = this.preSelectUsers.findIndex((selectedUser) => { return selectedUser.id === user.id; });
-        this.preSelectUsers.splice(indexToRemove, 1);
-        this.selectedUsersSubject.next(this.preSelectUsers);
+        const indexToRemove = this.selectedUsers.findIndex((selectedUser) => { return selectedUser.id === user.id; });
+        this.selectedUsers.splice(indexToRemove, 1);
+        this.selectedUsersSubject.next(this.selectedUsers);
     }
 
     getDisplayName(user): string {
@@ -227,13 +238,17 @@ export class PeopleCloudComponent implements OnInit {
         return this.mode === PeopleCloudComponent.MODE_MULTIPLE;
     }
 
+    isSingleMode(): boolean {
+        return this.mode !== PeopleCloudComponent.MODE_MULTIPLE;
+    }
+
     private hasPreSelectUsers(): boolean {
         return this.preSelectUsers && this.preSelectUsers.length > 0;
     }
 
     private resetSearchUsers() {
-        this._searchUsers = [];
-        this.searchUsersSubject.next(this._searchUsers);
+        this.searchUsers = [];
+        this.searchUsersSubject.next(this.searchUsers);
     }
 
     private setError() {
@@ -262,6 +277,20 @@ export class PeopleCloudComponent implements OnInit {
 
     private enableSearch() {
         this.searchUserCtrl.enable();
+    }
+
+    private resetSingleModeSelection() {
+        if (this.hasSelectedUsers()) {
+            this.onRemove(this.searchUsers[0]);
+        } 
+    }
+
+    private hasSelectedUsers(): boolean {
+        return this.selectedUsers && this.selectedUsers.length > 0;
+    }
+
+    getValue(): IdentityUserModel[] {
+        return this.selectedUsers;
     }
 
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://issues.alfresco.com/jira/browse/ADF-3934

* Removed/Deselected value is not emitted in single mode.
* Component is not disabled until client id is retrieved in multiple mode. 
* Pre-select users are not loaded in multiple mode

**What is the new behaviour?**

* Removed/Deselected value is emitted in single mode.
* Component is disabled until client id is retrieved in multiple mode. 
* Pre-select users are loaded in multiple mode
* Added new input to override default title

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
