### PR TITLE
[ADF-4462] - Should be possible to restore an old version of your file and the document list updated

### DIFF
--- a/e2e/content-services/version/version-actions.e2e.ts
+++ b/e2e/content-services/version/version-actions.e2e.ts
@@ -144,10 +144,10 @@ describe('Version component actions', () => {
 
         versionManagePage.checkFileVersionExist('1.1');
         versionManagePage.checkFileVersionExist('1.0');
+        versionManagePage.closeVersionDialog();
     });
 
     it('[C280007] Should be possible to restore an old version of your file and the document list updated', async () => {
-        await browser.refresh();
         contentServicesPage.versionManagerContent(fileModelVersionTwo.name);
         versionManagePage.restoreFileVersion('1.0');
         versionManagePage.checkFileVersionExist('2.0');

--- a/e2e/content-services/version/version-actions.e2e.ts
+++ b/e2e/content-services/version/version-actions.e2e.ts
@@ -146,10 +146,14 @@ describe('Version component actions', () => {
         versionManagePage.checkFileVersionExist('1.0');
     });
 
-    it('[C280007] Should be possible restore an old version of your file', () => {
+    it('[C280007] Should be possible restore an old version of your file and the document list updated', async () => {
+        await browser.refresh();
+        contentServicesPage.versionManagerContent(fileModelVersionTwo.name);
         versionManagePage.restoreFileVersion('1.0');
-
         versionManagePage.checkFileVersionExist('2.0');
+        versionManagePage.closeVersionDialog();
+        contentServicesPage.waitForTableBody();
+        contentServicesPage.checkContentIsDisplayed(txtFileModel.name);
     });
 
     it('[C307033] Should be possible to cancel the upload of a new version', async () => {

--- a/e2e/content-services/version/version-actions.e2e.ts
+++ b/e2e/content-services/version/version-actions.e2e.ts
@@ -146,7 +146,7 @@ describe('Version component actions', () => {
         versionManagePage.checkFileVersionExist('1.0');
     });
 
-    it('[C280007] Should be possible restore an old version of your file and the document list updated', async () => {
+    it('[C280007] Should be possible to restore an old version of your file and the document list updated', async () => {
         await browser.refresh();
         contentServicesPage.versionManagerContent(fileModelVersionTwo.name);
         versionManagePage.restoreFileVersion('1.0');


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

After restoring the old version of the file, the document list in Content Services was not updated with the restored file name.

**What is the new behaviour?**

After restoring the old version of the file, the document list in Content Services will be updated with the restored file name.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-4462