### PR TITLE
[ADF-4499] Form definition selector should only display standAlone co…

### DIFF
--- a/docs/process-services-cloud/components/form-definition-selector-cloud.component.md
+++ b/docs/process-services-cloud/components/form-definition-selector-cloud.component.md
@@ -6,7 +6,7 @@ Status: Active
 
 # [Form Definition Selector Cloud](../../../lib/process-services-cloud/src/lib/form/components/form-definition-selector-cloud.component.ts "Defined in form-definition-selector-cloud.component.ts")
 
-Allows one form to be selected.
+Allows one form to be selected from a dropdown list. For forms to be displayed in this component they will need to be compatible with standAlone tasks. 
 
 ## Basic Usage
 

--- a/lib/process-services-cloud/src/lib/form/components/form-definition-selector-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/form-definition-selector-cloud.component.spec.ts
@@ -42,7 +42,7 @@ describe('FormDefinitionCloudComponent', () => {
         fixture = TestBed.createComponent(FormDefinitionSelectorCloudComponent);
         element = fixture.nativeElement;
         service = TestBed.get(FormDefinitionSelectorCloudService);
-        getFormsSpy = spyOn(service, 'getForms').and.returnValue(of([{ id: 'fake-form', name: 'fakeForm' }]));
+        getFormsSpy = spyOn(service, 'getStandAloneTaskForms').and.returnValue(of([{ id: 'fake-form', name: 'fakeForm' }]));
     });
 
     it('should load the forms by default', () => {

--- a/lib/process-services-cloud/src/lib/form/components/form-definition-selector-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/form/components/form-definition-selector-cloud.component.ts
@@ -43,7 +43,7 @@ export class FormDefinitionSelectorCloudComponent implements OnInit {
     }
 
     ngOnInit(): void {
-        this.forms$ = this.formDefinitionCloudService.getForms(this.appName);
+        this.forms$ = this.formDefinitionCloudService.getStandAloneTaskForms(this.appName);
     }
 
     onSelect(event: MatSelectChange) {

--- a/lib/process-services-cloud/src/lib/form/models/form-definition-selector-cloud.model.ts
+++ b/lib/process-services-cloud/src/lib/form/models/form-definition-selector-cloud.model.ts
@@ -21,6 +21,7 @@ export class FormDefinitionSelectorCloudModel {
     name: string;
     description: string;
     version: string;
+    standAlone: string;
 
     constructor(obj?: any) {
         if (obj) {
@@ -28,6 +29,7 @@ export class FormDefinitionSelectorCloudModel {
             this.name = obj.name || null;
             this.description = obj.description || null;
             this.version = obj.version || null;
+            this.standAlone = obj.standAlone || null;
         }
     }
 }

--- a/lib/process-services-cloud/src/lib/form/services/form-definition-selector-cloud.service.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/services/form-definition-selector-cloud.service.spec.ts
@@ -17,7 +17,7 @@
 
 import { TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { AlfrescoApiService, CoreModule, setupTestBed, AppConfigService, AppConfigServiceMock } from '@alfresco/adf-core';
+import { AlfrescoApiService, CoreModule, setupTestBed, AppConfigService } from '@alfresco/adf-core';
 import { FormDefinitionSelectorCloudService } from './form-definition-selector-cloud.service';
 
 declare let jasmine: any;
@@ -51,11 +51,6 @@ const responseBody = [
     }
 ];
 
-const alfrescoApiServiceStub = {
-    getInstance() { },
-    load() { }
-};
-
 const oauth2Auth = jasmine.createSpyObj('oauth2Auth', ['callCustomApi']);
 
 describe('Form Definition Selector Cloud Service', () => {
@@ -71,8 +66,8 @@ describe('Form Definition Selector Cloud Service', () => {
         ],
         providers: [
             FormDefinitionSelectorCloudService,
-            { provide: AlfrescoApiService, useValue: alfrescoApiServiceStub },
-            { provide: AppConfigService, useClass: AppConfigServiceMock }
+            AlfrescoApiService,
+            AppConfigService
         ]
     });
 

--- a/lib/process-services-cloud/src/lib/form/services/form-definition-selector-cloud.service.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/services/form-definition-selector-cloud.service.spec.ts
@@ -1,0 +1,106 @@
+/*!
+ * @license
+ * Copyright 2019 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { AlfrescoApiService, CoreModule, setupTestBed, AppConfigService, AppConfigServiceMock } from '@alfresco/adf-core';
+import { FormDefinitionSelectorCloudService } from './form-definition-selector-cloud.service';
+
+declare let jasmine: any;
+
+const responseBody = [
+    {
+        formRepresentation: {
+            id: 'form-de8895be-d0d7-4434-beef-559b15305d72',
+            name: 'Form 1',
+            description: '',
+            version: 0,
+            standAlone: true
+        }
+    },
+    {
+        formRepresentation: {
+            id: 'form-de8895be-d0d7-4434-beef-fgr34ttgrtgd',
+            name: 'Form 2',
+            description: '',
+            version: 0,
+            standAlone: false
+        }
+    },
+    {
+        formRepresentation: {
+            id: 'form-de8895be-d0d7-4434-beef-53453453452',
+            name: 'Form 3',
+            description: '',
+            version: 0
+        }
+    }
+];
+
+const alfrescoApiServiceStub = {
+    getInstance() { },
+    load() { }
+};
+
+const oauth2Auth = jasmine.createSpyObj('oauth2Auth', ['callCustomApi']);
+
+describe('Form Definition Selector Cloud Service', () => {
+
+    let service: FormDefinitionSelectorCloudService;
+    let apiService: AlfrescoApiService;
+    const appName = 'app-name';
+
+    setupTestBed({
+        imports: [
+            NoopAnimationsModule,
+            CoreModule.forRoot()
+        ],
+        providers: [
+            FormDefinitionSelectorCloudService,
+            { provide: AlfrescoApiService, useValue: alfrescoApiServiceStub },
+            { provide: AppConfigService, useClass: AppConfigServiceMock }
+        ]
+    });
+
+    beforeEach(() => {
+        service = TestBed.get(FormDefinitionSelectorCloudService);
+        apiService = TestBed.get(AlfrescoApiService);
+        spyOn(apiService, 'getInstance').and.returnValue({ oauth2Auth: oauth2Auth });
+    });
+
+    it('should fetch all the forms when getForms is called', (done) => {
+        oauth2Auth.callCustomApi.and.returnValue(Promise.resolve(responseBody));
+
+        service.getForms(appName).subscribe((result) => {
+            expect(result).toBeDefined();
+            expect(result.length).toBe(3);
+            done();
+        });
+    });
+
+    it('hould fetch only standAlone enabled forms when getStandAloneTaskForms is called', (done) => {
+        oauth2Auth.callCustomApi.and.returnValue(Promise.resolve(responseBody));
+
+        service.getStandAloneTaskForms(appName).subscribe((result) => {
+            expect(result).toBeDefined();
+            expect(result.length).toBe(2);
+            expect(result[0].name).toBe('Form 1');
+            expect(result[1].name).toBe('Form 3');
+            done();
+        });
+    });
+});

--- a/lib/process-services-cloud/src/lib/form/services/form-definition-selector-cloud.service.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/services/form-definition-selector-cloud.service.spec.ts
@@ -87,7 +87,7 @@ describe('Form Definition Selector Cloud Service', () => {
         });
     });
 
-    it('hould fetch only standAlone enabled forms when getStandAloneTaskForms is called', (done) => {
+    it('should fetch only standAlone enabled forms when getStandAloneTaskForms is called', (done) => {
         oauth2Auth.callCustomApi.and.returnValue(Promise.resolve(responseBody));
 
         service.getStandAloneTaskForms(appName).subscribe((result) => {

--- a/lib/process-services-cloud/src/lib/form/services/form-definition-selector-cloud.service.ts
+++ b/lib/process-services-cloud/src/lib/form/services/form-definition-selector-cloud.service.ts
@@ -65,6 +65,33 @@ export class FormDefinitionSelectorCloudService extends BaseCloudService {
         );
     }
 
+    /**
+     * Get all forms of an app.
+     * @param appName Name of the application
+     * @returns Details of the forms
+     */
+    getStandAloneTaskForms(appName: string): Observable<FormDefinitionSelectorCloudModel[]> {
+
+        const queryUrl = this.buildGetFormsUrl(appName);
+        const bodyParam = {}, pathParams = {}, queryParams = {}, headerParams = {},
+            formParams = {}, contentTypes = ['application/json'], accepts = ['application/json'];
+        return from(
+            this.apiService
+                .getInstance()
+                .oauth2Auth.callCustomApi(
+                queryUrl, 'GET', pathParams, queryParams,
+                headerParams, formParams, bodyParam,
+                contentTypes, accepts, null, null)
+        ).pipe(
+            map((data: any) => {
+                return data
+                .filter((formData: any) => formData.formRepresentation.standAlone || formData.formRepresentation.standAlone === undefined)
+                .map((formData: any) => <FormDefinitionSelectorCloudModel> formData.formRepresentation);
+            }),
+            catchError((err) => this.handleError(err))
+        );
+    }
+
     private buildGetFormsUrl(appName: string): any {
         return `${this.getBasePath(appName)}/form/v1/forms`;
     }

--- a/lib/process-services-cloud/src/lib/form/services/form-definition-selector-cloud.service.ts
+++ b/lib/process-services-cloud/src/lib/form/services/form-definition-selector-cloud.service.ts
@@ -71,25 +71,13 @@ export class FormDefinitionSelectorCloudService extends BaseCloudService {
      * @returns Details of the forms
      */
     getStandAloneTaskForms(appName: string): Observable<FormDefinitionSelectorCloudModel[]> {
-
-        const queryUrl = this.buildGetFormsUrl(appName);
-        const bodyParam = {}, pathParams = {}, queryParams = {}, headerParams = {},
-            formParams = {}, contentTypes = ['application/json'], accepts = ['application/json'];
-        return from(
-            this.apiService
-                .getInstance()
-                .oauth2Auth.callCustomApi(
-                queryUrl, 'GET', pathParams, queryParams,
-                headerParams, formParams, bodyParam,
-                contentTypes, accepts, null, null)
-        ).pipe(
+        return from(this.getForms(appName)).pipe(
             map((data: any) => {
-                return data
-                .filter((formData: any) => formData.formRepresentation.standAlone || formData.formRepresentation.standAlone === undefined)
-                .map((formData: any) => <FormDefinitionSelectorCloudModel> formData.formRepresentation);
+                return data.filter((formData: any) => formData.standAlone || formData.standAlone === undefined);
             }),
             catchError((err) => this.handleError(err))
         );
+
     }
 
     private buildGetFormsUrl(appName: string): any {


### PR DESCRIPTION
…mpatible forms

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-4699
Form definition selector displays all forms contained in a certain app

**What is the new behaviour?**
The form definition selector should filter by forms that are standAlone task compatible.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-4699