### PR TITLE
[ADF-4267] expose stiky heder in document list

### DIFF
--- a/demo-shell/src/app/components/files/files.component.html
+++ b/demo-shell/src/app/components/files/files.component.html
@@ -211,7 +211,8 @@
                 </mat-menu>
             </adf-toolbar>
 
-            <adf-document-list
+            <div [ngClass]="{'adf-sticky-document-list': stickyHeader }">
+                <adf-document-list
                 #documentList
                 class="adf-file-list-container"
                 [permissionsStyle]="permissionsStyle"
@@ -228,6 +229,7 @@
                 [sortingMode]="sortingMode"
                 [showHeader]="showHeader"
                 [thumbnails]="thumbnails"
+                [stickyHeader]="stickyHeader"
                 (error)="onNavigationError($event)"
                 (success)="resetError()"
                 (ready)="emitReadyEvent($event)"
@@ -420,6 +422,7 @@
                     </content-action>
                 </content-actions>
             </adf-document-list>
+                </div>
             <adf-pagination
                 #standardPagination
                 *ngIf="!infiniteScrolling"
@@ -607,6 +610,12 @@
             </mat-slide-toggle>
         </section>
 
+        <section>
+            <mat-slide-toggle
+                color="primary" [(ngModel)]="stickyHeader" id="stickyHeader">
+                Sticky Header
+            </mat-slide-toggle>
+        </section>
 
         <h5>Upload</h5>
         <section *ngIf="acceptedFilesTypeShow">

--- a/demo-shell/src/app/components/files/files.component.ts
+++ b/demo-shell/src/app/components/files/files.component.ts
@@ -189,6 +189,7 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
 
     permissionsStyle: PermissionStyleModel[] = [];
     infiniteScrolling: boolean;
+    stickyHeader: boolean;
     warnOnMultipleUploads = false;
     thumbnails = false;
     enableCustomPermissionMessage = false;

--- a/docs/content-services/components/document-list.component.md
+++ b/docs/content-services/components/document-list.component.md
@@ -82,6 +82,7 @@ Displays the documents from a repository.
 | where | `string` |  | Filters the [`Node`](https://github.com/Alfresco/alfresco-js-api/blob/development/src/api/content-rest-api/docs/Node.md) list using the _where_ condition of the REST API (for example, isFolder=true). See the REST API documentation for more information. |
 | currentFolderId |  |  | The ID of the folder node to display or a reserved string alias for special sources |
 | rowFilter |  |  | Custom function to choose whether to show or hide rows. See the [Row Filter Model](../models/row-filter.model.md) page for more information. |
+| stickyHeader | `boolean` | false | Toggles the sticky header mode. |
 
 ### Events
 

--- a/lib/content-services/document-list/components/document-list.component.html
+++ b/lib/content-services/document-list/components/document-list.component.html
@@ -14,6 +14,7 @@
     [noPermission]="noPermission"
     [showHeader]="!isEmpty() && showHeader"
     [rowMenuCacheEnabled]="false"
+    [stickyHeader]="stickyHeader"
     (showRowContextMenu)="onShowRowContextMenu($event)"
     (showRowActionsMenu)="onShowRowActionsMenu($event)"
     (executeRowAction)="onExecuteRowAction($event)"

--- a/lib/content-services/document-list/components/document-list.component.scss
+++ b/lib/content-services/document-list/components/document-list.component.scss
@@ -9,6 +9,11 @@
         margin-top: 2px;
     }
 
+    .adf-sticky-document-list {
+        height: 310px;
+        overflow-y: auto;
+    }
+
     .adf-datatable-selected > svg {
         fill: mat-color($accent);
         width: 32px;

--- a/lib/content-services/document-list/components/document-list.component.ts
+++ b/lib/content-services/document-list/components/document-list.component.ts
@@ -235,6 +235,10 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
     @Input()
     imageResolver: any | null = null;
 
+    /** Toggles the sticky header mode. */
+    @Input()
+    stickyHeader: boolean = false;
+
     _currentFolderId: string = null;
 
     /** The ID of the folder node to display or a reserved string alias for special sources */

--- a/lib/core/about/about.component.ts
+++ b/lib/core/about/about.component.ts
@@ -42,10 +42,10 @@ export class AboutComponent implements OnInit {
 
     /** Commit corresponding to the version of ADF to be used. */
     @Input() githubUrlCommitAlpha = 'https://github.com/Alfresco/alfresco-ng2-components/commits/';
- 
+
     /** Toggles showing/hiding of extensions block. */
     @Input() showExtensions = true;
- 
+
     /** Regular expression for filtering dependencies packages. */
     @Input() regexp = '^(@alfresco)';
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**
I can set up a property of the DocumentLIst to stick the header during the scroll.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-4267