### PR TITLE
[ADF-3126] i18n support for info drawer tabs

### DIFF
--- a/demo-shell/src/app/components/file-view/file-view.component.html
+++ b/demo-shell/src/app/components/file-view/file-view.component.html
@@ -3,11 +3,11 @@
     <ng-template let-node="node" #sidebarRightTemplate>
         <adf-info-drawer [title]="'APP.INFO_DRAWER.TITLE' | translate">
 
-            <adf-info-drawer-tab [label]="'APP.INFO_DRAWER.COMMENTS' | translate">
+            <adf-info-drawer-tab label="APP.INFO_DRAWER.COMMENTS">
                 <adf-comments [nodeId]="nodeId" [readOnly]="!isCommentEnabled"></adf-comments>
             </adf-info-drawer-tab>
 
-            <adf-info-drawer-tab [label]="'APP.INFO_DRAWER.PROPERTIES' | translate">
+            <adf-info-drawer-tab label="APP.INFO_DRAWER.PROPERTIES">
                 <adf-content-metadata-card *ngIf="isPreset" [node]="node"
                                            [multi]="multi"
                                            [preset]="customPreset"
@@ -104,7 +104,7 @@
 
             </adf-info-drawer-tab>
 
-            <adf-info-drawer-tab [label]="'APP.INFO_DRAWER.VERSIONS' | translate">
+            <adf-info-drawer-tab label="APP.INFO_DRAWER.VERSIONS">
                 <mat-card>
                     <mat-card-content>
                         <adf-version-manager [node]="node"
@@ -120,7 +120,7 @@
     <ng-template let-node="node" #sidebarLeftTemplate>
         <adf-info-drawer [title]="'Viewer Options'">
 
-            <adf-info-drawer-tab [label]="'Settings'">
+            <adf-info-drawer-tab label="Settings">
                 <p class="toggle">
                     <mat-slide-toggle
                         id="adf-switch-custoname"

--- a/demo-shell/src/app/components/files/files.component.html
+++ b/demo-shell/src/app/components/files/files.component.html
@@ -447,13 +447,13 @@
             <div info-drawer-content>
 
                 <adf-info-drawer [title]="'Details'" *ngIf="documentList.selection[0]">
-                    <adf-info-drawer-tab [label]="'Properties'">
+                    <adf-info-drawer-tab label="Properties">
                         <adf-content-metadata-card
                             [node]="documentList.selection[0].entry"
                             [displayEmpty]="displayEmptyMetadata">
                         </adf-content-metadata-card>
                     </adf-info-drawer-tab>
-                    <adf-info-drawer-tab [label]="'Versions'">
+                    <adf-info-drawer-tab label="Versions">
                         <ng-container *ngIf="hasOneFileSelected();else choose_document_template">
                             <ng-container *ngIf="userHasPermissionToManageVersions(); else no_permission_to_versions">
                                 <adf-version-manager

--- a/docs/core/components/info-drawer-tab.component.md
+++ b/docs/core/components/info-drawer-tab.component.md
@@ -56,7 +56,7 @@ You can also combine `icon` and `label` properties.
 | Name | Type | Default value | Description |
 | ---- | ---- | ------------- | ----------- |
 | icon | `string` | null | Icon to render for the tab. |
-| label | `string` | "" | The title of the tab. |
+| label | `string` | "" | The title of the tab (string or translation key). |
 
 ## Details
 

--- a/docs/core/components/info-drawer.component.md
+++ b/docs/core/components/info-drawer.component.md
@@ -50,7 +50,7 @@ have any content you like:
 | Name | Type | Default value | Description |
 | ---- | ---- | ------------- | ----------- |
 | selectedIndex | `number` | 0 | The selected index tab. |
-| title | `string \| null` | null | The title of the info drawer. |
+| title | `string \| null` | null | The title of the info drawer (string or translation key). |
 
 ### Events
 

--- a/lib/core/info-drawer/info-drawer.component.html
+++ b/lib/core/info-drawer/info-drawer.component.html
@@ -9,7 +9,7 @@
     <ng-template #tabLayout>
         <mat-tab-group [(selectedIndex)]="selectedIndex" class="adf-info-drawer-tabs" (selectedTabChange)="onTabChange($event)">
             <mat-tab *ngFor="let contentBlock of contentBlocks"
-                [label]="contentBlock.label"
+                [label]="contentBlock.label | translate"
                 class="adf-info-drawer-tab">
 
                 <ng-template mat-tab-label>

--- a/lib/core/info-drawer/info-drawer.component.html
+++ b/lib/core/info-drawer/info-drawer.component.html
@@ -1,5 +1,5 @@
 <adf-info-drawer-layout>
-    <div *ngIf="title" info-drawer-title>{{title}}</div>
+    <div *ngIf="title" info-drawer-title>{{ title | translate }}</div>
     <ng-content *ngIf="!title" info-drawer-title select="[info-drawer-title]"></ng-content>
 
     <ng-content info-drawer-buttons select="[info-drawer-buttons]"></ng-content>
@@ -14,7 +14,7 @@
 
                 <ng-template mat-tab-label>
                     <mat-icon *ngIf="contentBlock.icon">{{ contentBlock.icon }}</mat-icon>
-                    <span *ngIf="contentBlock.label">{{ contentBlock.label }}</span>
+                    <span *ngIf="contentBlock.label">{{ contentBlock.label | translate }}</span>
                 </ng-template>
 
                 <ng-container *ngTemplateOutlet="contentBlock.content"></ng-container>

