### PR TITLE
[ADF-4600] Should be able to filter groups based on composite roles

### DIFF
--- a/e2e/process-services-cloud/people-group-cloud-component.e2e.ts
+++ b/e2e/process-services-cloud/people-group-cloud-component.e2e.ts
@@ -164,61 +164,61 @@ describe('People Groups Cloud Component', () => {
             it('No role filtering', () => {
                 peopleGroupCloudComponentPage.clearField(peopleGroupCloudComponentPage.groupRoleInput);
                 groupCloudComponentPage.searchGroups(groupNoRole.name);
-                groupCloudComponentPage.checkGroupIsDisplayed(`${groupNoRole.name}`);
+                groupCloudComponentPage.checkGroupIsDisplayed(groupNoRole.name);
                 groupCloudComponentPage.searchGroups(groupActiviti.name);
-                groupCloudComponentPage.checkGroupIsDisplayed(`${groupActiviti.name}`);
+                groupCloudComponentPage.checkGroupIsDisplayed(groupActiviti.name);
                 groupCloudComponentPage.searchGroups(groupAps.name);
-                groupCloudComponentPage.checkGroupIsDisplayed(`${groupAps.name}`);
+                groupCloudComponentPage.checkGroupIsDisplayed(groupAps.name);
             });
 
             it('One role filtering', () => {
                 peopleGroupCloudComponentPage.enterGroupRoles(`["${identityService.roles.aps_admin}"]`);
                 groupCloudComponentPage.searchGroups(groupAps.name);
-                groupCloudComponentPage.checkGroupIsDisplayed(`${groupAps.name}`);
+                groupCloudComponentPage.checkGroupIsDisplayed(groupAps.name);
                 groupCloudComponentPage.searchGroups(groupActiviti.name);
-                groupCloudComponentPage.checkGroupIsNotDisplayed(`${groupActiviti.name}`);
+                groupCloudComponentPage.checkGroupIsNotDisplayed(groupActiviti.name);
                 groupCloudComponentPage.searchGroups(groupNoRole.name);
-                groupCloudComponentPage.checkGroupIsNotDisplayed(`${groupNoRole.name}`);
+                groupCloudComponentPage.checkGroupIsNotDisplayed(groupNoRole.name);
             });
 
             it('[C309996] Should be able to filter groups based on composite roles Activit_Admin', () => {
                 peopleGroupCloudComponentPage.enterGroupRoles(`["${identityService.roles.activiti_admin}"]`);
                 groupCloudComponentPage.searchGroups(groupActiviti.name);
-                groupCloudComponentPage.checkGroupIsDisplayed(`${groupActiviti.name}`);
+                groupCloudComponentPage.checkGroupIsDisplayed(groupActiviti.name);
                 groupCloudComponentPage.searchGroups(groupNoRole.name);
-                groupCloudComponentPage.checkGroupIsNotDisplayed(`${groupNoRole.name}`);
+                groupCloudComponentPage.checkGroupIsNotDisplayed(groupNoRole.name);
                 groupCloudComponentPage.searchGroups(groupAps.name);
-                groupCloudComponentPage.checkGroupIsDisplayed(`${groupAps.name}`);
+                groupCloudComponentPage.checkGroupIsDisplayed(groupAps.name);
             });
 
             it('[C309996] Should be able to filter groups based on composite roles Aps_User', () => {
                 peopleGroupCloudComponentPage.enterGroupRoles(`["${identityService.roles.aps_user}"]`);
                 groupCloudComponentPage.searchGroups(groupActiviti.name);
-                groupCloudComponentPage.checkGroupIsNotDisplayed(`${groupActiviti.name}`);
+                groupCloudComponentPage.checkGroupIsNotDisplayed(groupActiviti.name);
                 groupCloudComponentPage.searchGroups(groupNoRole.name);
-                groupCloudComponentPage.checkGroupIsNotDisplayed(`${groupNoRole.name}`);
+                groupCloudComponentPage.checkGroupIsNotDisplayed(groupNoRole.name);
                 groupCloudComponentPage.searchGroups(groupAps.name);
-                groupCloudComponentPage.checkGroupIsDisplayed(`${groupAps.name}`);
+                groupCloudComponentPage.checkGroupIsDisplayed(groupAps.name);
             });
 
             it('[C309996] Should be able to filter groups based on composite roles Activiti_User', () => {
                 peopleGroupCloudComponentPage.enterGroupRoles(`["${identityService.roles.activiti_user}"]`);
                 groupCloudComponentPage.searchGroups(groupActiviti.name);
-                groupCloudComponentPage.checkGroupIsNotDisplayed(`${groupActiviti.name}`);
+                groupCloudComponentPage.checkGroupIsNotDisplayed(groupActiviti.name);
                 groupCloudComponentPage.searchGroups(groupNoRole.name);
-                groupCloudComponentPage.checkGroupIsNotDisplayed(`${groupNoRole.name}`);
+                groupCloudComponentPage.checkGroupIsNotDisplayed(groupNoRole.name);
                 groupCloudComponentPage.searchGroups(groupAps.name);
-                groupCloudComponentPage.checkGroupIsDisplayed(`${groupAps.name}`);
+                groupCloudComponentPage.checkGroupIsDisplayed(groupAps.name);
             });
 
             it('Multiple roles filtering', () => {
                 peopleGroupCloudComponentPage.enterGroupRoles(`["${identityService.roles.aps_admin}", "${identityService.roles.activiti_admin}"]`);
                 groupCloudComponentPage.searchGroups(groupActiviti.name);
-                groupCloudComponentPage.checkGroupIsDisplayed(`${groupActiviti.name}`);
+                groupCloudComponentPage.checkGroupIsDisplayed(groupActiviti.name);
                 groupCloudComponentPage.searchGroups(groupAps.name);
-                groupCloudComponentPage.checkGroupIsDisplayed(`${groupAps.name}`);
+                groupCloudComponentPage.checkGroupIsDisplayed(groupAps.name);
                 groupCloudComponentPage.searchGroups(groupNoRole.name);
-                groupCloudComponentPage.checkGroupIsNotDisplayed(`${groupNoRole.name}`);
+                groupCloudComponentPage.checkGroupIsNotDisplayed(groupNoRole.name);
             });
         });
 

