### PR TITLE
[ADF-3938] withCredentials TRUE the authguard should be skipped

### DIFF
--- a/lib/content-services/content-node-selector/content-node-selector-panel.component.ts
+++ b/lib/content-services/content-node-selector/content-node-selector-panel.component.ts
@@ -195,7 +195,7 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
 
     private isExcludedSiteContent(row: ShareDataRow): boolean {
         const entry = row.node.entry;
-        if (this._excludeSiteContent.length &&
+        if (this._excludeSiteContent && this._excludeSiteContent.length &&
             entry &&
             entry.properties &&
             entry.properties['st:componentId']) {
@@ -368,7 +368,7 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
      * @param entry
      */
     private attemptNodeSelection(entry: Node): void {
-        if (this.isSelectionValid(entry)) {
+        if (entry && this.isSelectionValid(entry)) {
             this.chosenNode = entry;
         } else {
             this.resetChosenNode();

--- a/lib/core/services/auth-guard-bpm.service.spec.ts
+++ b/lib/core/services/auth-guard-bpm.service.spec.ts
@@ -51,6 +51,16 @@ describe('AuthGuardService BPM', () => {
         expect(authGuard.canActivate(null, router)).toBeTruthy();
     }));
 
+    it('if the alfresco js api is configured with withCredentials true should canActivate be true', async(() => {
+        spyOn(authService, 'isBpmLoggedIn').and.returnValue(true);
+        appConfigService.config.auth = {};
+        appConfigService.config.auth.withCredentials = true;
+
+        const router: RouterStateSnapshot = <RouterStateSnapshot>  {url : 'some-url'};
+
+        expect(authGuard.canActivate(null, router)).toBeTruthy();
+    }));
+
     it('if the alfresco js api is NOT logged in should canActivate be false', async(() => {
         spyOn(authService, 'isBpmLoggedIn').and.returnValue(false);
         spyOn(routerService, 'navigate').and.stub();

--- a/lib/core/services/auth-guard-bpm.service.spec.ts
+++ b/lib/core/services/auth-guard-bpm.service.spec.ts
@@ -42,6 +42,7 @@ describe('AuthGuardService BPM', () => {
         appConfigService = TestBed.get(AppConfigService);
 
         appConfigService.config.providers = 'BPM';
+        appConfigService.config.auth = {};
     });
 
     it('if the alfresco js api is logged in should canActivate be true', async(() => {
@@ -53,7 +54,6 @@ describe('AuthGuardService BPM', () => {
 
     it('if the alfresco js api is configured with withCredentials true should canActivate be true', async(() => {
         spyOn(authService, 'isBpmLoggedIn').and.returnValue(true);
-        appConfigService.config.auth = {};
         appConfigService.config.auth.withCredentials = true;
 
         const router: RouterStateSnapshot = <RouterStateSnapshot>  {url : 'some-url'};

--- a/lib/core/services/auth-guard-bpm.service.ts
+++ b/lib/core/services/auth-guard-bpm.service.ts
@@ -38,7 +38,7 @@ export class AuthGuardBpm implements CanActivate, CanActivateChild {
     }
 
     checkLogin(redirectUrl: string): boolean {
-        let withCredentialsMode = this.appConfigService.get<boolean>('auth.withCredentials', false)
+        let withCredentialsMode = this.appConfigService.get<boolean>('auth.withCredentials', false);
 
         if (this.authService.isBpmLoggedIn() || withCredentialsMode) {
             return true;

--- a/lib/core/services/auth-guard-bpm.service.ts
+++ b/lib/core/services/auth-guard-bpm.service.ts
@@ -25,7 +25,9 @@ import { OauthConfigModel } from '../models/oauth-config.model';
     providedIn: 'root'
 })
 export class AuthGuardBpm implements CanActivate, CanActivateChild {
-    constructor(private authService: AuthenticationService, private router: Router, private appConfig: AppConfigService) {}
+
+    constructor(private authService: AuthenticationService, private router: Router, private appConfigService: AppConfigService) {
+    }
 
     canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
         return this.checkLogin(state.url);
@@ -36,7 +38,9 @@ export class AuthGuardBpm implements CanActivate, CanActivateChild {
     }
 
     checkLogin(redirectUrl: string): boolean {
-        if (this.authService.isBpmLoggedIn()) {
+        let withCredentialsMode = this.appConfigService.get<boolean>('auth.withCredentials', false)
+
+        if (this.authService.isBpmLoggedIn() || withCredentialsMode) {
             return true;
         }
 
@@ -50,11 +54,11 @@ export class AuthGuardBpm implements CanActivate, CanActivateChild {
     }
 
     isOAuthWithoutSilentLogin() {
-        let oauth: OauthConfigModel = this.appConfig.get<OauthConfigModel>(AppConfigValues.OAUTHCONFIG, null);
+        let oauth: OauthConfigModel = this.appConfigService.get<OauthConfigModel>(AppConfigValues.OAUTHCONFIG, null);
         return this.authService.isOauth() && oauth.silentLogin === false;
     }
 
     private getRouteDestinationForLogin(): string {
-        return this.appConfig && this.appConfig.get<string>(AppConfigValues.LOGIN_ROUTE) ? this.appConfig.get<string>(AppConfigValues.LOGIN_ROUTE) : 'login';
+        return this.appConfigService && this.appConfigService.get<string>(AppConfigValues.LOGIN_ROUTE) ? this.appConfigService.get<string>(AppConfigValues.LOGIN_ROUTE) : 'login';
     }
 }

--- a/lib/core/services/auth-guard-ecm.service.spec.ts
+++ b/lib/core/services/auth-guard-ecm.service.spec.ts
@@ -42,6 +42,7 @@ describe('AuthGuardService ECM', () => {
         appConfigService = TestBed.get(AppConfigService);
 
         appConfigService.config.providers = 'ECM';
+        appConfigService.config.auth = {};
     });
 
     it('if the alfresco js api is logged in should canActivate be true', async(() => {
@@ -53,7 +54,6 @@ describe('AuthGuardService ECM', () => {
 
     it('if the alfresco js api is configured with withCredentials true should canActivate be true', async(() => {
         spyOn(authService, 'isBpmLoggedIn').and.returnValue(true);
-        appConfigService.config.auth = {};
         appConfigService.config.auth.withCredentials = true;
 
         const router: RouterStateSnapshot = <RouterStateSnapshot>  {url : 'some-url'};

--- a/lib/core/services/auth-guard-ecm.service.spec.ts
+++ b/lib/core/services/auth-guard-ecm.service.spec.ts
@@ -51,6 +51,16 @@ describe('AuthGuardService ECM', () => {
         expect(authGuard.canActivate(null, router)).toBeTruthy();
     }));
 
+    it('if the alfresco js api is configured with withCredentials true should canActivate be true', async(() => {
+        spyOn(authService, 'isBpmLoggedIn').and.returnValue(true);
+        appConfigService.config.auth = {};
+        appConfigService.config.auth.withCredentials = true;
+
+        const router: RouterStateSnapshot = <RouterStateSnapshot>  {url : 'some-url'};
+
+        expect(authGuard.canActivate(null, router)).toBeTruthy();
+    }));
+
     it('if the alfresco js api is NOT logged in should canActivate be false', async(() => {
         spyOn(authService, 'isEcmLoggedIn').and.returnValue(false);
         spyOn(routerService, 'navigate').and.stub();

--- a/lib/core/services/auth-guard-ecm.service.ts
+++ b/lib/core/services/auth-guard-ecm.service.ts
@@ -42,7 +42,7 @@ export class AuthGuardEcm implements CanActivate {
     }
 
     checkLogin(redirectUrl: string): boolean {
-        let withCredentialsMode = this.appConfigService.get<boolean>('auth.withCredentials', false)
+        let withCredentialsMode = this.appConfigService.get<boolean>('auth.withCredentials', false);
 
         if (this.authService.isEcmLoggedIn() || withCredentialsMode) {
             return true;

--- a/lib/core/services/auth-guard-ecm.service.ts
+++ b/lib/core/services/auth-guard-ecm.service.ts
@@ -27,9 +27,10 @@ import { OauthConfigModel } from '../models/oauth-config.model';
     providedIn: 'root'
 })
 export class AuthGuardEcm implements CanActivate {
+
     constructor(private authService: AuthenticationService,
                 private router: Router,
-                private appConfig: AppConfigService) {
+                private appConfigService: AppConfigService) {
     }
 
     canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
@@ -41,7 +42,9 @@ export class AuthGuardEcm implements CanActivate {
     }
 
     checkLogin(redirectUrl: string): boolean {
-        if (this.authService.isEcmLoggedIn()) {
+        let withCredentialsMode = this.appConfigService.get<boolean>('auth.withCredentials', false)
+
+        if (this.authService.isEcmLoggedIn() || withCredentialsMode) {
             return true;
         }
 
@@ -55,13 +58,13 @@ export class AuthGuardEcm implements CanActivate {
     }
 
     isOAuthWithoutSilentLogin() {
-        let oauth: OauthConfigModel = this.appConfig.get<OauthConfigModel>(AppConfigValues.OAUTHCONFIG, null);
+        let oauth: OauthConfigModel = this.appConfigService.get<OauthConfigModel>(AppConfigValues.OAUTHCONFIG, null);
         return this.authService.isOauth() && oauth.silentLogin === false;
     }
 
     private getRouteDestinationForLogin(): string {
-        return this.appConfig &&
-            this.appConfig.get<string>(AppConfigValues.LOGIN_ROUTE) ?
-            this.appConfig.get<string>(AppConfigValues.LOGIN_ROUTE) : 'login';
+        return this.appConfigService &&
+        this.appConfigService.get<string>(AppConfigValues.LOGIN_ROUTE) ?
+            this.appConfigService.get<string>(AppConfigValues.LOGIN_ROUTE) : 'login';
     }
 }

--- a/lib/core/services/auth-guard.service.spec.ts
+++ b/lib/core/services/auth-guard.service.spec.ts
@@ -16,7 +16,7 @@
  */
 
 import { async, TestBed } from '@angular/core/testing';
-import { Router } from '@angular/router';
+import { Router, RouterStateSnapshot } from '@angular/router';
 import { AppConfigService } from '../app-config/app-config.service';
 import { AuthGuard } from './auth-guard.service';
 import { AuthenticationService } from './authentication.service';
@@ -26,8 +26,8 @@ import { CoreTestingModule } from '../testing/core.testing.module';
 describe('AuthGuardService', () => {
     let state;
     let authService: AuthenticationService;
-    let router: Router;
-    let service: AuthGuard;
+    let routerService: Router;
+    let authGuard: AuthGuard;
     let appConfigService: AppConfigService;
 
     setupTestBed({
@@ -38,80 +38,91 @@ describe('AuthGuardService', () => {
         localStorage.clear();
         state = { url: '' };
         authService = TestBed.get(AuthenticationService);
-        router = TestBed.get(Router);
-        service = TestBed.get(AuthGuard);
+        routerService = TestBed.get(Router);
+        authGuard = TestBed.get(AuthGuard);
         appConfigService = TestBed.get(AppConfigService);
+
+        appConfigService.config.auth = {};
     });
 
     it('if the alfresco js api is logged in should canActivate be true', async(() => {
-        spyOn(router, 'navigate');
+        spyOn(routerService, 'navigate');
         spyOn(authService, 'isLoggedIn').and.returnValue(true);
 
-        expect(service.canActivate(null, state)).toBeTruthy();
-        expect(router.navigate).not.toHaveBeenCalled();
+        expect(authGuard.canActivate(null, state)).toBeTruthy();
+        expect(routerService.navigate).not.toHaveBeenCalled();
     }));
 
     it('if the alfresco js api is NOT logged in should canActivate be false', async(() => {
         state.url = 'some-url';
-        spyOn(router, 'navigate');
+        spyOn(routerService, 'navigate');
         spyOn(authService, 'isLoggedIn').and.returnValue(false);
 
-        expect(service.canActivate(null, state)).toBeFalsy();
-        expect(router.navigate).toHaveBeenCalled();
+        expect(authGuard.canActivate(null, state)).toBeFalsy();
+        expect(routerService.navigate).toHaveBeenCalled();
+    }));
+
+    it('if the alfresco js api is configured with withCredentials true should canActivate be true', async(() => {
+        spyOn(authService, 'isBpmLoggedIn').and.returnValue(true);
+        appConfigService.config.auth.withCredentials = true;
+
+        const router: RouterStateSnapshot = <RouterStateSnapshot>  {url : 'some-url'};
+
+        expect(authGuard.canActivate(null, router)).toBeTruthy();
     }));
 
     it('should set redirect url', async(() => {
         state.url = 'some-url';
         appConfigService.config.loginRoute = 'login';
 
-        spyOn(router, 'navigate');
+        spyOn(routerService, 'navigate');
         spyOn(authService, 'setRedirect');
 
-        service.canActivate(null, state);
+        authGuard.canActivate(null, state);
 
         expect(authService.setRedirect).toHaveBeenCalledWith({
             provider: 'ALL', url: 'some-url'
         });
-        expect(router.navigate).toHaveBeenCalledWith(['/login']);
+        expect(routerService.navigate).toHaveBeenCalledWith(['/login']);
     }));
 
     it('should set redirect url with query params', async(() => {
         state.url = 'some-url;q=query';
         appConfigService.config.loginRoute = 'login';
 
-        spyOn(router, 'navigate');
+        spyOn(routerService, 'navigate');
         spyOn(authService, 'setRedirect');
 
-        service.canActivate(null, state);
+        authGuard.canActivate(null, state);
 
         expect(authService.setRedirect).toHaveBeenCalledWith({
             provider: 'ALL', url: 'some-url;q=query'
         });
-        expect(router.navigate).toHaveBeenCalledWith(['/login']);
+        expect(routerService.navigate).toHaveBeenCalledWith(['/login']);
     }));
 
     it('should get redirect url from config if there is one configured', async(() => {
         state.url = 'some-url';
         appConfigService.config.loginRoute = 'fakeLoginRoute';
 
-        spyOn(router, 'navigate');
+        spyOn(routerService, 'navigate');
         spyOn(authService, 'setRedirect');
 
-        service.canActivate(null, state);
+        authGuard.canActivate(null, state);
 
         expect(authService.setRedirect).toHaveBeenCalledWith({
             provider: 'ALL', url: 'some-url'
         });
-        expect(router.navigate).toHaveBeenCalledWith(['/fakeLoginRoute']);
+        expect(routerService.navigate).toHaveBeenCalledWith(['/fakeLoginRoute']);
     }));
 
     it('should pass actual redirect when no state segments exists', async(() => {
         state.url = '/';
 
-        spyOn(router, 'navigate');
+        spyOn(routerService, 'navigate');
         spyOn(authService, 'setRedirect');
 
-        service.canActivate(null, state);
+        authGuard.canActivate(null, state);
 
         expect(authService.setRedirect).toHaveBeenCalledWith({
             provider: 'ALL', url: '/'

--- a/lib/core/services/auth-guard.service.ts
+++ b/lib/core/services/auth-guard.service.ts
@@ -31,7 +31,7 @@ import { OauthConfigModel } from '../models/oauth-config.model';
 export class AuthGuard implements CanActivate, CanActivateChild {
     constructor(private authService: AuthenticationService,
                 private router: Router,
-                private appConfig: AppConfigService) {
+                private appConfigService: AppConfigService) {
     }
 
     canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> | Promise<boolean> | boolean {
@@ -44,7 +44,9 @@ export class AuthGuard implements CanActivate, CanActivateChild {
     }
 
     checkLogin(redirectUrl: string): boolean {
-        if (this.authService.isLoggedIn()) {
+        let withCredentialsMode = this.appConfigService.get<boolean>('auth.withCredentials', false);
+
+        if (this.authService.isLoggedIn() || withCredentialsMode) {
             return true;
         }
         if (!this.authService.isOauth() || this.isOAuthWithoutSilentLogin()) {
@@ -58,13 +60,13 @@ export class AuthGuard implements CanActivate, CanActivateChild {
     }
 
     isOAuthWithoutSilentLogin() {
-        let oauth: OauthConfigModel = this.appConfig.get<OauthConfigModel>(AppConfigValues.OAUTHCONFIG, null);
+        let oauth: OauthConfigModel = this.appConfigService.get<OauthConfigModel>(AppConfigValues.OAUTHCONFIG, null);
         return this.authService.isOauth() && oauth.silentLogin === false;
     }
 
     public getRouteDestinationForLogin(): string {
-        return this.appConfig &&
-        this.appConfig.get<string>(AppConfigValues.LOGIN_ROUTE) ?
-            this.appConfig.get<string>(AppConfigValues.LOGIN_ROUTE) : 'login';
+        return this.appConfigService &&
+        this.appConfigService.get<string>(AppConfigValues.LOGIN_ROUTE) ?
+            this.appConfigService.get<string>(AppConfigValues.LOGIN_ROUTE) : 'login';
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**
When you use a Kerberos env WithCredentials TRUE should disable the authguard. 
An alternative could be to not add at all the guard


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