--- a/lib/core/info-drawer/info-drawer.component.spec.ts
+++ b/lib/core/info-drawer/info-drawer.component.spec.ts
@@ -40,12 +40,12 @@ describe('InfoDrawerComponent', () => {
     });
 
     beforeEach(() => {
+        translateService = TestBed.get(TranslateService);
+        spyOn(translateService, 'get').and.callFake((key) => of(key));
+
         fixture = TestBed.createComponent(InfoDrawerComponent);
         element = fixture.nativeElement;
         component = fixture.componentInstance;
-        translateService = TestBed.get(TranslateService);
-
-        spyOn(translateService, 'get').and.callFake((key) => of(key));
     });
 
     it('should create instance of InfoDrawerComponent', () => {
@@ -106,12 +106,12 @@ describe('Custom InfoDrawer', () => {
     });
 
     beforeEach(() => {
+        translateService = TestBed.get(TranslateService);
+        spyOn(translateService, 'get').and.callFake((key) => of(key));
+
         fixture = TestBed.createComponent(CustomInfoDrawerComponent);
         fixture.detectChanges();
         component = fixture.componentInstance;
-        translateService = TestBed.get(TranslateService);
-
-        spyOn(translateService, 'get').and.callFake((key) => of(key));
     });
 
     it('should render the title', () => {

--- a/lib/core/info-drawer/info-drawer.component.spec.ts
+++ b/lib/core/info-drawer/info-drawer.component.spec.ts
@@ -23,11 +23,14 @@ import { InfoDrawerComponent } from './info-drawer.component';
 import { setupTestBed } from '../testing/setupTestBed';
 import { CoreModule } from '../core.module';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { of } from 'rxjs';
+import { TranslateService } from '@ngx-translate/core';
 
 describe('InfoDrawerComponent', () => {
     let element: HTMLElement;
     let component: InfoDrawerComponent;
     let fixture: ComponentFixture<InfoDrawerComponent>;
+    let translateService: TranslateService;
 
     setupTestBed({
         imports: [
@@ -40,6 +43,9 @@ describe('InfoDrawerComponent', () => {
         fixture = TestBed.createComponent(InfoDrawerComponent);
         element = fixture.nativeElement;
         component = fixture.componentInstance;
+        translateService = TestBed.get(TranslateService);
+
+        spyOn(translateService, 'get').and.callFake((key) => of(key));
     });
 
     it('should create instance of InfoDrawerComponent', () => {
@@ -87,6 +93,7 @@ class CustomInfoDrawerComponent extends InfoDrawerComponent {
 describe('Custom InfoDrawer', () => {
     let fixture: ComponentFixture<CustomInfoDrawerComponent>;
     let component: CustomInfoDrawerComponent;
+    let translateService: TranslateService;
 
     setupTestBed({
         imports: [
@@ -102,6 +109,9 @@ describe('Custom InfoDrawer', () => {
         fixture = TestBed.createComponent(CustomInfoDrawerComponent);
         fixture.detectChanges();
         component = fixture.componentInstance;
+        translateService = TestBed.get(TranslateService);
+
+        spyOn(translateService, 'get').and.callFake((key) => of(key));
     });
 
     it('should render the title', () => {

--- a/lib/core/info-drawer/info-drawer.module.ts
+++ b/lib/core/info-drawer/info-drawer.module.ts
@@ -21,6 +21,7 @@ import { MaterialModule } from '../material.module';
 
 import { InfoDrawerLayoutComponent, InfoDrawerTitleDirective, InfoDrawerButtonsDirective, InfoDrawerContentDirective } from './info-drawer-layout.component';
 import { InfoDrawerComponent, InfoDrawerTabComponent } from './info-drawer.component';
+import { TranslateModule } from '@ngx-translate/core';
 
 export function declarations() {
     return [
@@ -36,7 +37,8 @@ export function declarations() {
 @NgModule({
     imports: [
         CommonModule,
-        MaterialModule
+        MaterialModule,
+        TranslateModule.forChild()
     ],
     declarations: declarations(),
     exports: declarations()

--- a/lib/process-services/task-list/components/task-details.component.html
+++ b/lib/process-services/task-list/components/task-details.component.html
@@ -79,8 +79,8 @@
             </div>
         </div>
         <div class="adf-task-details-core-sidebar">
-            <adf-info-drawer *ngIf="showHeaderContent" title="{{ 'ADF_TASK_LIST.DETAILS.LABELS.INFO_DRAWER_TITLE' | translate }}" id="adf-task-details-core-sidebar-drawer" class="adf-task-details-core-sidebar-drawer">
-                <adf-info-drawer-tab label="{{ 'ADF_TASK_LIST.DETAILS.LABELS.INFO_DRAWER_TAB_DETAILS_TITLE' | translate }}">
+            <adf-info-drawer *ngIf="showHeaderContent" title="ADF_TASK_LIST.DETAILS.LABELS.INFO_DRAWER_TITLE" id="adf-task-details-core-sidebar-drawer" class="adf-task-details-core-sidebar-drawer">
+                <adf-info-drawer-tab label="ADF_TASK_LIST.DETAILS.LABELS.INFO_DRAWER_TAB_DETAILS_TITLE">
                     <div class="adf-assignment-container" *ngIf="showAssignee">
                         <adf-people-search
                             (searchPeople)="searchUser($event)"
@@ -107,7 +107,7 @@
                     </adf-people>
                 </adf-info-drawer-tab>
 
-                <adf-info-drawer-tab label="{{ 'ADF_TASK_LIST.DETAILS.LABELS.INFO_DRAWER_TAB_ACTIVITY_TITLE' | translate }}">
+                <adf-info-drawer-tab label="ADF_TASK_LIST.DETAILS.LABELS.INFO_DRAWER_TAB_ACTIVITY_TITLE">
                     <mat-card *ngIf="showComments">
                         <mat-card-content>
                             <adf-comments #activitiComments


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

Minor enhancement, add support for i18n for Info Drawer component and Tabs

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-3126