### PR TITLE
[ADF-3938] support for XMLHttpRequest.withCredentials flag

### DIFF
--- a/demo-shell/src/app.config.json
+++ b/demo-shell/src/app.config.json
@@ -3,7 +3,6 @@
     "ecmHost": "{protocol}//{hostname}{:port}",
     "bpmHost": "{protocol}//{hostname}{:port}",
     "identityHost": "{protocol}//{hostname}{:port}/auth/realms/alfresco",
-    "baseShareUrl": null,
     "loginRoute": "login",
     "providers": "ALL",
     "contextRootBpm": "activiti-app",

--- a/demo-shell/src/app.config.json
+++ b/demo-shell/src/app.config.json
@@ -9,6 +9,9 @@
     "contextRootBpm": "activiti-app",
     "authType" : "BASIC",
     "locale" : "en",
+    "auth": {
+      "withCredentials": true
+    },
     "oauth2": {
       "host": "{protocol}//{hostname}{:port}/auth/realms/alfresco",
       "clientId": "alfresco",

--- a/demo-shell/src/app.config.json
+++ b/demo-shell/src/app.config.json
@@ -10,7 +10,7 @@
     "authType" : "BASIC",
     "locale" : "en",
     "auth": {
-      "withCredentials": true
+      "withCredentials": false
     },
     "oauth2": {
       "host": "{protocol}//{hostname}{:port}/auth/realms/alfresco",

--- a/docs/core/app-config.service.md
+++ b/docs/core/app-config.service.md
@@ -156,3 +156,16 @@ of a property when the app config is loaded:
         console.log(logLevelValue); //this will be 'trace';
     });
 ```
+
+## XMLHttpRequest.withCredentials
+
+In the configuration file, you can enable [XMLHttpRequest.withCredentials](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials)
+for @alfresco/js-api calls and PDF Viewer.
+
+```json
+{
+    "auth": {
+      "withCredentials": true
+    }
+}
+```

--- a/docs/core/app-config.service.md
+++ b/docs/core/app-config.service.md
@@ -66,22 +66,6 @@ Example of the default settings file content:
 Note that the settings in the example above are the default ones supplied with the server.
 You can override the values in your custom `app.config.json` file if necessary. 
 
-You can change the path or name of the configuration file when importing the [`CoreModule`](../../lib/core/core.module.ts) in your main application.
-
-```ts
-...
-@NgModule({
-    imports: [
-        ...
-        CoreModule.forRoot({
-            appConfigFile: 'app.production.config.json'
-        })
-    ],
-    ...
-}
-export class AppModule { }
-```
-
 Below is a simple example of using the [`AppConfigService`](../core/app-config.service.md) in practice. 
 
 **[app.component](../../demo-shell/src/app/app.component.ts).ts**

--- a/lib/core/app-config/app-config.service.ts
+++ b/lib/core/app-config/app-config.service.ts
@@ -36,7 +36,8 @@ export enum AppConfigValues {
     ALFRESCO_REPOSITORY_NAME = 'alfrescoRepositoryName',
     LOG_LEVEL = 'logLevel',
     LOGIN_ROUTE = 'loginRoute',
-    DISABLECSRF = 'disableCSRF'
+    DISABLECSRF = 'disableCSRF',
+    AUTH_WITH_CREDENTIALS = 'auth.withCredentials'
 }
 
 export enum Status {

--- a/lib/core/app-config/schema.json
+++ b/lib/core/app-config/schema.json
@@ -833,6 +833,24 @@
         "OAUTH"
       ]
     },
+    "baseShareUrl": {
+      "description": "Custom url for shared links",
+      "type": "string"
+    },
+    "locale": {
+      "description": "Default application locale",
+      "type": "string"
+    },
+    "auth": {
+      "description": "Custom authentication settings",
+      "type": "object",
+      "properties": {
+        "withCredentials": {
+          "description": "Toggle XMLHttpRequest.withCredentials for @alfresco/js-api and PDF Viewer",
+          "type": "boolean"
+        }
+      }
+    },
     "oauth2": {
       "description": "AUTH configuration parameters",
       "type": "object",

--- a/lib/core/services/alfresco-api.service.ts
+++ b/lib/core/services/alfresco-api.service.ts
@@ -117,7 +117,7 @@ export class AlfrescoApiService {
             oauth.redirectUriLogout = window.location.origin + (oauth.redirectUriLogout || '/');
         }
 
-        const config = {
+        const config = new AlfrescoApiConfig({
             provider: this.appConfig.get<string>(AppConfigValues.PROVIDERS),
             hostEcm: this.appConfig.get<string>(AppConfigValues.ECMHOST),
             hostBpm: this.appConfig.get<string>(AppConfigValues.BPMHOST),
@@ -125,8 +125,9 @@ export class AlfrescoApiService {
             contextRootBpm: this.appConfig.get<string>(AppConfigValues.CONTEXTROOTBPM),
             contextRoot: this.appConfig.get<string>(AppConfigValues.CONTEXTROOTECM),
             disableCsrf: this.appConfig.get<boolean>(AppConfigValues.DISABLECSRF),
+            withCredentials: this.appConfig.get<boolean>(AppConfigValues.AUTH_WITH_CREDENTIALS, false),
             oauth2: oauth
-        };
+        });
 
         if (this.alfrescoApi && this.isDifferentConfig(this.lastConfig, config)) {
             this.lastConfig = config;
@@ -135,6 +136,7 @@ export class AlfrescoApiService {
             this.lastConfig = config;
             this.alfrescoApi = new AlfrescoApiCompatibility(config);
         }
+
     }
 
     isDifferentConfig(lastConfig: AlfrescoApiConfig, newConfig: AlfrescoApiConfig) {

--- a/lib/core/viewer/components/pdfViewer.component.ts
+++ b/lib/core/viewer/components/pdfViewer.component.ts
@@ -30,6 +30,7 @@ import { LogService } from '../../services/log.service';
 import { RenderingQueueServices } from '../services/rendering-queue.services';
 import { PdfPasswordDialogComponent } from './pdfViewer-password-dialog';
 import { MatDialog } from '@angular/material';
+import { AppConfigService } from './../../app-config/app-config.service';
 
 declare const pdfjsLib: any;
 declare const pdfjsViewer: any;
@@ -99,7 +100,8 @@ export class PdfViewerComponent implements OnChanges, OnDestroy {
     constructor(
         private dialog: MatDialog,
         private renderingQueueServices: RenderingQueueServices,
-        private logService: LogService) {
+        private logService: LogService,
+        private appConfigService: AppConfigService) {
         // needed to preserve "this" context
         this.onPageChange = this.onPageChange.bind(this);
         this.onPagesLoaded = this.onPagesLoaded.bind(this);
@@ -129,9 +131,14 @@ export class PdfViewerComponent implements OnChanges, OnDestroy {
     }
 
     executePdf(src) {
-
         pdfjsLib.GlobalWorkerOptions.workerSrc = 'pdf.worker.min.js';
-        this.loadingTask = pdfjsLib.getDocument(src);
+
+        const options = {
+            url: src,
+            withCredentials: this.appConfigService.get<boolean>('auth.withCredentials', undefined)
+        };
+
+        this.loadingTask = pdfjsLib.getDocument(options);
 
         this.loadingTask.onPassword = (callback, reason) => {
             this.onPdfPassword(callback, reason);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

- provide support for XMLHttpRequest.withCredentials (corresponding flag has been previously contributed to JS-API by the community)
- global (app config) setting to enable both PDF Viewer and JS-API flags

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No

refs https://github.com/Alfresco/alfresco-content-app/issues/894

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-3938