### PR TITLE
[ADF-4193] search error notifications and empty results

### DIFF
--- a/docs/content-services/services/search-query-builder.service.md
+++ b/docs/content-services/services/search-query-builder.service.md
@@ -11,6 +11,14 @@ Stores information from all the custom search and faceted search widgets, compil
 
 ## Class members
 
+### Events
+
+| Name | Type | Details |
+| --- | --- | --- |
+| updated | QueryBody | Raised when query gets updated but before query is executed |
+| executed | ResultSetPaging | Raised when query gets executed and results are available |
+| error | any | Raised when search api emits internal error |
+
 ### Methods
 
 -   **addFilterQuery**(query: `string`)<br/>

--- a/lib/content-services/search/search-query-builder.service.spec.ts
+++ b/lib/content-services/search/search-query-builder.service.spec.ts
@@ -613,4 +613,38 @@ describe('SearchQueryBuilder', () => {
         expect(compiled.highlight.mergeContiguous).toBe(true);
     });
 
+    it('should emit error event', (done) => {
+        const config: SearchConfiguration = {
+            categories: [
+                <any> { id: 'cat1', enabled: true }
+            ]
+        };
+        const builder = new SearchQueryBuilderService(buildConfig(config), null);
+        spyOn(builder, 'buildQuery').and.throwError('some error');
+
+        builder.error.subscribe(() => {
+            done();
+        });
+
+        builder.execute();
+    });
+
+    it('should emit empty results on error', (done) => {
+        const config: SearchConfiguration = {
+            categories: [
+                <any> { id: 'cat1', enabled: true }
+            ]
+        };
+        const builder = new SearchQueryBuilderService(buildConfig(config), null);
+        spyOn(builder, 'buildQuery').and.throwError('some error');
+
+        builder.executed.subscribe((data) => {
+            expect(data.list.entries).toEqual([]);
+            expect(data.list.pagination.totalItems).toBe(0);
+            done();
+        });
+
+        builder.execute();
+    });
+
 });

--- a/lib/content-services/search/search-query-builder.service.ts
+++ b/lib/content-services/search/search-query-builder.service.ts
@@ -42,8 +42,9 @@ export class SearchQueryBuilderService {
 
     private _userQuery = '';
 
-    updated: Subject<QueryBody> = new Subject();
-    executed: Subject<ResultSetPaging> = new Subject();
+    updated = new Subject<QueryBody>();
+    executed = new Subject<ResultSetPaging>();
+    error = new Subject();
 
     categories: Array<SearchCategory> = [];
     queryFragments: { [id: string]: string } = {};
@@ -196,10 +197,23 @@ export class SearchQueryBuilderService {
      * @returns Nothing
      */
     async execute() {
-        const query = this.buildQuery();
-        if (query) {
-            const resultSetPaging: ResultSetPaging = await this.alfrescoApiService.searchApi.search(query);
-            this.executed.next(resultSetPaging);
+        try {
+            const query = this.buildQuery();
+            if (query) {
+                const resultSetPaging: ResultSetPaging = await this.alfrescoApiService.searchApi.search(query);
+                this.executed.next(resultSetPaging);
+            }
+        } catch (error) {
+            this.error.next(error);
+
+            this.executed.next({
+                list: {
+                    pagination: {
+                        totalItems: 0
+                    },
+                    entries: []
+                }
+            });
         }
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

- Raise a new `error` event on internal search errors, so that apps can raise error notifications if needed
- Return empty data set of internal search errors so that UI can exit the "spinner" mode correctly

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-4193