### PR TITLE
[ADF-3989] appname duplicated after switching between saved filters

### DIFF
--- a/e2e/pages/adf/process-cloud/editProcessFilterCloudComponent.ts
+++ b/e2e/pages/adf/process-cloud/editProcessFilterCloudComponent.ts
@@ -113,7 +113,7 @@ export class EditProcessFilterCloudComponent {
         let appNameList = element.all(by.css('mat-option[data-automation-id="adf-cloud-edit-process-property-optionsappName"] span'));
         let appTextList = await appNameList.getText();
         let uniqueArray = appTextList.filter((appName) => {
-            let sameAppNameArray = appTextList.filter(element => element === appName);
+            let sameAppNameArray = appTextList.filter((eachApp) => eachApp === appName);
             return sameAppNameArray.length === 1;
         });
         return uniqueArray.length === appTextList.length;

--- a/e2e/pages/adf/process-cloud/editProcessFilterCloudComponent.ts
+++ b/e2e/pages/adf/process-cloud/editProcessFilterCloudComponent.ts
@@ -99,6 +99,32 @@ export class EditProcessFilterCloudComponent {
         Util.waitUntilElementIsVisible(this.selectedOption);
     }
 
+    setAppNameDropDown(option) {
+        this.clickOnDropDownArrow('appName');
+
+        let appNameElement = element.all(by.cssContainingText('mat-option span', option)).first();
+        Util.waitUntilElementIsClickable(appNameElement);
+        Util.waitUntilElementIsVisible(appNameElement);
+        appNameElement.click();
+        return this;
+    }
+
+    async checkAppNamesAreUnique() {
+        let appNameList = element.all(by.css('mat-option[data-automation-id="adf-cloud-edit-process-property-optionsappName"] span'));
+        let appTextList = await appNameList.getText();
+        let uniqueArray = appTextList.filter((appName) => {
+            let sameAppNameArray = appTextList.filter(element => element === appName);
+            return sameAppNameArray.length === 1;
+        });
+        return uniqueArray.length === appTextList.length;
+    }
+
+    getNumberOfAppNameOptions() {
+        this.clickOnDropDownArrow('appName');
+        let dropdownOptions = element.all(by.css('.mat-select-panel mat-option'));
+        return dropdownOptions.count();
+    }
+
     setProcessInstanceId(option) {
         return this.setProperty('processInstanceId', option);
     }

--- a/e2e/process-services-cloud/processListCloud.config.ts
+++ b/e2e/process-services-cloud/processListCloud.config.ts
@@ -22,89 +22,89 @@ export class ProcessListCloudConfiguration {
 
     getConfiguration() {
         return {
-    'presets': {
-    'default': [
-        {
-            'key': 'entry.id',
-            'type': 'text',
-            'title': 'ADF_CLOUD_PROCESS_LIST.PROPERTIES.ID',
-            'sortable': true
-        },
-        {
-            'key': 'entry.name',
-            'type': 'text',
-            'title': 'ADF_CLOUD_PROCESS_LIST.PROPERTIES.NAME',
-            'sortable': true
-        },
-        {
-            'key': 'entry.status',
-            'type': 'text',
-            'title': 'ADF_CLOUD_PROCESS_LIST.PROPERTIES.STATUS',
-            'sortable': true
-        },
-        {
-            'key': 'entry.startDate',
-            'type': 'date',
-            'title': 'ADF_CLOUD_PROCESS_LIST.PROPERTIES.START_DATE',
-            'sortable': true,
-            'format': 'timeAgo'
-        },
-        {
-            'key': 'entry.appName',
-            'type': 'text',
-            'title': 'ADF_CLOUD_PROCESS_LIST.PROPERTIES.APP_NAME',
-            'sortable': true
-        },
-        {
-            'key': 'entry.businessKey',
-            'type': 'text',
-            'title': 'ADF_CLOUD_PROCESS_LIST.PROPERTIES.BUSINESS_KEY',
-            'sortable': true
-        },
-        {
-            'key': 'entry.description',
-            'type': 'text',
-            'title': 'ADF_CLOUD_PROCESS_LIST.PROPERTIES.DESCRIPTION',
-            'sortable': true
-        },
-        {
-            'key': 'entry.initiator',
-            'type': 'text',
-            'title': 'ADF_CLOUD_PROCESS_LIST.PROPERTIES.INITIATOR',
-            'sortable': true
-        },
-        {
-            'key': 'entry.lastModified',
-            'type': 'date',
-            'title': 'ADF_CLOUD_PROCESS_LIST.PROPERTIES.LAST_MODIFIED',
-            'sortable': true
-        },
-        {
-            'key': 'entry.processName',
-            'type': 'text',
-            'title': 'ADF_CLOUD_PROCESS_LIST.PROPERTIES.PROCESS_NAME',
-            'sortable': true
-        },
-        {
-            'key': 'entry.processId',
-            'type': 'text',
-            'title': 'ADF_CLOUD_PROCESS_LIST.PROPERTIES.PROCESS_ID',
-            'sortable': true
-        },
-        {
-            'key': 'entry.processDefinitionId',
-            'type': 'text',
-            'title': 'ADF_CLOUD_PROCESS_LIST.PROPERTIES.PROCESS_DEFINITION_ID',
-            'sortable': true
-        },
-        {
-            'key': 'entry.processDefinitionKey',
-            'type': 'text',
-            'title': 'ADF_CLOUD_PROCESS_LIST.PROPERTIES.PROCESS_DEFINITION_KEY',
-            'sortable': true
-        }
-    ]
-    }
-};
+            'presets': {
+                'default': [
+                    {
+                        'key': 'entry.id',
+                        'type': 'text',
+                        'title': 'ADF_CLOUD_PROCESS_LIST.PROPERTIES.ID',
+                        'sortable': true
+                    },
+                    {
+                        'key': 'entry.name',
+                        'type': 'text',
+                        'title': 'ADF_CLOUD_PROCESS_LIST.PROPERTIES.NAME',
+                        'sortable': true
+                    },
+                    {
+                        'key': 'entry.status',
+                        'type': 'text',
+                        'title': 'ADF_CLOUD_PROCESS_LIST.PROPERTIES.STATUS',
+                        'sortable': true
+                    },
+                    {
+                        'key': 'entry.startDate',
+                        'type': 'date',
+                        'title': 'ADF_CLOUD_PROCESS_LIST.PROPERTIES.START_DATE',
+                        'sortable': true,
+                        'format': 'timeAgo'
+                    },
+                    {
+                        'key': 'entry.appName',
+                        'type': 'text',
+                        'title': 'ADF_CLOUD_PROCESS_LIST.PROPERTIES.APP_NAME',
+                        'sortable': true
+                    },
+                    {
+                        'key': 'entry.businessKey',
+                        'type': 'text',
+                        'title': 'ADF_CLOUD_PROCESS_LIST.PROPERTIES.BUSINESS_KEY',
+                        'sortable': true
+                    },
+                    {
+                        'key': 'entry.description',
+                        'type': 'text',
+                        'title': 'ADF_CLOUD_PROCESS_LIST.PROPERTIES.DESCRIPTION',
+                        'sortable': true
+                    },
+                    {
+                        'key': 'entry.initiator',
+                        'type': 'text',
+                        'title': 'ADF_CLOUD_PROCESS_LIST.PROPERTIES.INITIATOR',
+                        'sortable': true
+                    },
+                    {
+                        'key': 'entry.lastModified',
+                        'type': 'date',
+                        'title': 'ADF_CLOUD_PROCESS_LIST.PROPERTIES.LAST_MODIFIED',
+                        'sortable': true
+                    },
+                    {
+                        'key': 'entry.processName',
+                        'type': 'text',
+                        'title': 'ADF_CLOUD_PROCESS_LIST.PROPERTIES.PROCESS_NAME',
+                        'sortable': true
+                    },
+                    {
+                        'key': 'entry.processId',
+                        'type': 'text',
+                        'title': 'ADF_CLOUD_PROCESS_LIST.PROPERTIES.PROCESS_ID',
+                        'sortable': true
+                    },
+                    {
+                        'key': 'entry.processDefinitionId',
+                        'type': 'text',
+                        'title': 'ADF_CLOUD_PROCESS_LIST.PROPERTIES.PROCESS_DEFINITION_ID',
+                        'sortable': true
+                    },
+                    {
+                        'key': 'entry.processDefinitionKey',
+                        'type': 'text',
+                        'title': 'ADF_CLOUD_PROCESS_LIST.PROPERTIES.PROCESS_DEFINITION_KEY',
+                        'sortable': true
+                    }
+                ]
+            }
+        };
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**
The appName dropdown in the Process Cloud filters has no duplicate values after saving the filters.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-3989