### PR TITLE
[ADF-4039] Copy/Move of the files/folders is not working when the root folder of the user is chosen.

### DIFF
--- a/lib/content-services/document-list/components/document-list.component.spec.ts
+++ b/lib/content-services/document-list/components/document-list.component.spec.ts
@@ -941,7 +941,10 @@ describe('DocumentList', () => {
     it('should load folder by ID on init', () => {
         spyOn(documentList, 'loadFolder').and.returnValue(Promise.resolve());
 
-        documentList.ngOnChanges({ currentFolderId: new SimpleChange(null, '1d26e465-dea3-42f3-b415-faa8364b9692', true) });
+        documentList.currentFolderId = '1d26e465-dea3-42f3-b415-faa8364b9692';
+
+        fixture.detectChanges();
+
         expect(documentList.loadFolder).toHaveBeenCalled();
     });
 
@@ -1261,12 +1264,12 @@ describe('DocumentList', () => {
     });
 
     it('should add includeFields in the server request when present', () => {
-        fixture.detectChanges();
-        documentList.currentFolderId = 'fake-id';
-        documentList.includeFields = ['test-include'];
         spyOn(documentListService, 'getFolder').and.callThrough();
 
-        documentList.ngOnChanges({ currentFolderId: new SimpleChange(null, '-root-', false) });
+        documentList.includeFields = ['test-include'];
+        documentList.currentFolderId = 'fake-id';
+
+        fixture.detectChanges();
 
         expect(documentListService.getFolder).toHaveBeenCalledWith(null, {
             where: undefined,
@@ -1277,13 +1280,13 @@ describe('DocumentList', () => {
     });
 
     it('should add where in the server request when present', () => {
-        fixture.detectChanges();
-        documentList.currentFolderId = 'fake-id';
-        documentList.includeFields = ['test-include'];
-        documentList.where = '(isFolder=true)';
         spyOn(documentListService, 'getFolder').and.callThrough();
 
-        documentList.ngOnChanges({ currentFolderId: new SimpleChange(null, '-root-', false) });
+        documentList.includeFields = ['test-include'];
+        documentList.where = '(isFolder=true)';
+        documentList.currentFolderId = 'fake-id';
+
+        fixture.detectChanges();
 
         expect(documentListService.getFolder).toHaveBeenCalledWith(null, {
             where: '(isFolder=true)',

--- a/lib/content-services/document-list/components/document-list.component.ts
+++ b/lib/content-services/document-list/components/document-list.component.ts
@@ -56,6 +56,7 @@ import { NodeEntityEvent, NodeEntryEvent } from './node.event';
 import { CustomResourcesService } from './../services/custom-resources.service';
 import { NavigableComponentInterface } from '../../breadcrumb/navigable-component.interface';
 import { RowFilter } from '../data/row-filter.model';
+import { Observable } from 'rxjs/index';
 
 @Component({
     selector: 'adf-document-list',
@@ -624,19 +625,24 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
                 where: this.where
             }, this.includeFields)
                 .subscribe((nodePaging: NodePaging) => {
-                    this.onPageLoaded(nodePaging);
-                    this.getSourceNodeWithPath(nodeId);
+                    this.getSourceNodeWithPath(nodeId).subscribe((nodeEntry: NodeEntry) => {
+                        this.onPageLoaded(nodePaging);
+                    });
                 }, (err) => {
                     this.handleError(err);
                 });
         }
     }
 
-    getSourceNodeWithPath(nodeId: string) {
-        this.documentListService.getFolderNode(nodeId, this.includeFields).subscribe((nodeEntry: NodeEntry) => {
+    getSourceNodeWithPath(nodeId: string): Observable<NodeEntry> {
+        let getSourceObservable = this.documentListService.getFolderNode(nodeId, this.includeFields);
+
+        getSourceObservable.subscribe((nodeEntry: NodeEntry) => {
             this.folderNode = nodeEntry.entry;
             this.$folderNode.next(this.folderNode);
         });
+
+        return getSourceObservable;
     }
 
     resetSelection() {

--- a/lib/core/pagination/infinite-pagination.component.spec.ts
+++ b/lib/core/pagination/infinite-pagination.component.spec.ts
@@ -25,6 +25,7 @@ import { setupTestBed } from '../testing/setupTestBed';
 import { CoreTestingModule } from '../testing/core.testing.module';
 import { Component } from '@angular/core';
 import { PaginationModel } from '../models/pagination.model';
+import { RequestPaginationModel } from '../models/request-pagination.model';
 
 @Component({
     template: ``
@@ -152,7 +153,7 @@ describe('InfinitePaginationComponent', () => {
             expect(loadingSpinner).toBeNull();
         });
 
-        it('should trigger the loadMore event with the proper pagination object', (done) => {
+        it('should trigger the loadMore event with skipcount 0 to reload all the elements', (done) => {
             pagination = { maxItems: 444, skipCount: 25, totalItems: 55, hasMoreItems: true };
 
             component.target.pagination.next(pagination);
@@ -162,7 +163,25 @@ describe('InfinitePaginationComponent', () => {
             fixture.detectChanges();
 
             component.loadMore.subscribe((newPagination: Pagination) => {
-                expect(newPagination.skipCount).toBe(5);
+                expect(newPagination.skipCount).toBe(0);
+                done();
+            });
+
+            let loadMoreButton = fixture.debugElement.query(By.css('[data-automation-id="adf-infinite-pagination-button"]'));
+            loadMoreButton.triggerEventHandler('click', {});
+        });
+
+        it('should trigger the loadMore event with merge false to reload all the elements', (done) => {
+            pagination = { maxItems: 444, skipCount: 25, totalItems: 55, hasMoreItems: true };
+
+            component.target.pagination.next(pagination);
+
+            component.isLoading = false;
+            component.pageSize = 5;
+            fixture.detectChanges();
+
+            component.loadMore.subscribe((newPagination: RequestPaginationModel) => {
+                expect(newPagination.merge).toBe(false);
                 done();
             });
 
@@ -197,10 +216,10 @@ describe('InfinitePaginationComponent', () => {
             component.onLoadMore();
 
             expect(spyTarget).toHaveBeenCalledWith({
-                skipCount: 25,
+                skipCount: 0,
                 maxItems: 25,
                 hasMoreItems: false,
-                merge: true
+                merge: false
             });
         });
 
@@ -213,9 +232,9 @@ describe('InfinitePaginationComponent', () => {
 
             expect(spyTarget).toHaveBeenCalledWith({
                 maxItems: 7,
-                skipCount: 7,
+                skipCount: 0,
                 hasMoreItems: false,
-                merge: true
+                merge: false
             });
         });
 

--- a/lib/core/pagination/infinite-pagination.component.spec.ts
+++ b/lib/core/pagination/infinite-pagination.component.spec.ts
@@ -217,7 +217,7 @@ describe('InfinitePaginationComponent', () => {
 
             expect(spyTarget).toHaveBeenCalledWith({
                 skipCount: 0,
-                maxItems: 25,
+                maxItems: 50,
                 hasMoreItems: false,
                 merge: false
             });
@@ -231,7 +231,7 @@ describe('InfinitePaginationComponent', () => {
             component.onLoadMore();
 
             expect(spyTarget).toHaveBeenCalledWith({
-                maxItems: 7,
+                maxItems: 14,
                 skipCount: 0,
                 hasMoreItems: false,
                 merge: false

--- a/lib/core/pagination/infinite-pagination.component.ts
+++ b/lib/core/pagination/infinite-pagination.component.ts
@@ -84,7 +84,7 @@ export class InfinitePaginationComponent implements OnInit, OnDestroy, Paginatio
 
         this.userPreferencesService.select(UserPreferenceValues.PaginationSize).subscribe((pagSize) => {
             this.pageSize = this.pageSize || pagSize;
-            this.maxItems = this.pageSize;
+            this.requestPaginationModel.maxItems = this.pageSize;
         });
     }
 

--- a/lib/core/pagination/infinite-pagination.component.ts
+++ b/lib/core/pagination/infinite-pagination.component.ts
@@ -90,7 +90,12 @@ export class InfinitePaginationComponent implements OnInit, OnDestroy, Paginatio
     onLoadMore() {
         this.requestPaginationModel.skipCount = 0;
         this.requestPaginationModel.merge = false;
-        this.requestPaginationModel.maxItems += this.pageSize;
+
+        if (!this.requestPaginationModel.maxItems) {
+            this.requestPaginationModel.maxItems = this.pageSize;
+        } else {
+            this.requestPaginationModel.maxItems += this.pageSize;
+        }
 
         this.loadMore.next(this.requestPaginationModel);
 

--- a/lib/core/pagination/infinite-pagination.component.ts
+++ b/lib/core/pagination/infinite-pagination.component.ts
@@ -84,6 +84,7 @@ export class InfinitePaginationComponent implements OnInit, OnDestroy, Paginatio
 
         this.userPreferencesService.select(UserPreferenceValues.PaginationSize).subscribe((pagSize) => {
             this.pageSize = this.pageSize || pagSize;
+            this.maxItems = this.pageSize;
         });
     }
 
@@ -91,11 +92,7 @@ export class InfinitePaginationComponent implements OnInit, OnDestroy, Paginatio
         this.requestPaginationModel.skipCount = 0;
         this.requestPaginationModel.merge = false;
 
-        if (!this.requestPaginationModel.maxItems) {
-            this.requestPaginationModel.maxItems = this.pageSize;
-        } else {
-            this.requestPaginationModel.maxItems += this.pageSize;
-        }
+        this.requestPaginationModel.maxItems += this.pageSize;
 
         this.loadMore.next(this.requestPaginationModel);
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [X] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


Steps to reproduce the issue:

Login as your own user.
Create 2 Folders, Folder1 and Folder2.
Upload 2 files, fileA and fileB under Folder1, fileC and fileD under Folder2.
Navigate to fileC and click on 'Move' from the Actions Menu.
Move dialog is displayed.(Currently, the 'Move' icon is disabled by default, unless the user chooses a folder, unlike the behaviour on adfmaster)
Navigate to the root folder of the user and click on 'Move'.
The user gets the 'Move successful' message.
Current behaviour:
The user gets the 'Move successful' message but the chosen file hasn't moved.

Expected behavior:
The chosen file should be moved to the target folder chosen.

 

PS: The same behaviour has been noticed for the 'Copy' action as well. When user navigates to the root folder and clicks on 'Copy', the file is not copied and the following message is displayed : 'This name is already in use, try a different name'.

 

Please note, there is a work around for the above, if the user specifically chooses the Root folder, then the Copy and Move action are successful.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-4039