### PR TITLE
[ADF-4480] Viewer shows endless spinner for unsupported files

### DIFF
--- a/e2e/core/viewer/viewer-content-services-component.e2e.ts
+++ b/e2e/core/viewer/viewer-content-services-component.e2e.ts
@@ -307,6 +307,8 @@ describe('Content Services Viewer', () => {
         viewerPage.checkInfoButtonIsDisplayed();
 
         viewerPage.checkZoomInButtonIsNotDisplayed();
+        viewerPage.checkUnknownFormatIsDisplayed();
+        expect(viewerPage.getUnknownFormatMessage()).toBe('Couldn\'t load preview. Unknown format.');
 
         viewerPage.clickCloseButton();
     });

--- a/e2e/pages/adf/viewerPage.ts
+++ b/e2e/pages/adf/viewerPage.ts
@@ -100,6 +100,7 @@ export class ViewerPage {
 
     showTabWithIconSwitch = element(by.id('adf-tab-with-icon'));
     showTabWithIconAndLabelSwitch = element(by.id('adf-icon-and-label-tab'));
+    unknownFormat = element(by.css(`adf-viewer-unknown-format .adf-viewer__unknown-format-view`));
 
     checkCodeViewerIsDisplayed() {
         return BrowserVisibility.waitUntilElementIsVisible(this.codeViewer);
@@ -666,5 +667,15 @@ export class ViewerPage {
     getTabIconById(index: number) {
         const tab = element(by.css(`div[id="mat-tab-label-1-${index}"] div[class="mat-tab-label-content"] mat-icon`));
         return BrowserActions.getText(tab);
+    }
+
+    checkUnknownFormatIsDisplayed() {
+        BrowserVisibility.waitUntilElementIsVisible(this.unknownFormat);
+        return this;
+    }
+
+    getUnknownFormatMessage() {
+        const unknownFormatLabel = this.unknownFormat.element(by.css(`.label`));
+        return BrowserActions.getText(unknownFormatLabel);
     }
 }

--- a/e2e/pages/adf/viewerPage.ts
+++ b/e2e/pages/adf/viewerPage.ts
@@ -670,7 +670,7 @@ export class ViewerPage {
     }
 
     checkUnknownFormatIsDisplayed() {
-        BrowserVisibility.waitUntilElementIsVisible(this.unknownFormat);
+        return BrowserVisibility.waitUntilElementIsVisible(this.unknownFormat);
     }
 
     getUnknownFormatMessage() {

--- a/e2e/pages/adf/viewerPage.ts
+++ b/e2e/pages/adf/viewerPage.ts
@@ -671,7 +671,6 @@ export class ViewerPage {
 
     checkUnknownFormatIsDisplayed() {
         BrowserVisibility.waitUntilElementIsVisible(this.unknownFormat);
-        return this;
     }
 
     getUnknownFormatMessage() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
The current behaviour is to show endless spinner when the file is unsupported in th viewer.


**What is the new behaviour?**
The new behaviour is to show the unknown format message to the user.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-4480