### PR TITLE
[ADF-4795] The form is editable after completing the task in APS

### DIFF
--- a/lib/process-services/task-list/components/task-header.component.spec.ts
+++ b/lib/process-services/task-list/components/task-header.component.spec.ts
@@ -292,6 +292,20 @@ describe('TaskHeaderComponent', () => {
         });
     }));
 
+    it('should set editable to false if the task has already completed', async(() => {
+        component.taskDetails.endDate = new Date('05/05/2002');
+        component.refreshData();
+        fixture.detectChanges();
+
+        fixture.whenStable().then(() => {
+            const clickableForm = fixture.debugElement.query(By.css('[data-automation-id="header-formName"] .adf-textitem-clickable-value'));
+            expect(clickableForm.nativeElement.innerText).toBeUndefined();
+
+            const readOnlyForm = fixture.debugElement.query(By.css('[data-automation-id="header-formName"] .adf-textitem-ellipsis'));
+            expect(readOnlyForm.nativeElement.innerText).toBe('test form');
+        });
+    }));
+
     it('should display the default parent value if is undefined', async(() => {
         component.taskDetails.processInstanceId = null;
         component.refreshData();

--- a/lib/process-services/task-list/components/task-header.component.spec.ts
+++ b/lib/process-services/task-list/components/task-header.component.spec.ts
@@ -292,14 +292,15 @@ describe('TaskHeaderComponent', () => {
         });
     }));
 
-    it('should set editable to false if the task has already completed', async(() => {
+    it('should set clickable to false if the task has already completed', async(() => {
         component.taskDetails.endDate = new Date('05/05/2002');
+        component.formName = 'test form';
         component.refreshData();
         fixture.detectChanges();
 
         fixture.whenStable().then(() => {
             const clickableForm = fixture.debugElement.query(By.css('[data-automation-id="header-formName"] .adf-textitem-clickable-value'));
-            expect(clickableForm.nativeElement.innerText).toBeUndefined();
+            expect(clickableForm).toBeNull();
 
             const readOnlyForm = fixture.debugElement.query(By.css('[data-automation-id="header-formName"] .adf-textitem-ellipsis'));
             expect(readOnlyForm.nativeElement.innerText).toBe('test form');

--- a/lib/process-services/task-list/components/task-header.component.ts
+++ b/lib/process-services/task-list/components/task-header.component.ts
@@ -190,7 +190,7 @@ export class TaskHeaderComponent implements OnChanges, OnInit {
                     value: this.formName,
                     key: 'formName',
                     default: this.translationService.instant('ADF_TASK_LIST.PROPERTIES.FORM_NAME_DEFAULT'),
-                    clickable: !!this.formName,
+                    clickable: this.isFormClickable(),
                     icon: 'create'
                 }
             )
@@ -309,6 +309,10 @@ export class TaskHeaderComponent implements OnChanges, OnInit {
      */
     isCompleted(): boolean {
         return this.taskDetails && !!this.taskDetails.endDate;
+    }
+
+    isFormClickable(): boolean {
+        return !!this.formName && !this.isCompleted();
     }
 
     getTaskDuration(): string {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-4795
After completing a task, its form is still clickable which can trigger the attach form component and with it a change in the form of a task that has been already completed. 


**What is the new behaviour?**
After a task is completed the form can be seen but not interacted with.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
