### PR TITLE
[ADF-4716][ADF-3247] Tests for checking saved date format

### DIFF
--- a/e2e/process-services/dynamic-table-date-picker.e2e.ts
+++ b/e2e/process-services/dynamic-table-date-picker.e2e.ts
@@ -116,7 +116,6 @@ describe('Dynamic Table', () => {
             widget.dynamicTable().clickAddButton();
             widget.dynamicTable().addRandomStringOnDate(randomText.wrongDate);
             widget.dynamicTable().clickSaveButton();
-
             expect(widget.dynamicTable().checkErrorMessage()).toBe(randomText.error);
 
             widget.dynamicTable().clickDateWidget();
@@ -130,7 +129,6 @@ describe('Dynamic Table', () => {
         it('[C311456] Should be able to delete date that is not mandatory and save the Dynamic Table', () => {
             widget.dynamicTable().clickAddButton();
             widget.dynamicTable().clickSaveButton();
-
             expect(widget.dynamicTable().checkErrorMessage()).toBe(randomText.requiredError);
 
             widget.dynamicTable().clickDateWidget();

--- a/e2e/process-services/dynamic-table-date-picker.e2e.ts
+++ b/e2e/process-services/dynamic-table-date-picker.e2e.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { LoginPage, Widget, DatePickerPage } from '@alfresco/adf-testing';
+import { LoginPage, Widget, DatePickerPage, DateUtil } from '@alfresco/adf-testing';
 import { ProcessFiltersPage } from '../pages/adf/process-services/processFiltersPage';
 import { ProcessServiceTabBarPage } from '../pages/adf/process-services/processServiceTabBarPage';
 import { NavigationBarPage } from '../pages/adf/navigationBarPage';
@@ -69,10 +69,12 @@ describe('Dynamic Table', () => {
         const randomText = {
             date: '12/12/2012',
             wrongDate: 'HELLO WORLD',
-            dateTime: 'Test',
-            error: `Invalid 'columnDate' format.`
+            wrongDateTime: 'Test',
+            dateTime: '15/07/2019 23:55',
+            error: `Invalid 'columnDate' format.`,
+            requiredError: `Field 'columnDate' is required.`
         };
-
+        const currentDate = DateUtil.formatDate('DD-MM-YYYY');
         const rowPosition = 0;
 
         beforeAll(async (done) => {
@@ -107,7 +109,7 @@ describe('Dynamic Table', () => {
             widget.dynamicTable().clickAddButton();
             widget.dynamicTable().clickColumnDateTime();
 
-            expect(widget.dynamicTable().addRandomStringOnDateTime(randomText.dateTime)).toBe('');
+            expect(widget.dynamicTable().addRandomStringOnDateTime(randomText.wrongDateTime)).toBe('');
         });
 
         it('[C286279] Should be able to save row with Date field', () => {
@@ -122,6 +124,22 @@ describe('Dynamic Table', () => {
                 .checkDatePickerIsNotDisplayed();
             widget.dynamicTable().clickSaveButton();
             widget.dynamicTable().getTableRow(rowPosition);
+            expect(widget.dynamicTable().getTableCellText(rowPosition, 1)).toBe(currentDate);
+        });
+
+        it('[C311456] Should be able to delete date that is not mandatory and save the Dynamic Table', () => {
+            widget.dynamicTable().clickAddButton();
+            widget.dynamicTable().clickSaveButton();
+
+            expect(widget.dynamicTable().checkErrorMessage()).toBe(randomText.requiredError);
+
+            widget.dynamicTable().clickDateWidget();
+            datePicker.selectTodayDate()
+                .checkDatePickerIsNotDisplayed();
+            widget.dynamicTable().clickSaveButton();
+            widget.dynamicTable().getTableRow(rowPosition);
+            expect(widget.dynamicTable().getTableCellText(rowPosition, 1)).toBe(currentDate);
+            expect(widget.dynamicTable().getTableCellText(rowPosition, 2)).toBe('');
         });
     });
 

--- a/lib/testing/src/lib/core/pages/form/widgets/dynamicTableWidget.ts
+++ b/lib/testing/src/lib/core/pages/form/widgets/dynamicTableWidget.ts
@@ -120,6 +120,10 @@ export class DynamicTableWidget {
         return BrowserVisibility.waitUntilElementIsVisible(this.tableRow.get(rowNumber));
     }
 
+    getTableCellText(rowNumber: number, columnNumber: number) {
+        return BrowserActions.getText(this.tableRow.get(rowNumber).element(by.xpath(`td[${columnNumber}]`)));
+    }
+
     checkItemIsPresent(item) {
         const row = element(by.cssContainingText('table tbody tr td span', item));
         const present = BrowserVisibility.waitUntilElementIsVisible(row);


### PR DESCRIPTION
…e to save the dynamic table with non-required DateTime field.

**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Before the Date was not saved properly and was displayed differently to what was the selected Date after save.
Also, was not allowing the user to save the Dynamic table with DateTime field empty, when it is not mandatory.

**What is the new behaviour?**
The tests check now for the format of the saved date displayed to the user.
Also user is able to save the Dynamic Table now, with DateTime field empty, if it's not a mandatory field.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
