### PR TITLE
[ADF-4360] Fix Ellipsis on Date Cell Template

### DIFF
--- a/lib/core/datatable/components/datatable/datatable.component.html
+++ b/lib/core/datatable/components/datatable/datatable.component.html
@@ -27,7 +27,7 @@
                  tabindex="0"
                  title="{{ col.title | translate }}">
                 <span *ngIf="col.srTitle" class="adf-sr-only">{{ col.srTitle | translate }}</span>
-                <span *ngIf="col.title">{{ col.title | translate}}</span>
+                <span *ngIf="col.title" class="adf-datatable-cell-value">{{ col.title | translate}}</span>
             </div>
             <!-- Actions (right) -->
             <div *ngIf="actions && actionsPosition === 'right'" class="adf-actions-column adf-datatable-cell-header adf-datatable__actions-cell">

--- a/lib/core/datatable/components/datatable/datatable.component.scss
+++ b/lib/core/datatable/components/datatable/datatable.component.scss
@@ -331,6 +331,7 @@
                 overflow: hidden;
                 text-overflow: ellipsis;
                 word-break: break-all;
+                padding: 0 10px;
             }
 
             &:focus {

--- a/lib/core/datatable/components/datatable/date-cell.component.ts
+++ b/lib/core/datatable/components/datatable/date-cell.component.ts
@@ -31,6 +31,7 @@ import { AlfrescoApiService } from '../../../services/alfresco-api.service';
             <span
                 [attr.aria-label]="value$ | async | adfTimeAgo: currentLocale"
                 title="{{ tooltip | date: 'medium' }}"
+                class="adf-datatable-cell-value"
                 *ngIf="format === 'timeAgo'; else standard_date"
             >
                 {{ value$ | async | adfTimeAgo: currentLocale }}
@@ -39,6 +40,7 @@ import { AlfrescoApiService } from '../../../services/alfresco-api.service';
         <ng-template #standard_date>
             <span
                 title="{{ tooltip | date: format }}"
+                class="adf-datatable-cell-value"
                 [attr.aria-label]="value$ | async | date: format"
             >
                 {{ value$ | async | date: format }}
@@ -46,7 +48,7 @@ import { AlfrescoApiService } from '../../../services/alfresco-api.service';
         </ng-template>
     `,
     encapsulation: ViewEncapsulation.None,
-    host: { class: 'adf-date-cell' }
+    host: { class: 'adf-date-cell adf-datatable-cell' }
 })
 export class DateCellComponent extends DataTableCellComponent {
     currentLocale: string;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-4360
The template was missing a class that the datatable uses in order to apply the ellipsis

**What is the new behaviour?**
That class has been added and som other tweaks in the styling that improve the layout of the datatable component


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-4360