### PR TITLE
[ADF-4147] Add task details redirection toggle in cloud settings page

### DIFF
--- a/demo-shell/resources/i18n/en.json
+++ b/demo-shell/resources/i18n/en.json
@@ -310,6 +310,7 @@
   "SETTINGS_CLOUD": {
       "MULTISELECTION": "Multiselection",
       "TESTING_MODE": "Testing Mode",
-      "SELECTION_MODE": "Selection Mode"
+      "SELECTION_MODE": "Selection Mode",
+      "TASK_DETAILS_REDIRECTION": "Display task details on task click"
   }
 }

--- a/demo-shell/src/app/components/app-layout/cloud/cloud-settings.component.html
+++ b/demo-shell/src/app/components/app-layout/cloud/cloud-settings.component.html
@@ -1,10 +1,13 @@
 <div fxFlex fxLayout="column" class="adf-settings-container">
-    <mat-checkbox [color]="'primary'" [checked]="multiselect" (change)="toggleMultiselect()" data-automation-id="multiSelection">
+    <mat-slide-toggle [color]="'primary'" [checked]="multiselect" (change)="toggleMultiselect()" data-automation-id="multiSelection">
         {{ 'SETTINGS_CLOUD.MULTISELECTION' | translate }}
-    </mat-checkbox>
-    <mat-checkbox [color]="'primary'" [checked]="testingMode" (change)="toggleTestingMode()" data-automation-id="testingMode">
+    </mat-slide-toggle>
+    <mat-slide-toggle [color]="'primary'" [checked]="testingMode" (change)="toggleTestingMode()" data-automation-id="testingMode">
         {{ 'SETTINGS_CLOUD.TESTING_MODE' | translate }}
-    </mat-checkbox>
+    </mat-slide-toggle>
+    <mat-slide-toggle [color]="'primary'" [checked]="taskDetailsRedirection" (change)="toggleTaskDetailsRedirection()" data-automation-id="taskDetailsRedirection">
+        {{ 'SETTINGS_CLOUD.TASK_DETAILS_REDIRECTION' | translate }}
+    </mat-slide-toggle>
     <mat-form-field>
         <mat-label>
             {{ 'SETTINGS_CLOUD.SELECTION_MODE' | translate }}

--- a/demo-shell/src/app/components/app-layout/cloud/cloud-settings.component.ts
+++ b/demo-shell/src/app/components/app-layout/cloud/cloud-settings.component.ts
@@ -28,6 +28,7 @@ export class CloudSettingsComponent implements OnInit {
     multiselect: boolean;
     selectionMode: string;
     testingMode: boolean;
+    taskDetailsRedirection: boolean;
 
     selectionModeOptions = [
         { value: '', title: 'None' },
@@ -43,14 +44,11 @@ export class CloudSettingsComponent implements OnInit {
     }
 
     setCurrentSettings(settings) {
-        if (settings.multiselect !== undefined) {
+        if (settings) {
             this.multiselect = settings.multiselect;
-        }
-        if (settings.testingMode !== undefined) {
             this.testingMode = settings.testingMode;
-        }
-        if (settings.selectionMode !== undefined) {
             this.selectionMode = settings.selectionMode;
+            this.taskDetailsRedirection = settings.taskDetailsRedirection;
         }
     }
 
@@ -64,6 +62,11 @@ export class CloudSettingsComponent implements OnInit {
         this.setSetting();
     }
 
+    toggleTaskDetailsRedirection() {
+        this.taskDetailsRedirection = !this.taskDetailsRedirection;
+        this.setSetting();
+    }
+
     onSelectionModeChange() {
         this.setSetting();
     }
@@ -72,7 +75,8 @@ export class CloudSettingsComponent implements OnInit {
         this.cloudLayoutService.setCurrentSettings({
             multiselect: this.multiselect,
             testingMode: this.testingMode,
-            selectionMode: this.selectionMode
+            selectionMode: this.selectionMode,
+            taskDetailsRedirection: this.taskDetailsRedirection
         });
     }
 }

--- a/demo-shell/src/app/components/app-layout/cloud/processes-cloud-demo.component.ts
+++ b/demo-shell/src/app/components/app-layout/cloud/processes-cloud-demo.component.ts
@@ -85,13 +85,9 @@ export class ProcessesCloudDemoComponent implements OnInit {
     }
 
     setCurrentSettings(settings) {
-        if (settings.multiselect !== undefined) {
+        if (settings) {
             this.multiselect = settings.multiselect;
-        }
-        if (settings.testingMode !== undefined) {
             this.testingMode = settings.testingMode;
-        }
-        if (settings.selectionMode !== undefined) {
             this.selectionMode = settings.selectionMode;
         }
     }

--- a/demo-shell/src/app/components/app-layout/cloud/services/cloud-layout.service.ts
+++ b/demo-shell/src/app/components/app-layout/cloud/services/cloud-layout.service.ts
@@ -26,6 +26,7 @@ export class CloudLayoutService {
     private settings = {
         multiselect: false,
         testingMode: false,
+        taskDetailsRedirection: true,
         selectionMode: 'single'
     };
 

--- a/demo-shell/src/app/components/app-layout/cloud/tasks-cloud-demo.component.ts
+++ b/demo-shell/src/app/components/app-layout/cloud/tasks-cloud-demo.component.ts
@@ -48,6 +48,7 @@ export class TasksCloudDemoComponent implements OnInit {
     selectedRows: string[] = [];
     testingMode: boolean;
     selectionMode: string;
+    taskDetailsRedirection: boolean;
 
     constructor(
         private cloudLayoutService: CloudLayoutService,
@@ -79,14 +80,11 @@ export class TasksCloudDemoComponent implements OnInit {
     }
 
     setCurrentSettings(settings) {
-        if (settings.multiselect !== undefined) {
+        if (settings) {
             this.multiselect = settings.multiselect;
-        }
-        if (settings.testingMode !== undefined) {
             this.testingMode = settings.testingMode;
-        }
-        if (settings.selectionMode !== undefined) {
             this.selectionMode = settings.selectionMode;
+            this.selectionMode = settings.taskDetailsRedirection;
         }
     }
 
@@ -99,7 +97,7 @@ export class TasksCloudDemoComponent implements OnInit {
     }
 
     onRowClick(taskId) {
-        if (!this.multiselect && this.selectionMode !== 'multiple') {
+        if (!this.multiselect && this.selectionMode !== 'multiple' && this.taskDetailsRedirection) {
             this.router.navigate([`/cloud/${this.appName}/task-details/${taskId}`]);
         }
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
It's not possible to disable redirection to task details when a task is clicked in the task list cloud component.
https://issues.alfresco.com/jira/browse/ADF-4147

**What is the new behaviour?**
A new toggle has been added to the cloud settings page to enable this functionality.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-4147