### PR TITLE
[ADF-4077] fix performance issue getSite in processservice usign -my-

### DIFF
--- a/lib/content-services/content-node-selector/content-node-dialog.service.ts
+++ b/lib/content-services/content-node-selector/content-node-dialog.service.ts
@@ -104,9 +104,7 @@ export class ContentNodeDialogService {
      * @returns Information about the selected folder(s)
      */
     openFolderBrowseDialogBySite(): Observable<Node[]> {
-        return this.siteService.getSites().pipe(switchMap((response: SitePaging) => {
-            return this.openFolderBrowseDialogByFolderId(response.list.entries[0].entry.guid);
-        }));
+        return this.openFolderBrowseDialogByFolderId('-my-');
     }
 
     /**


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
The attachfolder from a repository in the process service is a bit slow because it perform a call to getall the sites before to open the dialog

Note this bug happen only when you have really tons of sites

**What is the new behaviour?**
I removed the call because anyway just getting the first sites without filter it and use -my- as start site is probably a better thing for performance and at a behaviour level


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-4077