### PR TITLE
[ADF-4721] Fix Material Datetime Picker date format

### DIFF
--- a/demo-shell/src/app.config.json
+++ b/demo-shell/src/app.config.json
@@ -441,7 +441,7 @@
   "dateValues":{
     "defaultDateFormat": "mediumDate",
     "defaultDateTimeFormat": "MMM d, y, H:mm",
-    "defaultLocale": "en-US"
+    "defaultLocale": "en"
   },
   "files": {
     "excluded": [

--- a/lib/core/card-view/components/card-view-dateitem/card-view-dateitem.component.ts
+++ b/lib/core/card-view/components/card-view-dateitem/card-view-dateitem.component.ts
@@ -68,7 +68,7 @@ export class CardViewDateItemComponent implements OnInit {
             this.dateAdapter.setLocale(locale);
         });
 
-        (<MomentDateAdapter> this.dateAdapter).overrideDisplayFormat = this.dateFormat;
+        (<MomentDateAdapter> this.dateAdapter).overrideDisplayFormat = 'MMM DD';
 
         if (this.property.value) {
             this.valueDate = moment(this.property.value, this.dateFormat);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-4721


**What is the new behaviour?**
The material datetime picker we use in the cardview was getting an angular date format instead of the moment.js format it should get.
The default locale for an ADF app is `en`. `en-US` is not a valid locale when trying to fetch the i18n file.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-4721