### PR TITLE
[ADF-4411] Keep js-api dependency in remove-dep... script

### DIFF
--- a/scripts/remove-alfresco-dependencies.sh
+++ b/scripts/remove-alfresco-dependencies.sh
@@ -2,8 +2,8 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 echo "====== Removing Alfresco dependencies from package.json ====="
 
-grep -wirn '@alfresco*' $DIR/../package.json
-
-sed -i '' '/@alfresco*/,// d' $DIR/../package.json
+grep -wirn '@alfresco\/adf*' $DIR/../package.json
+sed -i '' 's/"@alfresco\/adf-[^,]*,//' $DIR/../package.json
+sed -i '' '/^[[:space:]]*$/d' $DIR/../package.json
 
 echo "====== Alfresco dependencies removed from package.json ====="


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-4411


**What is the new behaviour?**
Now the script keeps the js-api dependency in package.json


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
