### PR TITLE
[ADF-4455] Fix whitespaces trim in multivalue metadata field

### DIFF
--- a/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.ts
+++ b/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.ts
@@ -107,11 +107,11 @@ export class CardViewTextItemComponent implements OnChanges {
     }
 
     prepareValueForUpload(property: CardViewTextItemModel, value: string): string | string [] {
-        const listOfValues = value;
         if (property.multivalued) {
-            return listOfValues.split(this.valueSeparator);
+            const listOfValues = value.split(this.valueSeparator.trim()).map((item) => item.trim());
+            return listOfValues;
         }
-        return listOfValues;
+        return value;
     }
 
     onTextAreaInputChange() {

--- a/lib/core/pipes/multi-value.pipe.ts
+++ b/lib/core/pipes/multi-value.pipe.ts
@@ -25,8 +25,8 @@ export class MultiValuePipe implements PipeTransform {
     transform(values: string | string [], valueSeparator: string = MultiValuePipe.DEFAULT_SEPARATOR): string {
 
         if (values && values instanceof Array) {
-            values.map((value) => value.trim());
-            return values.join(valueSeparator);
+            const valueList = values.map((value) => value.trim());
+            return valueList.join(valueSeparator);
         }
 
         return <string> values;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-4455
Metadata multivalue fields show and store items with white spaces.

**What is the new behaviour?**
Each one of these items should contain only the characters without whitespaces in the beginning/at the end. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-4455