### PR TITLE
Check remote env if is full before to start the e2e CS

### DIFF
--- a/scripts/check-env/check-cs-env.js
+++ b/scripts/check-env/check-cs-env.js
@@ -89,7 +89,10 @@ async function checkDiskSpaceFullEnv() {
 
         this.alfrescoJsApi.node.deleteNode(uploadedFile.entry.id, {permanent: true});
     } catch (error) {
-        console.log('Is not possible upload a new file possible content full');
+        console.log('=============================================================');
+        console.log('================ Not able to upload a file ==================');
+        console.log('================ Possible cause CS is full ==================');
+        console.log('=============================================================');
         process.exit(1);
     }
 

--- a/scripts/check-env/check-cs-env.js
+++ b/scripts/check-env/check-cs-env.js
@@ -1,5 +1,7 @@
 let alfrescoApi = require('@alfresco/js-api');
 let program = require('commander');
+const path = require('path');
+const fs = require('fs');
 
 let MAX_RETRY = 10;
 let counter = 0;
@@ -16,13 +18,14 @@ async function main() {
 
 
     await checkEnv();
+    await checkDiskSpaceFullEnv();
 }
 
 async function checkEnv() {
     try {
         this.alfrescoJsApi = new alfrescoApi.AlfrescoApiCompatibility({
             provider: 'ECM',
-            hostEcm:  program.host
+            hostEcm: program.host
         });
 
         await this.alfrescoJsApi.login(program.username, program.password);
@@ -40,6 +43,57 @@ async function checkEnv() {
     }
 }
 
+async function checkDiskSpaceFullEnv() {
+    this.alfrescoJsApi = new alfrescoApi.AlfrescoApiCompatibility({
+        provider: 'ECM',
+        hostEcm: program.host
+    });
+
+    await this.alfrescoJsApi.login(program.username, program.password);
+
+    let folder;
+
+    try {
+        folder = await alfrescoJsApi.nodes.addNode('-my-', {
+            'name': `try-env`,
+            'relativePath': `Builds`,
+            'nodeType': 'cm:folder'
+        }, {}, {
+            'overwrite': true
+        });
+
+    } catch (error) {
+        folder = await alfrescoJsApi.nodes.getNode('-my-', {
+            'relativePath': `Builds/try-env`,
+            'nodeType': 'cm:folder'
+        }, {}, {
+            'overwrite': true
+        });
+    }
+
+    try {
+        let pathFile = path.join(__dirname, '../../', 'README.md');
+        let file = fs.createReadStream(pathFile);
+
+        let uploadedFile = await alfrescoJsApi.upload.uploadFile(
+            file,
+            '',
+            folder.entry.id,
+            null,
+            {
+                'name': 'README.md',
+                'nodeType': 'cm:content',
+                'autoRename': true
+            }
+        );
+
+        this.alfrescoJsApi.node.deleteNode(uploadedFile.entry.id, {permanent: true});
+    } catch (error) {
+        console.log('Is not possible upload a new file possible content full');
+        process.exit(1);
+    }
+
+}
 
 function sleep(delay) {
     var start = new Date().getTime();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [x] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Disk full prevent the execution of the e2e

**What is the new behaviour?**
Try to upload a file before to start the e2e CS. 

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
