### PR TITLE
[ADF-4460] Fix for empty value upload widget on a form

### DIFF
--- a/demo-shell/src/app/components/cloud/community/community-task-details-cloud.component.html
+++ b/demo-shell/src/app/components/cloud/community/community-task-details-cloud.component.html
@@ -3,7 +3,7 @@
 <div fxLayout="column" fxFill fxLayoutGap="2px">
     <div fxLayout="row" fxFill>
         <div fxLayout="column" fxFlex="80%">
-            <adf-task-form-cloud
+            <adf-cloud-task-form
                 [appName]="''"
                 [taskId]="taskId"
                 (cancelClick)="goBack()"
@@ -11,7 +11,7 @@
                 (taskCompleted)="onTaskCompleted()"
                 (taskUnclaimed)="onUnclaimTask()"
                 (formSaved)="onFormSaved()">
-            </adf-task-form-cloud>
+            </adf-cloud-task-form>
         </div>
         <adf-cloud-task-header fxFlex
             [appName]="''"

--- a/lib/core/form/components/widgets/core/form-field.model.ts
+++ b/lib/core/form/components/widgets/core/form-field.model.ts
@@ -378,7 +378,7 @@ export class FormFieldModel extends FormWidgetModel {
                 if (this.value && this.value.length > 0) {
                     this.form.values[this.id] = this.value.map((elem) => elem.id).join(',');
                 } else {
-                    this.form.values[this.id] = [];
+                    this.form.values[this.id] = null;
                 }
                 break;
             case FormFieldTypes.TYPEAHEAD:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-4460
APS1 backend fails when an empty array is passed as the value of an upload widget.

**What is the new behaviour?**
APS1 and APS2 backends should work when null is passed as the value of an upload widget.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-4460