### PR TITLE
[ADF-4279] Demo-shell - Fix home component layout

### DIFF
--- a/demo-shell/src/app/components/home/home.component.scss
+++ b/demo-shell/src/app/components/home/home.component.scss
@@ -2,6 +2,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    height: 100%;
 }
 
 .adf-home-header-background {

--- a/lib/core/layout/components/layout-container/layout-container.component.scss
+++ b/lib/core/layout/components/layout-container/layout-container.component.scss
@@ -9,16 +9,8 @@
         overflow: hidden;
     }
 
-
     [dir='rtl'] .adf-rtl-container-alignment {
         margin-left: 10px!important;
-    }
-
-    ng-content {
-        display: block;
-        width: 100%;
-        height: 100%;
-        overflow: hidden;
     }
 
     .adf-sidenav--hidden {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-4279
The home component is not displayed in the middle

**What is the new behaviour?**
the ng-content tag does not bind styles so the styles come now from the child component in order to keep the same styling as before. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-4279