### PR TITLE
[ADF-4239] Updated and moved ADF introduction page

### DIFF
--- a/INTRODUCTION.md
+++ b/INTRODUCTION.md
@@ -1,39 +1,5 @@
-# Introduction to the Alfresco Application Development Framework
+# Introduction
 
-The Alfresco Application Development Framework (ADF) is based on the [Angular framework](https://angular.io/).
-ADF is provided by Alfresco to make it easy to build custom web applications to manage and view content in the [Alfresco Platform Repository](https://docs.alfresco.com/5.2/concepts/content-repo-about.html).
-
-As you probably know, there is a general user interface called [Alfresco Share](https://docs.alfresco.com/5.2/concepts/gs-intro.html) available out-of-the-box. 
-Share is usually used as a quick way of getting started with content management in Alfresco. It gives you access to pretty much all
-the features provided by the ACS system and a lot of customers customize it for their specific domain.
-
-However, there are use cases that Share does not fit very well, such as:
-
-- Feature-based clients, exposing functionality to perform a specific task(s)
-- Role-based clients, exposing functionality based on role 
-- Clients where the UI layout and style differs significantly from the Share layout and styling
-- [Mashup clients](http://whatis.techtarget.com/definition/mash-up)
-
-This is where ADF comes into play. You can use it to create exactly the user interface 
-(i.e. web client) that you require.  
- 
-The framework consists of several libraries that can be used to form a customized content management application. The available libraries are:
-
-- [Core](lib/core/README.md)
-- [Content Services](lib/content-services/README.md)
-- [Process Services](lib/process-services/README.md)
-- [Insights](lib/insights/README.md)
-
-
-You can browse documentation for all the components at the
-[ADF Component Catalog](https://alfresco.github.io/adf-component-catalog/).
-
-An overview of the architecture is shown below:
-
-<p align="center">
-  <img title="alfresco-angular-components-architecture" alt='alfresco' src='assets/alfresco-app-dev-framework-architecture.png'></img>
-</p>
-
-Here we can also see that there is an Alfresco JavaScript framework in use that wraps the Alfresco REST API, to make things easier for the client developer.
-
-
+See the [introduction page](docs/user-guide/adf-introduction.md) in our
+[documentation](docs/README.md) for an overview of ADF along with links
+to useful starting points.

--- a/docs/user-guide/adf-introduction.md
+++ b/docs/user-guide/adf-introduction.md
@@ -1,0 +1,35 @@
+---
+Title: Introduction to ADF
+Added: 2019-03-13
+---
+
+# Introduction to the Application Development Framework (ADF)
+
+Alfresco's Application Development Framework (ADF) lets you add your own custom front end to the existing Alfresco services.
+
+ADF is a set of custom [TypeScript](https://www.typescriptlang.org/) classes based on
+the [Angular](https://angular.io/) web application framework. The most important classes
+are the **components** that implement interactive UI features. 
+The components and other classes access information from Alfresco's main backend products,
+[Content Services](https://www.alfresco.com/platform/content-services-ecm) and
+[Process Services](https://www.alfresco.com/platform/process-services-bpm).
+You can combine these classes to produce your own custom web app with the exact styling,
+branding, and features that you need. Some examples of where this can be useful are:
+
+-   **Feature based apps** with functionality based around tasks that arise frequently
+    in your business.
+-   **Role based apps** where specific types of user have their own feature set, tailor-made
+    for their role in the business.
+-   [**Mashups**](https://whatis.techtarget.com/definition/mash-up) where Alfresco services
+    are integrated with services from other suppliers in the same app.
+
+## Getting started with ADF
+
+You can find full instructions for installing ADF and its prerequisites in our
+tutorial
+[*Creating your first ADF application*](../tutorials/creating-your-first-adf-application.md).
+When you have the environment and the scaffold app set up, the other
+[tutorials](/tutorials/README.md) then explain how to connect to the backend services
+and add custom features to your app. Use the [component reference](../README.md) pages
+to learn about component features and the [user guide](../user-guide/README.md)
+to learn about specific tasks and topics in depth.

--- a/docs/user-guide/adf-introduction.md
+++ b/docs/user-guide/adf-introduction.md
@@ -29,7 +29,7 @@ You can find full instructions for installing ADF and its prerequisites in our
 tutorial
 [*Creating your first ADF application*](../tutorials/creating-your-first-adf-application.md).
 When you have the environment and the scaffold app set up, the other
-[tutorials](/tutorials/README.md) then explain how to connect to the backend services
+[tutorials](../tutorials/README.md) then explain how to connect to the backend services
 and add custom features to your app. Use the [component reference](../README.md) pages
 to learn about component features and the [user guide](../user-guide/README.md)
 to learn about specific tasks and topics in depth.


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [x] Documentation
> - [ ] Other... Please describe:

**What is the new behaviour?**

Updated links and info in the introduction and moved it to the docs folder (but the new page is still linked from the original file). The main motivation for this is to give a good starting point when people search for just "ADF" in the Builder Network search.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
