### PR TITLE
[ADF-3964] Regression - No content template not displaying in search …

### DIFF
--- a/demo-shell/src/app/components/files/files.component.html
+++ b/demo-shell/src/app/components/files/files.component.html
@@ -226,16 +226,12 @@
                 (permissionError)="handlePermissionError($event)"
                 (name-click)="documentList.onNodeDblClick($event.detail?.node)">
                 <adf-custom-no-permission-template *ngIf="enableCustomPermissionMessage">
-                    <ng-template>
                         <h1>You don't have permissions</h1>
-                    </ng-template>
                 </adf-custom-no-permission-template>
                 <adf-custom-empty-content-template *ngIf="disableDragArea">
-                    <ng-template>
                         <div class="adf-empty_template">
                             <div class="adf-no-result-message">{{ 'SEARCH.NO_RESULT' | translate }}</div>
                         </div>
-                    </ng-template>
                 </adf-custom-empty-content-template>
                 <data-columns>
                     <data-column


### PR DESCRIPTION
…component

**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-3964
When there is no matching results the template is not been displayed

**What is the new behaviour?**
The empty content template is displayed wen there's no matching results


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-3964