### PR TITLE
[ADF-4404] fix typeahead validation

### DIFF
--- a/lib/core/form/components/widgets/core/form-field-validator.ts
+++ b/lib/core/form/components/widgets/core/form-field-validator.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
- /* tslint:disable:component-selector  */
+/* tslint:disable:component-selector  */
 
 import moment from 'moment-es6';
 import { FormFieldTypes } from './form-field-types';
@@ -24,6 +24,7 @@ import { FormFieldModel } from './form-field.model';
 export interface FormFieldValidator {
 
     isSupported(field: FormFieldModel): boolean;
+
     validate(field: FormFieldModel): boolean;
 
 }
@@ -500,8 +501,8 @@ export class FixedValueFieldValidator implements FormFieldValidator {
         return field.options.find((item) => item.name && item.name.toLocaleLowerCase() === field.value.toLocaleLowerCase()) ? true : false;
     }
 
-    hasValidId(field: FormFieldModel) {
-        return field.options[field.value - 1] ? true : false;
+    hasValidId(field: FormFieldModel): boolean {
+        return field.options.find((item) => item.id === field.value) ? true : false;
     }
 
     hasStringValue(field: FormFieldModel) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [X] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

typeahead fail if the id of the object value is too big

**What is the new behaviour?**


typeahead doesn't fail if the id of the object value is too big


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
