### PR TITLE
[ADF-4457] StorageService should be independent of AppConfigService

### DIFF
--- a/lib/content-services/content-metadata/components/content-metadata/content-metadata.component.ts
+++ b/lib/content-services/content-metadata/components/content-metadata/content-metadata.component.ts
@@ -18,7 +18,14 @@
 import { Component, Input, OnChanges, OnDestroy, OnInit, SimpleChanges, ViewEncapsulation } from '@angular/core';
 import { Node } from '@alfresco/js-api';
 import { Observable, Subject, of } from 'rxjs';
-import { CardViewItem, NodesApiService, LogService, CardViewUpdateService, AlfrescoApiService, TranslationService } from '@alfresco/adf-core';
+import {
+    CardViewItem,
+    NodesApiService,
+    LogService,
+    CardViewUpdateService,
+    AlfrescoApiService,
+    TranslationService
+} from '@alfresco/adf-core';
 import { ContentMetadataService } from '../../services/content-metadata.service';
 import { CardViewGroup } from '../../interfaces/content-metadata.interfaces';
 import { switchMap, takeUntil, catchError } from 'rxjs/operators';
@@ -78,7 +85,8 @@ export class ContentMetadataComponent implements OnChanges, OnInit, OnDestroy {
         private logService: LogService,
         private alfrescoApiService: AlfrescoApiService,
         private translationService: TranslationService
-    ) {}
+    ) {
+    }
 
     ngOnInit() {
         this.cardViewUpdateService.itemUpdated$
@@ -112,7 +120,8 @@ export class ContentMetadataComponent implements OnChanges, OnInit, OnDestroy {
 
         try {
             statusCode = JSON.parse(error.message).error.statusCode;
-        } catch {}
+        } catch {
+        }
 
         let message = `METADATA.ERRORS.${statusCode}`;
 
@@ -143,12 +152,12 @@ export class ContentMetadataComponent implements OnChanges, OnInit, OnDestroy {
         return this.nodesApiService.updateNode(this.node.id, nodeBody);
     }
 
-    showGroup(group: CardViewGroup) {
+    showGroup(group: CardViewGroup): boolean {
         const properties = group.properties.filter((property) => {
             return !!property.displayValue;
         });
 
-        return properties.length;
+        return properties.length > 0;
     }
 
     ngOnDestroy() {

--- a/lib/content-services/document-list/services/document-actions.service.spec.ts
+++ b/lib/content-services/document-list/services/document-actions.service.spec.ts
@@ -16,7 +16,7 @@
  */
 
 import { AlfrescoApiServiceMock, AppConfigService, ContentService,
-    setupTestBed, CoreModule, TranslationMock
+    setupTestBed, CoreModule, TranslationMock, StorageService
 } from '@alfresco/adf-core';
 import { FileNode, FolderNode } from '../../mock';
 import { ContentActionHandler } from '../models/content-action.model';
@@ -37,7 +37,7 @@ describe('DocumentActionsService', () => {
 
     beforeEach(() => {
         const contentService = new ContentService(null, null, null, null);
-        const alfrescoApiService = new AlfrescoApiServiceMock(new AppConfigService(null));
+        const alfrescoApiService = new AlfrescoApiServiceMock(new AppConfigService(null), new StorageService());
 
         documentListService = new DocumentListService(contentService, alfrescoApiService, null, null);
         service = new DocumentActionsService(null, null, new TranslationMock(), documentListService, contentService);

--- a/lib/content-services/document-list/services/document-list.service.spec.ts
+++ b/lib/content-services/document-list/services/document-list.service.spec.ts
@@ -16,7 +16,7 @@
  */
 
 import { AlfrescoApiServiceMock, AlfrescoApiService,
-    AppConfigService, ContentService, setupTestBed, CoreModule, LogService, AppConfigServiceMock } from '@alfresco/adf-core';
+    AppConfigService, ContentService, setupTestBed, CoreModule, LogService, AppConfigServiceMock, StorageService } from '@alfresco/adf-core';
 import { DocumentListService } from './document-list.service';
 import { CustomResourcesService } from './custom-resources.service';
 
@@ -70,7 +70,7 @@ describe('DocumentListService', () => {
     beforeEach(() => {
         const logService = new LogService(new AppConfigServiceMock(null));
         const contentService = new ContentService(null, null, null, null);
-        alfrescoApiService = new AlfrescoApiServiceMock(new AppConfigService(null));
+        alfrescoApiService = new AlfrescoApiServiceMock(new AppConfigService(null), new StorageService());
         const customActionService = new CustomResourcesService(alfrescoApiService, logService);
         service = new DocumentListService(contentService, alfrescoApiService, logService, customActionService);
         jasmine.Ajax.install();

--- a/lib/content-services/document-list/services/folder-actions.service.spec.ts
+++ b/lib/content-services/document-list/services/folder-actions.service.spec.ts
@@ -16,7 +16,8 @@
  */
 
 import { TestBed } from '@angular/core/testing';
-import { AlfrescoApiServiceMock, AppConfigService, ContentService, setupTestBed, CoreModule, TranslationMock } from '@alfresco/adf-core';
+import { AlfrescoApiServiceMock, AppConfigService, ContentService, setupTestBed,
+    CoreModule, TranslationMock, StorageService } from '@alfresco/adf-core';
 import { Observable } from 'rxjs';
 import { FileNode, FolderNode } from '../../mock';
 import { ContentActionHandler } from '../models/content-action.model';
@@ -39,7 +40,7 @@ describe('FolderActionsService', () => {
         appConfig.config.ecmHost = 'http://localhost:9876/ecm';
 
         const contentService = new ContentService(null, null, null, null);
-        const alfrescoApiService = new AlfrescoApiServiceMock(new AppConfigService(null));
+        const alfrescoApiService = new AlfrescoApiServiceMock(new AppConfigService(null), new StorageService());
         documentListService = new DocumentListService(contentService, alfrescoApiService, null, null);
         service = new FolderActionsService(null, documentListService, contentService,  new TranslationMock());
     });

--- a/lib/core/app-config/app-config.service.ts
+++ b/lib/core/app-config/app-config.service.ts
@@ -39,6 +39,7 @@ export enum AppConfigValues {
     DISABLECSRF = 'disableCSRF',
     AUTH_WITH_CREDENTIALS = 'auth.withCredentials',
     APPLICATION = 'application',
+    STORAGE_PREFIX = 'application.storagePrefix',
     NOTIFY_DURATION = 'notificationDefaultDuration'
 }
 

--- a/lib/core/app-config/debug-app-config.service.ts
+++ b/lib/core/app-config/debug-app-config.service.ts
@@ -17,26 +17,23 @@
 
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { StorageService } from '../services/storage.service';
 import { AppConfigService, AppConfigValues } from '../app-config/app-config.service';
 
 @Injectable()
 export class DebugAppConfigService extends AppConfigService {
-    constructor(http: HttpClient) {
+    constructor(private storage: StorageService, http: HttpClient) {
         super(http);
     }
 
     /** @override */
     get<T>(key: string, defaultValue?: T): T {
         if (key === AppConfigValues.OAUTHCONFIG) {
-            return <T> (JSON.parse(this.getItem(key)) || super.get<T>(key, defaultValue));
+            return <T> (JSON.parse(this.storage.getItem(key)) || super.get<T>(key, defaultValue));
         } else if (key === AppConfigValues.APPLICATION) {
             return undefined;
         } else {
-            return <T> (<any> this.getItem(key) || super.get<T>(key, defaultValue));
+            return <T> (<any> this.storage.getItem(key) || super.get<T>(key, defaultValue));
         }
-    }
-
-    getItem(key: string): string | null {
-        return localStorage.getItem(key);
     }
 }

--- a/lib/core/datatable/components/datatable/datatable-cell.component.spec.ts
+++ b/lib/core/datatable/components/datatable/datatable-cell.component.spec.ts
@@ -17,14 +17,14 @@
 
 import { DateCellComponent } from './date-cell.component';
 import { Subject } from 'rxjs';
-import { AlfrescoApiServiceMock, AppConfigService } from '@alfresco/adf-core';
+import { AlfrescoApiServiceMock, AppConfigService, StorageService } from '@alfresco/adf-core';
 import { Node } from '@alfresco/js-api';
 
 describe('DataTableCellComponent', () => {
     let alfrescoApiService: AlfrescoApiServiceMock;
 
     beforeEach(() => {
-        alfrescoApiService = new AlfrescoApiServiceMock(new AppConfigService(null));
+        alfrescoApiService = new AlfrescoApiServiceMock(new AppConfigService(null), new StorageService());
     });
 
     it('should use medium format by default', () => {

--- a/lib/core/dialogs/download-zip.dialog.spec.ts
+++ b/lib/core/dialogs/download-zip.dialog.spec.ts
@@ -102,7 +102,7 @@ describe('DownloadZipDialogComponent', () => {
 
     it('should call cancelDownload when CANCEL button is clicked', () => {
         fixture.detectChanges();
-        spyOn(component, 'cancelDownload').and.returnValue('');
+        spyOn(component, 'cancelDownload');
 
         const cancelButton: HTMLButtonElement = <HTMLButtonElement> element.querySelector('#cancel-button');
         cancelButton.click();
@@ -118,7 +118,7 @@ describe('DownloadZipDialogComponent', () => {
 
     it('should close dialog when download is completed', () => {
         component.download('fakeUrl', 'fileName');
-        spyOn(component, 'cancelDownload').and.returnValue('');
+        spyOn(component, 'cancelDownload');
         fixture.detectChanges();
         expect(dialogRef.close).toHaveBeenCalled();
     });
@@ -134,7 +134,7 @@ describe('DownloadZipDialogComponent', () => {
     it('should interrupt download when cancel button is clicked', () => {
         spyOn(component, 'downloadZip');
         spyOn(component, 'download');
-        spyOn(component, 'cancelDownload').and.returnValue('');
+        spyOn(component, 'cancelDownload');
 
         fixture.detectChanges();
 

--- a/lib/core/directives/node-favorite.directive.spec.ts
+++ b/lib/core/directives/node-favorite.directive.spec.ts
@@ -22,6 +22,7 @@ import { AlfrescoApiServiceMock } from '../mock/alfresco-api.service.mock';
 import { AppConfigService } from '../app-config/app-config.service';
 import { setupTestBed } from '../testing/setupTestBed';
 import { CoreTestingModule } from '../testing/core.testing.module';
+import { StorageService } from '../services/storage.service';
 
 describe('NodeFavoriteDirective', () => {
 
@@ -33,7 +34,7 @@ describe('NodeFavoriteDirective', () => {
     });
 
     beforeEach(() => {
-        alfrescoApiService = new AlfrescoApiServiceMock(new AppConfigService(null));
+        alfrescoApiService = new AlfrescoApiServiceMock(new AppConfigService(null), new StorageService());
         directive = new NodeFavoriteDirective( alfrescoApiService);
     });
 

--- a/lib/core/mock/alfresco-api.service.mock.ts
+++ b/lib/core/mock/alfresco-api.service.mock.ts
@@ -18,13 +18,15 @@
 import { Injectable } from '@angular/core';
 import { AppConfigService } from '../app-config/app-config.service';
 import { AlfrescoApiService } from '../services/alfresco-api.service';
+import { StorageService } from '../services/storage.service';
 
 /* tslint:disable:adf-file-name */
 @Injectable()
 export class AlfrescoApiServiceMock extends AlfrescoApiService {
 
-    constructor(protected appConfig: AppConfigService) {
-        super(appConfig);
+    constructor(protected appConfig: AppConfigService,
+                protected storageService: StorageService) {
+        super(appConfig, storageService);
         if (!this.alfrescoApi) {
             this.initAlfrescoApi();
         }

--- a/lib/core/mock/alfresco-api.service.mock.ts
+++ b/lib/core/mock/alfresco-api.service.mock.ts
@@ -31,4 +31,11 @@ export class AlfrescoApiServiceMock extends AlfrescoApiService {
             this.initAlfrescoApi();
         }
     }
+
+    initialize(): Promise<any> {
+        return new Promise((resolve) => {
+            this.alfrescoApiInitializedSubject.next();
+            resolve();
+        });
+    }
 }

--- a/lib/core/services/alfresco-api.service.ts
+++ b/lib/core/services/alfresco-api.service.ts
@@ -27,6 +27,7 @@ import { AlfrescoApiCompatibility, AlfrescoApiConfig } from '@alfresco/js-api';
 import { AppConfigService, AppConfigValues } from '../app-config/app-config.service';
 import { Subject } from 'rxjs';
 import { OauthConfigModel } from '../models/oauth-config.model';
+import { StorageService } from './storage.service';
 
 /* tslint:disable:adf-file-name */
 
@@ -95,7 +96,9 @@ export class AlfrescoApiService {
         return this.getInstance().core.groupsApi;
     }
 
-    constructor(protected appConfig: AppConfigService) {
+    constructor(
+        protected appConfig: AppConfigService,
+        protected storageService: StorageService) {
     }
 
     async load() {
@@ -115,6 +118,8 @@ export class AlfrescoApiService {
             oauth.redirectUriLogout = window.location.origin + (oauth.redirectUriLogout || '/');
         }
 
+        this.storageService.storagePrefix = this.appConfig.get<string>(AppConfigValues.STORAGE_PREFIX, '');
+
         const config = new AlfrescoApiConfig({
             provider: this.appConfig.get<string>(AppConfigValues.PROVIDERS),
             hostEcm: this.appConfig.get<string>(AppConfigValues.ECMHOST),
@@ -124,6 +129,7 @@ export class AlfrescoApiService {
             contextRoot: this.appConfig.get<string>(AppConfigValues.CONTEXTROOTECM),
             disableCsrf: this.appConfig.get<boolean>(AppConfigValues.DISABLECSRF),
             withCredentials: this.appConfig.get<boolean>(AppConfigValues.AUTH_WITH_CREDENTIALS, false),
+            domainPrefix: this.storageService.storagePrefix,
             oauth2: oauth
         });
 

--- a/lib/core/services/alfresco-api.service.ts
+++ b/lib/core/services/alfresco-api.service.ts
@@ -25,7 +25,7 @@ import {
 } from '@alfresco/js-api';
 import { AlfrescoApiCompatibility, AlfrescoApiConfig } from '@alfresco/js-api';
 import { AppConfigService, AppConfigValues } from '../app-config/app-config.service';
-import { Subject } from 'rxjs';
+import { Subject, Observable } from 'rxjs';
 import { OauthConfigModel } from '../models/oauth-config.model';
 import { StorageService } from './storage.service';
 
@@ -39,6 +39,9 @@ export class AlfrescoApiService {
      * Publish/subscribe to events related to node updates.
      */
     nodeUpdated = new Subject<Node>();
+
+    protected alfrescoApiInitializedSubject: Subject<any>;
+    alfrescoApiInitialized: Observable<any>;
 
     protected alfrescoApi: AlfrescoApiCompatibility;
 
@@ -99,11 +102,15 @@ export class AlfrescoApiService {
     constructor(
         protected appConfig: AppConfigService,
         protected storageService: StorageService) {
+        this.alfrescoApiInitializedSubject = new Subject();
+        this.alfrescoApiInitialized = this.alfrescoApiInitializedSubject.asObservable();
     }
 
     async load() {
         await this.appConfig.load().then(() => {
+            this.storageService.prefix = this.appConfig.get<string>(AppConfigValues.STORAGE_PREFIX, '');
             this.initAlfrescoApi();
+            this.alfrescoApiInitializedSubject.next();
         });
     }
 
@@ -118,8 +125,6 @@ export class AlfrescoApiService {
             oauth.redirectUriLogout = window.location.origin + (oauth.redirectUriLogout || '/');
         }
 
-        this.storageService.storagePrefix = this.appConfig.get<string>(AppConfigValues.STORAGE_PREFIX, '');
-
         const config = new AlfrescoApiConfig({
             provider: this.appConfig.get<string>(AppConfigValues.PROVIDERS),
             hostEcm: this.appConfig.get<string>(AppConfigValues.ECMHOST),
@@ -129,7 +134,7 @@ export class AlfrescoApiService {
             contextRoot: this.appConfig.get<string>(AppConfigValues.CONTEXTROOTECM),
             disableCsrf: this.appConfig.get<boolean>(AppConfigValues.DISABLECSRF),
             withCredentials: this.appConfig.get<boolean>(AppConfigValues.AUTH_WITH_CREDENTIALS, false),
-            domainPrefix: this.storageService.storagePrefix,
+            domainPrefix: this.storageService.prefix,
             oauth2: oauth
         });
 

--- a/lib/core/services/alfresco-api.service.ts
+++ b/lib/core/services/alfresco-api.service.ts
@@ -134,7 +134,6 @@ export class AlfrescoApiService {
             contextRoot: this.appConfig.get<string>(AppConfigValues.CONTEXTROOTECM),
             disableCsrf: this.appConfig.get<boolean>(AppConfigValues.DISABLECSRF),
             withCredentials: this.appConfig.get<boolean>(AppConfigValues.AUTH_WITH_CREDENTIALS, false),
-            domainPrefix: this.storageService.prefix,
             oauth2: oauth
         });
 

--- a/lib/core/services/auth-guard-sso-role.service.spec.ts
+++ b/lib/core/services/auth-guard-sso-role.service.spec.ts
@@ -40,7 +40,7 @@ describe('Auth Guard SSO role service', () => {
     });
 
     it('Should canActivate be true if the Role is present int the JWT token', async(() => {
-        spyOn(localStorage, 'getItem').and.returnValue('my-access_token');
+        spyOn(jwtHelperService, 'getAccessToken').and.returnValue('my-access_token');
         spyOn(jwtHelperService, 'decodeToken').and.returnValue({ 'realm_access': { roles: ['role1'] } });
 
         const router: ActivatedRouteSnapshot = new ActivatedRouteSnapshot();
@@ -50,7 +50,7 @@ describe('Auth Guard SSO role service', () => {
     }));
 
     it('Should canActivate be false if the Role is not present int the JWT token', async(() => {
-        spyOn(localStorage, 'getItem').and.returnValue('my-access_token');
+        spyOn(jwtHelperService, 'getAccessToken').and.returnValue('my-access_token');
         spyOn(jwtHelperService, 'decodeToken').and.returnValue({ 'realm_access': { roles: ['role3'] } });
 
         const router: ActivatedRouteSnapshot = new ActivatedRouteSnapshot();
@@ -60,7 +60,7 @@ describe('Auth Guard SSO role service', () => {
     }));
 
     it('Should not redirect if canActivate is', async(() => {
-        spyOn(localStorage, 'getItem').and.returnValue('my-access_token');
+        spyOn(jwtHelperService, 'getAccessToken').and.returnValue('my-access_token');
         spyOn(jwtHelperService, 'decodeToken').and.returnValue({ 'realm_access': { roles: ['role1'] } });
         spyOn(routerService, 'navigate').and.stub();
 
@@ -72,7 +72,7 @@ describe('Auth Guard SSO role service', () => {
     }));
 
     it('Should canActivate return false if the data Role to check is empty', async(() => {
-        spyOn(localStorage, 'getItem').and.returnValue('my-access_token');
+        spyOn(jwtHelperService, 'getAccessToken').and.returnValue('my-access_token');
         spyOn(jwtHelperService, 'decodeToken').and.returnValue({ 'realm_access': { roles: ['role1', 'role3'] } });
 
         const router: ActivatedRouteSnapshot = new ActivatedRouteSnapshot();
@@ -81,7 +81,7 @@ describe('Auth Guard SSO role service', () => {
     }));
 
     it('Should canActivate return false if the realm_access is not present', async(() => {
-        spyOn(localStorage, 'getItem').and.returnValue('my-access_token');
+        spyOn(jwtHelperService, 'getAccessToken').and.returnValue('my-access_token');
         spyOn(jwtHelperService, 'decodeToken').and.returnValue({});
 
         const router: ActivatedRouteSnapshot = new ActivatedRouteSnapshot();
@@ -90,7 +90,7 @@ describe('Auth Guard SSO role service', () => {
     }));
 
     it('Should redirect to the redirectURL if canActivate is false and redirectUrl is in data', async(() => {
-        spyOn(localStorage, 'getItem').and.returnValue('my-access_token');
+        spyOn(jwtHelperService, 'getAccessToken').and.returnValue('my-access_token');
         spyOn(jwtHelperService, 'decodeToken').and.returnValue({});
         spyOn(routerService, 'navigate').and.stub();
 
@@ -102,7 +102,7 @@ describe('Auth Guard SSO role service', () => {
     }));
 
     it('Should not redirect if canActivate is false and redirectUrl is not in  data', async(() => {
-        spyOn(localStorage, 'getItem').and.returnValue('my-access_token');
+        spyOn(jwtHelperService, 'getAccessToken').and.returnValue('my-access_token');
         spyOn(jwtHelperService, 'decodeToken').and.returnValue({});
         spyOn(routerService, 'navigate').and.stub();
 
@@ -137,7 +137,7 @@ describe('Auth Guard SSO role service', () => {
 
     it('Should canActivate be true if both Real Role and Client Role are present int the JWT token', () => {
         const route: ActivatedRouteSnapshot = new ActivatedRouteSnapshot();
-        spyOn(localStorage, 'getItem').and.returnValue('my-access_token');
+        spyOn(jwtHelperService, 'getAccessToken').and.returnValue('my-access_token');
 
         spyOn(jwtHelperService, 'decodeToken').and.returnValue({
             'realm_access': { roles: ['role1'] },
@@ -152,7 +152,7 @@ describe('Auth Guard SSO role service', () => {
 
     it('Should canActivate be false if the Client Role is not present int the JWT token with the correct role', () => {
         const route: ActivatedRouteSnapshot = new ActivatedRouteSnapshot();
-        spyOn(localStorage, 'getItem').and.returnValue('my-access_token');
+        spyOn(jwtHelperService, 'getAccessToken').and.returnValue('my-access_token');
 
         spyOn(jwtHelperService, 'decodeToken').and.returnValue({
             'realm_access': { roles: ['role1'] },
@@ -168,7 +168,7 @@ describe('Auth Guard SSO role service', () => {
     describe('ClientRole ', () => {
 
         it('Should be true if the resource_access contains the single role', () => {
-            spyOn(localStorage, 'getItem').and.returnValue('my-access_token');
+            spyOn(jwtHelperService, 'getAccessToken').and.returnValue('my-access_token');
 
             spyOn(jwtHelperService, 'decodeToken').and.returnValue(
                 {
@@ -180,7 +180,7 @@ describe('Auth Guard SSO role service', () => {
         });
 
         it('Should be true if the resource_access contains at least one of the roles', () => {
-            spyOn(localStorage, 'getItem').and.returnValue('my-access_token');
+            spyOn(jwtHelperService, 'getAccessToken').and.returnValue('my-access_token');
 
             spyOn(jwtHelperService, 'decodeToken').and.returnValue(
                 {
@@ -192,7 +192,7 @@ describe('Auth Guard SSO role service', () => {
         });
 
         it('Should be false if the resource_access does not contain the role', () => {
-            spyOn(localStorage, 'getItem').and.returnValue('my-access_token');
+            spyOn(jwtHelperService, 'getAccessToken').and.returnValue('my-access_token');
             spyOn(jwtHelperService, 'decodeToken').and.returnValue(
                 {
                     'resource_access': { fakeapp: { roles: ['role3'] } }
@@ -202,7 +202,7 @@ describe('Auth Guard SSO role service', () => {
         });
 
         it('Should be false if the resource_access does not contain the client role related to the app', () => {
-            spyOn(localStorage, 'getItem').and.returnValue('my-access_token');
+            spyOn(jwtHelperService, 'getAccessToken').and.returnValue('my-access_token');
             spyOn(jwtHelperService, 'decodeToken').and.returnValue(
                 {
                     'resource_access': { anotherfakeapp: { roles: ['role1'] } }

--- a/lib/core/services/auth-guard-sso-role.service.ts
+++ b/lib/core/services/auth-guard-sso-role.service.ts
@@ -18,7 +18,6 @@
 import { Injectable } from '@angular/core';
 import { JwtHelperService } from './jwt-helper.service';
 import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot } from '@angular/router';
-import { StorageService } from './storage.service';
 
 @Injectable({
     providedIn: 'root'
@@ -52,28 +51,22 @@ export class AuthGuardSsoRoleService implements CanActivate {
         return hasRole;
     }
 
-    constructor(private storageService: StorageService, private jwtHelperService: JwtHelperService, private router: Router) {
+    constructor(private jwtHelperService: JwtHelperService, private router: Router) {
     }
 
     getRealmRoles(): string[] {
         const access = this.jwtHelperService.getValueFromLocalAccessToken<any>('realm_access');
-        const roles = access ? access['roles'] : [];
-        return roles;
+        return access ? access['roles'] : [];
     }
 
     getClientRoles(client: string): string[] {
         const clientRole = this.jwtHelperService.getValueFromLocalAccessToken<any>('resource_access')[client];
-        const roles = clientRole ? clientRole['roles'] : [];
-        return roles;
-    }
-
-    getAccessToken(): string {
-        return this.storageService.getItem(JwtHelperService.USER_ACCESS_TOKEN);
+        return clientRole ? clientRole['roles'] : [];
     }
 
     hasRealmRole(role: string): boolean {
         let hasRole = false;
-        if (this.getAccessToken()) {
+        if (this.jwtHelperService.getAccessToken()) {
             const realmRoles = this.getRealmRoles();
             hasRole = realmRoles.some((currentRole) => {
                 return currentRole === role;
@@ -96,7 +89,7 @@ export class AuthGuardSsoRoleService implements CanActivate {
 
     hasClientRole(clientRole, role: string): boolean {
         let hasRole = false;
-        if (this.getAccessToken()) {
+        if (this.jwtHelperService.getAccessToken()) {
             const clientRoles = this.getClientRoles(clientRole);
             hasRole = clientRoles.some((currentRole) => {
                 return currentRole === role;

--- a/lib/core/services/automation.service.ts
+++ b/lib/core/services/automation.service.ts
@@ -46,10 +46,6 @@ export class CoreAutomationService {
             this.storageService.setItem(key, data);
         };
 
-        adfProxy.removeStorageItem = (key: string) => {
-            this.storageService.removeItem(key);
-        };
-
         adfProxy.setUserPreference = (key: string, data: any) => {
             this.userPreferencesService.set(key, data);
         };

--- a/lib/core/services/automation.service.ts
+++ b/lib/core/services/automation.service.ts
@@ -46,6 +46,10 @@ export class CoreAutomationService {
             this.storageService.setItem(key, data);
         };
 
+        adfProxy.removeStorageItem = (key: string) => {
+            this.storageService.removeItem(key);
+        };
+
         adfProxy.setUserPreference = (key: string, data: any) => {
             this.userPreferencesService.set(key, data);
         };

--- a/lib/core/services/jwt-helper.service.ts
+++ b/lib/core/services/jwt-helper.service.ts
@@ -79,8 +79,15 @@ export class JwtHelperService {
      * @returns Value from the token
      */
     getValueFromLocalAccessToken<T>(key: string): T {
-        const accessToken = localStorage.getItem(JwtHelperService.USER_ACCESS_TOKEN);
-        return this.getValueFromToken(accessToken, key);
+        return this.getValueFromToken(this.getAccessToken(), key);
+    }
+
+    /**
+     * Gets access token
+     * @returns access token
+     */
+    getAccessToken(): string {
+        return localStorage.getItem(JwtHelperService.USER_ACCESS_TOKEN);
     }
 
     /**

--- a/lib/core/services/storage.service.spec.ts
+++ b/lib/core/services/storage.service.spec.ts
@@ -46,7 +46,7 @@ describe('StorageService', () => {
 
         it('should get the prefix for the storage from app config', (done) => {
             appConfig.load().then(() => {
-                expect(storage.storagePrefix).toBe('ADF_APP_');
+                expect(storage.prefix).toBe('ADF_APP_');
                 done();
             });
         });
@@ -92,7 +92,7 @@ describe('StorageService', () => {
 
         it('should set an empty prefix when the it is not defined in the app config', (done) => {
             appConfig.load().then(() => {
-                expect(storage.storagePrefix).toBe('');
+                expect(storage.prefix).toBe('');
                 done();
             });
         });

--- a/lib/core/services/storage.service.spec.ts
+++ b/lib/core/services/storage.service.spec.ts
@@ -29,69 +29,83 @@ describe('StorageService', () => {
     const key = 'test_key';
     const value = 'test_value';
 
-    setupTestBed({
-        imports: [CoreTestingModule],
-        providers: [
-            { provide: AppConfigService, useClass: AppConfigServiceMock }
-        ]
-    });
+    describe('StorageService', () => {
+        setupTestBed({
+            imports: [CoreTestingModule]
+        });
 
-    beforeEach(() => {
-        appConfig = TestBed.get(AppConfigService);
-        appConfig.config = {
-            application: {
-                storagePrefix: 'ADF_APP'
-            }
-        };
-        storage = TestBed.get(StorageService);
-    });
+        beforeEach(() => {
+            appConfig = TestBed.get(AppConfigService);
+            appConfig.config = {
+                application: {
+                    storagePrefix: 'ADF_APP'
+                }
+            };
+            storage = TestBed.get(StorageService);
+        });
 
-    it('should get the prefix for the storage from app config', (done) => {
-        appConfig.load().then(() => {
-            expect(storage.storagePrefix).toBe('ADF_APP_');
-            done();
+        it('should get the prefix for the storage from app config', (done) => {
+            appConfig.load().then(() => {
+                expect(storage.storagePrefix).toBe('ADF_APP_');
+                done();
+            });
+        });
+
+        it('should set a property with the prefix in the local storage', (done) => {
+            storage.clear();
+
+            appConfig.load().then(() => {
+                storage.setItem(key, value);
+                const storageKey = localStorage.key(0);
+                expect(storageKey).toBe('ADF_APP_' + key);
+                expect(localStorage.getItem(storageKey)).toBe(value);
+                done();
+            });
+        });
+
+        it('should be able to get a property from the local storage', (done) => {
+            storage.clear();
+
+            appConfig.load().then(() => {
+                storage.setItem(key, value);
+
+                expect(storage.getItem(key)).toBe(value);
+                done();
+            });
         });
     });
 
-    it('should set an empty prefix when the it is not defined in the app config', (done) => {
-        appConfig.config.application.storagePrefix = '';
-        appConfig.load().then(() => {
-            expect(storage.storagePrefix).toBe('');
-            done();
+    describe('StorageService', () => {
+        setupTestBed({
+            imports: [CoreTestingModule]
         });
-    });
 
-    it('should set a property with the prefix in the local storage', (done) => {
-        storage.clear();
-
-        appConfig.load().then(() => {
-            storage.setItem(key, value);
-            expect(localStorage.hasOwnProperty('ADF_APP_' + key)).not.toBe(null);
-            expect(localStorage.getItem('ADF_APP_' + key)).toBe(value);
-            done();
+        beforeEach(() => {
+            appConfig = TestBed.get(AppConfigService);
+            appConfig.config = {
+                application: {
+                    storagePrefix: ''
+                }
+            };
+            storage = TestBed.get(StorageService);
         });
-    });
 
-    it('should set a property without a prefix in the local storage', (done) => {
-        storage.clear();
-        appConfig.config.application.storagePrefix = '';
-
-        appConfig.load().then(() => {
-            storage.setItem(key, value);
-            expect(localStorage.hasOwnProperty(key)).not.toBe(null);
-            expect(localStorage.getItem(key)).toBe(value);
-            done();
+        it('should set an empty prefix when the it is not defined in the app config', (done) => {
+            appConfig.load().then(() => {
+                expect(storage.storagePrefix).toBe('');
+                done();
+            });
         });
-    });
 
-    it('should be able to get a property from the local storage', (done) => {
-        storage.clear();
+        it('should set a property without a prefix in the local storage', (done) => {
+            appConfig.load().then(() => {
+                storage.setItem(key, value);
 
-        appConfig.load().then(() => {
-            storage.setItem(key, value);
-
-            expect(storage.getItem(key)).toBe(value);
-            done();
+                const storageKey = localStorage.key(0);
+                expect(storageKey).toBe(key);
+                expect(localStorage.getItem(storageKey)).toBe(value);
+                done();
+            });
         });
     });
 });

--- a/lib/core/services/storage.service.spec.ts
+++ b/lib/core/services/storage.service.spec.ts
@@ -101,9 +101,7 @@ describe('StorageService', () => {
             appConfig.load().then(() => {
                 storage.setItem(key, value);
 
-                const storageKey = localStorage.key(0);
-                expect(storageKey).toBe(key);
-                expect(localStorage.getItem(storageKey)).toBe(value);
+                expect(localStorage.getItem(key)).toBe(value);
                 done();
             });
         });

--- a/lib/core/services/storage.service.ts
+++ b/lib/core/services/storage.service.ts
@@ -16,7 +16,6 @@
  */
 
 import { Injectable } from '@angular/core';
-import { AppConfigService } from '../app-config/app-config.service';
 
 @Injectable({
     providedIn: 'root'
@@ -25,11 +24,18 @@ export class StorageService {
 
     private memoryStore: { [key: string]: any } = {};
     private useLocalStorage: boolean = false;
-    storagePrefix: string;
+    private _storagePrefix: string = '';
 
-    constructor(private appConfigService: AppConfigService) {
+    get storagePrefix() {
+        return this._storagePrefix;
+    }
+
+    set storagePrefix(prefix: string) {
+        this._storagePrefix = prefix ? prefix + '_' : '';
+    }
+
+    constructor() {
         this.useLocalStorage = this.storageAvailable('localStorage');
-        this.appConfigService.onLoad.subscribe(this.getAppPrefix.bind(this));
     }
 
     /**
@@ -103,19 +109,4 @@ export class StorageService {
             return false;
         }
     }
-
-    /**
-     * Sets the prefix that is used for the local storage of the app
-     * It assigns the string that is defined i the app config,
-     * empty prefix otherwise.
-     */
-    getAppPrefix() {
-        const appConfiguration = this.appConfigService.get<any>('application');
-        if (appConfiguration && appConfiguration.storagePrefix) {
-            this.storagePrefix = appConfiguration.storagePrefix + '_';
-        } else {
-            this.storagePrefix = '';
-        }
-    }
-
 }

--- a/lib/core/services/storage.service.ts
+++ b/lib/core/services/storage.service.ts
@@ -24,14 +24,14 @@ export class StorageService {
 
     private memoryStore: { [key: string]: any } = {};
     private useLocalStorage: boolean = false;
-    private _storagePrefix: string = '';
+    private _prefix: string = '';
 
-    get storagePrefix() {
-        return this._storagePrefix;
+    get prefix() {
+        return this._prefix;
     }
 
-    set storagePrefix(prefix: string) {
-        this._storagePrefix = prefix ? prefix + '_' : '';
+    set prefix(prefix: string) {
+        this._prefix = prefix ? prefix + '_' : '';
     }
 
     constructor() {
@@ -45,9 +45,9 @@ export class StorageService {
      */
     getItem(key: string): string | null {
         if (this.useLocalStorage) {
-            return localStorage.getItem(this.storagePrefix + key);
+            return localStorage.getItem(this.prefix + key);
         } else {
-            return this.memoryStore.hasOwnProperty(this.storagePrefix + key) ? this.memoryStore[this.storagePrefix + key] : null;
+            return this.memoryStore.hasOwnProperty(this.prefix + key) ? this.memoryStore[this.prefix + key] : null;
         }
     }
 
@@ -58,9 +58,9 @@ export class StorageService {
      */
     setItem(key: string, data: string) {
         if (this.useLocalStorage) {
-            localStorage.setItem(this.storagePrefix + key, data);
+            localStorage.setItem(this.prefix + key, data);
         } else {
-            this.memoryStore[this.storagePrefix + key] = data.toString();
+            this.memoryStore[this.prefix + key] = data.toString();
         }
     }
 
@@ -79,9 +79,9 @@ export class StorageService {
      */
     removeItem(key: string) {
         if (this.useLocalStorage) {
-            localStorage.removeItem(this.storagePrefix + key);
+            localStorage.removeItem(this.prefix + key);
         } else {
-            delete this.memoryStore[this.storagePrefix + key];
+            delete this.memoryStore[this.prefix + key];
         }
     }
 
@@ -92,7 +92,7 @@ export class StorageService {
      */
     hasItem(key: string): boolean {
         if (this.useLocalStorage) {
-            return localStorage.getItem(this.storagePrefix + key) ? true : false;
+            return localStorage.getItem(this.prefix + key) ? true : false;
         } else {
             return this.memoryStore.hasOwnProperty(key);
         }

--- a/lib/core/services/user-preferences.service.spec.ts
+++ b/lib/core/services/user-preferences.service.spec.ts
@@ -145,6 +145,13 @@ describe('UserPreferencesService', () => {
             expect(preferences.getDefaultLocale()).toBe('en');
         });
 
+        it('should return as locale the store locate', () => {
+            preferences.locale = 'fake-store-locate';
+            appConfig.config.locale = 'fake-locate-config';
+            spyOn(translate, 'getBrowserCultureLang').and.returnValue('fake-locate-browser');
+            expect(preferences.locale).toBe('fake-store-locate');
+        });
+
         it('should not store in the storage the locale if the app.config.json does not have a value', () => {
             preferences.locale = 'fake-store-locate';
             spyOn(translate, 'getBrowserCultureLang').and.returnValue('fake-locate-browser');
@@ -167,34 +174,11 @@ describe('UserPreferencesService', () => {
                 done();
             });
         });
-
-       it('should not store in the storage the locale if the app.config.json does not have a value', () => {
-        preferences.locale = 'fake-store-locate';
-        spyOn(translate, 'getBrowserCultureLang').and.returnValue('fake-locate-browser');
-        expect(preferences.locale).toBe('fake-store-locate');
-        expect(storage.getItem(UserPreferenceValues.Locale)).toBe(null);
     });
 
-    it('should stream the page size value when is set', (done) => {
-        preferences.paginationSize = 5;
-        changeDisposable = preferences.onChange.subscribe((userPreferenceStatus) => {
-            expect(userPreferenceStatus[UserPreferenceValues.PaginationSize]).toBe(5);
-            done();
-        });
-    });
+    describe('with language config', () => {
 
-    it('should stream the user preference status when changed', (done) => {
-        preferences.set('propertyA', 'valueA');
-        changeDisposable = preferences.onChange.subscribe((userPreferenceStatus) => {
-            expect(userPreferenceStatus.propertyA).toBe('valueA');
-            done();
-        });
-    });
-    });
-
-    describe('with languages config', () => {
-
-        it('should store default textOrientation based on language ', async(() => {
+        it('should store default textOrientation based on language', async(() => {
             appConfig.config.languages = [
                 {
                     key: 'fake-locale-config'
@@ -234,5 +218,22 @@ describe('UserPreferencesService', () => {
             expect(storage.getItem(textOrientation)).toBe(null);
         }));
 
+        it('should default to browser locale for textOrientation when locale is not defined in configuration', (done) => {
+            appConfig.config.languages = [
+                {
+                    key: 'fake-locale-browser',
+                    direction: 'rtl'
+                }
+            ];
+            spyOn(translate, 'getBrowserCultureLang').and.returnValue('fake-locale-browser');
+            preferences = new UserPreferencesService(translate, appConfig, storage, alfrescoApiService);
+            alfrescoApiService.initialize();
+
+            changeDisposable = preferences.onChange
+                .subscribe((userPreferenceStatus) => {
+                    expect(userPreferenceStatus['textOrientation']).toBe('rtl');
+                    done();
+            });
+        });
     });
 });

--- a/lib/core/services/user-preferences.service.spec.ts
+++ b/lib/core/services/user-preferences.service.spec.ts
@@ -23,6 +23,8 @@ import { UserPreferencesService, UserPreferenceValues } from './user-preferences
 import { setupTestBed } from '../testing/setupTestBed';
 import { CoreTestingModule } from '../testing/core.testing.module';
 import { AppConfigServiceMock } from '../mock/app-config.service.mock';
+import { AlfrescoApiService } from './alfresco-api.service';
+import { AlfrescoApiServiceMock } from '../mock/alfresco-api.service.mock';
 
 describe('UserPreferencesService', () => {
 
@@ -30,13 +32,15 @@ describe('UserPreferencesService', () => {
     let preferences: UserPreferencesService;
     let storage: StorageService;
     let appConfig: AppConfigServiceMock;
+    let alfrescoApiService: AlfrescoApiServiceMock;
     let translate: TranslateService;
     let changeDisposable: any;
 
     setupTestBed({
         imports: [CoreTestingModule],
         providers: [
-            { provide: AppConfigService, useClass: AppConfigServiceMock }
+            { provide: AppConfigService, useClass: AppConfigServiceMock },
+            { provide: AlfrescoApiService, useClass: AlfrescoApiServiceMock }
         ]
     });
 
@@ -51,6 +55,7 @@ describe('UserPreferencesService', () => {
 
         storage = TestBed.get(StorageService);
         translate = TestBed.get(TranslateService);
+        alfrescoApiService = new AlfrescoApiServiceMock(new AppConfigService(null), new StorageService());
     });
 
     beforeEach(() => {
@@ -65,155 +70,105 @@ describe('UserPreferencesService', () => {
         storage.clear();
     });
 
-    it('should get default pagination from app config', (done) => {
-        preferences = new UserPreferencesService(translate, appConfig, storage);
-        appConfig.config.pagination.size = 0;
-        appConfig.load().then(() => {
-            expect(preferences.paginationSize).toBe(0);
-            done();
+    describe(' with pagination config', () => {
+
+        beforeEach(() => {
+            preferences = new UserPreferencesService(translate, appConfig, storage, alfrescoApiService);
         });
-    });
 
-    it('should return supported page sizes defined in the app config', () => {
-        preferences = new UserPreferencesService(translate, appConfig, storage);
-        const supportedPages = preferences.supportedPageSizes;
-        appConfig.load();
-        expect(supportedPages).toEqual(supportedPaginationSize);
-    });
-
-    it('should use [GUEST] as default storage prefix', () => {
-        preferences = new UserPreferencesService(translate, appConfig, storage);
-        preferences.setStoragePrefix(null);
-        expect(preferences.getStoragePrefix()).toBe('GUEST');
-    });
-
-    it('should change storage prefix', () => {
-        preferences = new UserPreferencesService(translate, appConfig, storage);
-        preferences.setStoragePrefix('USER_A');
-        expect(preferences.getStoragePrefix()).toBe('USER_A');
-    });
-
-    it('should format property key for default prefix', () => {
-        preferences = new UserPreferencesService(translate, appConfig, storage);
-        preferences.setStoragePrefix(null);
-        expect(preferences.getPropertyKey('propertyA')).toBe('GUEST__propertyA');
-    });
-
-    it('should format property key for custom prefix', () => {
-        preferences = new UserPreferencesService(translate, appConfig, storage);
-        preferences.setStoragePrefix('USER_A');
-        expect(preferences.getPropertyKey('propertyA')).toBe('USER_A__propertyA');
-    });
-
-    it('should save value with default prefix', () => {
-        preferences = new UserPreferencesService(translate, appConfig, storage);
-        preferences.set('propertyA', 'valueA');
-        const propertyKey = preferences.getPropertyKey('propertyA');
-        expect(storage.getItem(propertyKey)).toBe('valueA');
-    });
-
-    it('should null value return default prefix', () => {
-        preferences = new UserPreferencesService(translate, appConfig, storage);
-        storage.setItem('paginationSize', null);
-        const paginationSize = preferences.getPropertyKey('paginationSize');
-        expect(preferences.get(paginationSize, 'default')).toBe('default');
-    });
-
-    it('should save value with custom prefix', () => {
-        preferences = new UserPreferencesService(translate, appConfig, storage);
-        preferences.setStoragePrefix('USER_A');
-        preferences.set('propertyA', 'valueA');
-        const propertyKey = preferences.getPropertyKey('propertyA');
-        expect(storage.getItem(propertyKey)).toBe('valueA');
-    });
-
-    it('should return as default locale the app.config locate as first', () => {
-        preferences = new UserPreferencesService(translate, appConfig, storage);
-        appConfig.config.locale = 'fake-locate-config';
-        spyOn(translate, 'getBrowserCultureLang').and.returnValue('fake-locate-browser');
-        expect(preferences.getDefaultLocale()).toBe('fake-locate-config');
-    });
-
-    it('should return as default locale the browser locale as second', () => {
-        preferences = new UserPreferencesService(translate, appConfig, storage);
-        spyOn(translate, 'getBrowserCultureLang').and.returnValue('fake-locate-browser');
-        expect(preferences.getDefaultLocale()).toBe('fake-locate-browser');
-    });
-
-    it('should return as default locale the component property as third ', () => {
-        preferences = new UserPreferencesService(translate, appConfig, storage);
-        spyOn(translate, 'getBrowserCultureLang').and.stub();
-        expect(preferences.getDefaultLocale()).toBe('en');
-    });
-
-    it('should return as locale the store locate', () => {
-        preferences = new UserPreferencesService(translate, appConfig, storage);
-        preferences.locale = 'fake-store-locate';
-        appConfig.config.locale = 'fake-locate-config';
-        spyOn(translate, 'getBrowserCultureLang').and.returnValue('fake-locate-browser');
-        expect(preferences.locale).toBe('fake-store-locate');
-    });
-
-    it('should store default textOrientation based on language ', async(() => {
-        appConfig.config.languages = [
-            {
-                key: 'fake-locale-config'
-            }
-        ];
-        appConfig.config.locale = 'fake-locale-config';
-        preferences = new UserPreferencesService(translate, appConfig, storage);
-        appConfig.load();
-        const textOrientation = preferences.getPropertyKey('textOrientation');
-        expect(storage.getItem(textOrientation)).toBe('ltr');
-    }));
-
-    it('should store textOrientation based on language config direction', async(() => {
-        appConfig.config.languages = [
-            {
-                key: 'fake-locale-config',
-                direction: 'rtl'
-            }
-        ];
-        appConfig.config.locale = 'fake-locale-config';
-        preferences = new UserPreferencesService(translate, appConfig, storage);
-        appConfig.load();
-        const textOrientation = preferences.getPropertyKey('textOrientation');
-        expect(storage.getItem(textOrientation)).toBe('rtl');
-    }));
-
-    it('should not store textOrientation based on language ', async(() => {
-        appConfig.config.languages = [
-            {
-                key: 'fake-locale-browser'
-            }
-        ];
-        preferences = new UserPreferencesService(translate, appConfig, storage);
-        appConfig.load();
-
-        const textOrientation = preferences.getPropertyKey('textOrientation');
-        expect(storage.getItem(textOrientation)).toBe(null);
-    }));
-
-    it('should default to browser locale for textOrientation when locale is not defined in configuration', (done) => {
-        appConfig.config.languages = [
-            {
-                key: 'fake-locale-browser',
-                direction: 'rtl'
-            }
-        ];
-        spyOn(translate, 'getBrowserCultureLang').and.returnValue('fake-locale-browser');
-        preferences = new UserPreferencesService(translate, appConfig, storage);
-        appConfig.load();
-
-        changeDisposable = preferences.onChange
-            .subscribe((userPreferenceStatus) => {
-                expect(userPreferenceStatus['textOrientation']).toBe('rtl');
+        it('should get default pagination from app config', (done) => {
+            appConfig.config.pagination.size = 0;
+            appConfig.load().then(() => {
+                expect(preferences.paginationSize).toBe(0);
                 done();
+            });
         });
-    });
 
-    it('should not store in the storage the locale if the app.config.json does not have a value', () => {
-        preferences = new UserPreferencesService(translate, appConfig, storage);
+        it('should return supported page sizes defined in the app config', () => {
+            const supportedPages = preferences.supportedPageSizes;
+            appConfig.load();
+            expect(supportedPages).toEqual(supportedPaginationSize);
+        });
+
+        it('should use [GUEST] as default storage prefix', () => {
+            preferences.setStoragePrefix(null);
+            expect(preferences.getStoragePrefix()).toBe('GUEST');
+        });
+
+        it('should change storage prefix', () => {
+            preferences.setStoragePrefix('USER_A');
+            expect(preferences.getStoragePrefix()).toBe('USER_A');
+        });
+
+        it('should format property key for default prefix', () => {
+            preferences.setStoragePrefix(null);
+            expect(preferences.getPropertyKey('propertyA')).toBe('GUEST__propertyA');
+        });
+
+        it('should format property key for custom prefix', () => {
+            preferences.setStoragePrefix('USER_A');
+            expect(preferences.getPropertyKey('propertyA')).toBe('USER_A__propertyA');
+        });
+
+        it('should save value with default prefix', () => {
+            preferences.set('propertyA', 'valueA');
+            const propertyKey = preferences.getPropertyKey('propertyA');
+            expect(storage.getItem(propertyKey)).toBe('valueA');
+        });
+
+        it('should null value return default prefix', () => {
+            storage.setItem('paginationSize', null);
+            const paginationSize = preferences.getPropertyKey('paginationSize');
+            expect(preferences.get(paginationSize, 'default')).toBe('default');
+        });
+
+        it('should save value with custom prefix', () => {
+            preferences.setStoragePrefix('USER_A');
+            preferences.set('propertyA', 'valueA');
+            const propertyKey = preferences.getPropertyKey('propertyA');
+            expect(storage.getItem(propertyKey)).toBe('valueA');
+        });
+
+        it('should return as default locale the app.config locate as first', () => {
+            appConfig.config.locale = 'fake-locate-config';
+            spyOn(translate, 'getBrowserCultureLang').and.returnValue('fake-locate-browser');
+            expect(preferences.getDefaultLocale()).toBe('fake-locate-config');
+        });
+
+        it('should return as default locale the browser locale as second', () => {
+            spyOn(translate, 'getBrowserCultureLang').and.returnValue('fake-locate-browser');
+            expect(preferences.getDefaultLocale()).toBe('fake-locate-browser');
+        });
+
+        it('should return as default locale the component property as third ', () => {
+            spyOn(translate, 'getBrowserCultureLang').and.stub();
+            expect(preferences.getDefaultLocale()).toBe('en');
+        });
+
+        it('should not store in the storage the locale if the app.config.json does not have a value', () => {
+            preferences.locale = 'fake-store-locate';
+            spyOn(translate, 'getBrowserCultureLang').and.returnValue('fake-locate-browser');
+            expect(preferences.locale).toBe('fake-store-locate');
+            expect(storage.getItem(UserPreferenceValues.Locale)).toBe(null);
+        });
+
+        it('should stream the page size value when is set', (done) => {
+            preferences.paginationSize = 5;
+            changeDisposable = preferences.onChange.subscribe((userPreferenceStatus) => {
+                expect(userPreferenceStatus[UserPreferenceValues.PaginationSize]).toBe(5);
+                done();
+            });
+        });
+
+        it('should stream the user preference status when changed', (done) => {
+            preferences.set('propertyA', 'valueA');
+            changeDisposable = preferences.onChange.subscribe((userPreferenceStatus) => {
+                expect(userPreferenceStatus.propertyA).toBe('valueA');
+                done();
+            });
+        });
+
+       it('should not store in the storage the locale if the app.config.json does not have a value', () => {
         preferences.locale = 'fake-store-locate';
         spyOn(translate, 'getBrowserCultureLang').and.returnValue('fake-locate-browser');
         expect(preferences.locale).toBe('fake-store-locate');
@@ -221,7 +176,6 @@ describe('UserPreferencesService', () => {
     });
 
     it('should stream the page size value when is set', (done) => {
-        preferences = new UserPreferencesService(translate, appConfig, storage);
         preferences.paginationSize = 5;
         changeDisposable = preferences.onChange.subscribe((userPreferenceStatus) => {
             expect(userPreferenceStatus[UserPreferenceValues.PaginationSize]).toBe(5);
@@ -230,11 +184,55 @@ describe('UserPreferencesService', () => {
     });
 
     it('should stream the user preference status when changed', (done) => {
-        preferences = new UserPreferencesService(translate, appConfig, storage);
         preferences.set('propertyA', 'valueA');
         changeDisposable = preferences.onChange.subscribe((userPreferenceStatus) => {
             expect(userPreferenceStatus.propertyA).toBe('valueA');
             done();
         });
+    });
+    });
+
+    describe('with languages config', () => {
+
+        it('should store default textOrientation based on language ', async(() => {
+            appConfig.config.languages = [
+                {
+                    key: 'fake-locale-config'
+                }
+            ];
+            appConfig.config.locale = 'fake-locale-config';
+            preferences = new UserPreferencesService(translate, appConfig, storage, alfrescoApiService);
+            alfrescoApiService.initialize();
+            const textOrientation = preferences.getPropertyKey('textOrientation');
+            expect(storage.getItem(textOrientation)).toBe('ltr');
+        }));
+
+        it('should store textOrientation based on language config direction', async(() => {
+            appConfig.config.languages = [
+                {
+                    key: 'fake-locale-config',
+                    direction: 'rtl'
+                }
+            ];
+            appConfig.config.locale = 'fake-locale-config';
+            preferences = new UserPreferencesService(translate, appConfig, storage, alfrescoApiService);
+            alfrescoApiService.initialize();
+            const textOrientation = preferences.getPropertyKey('textOrientation');
+            expect(storage.getItem(textOrientation)).toBe('rtl');
+        }));
+
+        it('should not store textOrientation based on language ', async(() => {
+            appConfig.config.languages = [
+                {
+                    key: 'fake-locale-browser'
+                }
+            ];
+            preferences = new UserPreferencesService(translate, appConfig, storage, alfrescoApiService);
+            alfrescoApiService.initialize();
+
+            const textOrientation = preferences.getPropertyKey('textOrientation');
+            expect(storage.getItem(textOrientation)).toBe(null);
+        }));
+
     });
 });

--- a/lib/core/services/user-preferences.service.ts
+++ b/lib/core/services/user-preferences.service.ts
@@ -55,6 +55,7 @@ export class UserPreferencesService {
     }
 
     private initUserPreferenceStatus() {
+        this.initStoragePrefix();
         this.initUserLanguage();
         this.set(UserPreferenceValues.PaginationSize, this.paginationSize);
         this.set(UserPreferenceValues.SupportedPageSizes, JSON.stringify(this.supportedPageSizes));
@@ -72,6 +73,10 @@ export class UserPreferencesService {
             this.setWithoutStore(UserPreferenceValues.Locale, locale);
             this.setWithoutStore('textOrientation', this.getLanguageByKey(locale).direction || 'ltr');
         }
+    }
+
+    private initStoragePrefix() {
+        this.storage.storagePrefix = this.appConfig.get<string>('application.storagePrefix', '');
     }
 
     /**

--- a/lib/core/services/user-preferences.service.ts
+++ b/lib/core/services/user-preferences.service.ts
@@ -22,6 +22,7 @@ import { AppConfigService, AppConfigValues } from '../app-config/app-config.serv
 import { LanguageItem } from '../language-menu/language.interface';
 import { StorageService } from './storage.service';
 import { distinctUntilChanged, map } from 'rxjs/operators';
+import { AlfrescoApiService } from './alfresco-api.service';
 
 export enum UserPreferenceValues {
     PaginationSize = 'paginationSize',
@@ -48,14 +49,14 @@ export class UserPreferencesService {
 
     constructor(public translate: TranslateService,
                 private appConfig: AppConfigService,
-                private storage: StorageService) {
-        this.appConfig.onLoad.subscribe(this.initUserPreferenceStatus.bind(this));
+                private storage: StorageService,
+                private alfrescoApiService: AlfrescoApiService) {
+        this.alfrescoApiService.alfrescoApiInitialized.subscribe(this.initUserPreferenceStatus.bind(this));
         this.onChangeSubject = new BehaviorSubject(this.userPreferenceStatus);
         this.onChange = this.onChangeSubject.asObservable();
     }
 
     private initUserPreferenceStatus() {
-        this.initStoragePrefix();
         this.initUserLanguage();
         this.set(UserPreferenceValues.PaginationSize, this.paginationSize);
         this.set(UserPreferenceValues.SupportedPageSizes, JSON.stringify(this.supportedPageSizes));
@@ -73,10 +74,6 @@ export class UserPreferencesService {
             this.setWithoutStore(UserPreferenceValues.Locale, locale);
             this.setWithoutStore('textOrientation', this.getLanguageByKey(locale).direction || 'ltr');
         }
-    }
-
-    private initStoragePrefix() {
-        this.storage.storagePrefix = this.appConfig.get<string>('application.storagePrefix', '');
     }
 
     /**

--- a/lib/process-services-cloud/src/lib/form/services/form-cloud.service.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/services/form-cloud.service.spec.ts
@@ -18,7 +18,7 @@
 import { TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { FormCloudService } from './form-cloud.service';
-import { AlfrescoApiService, CoreModule, setupTestBed, AppConfigService, AppConfigServiceMock } from '@alfresco/adf-core';
+import { AlfrescoApiService, CoreModule, setupTestBed, AppConfigService } from '@alfresco/adf-core';
 import { of } from 'rxjs';
 
 declare let jasmine: any;
@@ -26,11 +26,6 @@ declare let jasmine: any;
 const responseBody = {
     entry:
         { id: 'id', name: 'name', formKey: 'form-key' }
-};
-
-const alfrescoApiServiceStub = {
-    getInstance() { },
-    load() { }
 };
 
 const oauth2Auth = jasmine.createSpyObj('oauth2Auth', ['callCustomApi']);
@@ -48,11 +43,7 @@ describe('Form Cloud service', () => {
             NoopAnimationsModule,
             CoreModule.forRoot()
         ],
-        providers: [
-            FormCloudService,
-            { provide: AlfrescoApiService, useValue: alfrescoApiServiceStub },
-            { provide: AppConfigService, useClass: AppConfigServiceMock }
-        ]
+        providers: [FormCloudService, AlfrescoApiService, AppConfigService]
     });
 
     beforeEach(() => {

--- a/lib/process-services-cloud/src/lib/process/process-list/services/process-list-cloud.service.spec.ts
+++ b/lib/process-services-cloud/src/lib/process/process-list/services/process-list-cloud.service.spec.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 import { async } from '@angular/core/testing';
-import { setupTestBed } from '@alfresco/adf-core';
+import { setupTestBed, StorageService } from '@alfresco/adf-core';
 import { fakeProcessCloudList } from '../mock/process-list-service.mock';
 import { AlfrescoApiServiceMock, LogService, AppConfigService, CoreModule } from '@alfresco/adf-core';
 import { ProcessListCloudService } from './process-list-cloud.service';
@@ -62,7 +62,7 @@ describe('Activiti ProcessList Cloud Service', () => {
     });
 
     beforeEach(async(() => {
-        alfrescoApiMock = new AlfrescoApiServiceMock(new AppConfigService(null));
+        alfrescoApiMock = new AlfrescoApiServiceMock(new AppConfigService(null), new StorageService());
         service = new ProcessListCloudService(alfrescoApiMock,
             new AppConfigService(null),
             new LogService(new AppConfigService(null)));

--- a/lib/process-services-cloud/src/lib/task/services/task-cloud.service.spec.ts
+++ b/lib/process-services-cloud/src/lib/task/services/task-cloud.service.spec.ts
@@ -16,7 +16,7 @@
  */
 
 import { async, TestBed } from '@angular/core/testing';
-import { setupTestBed, IdentityUserService } from '@alfresco/adf-core';
+import { setupTestBed, IdentityUserService, StorageService } from '@alfresco/adf-core';
 import { AlfrescoApiServiceMock, LogService, AppConfigService, CoreModule } from '@alfresco/adf-core';
 import { TaskCloudService } from './task-cloud.service';
 import { taskCompleteCloudMock } from '../task-header/mocks/fake-complete-task.mock';
@@ -68,7 +68,7 @@ describe('Task Cloud Service', () => {
     });
 
     beforeEach(async(() => {
-        alfrescoApiMock = new AlfrescoApiServiceMock(new AppConfigService(null));
+        alfrescoApiMock = new AlfrescoApiServiceMock(new AppConfigService(null), new StorageService());
         identityUserService = TestBed.get(IdentityUserService);
         spyOn(identityUserService, 'getCurrentUserInfo').and.returnValue(cloudMockUser);
         service = new TaskCloudService(alfrescoApiMock,

--- a/lib/process-services-cloud/src/lib/task/task-list/services/task-list-cloud.service.spec.ts
+++ b/lib/process-services-cloud/src/lib/task/task-list/services/task-list-cloud.service.spec.ts
@@ -16,7 +16,7 @@
  */
 
 import { async } from '@angular/core/testing';
-import { setupTestBed } from '@alfresco/adf-core';
+import { setupTestBed, StorageService } from '@alfresco/adf-core';
 import { fakeTaskCloudList } from '../mock/fakeTaskResponseMock';
 import { AlfrescoApiServiceMock, LogService, AppConfigService, CoreModule } from '@alfresco/adf-core';
 import { TaskListCloudService } from './task-list-cloud.service';
@@ -64,7 +64,7 @@ describe('Activiti TaskList Cloud Service', () => {
     });
 
     beforeEach(async(() => {
-        alfrescoApiMock = new AlfrescoApiServiceMock(new AppConfigService(null));
+        alfrescoApiMock = new AlfrescoApiServiceMock(new AppConfigService(null), new StorageService());
         service = new TaskListCloudService(alfrescoApiMock,
                                            new AppConfigService(null),
                                            new LogService(new AppConfigService(null)));

--- a/lib/process-services/process-list/services/process-filter.service.spec.ts
+++ b/lib/process-services/process-list/services/process-filter.service.spec.ts
@@ -19,7 +19,8 @@ import { async } from '@angular/core/testing';
 import { mockError, fakeProcessFilters } from '../../mock';
 import { FilterProcessRepresentationModel } from '../models/filter-process.model';
 import { ProcessFilterService } from './process-filter.service';
-import { AlfrescoApiServiceMock, AlfrescoApiService, AppConfigService, setupTestBed, CoreModule } from '@alfresco/adf-core';
+import { AlfrescoApiServiceMock, AlfrescoApiService, AppConfigService,
+    setupTestBed, CoreModule, StorageService } from '@alfresco/adf-core';
 
 declare let jasmine: any;
 
@@ -36,7 +37,7 @@ describe('Process filter', () => {
     });
 
     beforeEach(() => {
-        apiService = new AlfrescoApiServiceMock(new AppConfigService(null));
+        apiService = new AlfrescoApiServiceMock(new AppConfigService(null), new StorageService());
         service = new ProcessFilterService(apiService);
         alfrescoApi = apiService.getInstance();
     });

--- a/lib/process-services/process-list/services/process.service.spec.ts
+++ b/lib/process-services/process-list/services/process.service.spec.ts
@@ -21,7 +21,8 @@ import { mockError, fakeProcessDef, fakeTasksList } from '../../mock';
 import { ProcessFilterParamRepresentationModel } from '../models/filter-process.model';
 import { ProcessInstanceVariable } from '../models/process-instance-variable.model';
 import { ProcessService } from './process.service';
-import { AlfrescoApiService, AlfrescoApiServiceMock, AppConfigService, setupTestBed, CoreModule } from '@alfresco/adf-core';
+import { AlfrescoApiService, AlfrescoApiServiceMock, AppConfigService,
+    setupTestBed, CoreModule, StorageService } from '@alfresco/adf-core';
 
 declare let moment: any;
 
@@ -38,7 +39,7 @@ describe('ProcessService', () => {
     });
 
     beforeEach(() => {
-        apiService = new AlfrescoApiServiceMock(new AppConfigService(null));
+        apiService = new AlfrescoApiServiceMock(new AppConfigService(null), new StorageService());
         service = new ProcessService(apiService);
         alfrescoApi = apiService.getInstance();
     });

--- a/lib/process-services/task-list/services/task-filter.service.spec.ts
+++ b/lib/process-services/task-list/services/task-filter.service.spec.ts
@@ -19,7 +19,7 @@ import { async } from '@angular/core/testing';
 import { fakeAppFilter, fakeAppPromise, fakeFilters } from '../../mock';
 import { FilterRepresentationModel } from '../models/filter.model';
 import { TaskFilterService } from './task-filter.service';
-import { AlfrescoApiServiceMock, LogService, AppConfigService, setupTestBed, CoreModule } from '@alfresco/adf-core';
+import { AlfrescoApiServiceMock, LogService, AppConfigService, setupTestBed, CoreModule, StorageService } from '@alfresco/adf-core';
 
 declare let jasmine: any;
 
@@ -34,7 +34,9 @@ describe('Activiti Task filter Service', () => {
     });
 
     beforeEach(async(() => {
-        service = new TaskFilterService(new AlfrescoApiServiceMock(new AppConfigService(null)), new LogService(new AppConfigService(null)));
+        service = new TaskFilterService(
+            new AlfrescoApiServiceMock(new AppConfigService(null), new StorageService()),
+            new LogService(new AppConfigService(null)));
         jasmine.Ajax.install();
     }));
 

--- a/lib/process-services/task-list/services/tasklist.service.spec.ts
+++ b/lib/process-services/task-list/services/tasklist.service.spec.ts
@@ -16,7 +16,7 @@
  */
 
 import { async } from '@angular/core/testing';
-import { UserProcessModel, setupTestBed, CoreModule } from '@alfresco/adf-core';
+import { UserProcessModel, setupTestBed, CoreModule, StorageService } from '@alfresco/adf-core';
 import { of } from 'rxjs';
 import {
     fakeCompletedTaskList,
@@ -50,7 +50,9 @@ describe('Activiti TaskList Service', () => {
     });
 
     beforeEach(async(() => {
-        service = new TaskListService(new AlfrescoApiServiceMock(new AppConfigService(null)), new LogService(new AppConfigService(null)));
+        service = new TaskListService(
+            new AlfrescoApiServiceMock(new AppConfigService(null), new StorageService()),
+            new LogService(new AppConfigService(null)));
         jasmine.Ajax.install();
     }));
 

--- a/lib/testing/src/lib/core/pages/login.page.ts
+++ b/lib/testing/src/lib/core/pages/login.page.ts
@@ -194,6 +194,10 @@ export class LoginPage {
         return this.login(username, password);
     }
 
+    async removeECMTicketFromStorage() {
+        await LocalStorageUtil.removeStorageItem('ticket-ECM');
+    }
+
     clickSignInButton() {
         BrowserActions.clickExecuteScript('#login-button');
     }

--- a/lib/testing/src/lib/core/pages/login.page.ts
+++ b/lib/testing/src/lib/core/pages/login.page.ts
@@ -194,10 +194,6 @@ export class LoginPage {
         return this.login(username, password);
     }
 
-    async removeECMTicketFromStorage() {
-        await LocalStorageUtil.removeStorageItem('ticket-ECM');
-    }
-
     clickSignInButton() {
         BrowserActions.clickExecuteScript('#login-button');
     }

--- a/lib/testing/src/lib/core/utils/local-storage.util.ts
+++ b/lib/testing/src/lib/core/utils/local-storage.util.ts
@@ -31,6 +31,12 @@ export class LocalStorageUtil {
         );
     }
 
+    static async removeStorageItem(field: string) {
+        await browser.executeScript(
+            'window.adf.removeStorageItem(`' + field + '`);'
+        );
+    }
+
     static async setUserPreference(field: string, value: any) {
         await browser.executeScript(
             'window.adf.setUserPreference(`' + field + '`, `' + value + '`);'

--- a/lib/testing/src/lib/process-services-cloud/actions/testing-alfresco-api.service.ts
+++ b/lib/testing/src/lib/process-services-cloud/actions/testing-alfresco-api.service.ts
@@ -28,7 +28,7 @@ export class TestingAlfrescoApiService extends AlfrescoApiService {
     constructor(public appConfig: AppConfigService, public storageService: StorageService) {
         super(null, null);
         const oauth = Object.assign({}, this.appConfig.get<any>(AppConfigValues.OAUTHCONFIG, null));
-        this.storageService.storagePrefix = this.appConfig.get<string>(AppConfigValues.STORAGE_PREFIX, '');
+        this.storageService.prefix = this.appConfig.get<string>(AppConfigValues.STORAGE_PREFIX, '');
         this.config = new AlfrescoApiConfig({
             provider: this.appConfig.get<string>(AppConfigValues.PROVIDERS),
             hostEcm: this.appConfig.get<string>(AppConfigValues.ECMHOST),
@@ -38,7 +38,7 @@ export class TestingAlfrescoApiService extends AlfrescoApiService {
             contextRoot: this.appConfig.get<string>(AppConfigValues.CONTEXTROOTECM),
             disableCsrf: this.appConfig.get<boolean>(AppConfigValues.DISABLECSRF),
             withCredentials: this.appConfig.get<boolean>(AppConfigValues.AUTH_WITH_CREDENTIALS, false),
-            domainPrefix: this.storageService.storagePrefix,
+            domainPrefix: this.storageService.prefix,
             oauth2: oauth
         });
     }

--- a/lib/testing/src/lib/process-services-cloud/actions/testing-alfresco-api.service.ts
+++ b/lib/testing/src/lib/process-services-cloud/actions/testing-alfresco-api.service.ts
@@ -16,7 +16,7 @@
  */
 
 import { AlfrescoApiCompatibility, AlfrescoApiConfig } from '@alfresco/js-api';
-import { AlfrescoApiService, AppConfigValues, AppConfigService } from '@alfresco/adf-core';
+import { AlfrescoApiService, AppConfigValues, AppConfigService, StorageService } from '@alfresco/adf-core';
 
 export class TestingAlfrescoApiService extends AlfrescoApiService {
 
@@ -25,9 +25,10 @@ export class TestingAlfrescoApiService extends AlfrescoApiService {
     config = {
     };
 
-    constructor(public appConfig: AppConfigService) {
-        super(null);
+    constructor(public appConfig: AppConfigService, public storageService: StorageService) {
+        super(null, null);
         const oauth = Object.assign({}, this.appConfig.get<any>(AppConfigValues.OAUTHCONFIG, null));
+        this.storageService.storagePrefix = this.appConfig.get<string>(AppConfigValues.STORAGE_PREFIX, '');
         this.config = new AlfrescoApiConfig({
             provider: this.appConfig.get<string>(AppConfigValues.PROVIDERS),
             hostEcm: this.appConfig.get<string>(AppConfigValues.ECMHOST),
@@ -37,6 +38,7 @@ export class TestingAlfrescoApiService extends AlfrescoApiService {
             contextRoot: this.appConfig.get<string>(AppConfigValues.CONTEXTROOTECM),
             disableCsrf: this.appConfig.get<boolean>(AppConfigValues.DISABLECSRF),
             withCredentials: this.appConfig.get<boolean>(AppConfigValues.AUTH_WITH_CREDENTIALS, false),
+            domainPrefix: this.storageService.storagePrefix,
             oauth2: oauth
         });
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,69 +1,69 @@
 {
   "name": "alfresco-components",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@alfresco/adf-content-services": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@alfresco/adf-content-services/-/adf-content-services-3.2.1.tgz",
-      "integrity": "sha512-dljtJUnvlA2OC1g9u8TyQEnoHqTEVl94AH6S7dcpWiACLCSMiwd5Zkdpe/p/5FWxPY4on53iIR31KJmyYXfoYQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@alfresco/adf-content-services/-/adf-content-services-3.3.0.tgz",
+      "integrity": "sha512-VzEqJC+e2CYtFSwSJDXI8PR7xFCozsV113CpLEW9GT1rcNOyZrwQUe1MZqD3iNJzZdtsw+VI1kfsOwX9v0LNeA==",
       "requires": {
         "tslib": "^1.9.0"
       }
     },
     "@alfresco/adf-core": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@alfresco/adf-core/-/adf-core-3.2.1.tgz",
-      "integrity": "sha512-BFaL3ARaErwvYa4OjgAgWbN0Pm1NMfULd9gFZROQCqPhr794KtwhGqIVmr+G6JjaQvIXMZ3hSTppKu63NyBoqA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@alfresco/adf-core/-/adf-core-3.3.0.tgz",
+      "integrity": "sha512-OKjG0FduZWj/Ux4O/hKtvz4opWCLrrRP0bsQfRPMfNymIUlHHhS12ciPVSlKaVlozrJ4poyjq8maGa8gqSDMcA==",
       "requires": {
         "tslib": "^1.9.0"
       }
     },
     "@alfresco/adf-extensions": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@alfresco/adf-extensions/-/adf-extensions-3.2.1.tgz",
-      "integrity": "sha512-ULYZmpRfR7ckLvNe/273DhgWvx7wvoUDzy1lsOIpFS0LfyfjEqEjOcQQ3V2DAcbR1Rl7cJ7+3RXkfVHmp/d6ng==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@alfresco/adf-extensions/-/adf-extensions-3.3.0.tgz",
+      "integrity": "sha512-Fvet22KpZ8zLGKccgsjlf9uEE2+47h0QMDMSX1S4tMbLlLs34PpHQiYNPOEKZgeV/kWx0+nhM7QhQUfH8NpRUA==",
       "requires": {
         "tslib": "^1.9.0"
       }
     },
     "@alfresco/adf-insights": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@alfresco/adf-insights/-/adf-insights-3.2.1.tgz",
-      "integrity": "sha512-6ktlzvoHJ2Pf6+Qcp/ua8rZ/RYuakO0Y6QeFNXlilVt3FK/jF1AmJT3Xj21tdnxOEzWAKTH1lb+rd/0itP+DoQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@alfresco/adf-insights/-/adf-insights-3.3.0.tgz",
+      "integrity": "sha512-EX04XBLz4tuGzG/pcJpkxUL8gjbUtr/njBa+J1R4V5H4Lk66pBf9okINZvSrNWExNSPKmuz/1YqmS+X5QMwAQQ==",
       "requires": {
         "tslib": "^1.9.0"
       }
     },
     "@alfresco/adf-process-services": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@alfresco/adf-process-services/-/adf-process-services-3.2.1.tgz",
-      "integrity": "sha512-cHNFYxzkUgvf0oqWJt87rnmEl9ujtJ2Jw73jR/Wcayk2QgOrmMuhaIaFlkgqhfudIHeXnpT2RfcgxcF7rWCWaA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@alfresco/adf-process-services/-/adf-process-services-3.3.0.tgz",
+      "integrity": "sha512-ib08V7g7h8BCkJ/lkkDTZPBOz8qSqD40aif5uySr8YX6QKSZ5KyEdfqKikYyEchISEOd0yhhN/nxZW1ExHb0iQ==",
       "requires": {
         "tslib": "^1.9.0"
       }
     },
     "@alfresco/adf-process-services-cloud": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@alfresco/adf-process-services-cloud/-/adf-process-services-cloud-3.2.1.tgz",
-      "integrity": "sha512-40IirZWLqRqTcJlYMwNRX7AyWUdrRzOHG2OPsAtTO4ozEub3UzYZDte/7uh7a52CoVsSz+Kx/oom8pGK+9MVoQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@alfresco/adf-process-services-cloud/-/adf-process-services-cloud-3.3.0.tgz",
+      "integrity": "sha512-7PQlXx4zi8uWk/Gp8A8ETicFFfHzEcaR9sI4UK+vUtPyG5MbDobbaPWLyn8iMZQniuCBk1oFwVRY2JrXf5Tciw==",
       "requires": {
         "tslib": "^1.9.0"
       }
     },
     "@alfresco/adf-testing": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@alfresco/adf-testing/-/adf-testing-3.2.1.tgz",
-      "integrity": "sha512-8RG80G3JMvB3QjtVRI4jsLXDUicvqXyc9TrTgOcH6ilYKKTqt6P+OJi3H45yLPhat41MwSeP1LgCoUW3d1SWHQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@alfresco/adf-testing/-/adf-testing-3.3.0.tgz",
+      "integrity": "sha512-xZUgLyuHTWwR22xdT7x5sh11vUrk/94thdfIFsYEuTX6X4W5lJkylF/C9fAuAPIuTkrAu8DWloUgSNVtyTCMVg==",
       "requires": {
         "tslib": "^1.9.0"
       }
     },
     "@alfresco/js-api": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@alfresco/js-api/-/js-api-3.2.1.tgz",
-      "integrity": "sha512-qaXftaHqFonWRKRmYxhB2/bEpUh5fvUj6cN+xuKUXIGgt9XxF76NpWkXnEEQLZ0BWg5upd19Q3N1x4E7DiNGUg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@alfresco/js-api/-/js-api-3.3.0.tgz",
+      "integrity": "sha512-A15Q5j4jVNFUI0hdw0zIGonU05Wbjvq8ZJBijrkC3fq904oYuq49giKpPkbXjowk9xBfZZejGvaDMT5jYTXlxg==",
       "requires": {
         "event-emitter": "0.3.4",
         "superagent": "3.8.2"
@@ -5629,11 +5629,12 @@
       },
       "dependencies": {
         "d": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-          "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+          "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
           "requires": {
-            "es5-ext": "^0.10.9"
+            "es5-ext": "^0.10.50",
+            "type": "^1.0.1"
           }
         }
       }
@@ -5663,11 +5664,12 @@
       },
       "dependencies": {
         "d": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-          "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+          "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
           "requires": {
-            "es5-ext": "^0.10.9"
+            "es5-ext": "^0.10.50",
+            "type": "^1.0.1"
           }
         }
       }
@@ -6527,7 +6529,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6548,12 +6551,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6568,17 +6573,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6695,7 +6703,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6707,6 +6716,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6721,6 +6731,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6728,12 +6739,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6752,6 +6765,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6832,7 +6846,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6844,6 +6859,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6929,7 +6945,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6965,6 +6982,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6984,6 +7002,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7027,12 +7046,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -17055,6 +17076,11 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
+    },
+    "type": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.0.1.tgz",
+      "integrity": "sha512-MAM5dBMJCJNKs9E7JXo4CXRAansRfG0nlJxW7Wf6GZzSOvH31zClSaHdIMWLehe/EGMBkqeC55rrkaOr5Oo7Nw=="
     },
     "type-check": {
       "version": "0.3.2",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-4457
StorageService depends on AppConfigService to work

**What is the new behaviour?**
StorageService does not depend on the AppConfigService anymore and the storage
prefix is set by the app initializer.
IdentityService now makes use of the StorageService

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
https://issues.alfresco.com/jira/browse/ADF-4457

**Other information**:
