### PR TITLE
[ADF-4405] [ADF-4423] Fix clipboard directive on json cell

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -126,7 +126,8 @@
     "uncheck",
     "subfolders",
     "ECMBPM",
-    "candidateuserapp"
+    "candidateuserapp",
+    "processwithvariables"
   ],
   "dictionaries": [
     "html",

--- a/lib/content-services/content-node-share/content-node-share.dialog.html
+++ b/lib/content-services/content-node-share/content-node-share.dialog.html
@@ -31,7 +31,7 @@
                     readonly="readonly">
                     <mat-icon class="adf-input-action" matSuffix
                           [clipboard-notification]="'SHARE.CLIPBOARD-MESSAGE' | translate"
-                          [adf-clipboard] target="sharedLinkInput">
+                          [adf-clipboard] [target]="sharedLinkInput">
                         link
                     </mat-icon>
             </mat-form-field>

--- a/lib/core/clipboard/clipboard.directive.ts
+++ b/lib/core/clipboard/clipboard.directive.ts
@@ -49,9 +49,11 @@ export class ClipboardDirective {
 
     @HostListener('mouseenter')
     showTooltip() {
-        const componentFactory = this.resolver.resolveComponentFactory(ClipboardComponent);
-        const componentRef = this.viewContainerRef.createComponent(componentFactory).instance;
-        componentRef.placeholder = this.placeholder;
+        if (this.placeholder) {
+            const componentFactory = this.resolver.resolveComponentFactory(ClipboardComponent);
+            const componentRef = this.viewContainerRef.createComponent(componentFactory).instance;
+            componentRef.placeholder = this.placeholder;
+        }
     }
 
     @HostListener('mouseleave')
@@ -79,7 +81,8 @@ export class ClipboardDirective {
     template: `
         <span class='adf-datatable-copy-tooltip'>{{ placeholder | translate }} </span>
         `,
-    encapsulation: ViewEncapsulation.None
+    encapsulation: ViewEncapsulation.None,
+    host: { class: 'adf-datatable-copy-content-tooltip-container' }
 })
 export class ClipboardComponent {
     placeholder: string;

--- a/lib/core/clipboard/clipboard.directive.ts
+++ b/lib/core/clipboard/clipboard.directive.ts
@@ -81,8 +81,7 @@ export class ClipboardDirective {
     template: `
         <span class='adf-datatable-copy-tooltip'>{{ placeholder | translate }} </span>
         `,
-    encapsulation: ViewEncapsulation.None,
-    host: { class: 'adf-datatable-copy-content-tooltip-container' }
+    encapsulation: ViewEncapsulation.None
 })
 export class ClipboardComponent {
     placeholder: string;

--- a/lib/core/datatable/components/datatable/json-cell.component.ts
+++ b/lib/core/datatable/components/datatable/json-cell.component.ts
@@ -27,9 +27,7 @@ import { DataTableCellComponent } from './datatable-cell.component';
                 <pre
                     class="adf-datatable-json-cell"
                     [adf-clipboard]="'CLIPBOARD.CLICK_TO_COPY'"
-                    [clipboard-notification]="'CLIPBOARD.SUCCESS_COPY'">
-                    {{ value$ | async | json }}
-                </pre>
+                    [clipboard-notification]="'CLIPBOARD.SUCCESS_COPY'">{{ value$ | async | json }}</pre>
             </span>
         </ng-container>
         <ng-template #defaultJsonTemplate>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-4423
https://issues.alfresco.com/jira/browse/ADF-4405
Json cell not displaying properly content inside
Directive not targeting correct HTML element

**What is the new behaviour?**
It targets the correct html element so it can display the tooltip correctly and copy the content into the clipboard


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-4423
https://issues.alfresco.com/jira/browse/ADF-4405