### PR TITLE
[ADF-4229] Fix big space issue when ADF set to RTL 

### DIFF
--- a/lib/core/layout/components/layout-container/layout-container.component.html
+++ b/lib/core/layout/components/layout-container/layout-container.component.html
@@ -10,7 +10,7 @@
     </mat-sidenav>
 
     <div>
-        <div [@contentAnimationLeft]="getContentAnimationStateLeft()" [@contentAnimationRight]="getContentAnimationStateRight()">
+        <div class="adf-rtl-container-alignment" [@contentAnimationLeft]="getContentAnimationStateLeft()" [@contentAnimationRight]="getContentAnimationStateRight()">
             <ng-content select="[app-layout-content]"></ng-content>
         </div>
     </div>

--- a/lib/core/layout/components/layout-container/layout-container.component.scss
+++ b/lib/core/layout/components/layout-container/layout-container.component.scss
@@ -10,7 +10,7 @@
     }
 
 
-    [dir="rtl"] .adf-rtl-container-alignment {
+    [dir='rtl'] .adf-rtl-container-alignment {
         margin-left: 10px!important;
     }
 

--- a/lib/core/layout/components/layout-container/layout-container.component.scss
+++ b/lib/core/layout/components/layout-container/layout-container.component.scss
@@ -9,6 +9,10 @@
         overflow: hidden;
     }
 
+    .adf-rtl-container-alignment{
+        margin-left: 4px !important;
+    }
+
     ng-content {
         display: block;
         width: 100%;

--- a/lib/core/layout/components/layout-container/layout-container.component.scss
+++ b/lib/core/layout/components/layout-container/layout-container.component.scss
@@ -9,8 +9,9 @@
         overflow: hidden;
     }
 
-    .adf-rtl-container-alignment{
-        margin-left: 4px !important;
+
+    [dir="rtl"] .adf-rtl-container-alignment {
+        margin-left: 10px!important;
     }
 
     ng-content {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/secure/RapidBoard.jspa?rapidView=529&view=detail&selectedIssue=ADF-4229


**What is the new behaviour?**
The container gets all the available space when ADF is set to RTL.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
