### PR TITLE
[ADF-4264] Fix content node selector breadcrumb and styling

### DIFF
--- a/lib/content-services/content-node-selector/content-node-selector-panel.component.html
+++ b/lib/content-services/content-node-selector/content-node-selector-panel.component.html
@@ -42,6 +42,7 @@
                 [target]="documentList"
                 [transform]="breadcrumbTransform"
                 [folderNode]="breadcrumbFolderNode"
+                [root]="breadcrumbFolderTitle"
                 data-automation-id="content-node-selector-content-breadcrumb">
             </adf-dropdown-breadcrumb>
         </adf-toolbar-title>

--- a/lib/content-services/content-node-selector/content-node-selector-panel.component.ts
+++ b/lib/content-services/content-node-selector/content-node-selector-panel.component.ts
@@ -153,6 +153,7 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
     inDialog: boolean = false;
     _chosenNode: Node = null;
     folderIdToShow: string | null = null;
+    breadcrumbFolderTitle: string | null = null;
 
     pagination: PaginationModel = this.DEFAULT_PAGINATION;
 
@@ -234,6 +235,7 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
      */
     siteChanged(chosenSite: SiteEntry): void {
         this.siteId = chosenSite.entry.guid;
+        this.setTitleIfCustomSite(chosenSite);
         this.updateResults();
 
     }
@@ -408,5 +410,13 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
      */
     onNodeSelect(event: any): void {
         this.attemptNodeSelection(event.detail.node.entry);
+    }
+
+    setTitleIfCustomSite(site: SiteEntry) {
+        if (this.customResourcesService.isCustomSource(site.entry.guid)) {
+            this.breadcrumbFolderTitle = site.entry.title;
+        } else {
+            this.breadcrumbFolderTitle = null;
+        }
     }
 }

--- a/lib/content-services/content-node-selector/name-location-cell/name-location-cell.component.scss
+++ b/lib/content-services/content-node-selector/name-location-cell/name-location-cell.component.scss
@@ -2,10 +2,8 @@
     $foreground: map-get($theme, foreground);
 
     .adf-name-location-cell {
+        display: grid;
         &-location {
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
             color: mat-color($foreground, base, 0.5);
             font-size: 12px;
         }

--- a/lib/content-services/content-node-selector/name-location-cell/name-location-cell.component.ts
+++ b/lib/content-services/content-node-selector/name-location-cell/name-location-cell.component.ts
@@ -21,8 +21,8 @@ import { DataRow } from '@alfresco/adf-core';
 @Component({
     selector: 'adf-name-location-cell',
     template: `
-        <div class="adf-name-location-cell-name">{{ name }}</div>
-        <div class="adf-name-location-cell-location" [title]="path">{{ path }}</div>
+        <div class="adf-name-location-cell-name adf-datatable-cell-value">{{ name }}</div>
+        <div class="adf-name-location-cell-location adf-datatable-cell-value" [title]="path">{{ path }}</div>
     `,
     styleUrls: ['./name-location-cell.component.scss'],
     encapsulation: ViewEncapsulation.None,

--- a/lib/core/datatable/components/datatable/datatable.component.html
+++ b/lib/core/datatable/components/datatable/datatable.component.html
@@ -160,10 +160,12 @@
                         </ng-container>
                     </div>
                     <div *ngIf="col.template" class="adf-datatable-cell-container">
-                        <ng-container
-                            [ngTemplateOutlet]="col.template"
-                            [ngTemplateOutletContext]="{ $implicit: { data: data, row: row, col: col }, value: data.getValue(row, col) }">
-                        </ng-container>
+                        <div class="adf-cell-value">
+                            <ng-container
+                                [ngTemplateOutlet]="col.template"
+                                [ngTemplateOutletContext]="{ $implicit: { data: data, row: row, col: col }, value: data.getValue(row, col) }">
+                            </ng-container>
+                        </div>
                     </div>
                 </div>
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
The breadcrumb of the content node selector does not show the current folder when it's a custom site. 
https://issues.alfresco.com/jira/browse/ADF-4264
https://issues.alfresco.com/jira/browse/ADF-4326

**What is the new behaviour?**
It now displays custom sites and the styles have been fixed.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-4264
https://issues.alfresco.com/jira/browse/ADF-4326