### PR TITLE
introduce page components for e2e testing

### DIFF
--- a/lib/testing/src/lib/core/components/breadcrumb.ts
+++ b/lib/testing/src/lib/core/components/breadcrumb.ts
@@ -1,0 +1,84 @@
+/*!
+ * @license
+ * Copyright 2016 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ElementFinder, ElementArrayFinder, by } from 'protractor';
+import { Component } from './component';
+
+export class Breadcrumb extends Component {
+    static selectors = {
+        root: 'adf-breadcrumb',
+        item: '.adf-breadcrumb-item',
+        currentItem: '.adf-breadcrumb-item-current'
+    };
+
+    items: ElementArrayFinder = this.component.all(
+        by.css(Breadcrumb.selectors.item)
+    );
+    currentItem: ElementFinder = this.component.element(
+        by.css(Breadcrumb.selectors.currentItem)
+    );
+
+    constructor(ancestor?: ElementFinder) {
+        super(Breadcrumb.selectors.root, ancestor);
+    }
+
+    getNthItem(nth: number): ElementFinder {
+        return this.items.get(nth - 1);
+    }
+
+    async getNthItemName(nth: number) {
+        return await this.getNthItem(nth).getText();
+    }
+
+    async getItemsCount() {
+        return await this.items.count();
+    }
+
+    async getAllItems() {
+        return this.items.map(async elem => {
+            const str = await elem.getText();
+            return str.split('\nchevron_right')[0];
+        });
+    }
+
+    async getFirstItemName() {
+        return await this.items.get(0).getText();
+    }
+
+    getCurrentItem() {
+        return this.currentItem;
+    }
+
+    async getCurrentItemName() {
+        return await this.currentItem.getText();
+    }
+
+    async clickItem(name: string) {
+        const elem = this.component.element(
+            by.css(`${Breadcrumb.selectors.item}[title=${name}]`)
+        );
+        await elem.click();
+    }
+
+    async clickNthItem(nth: number) {
+        await this.getNthItem(nth).click();
+    }
+
+    async getNthItemTooltip(nth: number) {
+        return await this.getNthItem(nth).getAttribute('title');
+    }
+}

--- a/lib/testing/src/lib/core/components/component.ts
+++ b/lib/testing/src/lib/core/components/component.ts
@@ -1,0 +1,50 @@
+/*!
+ * @license
+ * Copyright 2016 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ElementFinder, ExpectedConditions as EC, browser } from 'protractor';
+
+export abstract class Component {
+    component: ElementFinder;
+
+    waitTimeout = 10000;
+
+    constructor(selector: string, ancestor?: ElementFinder) {
+        const locator = selector;
+
+        this.component = ancestor
+            ? ancestor.$$(locator).first()
+            : browser.$$(locator).first();
+    }
+
+    async wait() {
+        await browser.wait(EC.presenceOf(this.component), this.waitTimeout);
+    }
+
+    async waitUntilElementClickable(element: ElementFinder) {
+        return await browser
+            .wait(EC.elementToBeClickable(element), this.waitTimeout)
+            .catch(Error);
+    }
+
+    async typeInField(elem: ElementFinder, value: string) {
+        for (let i = 0; i < value.length; i++) {
+            const c = value.charAt(i);
+            await elem.sendKeys(c);
+            await browser.sleep(100);
+        }
+    }
+}

--- a/lib/testing/src/lib/core/components/component.ts
+++ b/lib/testing/src/lib/core/components/component.ts
@@ -15,7 +15,12 @@
  * limitations under the License.
  */
 
-import { ElementFinder, ExpectedConditions as EC, browser } from 'protractor';
+import {
+    ElementFinder,
+    ExpectedConditions as EC,
+    browser,
+    protractor
+} from 'protractor';
 
 export abstract class Component {
     component: ElementFinder;
@@ -46,5 +51,19 @@ export abstract class Component {
             await elem.sendKeys(c);
             await browser.sleep(100);
         }
+    }
+
+    async pressEscape() {
+        return await browser
+            .actions()
+            .sendKeys(protractor.Key.ESCAPE)
+            .perform();
+    }
+
+    async pressTab() {
+        return await browser
+            .actions()
+            .sendKeys(protractor.Key.TAB)
+            .perform();
     }
 }

--- a/lib/testing/src/lib/core/components/component.ts
+++ b/lib/testing/src/lib/core/components/component.ts
@@ -19,8 +19,23 @@ import {
     ElementFinder,
     ExpectedConditions as EC,
     browser,
-    protractor
+    protractor,
+    by
 } from 'protractor';
