### PR TITLE
[ADF-4457] StorageService should be independent of AppConfigService

### DIFF
--- a/lib/content-services/document-list/services/document-actions.service.spec.ts
+++ b/lib/content-services/document-list/services/document-actions.service.spec.ts
@@ -16,7 +16,7 @@
  */
 
 import { AlfrescoApiServiceMock, AppConfigService, ContentService,
-    setupTestBed, CoreModule, TranslationMock
+    setupTestBed, CoreModule, TranslationMock, StorageService
 } from '@alfresco/adf-core';
 import { FileNode, FolderNode } from '../../mock';
 import { ContentActionHandler } from '../models/content-action.model';
@@ -37,7 +37,7 @@ describe('DocumentActionsService', () => {
 
     beforeEach(() => {
         const contentService = new ContentService(null, null, null, null);
-        const alfrescoApiService = new AlfrescoApiServiceMock(new AppConfigService(null));
+        const alfrescoApiService = new AlfrescoApiServiceMock(new AppConfigService(null), new StorageService());
 
         documentListService = new DocumentListService(contentService, alfrescoApiService, null, null);
         service = new DocumentActionsService(null, null, new TranslationMock(), documentListService, contentService);

--- a/lib/content-services/document-list/services/document-actions.service.spec.ts
+++ b/lib/content-services/document-list/services/document-actions.service.spec.ts
@@ -16,7 +16,7 @@
  */
 
 import { AlfrescoApiServiceMock, AppConfigService, ContentService,
-    setupTestBed, CoreModule, TranslationMock, StorageService
+    setupTestBed, CoreModule, TranslationMock
 } from '@alfresco/adf-core';
 import { FileNode, FolderNode } from '../../mock';
 import { ContentActionHandler } from '../models/content-action.model';
@@ -37,7 +37,7 @@ describe('DocumentActionsService', () => {
 
     beforeEach(() => {
         const contentService = new ContentService(null, null, null, null);
-        const alfrescoApiService = new AlfrescoApiServiceMock(new AppConfigService(null), new StorageService());
+        const alfrescoApiService = new AlfrescoApiServiceMock(new AppConfigService(null), null);
 
         documentListService = new DocumentListService(contentService, alfrescoApiService, null, null);
         service = new DocumentActionsService(null, null, new TranslationMock(), documentListService, contentService);

--- a/lib/content-services/document-list/services/document-list.service.spec.ts
+++ b/lib/content-services/document-list/services/document-list.service.spec.ts
@@ -17,7 +17,7 @@
 
 import { AlfrescoApiServiceMock, AlfrescoApiService,
     AppConfigService, ContentService, setupTestBed, CoreModule,
-    LogService, AppConfigServiceMock, StorageService } from '@alfresco/adf-core';
+    LogService, AppConfigServiceMock } from '@alfresco/adf-core';
 import { DocumentListService } from './document-list.service';
 import { CustomResourcesService } from './custom-resources.service';
 
@@ -71,7 +71,7 @@ describe('DocumentListService', () => {
     beforeEach(() => {
         const logService = new LogService(new AppConfigServiceMock(null));
         const contentService = new ContentService(null, null, null, null);
-        alfrescoApiService = new AlfrescoApiServiceMock(new AppConfigService(null), new StorageService());
+        alfrescoApiService = new AlfrescoApiServiceMock(new AppConfigService(null), null);
         const customActionService = new CustomResourcesService(alfrescoApiService, logService);
         service = new DocumentListService(contentService, alfrescoApiService, logService, customActionService);
         jasmine.Ajax.install();

--- a/lib/content-services/document-list/services/document-list.service.spec.ts
+++ b/lib/content-services/document-list/services/document-list.service.spec.ts
@@ -16,7 +16,8 @@
  */
 
 import { AlfrescoApiServiceMock, AlfrescoApiService,
-    AppConfigService, ContentService, setupTestBed, CoreModule, LogService, AppConfigServiceMock } from '@alfresco/adf-core';
+    AppConfigService, ContentService, setupTestBed, CoreModule,
+    LogService, AppConfigServiceMock, StorageService } from '@alfresco/adf-core';
 import { DocumentListService } from './document-list.service';
 import { CustomResourcesService } from './custom-resources.service';
 
@@ -70,7 +71,7 @@ describe('DocumentListService', () => {
     beforeEach(() => {
         const logService = new LogService(new AppConfigServiceMock(null));
         const contentService = new ContentService(null, null, null, null);
-        alfrescoApiService = new AlfrescoApiServiceMock(new AppConfigService(null));
+        alfrescoApiService = new AlfrescoApiServiceMock(new AppConfigService(null), new StorageService());
         const customActionService = new CustomResourcesService(alfrescoApiService, logService);
         service = new DocumentListService(contentService, alfrescoApiService, logService, customActionService);
         jasmine.Ajax.install();

--- a/lib/content-services/document-list/services/folder-actions.service.spec.ts
+++ b/lib/content-services/document-list/services/folder-actions.service.spec.ts
@@ -16,7 +16,8 @@
  */
 
 import { TestBed } from '@angular/core/testing';
-import { AlfrescoApiServiceMock, AppConfigService, ContentService, setupTestBed, CoreModule, TranslationMock } from '@alfresco/adf-core';
+import { AlfrescoApiServiceMock, AppConfigService, ContentService, setupTestBed,
+    CoreModule, TranslationMock, StorageService } from '@alfresco/adf-core';
 import { Observable } from 'rxjs';
 import { FileNode, FolderNode } from '../../mock';
 import { ContentActionHandler } from '../models/content-action.model';
@@ -39,7 +40,7 @@ describe('FolderActionsService', () => {
         appConfig.config.ecmHost = 'http://localhost:9876/ecm';
 
         const contentService = new ContentService(null, null, null, null);
-        const alfrescoApiService = new AlfrescoApiServiceMock(new AppConfigService(null));
+        const alfrescoApiService = new AlfrescoApiServiceMock(new AppConfigService(null), new StorageService());
         documentListService = new DocumentListService(contentService, alfrescoApiService, null, null);
         service = new FolderActionsService(null, documentListService, contentService,  new TranslationMock());
     });

--- a/lib/content-services/document-list/services/folder-actions.service.spec.ts
+++ b/lib/content-services/document-list/services/folder-actions.service.spec.ts
@@ -17,7 +17,7 @@
 
 import { TestBed } from '@angular/core/testing';
 import { AlfrescoApiServiceMock, AppConfigService, ContentService, setupTestBed,
-    CoreModule, TranslationMock, StorageService } from '@alfresco/adf-core';
+    CoreModule, TranslationMock } from '@alfresco/adf-core';
 import { Observable } from 'rxjs';
 import { FileNode, FolderNode } from '../../mock';
 import { ContentActionHandler } from '../models/content-action.model';
@@ -40,7 +40,7 @@ describe('FolderActionsService', () => {
         appConfig.config.ecmHost = 'http://localhost:9876/ecm';
 
         const contentService = new ContentService(null, null, null, null);
-        const alfrescoApiService = new AlfrescoApiServiceMock(new AppConfigService(null), new StorageService());
+        const alfrescoApiService = new AlfrescoApiServiceMock(new AppConfigService(null), null);
         documentListService = new DocumentListService(contentService, alfrescoApiService, null, null);
         service = new FolderActionsService(null, documentListService, contentService,  new TranslationMock());
     });

--- a/lib/core/app-config/app-config.service.ts
+++ b/lib/core/app-config/app-config.service.ts
@@ -39,7 +39,8 @@ export enum AppConfigValues {
     DISABLECSRF = 'disableCSRF',
     AUTH_WITH_CREDENTIALS = 'auth.withCredentials',
     APPLICATION = 'application',
-    NOTIFY_DURATION = 'notificationDefaultDuration'
+    NOTIFY_DURATION = 'notificationDefaultDuration',
+    STORAGE_PREFIX = 'application.storagePrefix'
 }
 
 export enum Status {

--- a/lib/core/datatable/components/datatable/datatable-cell.component.spec.ts
+++ b/lib/core/datatable/components/datatable/datatable-cell.component.spec.ts
@@ -19,13 +19,12 @@ import { DateCellComponent } from './date-cell.component';
 import { Subject } from 'rxjs';
 import { AlfrescoApiServiceMock, AppConfigService } from '@alfresco/adf-core';
 import { Node } from '@alfresco/js-api';
-import { StorageService } from 'core/services';
 
 describe('DataTableCellComponent', () => {
     let alfrescoApiService: AlfrescoApiServiceMock;
 
     beforeEach(() => {
-        alfrescoApiService = new AlfrescoApiServiceMock(new AppConfigService(null), new StorageService());
+        alfrescoApiService = new AlfrescoApiServiceMock(new AppConfigService(null), null);
     });
 
     it('should use medium format by default', () => {

--- a/lib/core/datatable/components/datatable/datatable-cell.component.spec.ts
+++ b/lib/core/datatable/components/datatable/datatable-cell.component.spec.ts
@@ -19,12 +19,13 @@ import { DateCellComponent } from './date-cell.component';
 import { Subject } from 'rxjs';
 import { AlfrescoApiServiceMock, AppConfigService } from '@alfresco/adf-core';
 import { Node } from '@alfresco/js-api';
+import { StorageService } from 'core/services';
 
 describe('DataTableCellComponent', () => {
     let alfrescoApiService: AlfrescoApiServiceMock;
 
     beforeEach(() => {
-        alfrescoApiService = new AlfrescoApiServiceMock(new AppConfigService(null));
+        alfrescoApiService = new AlfrescoApiServiceMock(new AppConfigService(null), new StorageService());
     });
 
     it('should use medium format by default', () => {

--- a/lib/core/directives/node-favorite.directive.spec.ts
+++ b/lib/core/directives/node-favorite.directive.spec.ts
@@ -22,7 +22,6 @@ import { AlfrescoApiServiceMock } from '../mock/alfresco-api.service.mock';
 import { AppConfigService } from '../app-config/app-config.service';
 import { setupTestBed } from '../testing/setupTestBed';
 import { CoreTestingModule } from '../testing/core.testing.module';
-import { StorageService } from 'core/services';
 
 describe('NodeFavoriteDirective', () => {
 
@@ -34,7 +33,7 @@ describe('NodeFavoriteDirective', () => {
     });
 
     beforeEach(() => {
-        alfrescoApiService = new AlfrescoApiServiceMock(new AppConfigService(null), new StorageService());
+        alfrescoApiService = new AlfrescoApiServiceMock(new AppConfigService(null), null);
         directive = new NodeFavoriteDirective( alfrescoApiService);
     });
 

--- a/lib/core/directives/node-favorite.directive.spec.ts
+++ b/lib/core/directives/node-favorite.directive.spec.ts
@@ -22,6 +22,7 @@ import { AlfrescoApiServiceMock } from '../mock/alfresco-api.service.mock';
 import { AppConfigService } from '../app-config/app-config.service';
 import { setupTestBed } from '../testing/setupTestBed';
 import { CoreTestingModule } from '../testing/core.testing.module';
+import { StorageService } from 'core/services';
 
 describe('NodeFavoriteDirective', () => {
 
@@ -33,7 +34,7 @@ describe('NodeFavoriteDirective', () => {
     });
 
     beforeEach(() => {
-        alfrescoApiService = new AlfrescoApiServiceMock(new AppConfigService(null));
+        alfrescoApiService = new AlfrescoApiServiceMock(new AppConfigService(null), new StorageService());
         directive = new NodeFavoriteDirective( alfrescoApiService);
     });
 

--- a/lib/core/mock/alfresco-api.service.mock.ts
+++ b/lib/core/mock/alfresco-api.service.mock.ts
@@ -18,13 +18,15 @@
 import { Injectable } from '@angular/core';
 import { AppConfigService } from '../app-config/app-config.service';
 import { AlfrescoApiService } from '../services/alfresco-api.service';
+import { StorageService } from '../services/storage.service';
 
 /* tslint:disable:adf-file-name */
 @Injectable()
 export class AlfrescoApiServiceMock extends AlfrescoApiService {
 
-    constructor(protected appConfig: AppConfigService) {
-        super(appConfig);
+    constructor(protected appConfig: AppConfigService,
+                protected storageService: StorageService) {
+        super(appConfig, storageService);
         if (!this.alfrescoApi) {
             this.initAlfrescoApi();
         }

--- a/lib/core/services/alfresco-api.service.ts
+++ b/lib/core/services/alfresco-api.service.ts
@@ -27,6 +27,7 @@ import { AlfrescoApiCompatibility, AlfrescoApiConfig } from '@alfresco/js-api';
 import { AppConfigService, AppConfigValues } from '../app-config/app-config.service';
 import { Subject } from 'rxjs';
 import { OauthConfigModel } from '../models/oauth-config.model';
+import { StorageService } from './storage.service';
 
 /* tslint:disable:adf-file-name */
 
@@ -95,7 +96,8 @@ export class AlfrescoApiService {
         return this.getInstance().core.groupsApi;
     }
 
-    constructor(protected appConfig: AppConfigService) {
+    constructor(protected appConfig: AppConfigService,
+                protected storageService: StorageService) {
     }
 
     async load() {
@@ -135,6 +137,7 @@ export class AlfrescoApiService {
             this.alfrescoApi = new AlfrescoApiCompatibility(config);
         }
 
+        this.storageService.storagePrefix = this.appConfig.get<string>(AppConfigValues.STORAGE_PREFIX, '');
     }
 
     isDifferentConfig(lastConfig: AlfrescoApiConfig, newConfig: AlfrescoApiConfig) {

--- a/lib/core/services/storage.service.spec.ts
+++ b/lib/core/services/storage.service.spec.ts
@@ -29,72 +29,83 @@ describe('StorageService', () => {
     const key = 'test_key';
     const value = 'test_value';
 
-    setupTestBed({
-        imports: [CoreTestingModule],
-        providers: [
-            { provide: AppConfigService, useClass: AppConfigServiceMock }
-        ]
-    });
+    describe('StorageService', () => {
+        setupTestBed({
+            imports: [CoreTestingModule]
+        });
 
-    beforeEach(() => {
-        appConfig = TestBed.get(AppConfigService);
-        appConfig.config = {
-            application: {
-                storagePrefix: 'ADF_APP'
-            }
-        };
-        storage = TestBed.get(StorageService);
-    });
+        beforeEach(() => {
+            appConfig = TestBed.get(AppConfigService);
+            appConfig.config = {
+                application: {
+                    storagePrefix: 'ADF_APP'
+                }
+            };
+            storage = TestBed.get(StorageService);
+        });
 
-    it('should get the prefix for the storage from app config', (done) => {
-        appConfig.load().then(() => {
-            expect(storage.storagePrefix).toBe('ADF_APP_');
-            done();
+        it('should get the prefix for the storage from app config', (done) => {
+            appConfig.load().then(() => {
+                expect(storage.storagePrefix).toBe('ADF_APP_');
+                done();
+            });
+        });
+
+        it('should set a property with the prefix in the local storage', (done) => {
+            storage.clear();
+
+            appConfig.load().then(() => {
+                storage.setItem(key, value);
+                const storageKey = localStorage.key(0);
+                expect(storageKey).toBe('ADF_APP_' + key);
+                expect(localStorage.getItem(storageKey)).toBe(value);
+                done();
+            });
+        });
+
+        it('should be able to get a property from the local storage', (done) => {
+            storage.clear();
+
+            appConfig.load().then(() => {
+                storage.setItem(key, value);
+
+                expect(storage.getItem(key)).toBe(value);
+                done();
+            });
         });
     });
 
-    it('should set an empty prefix when the it is not defined in the app config', (done) => {
-        appConfig.config.application.storagePrefix = '';
-        appConfig.load().then(() => {
-            expect(storage.storagePrefix).toBe('');
-            done();
+    describe('StorageService', () => {
+        setupTestBed({
+            imports: [CoreTestingModule]
         });
-    });
 
-    it('should set a property with the prefix in the local storage', (done) => {
-        storage.clear();
-
-        appConfig.load().then(() => {
-            storage.setItem(key, value);
-            const storageKey = localStorage.key(0);
-            expect(storageKey).toBe('ADF_APP_' + key);
-            expect(localStorage.getItem(storageKey)).toBe(value);
-            done();
+        beforeEach(() => {
+            appConfig = TestBed.get(AppConfigService);
+            appConfig.config = {
+                application: {
+                    storagePrefix: ''
+                }
+            };
+            storage = TestBed.get(StorageService);
         });
-    });
 
-    it('should set a property without a prefix in the local storage', (done) => {
-        storage.clear();
-        appConfig.config.application.storagePrefix = '';
-
-        appConfig.load().then(() => {
-            storage.setItem(key, value);
-
-            const storageKey = localStorage.key(0);
-            expect(storageKey).toBe(key);
-            expect(localStorage.getItem(storageKey)).toBe(value);
-            done();
+        it('should set an empty prefix when the it is not defined in the app config', (done) => {
+            appConfig.load().then(() => {
+                expect(storage.storagePrefix).toBe('');
+                done();
+            });
         });
-    });
 
-    it('should be able to get a property from the local storage', (done) => {
-        storage.clear();
+        it('should set a property without a prefix in the local storage', (done) => {
+            appConfig.load().then(() => {
+                storage.setItem(key, value);
 
-        appConfig.load().then(() => {
-            storage.setItem(key, value);
-
-            expect(storage.getItem(key)).toBe(value);
-            done();
+                const storageKey = localStorage.key(0);
+                expect(storageKey).toBe(key);
+                expect(localStorage.getItem(storageKey)).toBe(value);
+                done();
+            });
         });
     });
 });

--- a/lib/core/services/storage.service.ts
+++ b/lib/core/services/storage.service.ts
@@ -16,7 +16,6 @@
  */
 
 import { Injectable } from '@angular/core';
-import { AppConfigService } from '../app-config/app-config.service';
 
 @Injectable({
     providedIn: 'root'
@@ -25,11 +24,18 @@ export class StorageService {
 
     private memoryStore: { [key: string]: any } = {};
     private useLocalStorage: boolean = false;
-    storagePrefix: string;
+    private _storagePrefix: string = '';
 
-    constructor(private appConfigService: AppConfigService) {
+    get storagePrefix() {
+        return this._storagePrefix;
+    }
+
+    set storagePrefix(prefix: string) {
+        this._storagePrefix = prefix ? prefix + '_' : '';
+    }
+
+    constructor() {
         this.useLocalStorage = this.storageAvailable('localStorage');
-        this.appConfigService.onLoad.subscribe(this.getAppPrefix.bind(this));
     }
 
     /**
@@ -103,19 +109,4 @@ export class StorageService {
             return false;
         }
     }
-
-    /**
-     * Sets the prefix that is used for the local storage of the app
-     * It assigns the string that is defined i the app config,
-     * empty prefix otherwise.
-     */
-    getAppPrefix() {
-        const appConfiguration = this.appConfigService.get<any>('application');
-        if (appConfiguration && appConfiguration.storagePrefix) {
-            this.storagePrefix = appConfiguration.storagePrefix + '_';
-        } else {
-            this.storagePrefix = '';
-        }
-    }
-
 }

--- a/lib/process-services-cloud/src/lib/process/process-list/services/process-list-cloud.service.spec.ts
+++ b/lib/process-services-cloud/src/lib/process/process-list/services/process-list-cloud.service.spec.ts
@@ -17,7 +17,7 @@
 import { async } from '@angular/core/testing';
 import { fakeProcessCloudList } from '../mock/process-list-service.mock';
 import { AlfrescoApiServiceMock, LogService, AppConfigService,
-    CoreModule, setupTestBed, StorageService } from '@alfresco/adf-core';
+    CoreModule, setupTestBed } from '@alfresco/adf-core';
 import { ProcessListCloudService } from './process-list-cloud.service';
 import { ProcessQueryCloudRequestModel } from '../models/process-cloud-query-request.model';
 
@@ -62,7 +62,7 @@ describe('Activiti ProcessList Cloud Service', () => {
     });
 
     beforeEach(async(() => {
-        alfrescoApiMock = new AlfrescoApiServiceMock(new AppConfigService(null), new StorageService());
+        alfrescoApiMock = new AlfrescoApiServiceMock(new AppConfigService(null), null);
         service = new ProcessListCloudService(alfrescoApiMock,
             new AppConfigService(null),
             new LogService(new AppConfigService(null)));

--- a/lib/process-services-cloud/src/lib/process/process-list/services/process-list-cloud.service.spec.ts
+++ b/lib/process-services-cloud/src/lib/process/process-list/services/process-list-cloud.service.spec.ts
@@ -15,9 +15,9 @@
  * limitations under the License.
  */
 import { async } from '@angular/core/testing';
-import { setupTestBed } from '@alfresco/adf-core';
 import { fakeProcessCloudList } from '../mock/process-list-service.mock';
-import { AlfrescoApiServiceMock, LogService, AppConfigService, CoreModule } from '@alfresco/adf-core';
+import { AlfrescoApiServiceMock, LogService, AppConfigService,
+    CoreModule, setupTestBed, StorageService } from '@alfresco/adf-core';
 import { ProcessListCloudService } from './process-list-cloud.service';
 import { ProcessQueryCloudRequestModel } from '../models/process-cloud-query-request.model';
 
@@ -62,7 +62,7 @@ describe('Activiti ProcessList Cloud Service', () => {
     });
 
     beforeEach(async(() => {
-        alfrescoApiMock = new AlfrescoApiServiceMock(new AppConfigService(null));
+        alfrescoApiMock = new AlfrescoApiServiceMock(new AppConfigService(null), new StorageService());
         service = new ProcessListCloudService(alfrescoApiMock,
             new AppConfigService(null),
             new LogService(new AppConfigService(null)));

--- a/lib/process-services-cloud/src/lib/task/services/task-cloud.service.spec.ts
+++ b/lib/process-services-cloud/src/lib/task/services/task-cloud.service.spec.ts
@@ -17,7 +17,7 @@
 
 import { async, TestBed } from '@angular/core/testing';
 import { AlfrescoApiServiceMock, LogService, AppConfigService,
-    CoreModule, setupTestBed, IdentityUserService, StorageService } from '@alfresco/adf-core';
+    CoreModule, setupTestBed, IdentityUserService } from '@alfresco/adf-core';
 import { TaskCloudService } from './task-cloud.service';
 import { taskCompleteCloudMock } from '../task-header/mocks/fake-complete-task.mock';
 import { assignedTaskDetailsCloudMock, createdTaskDetailsCloudMock, emptyOwnerTaskDetailsCloudMock } from '../task-header/mocks/task-details-cloud.mock';
@@ -68,7 +68,7 @@ describe('Task Cloud Service', () => {
     });
 
     beforeEach(async(() => {
-        alfrescoApiMock = new AlfrescoApiServiceMock(new AppConfigService(null), new StorageService());
+        alfrescoApiMock = new AlfrescoApiServiceMock(new AppConfigService(null), null);
         identityUserService = TestBed.get(IdentityUserService);
         spyOn(identityUserService, 'getCurrentUserInfo').and.returnValue(cloudMockUser);
         service = new TaskCloudService(alfrescoApiMock,

--- a/lib/process-services-cloud/src/lib/task/services/task-cloud.service.spec.ts
+++ b/lib/process-services-cloud/src/lib/task/services/task-cloud.service.spec.ts
@@ -16,8 +16,8 @@
  */
 
 import { async, TestBed } from '@angular/core/testing';
-import { setupTestBed, IdentityUserService } from '@alfresco/adf-core';
-import { AlfrescoApiServiceMock, LogService, AppConfigService, CoreModule } from '@alfresco/adf-core';
+import { AlfrescoApiServiceMock, LogService, AppConfigService,
+    CoreModule, setupTestBed, IdentityUserService, StorageService } from '@alfresco/adf-core';
 import { TaskCloudService } from './task-cloud.service';
 import { taskCompleteCloudMock } from '../task-header/mocks/fake-complete-task.mock';
 import { assignedTaskDetailsCloudMock, createdTaskDetailsCloudMock, emptyOwnerTaskDetailsCloudMock } from '../task-header/mocks/task-details-cloud.mock';
@@ -68,7 +68,7 @@ describe('Task Cloud Service', () => {
     });
 
     beforeEach(async(() => {
-        alfrescoApiMock = new AlfrescoApiServiceMock(new AppConfigService(null));
+        alfrescoApiMock = new AlfrescoApiServiceMock(new AppConfigService(null), new StorageService());
         identityUserService = TestBed.get(IdentityUserService);
         spyOn(identityUserService, 'getCurrentUserInfo').and.returnValue(cloudMockUser);
         service = new TaskCloudService(alfrescoApiMock,

--- a/lib/process-services-cloud/src/lib/task/task-list/services/task-list-cloud.service.spec.ts
+++ b/lib/process-services-cloud/src/lib/task/task-list/services/task-list-cloud.service.spec.ts
@@ -16,9 +16,9 @@
  */
 
 import { async } from '@angular/core/testing';
-import { setupTestBed } from '@alfresco/adf-core';
 import { fakeTaskCloudList } from '../mock/fakeTaskResponseMock';
-import { AlfrescoApiServiceMock, LogService, AppConfigService, CoreModule } from '@alfresco/adf-core';
+import { AlfrescoApiServiceMock, LogService, AppConfigService,
+    CoreModule, setupTestBed, StorageService } from '@alfresco/adf-core';
 import { TaskListCloudService } from './task-list-cloud.service';
 import { TaskQueryCloudRequestModel } from '../models/filter-cloud-model';
 
@@ -64,7 +64,7 @@ describe('Activiti TaskList Cloud Service', () => {
     });
 
     beforeEach(async(() => {
-        alfrescoApiMock = new AlfrescoApiServiceMock(new AppConfigService(null));
+        alfrescoApiMock = new AlfrescoApiServiceMock(new AppConfigService(null), new StorageService());
         service = new TaskListCloudService(alfrescoApiMock,
                                            new AppConfigService(null),
                                            new LogService(new AppConfigService(null)));

--- a/lib/process-services-cloud/src/lib/task/task-list/services/task-list-cloud.service.spec.ts
+++ b/lib/process-services-cloud/src/lib/task/task-list/services/task-list-cloud.service.spec.ts
@@ -18,7 +18,7 @@
 import { async } from '@angular/core/testing';
 import { fakeTaskCloudList } from '../mock/fakeTaskResponseMock';
 import { AlfrescoApiServiceMock, LogService, AppConfigService,
-    CoreModule, setupTestBed, StorageService } from '@alfresco/adf-core';
+    CoreModule, setupTestBed } from '@alfresco/adf-core';
 import { TaskListCloudService } from './task-list-cloud.service';
 import { TaskQueryCloudRequestModel } from '../models/filter-cloud-model';
 
@@ -64,7 +64,7 @@ describe('Activiti TaskList Cloud Service', () => {
     });
 
     beforeEach(async(() => {
-        alfrescoApiMock = new AlfrescoApiServiceMock(new AppConfigService(null), new StorageService());
+        alfrescoApiMock = new AlfrescoApiServiceMock(new AppConfigService(null), null);
         service = new TaskListCloudService(alfrescoApiMock,
                                            new AppConfigService(null),
                                            new LogService(new AppConfigService(null)));

--- a/lib/process-services/process-list/services/process-filter.service.spec.ts
+++ b/lib/process-services/process-list/services/process-filter.service.spec.ts
@@ -19,7 +19,8 @@ import { async } from '@angular/core/testing';
 import { mockError, fakeProcessFilters } from '../../mock';
 import { FilterProcessRepresentationModel } from '../models/filter-process.model';
 import { ProcessFilterService } from './process-filter.service';
-import { AlfrescoApiServiceMock, AlfrescoApiService, AppConfigService, setupTestBed, CoreModule } from '@alfresco/adf-core';
+import { AlfrescoApiServiceMock, AlfrescoApiService, AppConfigService,
+    setupTestBed, CoreModule, StorageService } from '@alfresco/adf-core';
 
 declare let jasmine: any;
 
@@ -36,7 +37,7 @@ describe('Process filter', () => {
     });
 
     beforeEach(() => {
-        apiService = new AlfrescoApiServiceMock(new AppConfigService(null));
+        apiService = new AlfrescoApiServiceMock(new AppConfigService(null), new StorageService());
         service = new ProcessFilterService(apiService);
         alfrescoApi = apiService.getInstance();
     });

--- a/lib/process-services/process-list/services/process-filter.service.spec.ts
+++ b/lib/process-services/process-list/services/process-filter.service.spec.ts
@@ -20,7 +20,7 @@ import { mockError, fakeProcessFilters } from '../../mock';
 import { FilterProcessRepresentationModel } from '../models/filter-process.model';
 import { ProcessFilterService } from './process-filter.service';
 import { AlfrescoApiServiceMock, AlfrescoApiService, AppConfigService,
-    setupTestBed, CoreModule, StorageService } from '@alfresco/adf-core';
+    setupTestBed, CoreModule } from '@alfresco/adf-core';
 
 declare let jasmine: any;
 
@@ -37,7 +37,7 @@ describe('Process filter', () => {
     });
 
     beforeEach(() => {
-        apiService = new AlfrescoApiServiceMock(new AppConfigService(null), new StorageService());
+        apiService = new AlfrescoApiServiceMock(new AppConfigService(null), null);
         service = new ProcessFilterService(apiService);
         alfrescoApi = apiService.getInstance();
     });

--- a/lib/process-services/process-list/services/process.service.spec.ts
+++ b/lib/process-services/process-list/services/process.service.spec.ts
@@ -21,7 +21,8 @@ import { mockError, fakeProcessDef, fakeTasksList } from '../../mock';
 import { ProcessFilterParamRepresentationModel } from '../models/filter-process.model';
 import { ProcessInstanceVariable } from '../models/process-instance-variable.model';
 import { ProcessService } from './process.service';
-import { AlfrescoApiService, AlfrescoApiServiceMock, AppConfigService, setupTestBed, CoreModule } from '@alfresco/adf-core';
+import { AlfrescoApiService, AlfrescoApiServiceMock, AppConfigService,
+    setupTestBed, CoreModule, StorageService } from '@alfresco/adf-core';
 
 declare let moment: any;
 
@@ -38,7 +39,7 @@ describe('ProcessService', () => {
     });
 
     beforeEach(() => {
-        apiService = new AlfrescoApiServiceMock(new AppConfigService(null));
+        apiService = new AlfrescoApiServiceMock(new AppConfigService(null), new StorageService());
         service = new ProcessService(apiService);
         alfrescoApi = apiService.getInstance();
     });

--- a/lib/process-services/process-list/services/process.service.spec.ts
+++ b/lib/process-services/process-list/services/process.service.spec.ts
@@ -22,7 +22,7 @@ import { ProcessFilterParamRepresentationModel } from '../models/filter-process.
 import { ProcessInstanceVariable } from '../models/process-instance-variable.model';
 import { ProcessService } from './process.service';
 import { AlfrescoApiService, AlfrescoApiServiceMock, AppConfigService,
-    setupTestBed, CoreModule, StorageService } from '@alfresco/adf-core';
+    setupTestBed, CoreModule } from '@alfresco/adf-core';
 
 declare let moment: any;
 
@@ -39,7 +39,7 @@ describe('ProcessService', () => {
     });
 
     beforeEach(() => {
-        apiService = new AlfrescoApiServiceMock(new AppConfigService(null), new StorageService());
+        apiService = new AlfrescoApiServiceMock(new AppConfigService(null), null);
         service = new ProcessService(apiService);
         alfrescoApi = apiService.getInstance();
     });

--- a/lib/process-services/task-list/services/task-filter.service.spec.ts
+++ b/lib/process-services/task-list/services/task-filter.service.spec.ts
@@ -19,7 +19,8 @@ import { async } from '@angular/core/testing';
 import { fakeAppFilter, fakeAppPromise, fakeFilters } from '../../mock';
 import { FilterRepresentationModel } from '../models/filter.model';
 import { TaskFilterService } from './task-filter.service';
-import { AlfrescoApiServiceMock, LogService, AppConfigService, setupTestBed, CoreModule } from '@alfresco/adf-core';
+import { AlfrescoApiServiceMock, LogService, AppConfigService,
+    setupTestBed, CoreModule, StorageService } from '@alfresco/adf-core';
 
 declare let jasmine: any;
 
@@ -34,7 +35,9 @@ describe('Activiti Task filter Service', () => {
     });
 
     beforeEach(async(() => {
-        service = new TaskFilterService(new AlfrescoApiServiceMock(new AppConfigService(null)), new LogService(new AppConfigService(null)));
+        service = new TaskFilterService(
+            new AlfrescoApiServiceMock(new AppConfigService(null), new StorageService()),
+            new LogService(new AppConfigService(null)));
         jasmine.Ajax.install();
     }));
 

--- a/lib/process-services/task-list/services/task-filter.service.spec.ts
+++ b/lib/process-services/task-list/services/task-filter.service.spec.ts
@@ -20,7 +20,7 @@ import { fakeAppFilter, fakeAppPromise, fakeFilters } from '../../mock';
 import { FilterRepresentationModel } from '../models/filter.model';
 import { TaskFilterService } from './task-filter.service';
 import { AlfrescoApiServiceMock, LogService, AppConfigService,
-    setupTestBed, CoreModule, StorageService } from '@alfresco/adf-core';
+    setupTestBed, CoreModule } from '@alfresco/adf-core';
 
 declare let jasmine: any;
 
@@ -36,7 +36,7 @@ describe('Activiti Task filter Service', () => {
 
     beforeEach(async(() => {
         service = new TaskFilterService(
-            new AlfrescoApiServiceMock(new AppConfigService(null), new StorageService()),
+            new AlfrescoApiServiceMock(new AppConfigService(null), null),
             new LogService(new AppConfigService(null)));
         jasmine.Ajax.install();
     }));

--- a/lib/process-services/task-list/services/tasklist.service.spec.ts
+++ b/lib/process-services/task-list/services/tasklist.service.spec.ts
@@ -35,7 +35,7 @@ import { FilterRepresentationModel, TaskQueryRequestRepresentationModel } from '
 import { TaskDetailsModel } from '../models/task-details.model';
 import { TaskListService } from './tasklist.service';
 import { AlfrescoApiServiceMock, LogService, AppConfigService,
-    UserProcessModel, setupTestBed, CoreModule, StorageService } from '@alfresco/adf-core';
+    UserProcessModel, setupTestBed, CoreModule } from '@alfresco/adf-core';
 
 declare let jasmine: any;
 
@@ -51,7 +51,7 @@ describe('Activiti TaskList Service', () => {
 
     beforeEach(async(() => {
         service = new TaskListService(
-            new AlfrescoApiServiceMock(new AppConfigService(null), new StorageService()),
+            new AlfrescoApiServiceMock(new AppConfigService(null), null),
             new LogService(new AppConfigService(null)));
         jasmine.Ajax.install();
     }));

--- a/lib/process-services/task-list/services/tasklist.service.spec.ts
+++ b/lib/process-services/task-list/services/tasklist.service.spec.ts
@@ -16,7 +16,6 @@
  */
 
 import { async } from '@angular/core/testing';
-import { UserProcessModel, setupTestBed, CoreModule } from '@alfresco/adf-core';
 import { of } from 'rxjs';
 import {
     fakeCompletedTaskList,
@@ -35,7 +34,8 @@ import {
 import { FilterRepresentationModel, TaskQueryRequestRepresentationModel } from '../models/filter.model';
 import { TaskDetailsModel } from '../models/task-details.model';
 import { TaskListService } from './tasklist.service';
-import { AlfrescoApiServiceMock, LogService, AppConfigService } from '@alfresco/adf-core';
+import { AlfrescoApiServiceMock, LogService, AppConfigService,
+    UserProcessModel, setupTestBed, CoreModule, StorageService } from '@alfresco/adf-core';
 
 declare let jasmine: any;
 
@@ -50,7 +50,9 @@ describe('Activiti TaskList Service', () => {
     });
 
     beforeEach(async(() => {
-        service = new TaskListService(new AlfrescoApiServiceMock(new AppConfigService(null)), new LogService(new AppConfigService(null)));
+        service = new TaskListService(
+            new AlfrescoApiServiceMock(new AppConfigService(null), new StorageService()),
+            new LogService(new AppConfigService(null)));
         jasmine.Ajax.install();
     }));
 

--- a/lib/testing/src/lib/process-services-cloud/actions/testing-alfresco-api.service.ts
+++ b/lib/testing/src/lib/process-services-cloud/actions/testing-alfresco-api.service.ts
@@ -16,7 +16,7 @@
  */
 
 import { AlfrescoApiCompatibility, AlfrescoApiConfig } from '@alfresco/js-api';
-import { AlfrescoApiService, AppConfigValues, AppConfigService } from '@alfresco/adf-core';
+import { AlfrescoApiService, AppConfigValues, AppConfigService, StorageService } from '@alfresco/adf-core';
 
 export class TestingAlfrescoApiService extends AlfrescoApiService {
 
@@ -25,7 +25,7 @@ export class TestingAlfrescoApiService extends AlfrescoApiService {
     config = {
     };
 
-    constructor(public appConfig: AppConfigService) {
+    constructor(public appConfig: AppConfigService, protected storageService: StorageService) {
         super(null);
         const oauth = Object.assign({}, this.appConfig.get<any>(AppConfigValues.OAUTHCONFIG, null));
         this.config = new AlfrescoApiConfig({

--- a/lib/testing/src/lib/process-services-cloud/actions/testing-alfresco-api.service.ts
+++ b/lib/testing/src/lib/process-services-cloud/actions/testing-alfresco-api.service.ts
@@ -25,8 +25,9 @@ export class TestingAlfrescoApiService extends AlfrescoApiService {
     config = {
     };
 
-    constructor(public appConfig: AppConfigService, protected storageService: StorageService) {
-        super(null);
+    constructor(public appConfig: AppConfigService,
+                public storageService: StorageService) {
+        super(null, null);
         const oauth = Object.assign({}, this.appConfig.get<any>(AppConfigValues.OAUTHCONFIG, null));
         this.config = new AlfrescoApiConfig({
             provider: this.appConfig.get<string>(AppConfigValues.PROVIDERS),


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-4457
StorageService depends on AppConfigService to work. 

**What is the new behaviour?**
StorageService does not depend on the AppConfigService anymore and the storage 
prefix is set by the app initializer.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-4457