### PR TITLE
[ADF-4425] The separator for metadata can be set from the config editor

### DIFF
--- a/lib/content-services/content-metadata/services/property-groups-translator.service.ts
+++ b/lib/content-services/content-metadata/services/property-groups-translator.service.ts
@@ -53,10 +53,11 @@ export class PropertyGroupTranslatorService {
     constructor(private logService: LogService,
                 private multiValuePipe: MultiValuePipe,
                 private appConfig: AppConfigService) {
-        this.valueSeparator = this.appConfig.get<string>('content-metadata.multi-value-pipe-separator');
     }
 
     public translateToCardViewGroups(propertyGroups: OrganisedPropertyGroup[], propertyValues): CardViewGroup[] {
+        this.valueSeparator = this.appConfig.get<string>('content-metadata.multi-value-pipe-separator');
+
         return propertyGroups.map((propertyGroup) => {
             const translatedPropertyGroup: any = Object.assign({}, propertyGroup);
             translatedPropertyGroup.properties = this.translateArray(propertyGroup.properties, propertyValues);

--- a/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.ts
+++ b/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.ts
@@ -48,11 +48,11 @@ export class CardViewTextItemComponent implements OnChanges {
 
     constructor(private cardViewUpdateService: CardViewUpdateService,
                 private appConfig: AppConfigService) {
-        this.valueSeparator = this.appConfig.get<string>('content-metadata.multi-value-pipe-separator') || CardViewTextItemComponent.DEFAULT_SEPARATOR;
     }
 
     ngOnChanges(): void {
         this.editedValue = this.property.multiline ? this.property.displayValue : this.property.value;
+        this.valueSeparator = this.appConfig.get<string>('content-metadata.multi-value-pipe-separator');
     }
 
     showProperty(): boolean {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-4425
The separator for the config metadata can not be set from the config editor

**What is the new behaviour?**
Now, it's possible to config it from the config editor


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-4425