### PR TITLE
[ADF-4588] Datatable - fix copy content tooltip for ellipsis cell

### DIFF
--- a/lib/core/datatable/components/datatable/datatable.component.scss
+++ b/lib/core/datatable/components/datatable/datatable.component.scss
@@ -441,7 +441,6 @@
             &.adf-datatable-cell-header,
             .adf-datatable-content-cell {
                 max-width: calc(100% - 0.1px);
-                overflow: hidden;
                 text-overflow: ellipsis;
 
                 .adf-datatable-cell-value {

--- a/lib/core/datatable/components/datatable/datatable.component.scss
+++ b/lib/core/datatable/components/datatable/datatable.component.scss
@@ -441,6 +441,7 @@
             &.adf-datatable-cell-header,
             .adf-datatable-content-cell {
                 max-width: calc(100% - 0.1px);
+                overflow: hidden;
                 text-overflow: ellipsis;
 
                 .adf-datatable-cell-value {
@@ -449,6 +450,7 @@
                 }
             }
             .adf-datatable-content-cell {
+                overflow: unset;
                 position: absolute;
             }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-4588


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
