### PR TITLE
[ADF-4062] rename old hasPermission as allowableOperation and introduce the real…

### DIFF
--- a/demo-shell/src/app/components/file-view/file-view.component.ts
+++ b/demo-shell/src/app/components/file-view/file-view.component.ts
@@ -68,7 +68,7 @@ export class FileViewComponent implements OnInit {
                 this.nodeApiService.getNode(id).subscribe(
                     (node) => {
                         if (node && node.isFile) {
-                            this.isCommentEnabled = !this.contentServices.hasPermission(node, PermissionsEnum.UPDATE);
+                            this.isCommentEnabled = !this.contentServices.hasPermissions(node, PermissionsEnum.NOT_CONSUMER);
                             this.nodeId = id;
                             return;
                         }

--- a/demo-shell/src/app/components/files/files.component.html
+++ b/demo-shell/src/app/components/files/files.component.html
@@ -37,7 +37,7 @@
                               [acceptedFilesType]="getFileFiltering()"
                               [rootFolderId]="currentFolderId"
                               [versioning]="versioning"
-                              [adf-node-permission]="'create'"
+                              [adf-check-allowable-operation]="'create'"
                               [adf-nodes]="disableDragArea ? getCurrentDocumentListNode() : []"
                               (beginUpload)="onBeginUpload($event)">
             <div *ngIf="errorMessage" class="adf-error-message">
@@ -105,7 +105,7 @@
                         <mat-icon>get_app</mat-icon>
                     </button>
                     <button mat-icon-button
-                            adf-node-permission="delete"
+                            adf-check-allowable-operation="delete"
                             [adf-nodes]="documentList.selection"
                             title="{{ 'DOCUMENT_LIST.TOOLBAR.DELETE' | translate }}"
                             (delete)="onDeleteActionSuccess($event)"
@@ -190,7 +190,7 @@
                         <span>{{ 'DOCUMENT_LIST.TOOLBAR.DOWNLOAD' | translate }}</span>
                     </button>
                     <button mat-menu-item
-                            adf-node-permission="delete"
+                            adf-check-allowable-operation="delete"
                             [adf-nodes]="documentList.selection"
                             (delete)="onDeleteActionSuccess($event)"
                             [adf-delete]="documentList.selection">
@@ -612,7 +612,7 @@
                 [maxFilesSize]="maxSizeShow ? maxFilesSize : null"
                 (error)="openSnackMessage($event)"
                 [versioning]="versioning"
-                [adf-node-permission]="'create'"
+                [adf-check-allowable-operation]="'create'"
                 [adf-nodes]="enableUpload ? getCurrentDocumentListNode() : []"
                 (permissionEvent)="handlePermissionError($event)"
                 (beginUpload)="onBeginUpload($event)">
@@ -629,7 +629,7 @@
                 [uploadFolders]="folderUpload"
                 [versioning]="versioning"
                 (error)="openSnackMessage($event)"
-                [adf-node-permission]="'create'"
+                [adf-check-allowable-operation]="'create'"
                 [adf-nodes]="enableUpload ? getCurrentDocumentListNode() : []"
                 (permissionEvent)="handlePermissionError($event)">
             </adf-upload-button>

--- a/demo-shell/src/app/components/files/files.component.ts
+++ b/demo-shell/src/app/components/files/files.component.ts
@@ -263,8 +263,8 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
         this.onCreateFolder = this.contentService.folderCreate.subscribe((value) => this.onFolderAction(value));
         this.onEditFolder = this.contentService.folderEdit.subscribe((value) => this.onFolderAction(value));
 
-        // this.permissionsStyle.push(new PermissionStyleModel('document-list__create', PermissionsEnum.CREATE));
-        // this.permissionsStyle.push(new PermissionStyleModel('document-list__disable', PermissionsEnum.NOT_CREATE, false, true));
+        // this.permissionsStyle.push(new PermissionStyleModel('document-list__create', AllowableOperationsEnum.CREATE));
+        // this.permissionsStyle.push(new PermissionStyleModel('document-list__disable', AllowableOperationsEnum.NOT_CREATE, false, true));
     }
 
     ngOnDestroy() {
@@ -399,7 +399,7 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
         const showComments = this.showVersionComments;
         const allowDownload = this.allowVersionDownload;
 
-        if (this.contentService.hasPermission(contentEntry, 'update')) {
+        if (this.contentService.hasAllowableOperations(contentEntry, 'update')) {
             this.dialog.open(VersionManagerDialogAdapterComponent, {
                 data: { contentEntry: contentEntry, showComments: showComments, allowDownload: allowDownload },
                 panelClass: 'adf-version-manager-dialog',
@@ -414,7 +414,7 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
     onManageMetadata(event) {
         const contentEntry = event.value.entry;
 
-        if (this.contentService.hasPermission(contentEntry, 'update')) {
+        if (this.contentService.hasAllowableOperations(contentEntry, 'update')) {
             this.dialog.open(MetadataDialogAdapterComponent, {
                 data: {
                     contentEntry: contentEntry,
@@ -444,7 +444,7 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
 
     userHasPermissionToManageVersions(): boolean {
         const selection: Array<MinimalNodeEntity> = this.documentList.selection;
-        return this.contentService.hasPermission(selection[0].entry, 'update');
+        return this.contentService.hasAllowableOperations(selection[0].entry, 'update');
     }
 
     getNodeNameTooltip(row: DataRow, col: DataColumn): string {
@@ -459,7 +459,7 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
             const entry = selection[0].entry;
 
             if (entry && entry.isFolder) {
-                return this.contentService.hasPermission(entry, 'update');
+                return this.contentService.hasAllowableOperations(entry, 'update');
             }
         }
         return false;
@@ -467,7 +467,7 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
 
     canCreateContent(parentNode: MinimalNodeEntryEntity): boolean {
         if (parentNode) {
-            return this.contentService.hasPermission(parentNode, 'create');
+            return this.contentService.hasAllowableOperations(parentNode, 'create');
         }
         return false;
     }

--- a/docs/content-services/document-list.service.md
+++ b/docs/content-services/document-list.service.md
@@ -87,7 +87,7 @@ the `parentId`.
 
 ### Permissions
 
-The `hasPermission` method reports whether or not the user has the specified permission for the
+The `hasAllowableOperations` method reports whether or not the user has the specified permission for the
 node. The Permissions enum contains the values DELETE, UPDATE, CREATE, UPDATEPERMISSIONS, NOT_DELETE, NOT_UPDATE, NOT_CREATE and NOT_UPDATEPERMISSIONS but you can also supply these
 values via their string equivalents.
 

--- a/docs/content-services/permissions-style.model.md
+++ b/docs/content-services/permissions-style.model.md
@@ -28,7 +28,7 @@ and can be applied separately to files and folders by setting `isFile` and `isFo
 
 ### Permissions enum
 
-The [Permissions](https://github.com/Alfresco/alfresco-ng2-components/blob/development/lib/core/models/permissions.enum.ts)
+The [Permissions](https://github.com/Alfresco/alfresco-ng2-components/blob/development/lib/core/models/allowable-operations.enum.ts)
 enum contains all the valid permissions for which you can apply custom styles: **DELETE**, **UPDATE**,
 **CREATE**, **UPDATEPERMISSIONS**, **NOT_DELETE**, **NOT_UPDATE**, **NOT_CREATE**, **NOT_UPDATEPERMISSIONS**.
 
@@ -39,7 +39,7 @@ If you want to change the style on rows where the user can create content:
 ```ts
 let permissionsStyle: PermissionStyleModel[] = [];
 
-this.permissionsStyle.push(new PermissionStyleModel('document-list__create', PermissionsEnum.CREATE));        
+this.permissionsStyle.push(new PermissionStyleModel('document-list__create', AllowableOperationsEnum.CREATE));        
 ```
 
 ```html
@@ -58,7 +58,7 @@ If you want to change the style on the folders where the user doesn't have the p
 ```ts
 let permissionsStyle: PermissionStyleModel[] = [];
 
-this.permissionsStyle.push(new PermissionStyleModel('document-list__disable', PermissionsEnum.NOT_UPDATE, false, true));
+this.permissionsStyle.push(new PermissionStyleModel('document-list__disable', AllowableOperationsEnum.NOT_UPDATE, false, true));
 ```
 
 ```html

--- a/docs/core/content.service.md
+++ b/docs/core/content.service.md
@@ -60,10 +60,10 @@ Accesses app-generated data objects via URLs and file downloads.
     Checks if the node has the properties allowableOperations
     -   _node:_ `any`  - Node to check allowableOperations
     -   **Returns** `boolean` - True if the node has the property, false otherwise
--   **hasPermission**(node: `Node`, permission: [`PermissionsEnum`](../../lib/core/models/permissions.enum.ts)`|string`): `boolean`<br/>
+-   **hasAllowableOperations**(node: `Node`, permission: [`AllowableOperationsEnum`](../../lib/core/models/allowable-operations.enum.ts)`|string`): `boolean`<br/>
     Checks if the user has permissions on that node
     -   _node:_ `Node`  - Node to check allowableOperations
-    -   _permission:_ [`PermissionsEnum`](../../lib/core/models/permissions.enum.ts)`|string`  - Create, delete, update, updatePermissions, !create, !delete, !update, !updatePermissions
+    -   _permission:_ [`AllowableOperationsEnum`](../../lib/core/models/allowable-operations.enum.ts)`|string`  - Create, delete, update, updatePermissions, !create, !delete, !update, !updatePermissions
     -   **Returns** `boolean` - True if the user has the required permissions, false otherwise
 
 ## Details

--- a/docs/core/node-permission.directive.md
+++ b/docs/core/node-permission.directive.md
@@ -25,7 +25,7 @@ Selectively disables an HTML element or Angular component.
 ```html
 <adf-toolbar title="toolbar example">
     <button mat-icon-button
-            adf-node-permission="delete"
+            adf-check-allowable-operation="delete"
             [adf-nodes]="documentList.selection">
         <mat-icon>delete</mat-icon>
     </button>
@@ -65,7 +65,7 @@ node in the selection:
 ```html
 <adf-toolbar title="toolbar example">
     <button mat-icon-button
-            adf-node-permission="delete"
+            adf-check-allowable-operation="delete"
             [adf-nodes]="documentList.selection">
         <mat-icon>delete</mat-icon>
     </button>
@@ -89,7 +89,7 @@ for example). You can also use it in much the same way as you would with an HTML
 <alfresco-upload-drag-area
         [rootFolderId]="..."
         [versioning]="..."
-        [adf-node-permission]="'create'"
+        [adf-check-allowable-operation]="'create'"
         [adf-nodes]="getCurrentDocumentListNode()">
  ...
 </alfresco-upload-drag-area>

--- a/lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.html
+++ b/lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.html
@@ -12,7 +12,7 @@
     </mat-card-content>
     <mat-card-footer class="adf-content-metadata-card-footer" fxLayout="row" fxLayoutAlign="space-between stretch">
         <div>
-            <button *ngIf="!readOnly && hasPermission()"
+            <button *ngIf="!readOnly && hasAllowableOperations()"
                 mat-icon-button
                 (click)="toggleEdit()"
                 [attr.title]="'CORE.METADATA.ACTIONS.EDIT' | translate"

--- a/lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.spec.ts
+++ b/lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.spec.ts
@@ -20,7 +20,7 @@ import { By } from '@angular/platform-browser';
 import { Node } from '@alfresco/js-api';
 import { ContentMetadataCardComponent } from './content-metadata-card.component';
 import { ContentMetadataComponent } from '../content-metadata/content-metadata.component';
-import { setupTestBed, PermissionsEnum } from '@alfresco/adf-core';
+import { setupTestBed, AllowableOperationsEnum } from '@alfresco/adf-core';
 import { ContentTestingModule } from '../../../testing/content.testing.module';
 
 describe('ContentMetadataCardComponent', () => {
@@ -125,7 +125,7 @@ describe('ContentMetadataCardComponent', () => {
 
     it('should toggle editable by clicking on the button', () => {
         component.editable = true;
-        component.node.allowableOperations = [PermissionsEnum.UPDATE];
+        component.node.allowableOperations = [AllowableOperationsEnum.UPDATE];
         fixture.detectChanges();
 
         const button = fixture.debugElement.query(By.css('[data-automation-id="meta-data-card-toggle-edit"]'));
@@ -183,7 +183,7 @@ describe('ContentMetadataCardComponent', () => {
 
     it('should show the edit button if node does has `update` permissions', () => {
         component.readOnly = false;
-        component.node.allowableOperations = [PermissionsEnum.UPDATE];
+        component.node.allowableOperations = [AllowableOperationsEnum.UPDATE];
         fixture.detectChanges();
 
         const button = fixture.debugElement.query(By.css('[data-automation-id="meta-data-card-toggle-edit"]'));

--- a/lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.ts
+++ b/lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.ts
@@ -17,7 +17,7 @@
 
 import { Component, Input, ViewEncapsulation } from '@angular/core';
 import { Node } from '@alfresco/js-api';
-import { ContentService, PermissionsEnum } from '@alfresco/adf-core';
+import { ContentService, AllowableOperationsEnum } from '@alfresco/adf-core';
 
 @Component({
     selector: 'adf-content-metadata-card',
@@ -89,7 +89,7 @@ export class ContentMetadataCardComponent {
         this.expanded = !this.expanded;
     }
 
-    hasPermission() {
-        return this.contentService.hasPermission(this.node, PermissionsEnum.UPDATE);
+    hasAllowableOperations() {
+        return this.contentService.hasAllowableOperations(this.node, AllowableOperationsEnum.UPDATE);
     }
 }

--- a/lib/content-services/content-node-selector/content-node-dialog.service.ts
+++ b/lib/content-services/content-node-selector/content-node-dialog.service.ts
@@ -21,7 +21,7 @@ import { ContentService } from '@alfresco/adf-core';
 import { Subject, Observable, throwError } from 'rxjs';
 import { ShareDataRow } from '../document-list/data/share-data-row.model';
 import { Node, NodeEntry, SitePaging } from '@alfresco/js-api';
-import { DataColumn, SitesService, TranslationService, PermissionsEnum } from '@alfresco/adf-core';
+import { DataColumn, SitesService, TranslationService, AllowableOperationsEnum } from '@alfresco/adf-core';
 import { DocumentListService } from '../document-list/services/document-list.service';
 import { ContentNodeSelectorComponent } from './content-node-selector.component';
 import { ContentNodeSelectorComponentData } from './content-node-selector.component-data.interface';
@@ -71,7 +71,7 @@ export class ContentNodeDialogService {
     public openLockNodeDialog(contentEntry: Node): Subject<string> {
         const observable: Subject<string> = new Subject<string>();
 
-        if (this.contentService.hasPermission(contentEntry, PermissionsEnum.LOCK)) {
+        if (this.contentService.hasAllowableOperations(contentEntry, AllowableOperationsEnum.LOCK)) {
             this.dialog.open(NodeLockDialogComponent, {
                 data: {
                     node: contentEntry,
@@ -129,7 +129,7 @@ export class ContentNodeDialogService {
      * @returns Information about files that were copied/moved
      */
     openCopyMoveDialog(action: string, contentEntry: Node, permission?: string, excludeSiteContent?: string[]): Observable<Node[]> {
-        if (this.contentService.hasPermission(contentEntry, permission)) {
+        if (this.contentService.hasAllowableOperations(contentEntry, permission)) {
 
             const select = new Subject<Node[]>();
             select.subscribe({
@@ -185,7 +185,7 @@ export class ContentNodeDialogService {
             actionName: action,
             currentFolderId: contentEntry.id,
             imageResolver: this.imageResolver.bind(this),
-            isSelectionValid: this.hasPermissionOnNodeFolder.bind(this),
+            isSelectionValid: this.hasAllowableOperationsOnNodeFolder.bind(this),
             where: '(isFolder=true)',
             select: select
         };
@@ -225,7 +225,7 @@ export class ContentNodeDialogService {
 
     private imageResolver(row: ShareDataRow, col: DataColumn): string | null {
         const entry: Node = row.node.entry;
-        if (!this.contentService.hasPermission(entry, 'create')) {
+        if (!this.contentService.hasAllowableOperations(entry, 'create')) {
             return this.documentListService.getMimeTypeIcon('disable/folder');
         }
 
@@ -236,8 +236,8 @@ export class ContentNodeDialogService {
         return entry.isFile;
     }
 
-    private hasPermissionOnNodeFolder(entry: Node): boolean {
-        return this.isNodeFolder(entry) && this.contentService.hasPermission(entry, 'create');
+    private hasAllowableOperationsOnNodeFolder(entry: Node): boolean {
+        return this.isNodeFolder(entry) && this.contentService.hasAllowableOperations(entry, 'create');
     }
 
     private isNodeFolder(entry: Node): boolean {
@@ -249,7 +249,7 @@ export class ContentNodeDialogService {
     }
 
     private hasEntityCreatePermission(entry: Node): boolean {
-        return this.contentService.hasPermission(entry, 'create');
+        return this.contentService.hasAllowableOperations(entry, 'create');
     }
 
     private isSite(entry) {

--- a/lib/content-services/content-node-selector/content-node-selector-panel.component.spec.ts
+++ b/lib/content-services/content-node-selector/content-node-selector-panel.component.spec.ts
@@ -782,10 +782,10 @@ describe('ContentNodeSelectorComponent', () => {
 
             const entry: Node = <Node> {};
             const nodePage: NodePaging = <NodePaging> { list: {}, pagination: {} };
-            let hasPermission;
+            let hasAllowableOperations;
 
             function returnHasPermission(): boolean {
-                return hasPermission;
+                return hasAllowableOperations;
             }
 
             beforeEach(() => {
@@ -800,7 +800,7 @@ describe('ContentNodeSelectorComponent', () => {
                 });
 
                 it('should NOT be null after selecting node with the necessary permissions', async(() => {
-                    hasPermission = true;
+                    hasAllowableOperations = true;
                     component.documentList.folderNode = entry;
 
                     component.select.subscribe((nodes) => {
@@ -814,7 +814,7 @@ describe('ContentNodeSelectorComponent', () => {
                 }));
 
                 it('should be null after selecting node without the necessary permissions', async(() => {
-                    hasPermission = false;
+                    hasAllowableOperations = false;
                     component.documentList.folderNode = entry;
 
                     component.select.subscribe((nodes) => {
@@ -828,7 +828,7 @@ describe('ContentNodeSelectorComponent', () => {
                 }));
 
                 it('should NOT be null after clicking on a node (with the right permissions) in the list (onNodeSelect)', async(() => {
-                    hasPermission = true;
+                    hasAllowableOperations = true;
 
                     component.select.subscribe((nodes) => {
                         expect(nodes).toBeDefined();
@@ -841,7 +841,7 @@ describe('ContentNodeSelectorComponent', () => {
                 }));
 
                 it('should remain null when clicking on a node (with the WRONG permissions) in the list (onNodeSelect)', async(() => {
-                    hasPermission = false;
+                    hasAllowableOperations = false;
 
                     component.select.subscribe((nodes) => {
                         expect(nodes).toBeDefined();
@@ -856,7 +856,7 @@ describe('ContentNodeSelectorComponent', () => {
                 it('should become null when clicking on a node (with the WRONG permissions) after previously selecting a right node', async(() => {
                     component.select.subscribe((nodes) => {
 
-                        if (hasPermission) {
+                        if (hasAllowableOperations) {
                             expect(nodes).toBeDefined();
                             expect(nodes).not.toBeNull();
                             expect(component.chosenNode).not.toBeNull();
@@ -868,17 +868,17 @@ describe('ContentNodeSelectorComponent', () => {
                         }
                     });
 
-                    hasPermission = true;
+                    hasAllowableOperations = true;
                     component.onNodeSelect({ detail: { node: { entry } } });
                     fixture.detectChanges();
 
-                    hasPermission = false;
+                    hasAllowableOperations = false;
                     component.onNodeSelect({ detail: { node: { entry } } });
                     fixture.detectChanges();
                 }));
 
                 it('should be null when the chosenNode is reset', async(() => {
-                    hasPermission = true;
+                    hasAllowableOperations = true;
                     component.onNodeSelect({ detail: { node: { entry: <Node> {} } } });
                     fixture.detectChanges();
 

--- a/lib/content-services/content-node-share/content-node-share.dialog.ts
+++ b/lib/content-services/content-node-share/content-node-share.dialog.ts
@@ -123,7 +123,7 @@ export class ShareDialogComponent implements OnInit, OnDestroy {
     }
 
     get canUpdate() {
-        return this.contentService.hasPermission(this.data.node.entry, 'update');
+        return this.contentService.hasAllowableOperations(this.data.node.entry, 'update');
     }
 
     private openConfirmationDialog() {

--- a/lib/content-services/directives/node-lock.directive.ts
+++ b/lib/content-services/directives/node-lock.directive.ts
@@ -19,7 +19,7 @@
 
 import { Directive, ElementRef, Renderer2, HostListener, Input, AfterViewInit } from '@angular/core';
 import { Node } from '@alfresco/js-api';
-import { PermissionsEnum, ContentService } from '@alfresco/adf-core';
+import { AllowableOperationsEnum, ContentService } from '@alfresco/adf-core';
 import { ContentNodeDialogService } from '../content-node-selector/content-node-dialog.service';
 
 @Directive({
@@ -45,7 +45,7 @@ export class NodeLockDirective implements AfterViewInit {
     ) {}
 
     ngAfterViewInit() {
-        const hasPermission = this.contentService.hasPermission(this.node, PermissionsEnum.LOCK);
-        this.renderer.setProperty(this.element.nativeElement, 'disabled', !hasPermission);
+        const hasAllowableOperations = this.contentService.hasAllowableOperations(this.node, AllowableOperationsEnum.LOCK);
+        this.renderer.setProperty(this.element.nativeElement, 'disabled', !hasAllowableOperations);
     }
 }

--- a/lib/content-services/document-list/components/document-list.component.ts
+++ b/lib/content-services/document-list/components/document-list.component.ts
@@ -522,7 +522,7 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
             return action.disabled(node);
         }
 
-        if (action.permission && action.disableWithNoPermission && !this.contentService.hasPermission(node.entry, action.permission)) {
+        if (action.permission && action.disableWithNoPermission && !this.contentService.hasAllowableOperations(node.entry, action.permission)) {
             return true;
         }
 

--- a/lib/content-services/document-list/data/share-data-row.model.ts
+++ b/lib/content-services/document-list/data/share-data-row.model.ts
@@ -54,7 +54,7 @@ export class ShareDataRow implements DataRow {
 
             if (this.applyPermissionStyleToFolder(nodeEntity.entry, currentPermissionsStyle) || this.applyPermissionStyleToFile(nodeEntity.entry, currentPermissionsStyle)) {
 
-                if (this.contentService.hasPermission(nodeEntity.entry, currentPermissionsStyle.permission)) {
+                if (this.contentService.hasAllowableOperations(nodeEntity.entry, currentPermissionsStyle.permission)) {
                     permissionsClasses += ` ${currentPermissionsStyle.css}`;
                 }
             }
@@ -73,7 +73,7 @@ export class ShareDataRow implements DataRow {
     }
 
     isFolderAndHasPermissionToUpload(nodeEntry: NodeEntry): boolean {
-        return this.isFolder(nodeEntry) && this.contentService.hasPermission(nodeEntry.entry, 'create');
+        return this.isFolder(nodeEntry) && this.contentService.hasAllowableOperations(nodeEntry.entry, 'create');
     }
 
     isFolder(nodeEntry: NodeEntry): boolean {

--- a/lib/content-services/document-list/models/permissions-style.model.ts
+++ b/lib/content-services/document-list/models/permissions-style.model.ts
@@ -15,15 +15,15 @@
  * limitations under the License.
  */
 
-import { PermissionsEnum } from '@alfresco/adf-core';
+import { AllowableOperationsEnum } from '@alfresco/adf-core';
 
 export class PermissionStyleModel {
     css: string;
-    permission: PermissionsEnum;
+    permission: AllowableOperationsEnum;
     isFolder: boolean = true;
     isFile: boolean = true;
 
-    constructor(css: string, permission: PermissionsEnum, isFile: boolean = true, isFolder: boolean = true) {
+    constructor(css: string, permission: AllowableOperationsEnum, isFile: boolean = true, isFolder: boolean = true) {
         this.css = css;
         this.permission = permission;
         this.isFile = isFile;

--- a/lib/content-services/document-list/services/document-actions.service.ts
+++ b/lib/content-services/document-list/services/document-actions.service.ts
@@ -122,7 +122,7 @@ export class DocumentActionsService {
         let handlerObservable;
 
         if (this.canExecuteAction(node)) {
-            if (this.contentService.hasPermission(node.entry, permission)) {
+            if (this.contentService.hasAllowableOperations(node.entry, permission)) {
                 handlerObservable = this.documentListService.deleteNode(node.entry.id);
                 handlerObservable.subscribe(() => {
                     let message = this.translation.instant('CORE.DELETE_NODE.SINGULAR', { name: node.entry.name });

--- a/lib/content-services/document-list/services/folder-actions.service.ts
+++ b/lib/content-services/document-list/services/folder-actions.service.ts
@@ -118,7 +118,7 @@ export class FolderActionsService {
         let handlerObservable: Observable<any>;
 
         if (this.canExecuteAction(node)) {
-            if (this.contentService.hasPermission(node.entry, permission)) {
+            if (this.contentService.hasAllowableOperations(node.entry, permission)) {
                 handlerObservable = this.documentListService.deleteNode(node.entry.id);
                 handlerObservable.subscribe(() => {
                     if (target && typeof target.reload === 'function') {

--- a/lib/content-services/permission-manager/components/add-permission/add-permission.component.ts
+++ b/lib/content-services/permission-manager/components/add-permission/add-permission.component.ts
@@ -18,7 +18,7 @@
 import { Component, ViewEncapsulation, EventEmitter, Input, Output } from '@angular/core';
 import { NodeEntry, Node } from '@alfresco/js-api';
 import { NodePermissionService } from '../../services/node-permission.service';
-import { NodesApiService, ContentService, PermissionsEnum } from '@alfresco/adf-core';
+import { NodesApiService, ContentService, AllowableOperationsEnum } from '@alfresco/adf-core';
 
 @Component({
     selector: 'adf-add-permission',
@@ -55,12 +55,12 @@ export class AddPermissionComponent {
     }
 
     isAddEnabled(): boolean {
-        return this.contentService.hasPermission(this.currentNode, PermissionsEnum.UPDATEPERMISSIONS) &&
+        return this.contentService.hasAllowableOperations(this.currentNode, AllowableOperationsEnum.UPDATEPERMISSIONS) &&
                 this.selectedItems.length !== 0;
     }
 
     applySelection() {
-        if (this.contentService.hasPermission(this.currentNode, PermissionsEnum.UPDATEPERMISSIONS)) {
+        if (this.contentService.hasAllowableOperations(this.currentNode, AllowableOperationsEnum.UPDATEPERMISSIONS)) {
             this.nodePermissionService.updateNodePermissions(this.nodeId, this.selectedItems)
                 .subscribe(
                     (node) => {

--- a/lib/content-services/permission-manager/components/inherited-button.directive.ts
+++ b/lib/content-services/permission-manager/components/inherited-button.directive.ts
@@ -17,7 +17,7 @@
 
 /* tslint:disable:no-input-rename  */
 import { Directive, Input, Output, EventEmitter } from '@angular/core';
-import { NodesApiService, ContentService, PermissionsEnum } from '@alfresco/adf-core';
+import { NodesApiService, ContentService, AllowableOperationsEnum } from '@alfresco/adf-core';
 import { Node } from '@alfresco/js-api';
 
 @Directive({
@@ -47,7 +47,7 @@ export class InheritPermissionDirective {
 
     onInheritPermissionClicked() {
         this.nodeService.getNode(this.nodeId).subscribe((node: Node) => {
-            if (this.contentService.hasPermission(node, PermissionsEnum.UPDATEPERMISSIONS)) {
+            if (this.contentService.hasAllowableOperations(node, AllowableOperationsEnum.UPDATEPERMISSIONS)) {
                 const nodeBody = { permissions: { isInheritanceEnabled: !node.permissions.isInheritanceEnabled } };
                 this.nodeService.updateNode(this.nodeId, nodeBody, { include: ['permissions'] }).subscribe((nodeUpdated: Node) => {
                     this.updated.emit(nodeUpdated);

--- a/lib/content-services/permission-manager/services/node-permission-dialog.service.ts
+++ b/lib/content-services/permission-manager/services/node-permission-dialog.service.ts
@@ -22,7 +22,7 @@ import { AddPermissionDialogComponent } from '../components/add-permission/add-p
 import { AddPermissionDialogData } from '../components/add-permission/add-permission-dialog-data.interface';
 import { NodeEntry, Node } from '@alfresco/js-api';
 import { NodePermissionService } from './node-permission.service';
-import { ContentService, PermissionsEnum } from '@alfresco/adf-core';
+import { ContentService, AllowableOperationsEnum } from '@alfresco/adf-core';
 import { switchMap } from 'rxjs/operators';
 
 @Injectable({
@@ -42,7 +42,7 @@ export class NodePermissionDialogService {
      * @returns Node with updated permissions
      */
     openAddPermissionDialog(node: Node, title?: string): Observable<NodeEntry[]> {
-        if (this.contentService.hasPermission(node, PermissionsEnum.UPDATEPERMISSIONS)) {
+        if (this.contentService.hasAllowableOperations(node, AllowableOperationsEnum.UPDATEPERMISSIONS)) {
             const confirm = new Subject<NodeEntry[]>();
 
             confirm.subscribe({

--- a/lib/content-services/upload/components/upload-button.component.ts
+++ b/lib/content-services/upload/components/upload-button.component.ts
@@ -17,7 +17,7 @@
 
 import {
     ContentService, EXTENDIBLE_COMPONENT, FileUtils,
-    LogService, NodePermissionSubject, TranslationService, UploadService, PermissionsEnum
+    LogService, NodeAllowableOperationSubject, TranslationService, UploadService, AllowableOperationsEnum
 } from '@alfresco/adf-core';
 import {
     Component, EventEmitter, forwardRef, Input,
@@ -37,7 +37,7 @@ import { UploadBase } from './base-upload/upload-base';
     ],
     encapsulation: ViewEncapsulation.None
 })
-export class UploadButtonComponent extends UploadBase implements OnInit, OnChanges, NodePermissionSubject {
+export class UploadButtonComponent extends UploadBase implements OnInit, OnChanges, NodeAllowableOperationSubject {
 
     /** Allows/disallows upload folders (only for Chrome). */
     @Input()
@@ -59,7 +59,7 @@ export class UploadButtonComponent extends UploadBase implements OnInit, OnChang
     @Output()
     permissionEvent: EventEmitter<PermissionModel> = new EventEmitter<PermissionModel>();
 
-    private hasPermission: boolean = false;
+    private hasAllowableOperations: boolean = false;
 
     protected permissionValue: Subject<boolean> = new Subject<boolean>();
 
@@ -73,7 +73,7 @@ export class UploadButtonComponent extends UploadBase implements OnInit, OnChang
 
     ngOnInit() {
         this.permissionValue.subscribe((permission: boolean) => {
-            this.hasPermission = permission;
+            this.hasAllowableOperations = permission;
         });
     }
 
@@ -91,7 +91,7 @@ export class UploadButtonComponent extends UploadBase implements OnInit, OnChang
     onFilesAdded($event: any): void {
         let files: File[] = FileUtils.toFileArray($event.currentTarget.files);
 
-        if (this.hasPermission) {
+        if (this.hasAllowableOperations) {
             this.uploadFiles(files);
         } else {
             this.permissionEvent.emit(new PermissionModel({ type: 'content', action: 'upload', permission: 'create' }));
@@ -101,7 +101,7 @@ export class UploadButtonComponent extends UploadBase implements OnInit, OnChang
     }
 
     onDirectoryAdded($event: any): void {
-        if (this.hasPermission) {
+        if (this.hasAllowableOperations) {
             let files: File[] = FileUtils.toFileArray($event.currentTarget.files);
             this.uploadFiles(files);
         } else {
@@ -119,13 +119,13 @@ export class UploadButtonComponent extends UploadBase implements OnInit, OnChang
             };
 
             this.contentService.getNode(this.rootFolderId, opts).subscribe(
-                (res) => this.permissionValue.next(this.nodeHasPermission(res.entry, PermissionsEnum.CREATE)),
+                (res) => this.permissionValue.next(this.nodeHasPermission(res.entry, AllowableOperationsEnum.CREATE)),
                 (error) => this.error.emit(error)
             );
         }
     }
 
-    nodeHasPermission(node: Node, permission: PermissionsEnum | string): boolean {
-        return this.contentService.hasPermission(node, permission);
+    nodeHasPermission(node: Node, permission: AllowableOperationsEnum | string): boolean {
+        return this.contentService.hasAllowableOperations(node, permission);
     }
 }

--- a/lib/content-services/upload/components/upload-drag-area.component.ts
+++ b/lib/content-services/upload/components/upload-drag-area.component.ts
@@ -16,8 +16,8 @@
  */
 
 import {
-    EXTENDIBLE_COMPONENT, FileInfo, FileModel, FileUtils, NodePermissionSubject,
-    NotificationService, TranslationService, UploadService, ContentService, PermissionsEnum
+    EXTENDIBLE_COMPONENT, FileInfo, FileModel, FileUtils, NodeAllowableOperationSubject,
+    NotificationService, TranslationService, UploadService, ContentService, AllowableOperationsEnum
 } from '@alfresco/adf-core';
 import { Component, forwardRef, ViewEncapsulation, NgZone } from '@angular/core';
 import { UploadBase } from './base-upload/upload-base';
@@ -32,7 +32,7 @@ import { UploadBase } from './base-upload/upload-base';
     ],
     encapsulation: ViewEncapsulation.None
 })
-export class UploadDragAreaComponent extends UploadBase implements NodePermissionSubject {
+export class UploadDragAreaComponent extends UploadBase implements NodeAllowableOperationSubject {
 
     constructor(protected uploadService: UploadService,
                 protected translationService: TranslationService,
@@ -94,7 +94,7 @@ export class UploadDragAreaComponent extends UploadBase implements NodePermissio
     onUploadFiles(event: CustomEvent) {
         event.stopPropagation();
         event.preventDefault();
-        let isAllowed: boolean = this.contentService.hasPermission(event.detail.data.obj.entry, PermissionsEnum.CREATE);
+        let isAllowed: boolean = this.contentService.hasAllowableOperations(event.detail.data.obj.entry, AllowableOperationsEnum.CREATE);
         if (isAllowed) {
             let fileInfo: FileInfo[] = event.detail.files;
             if (this.isTargetNodeFolder(event)) {

--- a/lib/content-services/upload/components/upload-version-button.component.ts
+++ b/lib/content-services/upload/components/upload-version-button.component.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { PermissionsEnum  } from '@alfresco/adf-core';
+import { AllowableOperationsEnum  } from '@alfresco/adf-core';
 import { Component, forwardRef, Input, OnChanges, ViewEncapsulation, OnInit } from '@angular/core';
 import { Node } from '@alfresco/js-api';
 import { UploadButtonComponent } from './upload-button.component';
@@ -53,6 +53,6 @@ export class UploadVersionButtonComponent extends UploadButtonComponent implemen
     }
 
     checkPermission() {
-        this.permissionValue.next(this.nodeHasPermission(this.node, PermissionsEnum.UPDATE));
+        this.permissionValue.next(this.nodeHasPermission(this.node, AllowableOperationsEnum.UPDATE));
     }
 }

--- a/lib/content-services/version-manager/version-list.component.ts
+++ b/lib/content-services/version-manager/version-list.component.ts
@@ -71,11 +71,11 @@ export class VersionListComponent implements OnChanges {
     }
 
     canUpdate(): boolean {
-        return this.contentService.hasPermission(this.node, 'update') && this.versions.length > 1;
+        return this.contentService.hasAllowableOperations(this.node, 'update') && this.versions.length > 1;
     }
 
     canDelete(): boolean {
-        return this.contentService.hasPermission(this.node, 'delete') && this.versions.length > 1;
+        return this.contentService.hasAllowableOperations(this.node, 'delete') && this.versions.length > 1;
     }
 
     restore(versionId) {

--- a/lib/content-services/version-manager/version-manager.component.ts
+++ b/lib/content-services/version-manager/version-manager.component.ts
@@ -100,6 +100,6 @@ export class VersionManagerComponent {
     }
 
     canUpdate(): boolean {
-        return this.contentService.hasPermission(this.node, 'update');
+        return this.contentService.hasAllowableOperations(this.node, 'update');
     }
 }

--- a/lib/content-services/version-manager/version-upload.component.ts
+++ b/lib/content-services/version-manager/version-upload.component.ts
@@ -48,7 +48,7 @@ export class VersionUploadComponent {
     }
 
     canUpload(): boolean {
-        return this.contentService.hasPermission(this.node, 'update');
+        return this.contentService.hasAllowableOperations(this.node, 'update');
     }
 
     isMajorVersion(): boolean {

--- a/lib/core/directives/check-allowable-operation.directive.spec.ts
+++ b/lib/core/directives/check-allowable-operation.directive.spec.ts
@@ -17,16 +17,16 @@
 
 import { ChangeDetectorRef, Component, ElementRef, SimpleChange } from '@angular/core';
 import { ContentService } from './../services/content.service';
-import { NodePermissionDirective, NodePermissionSubject } from './node-permission.directive';
+import { CheckAllowableOperationDirective, NodeAllowableOperationSubject } from './check-allowable-operation.directive';
 
 @Component({
     selector: 'adf-text-subject'
 })
-class TestComponent implements NodePermissionSubject {
+class TestComponent implements NodeAllowableOperationSubject {
     disabled: boolean = false;
 }
 
-describe('NodePermissionDirective', () => {
+describe('CheckAllowableOperationDirective', () => {
 
     let changeDetectorMock: ChangeDetectorRef;
 
@@ -37,7 +37,7 @@ describe('NodePermissionDirective', () => {
     describe('HTML nativeElement as subject', () => {
 
         it('updates element once it is loaded', () => {
-            const directive = new NodePermissionDirective(null, null, null, changeDetectorMock);
+            const directive = new CheckAllowableOperationDirective(null, null, null, changeDetectorMock);
             spyOn(directive, 'updateElement').and.stub();
 
             const nodes = [{}, {}];
@@ -48,7 +48,7 @@ describe('NodePermissionDirective', () => {
         });
 
         it('updates element on nodes change', () => {
-            const directive = new NodePermissionDirective(null, null, null, changeDetectorMock);
+            const directive = new CheckAllowableOperationDirective(null, null, null, changeDetectorMock);
             spyOn(directive, 'updateElement').and.stub();
 
             const nodes = [{}, {}];
@@ -59,7 +59,7 @@ describe('NodePermissionDirective', () => {
         });
 
         it('updates element only on subsequent change', () => {
-            const directive = new NodePermissionDirective(null, null, null, changeDetectorMock);
+            const directive = new CheckAllowableOperationDirective(null, null, null, changeDetectorMock);
             spyOn(directive, 'updateElement').and.stub();
 
             const nodes = [{}, {}];
@@ -72,7 +72,7 @@ describe('NodePermissionDirective', () => {
         it('enables decorated element', () => {
             const renderer = jasmine.createSpyObj('renderer', ['removeAttribute']);
             const elementRef = new ElementRef({});
-            const directive = new NodePermissionDirective(elementRef, renderer, null, changeDetectorMock);
+            const directive = new CheckAllowableOperationDirective(elementRef, renderer, null, changeDetectorMock);
 
             directive.enableElement();
 
@@ -82,7 +82,7 @@ describe('NodePermissionDirective', () => {
         it('disables decorated element', () => {
             const renderer = jasmine.createSpyObj('renderer', ['setAttribute']);
             const elementRef = new ElementRef({});
-            const directive = new NodePermissionDirective(elementRef, renderer, null, changeDetectorMock);
+            const directive = new CheckAllowableOperationDirective(elementRef, renderer, null, changeDetectorMock);
 
             directive.disableElement();
 
@@ -90,7 +90,7 @@ describe('NodePermissionDirective', () => {
         });
 
         it('disables element when nodes not available', () => {
-            const directive = new NodePermissionDirective(null, null, null, changeDetectorMock);
+            const directive = new CheckAllowableOperationDirective(null, null, null, changeDetectorMock);
             spyOn(directive, 'disableElement').and.stub();
 
             directive.nodes = null;
@@ -102,9 +102,9 @@ describe('NodePermissionDirective', () => {
 
         it('enables element when all nodes have expected permission', () => {
             const contentService = new ContentService(null, null, null, null);
-            spyOn(contentService, 'hasPermission').and.returnValue(true);
+            spyOn(contentService, 'hasAllowableOperations').and.returnValue(true);
 
-            const directive = new NodePermissionDirective(null, null, contentService, changeDetectorMock);
+            const directive = new CheckAllowableOperationDirective(null, null, contentService, changeDetectorMock);
             spyOn(directive, 'enableElement').and.stub();
 
             directive.nodes = <any> [{}, {}];
@@ -115,9 +115,9 @@ describe('NodePermissionDirective', () => {
 
         it('disables element when one of the nodes have no permission', () => {
             const contentService = new ContentService(null, null, null, null);
-            spyOn(contentService, 'hasPermission').and.returnValue(false);
+            spyOn(contentService, 'hasAllowableOperations').and.returnValue(false);
 
-            const directive = new NodePermissionDirective(null, null, contentService, changeDetectorMock);
+            const directive = new CheckAllowableOperationDirective(null, null, contentService, changeDetectorMock);
             spyOn(directive, 'disableElement').and.stub();
 
             directive.nodes = <any> [{}, {}];
@@ -131,12 +131,12 @@ describe('NodePermissionDirective', () => {
 
         it('disables decorated component', () => {
             const contentService = new ContentService(null, null, null, null);
-            spyOn(contentService, 'hasPermission').and.returnValue(false);
+            spyOn(contentService, 'hasAllowableOperations').and.returnValue(false);
             spyOn(changeDetectorMock, 'detectChanges');
 
             let testComponent = new TestComponent();
             testComponent.disabled = false;
-            const directive = new NodePermissionDirective(null, null, contentService, changeDetectorMock, testComponent);
+            const directive = new CheckAllowableOperationDirective(null, null, contentService, changeDetectorMock, testComponent);
             directive.nodes = <any> [{}, {}];
 
             directive.updateElement();
@@ -147,12 +147,12 @@ describe('NodePermissionDirective', () => {
 
         it('enables decorated component', () => {
             const contentService = new ContentService(null, null, null, null);
-            spyOn(contentService, 'hasPermission').and.returnValue(true);
+            spyOn(contentService, 'hasAllowableOperations').and.returnValue(true);
             spyOn(changeDetectorMock, 'detectChanges');
 
             let testComponent = new TestComponent();
             testComponent.disabled = true;
-            const directive = new NodePermissionDirective(null, null, contentService, changeDetectorMock, testComponent);
+            const directive = new CheckAllowableOperationDirective(null, null, contentService, changeDetectorMock, testComponent);
             directive.nodes = <any> [{}, {}];
 
             directive.updateElement();

--- a/lib/core/directives/check-allowable-operation.directive.ts
+++ b/lib/core/directives/check-allowable-operation.directive.ts
@@ -22,19 +22,19 @@ import { NodeEntry } from '@alfresco/js-api';
 import { ContentService } from './../services/content.service';
 import { EXTENDIBLE_COMPONENT } from './../interface/injection.tokens';
 
-export interface NodePermissionSubject {
+export interface NodeAllowableOperationSubject {
     disabled: boolean;
 }
 
 @Directive({
-    selector: '[adf-node-permission]'
+    selector: '[adf-check-allowable-operation]'
 })
-export class NodePermissionDirective implements OnChanges {
+export class CheckAllowableOperationDirective implements OnChanges {
 
     /** Node permission to check (create, delete, update, updatePermissions,
      * !create, !delete, !update, !updatePermissions).
      */
-    @Input('adf-node-permission')
+    @Input('adf-check-allowable-operation')
     permission: string  = null;
 
     /** Nodes to check permission for. */
@@ -48,7 +48,7 @@ export class NodePermissionDirective implements OnChanges {
 
                 @Host()
                 @Optional()
-                @Inject(EXTENDIBLE_COMPONENT) private parentComponent?: NodePermissionSubject) {
+                @Inject(EXTENDIBLE_COMPONENT) private parentComponent?: NodeAllowableOperationSubject) {
     }
 
     ngOnChanges(changes: SimpleChanges) {
@@ -60,10 +60,10 @@ export class NodePermissionDirective implements OnChanges {
     /**
      * Updates disabled state for the decorated element
      *
-     * @memberof NodePermissionDirective
+     * @memberof CheckAllowableOperationDirective
      */
     updateElement(): boolean {
-        let enable = this.hasPermission(this.nodes, this.permission);
+        let enable = this.hasAllowableOperations(this.nodes, this.permission);
 
         if (enable) {
             this.enable();
@@ -95,7 +95,7 @@ export class NodePermissionDirective implements OnChanges {
     /**
      * Enables decorated element
      *
-     * @memberof NodePermissionDirective
+     * @memberof CheckAllowableOperationDirective
      */
     enableElement(): void {
         this.renderer.removeAttribute(this.elementRef.nativeElement, 'disabled');
@@ -104,7 +104,7 @@ export class NodePermissionDirective implements OnChanges {
     /**
      * Disables decorated element
      *
-     * @memberof NodePermissionDirective
+     * @memberof CheckAllowableOperationDirective
      */
     disableElement(): void {
         this.renderer.setAttribute(this.elementRef.nativeElement, 'disabled', 'true');
@@ -115,11 +115,11 @@ export class NodePermissionDirective implements OnChanges {
      *
      * @param  nodes Node collection to check
      * @param  permission Permission to check for each node
-     * @memberof NodePermissionDirective
+     * @memberof CheckAllowableOperationDirective
      */
-    hasPermission(nodes: NodeEntry[], permission: string): boolean {
+    hasAllowableOperations(nodes: NodeEntry[], permission: string): boolean {
         if (nodes && nodes.length > 0) {
-            return nodes.every((node) => this.contentService.hasPermission(node.entry, permission));
+            return nodes.every((node) => this.contentService.hasAllowableOperations(node.entry, permission));
         }
 
         return false;

--- a/lib/core/directives/directive.module.ts
+++ b/lib/core/directives/directive.module.ts
@@ -23,7 +23,7 @@ import { HighlightDirective } from './highlight.directive';
 import { LogoutDirective } from './logout.directive';
 import { NodeDeleteDirective } from './node-delete.directive';
 import { NodeFavoriteDirective } from './node-favorite.directive';
-import { NodePermissionDirective } from './node-permission.directive';
+import { CheckAllowableOperationDirective } from './check-allowable-operation.directive';
 import { NodeRestoreDirective } from './node-restore.directive';
 import { UploadDirective } from './upload.directive';
 import { NodeDownloadDirective } from './node-download.directive';
@@ -38,7 +38,7 @@ import { NodeDownloadDirective } from './node-download.directive';
         LogoutDirective,
         NodeDeleteDirective,
         NodeFavoriteDirective,
-        NodePermissionDirective,
+        CheckAllowableOperationDirective,
         NodeRestoreDirective,
         NodeDownloadDirective,
         UploadDirective
@@ -48,7 +48,7 @@ import { NodeDownloadDirective } from './node-download.directive';
         LogoutDirective,
         NodeDeleteDirective,
         NodeFavoriteDirective,
-        NodePermissionDirective,
+        CheckAllowableOperationDirective,
         NodeRestoreDirective,
         NodeDownloadDirective,
         UploadDirective

--- a/lib/core/directives/node-delete.directive.spec.ts
+++ b/lib/core/directives/node-delete.directive.spec.ts
@@ -44,7 +44,7 @@ class TestComponent {
 
 @Component({
     template: `
-        <div id="delete-component" [adf-node-permission]="selection"
+        <div id="delete-component" [adf-check-allowable-operation]="selection"
              [adf-delete]="selection"
              (delete)="onDelete($event)">
         </div>`
@@ -335,7 +335,7 @@ describe('NodeDeleteDirective', () => {
             });
         });
 
-        it('should not enable the button if adf-node-permission is present', (done) => {
+        it('should not enable the button if adf-check-allowable-operation is present', (done) => {
             elementWithPermissions.nativeElement.disabled = false;
             componentWithPermissions.selection = [];
 

--- a/lib/core/directives/node-delete.directive.ts
+++ b/lib/core/directives/node-delete.directive.ts
@@ -76,7 +76,7 @@ export class NodeDeleteDirective implements OnChanges {
         if (!this.selection || (this.selection && this.selection.length === 0)) {
             this.setDisableAttribute(true);
         } else {
-            if (!this.elementRef.nativeElement.hasAttribute('adf-node-permission')) {
+            if (!this.elementRef.nativeElement.hasAttribute('adf-check-allowable-operation')) {
                 this.setDisableAttribute(false);
             }
         }

--- a/lib/core/directives/public-api.ts
+++ b/lib/core/directives/public-api.ts
@@ -19,7 +19,7 @@ export * from './highlight.directive';
 export * from './logout.directive';
 export * from './node-delete.directive';
 export * from './node-favorite.directive';
-export * from './node-permission.directive';
+export * from './check-allowable-operation.directive';
 export * from './node-restore.directive';
 export * from './node-download.directive';
 export * from './upload.directive';

--- a/lib/core/models/allowable-operations.enum.ts
+++ b/lib/core/models/allowable-operations.enum.ts
@@ -15,14 +15,16 @@
  * limitations under the License.
  */
 
-export * from './file.model';
-export * from './allowable-operations.enum';
-export * from './permissions.enum';
-export * from './product-version.model';
-export * from './user-process.model';
-export * from './comment.model';
-export * from './ecm-company.model';
-export * from './redirection.model';
-export * from './pagination.model';
-export * from './oauth-config.model';
-export * from './request-pagination.model';
+ /* spellchecker: disable */
+export class AllowableOperationsEnum extends String {
+    static DELETE: string = 'delete';
+    static UPDATE: string = 'update';
+    static CREATE: string = 'create';
+    static COPY: string = 'copy';
+    static LOCK: string = 'lock';
+    static UPDATEPERMISSIONS: string = 'updatePermissions';
+    static NOT_DELETE: string = '!delete';
+    static NOT_UPDATE: string = '!update';
+    static NOT_CREATE: string = '!create';
+    static NOT_UPDATEPERMISSIONS: string = '!updatePermissions';
+}

--- a/lib/core/models/permissions.enum.ts
+++ b/lib/core/models/permissions.enum.ts
@@ -17,14 +17,12 @@
 
  /* spellchecker: disable */
 export class PermissionsEnum extends String {
-    static DELETE: string = 'delete';
-    static UPDATE: string = 'update';
-    static CREATE: string = 'create';
-    static COPY: string = 'copy';
-    static LOCK: string = 'lock';
-    static UPDATEPERMISSIONS: string = 'updatePermissions';
-    static NOT_DELETE: string = '!delete';
-    static NOT_UPDATE: string = '!update';
-    static NOT_CREATE: string = '!create';
-    static NOT_UPDATEPERMISSIONS: string = '!updatePermissions';
+    static CONTRIBUTOR: string = 'Contributor';
+    static CONSUMER: string = 'Consumer';
+    static COLLABORATOR: string = 'Collaborator';
+    static MANAGER: string = 'Manager';
+    static NOT_CONTRIBUTOR: string = '!Contributor';
+    static NOT_CONSUMER: string = '!Consumer';
+    static NOT_COLLABORATOR: string = '!Collaborator';
+    static NOT_MANAGER: string = '!Manager';
 }

--- a/lib/core/services/content.service.spec.ts
+++ b/lib/core/services/content.service.spec.ts
@@ -106,35 +106,67 @@ describe('ContentService', () => {
         });
     });
 
-    it('should havePermission be false if allowableOperation is not present in the node', () => {
-        let permissionNode = new Node({});
-        expect(contentService.hasPermission(permissionNode, 'create')).toBeFalsy();
+    describe('AllowableOperations', () => {
+
+        it('should hasAllowableOperations be false if allowableOperation is not present in the node', () => {
+            let permissionNode = new Node({});
+            expect(contentService.hasAllowableOperations(permissionNode, 'create')).toBeFalsy();
+        });
+
+        it('should hasAllowableOperations be true if allowableOperation is present and you have the permission for the request operation', () => {
+            let permissionNode = new Node({ allowableOperations: ['delete', 'update', 'create', 'updatePermissions'] });
+
+            expect(contentService.hasAllowableOperations(permissionNode, 'create')).toBeTruthy();
+        });
+
+        it('should hasAllowableOperations be false if allowableOperation is present but you don\'t have the permission for the request operation', () => {
+            let permissionNode = new Node({ allowableOperations: ['delete', 'update', 'updatePermissions'] });
+            expect(contentService.hasAllowableOperations(permissionNode, 'create')).toBeFalsy();
+        });
+
+        it('should hasAllowableOperations works in the opposite way with negate value', () => {
+            let permissionNode = new Node({ allowableOperations: ['delete', 'update', 'updatePermissions'] });
+            expect(contentService.hasAllowableOperations(permissionNode, '!create')).toBeTruthy();
+        });
+
+        it('should hasAllowableOperations return false if no permission parameter are passed', () => {
+            let permissionNode = new Node({ allowableOperations: ['delete', 'update', 'updatePermissions'] });
+            expect(contentService.hasAllowableOperations(permissionNode, null)).toBeFalsy();
+        });
+
+        it('should havePermission return true if permission parameter is copy', () => {
+            let permissionNode = null;
+            expect(contentService.hasAllowableOperations(permissionNode, 'copy')).toBeTruthy();
+        });
     });
 
-    it('should havePermission be true if allowableOperation is present and you have the permission for the request operation', () => {
-        let permissionNode = new Node({ allowableOperations: ['delete', 'update', 'create', 'updatePermissions'] });
+    describe('Permissions', () => {
 
-        expect(contentService.hasPermission(permissionNode, 'create')).toBeTruthy();
-    });
+        it('should havePermission be false if allowableOperation is not present in the node', () => {
+            let permissionNode = new Node({});
+            expect(contentService.hasPermissions(permissionNode, 'manager')).toBeFalsy();
+        });
 
-    it('should havePermission be false if allowableOperation is present but you don\'t have the permission for the request operation', () => {
-        let permissionNode = new Node({ allowableOperations: ['delete', 'update', 'updatePermissions'] });
-        expect(contentService.hasPermission(permissionNode, 'create')).toBeFalsy();
-    });
+        it('should havePermission be true if permissions is present and you have the permission for the request operation', () => {
+            let permissionNode = new Node({ permissions: { locallySet: [{ name: 'manager' }, { name: 'collaborator' }, { name: 'consumer' }] } });
 
-    it('should havePermission works in the opposite way with negate value', () => {
-        let permissionNode = new Node({ allowableOperations: ['delete', 'update', 'updatePermissions'] });
-        expect(contentService.hasPermission(permissionNode, '!create')).toBeTruthy();
-    });
+            expect(contentService.hasPermissions(permissionNode, 'manager')).toBeTruthy();
+        });
 
-    it('should havePermission return false id no permission parameter are passed', () => {
-        let permissionNode = new Node({ allowableOperations: ['delete', 'update', 'updatePermissions'] });
-        expect(contentService.hasPermission(permissionNode, null)).toBeFalsy();
-    });
+        it('should havePermission be false if permissions is present but you don\'t have the permission for the request operation', () => {
+            let permissionNode = new Node({ permissions: { locallySet: [{ name: 'collaborator' }, { name: 'consumer' }] } });
+            expect(contentService.hasPermissions(permissionNode, 'manager')).toBeFalsy();
+        });
 
-    it('should havePermission return true if permission parameter is copy', () => {
-        let permissionNode = null;
-        expect(contentService.hasPermission(permissionNode, 'copy')).toBeTruthy();
+        it('should havePermission works in the opposite way with negate value', () => {
+            let permissionNode = new Node({ permissions: { locallySet: [{ name: 'collaborator' }, { name: 'consumer' }] } });
+            expect(contentService.hasPermissions(permissionNode, '!manager')).toBeTruthy();
+        });
+
+        it('should havePermission return false if no permission parameter are passed', () => {
+            let permissionNode = new Node({ permissions: { locallySet: [{ name: 'collaborator' }, { name: 'consumer' }] } });
+            expect(contentService.hasPermissions(permissionNode, null)).toBeFalsy();
+        });
     });
 
     describe('Download blob', () => {


### PR DESCRIPTION
… hasPermissions

**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [X] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Meanwhile I was investigating this bug on the comments I noticed that we have a wrong concept of permission in ADF. 
What at the moment ins hasPermission in reality hasAllowableOperation and instead the hasPermission concept was completely missing:

Permission are in the default configuration:
https://docs.alfresco.com/5.2/references/permissions_share_components.html

```
'Contributor' , 'Consumer',  'Collaborator', 'Manager';
```

Instead the operations are:

```
'create', 'delete', 'edit' ....
```
Because is a  breaking change will be better add this modify here in 3.0.0 and explain it in the breaking change  guide

Note the same bug is present also in ACA: 
https://github.com/Alfresco/alfresco-content-app/blob/02029264659f29b7d71937cae5cb79686d52c6a5/src/app/components/info-drawer/comments-tab/comments-tab.component.ts#L46

this should be with this new modify:

                            this.isCommentEnabled = !this.contentServices.hasPermissions(node, PermissionsEnum.NOT_CONSUMER);


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [x] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-4062