### PR TITLE
[ADF-4454] Map upload field to UploadCloudWidget in task cloud form

### DIFF
--- a/demo-shell/src/app/components/cloud/community/community-task-details-cloud.component.ts
+++ b/demo-shell/src/app/components/cloud/community/community-task-details-cloud.component.ts
@@ -39,7 +39,6 @@ export class CommunityTaskDetailsCloudDemoComponent {
         this.route.parent.params.subscribe((params) => {
             this.appName = params.appName;
         });
-
     }
 
     isTaskValid(): boolean {

--- a/demo-shell/src/app/components/cloud/community/community-task-details-cloud.component.ts
+++ b/demo-shell/src/app/components/cloud/community/community-task-details-cloud.component.ts
@@ -17,8 +17,7 @@
 
 import { Component } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { UploadCloudWidgetComponent } from '@alfresco/adf-process-services-cloud';
-import { NotificationService, FormRenderingService } from '@alfresco/adf-core';
+import { NotificationService } from '@alfresco/adf-core';
 
 @Component({
     templateUrl: './community-task-details-cloud.component.html',
@@ -32,7 +31,6 @@ export class CommunityTaskDetailsCloudDemoComponent {
     constructor(
         private route: ActivatedRoute,
         private router: Router,
-        private formRenderingService: FormRenderingService,
         private notificationService: NotificationService
         ) {
         this.route.params.subscribe((params) => {
@@ -41,7 +39,6 @@ export class CommunityTaskDetailsCloudDemoComponent {
         this.route.parent.params.subscribe((params) => {
             this.appName = params.appName;
         });
-        this.formRenderingService.setComponentTypeResolver('upload', () => UploadCloudWidgetComponent, true);
 
     }
 

--- a/demo-shell/src/app/components/cloud/task-details-cloud-demo.component.ts
+++ b/demo-shell/src/app/components/cloud/task-details-cloud-demo.component.ts
@@ -17,8 +17,7 @@
 
 import { Component } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { UploadCloudWidgetComponent } from '@alfresco/adf-process-services-cloud';
-import { NotificationService, FormRenderingService } from '@alfresco/adf-core';
+import { NotificationService } from '@alfresco/adf-core';
 
 @Component({
     templateUrl: './task-details-cloud-demo.component.html',
@@ -32,7 +31,6 @@ export class TaskDetailsCloudDemoComponent {
     constructor(
         private route: ActivatedRoute,
         private router: Router,
-        private formRenderingService: FormRenderingService,
         private notificationService: NotificationService
         ) {
         this.route.params.subscribe((params) => {
@@ -41,7 +39,6 @@ export class TaskDetailsCloudDemoComponent {
         this.route.parent.params.subscribe((params) => {
             this.appName = params.appName;
         });
-        this.formRenderingService.setComponentTypeResolver('upload', () => UploadCloudWidgetComponent, true);
 
     }
 

--- a/lib/process-services-cloud/src/lib/task/task-form/components/task-form-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-form/components/task-form-cloud.component.ts
@@ -22,6 +22,8 @@ import {
 import { FormCloud } from '../../../form/models/form-cloud.model';
 import { TaskDetailsCloudModel } from '../../start-task/models/task-details-cloud.model';
 import { TaskCloudService } from '../../services/task-cloud.service';
+import { FormRenderingService } from '@alfresco/adf-core';
+import { UploadCloudWidgetComponent } from '../../../form/components/upload-cloud.widget';
 
 @Component({
     selector: 'adf-cloud-task-form',
@@ -89,7 +91,9 @@ export class TaskFormCloudComponent implements OnChanges {
     taskDetails: TaskDetailsCloudModel;
 
     constructor(
-        private taskCloudService: TaskCloudService) {
+        private taskCloudService: TaskCloudService,
+        private formRenderingService: FormRenderingService) {
+            this.formRenderingService.setComponentTypeResolver('upload', () => UploadCloudWidgetComponent, true);
     }
 
     ngOnChanges(changes: SimpleChanges) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

* Upload widget is mapped to cloud upload in different components that use task cloud form

**What is the new behaviour?**

* Upload widget mapping moved task cloud form

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
