### PR TITLE
[ADF-4567]Add a test for 'Should have all the fields on the task header cloud r…

### DIFF
--- a/lib/testing/src/lib/process-services-cloud/pages/task-form-cloud-component.page.ts
+++ b/lib/testing/src/lib/process-services-cloud/pages/task-form-cloud-component.page.ts
@@ -23,6 +23,7 @@ export class TaskFormCloudComponent {
 
     cancelButton = element(by.css("button[id='adf-cloud-cancel-task']"));
     completeButton = element(by.css('button[adf-cloud-complete-task]'));
+    claimButton = element(by.css('button[adf-cloud-claim-task]'));
 
     checkCompleteButtonIsDisplayed() {
         BrowserVisibility.waitUntilElementIsVisible(this.completeButton);
@@ -44,4 +45,9 @@ export class TaskFormCloudComponent {
         return this;
     }
 
-}
+    clickClaimButton() {
+        BrowserActions.click(this.claimButton);
+        return this;
+    }
+
+    }

--- a/lib/testing/src/lib/process-services-cloud/pages/task-header-cloud-component.page.ts
+++ b/lib/testing/src/lib/process-services-cloud/pages/task-header-cloud-component.page.ts
@@ -17,6 +17,7 @@
 
 import { element, by } from 'protractor';
 import { BrowserActions } from '../../core/utils/browser-actions';
+import { BrowserVisibility } from '../../core/utils/browser-visibility';
 
 export class TaskHeaderCloudPage {
 
@@ -32,6 +33,8 @@ export class TaskHeaderCloudPage {
     idField = element.all(by.css('span[data-automation-id*="id"] span')).first();
     descriptionField = element(by.css('span[data-automation-id*="description"] span'));
     taskPropertyList = element(by.css('adf-cloud-task-header adf-card-view div[class="adf-property-list"]'));
+    descriptionEditIcon = element(by.css('mat-icon[data-automation-id*="edit-icon-description"]'));
+    priorityEditIcon = element(by.css('mat-icon[data-automation-id*="edit-icon-priority"]'));
 
     getAssignee() {
         return BrowserActions.getText(this.assigneeField);
@@ -75,6 +78,22 @@ export class TaskHeaderCloudPage {
 
     getDueDate() {
         return BrowserActions.getText(this.dueDateField);
+    }
+
+    checkDescriptionEditIconIsDisplayed() {
+        return BrowserVisibility.waitUntilElementIsVisible(this.descriptionEditIcon);
+    }
+
+    checkPriorityEditIconIsDisplayed() {
+        return BrowserVisibility.waitUntilElementIsVisible(this.priorityEditIcon);
+    }
+
+    checkDescriptionEditIconIsNotDisplayed() {
+        return BrowserVisibility.waitUntilElementIsNotVisible(this.descriptionEditIcon);
+    }
+
+    checkPriorityEditIconIsNotDisplayed() {
+        return BrowserVisibility.waitUntilElementIsNotVisible(this.priorityEditIcon);
     }
 
 }


### PR DESCRIPTION
…eadonly when the task is unclaimed.'

**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-4567