### PR TITLE
[ADF-4788] Fix parsing of process variables from APS2 BE

### DIFF
--- a/lib/core/form/components/widgets/core/form-field.model.ts
+++ b/lib/core/form/components/widgets/core/form-field.model.ts
@@ -375,7 +375,7 @@ export class FormFieldModel extends FormWidgetModel {
             case FormFieldTypes.UPLOAD:
                 this.form.hasUpload = true;
                 if (this.value && this.value.length > 0) {
-                    this.form.values[this.id] = this.value.map((elem) => elem.id).join(',');
+                    this.form.values[this.id] = Array.isArray(this.value) ? this.value.map((elem) => elem.id).join(',') : [this.value];
                 } else {
                     this.form.values[this.id] = null;
                 }

--- a/lib/process-services-cloud/src/lib/form/models/form-cloud.model.ts
+++ b/lib/process-services-cloud/src/lib/form/models/form-cloud.model.ts
@@ -73,7 +73,6 @@ export class FormCloud extends FormBaseModel {
 
             if (formData && formData.length > 0) {
                 this.loadData(formData);
-                this.fixIncompatibilityFromPreviousAndNewForm(formData);
             }
 
             for (let i = 0; i < this.fields.length; i++) {
@@ -112,15 +111,6 @@ export class FormCloud extends FormBaseModel {
         }
 
         this.validateForm();
-    }
-
-    fixIncompatibilityFromPreviousAndNewForm(formData) {
-        Object.keys(this.values).forEach( (propertyName) => {
-            const fieldValue = formData.find((value) => { return value.name === propertyName; });
-            if (fieldValue) {
-                this.values[propertyName] = fieldValue.value;
-            }
-        });
     }
 
     hasTabs(): boolean {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-4788
Due to the way we parse process variables on Cloud Forms the date is being overwritten by the value from the BE without parsing it first. This results in a wrong value making the completion of a form fail.

**What is the new behaviour?**
The method that caused this issue has been removed and what this method was trying to fix has been added to the model that parses all the fields (form-field.model.ts)


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
