### PR TITLE
[ADF-4852] Make use of ADF-CLI command to update sha

### DIFF
--- a/scripts/travis/build/build.sh
+++ b/scripts/travis/build/build.sh
@@ -6,6 +6,8 @@ cd $DIR/../../../
 
 rm -rf tmp && mkdir tmp;
 
+npm install @alfresco/adf-cli@alpha
+./node_modules/@alfresco/adf-cli/bin/adf-cli update-commit-sha --pointer "HEAD" --pathPackage "$(pwd)"
 
 if [[ $TRAVIS_PULL_REQUEST == "false" ]];
 then
@@ -22,7 +24,6 @@ then
 
     ./scripts/npm-build-all.sh || exit 1;
 else
-    npm install @alfresco/adf-cli@alpha
     ./node_modules/@alfresco/adf-cli/bin/adf-cli update-version --alpha --pathPackage "$(pwd)"
 
     npm install;

--- a/scripts/travis/build/build.sh
+++ b/scripts/travis/build/build.sh
@@ -14,7 +14,6 @@ then
 
     if [[ $TRAVIS_BRANCH == "development" ]];
     then
-         #TODO remove when we are going to use the new about
         ./scripts/update-version.sh -gnu -nextalpha || exit 1;
     fi
 
@@ -27,6 +26,7 @@ else
     ./node_modules/@alfresco/adf-cli/bin/adf-cli update-version --alpha --pathPackage "$(pwd)"
 
     npm install;
+    
     ./scripts/smart-build.sh -b $TRAVIS_BRANCH  -gnu || exit 1;
 fi;
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
The new about page takes the running commit sha from the package.json. For this reason we need to update the package.json every time we push.
https://issues.alfresco.com/jira/browse/ADF-4852

**What is the new behaviour?**
This will allow the new About component to pick up the latest commit sha from the package.json


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
