### PR TITLE
Fromo mySuccessMethod to myExecuteSubmitMethod

### DIFF
--- a/docs/tutorials/using-components.md
+++ b/docs/tutorials/using-components.md
@@ -73,23 +73,23 @@ docs, we can see that it emits three events: `success`, `error` and `executeSubm
 
 We can subscribe to these events and have our custom code executed when these events are emitted. Let's hook into the `executeSubmit` and do a simple `alert()` when the form is submitted.
 
-Open `src/app/login/login.component.html` and add `(success)="mySuccessMethod($event)"` to the `<adf-login/>` component:
+Open `src/app/login/login.component.html` and add `(executeSubmit)="myExecuteSubmitMethod($event)"` to the `<adf-login/>` component:
 
 ```html
 <adf-login
 	[showRememberMe]="false"
 	[showLoginActions]="false"
-	(success)="mySuccessMethod($event)"
+	(executeSubmit)="myExecuteSubmitMethod($event)"
 	copyrightText="© 2017 Alfresco Software, Inc. All Rights Reserved."
 	successRoute="/documentlist">
 </adf-login>
 ```
 
-Next we need to implement `mySuccessMethod` in the typescript. Open `src/app/login/login.component.ts` and add a new method:
+Next we need to implement `myExecuteSubmitMethod` in the typescript. Open `src/app/login/login.component.ts` and add a new method:
 
 ```ts
 // Add this!
-mySuccessMethod(event: any) {
+myExecuteSubmitMethod(event: any) {
 	alert('Form was submitted!');
 	console.log(event);
 }
@@ -108,7 +108,7 @@ import { Component } from '@angular/core';
 export class LoginComponent {
 
 	// Add this!		
-	mySuccessMethod(event: any) {
+	myExecuteSubmitMethod(event: any) {
 		alert('Form was submitted!');
 		console.log(event);
 	}


### PR DESCRIPTION
In the tutorial, when working with events, it says that we want to show an allert when submitting the login form but in the code just below it binds the allert to the "success" event and not to the "executeSubmit" event. Also calls the method mySuccessMethod and not myExecuteSubmitMethod as it does at the very and of the Tutorial.

So i made the appropriate changes to adjust the code and the tutorial to show how to properly bind an allert to the "eventSubmit" event.

Regards
Luca Biondo

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [x ] Documentation
> - [ ] Other... Please describe:

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x ] No
