### PR TITLE
[ADF-4726] fileSize header is now left aligned with bottom cells

### DIFF
--- a/lib/core/datatable/components/datatable/datatable.component.scss
+++ b/lib/core/datatable/components/datatable/datatable.component.scss
@@ -333,6 +333,11 @@
             &.adf-datatable__header--sorted-desc::before {
                 content: '\e5db';
             }
+            &.adf-datatable-cell--fileSize.adf-datatable__header--sorted-asc::before,
+            &.adf-datatable-cell--fileSize.adf-datatable__header--sorted-desc::before {
+                left: -3px;
+                right: -3px;
+            }
 
             &.adf-datatable-checkbox {
                 display: flex;
@@ -388,6 +393,9 @@
                 screen and (-ms-high-contrast: none) {
                     padding: 17px 10px 10px;
                 }
+            }
+            &--fileSize .adf-datatable-cell-value {
+                padding: 0;
             }
 
             &:focus {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe: visual changes


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-4726


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
