### PR TITLE
[ADF-3401] Search filters - fix facet update

### DIFF
--- a/demo-shell/src/app.config.json
+++ b/demo-shell/src/app.config.json
@@ -102,6 +102,7 @@
           }
         ]
       },
+      "resetButton": true,
       "filterQueries": [
         { "query": "TYPE:'cm:folder' OR TYPE:'cm:content'" },
         { "query": "NOT cm:creator:System" }

--- a/demo-shell/src/app/components/search/search-result.component.html
+++ b/demo-shell/src/app/components/search/search-result.component.html
@@ -1,5 +1,5 @@
 <div class="adf-search-results__facets">
-    <adf-search-chip-list [searchFilter]="searchFilter"></adf-search-chip-list>
+    <adf-search-chip-list [searchFilter]="searchFilter" [clearAll]="true"></adf-search-chip-list>
 </div>
 
 <div class="adf-search-results">

--- a/docs/content-services/search-chip-list.component.md
+++ b/docs/content-services/search-chip-list.component.md
@@ -25,3 +25,4 @@ Displays search criteria as a set of "chips".
 | Name | Type | Default value | Description |
 | ---- | ---- | ------------- | ----------- |
 | searchFilter | [`SearchFilterComponent`](../content-services/search-filter.component.md) |  | Search filter to supply the data for the chips. |
+| clearAll | boolean | false | Enables or disables the display of a clear-all-filters button. |

--- a/docs/content-services/search-filter.component.md
+++ b/docs/content-services/search-filter.component.md
@@ -133,6 +133,17 @@ You can choose to filter facet field results using 'contains' instead of 'starts
 }
 ```
 
+You can choose to display a reset button by setting the 'resetButton' value to true.
+This 'clean up' button would make it easier for the final user to remove all bucket selections and all search filtering.
+
+```json
+{
+    "search": {
+        "resetButton": true
+    }
+}
+```
+
 You can also provide a set of queries that are always executed alongside the user-defined
 settings:
 

--- a/lib/content-services/i18n/en.json
+++ b/lib/content-services/i18n/en.json
@@ -200,7 +200,7 @@
       },
       "BUTTONS": {
         "CLEAR-ALL": {
-          "LABEL": "Clear all selections",
+          "LABEL": "Clear all",
           "TOOLTIP": "This will remove all selections"
         },
         "RESET-ALL": {

--- a/lib/content-services/i18n/en.json
+++ b/lib/content-services/i18n/en.json
@@ -198,6 +198,16 @@
         "SHOW-LESS": "Show less",
         "FILTER-CATEGORY": "Filter category"
       },
+      "BUTTONS": {
+        "CLEAR-ALL": {
+          "LABEL": "Clear all selections",
+          "TOOLTIP": "This will remove all selections"
+        },
+        "RESET-ALL": {
+          "LABEL": "Reset all",
+          "TOOLTIP": "This will reset all selections and all filters"
+        }
+      },
       "RANGE": {
         "FROM": "From",
         "TO": "To",

--- a/lib/content-services/search/components/search-chip-list/search-chip-list.component.html
+++ b/lib/content-services/search/components/search-chip-list/search-chip-list.component.html
@@ -1,5 +1,14 @@
 <mat-chip-list>
     <ng-container *ngIf="searchFilter && searchFilter.selectedBuckets.length">
+        <mat-chip *ngIf="clearAll && searchFilter.selectedBuckets.length > 1"
+                  color="primary"
+                  selected
+                  matTooltip="{{ 'SEARCH.FILTER.BUTTONS.CLEAR-ALL.TOOLTIP' | translate }}"
+                  matTooltipPosition="right"
+                  (click)="searchFilter.resetAllSelectedBuckets()">
+            {{ 'SEARCH.FILTER.BUTTONS.CLEAR-ALL.LABEL' | translate }}
+        </mat-chip>
+
         <mat-chip
             *ngFor="let selection of searchFilter.selectedBuckets"
             [removable]="true"

--- a/lib/content-services/search/components/search-chip-list/search-chip-list.component.ts
+++ b/lib/content-services/search/components/search-chip-list/search-chip-list.component.ts
@@ -29,4 +29,8 @@ export class SearchChipListComponent {
     /** Search filter to supply the data for the chips. */
     @Input()
     searchFilter: SearchFilterComponent;
+
+    /** Flag used to enable the display of a clear-all-filters button. */
+    @Input()
+    clearAll: boolean = false;
 }

--- a/lib/content-services/search/components/search-filter/models/search-filter-list.model.ts
+++ b/lib/content-services/search/components/search-filter/models/search-filter-list.model.ts
@@ -114,6 +114,13 @@ export class SearchFilterList<T> implements Iterable<T> {
         this.filteredItems.push(item);
     }
 
+    deleteItem(item) {
+        const removeIndex = this.items.indexOf(item);
+
+        this.items.splice(removeIndex, 1);
+        this.filteredItems.splice(removeIndex, 1);
+    }
+
     [Symbol.iterator](): Iterator<T> {
         let pointer = 0;
         let items = this.visibleItems;

--- a/lib/content-services/search/components/search-filter/models/search-filter-list.model.ts
+++ b/lib/content-services/search/components/search-filter/models/search-filter-list.model.ts
@@ -111,7 +111,7 @@ export class SearchFilterList<T> implements Iterable<T> {
 
     addItem(item) {
         this.items.push(item);
-        this.filteredItems.push(item);
+        this.applyFilter();
     }
 
     deleteItem(item) {

--- a/lib/content-services/search/components/search-filter/models/search-filter-list.model.ts
+++ b/lib/content-services/search/components/search-filter/models/search-filter-list.model.ts
@@ -109,6 +109,11 @@ export class SearchFilterList<T> implements Iterable<T> {
         this.filterText = '';
     }
 
+    addItem(item) {
+        this.items.push(item);
+        this.filteredItems.push(item);
+    }
+
     [Symbol.iterator](): Iterator<T> {
         let pointer = 0;
         let items = this.visibleItems;

--- a/lib/content-services/search/components/search-filter/models/search-filter-list.model.ts
+++ b/lib/content-services/search/components/search-filter/models/search-filter-list.model.ts
@@ -109,16 +109,20 @@ export class SearchFilterList<T> implements Iterable<T> {
         this.filterText = '';
     }
 
-    addItem(item) {
+    addItem(item: T) {
+        if (!item) {
+            return;
+        }
         this.items.push(item);
         this.applyFilter();
     }
 
-    deleteItem(item) {
+    deleteItem(item: T) {
         const removeIndex = this.items.indexOf(item);
-
-        this.items.splice(removeIndex, 1);
-        this.filteredItems.splice(removeIndex, 1);
+        if (removeIndex > -1) {
+            this.items.splice(removeIndex, 1);
+            this.filteredItems.splice(removeIndex, 1);
+        }
     }
 
     [Symbol.iterator](): Iterator<T> {

--- a/lib/content-services/search/components/search-filter/search-filter.component.html
+++ b/lib/content-services/search/components/search-filter/search-filter.component.html
@@ -1,5 +1,29 @@
 <mat-accordion multi="true" displayMode="flat">
 
+    <button *ngIf="responseFacets && selectedBuckets.length"
+            mat-button
+            color="primary"
+            matTooltip="This will remove all selections and all empty items"
+            matTooltipPosition="right"
+            (click)="resetAll()">
+        {{ 'RESET ALL' | translate }}
+    </button>
+    <br />
+    <button *ngIf="selectedBuckets.length"
+            mat-button
+            color="primary"
+            matTooltip="This will remove all selections"
+            matTooltipPosition="right"
+            (click)="resetAllSelectedBuckets()">
+        {{ 'clear all selections' | translate }}
+    </button><button *ngIf="canResetBuckets()"
+            mat-button
+            color="primary"
+            matTooltip="This will remove all empty items"
+            matTooltipPosition="right"
+            (click)="resetBuckets()">
+        {{ 'reset buckets' | translate }}
+    </button>
     <mat-expansion-panel
         *ngFor="let category of queryBuilder.categories"
         [attr.data-automation-id]="'expansion-panel-'+category.name"

--- a/lib/content-services/search/components/search-filter/search-filter.component.html
+++ b/lib/content-services/search/components/search-filter/search-filter.component.html
@@ -3,7 +3,7 @@
     <button *ngIf="responseFacets && selectedBuckets.length"
             mat-button
             color="primary"
-            matTooltip="This will remove all selections and all empty items"
+            matTooltip="This will reset all selections and all filters"
             matTooltipPosition="right"
             (click)="resetAll()">
         {{ 'RESET ALL' | translate }}
@@ -16,13 +16,6 @@
             matTooltipPosition="right"
             (click)="resetAllSelectedBuckets()">
         {{ 'clear all selections' | translate }}
-    </button><button *ngIf="canResetBuckets()"
-            mat-button
-            color="primary"
-            matTooltip="This will remove all empty items"
-            matTooltipPosition="right"
-            (click)="resetBuckets()">
-        {{ 'reset buckets' | translate }}
     </button>
     <mat-expansion-panel
         *ngFor="let category of queryBuilder.categories"

--- a/lib/content-services/search/components/search-filter/search-filter.component.html
+++ b/lib/content-services/search/components/search-filter/search-filter.component.html
@@ -1,6 +1,6 @@
 <mat-accordion multi="true" displayMode="flat">
 
-    <button *ngIf="responseFacets && selectedBuckets.length"
+    <button *ngIf="responseFacets"
             mat-button
             color="primary"
             matTooltip="This will reset all selections and all filters"

--- a/lib/content-services/search/components/search-filter/search-filter.component.html
+++ b/lib/content-services/search/components/search-filter/search-filter.component.html
@@ -62,13 +62,10 @@
                     [attr.data-automation-id]="'checkbox-'+field.label+'-'+(bucket.display || bucket.label)"
                     (change)="onToggleBucket($event, field, bucket)">
                     <div 
-                        matTooltip="{{ bucket.display || bucket.label | translate }}"
+                        matTooltip="{{ bucket.display || bucket.label | translate }} {{ getBucketCountDisplay(bucket) }}"
                         matTooltipPosition="right"
                         class="adf-facet-label">
-                        {{ bucket.display || bucket.label | translate }} 
-                        <span *ngIf="bucket.count!==null">(</span>
-                        {{ bucket.count }}
-                        <span *ngIf="bucket.count!==null">)</span>
+                        {{ bucket.display || bucket.label | translate }} {{ getBucketCountDisplay(bucket) }}
                     </div>
                 </mat-checkbox>
             </div>

--- a/lib/content-services/search/components/search-filter/search-filter.component.html
+++ b/lib/content-services/search/components/search-filter/search-filter.component.html
@@ -8,14 +8,6 @@
             (click)="resetAll()">
         {{ 'SEARCH.FILTER.BUTTONS.RESET-ALL.LABEL' | translate }}
     </button>
-    <button *ngIf="selectedBuckets.length"
-            mat-button
-            color="primary"
-            matTooltip="{{ 'SEARCH.FILTER.BUTTONS.CLEAR-ALL.TOOLTIP' | translate }}"
-            matTooltipPosition="right"
-            (click)="resetAllSelectedBuckets()">
-        {{ 'SEARCH.FILTER.BUTTONS.CLEAR-ALL.LABEL' | translate }}
-    </button>
     <mat-expansion-panel
         *ngFor="let category of queryBuilder.categories"
         [attr.data-automation-id]="'expansion-panel-'+category.name"

--- a/lib/content-services/search/components/search-filter/search-filter.component.html
+++ b/lib/content-services/search/components/search-filter/search-filter.component.html
@@ -3,19 +3,18 @@
     <button *ngIf="responseFacets"
             mat-button
             color="primary"
-            matTooltip="This will reset all selections and all filters"
+            matTooltip="{{ 'SEARCH.FILTER.BUTTONS.RESET-ALL.TOOLTIP' | translate }}"
             matTooltipPosition="right"
             (click)="resetAll()">
-        {{ 'RESET ALL' | translate }}
+        {{ 'SEARCH.FILTER.BUTTONS.RESET-ALL.LABEL' | translate }}
     </button>
-    <br />
     <button *ngIf="selectedBuckets.length"
             mat-button
             color="primary"
-            matTooltip="This will remove all selections"
+            matTooltip="{{ 'SEARCH.FILTER.BUTTONS.CLEAR-ALL.TOOLTIP' | translate }}"
             matTooltipPosition="right"
             (click)="resetAllSelectedBuckets()">
-        {{ 'clear all selections' | translate }}
+        {{ 'SEARCH.FILTER.BUTTONS.CLEAR-ALL.LABEL' | translate }}
     </button>
     <mat-expansion-panel
         *ngFor="let category of queryBuilder.categories"

--- a/lib/content-services/search/components/search-filter/search-filter.component.html
+++ b/lib/content-services/search/components/search-filter/search-filter.component.html
@@ -1,6 +1,6 @@
 <mat-accordion multi="true" displayMode="flat">
 
-    <button *ngIf="responseFacets"
+    <button *ngIf="displayResetButton && responseFacets"
             mat-button
             color="primary"
             matTooltip="{{ 'SEARCH.FILTER.BUTTONS.RESET-ALL.TOOLTIP' | translate }}"

--- a/lib/content-services/search/components/search-filter/search-filter.component.spec.ts
+++ b/lib/content-services/search/components/search-filter/search-filter.component.spec.ts
@@ -193,7 +193,7 @@ describe('SearchFilterComponent', () => {
 
         component.onDataLoaded(data);
 
-        expect(component.responseFacets.length).toBe(0);
+        expect(component.responseFacets).toBeNull();
     });
 
     it('should fetch facet fields from response payload', () => {
@@ -397,10 +397,10 @@ describe('SearchFilterComponent', () => {
         };
 
         component.responseFacets = <any> [
-            { label: 'f1', field: 'f1', buckets: {items: [
+            { type: 'field', label: 'f1', field: 'f1', buckets: {items: [
                 { label: 'b1', count: 10, filterQuery: 'filter', checked: true },
                 { label: 'b2', count: 1, filterQuery: 'filter2' }] }},
-            { label: 'f2', field: 'f2', buckets: {items: [] }}
+            { type: 'field', label: 'f2', field: 'f2', buckets: {items: [] }}
         ];
         component.queryBuilder.addUserFacetBucket({ label: 'f1', field: 'f1' }, component.responseFacets[0].buckets.items[0]);
 
@@ -437,10 +437,10 @@ describe('SearchFilterComponent', () => {
         };
 
         component.responseFacets = <any> [
-            { label: 'f1', field: 'f1', buckets: {items: [
+            { type: 'field', label: 'f1', field: 'f1', buckets: {items: [
                         { label: 'b1', count: 10, filterQuery: 'filter', checked: true },
                         { label: 'b2', count: 1, filterQuery: 'filter2' }] }},
-            { label: 'f2', field: 'f2', buckets: {items: [] }}
+            { type: 'field', label: 'f2', field: 'f2', buckets: {items: [] }}
         ];
         component.queryBuilder.addUserFacetBucket({ label: 'f1', field: 'f1' }, component.responseFacets[0].buckets.items[0]);
 
@@ -477,10 +477,10 @@ describe('SearchFilterComponent', () => {
         };
 
         component.responseFacets = <any> [
-            { label: 'f1', field: 'f1', buckets: {items: [
+            { type: 'field', label: 'f1', field: 'f1', buckets: {items: [
                         { label: 'b1', count: 10, filterQuery: 'filter', checked: true },
                         { label: 'b2', count: 1, filterQuery: 'filter2' }] }},
-            { label: 'f2', field: 'f2', buckets: {items: [] }}
+            { type: 'field', label: 'f2', field: 'f2', buckets: {items: [] }}
         ];
         component.queryBuilder.addUserFacetBucket({ label: 'f1', field: 'f1' }, component.responseFacets[0].buckets.items[0]);
         const data = {

--- a/lib/content-services/search/components/search-filter/search-filter.component.ts
+++ b/lib/content-services/search/components/search-filter/search-filter.component.ts
@@ -204,7 +204,7 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
             const responseBuckets = this.getResponseBuckets(responseField, field)
                 .filter(this.getFilterByMinCount(field.mincount));
 
-            const alreadyExistingField = (this.responseFacets || []).find((response) => response.type === 'field' && response.label === field.label);
+            const alreadyExistingField = (this.responseFacets || []).find((response) => response.type === itemType && response.label === field.label);
             if (alreadyExistingField) {
 
                 const alreadyExistingBuckets = alreadyExistingField.buckets && alreadyExistingField.buckets.items || [];

--- a/lib/content-services/search/components/search-filter/search-filter.component.ts
+++ b/lib/content-services/search/components/search-filter/search-filter.component.ts
@@ -196,7 +196,6 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
         this.parseFacetFields(context);
         this.parseFacetIntervals(context);
         this.parseFacetQueries(context);
-
     }
 
     private parseFacetItems(context: ResultSetContext, configFacetFields: FacetField[], itemType: string) {
@@ -209,15 +208,27 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
             if (alreadyExistingField) {
 
                 const alreadyExistingBuckets = alreadyExistingField.buckets && alreadyExistingField.buckets.items || [];
+
+                const shouldDelete = [];
                 alreadyExistingBuckets
                     .map((bucket) => {
                         const responseBucket = ((responseField && responseField.buckets) || []).find((respBucket) => respBucket.label === bucket.label);
 
+                        if (!responseBucket) {
+                            shouldDelete.push(bucket);
+                        }
                         bucket.count = responseBucket ? this.getCountValue(responseBucket) : 0;
                         return bucket;
                     });
+                const hasSelection = this.selectedBuckets
+                    .find((selBuckets) => alreadyExistingField.label === selBuckets.field.label && alreadyExistingField.type === selBuckets.field.type);
 
-                // add only the new ones to the existing'SearchFilterList' and update the already existing ones:
+                if (!hasSelection && shouldDelete.length) {
+                    shouldDelete.forEach((bucket) => {
+                        alreadyExistingField.buckets.deleteItem(bucket);
+                    });
+                }
+
                 responseBuckets.forEach((respBucket) => {
                     const existingBucket = alreadyExistingBuckets.find((oldBucket) => oldBucket.label === respBucket.label);
 
@@ -243,7 +254,7 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
                 }
                 this.responseFacets.push(<FacetField> {
                     ...field,
-                    type: responseField.type,
+                    type: responseField.type || itemType,
                     label: field.label,
                     pageSize: field.pageSize | this.DEFAULT_PAGE_SIZE,
                     currentPageSize: field.pageSize | this.DEFAULT_PAGE_SIZE,
@@ -287,15 +298,27 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
             if (alreadyExistingField) {
 
                 const alreadyExistingBuckets = alreadyExistingField.buckets && alreadyExistingField.buckets.items || [];
+
+                const shouldDelete = [];
                 alreadyExistingBuckets
                     .map((bucket) => {
                         const responseBucket = ((responseField && responseField.buckets) || []).find((respBucket) => respBucket.label === bucket.label);
 
+                        if (!responseBucket) {
+                            shouldDelete.push(bucket);
+                        }
                         bucket.count = responseBucket ? this.getCountValue(responseBucket) : 0;
                         return bucket;
                     });
+                const hasSelection = this.selectedBuckets
+                    .find((selBuckets) => alreadyExistingField.label === selBuckets.field.label && alreadyExistingField.type === selBuckets.field.type);
 
-                // add only the new ones to the existing'SearchFilterList' and update the already existing ones:
+                if (!hasSelection && shouldDelete.length) {
+                    shouldDelete.forEach((bucket) => {
+                        alreadyExistingField.buckets.deleteItem(bucket);
+                    });
+                }
+
                 responseBuckets.forEach((respBucket) => {
                     const existingBucket = alreadyExistingBuckets.find((oldBucket) => oldBucket.label === respBucket.label);
 
@@ -321,7 +344,7 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
                 }
                 this.responseFacets.push(<FacetField> {
                     field: group,
-                    type: responseField.type,
+                    type: responseField.type || 'query',
                     label: group,
                     pageSize: this.DEFAULT_PAGE_SIZE,
                     currentPageSize: this.DEFAULT_PAGE_SIZE,

--- a/lib/content-services/search/components/search-filter/search-filter.component.ts
+++ b/lib/content-services/search/components/search-filter/search-filter.component.ts
@@ -217,7 +217,7 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
                         if (!responseBucket) {
                             shouldDelete.push(bucket);
                         }
-                        bucket.count = responseBucket ? this.getCountValue(responseBucket) : 0;
+                        bucket.count = this.getCountValue(responseBucket);
                         return bucket;
                     });
                 const hasSelection = this.selectedBuckets
@@ -307,7 +307,7 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
                         if (!responseBucket) {
                             shouldDelete.push(bucket);
                         }
-                        bucket.count = responseBucket ? this.getCountValue(responseBucket) : 0;
+                        bucket.count = this.getCountValue(responseBucket);
                         return bucket;
                     });
                 const hasSelection = this.selectedBuckets

--- a/lib/content-services/search/components/search-filter/search-filter.component.ts
+++ b/lib/content-services/search/components/search-filter/search-filter.component.ts
@@ -149,6 +149,35 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
         }
     }
 
+    resetAllSelectedBuckets() {
+        this.responseFacets.forEach((field) => {
+            if (field && field.buckets) {
+                for (let bucket of field.buckets.items) {
+                    bucket.checked = false;
+                    this.queryBuilder.removeUserFacetBucket(field, bucket);
+                }
+                this.updateSelectedBuckets();
+            }
+        });
+        this.queryBuilder.update();
+    }
+
+    resetAll() {
+        this.resetAllSelectedBuckets();
+        this.responseFacets = null;
+    }
+
+    canResetBuckets() {
+        return this.responseFacets && !this.selectedBuckets.length;
+    }
+
+    resetBuckets() {
+        if (this.canResetBuckets()) {
+            this.responseFacets = null;
+            this.queryBuilder.update();
+        }
+    }
+
     shouldExpand(field: FacetField): boolean {
         return this.facetExpanded[field.type] || this.facetExpanded['default'];
     }

--- a/lib/content-services/search/components/search-filter/search-filter.component.ts
+++ b/lib/content-services/search/components/search-filter/search-filter.component.ts
@@ -195,10 +195,10 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
 
     private parseFacetItems(context: ResultSetContext, configFacetFields: FacetField[], itemType: string) {
         configFacetFields.forEach((field) => {
-            const responseField = this.getApiResponseField(context, itemType, field.label);
+            const responseField = this.findFacet(context, itemType, field.label);
             const responseBuckets = this.getResponseBuckets(responseField, field)
                 .filter(this.getFilterByMinCount(field.mincount));
-            const alreadyExistingField = this.getAlreadyDisplayedField(itemType, field.label);
+            const alreadyExistingField = this.findResponseFacet(itemType, field.label);
 
             if (alreadyExistingField) {
                 const alreadyExistingBuckets = alreadyExistingField.buckets && alreadyExistingField.buckets.items || [];
@@ -250,10 +250,10 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
         const mincountFilter = this.getFilterByMinCount(mincount);
 
         Object.keys(configGroups).forEach((group) => {
-            const responseField = this.getApiResponseField(context, 'query', group);
+            const responseField = this.findFacet(context, 'query', group);
             const responseBuckets = this.getResponseQueryBuckets(responseField, configGroups[group])
                 .filter(mincountFilter);
-            const alreadyExistingField = this.getAlreadyDisplayedField('query', group);
+            const alreadyExistingField = this.findResponseFacet('query', group);
 
             if (alreadyExistingField) {
                 const alreadyExistingBuckets = alreadyExistingField.buckets && alreadyExistingField.buckets.items || [];
@@ -357,11 +357,11 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
         return `${fieldName}:${startLimit}"${start}" TO "${end}"${endLimit}`;
     }
 
-    private getApiResponseField(context: ResultSetContext, itemType: string, fieldLabel: string): GenericFacetResponse {
+    private findFacet(context: ResultSetContext, itemType: string, fieldLabel: string): GenericFacetResponse {
         return (context.facets || []).find((response) => response.type === itemType && response.label === fieldLabel) || {};
     }
 
-    private getAlreadyDisplayedField(itemType: string, fieldLabel: string): FacetField {
+    private findResponseFacet(itemType: string, fieldLabel: string): FacetField {
         return (this.responseFacets || []).find((response) => response.type === itemType && response.label === fieldLabel);
     }
 
@@ -373,7 +373,7 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
                 const responseBucket = ((responseField && responseField.buckets) || []).find((respBucket) => respBucket.label === bucket.label);
 
                 if (!responseBucket) {
-                    shouldDelete.push(bucket);
+                    bucketsToDelete.push(bucket);
                 }
                 bucket.count = this.getCountValue(responseBucket);
                 return bucket;
@@ -382,8 +382,8 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
         const hasSelection = this.selectedBuckets
             .find((selBuckets) => alreadyExistingField.label === selBuckets.field.label && alreadyExistingField.type === selBuckets.field.type);
 
-        if (!hasSelection && shouldDelete.length) {
-            shouldDelete.forEach((bucket) => {
+        if (!hasSelection && bucketsToDelete.length) {
+            bucketsToDelete.forEach((bucket) => {
                 alreadyExistingField.buckets.deleteItem(bucket);
             });
         }

--- a/lib/content-services/search/components/search-filter/search-filter.component.ts
+++ b/lib/content-services/search/components/search-filter/search-filter.component.ts
@@ -324,6 +324,10 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
             || 0;
     }
 
+    getBucketCountDisplay(bucket: FacetFieldBucket): string {
+        return bucket.count === null ? '' : `(${bucket.count})`;
+    }
+
     private getFilterByMinCount(mincountInput: number) {
         return (bucket) => {
             let mincount = mincountInput;

--- a/lib/content-services/search/components/search-filter/search-filter.component.ts
+++ b/lib/content-services/search/components/search-filter/search-filter.component.ts
@@ -49,7 +49,7 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
     facetExpanded = {
         'default': false
     };
-
+    displayResetButton: boolean;
     selectedBuckets: Array<{ field: FacetField, bucket: FacetFieldBucket }> = [];
 
     constructor(public queryBuilder: SearchQueryBuilderService,
@@ -66,6 +66,7 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
         if (queryBuilder.config && queryBuilder.config.facetIntervals) {
             this.facetExpanded['interval'] = queryBuilder.config.facetIntervals.expanded;
         }
+        this.displayResetButton = this.queryBuilder.config && !!this.queryBuilder.config.resetButton;
 
         this.queryBuilder.updated.pipe(
             takeWhile(() => this.isAlive)

--- a/lib/content-services/search/components/search-filter/search-filter.component.ts
+++ b/lib/content-services/search/components/search-filter/search-filter.component.ts
@@ -366,7 +366,7 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
     }
 
     private updateExistingBuckets(responseField, responseBuckets, alreadyExistingField, alreadyExistingBuckets) {
-        const shouldDelete = [];
+        const bucketsToDelete = [];
 
         alreadyExistingBuckets
             .map((bucket) => {

--- a/lib/content-services/search/components/search-filter/search-filter.component.ts
+++ b/lib/content-services/search/components/search-filter/search-filter.component.ts
@@ -173,17 +173,6 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
         this.responseFacets = null;
     }
 
-    canResetBuckets() {
-        return this.responseFacets && !this.selectedBuckets.length;
-    }
-
-    resetBuckets() {
-        if (this.canResetBuckets()) {
-            this.responseFacets = null;
-            this.queryBuilder.update();
-        }
-    }
-
     shouldExpand(field: FacetField): boolean {
         return this.facetExpanded[field.type] || this.facetExpanded['default'];
     }

--- a/lib/content-services/search/components/search-radio/search-radio.component.ts
+++ b/lib/content-services/search/components/search-radio/search-radio.component.ts
@@ -62,9 +62,10 @@ export class SearchRadioComponent implements SearchWidget, OnInit {
             }
         }
 
-        this.setValue(
-            this.getSelectedValue()
-        );
+        const initialValue = this.getSelectedValue();
+        if (initialValue) {
+            this.setValue(initialValue);
+        }
     }
 
     private getSelectedValue(): string {

--- a/lib/content-services/search/components/search-radio/search-radio.component.ts
+++ b/lib/content-services/search/components/search-radio/search-radio.component.ts
@@ -63,7 +63,7 @@ export class SearchRadioComponent implements SearchWidget, OnInit {
         }
 
         const initialValue = this.getSelectedValue();
-        if (initialValue) {
+        if (initialValue !== null) {
             this.setValue(initialValue);
         }
     }

--- a/lib/content-services/search/search-configuration.interface.ts
+++ b/lib/content-services/search/search-configuration.interface.ts
@@ -27,6 +27,7 @@ export interface SearchConfiguration {
     categories: SearchCategory[];
     filterQueries?: FilterQuery[];
     filterWithContains?: boolean;
+    resetButton?: boolean;
     facetQueries?: {
         label?: string;
         pageSize?: number;

--- a/lib/core/app-config/schema.json
+++ b/lib/core/app-config/schema.json
@@ -926,6 +926,9 @@
         "filterWithContains": {
           "type": "boolean"
         },
+        "resetButton": {
+          "type": "boolean"
+        },
         "facetFields": {
           "type": "object",
           "required": [


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-3401
The new facet items received in the response are not added to the search filter component.

**What is the new behaviour?**
When a facet is received in the response and is already displayed, then only its bucket count is updated, otherwise, **the new facet is now added to the displayed items of the search filter component**. 
The already displayed facets are removed when they are no longer received in the response. For better UX, such ‘empty’ facets are kept on the categories while is a selection done by the user. 
Any filtering is applied also to the new facets received from response and any facet selections done by the user will not be lost. 
Two clean up buttons are now displayed to make it easier for the user to remove all selections or reset entire search filters. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
dependent on [[ADF-3496] Grouped facet queries #4209](https://github.com/Alfresco/alfresco-ng2-components/pull/4209)