### PR TITLE
[ADF-4764] Hide placeholder in Amount Widget in readOnly mode

### DIFF
--- a/lib/core/form/components/widgets/amount/amount.widget.html
+++ b/lib/core/form/components/widgets/amount/amount.widget.html
@@ -7,7 +7,7 @@
                 type="text"
                 [id]="field.id"
                 [required]="isRequired()"
-                [placeholder]="field.placeholder"
+                [placeholder]="placeholder"
                 [value]="field.value"
                 [(ngModel)]="field.value"
                 (ngModelChange)="onFieldChanged(field)"

--- a/lib/core/form/components/widgets/amount/amount.widget.spec.ts
+++ b/lib/core/form/components/widgets/amount/amount.widget.spec.ts
@@ -56,4 +56,24 @@ describe('AmountWidgetComponent', () => {
         expect(widget.currency).toBe(AmountWidgetComponent.DEFAULT_CURRENCY);
     });
 
+    it('should setup empty placeholder in readOnly mode', () => {
+        widget.field = new FormFieldModel(null, {
+            readOnly: true,
+            placeholder: '1234'
+        });
+
+        widget.ngOnInit();
+        expect(widget.placeholder).toBe('');
+    });
+
+    it('should setup placeholder when readOnly is false', () => {
+        widget.field = new FormFieldModel(null, {
+            readOnly: false,
+            placeholder: '1234'
+        });
+
+        widget.ngOnInit();
+        expect(widget.placeholder).toBe('1234');
+    });
+
 });

--- a/lib/core/form/components/widgets/amount/amount.widget.ts
+++ b/lib/core/form/components/widgets/amount/amount.widget.ts
@@ -34,6 +34,10 @@ export class AmountWidgetComponent extends WidgetComponent implements OnInit {
 
     currency: string = AmountWidgetComponent.DEFAULT_CURRENCY;
 
+    get placeholder() {
+        return !this.field.readOnly ? this.field.placeholder : '';
+    }
+
     constructor(public formService: FormService) {
         super(formService);
     }

--- a/lib/core/form/components/widgets/amount/amount.widget.ts
+++ b/lib/core/form/components/widgets/amount/amount.widget.ts
@@ -34,7 +34,7 @@ export class AmountWidgetComponent extends WidgetComponent implements OnInit {
 
     currency: string = AmountWidgetComponent.DEFAULT_CURRENCY;
 
-    get placeholder() {
+    get placeholder(): string {
         return !this.field.readOnly ? this.field.placeholder : '';
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-4764
The placeholder is shown in readOnly mode and this makes things confusing as the placeholder and a real value in the field look identical.
https://issues.alfresco.com/jira/browse/ADF-4764

**What is the new behaviour?**
When a form is displayed in readOnly mode the placeholders for the Amount Widget are not displayed any more.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
