### PR TITLE
[ADF-4546] Visibility conditions for Form variables don't work on Multiline Widget.

### DIFF
--- a/demo-shell/src/app/components/app-layout/cloud/form-demo/cloud-form-demo.component.ts
+++ b/demo-shell/src/app/components/app-layout/cloud/form-demo/cloud-form-demo.component.ts
@@ -54,7 +54,8 @@ export class FormCloudDemoComponent implements OnInit, OnDestroy {
     }
 
     ngOnInit() {
-        this.formConfig = this.automationService.forms.getFormCloudDefinition();
+        const formDefinitionJSON = this.automationService.forms.getFormCloudDefinition();
+        this.formConfig = JSON.stringify(formDefinitionJSON);
         this.parseForm();
     }
 

--- a/lib/core/form/services/widget-visibility.service.spec.ts
+++ b/lib/core/form/services/widget-visibility.service.spec.ts
@@ -898,4 +898,78 @@ describe('WidgetVisibilityService', () => {
             expect(contModel.isVisible).toBeFalsy();
         });
     });
+
+    describe('Visibility based on form variables', () => {
+
+        const fakeFormWithVariables = new FormModel(fakeFormJson);
+        let visibilityObjTest: WidgetVisibilityModel;
+
+        beforeEach(() => {
+            visibilityObjTest = new WidgetVisibilityModel();
+        });
+
+        it('should set visibility to true when validation for string variables succeeds', () => {
+            visibilityObjTest.leftRestResponseId = 'name';
+            visibilityObjTest.operator = '==';
+            visibilityObjTest.rightValue = 'abc';
+            const isVisible = service.isFieldVisible(fakeFormWithVariables, visibilityObjTest);
+
+            expect(isVisible).toBeTruthy();
+        });
+
+        it('should set visibility to false when validation for string variables fails', () => {
+            visibilityObjTest.leftRestResponseId = 'name';
+            visibilityObjTest.operator = '==';
+            visibilityObjTest.rightValue = 'abc1';
+            const isVisible = service.isFieldVisible(fakeFormWithVariables, visibilityObjTest);
+
+            expect(isVisible).toBeFalsy();
+        });
+
+        it('should set visibility to true when validation for integer variables succeeds', () => {
+            visibilityObjTest.leftRestResponseId = 'age';
+            visibilityObjTest.operator = '==';
+            visibilityObjTest.rightValue = '11';
+            const isVisible = service.isFieldVisible(fakeFormWithVariables, visibilityObjTest);
+
+            expect(isVisible).toBeTruthy();
+        });
+
+        it('should set visibility to false when validation for integer variables fails', () => {
+            visibilityObjTest.leftRestResponseId = 'age';
+            visibilityObjTest.operator = '==';
+            visibilityObjTest.rightValue = '13';
+            const isVisible = service.isFieldVisible(fakeFormWithVariables, visibilityObjTest);
+
+            expect(isVisible).toBeFalsy();
+        });
+
+        it('should set visibility to true when validation for date variables succeeds', () => {
+            visibilityObjTest.leftRestResponseId = 'dob';
+            visibilityObjTest.operator = '==';
+            visibilityObjTest.rightValue = '2019-05-13';
+            const isVisible = service.isFieldVisible(fakeFormWithVariables, visibilityObjTest);
+
+            expect(isVisible).toBeTruthy();
+        });
+
+        it('should set visibility to false when validation for date variables fails', () => {
+            visibilityObjTest.leftRestResponseId = 'dob';
+            visibilityObjTest.operator = '==';
+            visibilityObjTest.rightValue = '2019-05-15';
+            const isVisible = service.isFieldVisible(fakeFormWithVariables, visibilityObjTest);
+
+            expect(isVisible).toBeFalsy();
+        });
+
+        it('should validate visiblity for form fields by finding the field with id', () => {
+            visibilityObjTest.leftRestResponseId = '0207b649-ff07-4f3a-a589-d10afa507b9b';
+            visibilityObjTest.operator = '==';
+            visibilityObjTest.rightValue = '2019-05-13';
+            const isVisible = service.isFieldVisible(fakeFormWithVariables, visibilityObjTest);
+
+            expect(isVisible).toBeTruthy();
+        });
+
+    });
 });

