### PR TITLE
[ADF-4442] Show whole app config in config editor

### DIFF
--- a/demo-shell/src/app/components/config-editor/config-editor.component.html
+++ b/demo-shell/src/app/components/config-editor/config-editor.component.html
@@ -1,77 +1,8 @@
 <div>
     <mat-nav-list class="adf-list-confgurations">
-        <mat-list-item  (click)="metadataConfClick()">
-            <a matLine id="adf-metadata-conf">Metadata App config editor</a>
-            <button mat-icon-button>
-                <mat-icon>info</mat-icon>
-            </button>
-        </mat-list-item>
 
-        <mat-list-item (click)="searchConfClick()">
-            <a matLine id="adf-search-conf" >Search App config editor</a>
-            <button mat-icon-button>
-                <mat-icon>info</mat-icon>
-            </button>
-        </mat-list-item>
-
-        <mat-list-item (click)="fileConfClick()">
-            <a matLine id="adf-file-conf" >Excluded config file</a>
-            <button mat-icon-button>
-                <mat-icon>info</mat-icon>
-            </button>
-        </mat-list-item>
-
-        <mat-list-item (click)="taskHeaderConfClick()">
-            <a matLine id="adf-task-conf" >Task header</a>
-            <button mat-icon-button>
-                <mat-icon>info</mat-icon>
-            </button>
-        </mat-list-item>
-
-        <mat-list-item (click)="processInstanceHeaderConfClick()">
-            <a matLine id="adf-process-conf" >Process instance Header</a>
-            <button mat-icon-button>
-                <mat-icon>info</mat-icon>
-            </button>
-        </mat-list-item>
-
-        <mat-list-item (click)="startProcessConfClick()">
-            <a matLine id="adf-start-process-conf">Start process</a>
-            <button mat-icon-button>
-                <mat-icon>info</mat-icon>
-            </button>
-        </mat-list-item>
-
-        <mat-list-item (click)="applicationListCloudConfClick()">
-            <a matLine id="adf-apps-cloud-conf">Application List Cloud</a>
-            <button mat-icon-button>
-                <mat-icon>info</mat-icon>
-            </button>
-        </mat-list-item>
-
-        <mat-list-item (click)="taskListCloudConfClick()">
-            <a matLine id="adf-task-list-cloud-conf">Task List Cloud</a>
-            <button mat-icon-button>
-                <mat-icon>info</mat-icon>
-            </button>
-        </mat-list-item>
-
-        <mat-list-item (click)="editProcessFilterConfClick()">
-            <a matLine id="adf-edit-process-filter-conf">Edit process filter</a>
-            <button mat-icon-button>
-                <mat-icon>info</mat-icon>
-            </button>
-        </mat-list-item>
-
-        <mat-list-item (click)="processListCloudConfClick()">
-            <a matLine id="adf-process-list-cloud-conf">Process List Cloud</a>
-            <button mat-icon-button>
-                <mat-icon>info</mat-icon>
-            </button>
-        </mat-list-item>
-
-        <mat-list-item (click)="editTaskFilterConfClick()">
-            <a matLine id="adf-edit-task-filter-conf">Edit task filter</a>
+        <mat-list-item  (click)="appConfigClick()">
+            <a matLine id="adf-app-conf">App Config Editor</a>
             <button mat-icon-button>
                 <mat-icon>info</mat-icon>
             </button>

