### PR TITLE
[ADF-4478] Fix layout container and empty template

### DIFF
--- a/lib/core/datatable/components/datatable/datatable.component.scss
+++ b/lib/core/datatable/components/datatable/datatable.component.scss
@@ -578,6 +578,7 @@
 
         .adf-datatable-body {
             .adf-datatable-row {
+                height: 100%;
                 background-color: mat-color($background, card);
                 border: none !important;
 

--- a/lib/core/layout/components/layout-container/layout-container.component.scss
+++ b/lib/core/layout/components/layout-container/layout-container.component.scss
@@ -14,7 +14,7 @@
     }
 
     .adf-container-full-width {
-        width: 100%;
+        width: inherit;
     }
 
     .adf-sidenav--hidden {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-4478
Datatable width broken on third party apps and empty layout not taking the whole height when sticky header is enabled 

**What is the new behaviour?**
Datatable width fixed on third party apps and empty layout takes the whole height when sticky header is enabled 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**: