### PR TITLE
[ADF-4753] - fixed calling for standalone task

### DIFF
--- a/lib/process-services-cloud/src/lib/form/components/form-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/form-cloud.component.spec.ts
@@ -238,35 +238,34 @@ describe('FormCloudComponent', () => {
     });
 
     it('should call the process storage to retrieve the folder with only the taskId', fakeAsync(() => {
-        spyOn(formComponent, 'getFormByTaskId').and.stub();
+        spyOn(formCloudService, 'getTaskForm').and.returnValue(of(cloudFormMock));
+        spyOn(formCloudService, 'getTaskVariables').and.returnValue(of({list: { entries: []}}));
         spyOn(formCloudService, 'getProcessStorageFolderTask')
             .and.returnValue( of({nodeId : '123', path: '/a/path/type', type: 'fakeType'}));
         const taskId = '<task id>';
         const appName = 'test-app';
         formComponent.appName = appName;
-        formComponent.form = new FormCloud({id : 'fake-form-id'});
-        formComponent.form['hasUpload'] = true;
         formComponent.taskId = taskId;
         formComponent.readOnly = false;
 
-        const change = new SimpleChange(null, 'new-app-name', true);
+        const change = new SimpleChange(null, appName, true);
         formComponent.ngOnChanges({ 'appName': change });
         tick();
+
         expect(formCloudService.getProcessStorageFolderTask).toHaveBeenCalledWith(appName, taskId, undefined);
         expect(formComponent.form.nodeId).toBe('123');
         expect(formComponent.form.contentHost).toBe('/a/path/type');
     }));
 
     it('should call the process storage to retrieve the folder with taskId and processInstanceId', fakeAsync(() => {
-        spyOn(formComponent, 'getFormByTaskId').and.stub();
+        spyOn(formCloudService, 'getTaskForm').and.returnValue(of(cloudFormMock));
+        spyOn(formCloudService, 'getTaskVariables').and.returnValue(of({list: { entries: []}}));
         spyOn(formCloudService, 'getProcessStorageFolderTask')
             .and.returnValue( of({nodeId : '123', path: '/a/path/type', type: 'fakeType'}));
         const taskId = '<task id>';
         const processInstanceId = 'i-am-the-process-instance-id';
         const appName = 'test-app';
         formComponent.appName = appName;
-        formComponent.form = new FormCloud({id : 'fake-form-id'});
-        formComponent.form['hasUpload'] = true;
         formComponent.taskId = taskId;
         formComponent.processInstanceId = processInstanceId;
         formComponent.readOnly = false;

--- a/lib/process-services-cloud/src/lib/form/components/form-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/form-cloud.component.spec.ts
@@ -246,7 +246,6 @@ describe('FormCloudComponent', () => {
         const appName = 'test-app';
         formComponent.appName = appName;
         formComponent.taskId = taskId;
-        formComponent.readOnly = false;
 
         const change = new SimpleChange(null, appName, true);
         formComponent.ngOnChanges({ 'appName': change });
@@ -268,7 +267,6 @@ describe('FormCloudComponent', () => {
         formComponent.appName = appName;
         formComponent.taskId = taskId;
         formComponent.processInstanceId = processInstanceId;
-        formComponent.readOnly = false;
 
         const change = new SimpleChange(null, 'new-app-name', true);
         formComponent.ngOnChanges({ 'appName': change });

--- a/lib/process-services-cloud/src/lib/form/components/form-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/form/components/form-cloud.component.ts
@@ -117,10 +117,8 @@ export class FormCloudComponent extends FormBaseComponent implements OnChanges, 
     ngOnChanges(changes: SimpleChanges) {
         const appName = changes['appName'];
         if (appName && appName.currentValue) {
-            if (this.taskId && this.processInstanceId) {
+            if (this.taskId) {
                 this.getFormDefinitionWithFolderTask(this.appName, this.taskId, this.processInstanceId);
-            } else if (this.taskId) {
-                this.getFormByTaskId(this.appName, this.taskId);
             } else if (this.formId) {
                 this.getFormById(appName.currentValue, this.formId);
             }

--- a/lib/process-services-cloud/src/lib/form/services/form-cloud.service.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/services/form-cloud.service.spec.ts
@@ -138,7 +138,6 @@ describe('Form Cloud service', () => {
                 expect(oauth2Auth.callCustomApi.calls.mostRecent().args[1]).toBe('GET');
                 done();
             });
-
         });
 
         it('should fetch task form flattened', (done) => {
@@ -185,6 +184,45 @@ describe('Form Cloud service', () => {
                 done();
             });
 
+        });
+
+        it('should fetch process storage folder with process instance id and task id', (done) => {
+            oauth2Auth.callCustomApi.and.returnValue(Promise.resolve({
+                    nodeId: 'fake-node-id-really-long',
+                    path: 'path/to/node/id',
+                    type: 'nodeType'
+              }));
+
+            service.getProcessStorageFolderTask(appName, taskId, processInstanceId).subscribe((result) => {
+                expect(result).toBeDefined();
+                expect(result).not.toBeNull();
+                expect(result.nodeId).toBe('fake-node-id-really-long');
+                expect(result.path).toBe('path/to/node/id');
+                expect(result.type).toBe('nodeType');
+                expect(oauth2Auth.callCustomApi.calls.mostRecent().args[0].endsWith(`${appName}/process-storage/v1/folders/${processInstanceId}/${taskId}`)).toBeTruthy();
+                expect(oauth2Auth.callCustomApi.calls.mostRecent().args[1]).toBe('GET');
+                done();
+            });
+        });
+
+
+        it('should fetch process storage folder with task id only', (done) => {
+            oauth2Auth.callCustomApi.and.returnValue(Promise.resolve({
+                    nodeId: 'fake-node-id-really-long',
+                    path: 'path/to/node/id',
+                    type: 'nodeType'
+              }));
+
+            service.getProcessStorageFolderTask(appName, taskId, null).subscribe((result) => {
+                expect(result).toBeDefined();
+                expect(result).not.toBeNull();
+                expect(result.nodeId).toBe('fake-node-id-really-long');
+                expect(result.path).toBe('path/to/node/id');
+                expect(result.type).toBe('nodeType');
+                expect(oauth2Auth.callCustomApi.calls.mostRecent().args[0].endsWith(`${appName}/process-storage/v1/folders/${taskId}`)).toBeTruthy();
+                expect(oauth2Auth.callCustomApi.calls.mostRecent().args[1]).toBe('GET');
+                done();
+            });
         });
 
     });

--- a/lib/process-services-cloud/src/lib/form/services/form-cloud.service.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/services/form-cloud.service.spec.ts
@@ -205,7 +205,6 @@ describe('Form Cloud service', () => {
             });
         });
 
-
         it('should fetch process storage folder with task id only', (done) => {
             oauth2Auth.callCustomApi.and.returnValue(Promise.resolve({
                     nodeId: 'fake-node-id-really-long',

--- a/lib/process-services-cloud/src/lib/form/services/form-cloud.service.ts
+++ b/lib/process-services-cloud/src/lib/form/services/form-cloud.service.ts
@@ -299,7 +299,9 @@ export class FormCloudService extends BaseCloudService {
     }
 
     private buildFolderTask(appName: string, taskId: string, processInstanceId: string): string {
-        return `${this.getBasePath(appName)}/process-storage/v1/folders/${processInstanceId}/${taskId}`;
+        return processInstanceId
+            ? `${this.getBasePath(appName)}/process-storage/v1/folders/${processInstanceId}/${taskId}`
+            : `${this.getBasePath(appName)}/process-storage/v1/folders/${taskId}`;
     }
 
     private handleError(error: any) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [X] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Process definition id is mandatory for form with attach file


**What is the new behaviour?**
To meet the requirements for the standalone task processInstsanceId is not mandatory anymore for some of the calls related to the standalone task.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-4753