### PR TITLE
[ADF-4372] Fix json type Data Column styles

### DIFF
--- a/lib/core/datatable/components/datatable/json-cell.component.scss
+++ b/lib/core/datatable/components/datatable/json-cell.component.scss
@@ -1,0 +1,4 @@
+.adf-datatable-json-cell {
+    white-space: pre-wrap;
+    word-wrap: break-word;
+}

--- a/lib/core/datatable/components/datatable/json-cell.component.ts
+++ b/lib/core/datatable/components/datatable/json-cell.component.ts
@@ -24,10 +24,11 @@ import { DataTableCellComponent } from './datatable-cell.component';
     template: `
         <ng-container>
             <span class="adf-datatable-cell-value">
-                <pre>{{ value$ | async | json }}</pre>
+                <pre class="adf-datatable-json-cell">{{ value$ | async | json }}</pre>
             </span>
         </ng-container>
     `,
+    styleUrls: ['./json-cell.component.scss'],
     encapsulation: ViewEncapsulation.None,
     host: { class: 'adf-datatable-cell' }
 })


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-4372
When json is to wide it breaks data column layout

**What is the new behaviour?**
New styles added to make the json fit the given space.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-4372