### PR TITLE
[ADF-4083] Parse 'escaped' empty spaced labels inside facetFields

### DIFF
--- a/e2e/pages/adf/searchFiltersPage.ts
+++ b/e2e/pages/adf/searchFiltersPage.ts
@@ -68,6 +68,10 @@ export class SearchFiltersPage {
         return this.searchCategoriesPage.checkListFiltersPage(this.fileTypeFilter);
     }
 
+    checkCustomFacetFieldLabelIsDisplayed(fieldLabel) {
+        Util.waitUntilElementIsVisible(element(by.css(`mat-expansion-panel[data-automation-id="expansion-panel-${fieldLabel}"]`)));
+    }
+
     sizeSliderFilterPage() {
         return this.searchCategoriesPage.sliderFilter(this.sizeSliderFilter);
     }

--- a/e2e/search/search-filters.e2e.ts
+++ b/e2e/search/search-filters.e2e.ts
@@ -225,4 +225,21 @@ describe('Search Filters', () => {
             .checkFacetIntervalsByModifiedIsExpanded();
     });
 
+    it('[C299124] Should be able to parse escaped empty spaced labels inside facetFields', () => {
+        navigationBar.clickConfigEditorButton();
+        configEditor.clickSearchConfiguration();
+        configEditor.clickClearButton();
+        jsonFile.facetFields.fields[0].label = 'My File Types';
+        jsonFile.facetFields.fields[1].label = 'My File Sizes';
+        configEditor.enterBigConfigurationText(JSON.stringify(jsonFile));
+        configEditor.clickSaveButton();
+
+        searchDialog.clickOnSearchIcon()
+            .enterTextAndPressEnter('*');
+
+        searchResults.tableIsLoaded();
+        searchFiltersPage.checkCustomFacetFieldLabelIsDisplayed("My File Types");
+        searchFiltersPage.checkCustomFacetFieldLabelIsDisplayed("My File Sizes");
+    });
+
 });

--- a/e2e/search/search-filters.e2e.ts
+++ b/e2e/search/search-filters.e2e.ts
@@ -238,8 +238,8 @@ describe('Search Filters', () => {
             .enterTextAndPressEnter('*');
 
         searchResults.tableIsLoaded();
-        searchFiltersPage.checkCustomFacetFieldLabelIsDisplayed("My File Types");
-        searchFiltersPage.checkCustomFacetFieldLabelIsDisplayed("My File Sizes");
+        searchFiltersPage.checkCustomFacetFieldLabelIsDisplayed('My File Types');
+        searchFiltersPage.checkCustomFacetFieldLabelIsDisplayed('My File Sizes');
     });
 
 });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-4083