### PR TITLE
[ADF-4447] -  Should be able to choose which aspect to show expanded in the info-drawer

### DIFF
--- a/e2e/content-services/metadata/metadata-properties.e2e.ts
+++ b/e2e/content-services/metadata/metadata-properties.e2e.ts
@@ -186,4 +186,31 @@ describe('CardView Component - properties', () => {
 
         metadataViewPage.informationButtonIsNotDisplayed();
     });
+
+    it('[C307975] Should be able to choose which aspect to show expanded in the info-drawer', () => {
+        viewerPage.viewFile(pngFileModel.name);
+        viewerPage.clickInfoButton();
+        viewerPage.checkInfoSideBarIsDisplayed();
+        metadataViewPage.clickOnPropertiesTab();
+
+        metadataViewPage.typeAspectName('EXIF');
+        metadataViewPage.clickApplyAspect();
+
+        metadataViewPage.checkMetadataGroupIsExpand('EXIF');
+        metadataViewPage.checkMetadataGroupIsNotExpand('properties');
+        check(metadataViewPage.displayEmptySwitch);
+
+        metadataViewPage.checkPropertyIsVisible('properties.exif:flash', 'boolean');
+        metadataViewPage.checkPropertyIsVisible('properties.exif:model', 'textitem');
+
+        metadataViewPage.typeAspectName('nonexistent');
+        metadataViewPage.clickApplyAspect();
+        metadataViewPage.checkMetadataGroupIsNotPresent('nonexistent');
+
+        metadataViewPage.typeAspectName('Properties');
+        metadataViewPage.clickApplyAspect();
+        metadataViewPage.checkMetadataGroupIsPresent('properties');
+        metadataViewPage.checkMetadataGroupIsExpand('properties');
+
+    });
 });

--- a/e2e/pages/adf/metadataViewPage.ts
+++ b/e2e/pages/adf/metadataViewPage.ts
@@ -44,6 +44,8 @@ export class MetadataViewPage {
     presetSwitch = element(by.id('adf-toggle-custom-preset'));
     defaultPropertiesSwitch = element(by.id('adf-metadata-default-properties'));
     closeButton = element(by.cssContainingText('button.mat-button span', 'Close'));
+    displayAspect = element(by.css(`input[placeholder='Display Aspect']`));
+    applyAspect = element(by.cssContainingText(`button span.mat-button-wrapper`, 'Apply Aspect'));
 
     getTitle(): promise.Promise<string> {
         BrowserVisibility.waitUntilElementIsVisible(this.title);
@@ -288,5 +290,16 @@ export class MetadataViewPage {
     clickCloseButton() {
         BrowserVisibility.waitUntilElementIsVisible(this.closeButton);
         this.closeButton.click();
+    }
+
+    typeAspectName(aspectName) {
+        BrowserVisibility.waitUntilElementIsVisible(this.displayAspect);
+        this.displayAspect.clear();
+        this.displayAspect.sendKeys(aspectName);
+    }
+
+    clickApplyAspect() {
+        BrowserVisibility.waitUntilElementIsVisible(this.applyAspect);
+        this.applyAspect.click();
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**
There is a 'Display Aspect' input field, where user can type the aspect name. Clicking on 'Apply Aspect' button in the Viewer - Properties tab, will display the new Aspect and it's associated properties in the expanded form.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-4359
https://issues.alfresco.com/jira/browse/ADF-4447