### PR TITLE
[ADF-4359] - Add the possibility to chose wich panel to show first in info-drawer

### DIFF
--- a/demo-shell/src/app/components/file-view/file-view.component.html
+++ b/demo-shell/src/app/components/file-view/file-view.component.html
@@ -12,12 +12,14 @@
                                            [multi]="multi"
                                            [preset]="customPreset"
                                            [readOnly]="isReadOnly"
+                                           [displayAspect]="showAspect"
                                            [displayDefaultProperties]="displayDefaultProperties"
                                            [displayEmpty]="displayEmptyMetadata"></adf-content-metadata-card>
 
                 <adf-content-metadata-card *ngIf="!isPreset" [node]="node"
                                            [multi]="multi"
                                            [readOnly]="isReadOnly"
+                                           [displayAspect]="showAspect"
                                            [displayDefaultProperties]="displayDefaultProperties"
                                            [displayEmpty]="displayEmptyMetadata"></adf-content-metadata-card>
 
@@ -72,6 +74,19 @@
                 </p>
 
                 <p class="toggle">
+
+                    <mat-form-field floatPlaceholder="float">
+                        <input matInput
+                               placeholder="Display Aspect"
+                               [(ngModel)]="desiredAspect">
+                    </mat-form-field>
+
+                    <button mat-raised-button (click)="applyAspect()" color="primary">
+                        Apply Aspect
+                    </button>
+                </p>
+
+                <p class="toggle">
                     <ng-container *ngIf="isPreset">
                         <mat-form-field floatPlaceholder="float">
                             <input matInput
@@ -118,7 +133,7 @@
 
                 <p class="toggle">
                     <ng-container *ngIf="customName">
-                        <mat-form-field floatPlaceholder="float">
+                        <mat-form-field floatLabel="never">
                             <input matInput
                                    placeholder="Custom Name"
                                    [(ngModel)]="displayName"

