### PR TITLE
[ADF-4215] not store locale if not present in app.config.json or changed by the language picker

### DIFF
--- a/lib/core/services/user-preferences.service.spec.ts
+++ b/lib/core/services/user-preferences.service.spec.ts
@@ -135,6 +135,14 @@ describe('UserPreferencesService', () => {
         expect(preferences.locale).toBe('fake-store-locate');
     });
 
+    it('should not store in the storage the locale if the app.config.json does not have a value', () => {
+        preferences.locale = 'fake-store-locate';
+        spyOn(translate, 'getBrowserCultureLang').and.returnValue('fake-locate-browser');
+        expect(preferences.locale).toBe('fake-store-locate');
+
+        expect(storage.getItem(UserPreferenceValues.Locale)).toBe(null);
+    });
+
     it('should stream the page size value when is set', (done) => {
         preferences.paginationSize = 5;
         changeDisposable = preferences.onChange.subscribe((userPreferenceStatus) => {

--- a/lib/core/services/user-preferences.service.ts
+++ b/lib/core/services/user-preferences.service.ts
@@ -52,9 +52,17 @@ export class UserPreferencesService {
     }
 
     private initUserPreferenceStatus() {
-        this.set(UserPreferenceValues.Locale, (this.locale || this.getDefaultLocale()));
+        this.initUserLanguage();
         this.set(UserPreferenceValues.PaginationSize, this.paginationSize);
         this.set(UserPreferenceValues.SupportedPageSizes, JSON.stringify(this.supportedPageSizes));
+    }
+
+    private initUserLanguage() {
+        if (this.locale || this.appConfig.get<string>(UserPreferenceValues.Locale)) {
+            this.set(UserPreferenceValues.Locale, (this.locale || this.getDefaultLocale()));
+        } else {
+            this.setWithoutStore(UserPreferenceValues.Locale, (this.locale || this.getDefaultLocale()));
+        }
     }
 
     /**
@@ -98,6 +106,19 @@ export class UserPreferencesService {
             this.getPropertyKey(property),
             value
         );
+        this.userPreferenceStatus[property] = value;
+        this.onChangeSubject.next(this.userPreferenceStatus);
+    }
+
+    /**
+     * Sets a preference property.
+     * @param property Name of the property
+     * @param value New value for the property
+     */
+    setWithoutStore(property: string, value: any) {
+        if (!property) {
+            return;
+        }
         this.userPreferenceStatus[property] = value;
         this.onChangeSubject.next(this.userPreferenceStatus);
     }


### PR DESCRIPTION
…language picker

**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [X] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**
Note I changed this behavior, if the user :

doesn't have any language preference in the app.config.json
doesn't change by the language from the language menu
we don't store it in the local store.  If one of the two events above happens the only way to change the language is still delete the key from the storage and we can not change this behavior.

Note 2 the priority for the language used in ADF is still the one descried here:

https://github.com/Alfresco/alfresco-ng2-components/blob/development/docs/user-guide/internationalization.md




**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-4215