### PR TITLE
[ADF-4034] Task list cloud - The Deleted task is changing the Status from "Deleted" in "Canceled"

### DIFF
--- a/lib/process-services-cloud/src/lib/task/task-filters/components/edit-task-filter-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/task/task-filters/components/edit-task-filter-cloud.component.spec.ts
@@ -190,7 +190,7 @@ describe('EditTaskFilterCloudComponent', () => {
             fixture.detectChanges();
             fixture.whenStable().then(() => {
                 const statusOptions = fixture.debugElement.queryAll(By.css('.mat-option-text'));
-                expect(statusOptions.length).toEqual(7);
+                expect(statusOptions.length).toEqual(6);
             });
         }));
 

--- a/lib/process-services-cloud/src/lib/task/task-filters/components/edit-task-filter-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-filters/components/edit-task-filter-cloud.component.ts
@@ -94,8 +94,7 @@ export class EditTaskFilterCloudComponent implements OnInit, OnChanges {
         { label: 'CANCELLED', value: 'CANCELLED' },
         { label: 'ASSIGNED', value: 'ASSIGNED' },
         { label: 'SUSPENDED', value: 'SUSPENDED' },
-        { label: 'COMPLETED', value: 'COMPLETED' },
-        { label: 'DELETED', value: 'DELETED' }
+        { label: 'COMPLETED', value: 'COMPLETED' }
     ];
 
     directions = [


### PR DESCRIPTION

Removed DELETED status
Modified unit test to check recent changes

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
'Deleted' option is available in the Task Status dropdown


**What is the new behaviour?**
'Deleted' option is not shown in the Task Status dropdown


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**: NA