--- a/demo-shell/src/app/components/file-view/file-view.component.ts
+++ b/demo-shell/src/app/components/file-view/file-view.component.ts
@@ -55,6 +55,8 @@ export class FileViewComponent implements OnInit {
     isCommentEnabled = false;
     showTabWithIcon = false;
     showTabWithIconAndLabel = false;
+    desiredAspect: string = null;
+    showAspect: string = null;
 
     constructor(private router: Router,
                 private route: ActivatedRoute,
@@ -187,5 +189,9 @@ export class FileViewComponent implements OnInit {
         setTimeout(() => {
             this.isPreset = true;
         }, 100);
+    }
+
+    applyAspect() {
+        this.showAspect = this.desiredAspect;
     }
 }

--- a/docs/content-services/components/content-metadata-card.component.md
+++ b/docs/content-services/components/content-metadata-card.component.md
@@ -34,6 +34,7 @@ Displays and edits metadata related to a node.
 | preset | `string` |  | (required) Name of the metadata preset, which defines aspects and their properties. |
 | readOnly | `boolean` | false | (optional) This flag sets the metadata in read only mode preventing changes. |
 | displayDefaultProperties | `boolean` |  | (optional) This flag displays/hides the metadata properties. |
+| displayAspect | `string` |  | (optional) This flag displays the desired metadata property in the expanded card |
 
 ## Details
 

--- a/e2e/content-services/metadata/metadata-properties.e2e.ts
+++ b/e2e/content-services/metadata/metadata-properties.e2e.ts
@@ -135,7 +135,7 @@ describe('CardView Component - properties', () => {
         metadataViewPage.clickOnInformationButton();
 
         metadataViewPage.checkMetadataGroupIsNotExpand('EXIF');
-        metadataViewPage.checkMetadataGroupIsExpand('properties');
+        metadataViewPage.checkMetadataGroupIsNotExpand('properties');
 
         metadataViewPage.clickMetadataGroup('properties');
 

--- a/e2e/content-services/metadata/metadata-properties.e2e.ts
+++ b/e2e/content-services/metadata/metadata-properties.e2e.ts
@@ -135,7 +135,7 @@ describe('CardView Component - properties', () => {
         metadataViewPage.clickOnInformationButton();
 
         metadataViewPage.checkMetadataGroupIsNotExpand('EXIF');
-        metadataViewPage.checkMetadataGroupIsNotExpand('properties');
+        metadataViewPage.checkMetadataGroupIsExpand('properties');
 
         metadataViewPage.clickMetadataGroup('properties');
 

--- a/e2e/pages/adf/metadataViewPage.ts
+++ b/e2e/pages/adf/metadataViewPage.ts
@@ -115,6 +115,7 @@ export class MetadataViewPage {
 
     editIconClick(): promise.Promise<void> {
         BrowserVisibility.waitUntilElementIsVisible(this.editIcon);
+        BrowserVisibility.waitUntilElementIsClickable(this.editIcon);
         return this.editIcon.click();
     }
 
@@ -167,7 +168,7 @@ export class MetadataViewPage {
 
     editPropertyIconIsDisplayed(propertyName: string) {
         const editPropertyIcon = element(by.css('mat-icon[data-automation-id="card-textitem-edit-icon-' + propertyName + '"]'));
-        BrowserVisibility.waitUntilElementIsVisible(editPropertyIcon);
+        BrowserVisibility.waitUntilElementIsPresent(editPropertyIcon);
     }
 
     updatePropertyIconIsDisplayed(propertyName: string) {
@@ -264,13 +265,13 @@ export class MetadataViewPage {
 
     checkMetadataGroupIsNotExpand(groupName: string) {
         const group = element(by.css('mat-expansion-panel[data-automation-id="adf-metadata-group-' + groupName + '"] > mat-expansion-panel-header'));
-        BrowserVisibility.waitUntilElementIsVisible(group);
+        BrowserVisibility.waitUntilElementIsPresent(group);
         expect(group.getAttribute('class')).not.toContain('mat-expanded');
     }
 
     getMetadataGroupTitle(groupName: string): promise.Promise<string> {
         const group = element(by.css('mat-expansion-panel[data-automation-id="adf-metadata-group-' + groupName + '"] > mat-expansion-panel-header > span > mat-panel-title'));
-        BrowserVisibility.waitUntilElementIsVisible(group);
+        BrowserVisibility.waitUntilElementIsPresent(group);
         return group.getText();
     }
 

--- a/lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.html
+++ b/lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.html
@@ -7,6 +7,7 @@
             [displayEmpty]="displayEmpty"
             [editable]="editable"
             [multi]="multi"
+            [displayAspect]="displayAspect"
             [preset]="preset">
         </adf-content-metadata>
     </mat-card-content>

--- a/lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.spec.ts
+++ b/lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.spec.ts
@@ -22,6 +22,7 @@ import { ContentMetadataCardComponent } from './content-metadata-card.component'
 import { ContentMetadataComponent } from '../content-metadata/content-metadata.component';
 import { setupTestBed, AllowableOperationsEnum } from '@alfresco/adf-core';
 import { ContentTestingModule } from '../../../testing/content.testing.module';
+import { SimpleChange } from '@angular/core';
 
 describe('ContentMetadataCardComponent', () => {
 
@@ -189,4 +190,17 @@ describe('ContentMetadataCardComponent', () => {
         const button = fixture.debugElement.query(By.css('[data-automation-id="meta-data-card-toggle-edit"]'));
         expect(button).not.toBeNull();
     });
+
+    it('should expand the card when custom display aspect is valid', () => {
+        expect(component.expanded).toBeFalsy();
+
+        let displayAspect = new SimpleChange(null , 'EXIF', true);
+        component.ngOnChanges({ displayAspect });
+        expect(component.expanded).toBeTruthy();
+
+        displayAspect = new SimpleChange('EXIF' , null, false);
+        component.ngOnChanges({ displayAspect });
+        expect(component.expanded).toBeTruthy();
+    });
+
 });

--- a/lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.ts
+++ b/lib/content-services/content-metadata/components/content-metadata-card/content-metadata-card.component.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Component, Input, ViewEncapsulation } from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges, ViewEncapsulation } from '@angular/core';
 import { Node } from '@alfresco/js-api';
 import { ContentService, AllowableOperationsEnum } from '@alfresco/adf-core';
 
@@ -26,7 +26,7 @@ import { ContentService, AllowableOperationsEnum } from '@alfresco/adf-core';
     encapsulation: ViewEncapsulation.None,
     host: { 'class': 'adf-content-metadata-card' }
 })
-export class ContentMetadataCardComponent {
+export class ContentMetadataCardComponent implements OnChanges {
     /** (required) The node entity to fetch metadata about */
     @Input()
     node: Node;
@@ -36,6 +36,12 @@ export class ContentMetadataCardComponent {
      */
     @Input()
     displayEmpty: boolean = false;
+
+    /** (optional) This flag displays desired aspect when open for the first time
+     * fields.
+     */
+    @Input()
+    displayAspect: string = null;
 
     /** (required) Name of the metadata preset, which defines aspects
      * and their properties.
@@ -75,6 +81,12 @@ export class ContentMetadataCardComponent {
     expanded: boolean;
 
     constructor(private contentService: ContentService) {
+    }
+
+    ngOnChanges(changes: SimpleChanges): void {
+        if (changes.displayAspect && changes.displayAspect.currentValue) {
+            this.expanded = true;
+        }
     }
 
     onDisplayDefaultPropertiesChange(): void {

--- a/lib/content-services/content-metadata/components/content-metadata/content-metadata.component.html
+++ b/lib/content-services/content-metadata/components/content-metadata/content-metadata.component.html
@@ -2,8 +2,8 @@
     <mat-accordion displayMode="flat" [multi]="multi">
         <mat-expansion-panel
             *ngIf="displayDefaultProperties"
-            [expanded]="!expanded"
-            [hideToggle]="!expanded"
+            [expanded]="!expanded || !displayAspect"
+            [hideToggle]="!expanded || !displayAspect"
             [attr.data-automation-id]="'adf-metadata-group-properties'" >
             <mat-expansion-panel-header>
                 <mat-panel-title>
@@ -23,7 +23,7 @@
                 <div *ngFor="let group of groupedProperties; let first = first;" class="adf-metadata-grouped-properties-container">
                     <mat-expansion-panel *ngIf="showGroup(group) || editable"
                     [attr.data-automation-id]="'adf-metadata-group-' + group.title"
-                    [expanded]="!displayDefaultProperties && first">
+                    [expanded]="canExpandTheCard(group) || !displayDefaultProperties && first">
                         <mat-expansion-panel-header>
                             <mat-panel-title>
                                 {{ group.title | translate }}

--- a/lib/content-services/content-metadata/components/content-metadata/content-metadata.component.html
+++ b/lib/content-services/content-metadata/components/content-metadata/content-metadata.component.html
@@ -2,8 +2,8 @@
     <mat-accordion displayMode="flat" [multi]="multi">
         <mat-expansion-panel
             *ngIf="displayDefaultProperties"
-            [expanded]="!expanded || !displayAspect"
-            [hideToggle]="!expanded || !displayAspect"
+            [expanded]="canExpandProperties()"
+            [hideToggle]="canExpandProperties()"
             [attr.data-automation-id]="'adf-metadata-group-properties'" >
             <mat-expansion-panel-header>
                 <mat-panel-title>

--- a/lib/content-services/content-metadata/components/content-metadata/content-metadata.component.spec.ts
+++ b/lib/content-services/content-metadata/components/content-metadata/content-metadata.component.spec.ts
@@ -312,21 +312,30 @@ describe('ContentMetadataComponent', () => {
             component.displayEmpty = true;
 
             fixture.detectChanges();
-            const defaultProp = queryDom(fixture);
-            const exifProp = queryDom(fixture, 'EXIF');
-            const customProp = queryDom(fixture, 'CUSTOM');
+            let defaultProp = queryDom(fixture);
+            let exifProp = queryDom(fixture, 'EXIF');
+            let customProp = queryDom(fixture, 'CUSTOM');
             expect(defaultProp.componentInstance.expanded).toBeFalsy();
             expect(exifProp.componentInstance.expanded).toBeTruthy();
             expect(customProp.componentInstance.expanded).toBeFalsy();
 
             component.displayAspect = 'CUSTOM';
             fixture.detectChanges();
-            const updatedDefault = queryDom(fixture);
-            const updatedExif = queryDom(fixture, 'EXIF');
-            const updatedCustom = queryDom(fixture, 'CUSTOM');
-            expect(updatedDefault.componentInstance.expanded).toBeFalsy();
-            expect(updatedExif.componentInstance.expanded).toBeFalsy();
-            expect(updatedCustom.componentInstance.expanded).toBeTruthy();
+            defaultProp = queryDom(fixture);
+            exifProp = queryDom(fixture, 'EXIF');
+            customProp = queryDom(fixture, 'CUSTOM');
+            expect(defaultProp.componentInstance.expanded).toBeFalsy();
+            expect(exifProp.componentInstance.expanded).toBeFalsy();
+            expect(customProp.componentInstance.expanded).toBeTruthy();
+
+            component.displayAspect = 'Properties';
+            fixture.detectChanges();
+            defaultProp = queryDom(fixture);
+            exifProp = queryDom(fixture, 'EXIF');
+            customProp = queryDom(fixture, 'CUSTOM');
+            expect(defaultProp.componentInstance.expanded).toBeTruthy();
+            expect(exifProp.componentInstance.expanded).toBeFalsy();
+            expect(customProp.componentInstance.expanded).toBeFalsy();
 
         }));
 
@@ -340,21 +349,6 @@ describe('ContentMetadataComponent', () => {
             const exifProp = queryDom(fixture, 'EXIF');
             const customProp = queryDom(fixture, 'CUSTOM');
             expect(defaultProp.componentInstance.expanded).toBeFalsy();
-            expect(exifProp.componentInstance.expanded).toBeFalsy();
-            expect(customProp.componentInstance.expanded).toBeFalsy();
-
-        }));
-
-        it('should expand the properties section when input is null', async(() => {
-            component.displayAspect = null;
-            component.expanded = true;
-            component.displayEmpty = true;
-
-            fixture.detectChanges();
-            const defaultProp = queryDom(fixture);
-            const exifProp = queryDom(fixture, 'EXIF');
-            const customProp = queryDom(fixture, 'CUSTOM');
-            expect(defaultProp.componentInstance.expanded).toBeTruthy();
             expect(exifProp.componentInstance.expanded).toBeFalsy();
             expect(customProp.componentInstance.expanded).toBeFalsy();
 

--- a/lib/content-services/content-metadata/components/content-metadata/content-metadata.component.ts
+++ b/lib/content-services/content-metadata/components/content-metadata/content-metadata.component.ts
@@ -126,4 +126,8 @@ export class ContentMetadataComponent implements OnChanges, OnInit, OnDestroy {
         return group.title === this.displayAspect;
     }
 
+    public canExpandProperties(): boolean {
+        return !this.expanded || this.displayAspect === 'Properties';
+    }
+
 }

--- a/lib/content-services/content-metadata/components/content-metadata/content-metadata.component.ts
+++ b/lib/content-services/content-metadata/components/content-metadata/content-metadata.component.ts
@@ -61,6 +61,10 @@ export class ContentMetadataComponent implements OnChanges, OnInit, OnDestroy {
     @Input()
     displayDefaultProperties: boolean = true;
 
+    /** (Optional) shows the given aspect in the expanded  card */
+    @Input()
+    displayAspect: string = null;
+
     basicProperties$: Observable<CardViewItem[]>;
     groupedProperties$: Observable<CardViewGroup[]>;
     disposableNodeUpdate: Subscription;
@@ -116,6 +120,10 @@ export class ContentMetadataComponent implements OnChanges, OnInit, OnDestroy {
 
     ngOnDestroy() {
         this.disposableNodeUpdate.unsubscribe();
+    }
+
+    public canExpandTheCard(group: CardViewGroup): boolean {
+        return group.title === this.displayAspect;
     }
 
 }

--- a/lib/content-services/content-metadata/components/content-metadata/mock-data.ts
+++ b/lib/content-services/content-metadata/components/content-metadata/mock-data.ts
@@ -1,0 +1,74 @@
+/*!
+ * @license
+ * Copyright 2019 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const mockGroupProperties = [
+    {
+        'title': 'EXIF',
+        'properties': [
+            {
+                'label': 'Image Width',
+                'value': 363,
+                'key': 'properties.exif:pixelXDimension',
+                'default': null,
+                'editable': true,
+                'clickable': false,
+                'icon': '',
+                'data': null,
+                'type': 'int',
+                'multiline': false,
+                'pipes': [],
+                'clickCallBack': null,
+                displayValue: 400
+            },
+            {
+                'label': 'Image Height',
+                'value': 400,
+                'key': 'properties.exif:pixelYDimension',
+                'default': null,
+                'editable': true,
+                'clickable': false,
+                'icon': '',
+                'data': null,
+                'type': 'int',
+                'multiline': false,
+                'pipes': [],
+                'clickCallBack': null,
+                displayValue: 400
+            }
+        ]
+    },
+    {
+        'title': 'CUSTOM',
+        'properties': [
+            {
+                'label': 'Height',
+                'value': 400,
+                'key': 'properties.custom:abc',
+                'default': null,
+                'editable': true,
+                'clickable': false,
+                'icon': '',
+                'data': null,
+                'type': 'int',
+                'multiline': false,
+                'pipes': [],
+                'clickCallBack': null,
+                displayValue: 400
+            }
+        ]
+    }
+];


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

It enables the user to open the info with the desired aspect in the expanded mode
![feature-1](https://user-images.githubusercontent.com/14145706/56648273-a45efd80-66a0-11e9-866b-4f13c7df4b80.gif)




**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
