### PR TITLE
[ADF-4682] Fix displayed date in date time and date widget

### DIFF
--- a/lib/core/form/components/widgets/date-time/date-time.widget.ts
+++ b/lib/core/form/components/widgets/date-time/date-time.widget.ts
@@ -70,7 +70,7 @@ export class DateTimeWidgetComponent extends WidgetComponent implements OnInit {
                 this.maxDate = moment(this.field.maxValue, 'YYYY-MM-DDTHH:mm:ssZ');
             }
         }
-        this.displayDate = moment(this.field.value, this.field.dateDisplayFormat);
+        this.displayDate = moment(this.field.value);
     }
 
     onDateChanged(newDateValue) {

--- a/lib/core/form/components/widgets/date/date.widget.ts
+++ b/lib/core/form/components/widgets/date/date.widget.ts
@@ -68,7 +68,7 @@ export class DateWidgetComponent extends WidgetComponent implements OnInit {
                 this.maxDate = moment(this.field.maxValue, this.DATE_FORMAT);
             }
         }
-        this.displayDate = moment(this.field.value, this.field.dateDisplayFormat);
+        this.displayDate = moment(this.field.value);
     }
 
     onDateChanged(newDateValue) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-4682
The date in this two widgets do not match the display date format value. 

**What is the new behaviour?**
The display date was formatted twice and this resulted in an error that changed and transformed the date to display.
The moment adapter that we use is in change of replacing and formatting this new date according to its display format

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-4682