### PR TITLE
Link objects have broken thumbnail icons

### DIFF
--- a/lib/content-services/document-list/data/share-datatable-adapter.ts
+++ b/lib/content-services/document-list/data/share-datatable-adapter.ts
@@ -118,8 +118,10 @@ export class ShareDataTableAdapter implements DataTableAdapter {
             }
 
             if (node.entry.isFile) {
-                if (this.thumbnails) {
+                if (this.thumbnails && node.entry.nodeType != "app:filelink") {
                     return this.documentListService.getDocumentThumbnailUrl(node);
+                } else if (this.thumbnails && "cm:destination" in node.entry.properties) {
+                    return this.documentListService.getDocumentThumbnailUrl(node.entry.properties["cm:destination"]);
                 }
             }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
If a directory listing includes a link object, thumbnails for that object will be broken in the file list.


**What is the new behaviour?**
Show the thumbnail for the destination node, if it exists.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
