### PR TITLE
display each test duration for e2e runs

### DIFF
--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -212,7 +212,15 @@ exports.config = {
 
         browser.manage().window().setSize(width, height);
 
-        jasmine.getEnv().addReporter(new SpecReporter({spec: {displayStacktrace: true}}));
+        jasmine.getEnv().addReporter(
+            new SpecReporter({
+                spec: {
+                    displayStacktrace: true,
+                    displayDuration: true
+                }
+            })
+        );
+
         let generatedSuiteName = Math.random().toString(36).substr(2, 5);
         let junitReporter = new jasmineReporters.JUnitXmlReporter({
             consolidateAll: true,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

Enable time information for each e2e tests, should help to identify/address the slowest tests

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
