### PR TITLE
[ADF-4010] fix icon clashes in adf-icon

### DIFF
--- a/demo-shell/src/app/components/icons/icons.component.html
+++ b/demo-shell/src/app/components/icons/icons.component.html
@@ -9,12 +9,12 @@
 <div>
     <div><strong>Markup:</strong></div>
     <pre>
-    &lt;adf-icon value="alarm"&gt;&lt;/adf-icon&gt;</pre>
+    &lt;adf-icon value="folder"&gt;&lt;/adf-icon&gt;</pre>
 </div>
 
 <div>
     <div><strong>Result:</strong></div>
-    <adf-icon value="alarm"></adf-icon>
+    <adf-icon value="folder"></adf-icon>
 </div>
 
 <h2>Named icons</h2>
@@ -50,10 +50,10 @@
 <div>
     <div><strong>Markup:</strong></div>
     <pre>
-    &lt;adf-icon value="image/gif"&gt;&lt;/adf-icon&gt;</pre>
+    &lt;adf-icon value="adf:folder"&gt;&lt;/adf-icon&gt;</pre>
 </div>
 
 <div>
     <div><strong>Result:</strong></div>
-    <adf-icon value="image/gif"></adf-icon>
+    <adf-icon value="adf:folder"></adf-icon>
 </div>

--- a/docs/core/icon.component.md
+++ b/docs/core/icon.component.md
@@ -71,10 +71,11 @@ In the HTML, you can now use the icon as shown below:
 
 ### Thumbnail Service
 
-You can also use icons registered with the [Thumbnail Service](thumbnail.service.md):
+You can also reference the icons registered with the [Thumbnail Service](thumbnail.service.md)
+by utilising the `adf:` namespace.
 
 ```html
-<adf-icon value="image/gif"></adf-icon>
+<adf-icon value="adf:image/gif"></adf-icon>
 ```
 
 ## See also

--- a/lib/core/icon/icon.component.ts
+++ b/lib/core/icon/icon.component.ts
@@ -21,7 +21,6 @@ import {
     ViewEncapsulation,
     ChangeDetectionStrategy
 } from '@angular/core';
-import { ThumbnailService } from '../services/thumbnail.service';
 import { ThemePalette } from '@angular/material';
 
 @Component({
@@ -47,14 +46,10 @@ export class IconComponent {
     @Input()
     set value(value: string) {
         this._value = value || 'settings';
-        this._isCustom =
-            this._value.includes(':') ||
-            this.thumbnailService.mimeTypeIcons[value];
+        this._isCustom = this._value.includes(':');
     }
 
     get isCustom(): boolean {
         return this._isCustom;
     }
-
-    constructor(private thumbnailService: ThumbnailService) {}
 }

--- a/lib/core/icon/icon.module.ts
+++ b/lib/core/icon/icon.module.ts
@@ -19,6 +19,7 @@ import { NgModule } from '@angular/core';
 import { IconComponent } from './icon.component';
 import { MatIconModule } from '@angular/material';
 import { CommonModule } from '@angular/common';
+import { ThumbnailService } from '../services/thumbnail.service';
 
 @NgModule({
     imports: [
@@ -30,6 +31,9 @@ import { CommonModule } from '@angular/common';
     ],
     exports: [
         IconComponent
+    ],
+    providers: [
+        ThumbnailService
     ]
 })
 export class IconModule {}

--- a/lib/core/services/thumbnail.service.ts
+++ b/lib/core/services/thumbnail.service.ts
@@ -157,7 +157,10 @@ export class ThumbnailService {
 
     constructor(public contentService: ContentService, matIconRegistry: MatIconRegistry, sanitizer: DomSanitizer) {
         Object.keys(this.mimeTypeIcons).forEach((key) => {
-            matIconRegistry.addSvgIcon(key, sanitizer.bypassSecurityTrustResourceUrl(this.mimeTypeIcons[key]));
+            const url = sanitizer.bypassSecurityTrustResourceUrl(this.mimeTypeIcons[key]);
+
+            matIconRegistry.addSvgIcon(key, url);
+            matIconRegistry.addSvgIconInNamespace('adf', key, url);
         });
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Some icons from the Thumbnail service overwrite the Material icons when used in the <adf-icon> component.

**What is the new behaviour?**

- Use `adf:` namespace for the ADF components registered by the Thumbnail service.
- Update demo shell to show two `folder` icons from Material and ADF namespace

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-4010