### PR TITLE
[ADF-4000] Fix custom directive selectors on Datatable component

### DIFF
--- a/docs/core/empty-content.component.md
+++ b/docs/core/empty-content.component.md
@@ -16,13 +16,11 @@ Provides a generic "Empty Content" placeholder for components.
 ```html
 <adf-document-list>
     <empty-folder-content>
-        <ng-template>
             <adf-empty-content
                 icon="star_rate"
                 title="APP.BROWSE.FAVORITES.EMPTY_STATE.TITLE"
                 subtitle="APP.BROWSE.FAVORITES.EMPTY_STATE.TEXT">
             </adf-empty-content>
-        </ng-template>
     </empty-folder-content>
 </adf-document-list>
 ```
@@ -44,13 +42,11 @@ Provides a generic "Empty Content" placeholder for components.
 ```html
 <adf-document-list>
     <empty-folder-content>
-        <ng-template>
             <adf-empty-content
                 icon="star_rate"
                 title="APP.BROWSE.FAVORITES.EMPTY_STATE.TITLE"
                 subtitle="APP.BROWSE.FAVORITES.EMPTY_STATE.TEXT">
             </adf-empty-content>
-        </ng-template>
     </empty-folder-content>
 </adf-document-list>
 ```
@@ -62,14 +58,12 @@ You can also use multiple lines instead of the subtitle section:
 ```html
 <adf-document-list>
     <empty-folder-content>
-        <ng-template>
             <adf-empty-content
                 icon="delete"
                 title="APP.BROWSE.TRASHCAN.EMPTY_STATE.TITLE">
                 <p class="adf-empty-content__text">{{ 'APP.BROWSE.TRASHCAN.EMPTY_STATE.FIRST_TEXT' | translate }}</p>
                 <p class="adf-empty-content__text">{{ 'APP.BROWSE.TRASHCAN.EMPTY_STATE.SECOND_TEXT' | translate }}</p>
             </adf-empty-content>
-        </ng-template>
     </empty-folder-content>
 </adf-document-list>
 ```

--- a/lib/content-services/document-list/components/document-list.component.html
+++ b/lib/content-services/document-list/components/document-list.component.html
@@ -34,7 +34,7 @@
                 </div>
                 <!-- <div adf-empty-list-header class="adf-empty-list-header"> {{'ADF-DOCUMENT-LIST.EMPTY.HEADER' | translate}} </div> -->
             </adf-empty-list>
-            <ng-content select="adf-custom-empty-content-template"></ng-content>
+            <ng-content select="adf-custom-empty-content-template, empty-folder-content"></ng-content>
         </ng-template>
     </adf-no-content-template>
 
@@ -44,7 +44,7 @@
                 <mat-icon>ic_error</mat-icon>
                 <p class="adf-no-permission__template--text">{{ 'ADF-DOCUMENT-LIST.NO_PERMISSION' | translate }}</p>
             </div>
-            <ng-content select="adf-custom-no-permission-template"></ng-content>
+            <ng-content select="adf-custom-no-permission-template, no-permission-content"></ng-content>
         </ng-template>
     </adf-no-permission-template>
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-4000
Old template selectors were no longer working.


**What is the new behaviour?**
The use-case examples have been updated and the selector is usable once again, until it's deprecated.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-4000