--- a/lib/core/form/services/widget-visibility.service.ts
+++ b/lib/core/form/services/widget-visibility.service.ts
@@ -75,7 +75,7 @@ export class WidgetVisibilityService {
         }
     }
 
-    getLeftValue(form: FormModel, visibilityObj: WidgetVisibilityModel) {
+    getLeftValue(form: FormModel, visibilityObj: WidgetVisibilityModel): string {
         let leftValue = '';
         if (visibilityObj.leftRestResponseId && visibilityObj.leftRestResponseId !== 'null') {
             leftValue = this.getVariableValue(form, visibilityObj.leftRestResponseId, this.processVarList);
@@ -86,7 +86,7 @@ export class WidgetVisibilityService {
         return leftValue;
     }
 
-    getRightValue(form: FormModel, visibilityObj: WidgetVisibilityModel) {
+    getRightValue(form: FormModel, visibilityObj: WidgetVisibilityModel): string {
         let valueFound = '';
         if (visibilityObj.rightRestResponseId) {
             valueFound = this.getVariableValue(form, visibilityObj.rightRestResponseId, this.processVarList);
@@ -102,7 +102,7 @@ export class WidgetVisibilityService {
         return valueFound;
     }
 
-    getFormValue(form: FormModel, fieldId: string) {
+    getFormValue(form: FormModel, fieldId: string): any {
         let value = this.getFieldValue(form.values, fieldId);
 
         if (!value) {
@@ -112,7 +112,7 @@ export class WidgetVisibilityService {
         return value;
     }
 
-    getFieldValue(valueList: any, fieldId: string) {
+    getFieldValue(valueList: any, fieldId: string): any {
         let dropDownFilterByName, valueFound;
         if (fieldId && fieldId.indexOf('_LABEL') > 0) {
             dropDownFilterByName = fieldId.substring(0, fieldId.length - 6);
@@ -127,7 +127,7 @@ export class WidgetVisibilityService {
         return valueFound;
     }
 
-    searchValueInForm(form: FormModel, fieldId: string) {
+    searchValueInForm(form: FormModel, fieldId: string): string {
         let fieldValue = '';
         form.getFormFields().forEach((formField: FormFieldModel) => {
             if (this.isSearchedField(formField, fieldId)) {
@@ -145,7 +145,7 @@ export class WidgetVisibilityService {
         return fieldValue;
     }
 
-    private getObjectValue(field: FormFieldModel, fieldId: string) {
+    private getObjectValue(field: FormFieldModel, fieldId: string): string {
         let value = '';
         if (field.value && field.value.name) {
             value = field.value.name;
@@ -181,31 +181,47 @@ export class WidgetVisibilityService {
         return formattedFieldName;
     }
 
-    getVariableValue(form: FormModel, name: string, processVarList: TaskProcessVariableModel[]) {
+    getVariableValue(form: FormModel, name: string, processVarList: TaskProcessVariableModel[]): string {
         return this.getFormVariableValue(form, name) ||
             this.getProcessVariableValue(name, processVarList);
     }
 
-    private getFormVariableValue(form: FormModel, identifier: string) {
-        const variables = form.json.variables || (form.json.formRepresentation && form.json.formRepresentation.formDefinition.variables);
+    private getFormVariableValue(form: FormModel, identifier: string): string {
+        const variables = this.getFormVariables(form);
         if (variables) {
             const formVariable = variables.find((formVar) => {
                 return formVar.name === identifier || formVar.id === identifier;
             });
 
-            let value = formVariable ? formVariable.value : formVariable;
-            if (moment(value, 'YYYY-MM-DD', true).isValid()) {
-                value = value + 'T00:00:00.000Z';
+            let value;
+            if (formVariable) {
+                value = formVariable.value;
+                if (formVariable.type === 'date') {
+                    value += 'T00:00:00.000Z';
+                }
             }
 
             return value;
         }
     }
 
-    private getProcessVariableValue(name: string, processVarList: TaskProcessVariableModel[]) {
-        if (this.processVarList) {
-            const processVariable = this.processVarList.find((variable) => variable.id === name);
-            return processVariable ? processVariable.value : processVariable;
+    private getFormVariables(form: FormModel): any[] {
+        let variables;
+        if (form.json.formRepresentation) {
+            variables = form.json.formRepresentation.formDefinition.variables;
+        } else {
+            variables = form.json.variables;
+        }
+
+        return variables;
+    }
+
+    private getProcessVariableValue(name: string, processVarList: TaskProcessVariableModel[]): string {
+        if (processVarList) {
+            const processVariable = processVarList.find((variable) => variable.id === name);
+            if (processVariable) {
+                return processVariable.value;
+            }
         }
     }
 
@@ -266,7 +282,7 @@ export class WidgetVisibilityService {
             );
     }
 
-    toJson(res: any) {
+    toJson(res: any): any {
         return res || {};
     }
 

--- a/lib/core/form/services/widget-visibility.service.ts
+++ b/lib/core/form/services/widget-visibility.service.ts
@@ -186,10 +186,19 @@ export class WidgetVisibilityService {
             this.getProcessVariableValue(name, processVarList);
     }
 
-    private getFormVariableValue(form: FormModel, name: string) {
-        if (form.json.variables) {
-            const formVariable = form.json.variables.find((formVar) => formVar.name === name);
-            return formVariable ? formVariable.value : formVariable;
+    private getFormVariableValue(form: FormModel, identifier: string) {
+        const variables = form.json.variables || (form.json.formRepresentation && form.json.formRepresentation.formDefinition.variables);
+        if (variables) {
+            const formVariable = variables.find((formVar) => {
+                return formVar.name === identifier || formVar.id === identifier;
+            });
+
+            let value = formVariable ? formVariable.value : formVariable;
+            if (moment(value, 'YYYY-MM-DD', true).isValid()) {
+                value = value + 'T00:00:00.000Z';
+            }
+
+            return value;
         }
     }
 

--- a/lib/core/mock/form/widget-visibility.service.mock.ts
+++ b/lib/core/mock/form/widget-visibility.service.mock.ts
@@ -93,5 +93,25 @@ export let fakeFormJson = {
                 ]
             }
         }
+    ],
+    variables: [
+        {
+            'id': 'e621e8ff-42a6-499c-8121-33c7c35d8641',
+            'name': 'age',
+            'type': 'integer',
+            'value': 11
+        },
+        {
+            'id': '4f8aa99e-8526-429c-9d99-809978489d96',
+            'name': 'name',
+            'type': 'string',
+            'value': 'abc'
+        },
+        {
+            'id': '0207b649-ff07-4f3a-a589-d10afa507b9b',
+            'name': 'dob',
+            'type': 'date',
+            'value': '2019-05-13'
+        }
     ]
 };


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

* In cloud-form visiblity fails when the visibility conditions are configured based on form variables
* The visibility conditon fails when the conditon is based form variables of date type

https://issues.alfresco.com/jira/browse/ADF-4546

**What is the new behaviour?**

* In old cloud form the variable defintion does not have id and the visibity conditions used variable name. The cloud-form visiblity condtions uss the new id property of the variables. So the variable value reading has been modified to find variables using id as well.

* If the form variable is of date type then the value was not converted to the required format and the visibility condtion based date form variable always failed. This behaviour has been fixed by converting the date form value to the appropriate type.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
