### PR TITLE
[ADF-4677] Make time ago use Angular Date formats

### DIFF
--- a/lib/core/pipes/time-ago.pipe.ts
+++ b/lib/core/pipes/time-ago.pipe.ts
@@ -19,6 +19,7 @@ import moment from 'moment-es6';
 import { Pipe, PipeTransform } from '@angular/core';
 import { AppConfigService } from '../app-config/app-config.service';
 import { UserPreferenceValues, UserPreferencesService } from '../services/user-preferences.service';
+import { DatePipe } from '@angular/common';
 
 @Pipe({
     name: 'adfTimeAgo'
@@ -26,7 +27,7 @@ import { UserPreferenceValues, UserPreferencesService } from '../services/user-p
 export class TimeAgoPipe implements PipeTransform {
 
     static DEFAULT_LOCALE = 'en-US';
-    static DEFAULT_DATE_TIME_FORMAT = 'DD/MM/YYYY HH:mm';
+    static DEFAULT_DATE_TIME_FORMAT = 'dd/MM/yyyy HH:mm';
 
     defaultLocale: string;
     defaultDateTimeFormat: string;
@@ -44,7 +45,12 @@ export class TimeAgoPipe implements PipeTransform {
             const actualLocale = locale || this.defaultLocale;
             const then = moment(value);
             const diff = moment().locale(actualLocale).diff(then, 'days');
-            return diff > 7 ? then.locale(actualLocale).format(this.defaultDateTimeFormat) : then.locale(actualLocale).fromNow();
+            if ( diff > 7) {
+                const datePipe: DatePipe = new DatePipe(actualLocale);
+                return datePipe.transform(value, this.defaultDateTimeFormat);
+            } else {
+                return then.locale(actualLocale).fromNow();
+            }
         }
         return '';
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Date isn't displayed properly in DocumentList
https://issues.alfresco.com/jira/browse/ADF-4677

**What is the new behaviour?**
The timeAgo pipe was using Moment formats to build dates instead of the Angular Date formats that are needed to make it work


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-4677