--- a/demo-shell/src/app/components/config-editor/config-editor.component.ts
+++ b/demo-shell/src/app/components/config-editor/config-editor.component.ts
@@ -32,7 +32,7 @@ export class ConfigEditorComponent {
 
     editor: any;
     code: any;
-    field = 'content-metadata';
+    field: string;
     invalidJson = false;
     isUserPreference = false;
     userPreferenceProperty: string;
@@ -53,7 +53,7 @@ export class ConfigEditorComponent {
     constructor(private appConfig: AppConfigService,
                 private userPreferencesService: UserPreferencesService,
                 private notificationService: NotificationService) {
-        this.code = JSON.stringify(appConfig.config['content-metadata']);
+        this.code = JSON.stringify(appConfig.config);
     }
 
     onSave() {
@@ -61,7 +61,7 @@ export class ConfigEditorComponent {
             if (this.isUserPreference) {
                 this.userPreferencesService.set(this.userPreferenceProperty, JSON.parse(this.editor.getValue()));
             } else {
-                this.appConfig.config[this.field] = JSON.parse(this.editor.getValue());
+                this.appConfig.config = JSON.parse(this.editor.getValue());
             }
         } catch (error) {
             this.invalidJson = true;
@@ -77,10 +77,9 @@ export class ConfigEditorComponent {
         this.code = '';
     }
 
-    fileConfClick() {
+    appConfigClick() {
         this.isUserPreference = false;
-        this.code = JSON.stringify(this.appConfig.config['files']);
-        this.field = 'files';
+        this.code = JSON.stringify(this.appConfig.config);
         this.indentCode();
     }
 
@@ -94,69 +93,6 @@ export class ConfigEditorComponent {
             this.indentCode();
         });
 
-        this.indentCode();
-    }
-
-    searchConfClick() {
-        this.isUserPreference = false;
-        this.code = JSON.stringify(this.appConfig.config['search']);
-        this.field = 'search';
-        this.indentCode();
-    }
-
-    metadataConfClick() {
-        this.isUserPreference = false;
-        this.code = JSON.stringify(this.appConfig.config['content-metadata']);
-        this.field = 'content-metadata';
-        this.indentCode();
-    }
-
-    taskHeaderConfClick() {
-        this.isUserPreference = false;
-        this.code = JSON.stringify(this.appConfig.config['adf-task-header']);
-        this.field = 'adf-task-header';
-        this.indentCode();
-    }
-
-    processInstanceHeaderConfClick() {
-        this.isUserPreference = false;
-        this.code = JSON.stringify(this.appConfig.config['adf-process-instance-header']);
-        this.field = 'adf-process-instance-header';
-        this.indentCode();
-    }
-
-    startProcessConfClick() {
-        this.isUserPreference = false;
-        this.code = JSON.stringify(this.appConfig.config['adf-start-process']);
-        this.field = 'adf-start-process';
-        this.indentCode();
-    }
-
-    taskListCloudConfClick() {
-        this.isUserPreference = false;
-        this.code = JSON.stringify(this.appConfig.config['adf-cloud-task-list']);
-        this.field = 'adf-cloud-task-list';
-        this.indentCode();
-    }
-
-    editProcessFilterConfClick() {
-        this.isUserPreference = false;
-        this.code = JSON.stringify(this.appConfig.config['adf-edit-process-filter']);
-        this.field = 'adf-edit-process-filter';
-        this.indentCode();
-    }
-
-    editTaskFilterConfClick() {
-        this.isUserPreference = false;
-        this.code = JSON.stringify(this.appConfig.config['adf-edit-task-filter']);
-        this.field = 'adf-edit-task-filter';
-        this.indentCode();
-    }
-
-    processListCloudConfClick() {
-        this.isUserPreference = false;
-        this.code = JSON.stringify(this.appConfig.config['adf-cloud-process-list']);
-        this.field = 'adf-cloud-process-list';
         this.indentCode();
     }
 
@@ -178,13 +114,6 @@ export class ConfigEditorComponent {
             this.field = 'adf-supported-page-size';
             this.indentCode();
         });
-    }
-
-    applicationListCloudConfClick() {
-        this.isUserPreference = false;
-        this.code = JSON.stringify(this.appConfig.config['alfresco-deployed-apps']);
-        this.field = 'alfresco-deployed-apps';
-        this.indentCode();
     }
 
     indentCode() {

--- a/e2e/content-services/upload/excluded-file.e2e.ts
+++ b/e2e/content-services/upload/excluded-file.e2e.ts
@@ -17,11 +17,10 @@
 
 import { element, by, browser } from 'protractor';
 
-import { LoginPage } from '@alfresco/adf-testing';
+import { LoginPage, LocalStorageUtil } from '@alfresco/adf-testing';
 import { ContentServicesPage } from '../../pages/adf/contentServicesPage';
 import { UploadDialog } from '../../pages/adf/dialog/uploadDialog';
 import { UploadToggles } from '../../pages/adf/dialog/uploadToggles';
-import { NavigationBarPage } from '../../pages/adf/navigationBarPage';
 
 import { AcsUserModel } from '../../models/ACS/acsUserModel';
 import { FileModel } from '../../models/ACS/fileModel';
@@ -32,7 +31,6 @@ import resources = require('../../util/resources');
 
 import { AlfrescoApiCompatibility as AlfrescoApi } from '@alfresco/js-api';
 import { DropActions } from '../../actions/drop.actions';
-import { ConfigEditorPage } from '../../pages/adf/configEditorPage';
 
 describe('Upload component - Excluded Files', () => {
 
@@ -41,8 +39,6 @@ describe('Upload component - Excluded Files', () => {
     const uploadToggles = new UploadToggles();
     const loginPage = new LoginPage();
     const acsUser = new AcsUserModel();
-    const navigationBarPage = new NavigationBarPage();
-    const configEditorPage = new ConfigEditorPage();
 
     const iniExcludedFile = new FileModel({
         'name': resources.Files.ADF_DOCUMENTS.INI.file_name,
@@ -122,24 +118,20 @@ describe('Upload component - Excluded Files', () => {
         });
     });
 
-    it('[C212862] Should not allow upload file excluded in the files extension of app.config.json', () => {
+    it('[C212862] Should not allow upload file excluded in the files extension of app.config.json', async () => {
 
-        navigationBarPage.clickConfigEditorButton();
-        configEditorPage.clickFileConfiguration();
+        const filesConfig = {
+            'excluded': [
+                '.DS_Store',
+                'desktop.ini',
+                '*.txt'
+            ],
+            'match-options': {
+                'nocase': true
+            }
+        };
 
-        configEditorPage.clickClearButton();
-
-        configEditorPage.enterConfiguration('{' +
-            '"excluded": [' +
-                '".DS_Store",' +
-                '"desktop.ini",' +
-                '"*.txt"' +
-            '],' +
-            '"match-options": {' +
-                '"nocase": true' +
-            '}}');
-
-        configEditorPage.clickSaveButton();
+        await LocalStorageUtil.setConfigField('files', JSON.stringify(filesConfig));
 
         contentServicesPage.goToDocumentList();
 
@@ -148,27 +140,22 @@ describe('Upload component - Excluded Files', () => {
             .checkContentIsNotDisplayed(txtFileModel.name);
     });
 
-    it('[C274688] Should extension type added as excluded and accepted not be uploaded', () => {
+    it('[C274688] Should extension type added as excluded and accepted not be uploaded', async () => {
 
         browser.refresh();
 
-        navigationBarPage.clickConfigEditorButton();
+        const filesConfig = {
+            'excluded': [
+                '.DS_Store',
+                'desktop.ini',
+                '*.png'
+            ],
+            'match-options': {
+                'nocase': true
+            }
+        };
 
-        configEditorPage.clickFileConfiguration();
-
-        configEditorPage.clickClearButton();
-
-        configEditorPage.enterConfiguration('{' +
-            '"excluded": [' +
-                '".DS_Store",' +
-                '"desktop.ini",' +
-                '"*.png"' +
-            '],' +
-            '"match-options": {' +
-                '"nocase": true' +
-            '}}');
-
-        configEditorPage.clickSaveButton();
+        await LocalStorageUtil.setConfigField('files', JSON.stringify(filesConfig));
 
         contentServicesPage.goToDocumentList();
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-4442
The config editor could only target those properties that were prepared for that.

**What is the new behaviour?**
The new config editor shoes the whole app.config.json file and the user preference properties


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-4442