### PR TITLE
[ADF-4633] DemoShell - MatIcon directionality

### DIFF
--- a/demo-shell/src/app/app.component.scss
+++ b/demo-shell/src/app/app.component.scss
@@ -12,6 +12,10 @@ router-outlet[name='overlay'] + * {
     width: 100%;
 }
 
+[dir='rtl'] .mat-icon {
+    transform: scale(-1, 1);
+}
+
 @media (max-width: 425px) {
     adf-content-node-selector {
         .adf-content-node-selector-content-list {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
[ADF-4633](https://issues.alfresco.com/jira/browse/ADF-4633)


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
[mat-icon](https://material.angular.io/components/icon/overview#bidirectionality) doesn't support directionality out of the box and manually adding the proposed class to every icon and remembering to do this its an overload. 

❗️ Documentation for this change has been documented in https://github.com/Alfresco/alfresco-ng2-components/pull/4814