### PR TITLE
Removing C268119 test that shouldn't be automated

### DIFF
--- a/e2e/content-services/document-list/document-list-component.e2e.ts
+++ b/e2e/content-services/document-list/document-list-component.e2e.ts
@@ -365,23 +365,6 @@ describe('Document List Component', () => {
         done();
     });
 
-    it('[C268119] - ygj letters rendering in document list', async (done) => {
-        acsUser = new AcsUserModel();
-        /* cspell:disable-next-line */
-        let folderName = 'ggggggjjjjjjjjjjjjyyyyyy';
-        await this.alfrescoJsApi.login(TestConfig.adf.adminEmail, TestConfig.adf.adminPassword);
-        await this.alfrescoJsApi.core.peopleApi.addPerson(acsUser);
-        await this.alfrescoJsApi.login(acsUser.id, acsUser.password);
-        uploadedFolder = await uploadActions.createFolder(this.alfrescoJsApi, folderName, '-my-');
-        loginPage.loginToContentServicesUsingUserModel(acsUser);
-        contentServicesPage.clickOnContentServices();
-        let lineHeight = await contentServicesPage.getStyleValueForRowText(folderName, 'line-height');
-        let fontSize = await contentServicesPage.getStyleValueForRowText(folderName, 'font-size');
-        let actualFontValue = (parseInt(fontSize, 10) * 1.12).toFixed(2);
-        expect(lineHeight).toBe(actualFontValue + 'px');
-        done();
-    });
-
     it('[C279970] Should display Islocked field for folders', async (done) => {
         acsUser = new AcsUserModel();
         let folderNameA = `MEESEEKS_${Util.generateRandomString(5)}_LOOK_AT_ME`;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
This test is about visual elements, we agreed that we shouldn't automate this kind of tests.


**What is the new behaviour?**
This test has to be tested manually


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
