### PR TITLE
[ADF-4809] Automation for non-editable task details when completed

### DIFF
--- a/e2e/pages/adf/process-services/taskDetailsPage.ts
+++ b/e2e/pages/adf/process-services/taskDetailsPage.ts
@@ -64,6 +64,31 @@ export class TaskDetailsPage {
     attachFormName: ElementFinder = element(by.css('span[class="adf-form-title ng-star-inserted"]'));
     emptyTaskDetails: ElementFinder = element(by.css('adf-task-details > div > div'));
 
+    async checkEditableAssigneeIsNotDisplayed(): Promise<void> {
+        const editableAssignee = element(by.css('span[data-automation-id="card-textitem-value-assignee"][class*="clickable"]'));
+        await BrowserVisibility.waitUntilElementIsNotVisible(editableAssignee);
+    }
+
+    async checkEditableFormIsNotDisplayed(): Promise<void> {
+        const editableForm = element(by.css('span[data-automation-id="card-textitem-value-formName"][class*="clickable"]'));
+        await BrowserVisibility.waitUntilElementIsNotVisible(editableForm);
+    }
+
+    async checkEditDescriptionButtonIsNotDisplayed(): Promise<void> {
+        const editDescriptionButton = element(by.css('mat-icon[data-automation-id="card-textitem-edit-icon-description"]'));
+        await BrowserVisibility.waitUntilElementIsNotVisible(editDescriptionButton);
+    }
+
+    async checkEditPriorityButtonIsNotDisplayed(): Promise<void> {
+        const editPriorityButton = element(by.css('mat-icon[data-automation-id="card-textitem-edit-icon-priority"]'));
+        await BrowserVisibility.waitUntilElementIsNotVisible(editPriorityButton);
+    }
+
+    async checkDueDatePickerButtonIsNotDisplayed(): Promise<void> {
+        const dueDatePickerButton = element(by.css('mat-datetimepicker-toggle[data-automation-id="datepickertoggle-dueDate"]'));
+        await BrowserVisibility.waitUntilElementIsNotVisible(dueDatePickerButton);
+    }
+
     getTaskDetailsTitle(): Promise<string> {
         return BrowserActions.getText(this.taskDetailsTitle);
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe:
Automation for non-editable task details when the task is completed.

**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-4795