### PR TITLE
adf-icon: expose color property

### DIFF
--- a/docs/core/icon.component.md
+++ b/docs/core/icon.component.md
@@ -28,7 +28,8 @@ Provides a universal way of rendering registered and named icons.
 
 | Name | Type | Default value | Description |
 | ---- | ---- | ------------- | ----------- |
-| value | `string` |  | Icon value, which can be either a ligature name or a custom icon in the format `[namespace]:[name]`. |
+| value | `string` | | Icon value, which can be either a ligature name or a custom icon in the format `[namespace]:[name]`. |
+| color | ThemePalette | |Theme color palette for the component. |
 
 ## Details
 

--- a/lib/core/icon/icon.component.html
+++ b/lib/core/icon/icon.component.html
@@ -1,7 +1,7 @@
 <ng-container *ngIf="isCustom; else: default">
-  <mat-icon [svgIcon]="value"></mat-icon>
+  <mat-icon [color]="color" [svgIcon]="value"></mat-icon>
 </ng-container>
 
 <ng-template #default>
-  <mat-icon>{{ value }}</mat-icon>
+  <mat-icon [color]="color">{{ value }}</mat-icon>
 </ng-template>

--- a/lib/core/icon/icon.component.ts
+++ b/lib/core/icon/icon.component.ts
@@ -22,6 +22,7 @@ import {
     ChangeDetectionStrategy
 } from '@angular/core';
 import { ThumbnailService } from '../services/thumbnail.service';
+import { ThemePalette } from '@angular/material';
 
 @Component({
     selector: 'adf-icon',
@@ -34,6 +35,9 @@ import { ThumbnailService } from '../services/thumbnail.service';
 export class IconComponent {
     private _value = '';
     private _isCustom = false;
+
+    @Input()
+    color: ThemePalette;
 
     get value(): string {
         return this._value;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

It is not possible to set the color of the underlying icon (accent, primary, etc.)

**What is the new behaviour?**

Expose the [color] property of the wrapped icon.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
