### PR TITLE
[ADF-1344] Old directive selectors should still be usable

### DIFF
--- a/lib/core/form/components/start-form.component.html
+++ b/lib/core/form/components/start-form.component.html
@@ -18,7 +18,8 @@
         </mat-card-content>
         <mat-card-content class="adf-start-form-actions" *ngIf="showOutcomeButtons && form.hasOutcomes()"
                           #outcomesContainer>
-            <ng-content select="[adf-form-custom-button]"></ng-content>
+            <ng-content select="[adf-form-custom-button], [form-custom-button]"></ng-content>
+
             <button *ngFor="let outcome of form.outcomes"
                     mat-button
                     [attr.data-automation-id]="'adf-form-' + outcome.name  | lowercase"

--- a/lib/core/layout/components/sidebar-action/sidebar-action-menu.component.html
+++ b/lib/core/layout/components/sidebar-action/sidebar-action-menu.component.html
@@ -1,16 +1,16 @@
 <div class="adf-sidebar-action-menu">
     <button *ngIf="isExpanded()" mat-raised-button class="adf-sidebar-action-menu-button" data-automation-id="create-button" [matMenuTriggerFor]="adfSidebarMenu">
         <span *ngIf="title" class="adf-sidebar-action-menu-text">{{ title }}</span>
-        <ng-content select="[adf-sidebar-menu-title-icon]"></ng-content>
+        <ng-content select="[adf-sidebar-menu-title-icon], [sidebar-menu-title-icon]"></ng-content>
     </button>
 
     <div *ngIf="!isExpanded()" class="adf-sidebar-action-menu-icon" [matMenuTriggerFor]="adfSidebarMenu">
-        <ng-content select="[adf-sidebar-menu-expand-icon]"></ng-content>
+        <ng-content select="[adf-sidebar-menu-expand-icon], [sidebar-menu-expand-icon]"></ng-content>
     </div>
 
     <mat-menu #adfSidebarMenu="matMenu" class="adf-sidebar-action-menu-panel" [overlapTrigger]="false" yPosition="below">
         <div class="adf-sidebar-action-menu-options" [style.width.px]="width">
-            <ng-content select="[adf-sidebar-menu-options]"></ng-content>
+            <ng-content select="[adf-sidebar-menu-options], [sidebar-menu-options]"></ng-content>
         </div>
     </mat-menu>
 </div>

--- a/lib/process-services/people/components/people-search/people-search.component.html
+++ b/lib/process-services/people/components/people-search/people-search.component.html
@@ -1,5 +1,5 @@
 <div class="adf-search-text-header">
-    <ng-content select="[adf-people-search-title]"></ng-content>
+    <ng-content select="[adf-people-search-title], [people-search-title]"></ng-content>
 </div>
 
 <adf-people-search-field [performSearch]="performSearch" (rowClick)="onRowClick($event)"></adf-people-search-field>
@@ -9,6 +9,6 @@
         {{'ADF_TASK_LIST.PEOPLE.DIALOG_CLOSE' | translate }}
     </button>
     <button mat-button type="button" id="add-people" (click)="involveUserAndClose()">
-        <ng-content select="[adf-people-search-action-label]"></ng-content>
+        <ng-content select="[adf-people-search-action-label], [people-search-action-label]"></ng-content>
     </button>
 </div>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-1344
Some old selectors are not working after adding the new ones where the adf- prefix is required.

**What is the new behaviour?**
These old selectors are still going to be usable but they'll be deprecated.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-1344