### PR TITLE
fix adf-delete directive NodeResult

### DIFF
--- a/lib/core/directives/node-delete.directive.ts
+++ b/lib/core/directives/node-delete.directive.ts
@@ -110,7 +110,7 @@ export class NodeDeleteDirective implements OnChanges {
 
         let promise;
 
-        if (node.entry.hasOwnProperty('archivedAt')) {
+        if (node.entry.hasOwnProperty('archivedAt') && node.entry['archivedAt']) {
             promise = this.alfrescoApiService.nodesApi.purgeDeletedNode(id);
         } else {
             promise = this.alfrescoApiService.nodesApi.deleteNode(id, { permanent: this.permanent });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
when you want to use the "adf-delete" directive from a search result ("search api" which returns a json (context, entries, pagination), an error occurs because the "archived_at" metadata exists but it is null!
 


**What is the new behaviour?**
the deletion works because I test if the "archived_at" property exists but also if it is different from null!


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
