### PR TITLE
[ADF-4016] Added page with version compatibility table

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,11 +10,6 @@ section discusses particular techniques in depth. The other sections are referen
 libraries. Click the name of an item to see its documentation or click the source link to see
 its main source file. Note that ADF is developed continuously, so the source files for some items may be listed here before their documentation is available.
 
-See the [Version Index](versionIndex.md) for a list of components ordered by
-the ADF version where they were introduced. You can see the full details of each release
-in the [Release notes](release-notes/README.md) section. The [roadmap](roadmap.md)
-contains a preview of features we hope to release in future versions of ADF.
-
 Components are sometimes marked with an icon to show their status. No icon indicates
 that the component is complete and suitable for normal use. The other status levels are:
 
@@ -27,6 +22,18 @@ that the component is complete and suitable for normal use. The other status lev
 
 There is also a set of ADF tutorials that describe how to accomplish tasks step-by-step.
 See the [Tutorials index](tutorials/README.md) for the full list.
+
+A few other pages of information are also available:
+
+-   The [Version Index](versionIndex.md) has a list of components ordered by
+    the ADF version where they were introduced.
+-   The [Release notes](release-notes/README.md) section has details of all
+    the features introduced and bugs fixed with each release.
+-   The [Version compatibility](compatibility.md) page shows which versions
+    of Alfresco's backend servies (ACS and APS) are compatible with each released
+    version of ADF.
+-   The [Roadmap](roadmap.md)
+    contains a preview of features we hope to release in future versions of ADF.
 
 ## Contents
 

--- a/docs/abn-tree.yml
+++ b/docs/abn-tree.yml
@@ -22,4 +22,5 @@
 - insights: 'Insights API'
 - roadmap.md: 'Roadmap'
 - versionIndex.md: 'Version index'
+- compatibility.md: 'Version compatibility'
 - release-notes: 'Release notes'

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,19 @@
+---
+Title: Version compatibility
+---
+
+# Version compatibility
+
+The table below shows the versions of Alfresco's backend services that
+have been tested with recent versions of ADF. Note that *smoke testing*
+means that the version should be safe to use (ie, it won't "catch fire")
+but it is not guaranteed to be free of minor issues or missing features.
+
+You can find further information about released versions of ADF in the
+[version index](versionIndex.md) and the [release notes](release-notes/README.md).
+
+| ADF version | ACS versions | APS versions |
+| -- | -- | -- |
+| [2.6](versionIndex.md#v260) | **Full test:** v6.0, v5.2.4 <br/> **Smoke test:** v5.3.2 | **Full test:** v1.9.0 <br/>**Smoke test:** v1.8.1, v1.7.0, v1.6.4  |
+| [2.5](versionIndex.md#v250) | **Full test:** v5.2.3 | **Full test:** v1.6.4 |
+| [2.4](versionIndex.md#v240) | **Full test:** v5.2.3 <br/> **Smoke test:** v6.0.0 | **Full test:** v1.8.1 <br/> **Smoke test:** v1.9.0, v1.8.0, v1.7.0, v1.6.4 |

--- a/docs/versionIndex.md
+++ b/docs/versionIndex.md
@@ -6,7 +6,9 @@ Title: Version index
 
 Below are the details of all released versions of ADF since general
 availability (v2.0.0). See the [main index page](README.md) for a list
-of components organized by ADF libraries.
+of components organized by ADF libraries. See the
+[version compatibility page](compatibility.md) for full details of which
+backend services have been tested with each released version of ADF.
 
 ## Versions
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe:

**What is the new behaviour?**

Added version compatibility page. The info for v2.5 was missing from the original RtoR document but I've used the info from the version index for the time being.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