+
+/**
+ * Tagged template to convert a sting to an `ElementFinder`.
+ * @example ```const item = byCss`.adf-breadcrumb-item-current`;```
+ * @example ```const item = byCss`${variable}`;```
+ * @returns Instance of `ElementFinder` type.
+ */
+export function byCss(
+    literals: TemplateStringsArray,
+    ...placeholders: string[]
+): ElementFinder {
+    const selector = literals[0] || placeholders[0];
+    return browser.element(by.css(selector));
+}
 
 export abstract class Component {
     component: ElementFinder;

--- a/lib/testing/src/lib/core/components/confirmDialog.ts
+++ b/lib/testing/src/lib/core/components/confirmDialog.ts
@@ -1,0 +1,132 @@
+/*!
+ * @license
+ * Copyright 2016 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    ElementFinder,
+    by,
+    browser,
+    ExpectedConditions as EC
+} from 'protractor';
+import { Component } from './component';
+
+export class ConfirmDialog extends Component {
+    static selectors = {
+        root: 'adf-confirm-dialog',
+
+        title: '.mat-dialog-title',
+        content: '.mat-dialog-content',
+        accept: 'adf-confirm-accept',
+        cancel: 'adf-confirm-cancel',
+        actionButton: 'adf-confirm'
+    };
+
+    title: ElementFinder = this.component.element(
+        by.css(ConfirmDialog.selectors.title)
+    );
+    content: ElementFinder = this.component.element(
+        by.css(ConfirmDialog.selectors.content)
+    );
+    acceptButton: ElementFinder = this.component.element(
+        by.id(ConfirmDialog.selectors.accept)
+    );
+    cancelButton: ElementFinder = this.component.element(
+        by.id(ConfirmDialog.selectors.cancel)
+    );
+    actionButton: ElementFinder = this.component.element(
+        by.id(ConfirmDialog.selectors.actionButton)
+    );
+
+    constructor(ancestor?: ElementFinder) {
+        super(ConfirmDialog.selectors.root, ancestor);
+    }
+
+    async waitForDialogToClose() {
+        await browser.wait(EC.stalenessOf(this.title), this.waitTimeout);
+    }
+
+    async waitForDialogToOpen() {
+        await browser.wait(EC.presenceOf(this.title), this.waitTimeout);
+    }
+
+    async isDialogOpen() {
+        return await browser.isElementPresent(
+            by.css(ConfirmDialog.selectors.root)
+        );
+    }
+
+    async getTitle() {
+        return await this.title.getText();
+    }
+
+    async getText() {
+        return await this.content.getText();
+    }
+
+    getButtonByName(name: string) {
+        return this.component.element(by.buttonText(name));
+    }
+
+    async clickButton(name: string) {
+        const button = this.getButtonByName(name);
+        await button.click();
+    }
+
+    async isButtonEnabled(name: string) {
+        const button = this.getButtonByName(name);
+        return await button.isEnabled();
+    }
+
+    async isOkEnabled() {
+        return await this.isButtonEnabled('OK');
+    }
+
+    async isCancelEnabled() {
+        return await this.isButtonEnabled('Cancel');
+    }
+
+    async isKeepEnabled() {
+        return await this.isButtonEnabled('Keep');
+    }
+
+    async isDeleteEnabled() {
+        return await this.isButtonEnabled('Delete');
+    }
+
+    async isRemoveEnabled() {
+        return await this.isButtonEnabled('Remove');
+    }
+
+    async clickOk() {
+        return await this.clickButton('OK');
+    }
+
+    async clickCancel() {
+        return await this.clickButton('Cancel');
+    }
+
+    async clickKeep() {
+        return await this.clickButton('Keep');
+    }
+
+    async clickDelete() {
+        return await this.clickButton('Delete');
+    }
+
+    async clickRemove() {
+        return await this.clickButton('Remove');
+    }
+}

--- a/lib/testing/src/lib/core/components/copyMoveDialog.ts
+++ b/lib/testing/src/lib/core/components/copyMoveDialog.ts
@@ -1,0 +1,121 @@
+/*!
+ * @license
+ * Copyright 2016 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ElementFinder, by, browser, ExpectedConditions as EC } from 'protractor';
+import { Component } from './component';
+
+export class CopyMoveDialog extends Component {
+  static selectors = {
+    root: '.adf-content-node-selector-dialog',
+
+    title: '.mat-dialog-title',
+    content: '.mat-dialog-content',
+    locationDropDown: 'site-dropdown-container',
+    locationOption: '.mat-option .mat-option-text',
+
+    dataTable: '.adf-datatable-body',
+    row: '.adf-datatable-row[role]',
+    selectedRow: '.adf-is-selected',
+
+    button: '.mat-dialog-actions button'
+  };
+
+  title: ElementFinder = this.component.element(by.css(CopyMoveDialog.selectors.title));
+  content: ElementFinder = this.component.element(by.css(CopyMoveDialog.selectors.content));
+  dataTable: ElementFinder = this.component.element(by.css(CopyMoveDialog.selectors.dataTable));
+  locationDropDown: ElementFinder = this.component.element(by.id(CopyMoveDialog.selectors.locationDropDown));
+  locationPersonalFiles: ElementFinder = browser.element(by.cssContainingText(CopyMoveDialog.selectors.locationOption, 'Personal Files'));
+  locationFileLibraries: ElementFinder = browser.element(by.cssContainingText(CopyMoveDialog.selectors.locationOption, 'File Libraries'));
+
+  row: ElementFinder = this.component.element(by.css(CopyMoveDialog.selectors.row));
+
+  cancelButton: ElementFinder = this.component.element(by.cssContainingText(CopyMoveDialog.selectors.button, 'Cancel'));
+  copyButton: ElementFinder = this.component.element(by.cssContainingText(CopyMoveDialog.selectors.button, 'Copy'));
+  moveButton: ElementFinder = this.component.element(by.cssContainingText(CopyMoveDialog.selectors.button, 'Move'));
+
+  constructor(ancestor?: ElementFinder) {
+    super(CopyMoveDialog.selectors.root, ancestor);
+  }
+
+  async waitForDialogToClose() {
+    await browser.wait(EC.stalenessOf(this.title), this.waitTimeout);
+  }
+
+  async waitForDropDownToOpen() {
+    await browser.wait(EC.presenceOf(this.locationPersonalFiles), this.waitTimeout);
+  }
+
+  async waitForDropDownToClose() {
+    await browser.wait(EC.stalenessOf(browser.$(CopyMoveDialog.selectors.locationOption)), this.waitTimeout);
+  }
+
+  async waitForRowToBeSelected() {
+    await browser.wait(EC.presenceOf(this.component.element(by.css(CopyMoveDialog.selectors.selectedRow))), this.waitTimeout);
+  }
+
+  async isDialogOpen() {
+    return await browser.$(CopyMoveDialog.selectors.root).isDisplayed();
+  }
+
+  async getTitle() {
+    return await this.title.getText();
+  }
+
+  async clickCancel() {
+    await this.cancelButton.click();
+    await this.waitForDialogToClose();
+  }
+
+  async clickCopy() {
+    await this.copyButton.click();
+  }
+
+  async clickMove() {
+    await this.moveButton.click();
+  }
+
+  getRow(folderName: string) {
+    return this.dataTable.element(by.cssContainingText('.adf-name-location-cell', folderName));
+  }
+
+  async doubleClickOnRow(name: string) {
+    const item = this.getRow(name);
+    await this.waitUntilElementClickable(item);
+    await browser.actions().mouseMove(item).perform();
+    await browser.actions().click().click().perform();
+  }
+
+  async selectLocation(location: 'Personal Files' | 'File Libraries') {
+    await this.locationDropDown.click();
+    await this.waitForDropDownToOpen();
+
+    if (location === 'Personal Files') {
+      await this.locationPersonalFiles.click();
+    } else {
+      await this.locationFileLibraries.click();
+    }
+
+    await this.waitForDropDownToClose();
+  }
+
+  async selectDestination(folderName: string) {
+    const row = this.getRow(folderName);
+    await this.waitUntilElementClickable(row);
+    await row.click();
+    await this.waitForRowToBeSelected();
+  }
+}

--- a/lib/testing/src/lib/core/components/dateTimePicker.ts
+++ b/lib/testing/src/lib/core/components/dateTimePicker.ts
@@ -1,0 +1,97 @@
+/*!
+ * @license
+ * Copyright 2016 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    ElementFinder,
+    by,
+    browser,
+    ExpectedConditions as EC
+} from 'protractor';
+import { Component } from './component';
+import * as moment from 'moment';
+
+export class DateTimePicker extends Component {
+    static selectors = {
+        root: '.mat-datetimepicker-popup',
+
+        header: '.mat-datetimepicker-calendar-header',
+        year: '.mat-datetimepicker-calendar-header-year',
+        date: '.mat-datetimepicker-calendar-header-date',
+
+        content: '.mat-datetimepicker-calendar-content',
+        dayPicker: 'mat-datetimepicker-month-view',
+
+        today: '.mat-datetimepicker-calendar-body-today',
+        firstActiveDay:
+            '.mat-datetimepicker-calendar-body-active .mat-datetimepicker-calendar-body-cell-content'
+    };
+
+    calendar: ElementFinder = browser.element(
+        by.css(DateTimePicker.selectors.root)
+    );
+    headerDate: ElementFinder = this.component.element(
+        by.css(DateTimePicker.selectors.date)
+    );
+    headerYear: ElementFinder = this.component.element(
+        by.css(DateTimePicker.selectors.year)
+    );
+    dayPicker: ElementFinder = this.component.element(
+        by.css(DateTimePicker.selectors.dayPicker)
+    );
+
+    constructor(ancestor?: ElementFinder) {
+        super(DateTimePicker.selectors.root, ancestor);
+    }
+
+    async waitForDateTimePickerToOpen() {
+        await browser.wait(EC.presenceOf(this.calendar), this.waitTimeout);
+    }
+
+    async waitForDateTimePickerToClose() {
+        await browser.wait(EC.stalenessOf(this.calendar), this.waitTimeout);
+    }
+
+    async isCalendarOpen() {
+        return await browser.isElementPresent(
+            by.css(DateTimePicker.selectors.root)
+        );
+    }
+
+    async getDate() {
+        return await this.headerDate.getText();
+    }
+
+    async getYear() {
+        return await this.headerYear.getText();
+    }
+
+    async setDefaultDay() {
+        const today = moment();
+        const tomorrow = today.add(1, 'day');
+        const dayOfTomorrow = tomorrow.date();
+        const date = await this.getDate();
+        const year = await this.getYear();
+        const elem = this.dayPicker.element(
+            by.cssContainingText(
+                DateTimePicker.selectors.firstActiveDay,
+                `${dayOfTomorrow}`
+            )
+        );
+        await elem.click();
+        return `${date} ${year}`;
+    }
+}

--- a/lib/testing/src/lib/core/components/dateTimePicker.ts
+++ b/lib/testing/src/lib/core/components/dateTimePicker.ts
@@ -22,7 +22,7 @@ import {
     ExpectedConditions as EC
 } from 'protractor';
 import { Component } from './component';
-import * as moment from 'moment';
+import moment from 'moment-es6';
 
 export class DateTimePicker extends Component {
     static selectors = {

--- a/lib/testing/src/lib/core/components/folderDialog.ts
+++ b/lib/testing/src/lib/core/components/folderDialog.ts
@@ -1,0 +1,126 @@
+/*!
+ * @license
+ * Copyright 2016 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ElementFinder, by, browser, protractor, ExpectedConditions as EC } from 'protractor';
+import { Component } from './component';
+
+export class CreateOrEditFolderDialog extends Component {
+  static selectors = {
+    root: 'adf-folder-dialog',
+
+    title: '.mat-dialog-title',
+    nameInput: 'input[placeholder="Name" i]',
+    descriptionTextArea: 'textarea[placeholder="Description" i]',
+    button: '.mat-dialog-actions button',
+    validationMessage: '.mat-hint span'
+  };
+
+  title: ElementFinder = this.component.element(by.css(CreateOrEditFolderDialog.selectors.title));
+  nameInput: ElementFinder = this.component.element(by.css(CreateOrEditFolderDialog.selectors.nameInput));
+  descriptionTextArea: ElementFinder = this.component.element(by.css(CreateOrEditFolderDialog.selectors.descriptionTextArea));
+  createButton: ElementFinder = this.component.element(by.cssContainingText(CreateOrEditFolderDialog.selectors.button, 'Create'));
+  cancelButton: ElementFinder = this.component.element(by.cssContainingText(CreateOrEditFolderDialog.selectors.button, 'Cancel'));
+  updateButton: ElementFinder = this.component.element(by.cssContainingText(CreateOrEditFolderDialog.selectors.button, 'Update'));
+  validationMessage: ElementFinder = this.component.element(by.css(CreateOrEditFolderDialog.selectors.validationMessage));
+
+  constructor(ancestor?: ElementFinder) {
+    super(CreateOrEditFolderDialog.selectors.root, ancestor);
+  }
+
+  async waitForDialogToOpen() {
+    await browser.wait(EC.presenceOf(this.title), this.waitTimeout);
+    await browser.wait(EC.presenceOf(browser.element(by.css('.cdk-overlay-backdrop'))), this.waitTimeout);
+  }
+
+  async waitForDialogToClose() {
+    await browser.wait(EC.stalenessOf(this.title), this.waitTimeout, '---- timeout waiting for dialog to close ----');
+  }
+
+  async isDialogOpen() {
+    return await browser.isElementPresent(by.css(CreateOrEditFolderDialog.selectors.root));
+  }
+
+  async getTitle() {
+    return await this.title.getText();
+  }
+
+  async isValidationMessageDisplayed() {
+    return await this.validationMessage.isDisplayed();
+  }
+
+  async isUpdateButtonEnabled() {
+    return this.updateButton.isEnabled();
+  }
+
+  async isCreateButtonEnabled() {
+    return this.createButton.isEnabled();
+  }
+
+  async isCancelButtonEnabled() {
+    return this.cancelButton.isEnabled();
+  }
+
+  async isNameDisplayed() {
+    return await this.nameInput.isDisplayed();
+  }
+
+  async isDescriptionDisplayed() {
+    return await this.descriptionTextArea.isDisplayed();
+  }
+
+  async getValidationMessage() {
+    await this.isValidationMessageDisplayed();
+    return await this.validationMessage.getText();
+  }
+
+  async getName() {
+    return await this.nameInput.getAttribute('value');
+  }
+
+  async getDescription() {
+    return await this.descriptionTextArea.getAttribute('value');
+  }
+
+  async enterName(name: string) {
+    await this.nameInput.clear();
+    await this.typeInField(this.nameInput, name);
+  }
+
+  async enterDescription(description: string) {
+    await this.descriptionTextArea.clear();
+    await this.typeInField(this.descriptionTextArea, description);
+  }
+
+  async deleteNameWithBackspace() {
+    await this.nameInput.clear();
+    await this.nameInput.sendKeys(' ', protractor.Key.CONTROL, 'a', protractor.Key.NULL, protractor.Key.BACK_SPACE);
+  }
+
+  async clickCreate() {
+    await this.createButton.click();
+  }
+
+  async clickCancel() {
+    await this.cancelButton.click();
+    await this.waitForDialogToClose();
+  }
+
+  async clickUpdate() {
+    await this.updateButton.click();
+  }
+
+}

--- a/lib/testing/src/lib/core/components/libraryDialog.ts
+++ b/lib/testing/src/lib/core/components/libraryDialog.ts
@@ -1,0 +1,163 @@
+/*!
+ * @license
+ * Copyright 2016 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ElementFinder, by, browser, protractor, ExpectedConditions as EC } from 'protractor';
+import { Component } from './component';
+
+export class LibraryDialog extends Component {
+  static selectors = {
+    root: 'adf-library-dialog',
+
+    title: '.mat-dialog-title',
+    nameInput: 'input[placeholder="Name" i]',
+    libraryIdInput: 'input[placeholder="Library ID" i]',
+    descriptionTextArea: 'textarea[placeholder="Description" i]',
+    button: '.mat-dialog-actions button',
+    radioButton: '.mat-radio-label',
+    radioChecked: 'mat-radio-checked',
+    errorMessage: '.mat-error'
+  };
+
+  title: ElementFinder = this.component.element(by.css(LibraryDialog.selectors.title));
+  nameInput: ElementFinder = this.component.element(by.css(LibraryDialog.selectors.nameInput));
+  libraryIdInput: ElementFinder = this.component.element(by.css(LibraryDialog.selectors.libraryIdInput));
+  descriptionTextArea: ElementFinder = this.component.element(by.css(LibraryDialog.selectors.descriptionTextArea));
+  visibilityPublic: ElementFinder = this.component.element(by.cssContainingText(LibraryDialog.selectors.radioButton, 'Public'));
+  visibilityModerated: ElementFinder = this.component.element(by.cssContainingText(LibraryDialog.selectors.radioButton, 'Moderated'));
+  visibilityPrivate: ElementFinder = this.component.element(by.cssContainingText(LibraryDialog.selectors.radioButton, 'Private'));
+  createButton: ElementFinder = this.component.element(by.cssContainingText(LibraryDialog.selectors.button, 'Create'));
+  cancelButton: ElementFinder = this.component.element(by.cssContainingText(LibraryDialog.selectors.button, 'Cancel'));
+  errorMessage: ElementFinder = this.component.element(by.css(LibraryDialog.selectors.errorMessage));
+
+  constructor(ancestor?: ElementFinder) {
+    super(LibraryDialog.selectors.root, ancestor);
+  }
+
+  async waitForDialogToOpen() {
+    await browser.wait(EC.presenceOf(this.title), this.waitTimeout);
+    await browser.wait(EC.presenceOf(browser.element(by.css('.cdk-overlay-backdrop'))), this.waitTimeout);
+  }
+
+  async waitForDialogToClose() {
+    await browser.wait(EC.stalenessOf(this.title), this.waitTimeout);
+  }
+
+  async isDialogOpen() {
+    return await browser.isElementPresent(by.css(LibraryDialog.selectors.root));
+  }
+
+  async getTitle() {
+    return await this.title.getText();
+  }
+
+  async isErrorMessageDisplayed() {
+    return await this.errorMessage.isDisplayed();
+  }
+
+  async getErrorMessage() {
+    await this.isErrorMessageDisplayed();
+    return await this.errorMessage.getText();
+  }
+
+  async isNameDisplayed() {
+    return await this.nameInput.isDisplayed();
+  }
+
+  async isLibraryIdDisplayed() {
+    return await this.libraryIdInput.isDisplayed();
+  }
+
+  async isDescriptionDisplayed() {
+    return await this.descriptionTextArea.isDisplayed();
+  }
+
+  async isPublicDisplayed() {
+    return await this.visibilityPublic.isDisplayed();
+  }
+
+  async isModeratedDisplayed() {
+    return await this.visibilityModerated.isDisplayed();
+  }
+
+  async isPrivateDisplayed() {
+    return await this.visibilityPrivate.isDisplayed();
+  }
+
+  async enterName(name: string) {
+    await this.nameInput.clear();
+    await this.typeInField(this.nameInput, name);
+  }
+
+  async enterLibraryId(id: string) {
+    await this.libraryIdInput.clear();
+    await this.typeInField(this.libraryIdInput, id);
+  }
+
+  async enterDescription(description: string) {
+    await this.descriptionTextArea.clear();
+    await this.typeInField(this.descriptionTextArea, description);
+  }
+
+  async deleteNameWithBackspace() {
+    await this.nameInput.clear();
+    await this.nameInput.sendKeys(' ', protractor.Key.CONTROL, 'a', protractor.Key.NULL, protractor.Key.BACK_SPACE);
+  }
+
+  async isCreateEnabled() {
+    return await this.createButton.isEnabled();
+  }
+
+  async isCancelEnabled() {
+    return await this.cancelButton.isEnabled();
+  }
+
+  async clickCreate() {
+    await this.createButton.click();
+  }
+
+  async clickCancel() {
+    await this.cancelButton.click();
+    await this.waitForDialogToClose();
+  }
+
+  async isPublicChecked() {
+    const elemClass = await this.visibilityPublic.element(by.xpath('..')).getAttribute('class');
+    return await elemClass.includes(LibraryDialog.selectors.radioChecked);
+  }
+
+  async isModeratedChecked() {
+    const elemClass = await this.visibilityModerated.element(by.xpath('..')).getAttribute('class');
+    return await elemClass.includes(LibraryDialog.selectors.radioChecked);
+  }
+
+  async isPrivateChecked() {
+    const elemClass = await this.visibilityPrivate.element(by.xpath('..')).getAttribute('class');
+    return await elemClass.includes(LibraryDialog.selectors.radioChecked);
+  }
+
+  async selectPublic() {
+    await this.visibilityPublic.click();
+  }
+
+  async selectModerated() {
+    await this.visibilityModerated.click();
+  }
+
+  async selectPrivate() {
+    await this.visibilityPrivate.click();
+  }
+}

--- a/lib/testing/src/lib/core/components/login.ts
+++ b/lib/testing/src/lib/core/components/login.ts
@@ -1,0 +1,109 @@
+/*!
+ * @license
+ * Copyright 2016 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { by, ElementFinder } from 'protractor';
+import { Component } from './component';
+
+export class LoginComponent extends Component {
+  static selectors = {
+    root: 'adf-login',
+
+    usernameInput: by.css('input#username'),
+    passwordInput: by.css('input#password'),
+    passwordVisibility: by.css('.adf-login-password-icon'),
+    submitButton: by.css('button#login-button'),
+    errorMessage: by.css('.adf-login-error-message'),
+    copyright: by.css('.adf-copyright')
+  };
+
+  usernameInput: ElementFinder = this.component.element(LoginComponent.selectors.usernameInput);
+  passwordInput: ElementFinder = this.component.element(LoginComponent.selectors.passwordInput);
+  submitButton: ElementFinder = this.component.element(LoginComponent.selectors.submitButton);
+  errorMessage: ElementFinder = this.component.element(LoginComponent.selectors.errorMessage);
+  copyright: ElementFinder = this.component.element(LoginComponent.selectors.copyright);
+  passwordVisibility: ElementFinder = this.component.element(LoginComponent.selectors.passwordVisibility);
+
+  constructor(ancestor?: ElementFinder) {
+    super(LoginComponent.selectors.root, ancestor);
+  }
+
+  async enterUsername(username: string) {
+    const { usernameInput } = this;
+
+    await usernameInput.clear();
+    await usernameInput.sendKeys(username);
+  }
+
+  async enterPassword(password: string) {
+    const { passwordInput } = this;
+
+    await passwordInput.clear();
+    await passwordInput.sendKeys(password);
+  }
+
+  async enterCredentials(username: string, password: string) {
+    await this.enterUsername(username);
+    await this.enterPassword(password);
+  }
+
+  submit() {
+    return this.submitButton.click();
+  }
+
+  async clickPasswordVisibility() {
+    return await this.passwordVisibility.click();
+  }
+
+  async getPasswordVisibility() {
+    const text = await this.passwordVisibility.getText();
+    if (text.endsWith('visibility_off')) {
+      return false;
+    } else {
+      if (text.endsWith('visibility')) {
+        return true;
+      }
+    }
+  }
+
+  async isPasswordDisplayed() {
+    const type = await this.passwordInput.getAttribute('type');
+    if (type === 'text') {
+      return true;
+    } else {
+      if (type === 'password') {
+        return false;
+      }
+    }
+  }
+
+  async isUsernameEnabled() {
+    return await this.usernameInput.isEnabled();
+  }
+
+  async isPasswordEnabled() {
+    return await this.passwordInput.isEnabled();
+  }
+
+  async isSubmitEnabled() {
+    return await this.submitButton.isEnabled();
+  }
+
+  async isPasswordHidden() {
+    return !(await this.getPasswordVisibility());
+  }
+
+}

--- a/lib/testing/src/lib/core/components/metadataCard.ts
+++ b/lib/testing/src/lib/core/components/metadataCard.ts
@@ -1,0 +1,56 @@
+/*!
+ * @license
+ * Copyright 2016 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ElementFinder, by, browser, ExpectedConditions as EC, ElementArrayFinder } from 'protractor';
+import { Component } from './component';
+
+export class MetadataCard extends Component {
+  static selectors = {
+    root: 'adf-content-metadata-card',
+    footer: '.adf-content-metadata-card-footer',
+    expandButton: '[data-automation-id="meta-data-card-toggle-expand"]',
+    expansionPanel: '.adf-metadata-grouped-properties-container mat-expansion-panel'
+  };
+
+  footer: ElementFinder = this.component.element(by.css(MetadataCard.selectors.footer));
+  expandButton: ElementFinder = this.component.element(by.css(MetadataCard.selectors.expandButton));
+  expansionPanels: ElementArrayFinder = this.component.all(by.css(MetadataCard.selectors.expansionPanel));
+
+  constructor(ancestor?: ElementFinder) {
+    super(MetadataCard.selectors.root, ancestor);
+  }
+
+  async isExpandPresent() {
+    return await this.expandButton.isPresent();
+  }
+
+  async clickExpandButton() {
+    await this.expandButton.click();
+  }
+
+  async waitForFirstExpansionPanel() {
+    return await browser.wait(EC.presenceOf(this.expansionPanels.get(0)), this.waitTimeout);
+  }
+
+  async isExpansionPanelPresent(index) {
+    return await this.expansionPanels.get(index).isPresent();
+  }
+
+  async getComponentIdOfPanel(index) {
+    return await this.expansionPanels.get(index).getAttribute('data-automation-id');
+  }
+}

--- a/lib/testing/src/lib/core/components/nodeVersionsDialog.ts
+++ b/lib/testing/src/lib/core/components/nodeVersionsDialog.ts
@@ -1,0 +1,58 @@
+/*!
+ * @license
+ * Copyright 2016 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ElementFinder, by, browser, ExpectedConditions as EC } from 'protractor';
+import { Component } from './component';
+
+export class NodeVersionsDialog extends Component {
+  static selectors = {
+    root: '.aca-node-versions-dialog',
+
+    title: '.mat-dialog-title',
+    content: '.mat-dialog-content',
+    button: '.mat-button'
+  };
+
+  title: ElementFinder = this.component.element(by.css(NodeVersionsDialog.selectors.title));
+  content: ElementFinder = this.component.element(by.css(NodeVersionsDialog.selectors.content));
+  closeButton: ElementFinder = this.component.element(by.cssContainingText(NodeVersionsDialog.selectors.button, 'Close'));
+
+  constructor(ancestor?: ElementFinder) {
+    super(NodeVersionsDialog.selectors.root, ancestor);
+  }
+
+  async waitForDialogToClose() {
+    return await browser.wait(EC.stalenessOf(this.title), this.waitTimeout);
+  }
+
+  async isDialogOpen() {
+    return await browser.$(NodeVersionsDialog.selectors.root).isDisplayed();
+  }
+
+  async getTitle() {
+    return await this.title.getText();
+  }
+
+  async getText() {
+    return await this.content.getText();
+  }
+
+  async clickClose() {
+    await this.closeButton.click();
+    await this.waitForDialogToClose();
+  }
+}

--- a/lib/testing/src/lib/core/components/public-api.ts
+++ b/lib/testing/src/lib/core/components/public-api.ts
@@ -1,0 +1,29 @@
+/*!
+ * @license
+ * Copyright 2016 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './breadcrumb';
+export * from './component';
+export * from './confirmDialog';
+export * from './copyMoveDialog';
+export * from './dateTimePicker';
+export * from './folderDialog';
+export * from './libraryDialog';
+export * from './login';
+export * from './metadataCard';
+export * from './nodeVersionsDialog';
+export * from './shareDialog';
+export * from './versionUploadDialog';

--- a/lib/testing/src/lib/core/components/shareDialog.ts
+++ b/lib/testing/src/lib/core/components/shareDialog.ts
@@ -1,0 +1,148 @@
+/*!
+ * @license
+ * Copyright 2016 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ElementFinder, ElementArrayFinder, by, browser, ExpectedConditions as EC } from 'protractor';
+import { DateTimePicker } from './dateTimePicker';
+import { Component } from './component';
+
+export class ShareDialog extends Component {
+  static selectors = {
+    root: '.adf-share-dialog',
+
+    title: `[data-automation-id='adf-share-dialog-title']`,
+    info: '.adf-share-link__info',
+    label: '.adf-share-link__label',
+    shareToggle: `[data-automation-id='adf-share-toggle']`,
+    linkUrl: `[data-automation-id='adf-share-link']`,
+    inputAction: '.adf-input-action',
+    expireToggle: `[data-automation-id='adf-expire-toggle']`,
+    datetimePickerButton: '.mat-datetimepicker-toggle',
+    expirationInput: 'input[formcontrolname="time"]',
+    button: `[data-automation-id='adf-share-dialog-close']`
+  };
+
+  dateTimePicker = new DateTimePicker();
+
+  title: ElementFinder = this.component.element(by.css(ShareDialog.selectors.title));
+  infoText: ElementFinder = this.component.element(by.css(ShareDialog.selectors.info));
+  labels: ElementArrayFinder = this.component.all(by.css(ShareDialog.selectors.label));
+  shareToggle: ElementFinder = this.component.element(by.css(ShareDialog.selectors.shareToggle));
+  url: ElementFinder = this.component.element(by.css(ShareDialog.selectors.linkUrl));
+  urlAction: ElementFinder = this.component.element(by.css(ShareDialog.selectors.inputAction));
+  expireToggle: ElementFinder = this.component.element(by.css(ShareDialog.selectors.expireToggle));
+  expireInput: ElementFinder = this.component.element(by.css(ShareDialog.selectors.expirationInput));
+  datetimePickerButton: ElementFinder = this.component.element(by.css(ShareDialog.selectors.datetimePickerButton));
+  closeButton: ElementFinder = this.component.element(by.css(ShareDialog.selectors.button));
+
+  constructor(ancestor?: ElementFinder) {
+    super(ShareDialog.selectors.root, ancestor);
+  }
+
+  async waitForDialogToClose() {
+    await browser.wait(EC.stalenessOf(this.title), this.waitTimeout, 'share dialog did not close');
+  }
+
+  async waitForDialogToOpen() {
+    await browser.wait(EC.presenceOf(this.title), this.waitTimeout);
+  }
+
+  async isDialogOpen() {
+    return await browser.isElementPresent(by.css(ShareDialog.selectors.root));
+  }
+
+  async getTitle() {
+    return await this.title.getText();
+  }
+
+  async getInfoText() {
+    return await this.infoText.getText();
+  }
+
+  getLabels() {
+    return this.labels;
+  }
+
+  async getLinkUrl() {
+    return await this.url.getAttribute('value');
+  }
+
+  async isUrlReadOnly() {
+    return await this.url.getAttribute('readonly');
+  }
+
+  async isCloseEnabled() {
+    return await this.closeButton.isEnabled();
+  }
+
+  async clickClose() {
+    await this.closeButton.click();
+    await this.waitForDialogToClose();
+  }
+
+  getShareToggle() {
+    return this.shareToggle;
+  }
+
+  getExpireToggle() {
+    return this.expireToggle;
+  }
+
+  getExpireInput() {
+    return this.expireInput;
+  }
+
+  async isShareToggleChecked() {
+    const toggleClass = await this.getShareToggle().getAttribute('class');
+    return toggleClass.includes('checked');
+  }
+
+  async isShareToggleDisabled() {
+    const toggleClass = await this.getShareToggle().getAttribute('class');
+    return toggleClass.includes('mat-disabled');
+  }
+
+  async isExpireToggleEnabled() {
+    const toggleClass = await this.getExpireToggle().getAttribute('class');
+    return toggleClass.includes('checked');
+  }
+
+  async copyUrl() {
+    return await this.urlAction.click();
+  }
+
+  async openDatetimePicker() {
+    return await this.datetimePickerButton.click();
+  }
+
+  async closeDatetimePicker() {
+    if (await this.dateTimePicker.isCalendarOpen()) {
+      return await this.datetimePickerButton.click();
+    }
+  }
+
+  async getExpireDate() {
+    return await this.getExpireInput().getAttribute('value');
+  }
+
+  async clickExpirationToggle() {
+    await this.expireToggle.click();
+  }
+
+  async clickShareToggle() {
+    await this.shareToggle.click();
+  }
+}

--- a/lib/testing/src/lib/core/components/versionUploadDialog.ts
+++ b/lib/testing/src/lib/core/components/versionUploadDialog.ts
@@ -1,0 +1,107 @@
+/*!
+ * @license
+ * Copyright 2016 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ElementFinder, by, browser, ExpectedConditions as EC } from 'protractor';
+import { Component } from './component';
+
+export class VersionUploadDialog extends Component {
+  static selectors = {
+    root: '.aca-node-version-upload-dialog',
+
+    title: '.mat-dialog-title',
+    content: '.mat-dialog-content',
+    button: '.mat-button',
+
+    radioButton: `.mat-radio-label`,
+
+    descriptionTextArea: 'textarea'
+  };
+
+  title: ElementFinder = this.component.element(by.css(VersionUploadDialog.selectors.title));
+  content: ElementFinder = this.component.element(by.css(VersionUploadDialog.selectors.content));
+  cancelButton: ElementFinder = this.component.element(by.cssContainingText(VersionUploadDialog.selectors.button, 'Cancel'));
+  uploadButton: ElementFinder = this.component.element(by.cssContainingText(VersionUploadDialog.selectors.button, 'Upload'));
+
+  majorOption: ElementFinder = this.component.element(by.cssContainingText(VersionUploadDialog.selectors.radioButton, 'Major'));
+  minorOption: ElementFinder = this.component.element(by.cssContainingText(VersionUploadDialog.selectors.radioButton, 'Minor'));
+
+  description: ElementFinder = this.component.element(by.css(VersionUploadDialog.selectors.descriptionTextArea));
+
+  constructor(ancestor?: ElementFinder) {
+    super(VersionUploadDialog.selectors.root, ancestor);
+  }
+
+  async waitForDialogToClose() {
+    return await browser.wait(EC.stalenessOf(this.title), this.waitTimeout);
+  }
+
+  async isDialogOpen() {
+    return await browser.$(VersionUploadDialog.selectors.root).isDisplayed();
+  }
+
+  async getTitle() {
+    return await this.title.getText();
+  }
+
+  async getText() {
+    return await this.content.getText();
+  }
+
+  async isDescriptionDisplayed() {
+    return await this.description.isDisplayed();
+  }
+
+  async isMinorOptionDisplayed() {
+    return await this.minorOption.isDisplayed();
+  }
+
+  async isMajorOptionDisplayed() {
+    return await this.majorOption.isDisplayed();
+  }
+
+  async isCancelButtonEnabled() {
+    return this.cancelButton.isEnabled();
+  }
+
+  async isUploadButtonEnabled() {
+    return this.uploadButton.isEnabled();
+  }
+
+  async clickCancel() {
+    await this.cancelButton.click();
+    await this.waitForDialogToClose();
+  }
+
+  async clickUpload() {
+    await this.uploadButton.click();
+    await this.waitForDialogToClose();
+  }
+
+  async clickMajor() {
+    return await this.majorOption.click();
+  }
+
+  async clickMinor() {
+    return await this.minorOption.click();
+  }
+
+  async enterDescription(description: string) {
+    await this.description.clear();
+    await this.typeInField(this.description, description);
+  }
+
+}

--- a/lib/testing/src/lib/core/public-api.ts
+++ b/lib/testing/src/lib/core/public-api.ts
@@ -4,3 +4,4 @@
 
 export * from './browser-visibility';
 export * from './pages/public-api';
+export * from './components/public-api';

--- a/tslint.json
+++ b/tslint.json
@@ -169,7 +169,6 @@
         "format": "PascalCase"
       }
     ],
-    "arrow-parens": true,
     "no-input-prefix": true,
     "ordered-imports": false,
     "template-conditional-complexity": [true, 2],


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

- port the generic page components used to test ADF in ACA e2e tests
- should help to unify and simplify e2e across projects

this PR also introduces a tagged template `byCss` (ES6) that greatly reduces the amount of code when working with Protractor elements:

```typescript
const item = byCss`.adf-breadcrumb-item-current`;
// or
const variable = '.some-class';
const element: ElementFinder = byCss`${variable}`
``` 

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
