### PR TITLE
[ADF-4013] Fixed anchor generation in ToC doc tool

### DIFF
--- a/tools/doc/doctool.config.json
+++ b/tools/doc/doctool.config.json
@@ -21,7 +21,7 @@
             "toc"
         ],
         "dev": [
-            "fileChecker"
+            "toc"
         ]
     },
     "statusIcons": {

--- a/tools/doc/tools/toc.js
+++ b/tools/doc/tools/toc.js
@@ -135,7 +135,11 @@ function makeToc(tree) {
             context.headings.push({
                 "level": heading.item.depth - 2,
                 "title": linkTitle,
-                "anchor": "#" + linkTitle.toLowerCase().replace(/ /g, "-").replace(/[:;@\.,'"`$\(\)\/]/g ,"")
+                //"anchor": "#" + linkTitle.toLowerCase().replace(/ /g, "-").replace(/[:;@\.,'"`$\(\)\/]/g ,"")
+                "anchor": "#" + linkTitle.toLowerCase()
+                                .replace(/\W/g ,"-")
+                                .replace(/-+/g, '-')
+                                .replace(/-+$/, '')
             })
         };
     });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [x] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Table of contents tool for the docs generates an incorrect anchor for the link when certain characters are in the corresponding heading text.

**What is the new behaviour?**

Tool is updated to filter out the characters correctly. The file where the error was detected (Login component page) appears to have been fixed already.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
