### PR TITLE
[ADF-4042] fix reset pagination issue when enter in a folder

### DIFF
--- a/lib/content-services/content-node-selector/content-node-selector-panel.component.spec.ts
+++ b/lib/content-services/content-node-selector/content-node-selector-panel.component.spec.ts
@@ -742,17 +742,21 @@ describe('ContentNodeSelectorComponent', () => {
                 });
 
                 it('button callback should load the next batch of folder results when there is no searchTerm', () => {
-                    const skipCount = 5;
-
                     component.searchTerm = '';
                     fixture.detectChanges();
 
-                    component.getNextPageOfSearch({ skipCount });
+                    component.getNextPageOfSearch({
+                        hasMoreItems: false,
+                        skipCount: 10,
+                        maxItems: 45,
+                        totalItems: 0
+                    });
+
                     fixture.detectChanges();
                     expect(component.searchTerm).toBe('');
 
                     expect(component.infiniteScroll).toBeTruthy();
-                    expect(component.skipCount).toBe(skipCount);
+                    expect(component.pagination.maxItems).toBe(45);
                     expect(searchSpy).not.toHaveBeenCalled();
                 });
 

--- a/lib/content-services/document-list/components/document-list.component.spec.ts
+++ b/lib/content-services/document-list/components/document-list.component.spec.ts
@@ -1295,4 +1295,24 @@ describe('DocumentList', () => {
             rootFolderId: 'fake-id'
         }, ['test-include']);
     });
+
+    it('should reset the pagination when enter in a new folder', () => {
+        let folder = new FolderNode();
+        documentList.navigationMode = DocumentListComponent.SINGLE_CLICK_NAVIGATION;
+        documentList.updatePagination({
+            maxItems: 10,
+            skipCount: 10
+        });
+
+        spyOn(documentListService, 'getFolder').and.callThrough();
+
+        documentList.onNodeClick(folder);
+
+        expect(documentListService.getFolder).toHaveBeenCalledWith(null, {
+            maxItems: 25,
+            skipCount: 0,
+            rootFolderId: 'folder-id',
+            where: undefined
+        }, undefined);
+    });
 });

--- a/lib/content-services/document-list/components/document-list.component.ts
+++ b/lib/content-services/document-list/components/document-list.component.ts
@@ -301,8 +301,10 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
                 private thumbnailService: ThumbnailService,
                 private alfrescoApiService: AlfrescoApiService) {
 
+        this.maxItems = this.maxItems ? this.maxItems : this.preferences.paginationSize;
+
         this._pagination = <PaginationModel> {
-            maxItems: this.maxItems || this.preferences.paginationSize,
+            maxItems: this.maxItems,
             skipCount: 0,
             totalItems: 0,
             hasMoreItems: false
@@ -834,7 +836,8 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
     }
 
     private resetNewFolderPagination() {
-        this.pagination.value.skipCount = 0;
+        this._pagination.skipCount = 0;
+        this._pagination.maxItems = this.maxItems;
     }
 
     ngOnDestroy() {

--- a/lib/core/pagination/infinite-pagination.component.ts
+++ b/lib/core/pagination/infinite-pagination.component.ts
@@ -104,6 +104,7 @@ export class InfinitePaginationComponent implements OnInit, OnDestroy, Paginatio
 
     reset() {
         this.pagination.skipCount = 0;
+        this.pagination.maxItems = this.pageSize;
         this.target.updatePagination(this.pagination);
     }
 

--- a/lib/core/pagination/pagination.component.ts
+++ b/lib/core/pagination/pagination.component.ts
@@ -25,7 +25,7 @@ import { PaginatedComponent } from './paginated-component.interface';
 import { PaginationComponentInterface } from './pagination-component.interface';
 import { Subscription } from 'rxjs';
 import { PaginationModel } from '../models/pagination.model';
-import { UserPreferencesService } from '../services/user-preferences.service';
+import { UserPreferencesService, UserPreferenceValues } from '../services/user-preferences.service';
 
 @Component({
     selector: 'adf-pagination',
@@ -60,7 +60,7 @@ export class PaginationComponent implements OnInit, OnDestroy, PaginationCompone
 
     /** Pagination object. */
     @Input()
-    pagination: PaginationModel;
+    pagination: PaginationModel = PaginationComponent.DEFAULT_PAGINATION;
 
     /** Emitted when pagination changes in any way. */
     @Output()
@@ -85,17 +85,14 @@ export class PaginationComponent implements OnInit, OnDestroy, PaginationCompone
     private paginationSubscription: Subscription;
 
     constructor(private cdr: ChangeDetectorRef, private userPreferencesService: UserPreferencesService) {
+        this.userPreferencesService.select(UserPreferenceValues.PaginationSize).subscribe((pagSize) => {
+            this.pagination.maxItems = pagSize;
+        });
     }
 
     ngOnInit() {
-        if (!this.pagination) {
-            let defaultPagination = PaginationComponent.DEFAULT_PAGINATION;
-            defaultPagination.maxItems = this.userPreferencesService.paginationSize;
-            this.pagination = defaultPagination;
-        }
-
         if (!this.supportedPageSizes) {
-            this.supportedPageSizes =  this.userPreferencesService.supportedPageSizes;
+            this.supportedPageSizes = this.userPreferencesService.supportedPageSizes;
         }
 
         if (this.target) {
@@ -213,7 +210,7 @@ export class PaginationComponent implements OnInit, OnDestroy, PaginationCompone
 
     onChangePageSize(maxItems: number) {
         this.pagination.skipCount = 0;
-        this.pagination.maxItems = maxItems;
+        this.userPreferencesService.paginationSize = maxItems;
         this.handlePaginationEvent(PaginationComponent.ACTIONS.CHANGE_PAGE_SIZE, {
             skipCount: 0,
             maxItems


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


Preconditions

create a folder inside 'User Homes'
add file/folder inside it
make sure that it's displayed on a page > 2 (name it like 'z-something...')
Steps:

go inside ‘User Homes’ from http://adfdev.envalfresco.com/files
and then on any of the next pages
get inside any of the non-empty folders
Expected
the content on the folder should be shown
Actual
the folder is displayed as being empty

Refresh would show the actual content

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-4042