### PR TITLE
[ADF-4861] Fix memory leak in Date widgets and Form Cloud Model

### DIFF
--- a/lib/core/form/components/widgets/core/form-field.model.ts
+++ b/lib/core/form/components/widgets/core/form-field.model.ts
@@ -83,8 +83,8 @@ export class FormFieldModel extends FormWidgetModel {
         return this._value;
     }
 
-    set value(v: any) {
-        this._value = v;
+    set value(value: any) {
+        this._value = value;
         this.updateForm();
     }
 

--- a/lib/core/form/components/widgets/date-time/date-time.widget.spec.ts
+++ b/lib/core/form/components/widgets/date-time/date-time.widget.spec.ts
@@ -87,23 +87,6 @@ describe('DateTimeWidgetComponent', () => {
         expect(widget.maxDate.isSame(expected)).toBeTruthy();
     });
 
-    it('should eval visibility on date changed', () => {
-        spyOn(widget, 'onFieldChanged').and.callThrough();
-
-        const field = new FormFieldModel(new FormModel(), {
-            id: 'date-field-id',
-            name: 'date-name',
-            value: '09-12-9999 10:00 AM',
-            type: 'datetime',
-            readOnly: 'false'
-        });
-
-        widget.field = field;
-
-        widget.onDateChanged({ value: moment('1982-03-13T10:00:000Z') });
-        expect(widget.onFieldChanged).toHaveBeenCalledWith(field);
-    });
-
     describe('template check', () => {
 
         it('should show visible date widget', async(() => {

--- a/lib/core/form/components/widgets/date-time/date-time.widget.ts
+++ b/lib/core/form/components/widgets/date-time/date-time.widget.ts
@@ -94,7 +94,6 @@ export class DateTimeWidgetComponent extends WidgetComponent implements OnInit, 
         } else {
             this.field.value = null;
         }
-        this.onFieldChanged(this.field);
     }
 
 }

--- a/lib/core/form/components/widgets/date/date.widget.spec.ts
+++ b/lib/core/form/components/widgets/date/date.widget.spec.ts
@@ -81,23 +81,6 @@ describe('DateWidgetComponent', () => {
         expect(widget.maxDate.isSame(expected)).toBeTruthy();
     });
 
-    it('should eval visibility on date changed', () => {
-        spyOn(widget, 'onFieldChanged').and.callThrough();
-
-        const field = new FormFieldModel(new FormModel(), {
-            id: 'date-field-id',
-            name: 'date-name',
-            value: '9-9-9999',
-            type: 'date',
-            readOnly: 'false'
-        });
-
-        widget.field = field;
-
-        widget.onDateChanged({ value: moment('12/12/2012') });
-        expect(widget.onFieldChanged).toHaveBeenCalledWith(field);
-    });
-
     describe('template check', () => {
 
         afterEach(() => {

--- a/lib/core/form/components/widgets/date/date.widget.ts
+++ b/lib/core/form/components/widgets/date/date.widget.ts
@@ -89,6 +89,5 @@ export class DateWidgetComponent extends WidgetComponent implements OnInit, OnDe
         } else {
             this.field.value = null;
         }
-        this.onFieldChanged(this.field);
     }
 }

--- a/lib/process-services-cloud/src/lib/form/components/date-cloud/date-cloud.widget.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/date-cloud/date-cloud.widget.spec.ts
@@ -80,23 +80,6 @@ describe('DateWidgetComponent', () => {
         expect(widget.maxDate.isSame(expected)).toBeTruthy();
     });
 
-    it('should eval visibility on date changed', () => {
-        spyOn(widget, 'onFieldChanged').and.callThrough();
-
-        const field = new FormFieldModel(new FormModel(), {
-            id: 'date-field-id',
-            name: 'date-name',
-            value: '9999-9-9',
-            type: 'date',
-            readOnly: 'false'
-        });
-
-        widget.field = field;
-
-        widget.onDateChanged({ value: moment('12/12/2012') });
-        expect(widget.onFieldChanged).toHaveBeenCalledWith(field);
-    });
-
     describe('template check', () => {
 
         afterEach(() => {

--- a/lib/process-services-cloud/src/lib/form/components/date-cloud/date-cloud.widget.ts
+++ b/lib/process-services-cloud/src/lib/form/components/date-cloud/date-cloud.widget.ts
@@ -86,6 +86,5 @@ export class DateCloudWidgetComponent extends WidgetComponent implements OnInit,
         } else {
             this.field.value = null;
         }
-        this.onFieldChanged(this.field);
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
These widgets were validation the value of a their fields several times every time the value was changed.
https://issues.alfresco.com/jira/browse/ADF-4861

**What is the new behaviour?**
Now it only checks once and for all the field's value when it's updated/changed.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
