### PR TITLE
[ADF-4225] Viewer extension accept multiple file type

### DIFF
--- a/demo-shell/resources/i18n/ar.json
+++ b/demo-shell/resources/i18n/ar.json
@@ -7,7 +7,7 @@
       "VERSIONS": "الإصدارات"
     },
     "HOME": {
-      "TITLE": "المكونات الزاوّية لـ Alfresco",
+      "TITLE": "Alfresco المكونات الزاوّية لـ",
       "DOCUMENTATION": "الوثائق"
     },
     "LOGOUT": {

--- a/docs/extensions/README.md
+++ b/docs/extensions/README.md
@@ -17,6 +17,7 @@ for more information about installing and using the source code.
 | Name | Description | Source link |
 | ---- | ----------- | ----------- |
 | [Dynamic component](dynamic.component.md) ![Experimental](../docassets/images/ExperimentalIcon.png) | Displays dynamically-loaded extension components. | [Source](../../lib/extensions/src/lib/components/dynamic-component/dynamic.component.ts) |
+| [Preview Extension component](preview-extension.component.md) ![Experimental](../docassets/images/ExperimentalIcon.png) | Preview extension component. | [Source](../../lib/extensions/src/lib/components/viewer/preview-extension.component.ts) |
 
 ## Services
 

--- a/docs/extensions/preview-extension.component.md
+++ b/docs/extensions/preview-extension.component.md
@@ -1,0 +1,106 @@
+---
+Title: Dynamic Component
+Added: v3.1.0
+Status: Experimental
+Last reviewed: 2018-04-12
+---
+
+# [Preview Extension component](../../lib/extensions/src/lib/components/viewer/preview-extension.component.ts "Defined in preview-extension.component.ts")
+
+Displays dynamically-loaded extension components.
+If you want give a look on a real working viewer extension project you can look at [aca monaco extensio](https://github.com/eromano/aca-monaco-extension)
+## Class members
+
+### Properties
+
+The viewer component when it recognize a new extension always pass the following two parameter as input:
+
+| Name | Type | Default value | Description |
+| ---- | ---- | ------------- | ----------- |
+| url | `string` |  | URL Of the content in the repository |
+| node | `Node` |  | Node of the content to display |
+
+
+## Details
+
+If you want create your custom extension viewer you need to create the following files in a separate project:
+
+
+The Module needs to know which is the Id of your extension:
+
+```ts
+export class YourExtensionViewerModule {
+  constructor(extensions: ExtensionService) {
+    extensions.setComponents({
+      'your-extension.main.component': YourExtensionViewerComponent
+    });
+  }
+}
+
+```
+
+
+Your viewer component extension business logic:
+
+```ts
+import { Node } from '@alfresco/js-api';
+import { ViewerExtensionInterface } from '@alfresco/adf-extensions';
+
+@Component({
+  selector: 'your-extension-viewer',
+  templateUrl: './your-extension-view.component.html',
+  styleUrls: ['./your-extension-view.component.css'],
+  encapsulation: ViewEncapsulation.None
+})
+export class YourExtensionViewerComponent implements ViewerExtensionInterface {
+
+  showToolbar = true;
+
+  @Input()
+  url: string;
+
+  @Input()
+  node: Node;
+  
+  
+  ....YOUR CUSTOM LOGIC
+}
+
+```
+
+Your viewer component template:
+
+```HTML
+
+<div> This is your custom extension viewer template</div>
+
+```
+
+Your viewer component extension.json:
+
+
+```JSON
+{
+  "$version": "1.0.0",
+  "$name": "my viewer extension",
+  "$description": "my viewer  plugin",
+  "features": {
+    "viewer": {
+      "content": [
+        {
+          "id": "dev.tools.viewer.viewer",
+          "fileExtension": ["png", "jpg"],
+          "component": "your-extension.main.component"
+        }
+      ]
+    }
+  }
+}
+
+```
+
+
+
+## See also
+
+-   [Extension service](../../lib/extensions/src/lib/services/extension.service.ts)

--- a/lib/core/viewer/components/viewer.component.html
+++ b/lib/core/viewer/components/viewer.component.html
@@ -196,10 +196,9 @@
                         </ng-container>
 
                         <ng-container *ngSwitchCase="'custom'">
-
                             <ng-container  *ngFor="let ext of viewerExtensions">
                                 <adf-preview-extension
-                                    *ngIf="extension === ext.fileExtension"
+                                    *ngIf="checkExtensions(ext.fileExtension)"
                                     [id]="ext.component"
                                     [node]="nodeEntry.entry"
                                     [url]="urlFileContent"

--- a/lib/core/viewer/components/viewer.component.ts
+++ b/lib/core/viewer/components/viewer.component.ts
@@ -706,12 +706,12 @@ export class ViewerComponent implements OnChanges, OnInit, OnDestroy {
     }
 
     checkExtensions(extensionAllowed) {
-        if (typeof extensionAllowed ===  "string") {
+        if (typeof extensionAllowed ===  'string') {
             return this.extension.toLowerCase() === extensionAllowed.toLowerCase();
         } else if (extensionAllowed.length > 0) {
             return extensionAllowed.find((currentExtension) => {
                 return this.extension.toLowerCase() === currentExtension.toLowerCase();
-            })
+            });
         }
 
     }

--- a/lib/core/viewer/components/viewer.component.ts
+++ b/lib/core/viewer/components/viewer.component.ts
@@ -533,11 +533,11 @@ export class ViewerComponent implements OnChanges, OnInit, OnDestroy {
     }
 
     isCustomViewerExtension(extension: string): boolean {
-        const extensions = this.externalExtensions || [];
+        const extensions: any = this.externalExtensions || [];
 
         if (extension && extensions.length > 0) {
             extension = extension.toLowerCase();
-            return extensions.indexOf(extension) >= 0;
+            return extensions.flat().indexOf(extension) >= 0;
         }
 
         return false;
@@ -703,6 +703,17 @@ export class ViewerComponent implements OnChanges, OnInit, OnDestroy {
                 }
             }, 1000);
         });
+    }
+
+    checkExtensions(extensionAllowed) {
+        if (typeof extensionAllowed ===  "string") {
+            return this.extension.toLowerCase() === extensionAllowed.toLowerCase();
+        } else if (extensionAllowed.length > 0) {
+            return extensionAllowed.find((currentExtension) => {
+                return this.extension.toLowerCase() === currentExtension.toLowerCase();
+            })
+        }
+
     }
 
     private generateCacheBusterNumber() {

--- a/lib/extensions/src/lib/components/viewer/viewer-extension.interface.ts
+++ b/lib/extensions/src/lib/components/viewer/viewer-extension.interface.ts
@@ -15,8 +15,10 @@
  * limitations under the License.
  */
 
-export * from './viewer/viewer-extension.interface';
-export * from './viewer/preview-extension.component';
-export * from './dynamic-column/dynamic-column.component';
-export * from './dynamic-component/dynamic.component';
-export * from './dynamic-tab/dynamic-tab.component';
+import { Node } from '@alfresco/js-api';
+
+export interface ViewerExtensionInterface {
+    url: string;
+    nameFile: string;
+    node: Node;
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**
As a developer, I want to create a viewer extension that can target multiple types.

For example:
```json
"$version": "1.0.0",
 "$name": "my viewer extension",
 "$description": "my viewer plugin",
 "features": {
 "viewer": {
 "content": [
 {
 "id": "dev.tools.viewer.viewer",
 "fileExtension": ["png", "jpg"],
 "component": "your-extension.main.component"
 }
 ]
 }
 }
}
```

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