--- a/e2e/process-services-cloud/people-group-cloud-component.e2e.ts
+++ b/e2e/process-services-cloud/people-group-cloud-component.e2e.ts
@@ -45,6 +45,7 @@ describe('People Groups Cloud Component', () => {
         let groupAps;
         let groupActiviti;
         let groupNoRole;
+        let apsUserRoleId;
         let apsAdminRoleId;
         let activitiAdminRoleId;
         let clientActivitiAdminRoleId, clientActivitiUserRoleId;
@@ -73,7 +74,9 @@ describe('People Groups Cloud Component', () => {
 
             groupAps = await groupIdentityService.createIdentityGroup();
             apsAdminRoleId = await rolesService.getRoleIdByRoleName(identityService.roles.aps_admin);
+            apsUserRoleId = await rolesService.getRoleIdByRoleName(identityService.roles.aps_user);
             await groupIdentityService.assignRole(groupAps.id, apsAdminRoleId, identityService.roles.aps_admin);
+            await groupIdentityService.assignRole(groupAps.id, apsAdminRoleId, identityService.roles.aps_user);
             activitiAdminRoleId = await rolesService.getRoleIdByRoleName(identityService.roles.activiti_admin);
             await groupIdentityService.assignRole(groupActiviti.id, activitiAdminRoleId, identityService.roles.activiti_admin);
             groupNoRole = await groupIdentityService.createIdentityGroup();
@@ -176,6 +179,36 @@ describe('People Groups Cloud Component', () => {
                 groupCloudComponentPage.checkGroupIsNotDisplayed(`${groupActiviti.name}`);
                 groupCloudComponentPage.searchGroups(groupNoRole.name);
                 groupCloudComponentPage.checkGroupIsNotDisplayed(`${groupNoRole.name}`);
+            });
+
+            it('[C309996] Should be able to filter groups based on composite roles Activit_Admin', () => {
+                peopleGroupCloudComponentPage.enterGroupRoles(`["${CONSTANTS.ROLES.ACTIVITI_ADMIN}"]`);
+                groupCloudComponentPage.searchGroups(groupActiviti.name);
+                groupCloudComponentPage.checkGroupIsDisplayed(`${groupActiviti.name}`);
+                groupCloudComponentPage.searchGroups(groupNoRole.name);
+                groupCloudComponentPage.checkGroupIsNotDisplayed(`${groupNoRole.name}`);
+                groupCloudComponentPage.searchGroups(groupAps.name);
+                groupCloudComponentPage.checkGroupIsDisplayed(`${groupAps.name}`);
+            });
+
+            it('[C309996] Should be able to filter groups based on composite roles Aps_User', () => {
+                peopleGroupCloudComponentPage.enterGroupRoles(`["${CONSTANTS.ROLES.APS_USER}"]`);
+                groupCloudComponentPage.searchGroups(groupActiviti.name);
+                groupCloudComponentPage.checkGroupIsNotDisplayed(`${groupActiviti.name}`);
+                groupCloudComponentPage.searchGroups(groupNoRole.name);
+                groupCloudComponentPage.checkGroupIsNotDisplayed(`${groupNoRole.name}`);
+                groupCloudComponentPage.searchGroups(groupAps.name);
+                groupCloudComponentPage.checkGroupIsDisplayed(`${groupAps.name}`);
+            });
+
+            it('[C309996] Should be able to filter groups based on composite roles Activiti_User', () => {
+                peopleGroupCloudComponentPage.enterGroupRoles(`["${CONSTANTS.ROLES.ACTIVITI_USER}"]`);
+                groupCloudComponentPage.searchGroups(groupActiviti.name);
+                groupCloudComponentPage.checkGroupIsNotDisplayed(`${groupActiviti.name}`);
+                groupCloudComponentPage.searchGroups(groupNoRole.name);
+                groupCloudComponentPage.checkGroupIsNotDisplayed(`${groupNoRole.name}`);
+                groupCloudComponentPage.searchGroups(groupAps.name);
+                groupCloudComponentPage.checkGroupIsDisplayed(`${groupAps.name}`);
             });
 
             it('Multiple roles filtering', () => {

--- a/e2e/process-services-cloud/people-group-cloud-component.e2e.ts
+++ b/e2e/process-services-cloud/people-group-cloud-component.e2e.ts
@@ -76,7 +76,7 @@ describe('People Groups Cloud Component', () => {
             apsAdminRoleId = await rolesService.getRoleIdByRoleName(identityService.roles.aps_admin);
             apsUserRoleId = await rolesService.getRoleIdByRoleName(identityService.roles.aps_user);
             await groupIdentityService.assignRole(groupAps.id, apsAdminRoleId, identityService.roles.aps_admin);
-            await groupIdentityService.assignRole(groupAps.id, apsAdminRoleId, identityService.roles.aps_user);
+            await groupIdentityService.assignRole(groupAps.id, apsUserRoleId, identityService.roles.aps_user);
             activitiAdminRoleId = await rolesService.getRoleIdByRoleName(identityService.roles.activiti_admin);
             await groupIdentityService.assignRole(groupActiviti.id, activitiAdminRoleId, identityService.roles.activiti_admin);
             groupNoRole = await groupIdentityService.createIdentityGroup();
@@ -182,7 +182,7 @@ describe('People Groups Cloud Component', () => {
             });
 
             it('[C309996] Should be able to filter groups based on composite roles Activit_Admin', () => {
-                peopleGroupCloudComponentPage.enterGroupRoles(`["${CONSTANTS.ROLES.ACTIVITI_ADMIN}"]`);
+                peopleGroupCloudComponentPage.enterGroupRoles(`["${identityService.roles.activiti_admin}"]`);
                 groupCloudComponentPage.searchGroups(groupActiviti.name);
                 groupCloudComponentPage.checkGroupIsDisplayed(`${groupActiviti.name}`);
                 groupCloudComponentPage.searchGroups(groupNoRole.name);
@@ -192,7 +192,7 @@ describe('People Groups Cloud Component', () => {
             });
 
             it('[C309996] Should be able to filter groups based on composite roles Aps_User', () => {
-                peopleGroupCloudComponentPage.enterGroupRoles(`["${CONSTANTS.ROLES.APS_USER}"]`);
+                peopleGroupCloudComponentPage.enterGroupRoles(`["${identityService.roles.aps_user}"]`);
                 groupCloudComponentPage.searchGroups(groupActiviti.name);
                 groupCloudComponentPage.checkGroupIsNotDisplayed(`${groupActiviti.name}`);
                 groupCloudComponentPage.searchGroups(groupNoRole.name);
@@ -202,7 +202,7 @@ describe('People Groups Cloud Component', () => {
             });
 
             it('[C309996] Should be able to filter groups based on composite roles Activiti_User', () => {
-                peopleGroupCloudComponentPage.enterGroupRoles(`["${CONSTANTS.ROLES.ACTIVITI_USER}"]`);
+                peopleGroupCloudComponentPage.enterGroupRoles(`["${identityService.roles.activiti_user}"]`);
                 groupCloudComponentPage.searchGroups(groupActiviti.name);
                 groupCloudComponentPage.checkGroupIsNotDisplayed(`${groupActiviti.name}`);
                 groupCloudComponentPage.searchGroups(groupNoRole.name);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
GroupCloudService - Use composite api to fetch group roles
APS_ADMIN, APS_USER both are composite roles.
APS_ADMIN role is inherited from the ACTIVITI_ADMIN.
APS_USER role is inherited from the ACTIVITI_USER.
Any group with the "APS_ADMIN" role will now also inherit the "ACTIVITI_ADMIN" role too.
So i have a group called "GROUP_ADMIN_1" and is assigned with APS_ADMIN role.
Current Behaviour:
 Able to filter "GROUP_ADMIN_1" with the "APS_ADMIN" role, but not with the "ACTIVITI_ADMIN" role.
Expected Behaviour:
We should be able to filter "GROUP_ADMIN_1" with both roles "APS_ADMIN", "ACTIVITI_ADMIN".