### PR TITLE
[ADF-4376] Fix Sticky Header in Datatable Component

### DIFF
--- a/demo-shell/src/app/components/datatable/datatable.component.html
+++ b/demo-shell/src/app/components/datatable/datatable.component.html
@@ -10,7 +10,7 @@
     Sticky header
 </mat-slide-toggle>
 
-<div style="height: 310px; overflow-y: auto;">
+<div style="height: 310px;">
     <adf-datatable
         #dataTable
         [data]="data"

--- a/demo-shell/src/app/components/datatable/datatable.component.html
+++ b/demo-shell/src/app/components/datatable/datatable.component.html
@@ -10,7 +10,7 @@
     Sticky header
 </mat-slide-toggle>
 
-<div style="height: 310px;">
+<div style="height: 310px; overflow-y: auto;">
     <adf-datatable
         #dataTable
         [data]="data"

--- a/demo-shell/src/app/components/datatable/datatable.component.ts
+++ b/demo-shell/src/app/components/datatable/datatable.component.ts
@@ -129,7 +129,7 @@ export class DataTableComponent {
             [
                 { type: 'image', key: 'icon', title: '', srTitle: 'Thumbnail' },
                 { type: 'text', key: 'id', title: 'Id', sortable: true , cssClass: '' },
-                { type: 'text', key: 'createdOn', title: 'Created On', sortable: true, cssClass: 'adf-ellipsis-cell adf-expand-cell-2' },
+                { type: 'date', key: 'createdOn', title: 'Created On', sortable: true, cssClass: 'adf-ellipsis-cell adf-expand-cell-2' },
                 { type: 'text', key: 'name', title: 'Name', cssClass: 'adf-ellipsis-cell', sortable: true },
                 { type: 'text', key: 'createdBy.name', title: 'Created By', sortable: true, cssClass: ''},
                 { type: 'json', key: 'json', title: 'Json', cssClass: 'adf-expand-cell-2'}

--- a/e2e/content-services/permissions/permissions-component.e2e.ts
+++ b/e2e/content-services/permissions/permissions-component.e2e.ts
@@ -27,10 +27,10 @@ import { UploadActions } from '../../actions/ACS/upload.actions';
 import { StringUtil } from '@alfresco/adf-testing';
 import { browser, protractor } from 'protractor';
 import { FolderModel } from '../../models/ACS/folderModel';
-import { SearchDialog } from '../../pages/adf/dialog/searchDialog';
 import { ViewerPage } from '../../pages/adf/viewerPage';
 import { NotificationPage } from '../../pages/adf/notificationPage';
 import { MetadataViewPage } from '../../pages/adf/metadataViewPage';
+import { NavigationBarPage } from '../../pages/adf/navigationBarPage';
 import { UploadDialog } from '../../pages/adf/dialog/uploadDialog';
 
 describe('Permissions Component', function () {
@@ -38,11 +38,11 @@ describe('Permissions Component', function () {
     const loginPage = new LoginPage();
     const contentServicesPage = new ContentServicesPage();
     const permissionsPage = new PermissionsPage();
+    const navigationBarPage = new NavigationBarPage();
     const uploadActions = new UploadActions();
 
     const contentList = contentServicesPage.getDocumentList();
 
-    const searchDialog = new SearchDialog();
     const viewerPage = new ViewerPage();
     const metadataViewPage = new MetadataViewPage();
     const notificationPage = new NotificationPage();
@@ -92,21 +92,15 @@ describe('Permissions Component', function () {
         await alfrescoJsApi.login(TestConfig.adf.adminEmail, TestConfig.adf.adminPassword);
 
         await alfrescoJsApi.core.peopleApi.addPerson(fileOwnerUser);
-
         await alfrescoJsApi.core.peopleApi.addPerson(filePermissionUser);
-
         await alfrescoJsApi.core.groupsApi.createGroup(groupBody);
 
         await alfrescoJsApi.login(fileOwnerUser.id, fileOwnerUser.password);
 
         roleConsumerFolder = await uploadActions.createFolder(alfrescoJsApi, roleConsumerFolderModel.name, '-my-');
-
         roleCoordinatorFolder = await uploadActions.createFolder(alfrescoJsApi, roleCoordinatorFolderModel.name, '-my-');
-
         roleContributorFolder = await uploadActions.createFolder(alfrescoJsApi, roleContributorFolderModel.name, '-my-');
-
         roleCollaboratorFolder = await uploadActions.createFolder(alfrescoJsApi, roleCollaboratorFolderModel.name, '-my-');
-
         roleEditorFolder = await uploadActions.createFolder(alfrescoJsApi, roleEditorFolderModel.name, '-my-');
 
         folders = [roleConsumerFolder, roleContributorFolder, roleCoordinatorFolder, roleCollaboratorFolder, roleEditorFolder];
@@ -114,131 +108,78 @@ describe('Permissions Component', function () {
         await alfrescoJsApi.core.nodesApi.updateNode(roleConsumerFolder.entry.id,
 
             {
-
                 permissions: {
-
                     locallySet: [{
-
                         authorityId: filePermissionUser.getId(),
-
                         name: 'Consumer',
-
                         accessStatus: 'ALLOWED'
-
                     }]
-
                 }
-
             });
 
         await alfrescoJsApi.core.nodesApi.updateNode(roleCollaboratorFolder.entry.id,
-
             {
-
                 permissions: {
-
                     locallySet: [{
-
                         authorityId: filePermissionUser.getId(),
-
                         name: 'Collaborator',
-
                         accessStatus: 'ALLOWED'
-
                     }]
-
                 }
-
             });
 
         await alfrescoJsApi.core.nodesApi.updateNode(roleCoordinatorFolder.entry.id,
-
             {
-
                 permissions: {
-
                     locallySet: [{
-
                         authorityId: filePermissionUser.getId(),
-
                         name: 'Coordinator',
-
                         accessStatus: 'ALLOWED'
-
                     }]
-
                 }
-
             });
 
         await alfrescoJsApi.core.nodesApi.updateNode(roleContributorFolder.entry.id,
 
             {
-
                 permissions: {
-
                     locallySet: [{
-
                         authorityId: filePermissionUser.getId(),
-
                         name: 'Contributor',
-
                         accessStatus: 'ALLOWED'
-
                     }]
-
                 }
-
             });
 
         await alfrescoJsApi.core.nodesApi.updateNode(roleEditorFolder.entry.id,
 
             {
-
                 permissions: {
-
                     locallySet: [{
-
                         authorityId: filePermissionUser.getId(),
-
                         name: 'Editor',
-
                         accessStatus: 'ALLOWED'
-
                     }]
-
                 }
-
             });
 
         await uploadActions.uploadFile(alfrescoJsApi, fileModel.location, 'RoleConsumer' + fileModel.name, roleConsumerFolder.entry.id);
-
         await uploadActions.uploadFile(alfrescoJsApi, fileModel.location, 'RoleContributor' + fileModel.name, roleContributorFolder.entry.id);
-
         await uploadActions.uploadFile(alfrescoJsApi, fileModel.location, 'RoleCoordinator' + fileModel.name, roleCoordinatorFolder.entry.id);
-
         await uploadActions.uploadFile(alfrescoJsApi, fileModel.location, 'RoleCollaborator' + fileModel.name, roleCollaboratorFolder.entry.id);
-
         await uploadActions.uploadFile(alfrescoJsApi, fileModel.location, 'RoleEditor' + fileModel.name, roleEditorFolder.entry.id);
 
-        browser.driver.sleep(15000); // wait search get the groups, files and folders
-
         done();
-
     });
 
     afterAll(async (done) => {
-
         await alfrescoJsApi.login(TestConfig.adf.adminEmail, TestConfig.adf.adminPassword);
-
         await folders.forEach(function (folder) {
-
             uploadActions.deleteFilesOrFolder(alfrescoJsApi, folder.entry.id);
 
         });
 
         done();
-
     });
 
     describe('Inherit and assigning permissions', function () {
@@ -252,11 +193,8 @@ describe('Permissions Component', function () {
             loginPage.loginToContentServicesUsingUserModel(fileOwnerUser);
 
             contentServicesPage.goToDocumentList();
-
             contentServicesPage.checkContentIsDisplayed(fileModel.name);
-
             contentServicesPage.checkSelectedSiteIsDisplayed('My files');
-
             contentList.rightClickOnRow(fileModel.name);
 
             contentServicesPage.pressContextMenuActionNamed('Permission');
@@ -481,28 +419,13 @@ describe('Permissions Component', function () {
 
             loginPage.loginToContentServicesUsingUserModel(filePermissionUser);
 
-            contentServicesPage.goToDocumentList();
-
-            searchDialog
-
-                .checkSearchIconIsVisible()
-
-                .clickOnSearchIcon()
-
-                .checkSearchBarIsVisible()
-
-                .enterText(roleConsumerFolderModel.name)
-
-                .resultTableContainsRow(roleConsumerFolderModel.name)
-
-                .clickOnSpecificRow(roleConsumerFolderModel.name);
+            navigationBarPage.openContentServicesFolder(roleConsumerFolder.entry.id);
 
             contentServicesPage.checkContentIsDisplayed('RoleConsumer' + fileModel.name);
 
             contentList.doubleClickRow('RoleConsumer' + fileModel.name);
 
             viewerPage.checkFileIsLoaded();
-
             viewerPage.clickCloseButton();
 
             contentList.waitForTableBody();
@@ -527,28 +450,13 @@ describe('Permissions Component', function () {
 
             loginPage.loginToContentServicesUsingUserModel(filePermissionUser);
 
-            contentServicesPage.goToDocumentList();
-
-            searchDialog
-
-                .checkSearchIconIsVisible()
-
-                .clickOnSearchIcon()
-
-                .checkSearchBarIsVisible()
-
-                .enterText(roleContributorFolderModel.name)
-
-                .resultTableContainsRow(roleContributorFolderModel.name)
-
-                .clickOnSpecificRow(roleContributorFolderModel.name);
+            navigationBarPage.openContentServicesFolder(roleContributorFolder.entry.id);
 
             contentServicesPage.checkContentIsDisplayed('RoleContributor' + fileModel.name);
 
             contentList.doubleClickRow('RoleContributor' + fileModel.name);
 
             viewerPage.checkFileIsLoaded();
-
             viewerPage.clickCloseButton();
 
             contentList.waitForTableBody();
@@ -566,7 +474,6 @@ describe('Permissions Component', function () {
             contentServicesPage.uploadFile(testFileModel.location).checkContentIsDisplayed(testFileModel.name);
 
             uploadDialog.fileIsUploaded(testFileModel.name);
-
             uploadDialog.clickOnCloseButton().dialogIsNotDisplayed();
 
         });
@@ -575,28 +482,13 @@ describe('Permissions Component', function () {
 
             loginPage.loginToContentServicesUsingUserModel(filePermissionUser);
 
-            contentServicesPage.goToDocumentList();
-
-            searchDialog
-
-                .checkSearchIconIsVisible()
-
-                .clickOnSearchIcon()
-
-                .checkSearchBarIsVisible()
-
-                .enterText(roleEditorFolderModel.name)
-
-                .resultTableContainsRow(roleEditorFolderModel.name)
-
-                .clickOnSpecificRow(roleEditorFolderModel.name);
+            navigationBarPage.openContentServicesFolder(roleEditorFolder.entry.id);
 
             contentServicesPage.checkContentIsDisplayed('RoleEditor' + fileModel.name);
 
             contentList.doubleClickRow('RoleEditor' + fileModel.name);
 
             viewerPage.checkFileIsLoaded();
-
             viewerPage.clickCloseButton();
 
             contentList.waitForTableBody();
@@ -616,9 +508,7 @@ describe('Permissions Component', function () {
                 await metadataViewPage.editIconClick();
 
                 metadataViewPage.editPropertyIconIsDisplayed('properties.cm:title');
-
                 metadataViewPage.clickEditPropertyIcons('properties.cm:title');
-
                 metadataViewPage.enterPropertyText('properties.cm:title', 'newTitle1');
 
                 await metadataViewPage.clickUpdatePropertyIcon('properties.cm:title');
@@ -639,28 +529,13 @@ describe('Permissions Component', function () {
 
             loginPage.loginToContentServicesUsingUserModel(filePermissionUser);
 
-            contentServicesPage.goToDocumentList();
-
-            searchDialog
-
-                .checkSearchIconIsVisible()
-
-                .clickOnSearchIcon()
-
-                .checkSearchBarIsVisible()
-
-                .enterText(roleCollaboratorFolderModel.name)
-
-                .resultTableContainsRow(roleCollaboratorFolderModel.name)
-
-                .clickOnSpecificRow(roleCollaboratorFolderModel.name);
+            navigationBarPage.openContentServicesFolder(roleCollaboratorFolder.entry.id);
 
             contentServicesPage.checkContentIsDisplayed('RoleCollaborator' + fileModel.name);
 
             contentList.doubleClickRow('RoleCollaborator' + fileModel.name);
 
             viewerPage.checkFileIsLoaded();
-
             viewerPage.clickCloseButton();
 
             contentList.waitForTableBody();
@@ -680,9 +555,7 @@ describe('Permissions Component', function () {
                 await metadataViewPage.editIconClick();
 
                 metadataViewPage.editPropertyIconIsDisplayed('properties.cm:title');
-
                 metadataViewPage.clickEditPropertyIcons('properties.cm:title');
-
                 metadataViewPage.enterPropertyText('properties.cm:title', 'newTitle2');
 
                 await metadataViewPage.clickUpdatePropertyIcon('properties.cm:title');
@@ -694,7 +567,6 @@ describe('Permissions Component', function () {
                 contentServicesPage.uploadFile(testFileModel.location).checkContentIsDisplayed(testFileModel.name);
 
                 uploadDialog.fileIsUploaded(testFileModel.name);
-
                 uploadDialog.clickOnCloseButton().dialogIsNotDisplayed();
 
             });
@@ -705,28 +577,13 @@ describe('Permissions Component', function () {
 
             loginPage.loginToContentServicesUsingUserModel(filePermissionUser);
 
-            contentServicesPage.goToDocumentList();
-
-            searchDialog
-
-                .checkSearchIconIsVisible()
-
-                .clickOnSearchIcon()
-
-                .checkSearchBarIsVisible()
-
-                .enterText(roleCoordinatorFolderModel.name)
-
-                .resultTableContainsRow(roleCoordinatorFolderModel.name)
-
-                .clickOnSpecificRow(roleCoordinatorFolderModel.name);
+            navigationBarPage.openContentServicesFolder(roleCoordinatorFolder.entry.id);
 
             contentServicesPage.checkContentIsDisplayed('RoleCoordinator' + fileModel.name);
 
             contentList.doubleClickRow('RoleCoordinator' + fileModel.name);
 
             viewerPage.checkFileIsLoaded();
-
             viewerPage.clickCloseButton();
 
             contentList.waitForTableBody();
@@ -740,9 +597,7 @@ describe('Permissions Component', function () {
                 await metadataViewPage.editIconClick();
 
                 metadataViewPage.editPropertyIconIsDisplayed('properties.cm:title');
-
                 metadataViewPage.clickEditPropertyIcons('properties.cm:title');
-
                 metadataViewPage.enterPropertyText('properties.cm:title', 'newTitle3');
 
                 await metadataViewPage.clickUpdatePropertyIcon('properties.cm:title');
@@ -750,17 +605,13 @@ describe('Permissions Component', function () {
                 expect(metadataViewPage.getPropertyText('properties.cm:title')).toEqual('newTitle3');
 
                 metadataViewPage.clickCloseButton();
-
                 contentServicesPage.uploadFile(pngFileModel.location).checkContentIsDisplayed(pngFileModel.name);
 
                 uploadDialog.fileIsUploaded(pngFileModel.name);
-
                 uploadDialog.clickOnCloseButton().dialogIsNotDisplayed();
 
                 contentServicesPage.checkContentIsDisplayed('RoleCoordinator' + fileModel.name);
-
                 contentServicesPage.deleteContent('RoleCoordinator' + fileModel.name);
-
                 contentServicesPage.checkContentIsNotDisplayed('RoleCoordinator' + fileModel.name);
 
             });
@@ -771,24 +622,9 @@ describe('Permissions Component', function () {
 
             loginPage.loginToContentServicesUsingUserModel(filePermissionUser);
 
-            contentServicesPage.goToDocumentList();
-
-            searchDialog
-
-                .checkSearchIconIsVisible()
-
-                .clickOnSearchIcon()
-
-                .checkSearchBarIsVisible()
-
-                .enterText(roleConsumerFolderModel.name)
-
-                .resultTableContainsRow(roleConsumerFolderModel.name)
-
-                .clickOnSpecificRow(roleConsumerFolderModel.name);
+            navigationBarPage.openContentServicesFolder(roleConsumerFolder.entry.id);
 
             contentServicesPage.checkContentIsDisplayed('RoleConsumer' + fileModel.name);
-
             contentServicesPage.checkSelectedSiteIsDisplayed('My files');
 
             contentList.rightClickOnRow('RoleConsumer' + fileModel.name);
@@ -796,13 +632,10 @@ describe('Permissions Component', function () {
             contentServicesPage.pressContextMenuActionNamed('Permission');
 
             permissionsPage.checkPermissionInheritedButtonIsDisplayed();
-
             permissionsPage.checkAddPermissionButtonIsDisplayed();
-
             permissionsPage.clickPermissionInheritedButton();
 
             notificationPage.checkNotifyContains('You are not allowed to change permissions');
-
             notificationPage.checkNotificationSnackBarIsNotDisplayed();
 
             permissionsPage.clickAddPermissionButton();

--- a/e2e/content-services/permissions/site-permissions.e2e.ts
+++ b/e2e/content-services/permissions/site-permissions.e2e.ts
@@ -16,63 +16,38 @@
  */
 
 import { PermissionsPage } from '../../pages/adf/permissionsPage';
-
 import { LoginPage } from '@alfresco/adf-testing';
-
 import { ContentServicesPage } from '../../pages/adf/contentServicesPage';
-
 import { AcsUserModel } from '../../models/ACS/acsUserModel';
-
 import TestConfig = require('../../test.config');
-
 import resources = require('../../util/resources');
-
 import { AlfrescoApiCompatibility as AlfrescoApi } from '@alfresco/js-api';
-
 import { FileModel } from '../../models/ACS/fileModel';
-
 import { UploadActions } from '../../actions/ACS/upload.actions';
-
 import { StringUtil } from '@alfresco/adf-testing';
-
 import { browser, protractor } from 'protractor';
-
-import { SearchDialog } from '../../pages/adf/dialog/searchDialog';
-
 import { ViewerPage } from '../../pages/adf/viewerPage';
-
 import { NotificationPage } from '../../pages/adf/notificationPage';
-
 import CONSTANTS = require('../../util/constants');
-
 import { MetadataViewPage } from '../../pages/adf/metadataViewPage';
-
 import { UploadDialog } from '../../pages/adf/dialog/uploadDialog';
-
 import { VersionManagePage } from '../../pages/adf/versionManagerPage';
+import { NavigationBarPage } from '../../pages/adf/navigationBarPage';
 
 describe('Permissions Component', function () {
 
     const loginPage = new LoginPage();
-
     const contentServicesPage = new ContentServicesPage();
-
     const permissionsPage = new PermissionsPage();
-
     const uploadActions = new UploadActions();
 
     const contentList = contentServicesPage.getDocumentList();
 
-    const searchDialog = new SearchDialog();
-
     const viewerPage = new ViewerPage();
-
+    const navigationBarPage = new NavigationBarPage();
     const metadataViewPage = new MetadataViewPage();
-
     const notificationPage = new NotificationPage();
-
     const versionManagePage = new VersionManagePage();
-
     const uploadDialog = new UploadDialog();
 
     let folderOwnerUser, consumerUser, siteConsumerUser, contributorUser, managerUser, collaboratorUser;
@@ -80,49 +55,32 @@ describe('Permissions Component', function () {
     let publicSite, privateSite, folderName;
 
     const fileModel = new FileModel({
-
         'name': resources.Files.ADF_DOCUMENTS.TXT_0B.file_name,
-
         'location': resources.Files.ADF_DOCUMENTS.TXT_0B.file_location
-
     });
 
     const testFileModel = new FileModel({
-
         'name': resources.Files.ADF_DOCUMENTS.TEST.file_name,
-
         'location': resources.Files.ADF_DOCUMENTS.TEST.file_location
-
     });
 
     const pngFileModel = new FileModel({
-
         'name': resources.Files.ADF_DOCUMENTS.PNG.file_name,
-
         'location': resources.Files.ADF_DOCUMENTS.PNG.file_location
-
     });
 
     const alfrescoJsApi = new AlfrescoApi({
-
         provider: 'ECM',
-
         hostEcm: TestConfig.adf.url
-
     });
 
     let siteFolder, privateSiteFile;
 
     folderOwnerUser = new AcsUserModel();
-
     consumerUser = new AcsUserModel();
-
     siteConsumerUser = new AcsUserModel();
-
     collaboratorUser = new AcsUserModel();
-
     contributorUser = new AcsUserModel();
-
     managerUser = new AcsUserModel();
 
     beforeAll(async (done) => {
@@ -130,17 +88,11 @@ describe('Permissions Component', function () {
         await alfrescoJsApi.login(TestConfig.adf.adminEmail, TestConfig.adf.adminPassword);
 
         await alfrescoJsApi.core.peopleApi.addPerson(folderOwnerUser);
-
         await alfrescoJsApi.core.peopleApi.addPerson(siteConsumerUser);
-
         await alfrescoJsApi.core.peopleApi.addPerson(consumerUser);
-
         await alfrescoJsApi.core.peopleApi.addPerson(contributorUser);
-
         await alfrescoJsApi.core.peopleApi.addPerson(collaboratorUser);
-
         await alfrescoJsApi.core.peopleApi.addPerson(managerUser);
-
         await alfrescoJsApi.login(folderOwnerUser.id, folderOwnerUser.password);
 
         const publicSiteName = `PUBLIC_TEST_SITE_${StringUtil.generateRandomString(5)}`;
@@ -154,47 +106,31 @@ describe('Permissions Component', function () {
         const privateSiteBody = {visibility: 'PRIVATE', title: privateSiteName};
 
         publicSite = await alfrescoJsApi.core.sitesApi.createSite(publicSiteBody);
-
         privateSite = await alfrescoJsApi.core.sitesApi.createSite(privateSiteBody);
 
         await alfrescoJsApi.core.sitesApi.addSiteMember(publicSite.entry.id, {
-
             id: siteConsumerUser.id,
-
             role: CONSTANTS.CS_USER_ROLES.CONSUMER
-
         });
 
         await alfrescoJsApi.core.sitesApi.addSiteMember(publicSite.entry.id, {
-
             id: collaboratorUser.id,
-
             role: CONSTANTS.CS_USER_ROLES.COLLABORATOR
-
         });
 
         await alfrescoJsApi.core.sitesApi.addSiteMember(publicSite.entry.id, {
-
             id: contributorUser.id,
-
             role: CONSTANTS.CS_USER_ROLES.CONTRIBUTOR
-
         });
 
         await alfrescoJsApi.core.sitesApi.addSiteMember(publicSite.entry.id, {
-
             id: managerUser.id,
-
             role: CONSTANTS.CS_USER_ROLES.MANAGER
-
         });
 
         await alfrescoJsApi.core.sitesApi.addSiteMember(privateSite.entry.id, {
-
             id: managerUser.id,
-
             role: CONSTANTS.CS_USER_ROLES.MANAGER
-
         });
 
         siteFolder = await uploadActions.createFolder(alfrescoJsApi, folderName, publicSite.entry.guid);
@@ -204,26 +140,16 @@ describe('Permissions Component', function () {
         await alfrescoJsApi.core.nodesApi.updateNode(privateSiteFile.entry.id,
 
             {
-
                 permissions: {
-
                     locallySet: [{
-
                         authorityId: managerUser.getId(),
-
                         name: 'SiteConsumer',
-
                         accessStatus: 'ALLOWED'
-
                     }]
-
                 }
-
             });
 
         await uploadActions.uploadFile(alfrescoJsApi, fileModel.location, 'Site' + fileModel.name, siteFolder.entry.id);
-
-        browser.driver.sleep(15000); // wait search get the groups, files and folders
 
         done();
 
@@ -232,13 +158,10 @@ describe('Permissions Component', function () {
     afterAll(async (done) => {
 
         await alfrescoJsApi.login(TestConfig.adf.adminEmail, TestConfig.adf.adminPassword);
-
         await alfrescoJsApi.core.sitesApi.deleteSite(publicSite.entry.id);
-
         await alfrescoJsApi.core.sitesApi.deleteSite(privateSite.entry.id);
 
         done();
-
     });
 
     describe('Role Site Dropdown', function () {
@@ -303,21 +226,7 @@ describe('Permissions Component', function () {
 
             loginPage.loginToContentServicesUsingUserModel(siteConsumerUser);
 
-            contentServicesPage.goToDocumentList();
-
-            searchDialog
-
-                .checkSearchIconIsVisible()
-
-                .clickOnSearchIcon()
-
-                .checkSearchBarIsVisible()
-
-                .enterText(folderName)
-
-                .resultTableContainsRow(folderName)
-
-                .clickOnSpecificRow(folderName);
+            navigationBarPage.openContentServicesFolder(siteFolder.entry.id);
 
             contentServicesPage.checkContentIsDisplayed('Site' + fileModel.name);
 
@@ -349,21 +258,7 @@ describe('Permissions Component', function () {
 
             loginPage.loginToContentServicesUsingUserModel(contributorUser);
 
-            contentServicesPage.goToDocumentList();
-
-            searchDialog
-
-                .checkSearchIconIsVisible()
-
-                .clickOnSearchIcon()
-
-                .checkSearchBarIsVisible()
-
-                .enterText(folderName)
-
-                .resultTableContainsRow(folderName)
-
-                .clickOnSpecificRow(folderName);
+            navigationBarPage.openContentServicesFolder(siteFolder.entry.id);
 
             contentServicesPage.checkContentIsDisplayed('Site' + fileModel.name);
 
@@ -397,21 +292,7 @@ describe('Permissions Component', function () {
 
             loginPage.loginToContentServicesUsingUserModel(collaboratorUser);
 
-            contentServicesPage.goToDocumentList();
-
-            searchDialog
-
-                .checkSearchIconIsVisible()
-
-                .clickOnSearchIcon()
-
-                .checkSearchBarIsVisible()
-
-                .enterText(folderName)
-
-                .resultTableContainsRow(folderName)
-
-                .clickOnSpecificRow(folderName);
+            navigationBarPage.openContentServicesFolder(siteFolder.entry.id);
 
             contentServicesPage.checkContentIsDisplayed('Site' + fileModel.name);
 
@@ -463,21 +344,7 @@ describe('Permissions Component', function () {
 
             loginPage.loginToContentServicesUsingUserModel(managerUser);
 
-            contentServicesPage.goToDocumentList();
-
-            searchDialog
-
-                .checkSearchIconIsVisible()
-
-                .clickOnSearchIcon()
-
-                .checkSearchBarIsVisible()
-
-                .enterText(folderName)
-
-                .resultTableContainsRow(folderName)
-
-                .clickOnSpecificRow(folderName);
+            navigationBarPage.openContentServicesFolder(siteFolder.entry.id);
 
             contentServicesPage.checkContentIsDisplayed('Site' + fileModel.name);
 

--- a/e2e/content-services/permissions/site-permissions.e2e.ts
+++ b/e2e/content-services/permissions/site-permissions.e2e.ts
@@ -31,7 +31,6 @@ import { NotificationPage } from '../../pages/adf/notificationPage';
 import CONSTANTS = require('../../util/constants');
 import { MetadataViewPage } from '../../pages/adf/metadataViewPage';
 import { UploadDialog } from '../../pages/adf/dialog/uploadDialog';
-import { VersionManagePage } from '../../pages/adf/versionManagerPage';
 import { NavigationBarPage } from '../../pages/adf/navigationBarPage';
 
 describe('Permissions Component', function () {
@@ -47,7 +46,6 @@ describe('Permissions Component', function () {
     const navigationBarPage = new NavigationBarPage();
     const metadataViewPage = new MetadataViewPage();
     const notificationPage = new NotificationPage();
-    const versionManagePage = new VersionManagePage();
     const uploadDialog = new UploadDialog();
 
     let folderOwnerUser, consumerUser, siteConsumerUser, contributorUser, managerUser, collaboratorUser;
@@ -181,23 +179,14 @@ describe('Permissions Component', function () {
             contentServicesPage.pressContextMenuActionNamed('Permission');
 
             permissionsPage.checkPermissionInheritedButtonIsDisplayed();
-
             permissionsPage.checkAddPermissionButtonIsDisplayed();
-
             permissionsPage.clickAddPermissionButton();
-
             permissionsPage.checkAddPermissionDialogIsDisplayed();
-
             permissionsPage.checkSearchUserInputIsDisplayed();
-
             permissionsPage.searchUserOrGroup(consumerUser.getId());
-
             permissionsPage.clickUserOrGroup(consumerUser.getFirstName());
-
             permissionsPage.checkUserOrGroupIsAdded(consumerUser.getId());
-
             done();
-
         });
 
         it('[C277002] Should display the Role Site dropdown', () => {
@@ -341,21 +330,16 @@ describe('Permissions Component', function () {
         });
 
         it('[C277006] Role SiteManager', () => {
-
             loginPage.loginToContentServicesUsingUserModel(managerUser);
-
             navigationBarPage.openContentServicesFolder(siteFolder.entry.id);
-
             contentServicesPage.checkContentIsDisplayed('Site' + fileModel.name);
 
             contentList.doubleClickRow('Site' + fileModel.name);
 
             viewerPage.checkFileIsLoaded();
-
             viewerPage.clickCloseButton();
 
             contentList.waitForTableBody();
-
             contentServicesPage.metadataContent('Site' + fileModel.name);
 
             metadataViewPage.editIconIsDisplayed();
@@ -365,9 +349,7 @@ describe('Permissions Component', function () {
                 await metadataViewPage.editIconClick();
 
                 metadataViewPage.editPropertyIconIsDisplayed('properties.cm:description');
-
                 metadataViewPage.clickEditPropertyIcons('properties.cm:description');
-
                 metadataViewPage.enterDescriptionText('newDescription');
 
                 await metadataViewPage.clickUpdatePropertyIcon('properties.cm:description');
@@ -375,78 +357,15 @@ describe('Permissions Component', function () {
                 expect(metadataViewPage.getPropertyText('properties.cm:description')).toEqual('newDescription');
 
                 metadataViewPage.clickCloseButton();
-
                 contentServicesPage.uploadFile(testFileModel.location).checkContentIsDisplayed(testFileModel.name);
 
                 uploadDialog.fileIsUploaded(testFileModel.name);
-
                 uploadDialog.clickOnCloseButton().dialogIsNotDisplayed();
 
                 contentServicesPage.checkContentIsDisplayed('Site' + fileModel.name);
-
                 contentServicesPage.deleteContent('Site' + fileModel.name);
-
                 contentServicesPage.checkContentIsNotDisplayed('Site' + fileModel.name);
-
             });
-
-        });
-
-    });
-
-    describe('Site Consumer - Add new version', function () {
-
-        it('[C277118] Should be able to add new version with Site Consumer permission on file', () => {
-
-            loginPage.loginToContentServicesUsingUserModel(managerUser);
-
-            browser.get(TestConfig.adf.url + '/files/' + privateSite.entry.guid);
-
-            contentServicesPage.checkContentIsDisplayed('privateSite' + fileModel.name);
-
-            contentList.doubleClickRow('privateSite' + fileModel.name);
-
-            viewerPage.checkFileIsLoaded();
-
-            viewerPage.checkInfoButtonIsDisplayed();
-
-            viewerPage.clickInfoButton();
-
-            viewerPage.checkInfoSideBarIsDisplayed();
-
-            viewerPage.clickMoveRightChevron();
-
-            viewerPage.clickMoveRightChevron();
-
-            viewerPage.clickOnTab('Versions');
-
-            viewerPage.checkTabIsActive('Versions');
-
-            versionManagePage
-
-                .checkUploadNewVersionsButtonIsDisplayed()
-
-                .clickAddNewVersionsButton()
-
-                .checkMajorChangeIsDisplayed()
-
-                .checkMinorChangeIsDisplayed()
-
-                .checkCommentTextIsDisplayed()
-
-                .checkCancelButtonIsDisplayed();
-
-            versionManagePage.uploadNewVersionFile(pngFileModel.location);
-
-            versionManagePage.checkFileVersionExist('1.0');
-
-            expect(versionManagePage.getFileVersionName('1.0')).toEqual('privateSite' + fileModel.name);
-
-            versionManagePage.checkFileVersionExist('1.1');
-
-            expect(versionManagePage.getFileVersionName('1.1')).toEqual(pngFileModel.name);
-
-            viewerPage.checkFileNameIsDisplayed(pngFileModel.name);
 
         });
 

--- a/e2e/pages/adf/contentServicesPage.ts
+++ b/e2e/pages/adf/contentServicesPage.ts
@@ -58,8 +58,6 @@ export class ContentServicesPage {
     emptyRecent = element(by.css('.adf-container-recent .adf-empty-list__title'));
     gridViewButton = element(by.css('button[data-automation-id="document-list-grid-view"]'));
     cardViewContainer = element(by.css('div.adf-document-list-container div.adf-datatable-card'));
-    chooseButton = element(by.css('button[data-automation-id="content-node-selector-actions-choose"]'));
-    searchInputElement = element(by.css('input[data-automation-id="content-node-selector-search-input"]'));
     shareNodeButton = element(by.cssContainingText('mat-icon', ' share '));
     nameColumnHeader = 'name';
     createdByColumnHeader = 'createdByUser.displayName';

--- a/e2e/proxy.ts
+++ b/e2e/proxy.ts
@@ -15,11 +15,13 @@
  * limitations under the License.
  */
 
+/* tslint:disable */
+
 import { browser } from 'protractor';
 
 export async function setConfigField(field: string, value: string) {
 
     return browser.executeScript(
-        "window.adf.setConfigField(`"+field + "`, `" + value + "`);"
+        "window.adf.setConfigField(`" + field + "`, `" + value + "`);"
     );
 }

--- a/lib/content-services/content-node-selector/content-node-selector-panel.component.scss
+++ b/lib/content-services/content-node-selector/content-node-selector-panel.component.scss
@@ -142,6 +142,7 @@
                         .adf-datatable-cell {
 
                             & .adf-name-location-cell-location {
+                                padding: 0;
                                 display: block;
                             }
 

--- a/lib/core/datatable/components/datatable/datatable.component.scss
+++ b/lib/core/datatable/components/datatable/datatable.component.scss
@@ -165,6 +165,7 @@
     .adf-datatable-list {
         display: flex;
         flex-direction: column;
+        height: 100%;
         background-color: mat-color($background, card);
         border: $data-table-dividers;
 
@@ -334,9 +335,7 @@
             }
 
             .adf-datatable-cell-value {
-                overflow: hidden;
-                text-overflow: ellipsis;
-                word-break: break-all;
+                word-break: break-word;
                 padding: 0 10px;
             }
 
@@ -504,20 +503,19 @@
 
     .adf-sticky-header {
         border-top: 0;
-        max-width: calc(100% - 0.2em);
 
         .adf-datatable-header {
-            position: absolute;
-            background-color: mat-color($background, card);
-            display: flex;
-            z-index: 10;
+            display: block;
+            margin-right: 0;
             border-top: $data-table-dividers;
             border-bottom: $data-table-dividers;
-            width: calc(100% - 17.4em);
         }
 
         .adf-datatable-body {
-            margin-top: 57px;
+            display: block;
+            flex: 1;
+            overflow-y: scroll;
+            margin-top: -1px;
         }
     }
 

--- a/lib/core/datatable/components/datatable/datatable.component.scss
+++ b/lib/core/datatable/components/datatable/datatable.component.scss
@@ -165,7 +165,6 @@
     .adf-datatable-list {
         display: flex;
         flex-direction: column;
-        height: 100%;
         background-color: mat-color($background, card);
         border: $data-table-dividers;
 
@@ -503,6 +502,7 @@
 
     .adf-sticky-header {
         border-top: 0;
+        height: 100%;
 
         .adf-datatable-header {
             display: block;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Sticky header overflows when active
https://issues.alfresco.com/jira/browse/ADF-4374

**What is the new behaviour?**
The sticky header now works no matter the width of the page.
the date cell template has been improved
the content node selector has been improved

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-4374