### PR TITLE
[ADF-4083] search facetIntervals - empty spaced labels support 

### DIFF
--- a/demo-shell/src/app.config.json
+++ b/demo-shell/src/app.config.json
@@ -136,7 +136,7 @@
         "expanded": true,
         "intervals":[
           {
-            "label":"TheCreated",
+            "label":"The Created",
             "field":"cm:created",
             "sets":[
               { "label":"lastYear", "start":"2018", "end":"2019", "endInclusive":false },

--- a/e2e/pages/adf/searchFiltersPage.ts
+++ b/e2e/pages/adf/searchFiltersPage.ts
@@ -37,7 +37,7 @@ export class SearchFiltersPage {
         'mat-expansion-panel[data-automation-id="expansion-panel-My facet queries"]'));
     facetQueriesTypeGroup = element(by.css('mat-expansion-panel[data-automation-id="expansion-panel-Type facet queries"]'));
     facetQueriesSizeGroup = element(by.css('mat-expansion-panel[data-automation-id="expansion-panel-Size facet queries"]'));
-    facetIntervalsByCreated = element(by.css('mat-expansion-panel[data-automation-id="expansion-panel-TheCreated"]'));
+    facetIntervalsByCreated = element(by.css('mat-expansion-panel[data-automation-id="expansion-panel-The Created"]'));
     facetIntervalsByModified = element(by.css('mat-expansion-panel[data-automation-id="expansion-panel-TheModified"]'));
 
     checkSearchFiltersIsDisplayed() {

--- a/lib/content-services/search/components/search-filter/search-filter.component.ts
+++ b/lib/content-services/search/components/search-filter/search-filter.component.ts
@@ -189,7 +189,7 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
         }
     }
 
-    private parseFacetItems(context: ResultSetContext, configFacetFields: Array<FacetField>, itemType: string): FacetField[] {
+    private parseFacetItems(context: ResultSetContext, configFacetFields: FacetField[], itemType: string): FacetField[] {
         return configFacetFields.map((field) => {
             const responseField = (context.facets || []).find((response) => response.type === itemType && response.label === field.label) || {};
             const responseBuckets = this.getResponseBuckets(responseField, field)
@@ -314,20 +314,20 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
         };
     }
 
-    private getCorrespondingFilterQuery (field: FacetField, bucketLabel: string): string {
+    private getCorrespondingFilterQuery (facetField: FacetField, bucketLabel: string): string {
         let filterQuery = null;
 
-        if (field.field && bucketLabel) {
+        if (facetField.field && bucketLabel) {
 
-            if (field.sets) {
-                const configSet = field.sets.find((set) => bucketLabel === set.label);
+            if (facetField.sets) {
+                const configSet = facetField.sets.find((set) => bucketLabel === set.label);
 
                 if (configSet) {
-                    filterQuery = this.buildIntervalQuery(field.field, configSet);
+                    filterQuery = this.buildIntervalQuery(facetField.field, configSet);
                 }
 
             } else {
-                filterQuery = `${field.field}:"${bucketLabel}"`;
+                filterQuery = `${facetField.field}:"${bucketLabel}"`;
             }
         }
 

--- a/lib/content-services/search/components/search-filter/search-filter.component.ts
+++ b/lib/content-services/search/components/search-filter/search-filter.component.ts
@@ -314,10 +314,32 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
         };
     }
 
-    private getCorrespondingFilterQuery (configFacetItem: FacetField, bucketLabel: string): string {
-        if (!configFacetItem.field || !bucketLabel) {
+    // remove once [SEARCH-1487] issue is fixed
+    private getCorrespondingFilterQuery (field, bucketLabel: string): string {
+        if (!field.field || !bucketLabel) {
             return null;
         }
-        return `${configFacetItem.field}:"${bucketLabel}"`;
+
+        if (!field.sets) {
+            return `${field.field}:"${bucketLabel}"`;
+
+        } else {
+            const configSet = field.sets.find((set) => bucketLabel === set.label);
+
+            if (configSet) {
+                return this.buildIntervalQuery(field.field, configSet);
+            }
+        }
+
+        return null;
+    }
+
+    private buildIntervalQuery(fieldName, interval): string {
+        const start = interval.start;
+        const end = interval.end;
+        const startLimit = (interval.startInclusive === undefined || interval.startInclusive === true) ? '[' : '<';
+        const endLimit = (interval.endInclusive === undefined || interval.endInclusive === true) ? ']' : '>';
+
+        return `${fieldName}:${startLimit}"${start}" TO "${end}"${endLimit}`;
     }
 }

--- a/lib/content-services/search/components/search-filter/search-filter.component.ts
+++ b/lib/content-services/search/components/search-filter/search-filter.component.ts
@@ -314,7 +314,6 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
         };
     }
 
-    // remove once [SEARCH-1487] issue is fixed
     private getCorrespondingFilterQuery (field, bucketLabel: string): string {
         if (!field.field || !bucketLabel) {
             return null;

--- a/lib/content-services/search/components/search-filter/search-filter.component.ts
+++ b/lib/content-services/search/components/search-filter/search-filter.component.ts
@@ -189,7 +189,7 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
         }
     }
 
-    private parseFacetItems(context: ResultSetContext, configFacetFields, itemType): FacetField[] {
+    private parseFacetItems(context: ResultSetContext, configFacetFields: Array<FacetField>, itemType: string): FacetField[] {
         return configFacetFields.map((field) => {
             const responseField = (context.facets || []).find((response) => response.type === itemType && response.label === field.label) || {};
             const responseBuckets = this.getResponseBuckets(responseField, field)
@@ -314,7 +314,7 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
         };
     }
 
-    private getCorrespondingFilterQuery (field, bucketLabel: string): string {
+    private getCorrespondingFilterQuery (field: FacetField, bucketLabel: string): string {
         if (!field.field || !bucketLabel) {
             return null;
         }
@@ -333,7 +333,7 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
         return null;
     }
 
-    private buildIntervalQuery(fieldName, interval): string {
+    private buildIntervalQuery(fieldName: string, interval: any): string {
         const start = interval.start;
         const end = interval.end;
         const startLimit = (interval.startInclusive === undefined || interval.startInclusive === true) ? '[' : '<';

--- a/lib/content-services/search/components/search-filter/search-filter.component.ts
+++ b/lib/content-services/search/components/search-filter/search-filter.component.ts
@@ -314,20 +314,20 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
         };
     }
 
-    private getCorrespondingFilterQuery (facetField: FacetField, bucketLabel: string): string {
+    private getCorrespondingFilterQuery (configFacetField: FacetField, bucketLabel: string): string {
         let filterQuery = null;
 
-        if (facetField.field && bucketLabel) {
+        if (configFacetField.field && bucketLabel) {
 
-            if (facetField.sets) {
-                const configSet = facetField.sets.find((set) => bucketLabel === set.label);
+            if (configFacetField.sets) {
+                const configSet = configFacetField.sets.find((set) => bucketLabel === set.label);
 
                 if (configSet) {
-                    filterQuery = this.buildIntervalQuery(facetField.field, configSet);
+                    filterQuery = this.buildIntervalQuery(configFacetField.field, configSet);
                 }
 
             } else {
-                filterQuery = `${facetField.field}:"${bucketLabel}"`;
+                filterQuery = `${configFacetField.field}:"${bucketLabel}"`;
             }
         }
 

--- a/lib/content-services/search/components/search-filter/search-filter.component.ts
+++ b/lib/content-services/search/components/search-filter/search-filter.component.ts
@@ -315,22 +315,23 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
     }
 
     private getCorrespondingFilterQuery (field: FacetField, bucketLabel: string): string {
-        if (!field.field || !bucketLabel) {
-            return null;
-        }
+        let filterQuery = null;
 
-        if (!field.sets) {
-            return `${field.field}:"${bucketLabel}"`;
+        if (field.field && bucketLabel) {
 
-        } else {
-            const configSet = field.sets.find((set) => bucketLabel === set.label);
+            if (field.sets) {
+                const configSet = field.sets.find((set) => bucketLabel === set.label);
 
-            if (configSet) {
-                return this.buildIntervalQuery(field.field, configSet);
+                if (configSet) {
+                    filterQuery = this.buildIntervalQuery(field.field, configSet);
+                }
+
+            } else {
+                filterQuery = `${field.field}:"${bucketLabel}"`;
             }
         }
 
-        return null;
+        return filterQuery;
     }
 
     private buildIntervalQuery(fieldName: string, interval: any): string {

--- a/lib/content-services/search/components/search-filter/search-filter.component.ts
+++ b/lib/content-services/search/components/search-filter/search-filter.component.ts
@@ -314,20 +314,20 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
         };
     }
 
-    private getCorrespondingFilterQuery (configFacetField: FacetField, bucketLabel: string): string {
+    private getCorrespondingFilterQuery (configFacetItem: FacetField, bucketLabel: string): string {
         let filterQuery = null;
 
-        if (configFacetField.field && bucketLabel) {
+        if (configFacetItem.field && bucketLabel) {
 
-            if (configFacetField.sets) {
-                const configSet = configFacetField.sets.find((set) => bucketLabel === set.label);
+            if (configFacetItem.sets) {
+                const configSet = configFacetItem.sets.find((set) => bucketLabel === set.label);
 
                 if (configSet) {
-                    filterQuery = this.buildIntervalQuery(configFacetField.field, configSet);
+                    filterQuery = this.buildIntervalQuery(configFacetItem.field, configSet);
                 }
 
             } else {
-                filterQuery = `${configFacetField.field}:"${bucketLabel}"`;
+                filterQuery = `${configFacetItem.field}:"${bucketLabel}"`;
             }
         }
 

--- a/lib/content-services/search/facet-field.interface.ts
+++ b/lib/content-services/search/facet-field.interface.ts
@@ -31,4 +31,5 @@ export interface FacetField {
     currentPageSize?: number;
     checked?: boolean;
     type?: string;
+    [propName: string]: any;
 }

--- a/lib/content-services/search/search-configuration.interface.ts
+++ b/lib/content-services/search/search-configuration.interface.ts
@@ -22,28 +22,28 @@ import { SearchCategory } from './search-category.interface';
 import { SearchSortingDefinition } from './search-sorting-definition.interface';
 
 export interface SearchConfiguration {
-    include?: Array<string>;
-    fields?: Array<string>;
-    categories: Array<SearchCategory>;
-    filterQueries?: Array<FilterQuery>;
+    include?: string[];
+    fields?: string[];
+    categories: SearchCategory[];
+    filterQueries?: FilterQuery[];
     filterWithContains?: boolean;
     facetQueries?: {
         label?: string;
         pageSize?: number;
         expanded?: boolean;
         mincount?: number;
-        queries: Array<FacetQuery>;
+        queries: FacetQuery[];
     };
     facetFields?: {
         expanded?: boolean;
-        fields: Array<FacetField>;
+        fields: FacetField[];
     };
     facetIntervals?: {
         expanded?: boolean;
-        intervals: Array<FacetField>;
+        intervals: FacetField[];
     };
     sorting?: {
-        options: Array<SearchSortingDefinition>;
-        defaults: Array<SearchSortingDefinition>;
+        options: SearchSortingDefinition[];
+        defaults: SearchSortingDefinition[];
     };
 }

--- a/lib/content-services/search/search-configuration.interface.ts
+++ b/lib/content-services/search/search-configuration.interface.ts
@@ -40,7 +40,7 @@ export interface SearchConfiguration {
     };
     facetIntervals?: {
         expanded?: boolean;
-        intervals: Array<any>;
+        intervals: Array<FacetField>;
     };
     sorting?: {
         options: Array<SearchSortingDefinition>;

--- a/lib/content-services/search/search-query-builder.service.spec.ts
+++ b/lib/content-services/search/search-query-builder.service.spec.ts
@@ -425,16 +425,16 @@ describe('SearchQueryBuilder', () => {
                         label: 'test_intervals1',
                         field: 'f1',
                         sets: [
-                            { label: 'interval1', start: 's1', end: 'e1' },
-                            { label: 'interval2', start: 's2', end: 'e2' }
+                            { label: 'interval1', start: 's1', end: 'e1', startInclusive: true, endInclusive: true  },
+                            { label: 'interval2', start: 's2', end: 'e2', startInclusive: false, endInclusive: true }
                         ]
                     },
                     {
                         label: 'test_intervals2',
                         field: 'f2',
                         sets: [
-                            { label: 'interval3', start: 's3', end: 'e3' },
-                            { label: 'interval4', start: 's4', end: 'e4' }
+                            { label: 'interval3', start: 's3', end: 'e3', startInclusive: true, endInclusive: false },
+                            { label: 'interval4', start: 's4', end: 'e4', startInclusive: false, endInclusive: false }
                         ]
                     }
                 ]

--- a/lib/content-services/search/search-query-builder.service.spec.ts
+++ b/lib/content-services/search/search-query-builder.service.spec.ts
@@ -447,6 +447,51 @@ describe('SearchQueryBuilder', () => {
         expect(compiled.facetIntervals).toEqual(jasmine.objectContaining(config.facetIntervals));
     });
 
+    it('should build query with custom facet intervals automatically getting their request compatible labels', () => {
+        const spacesLabel = {
+            configValue: 'label with spaces',
+            requestCompatibleValue: '"label with spaces"'
+        };
+        const noSpacesLabel = {
+            configValue: 'label',
+            requestCompatibleValue: 'label'
+        };
+
+        const config: SearchConfiguration = {
+            categories: [
+                <any> { id: 'cat1', enabled: true }
+            ],
+            facetIntervals: {
+                intervals: [
+                    {
+                        label: spacesLabel.configValue,
+                        field: 'f1',
+                        sets: [
+                            { label: 'interval1', start: 's1', end: 'e1' },
+                            { label: 'interval2', start: 's2', end: 'e2' }
+                        ]
+                    },
+                    {
+                        label: noSpacesLabel.configValue,
+                        field: 'f2',
+                        sets: [
+                            { label: 'interval3', start: 's3', end: 'e3' },
+                            { label: 'interval4', start: 's4', end: 'e4' }
+                        ]
+                    }
+                ]
+            }
+        };
+        const builder = new SearchQueryBuilderService(buildConfig(config), null);
+        builder.queryFragments['cat1'] = 'cm:name:test';
+
+        const compiled = builder.buildQuery();
+        expect(compiled.facetIntervals.intervals[0].label).toEqual(spacesLabel.requestCompatibleValue);
+        expect(compiled.facetIntervals.intervals[0].label).not.toEqual(spacesLabel.configValue);
+        expect(compiled.facetIntervals.intervals[1].label).toEqual(noSpacesLabel.requestCompatibleValue);
+        expect(compiled.facetIntervals.intervals[1].label).toEqual(noSpacesLabel.configValue);
+    });
+
     it('should build query with sorting', () => {
         const config: SearchConfiguration = {
             fields: [],

--- a/lib/content-services/search/search-query-builder.service.spec.ts
+++ b/lib/content-services/search/search-query-builder.service.spec.ts
@@ -456,6 +456,10 @@ describe('SearchQueryBuilder', () => {
             configValue: 'label',
             requestCompatibleValue: 'label'
         };
+        const spacesLabelForSet = {
+            configValue: 'label for set',
+            requestCompatibleValue: '"label for set"'
+        };
 
         const config: SearchConfiguration = {
             categories: [
@@ -467,7 +471,7 @@ describe('SearchQueryBuilder', () => {
                         label: spacesLabel.configValue,
                         field: 'f1',
                         sets: [
-                            { label: 'interval1', start: 's1', end: 'e1' },
+                            { label: spacesLabelForSet.configValue, start: 's1', end: 'e1' },
                             { label: 'interval2', start: 's2', end: 'e2' }
                         ]
                     },
@@ -490,6 +494,9 @@ describe('SearchQueryBuilder', () => {
         expect(compiled.facetIntervals.intervals[0].label).not.toEqual(spacesLabel.configValue);
         expect(compiled.facetIntervals.intervals[1].label).toEqual(noSpacesLabel.requestCompatibleValue);
         expect(compiled.facetIntervals.intervals[1].label).toEqual(noSpacesLabel.configValue);
+
+        expect(compiled.facetIntervals.intervals[0].sets[0].label).toEqual(spacesLabelForSet.requestCompatibleValue);
+
     });
 
     it('should build query with sorting', () => {

--- a/lib/content-services/search/search-query-builder.service.ts
+++ b/lib/content-services/search/search-query-builder.service.ts
@@ -325,7 +325,13 @@ export class SearchQueryBuilderService {
                 intervals: configIntervals.intervals.map((interval) => <any> {
                     label: this.getSupportedLabel(interval.label),
                     field: interval.field,
-                    sets: interval.sets
+                    sets: interval.sets.map((set) => <any> {
+                        label: this.getSupportedLabel(set.label),
+                        start: set.start,
+                        end: set.end,
+                        startInclusive: set.startInclusive,
+                        endInclusive: set.endInclusive
+                    })
                 })
             };
         }

--- a/lib/content-services/search/search-query-builder.service.ts
+++ b/lib/content-services/search/search-query-builder.service.ts
@@ -323,7 +323,7 @@ export class SearchQueryBuilderService {
 
             return {
                 intervals: configIntervals.intervals.map((interval) => <any> {
-                    label: interval.label,
+                    label: this.getSupportedLabel(interval.label),
                     field: interval.field,
                     sets: interval.sets
                 })


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe:
 There was a API limitation so that the response was not correct for the facet intervals that had labels with spaces inside them. This problem is now fixed.
  The filter component is now changed by this PR so to also support such labels for facet intervals.

**What is the current behaviour?** (You can also link to an open issue here)
Facet intervals cannot have spaces inside labels, because the current response parser cannot fetch the response https://issues.alfresco.com/jira/browse/ADF-4083


**What is the new behaviour?**
Facet intervals can now have labels with spaces. In order for the API to return the correct response, such labels need to be wrapped inside quotes.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
This PR is dependent on Facet intervals on search filter #4255