### PR TITLE
[ADF-4449] added subject for terminating upload dialog

### DIFF
--- a/lib/content-services/upload/components/file-uploading-dialog.component.spec.ts
+++ b/lib/content-services/upload/components/file-uploading-dialog.component.spec.ts
@@ -93,6 +93,15 @@ describe('FileUploadingDialogComponent', () => {
 
             expect(component.totalErrors).toEqual(totalErrors);
         });
+
+        it('should close the dialog when terminate event is sent', () => {
+            uploadService.addToQueue(...fileList);
+            uploadService.uploadFilesInTheQueue(emitter);
+            expect(component.isDialogActive).toBe(true);
+            uploadService.terminateUpload.next();
+
+            expect(component.isDialogActive).toBe(false);
+        });
     });
 
     describe('toggleConfirmation()', () => {

--- a/lib/content-services/upload/components/file-uploading-dialog.component.ts
+++ b/lib/content-services/upload/components/file-uploading-dialog.component.ts
@@ -51,6 +51,7 @@ export class FileUploadingDialogComponent implements OnInit, OnDestroy {
     private counterSubscription: Subscription;
     private fileUploadSubscription: Subscription;
     private errorSubscription: Subscription;
+    private terminateSubscription: Subscription;
 
     constructor(private uploadService: UploadService,
                 private changeDetector: ChangeDetectorRef) {
@@ -97,6 +98,8 @@ export class FileUploadingDialogComponent implements OnInit, OnDestroy {
                 }
             }
         });
+
+        this.terminateSubscription = this.uploadService.terminateUpload.subscribe(() => this.close());
     }
 
     /**
@@ -147,5 +150,6 @@ export class FileUploadingDialogComponent implements OnInit, OnDestroy {
         this.counterSubscription.unsubscribe();
         this.fileUploadSubscription.unsubscribe();
         this.errorSubscription.unsubscribe();
+        this.terminateSubscription.unsubscribe();
     }
 }

--- a/lib/core/services/upload.service.ts
+++ b/lib/core/services/upload.service.ts
@@ -53,6 +53,7 @@ export class UploadService {
     fileUploadComplete: Subject<FileUploadCompleteEvent> = new Subject<FileUploadCompleteEvent>();
     fileUploadDeleted: Subject<FileUploadDeleteEvent> = new Subject<FileUploadDeleteEvent>();
     fileDeleted: Subject<string> = new Subject<string>();
+    terminateUpload: Subject<string> = new Subject<string>();
 
     constructor(protected apiService: AlfrescoApiService, private appConfigService: AppConfigService) {
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [X] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
there's no way from outside to terminate/close the upload dialog


**What is the new behaviour?**
added a subject that will close the upload dialog when streamed a value.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-4449