### PR TITLE
[ADF-4524] Checkbox widget is not displayed on a form on APS1 when having some visibility conditions on it

### DIFF
--- a/lib/core/form/services/widget-visibility.service.spec.ts
+++ b/lib/core/form/services/widget-visibility.service.spec.ts
@@ -38,6 +38,7 @@ describe('WidgetVisibilityService', () => {
 
     let service: WidgetVisibilityService;
     let booleanResult: boolean;
+    let stringResult: string;
     const stubFormWithFields = new FormModel(fakeFormJson);
 
     setupTestBed({
@@ -61,49 +62,29 @@ describe('WidgetVisibilityService', () => {
 
     describe('should be able to evaluate logic operations', () => {
 
-        it('using AND and return true', () => {
-            booleanResult = service.evaluateLogicalOperation('and', true, true);
-            expect(booleanResult).toBeTruthy();
+        it('using AND', () => {
+            stringResult = service.getLogicalOperator('and');
+            expect(stringResult).toBe(' && ');
         });
 
-        it('using AND and return false', () => {
-            booleanResult = service.evaluateLogicalOperation('and', true, false);
-            expect(booleanResult).toBeFalsy();
+        it('using OR', () => {
+            stringResult = service.getLogicalOperator('or');
+            expect(stringResult).toBe(' || ');
         });
 
-        it('using OR and return true', () => {
-            booleanResult = service.evaluateLogicalOperation('or', true, false);
-            expect(booleanResult).toBeTruthy();
+        it('using AND NOT', () => {
+            stringResult = service.getLogicalOperator('and-not');
+            expect(stringResult).toBe(' && !');
         });
 
-        it('using OR and return false', () => {
-            booleanResult = service.evaluateLogicalOperation('or', false, false);
-            expect(booleanResult).toBeFalsy();
-        });
-
-        it('using AND NOT and return true', () => {
-            booleanResult = service.evaluateLogicalOperation('and-not', true, false);
-            expect(booleanResult).toBeTruthy();
-        });
-
-        it('using AND NOT and return false', () => {
-            booleanResult = service.evaluateLogicalOperation('and-not', false, false);
-            expect(booleanResult).toBeFalsy();
-        });
-
-        it('using OR NOT and return true', () => {
-            booleanResult = service.evaluateLogicalOperation('or-not', true, true);
-            expect(booleanResult).toBeTruthy();
-        });
-
-        it('using OR NOT and return false', () => {
-            booleanResult = service.evaluateLogicalOperation('or-not', false, true);
-            expect(booleanResult).toBeFalsy();
+        it('using OR NOT', () => {
+            stringResult = service.getLogicalOperator('or-not');
+            expect(stringResult).toBe(' || !');
         });
 
         it('should fail with invalid operation', () => {
-            booleanResult = service.evaluateLogicalOperation(undefined, false, true);
-            expect(booleanResult).toBeUndefined();
+            stringResult = service.getLogicalOperator('');
+            expect(stringResult).toBeUndefined();
         });
     });
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Sicne the visibility condition is evaluated in a diffrent way in ADF than the APS1 angular 1 app, some visibility conditions are wrongly evaluated in ADF. ADF uses recursion to evaluate the conditions as result an expression like `false && true && false || false || true`  is evaluated as `false && (true && (false || (false || true)))` and results `false` instead of `true`.

**What is the new behaviour?**

* Used eval to evaluate the expression

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
