### PR TITLE
[ADF-4800] fix date issue +1 time zone in date widget

### DIFF
--- a/lib/core/form/components/widgets/core/form-field.model.ts
+++ b/lib/core/form/components/widgets/core/form-field.model.ts
@@ -398,7 +398,7 @@ export class FormFieldModel extends FormWidgetModel {
                 }
                 break;
             case FormFieldTypes.DATETIME:
-                const dateTimeValue = moment(this.value, this.dateDisplayFormat, true);
+                const dateTimeValue = moment(this.value, this.dateDisplayFormat, true).utc();
                 if (dateTimeValue && dateTimeValue.isValid()) {
                     /* cspell:disable-next-line */
                     this.form.values[this.id] = dateTimeValue.format('YYYY-MM-DDTHH:mm:ssZ');

--- a/lib/core/form/components/widgets/date-time/date-time.widget.ts
+++ b/lib/core/form/components/widgets/date-time/date-time.widget.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
- /* tslint:disable:component-selector  */
+/* tslint:disable:component-selector  */
 
 import { Component, OnInit, ViewEncapsulation, OnDestroy } from '@angular/core';
 import { DateAdapter, MAT_DATE_FORMATS } from '@angular/material';
@@ -75,7 +75,10 @@ export class DateTimeWidgetComponent extends WidgetComponent implements OnInit, 
                 this.maxDate = moment(this.field.maxValue, 'YYYY-MM-DDTHH:mm:ssZ');
             }
         }
-        this.displayDate = moment(this.field.value, this.field.dateDisplayFormat);
+        this.displayDate = moment(this.field.value, this.field.dateDisplayFormat)
+            .add(
+                moment(this.field.value, this.field.dateDisplayFormat).utcOffset(),
+                'minutes');
     }
 
     ngOnDestroy() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

The datetime is saved an hour less when completing a form task in Process Services APS1.

Upload the attached form in the activiti-app and publish it.

Steps to reproduce the issue:

Log into ADF as a process services aps1 user.
Open the TaskApp, and create a new task. Choose the Date form.
Select the DateTime as currentdate - 1year or any datetime before that. So if it's 8th of August today, choose the Date as 8-8-201808:15 PM
Complete the task.
Current behaviour:
The task is completed successfully and is listed in the Completed Tasks list. but when you observe the saved date, it is saved as 8-8-201807:15 PM

Expected behaviour:
The Date will be saved as 8-8-201808:15 PM



**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
