### PR TITLE
[ADF-4865] Upload Dialog - row actions not accessible by keyboard alone

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -128,7 +128,8 @@
     "ECMBPM",
     "processwithvariables",
     "dropdownrestprocess",
-    "devops"
+    "devops",
+    "mouseenter"
   ],
   "dictionaries": [
     "html",

--- a/docs/README.md
+++ b/docs/README.md
@@ -292,6 +292,7 @@ for more information about installing and using the source code.
 | [Folder Edit directive](content-services/directives/folder-edit.directive.md) | Allows folders to be edited. | [Source](../lib/content-services/folder-directive/folder-edit.directive.ts) |
 | [Inherit Permission directive](content-services/directives/inherited-button.directive.md) | Update the current node by adding/removing the inherited permissions. | [Source](../lib/content-services/permission-manager/components/inherited-button.directive.ts) |
 | [Node Lock directive](content-services/directives/node-lock.directive.md) | Locks or unlocks a node. | [Source](../lib/content-services/directives/node-lock.directive.ts) |
+| [Toggle Icon directive](content-services/directives/toggle-icon.directive.md) | Toggle icon on mouse and keyboard event. | [Source](../lib/content-services/upload/directives/toggle-icon.directive.ts) |
 
 ### Dialogs
 

--- a/docs/content-services/directives/toggle-icon.directive.md
+++ b/docs/content-services/directives/toggle-icon.directive.md
@@ -1,0 +1,34 @@
+---
+Title: Toggle Icon directive
+Added: v2.0.0
+Status: Active
+Last reviewed: 2019-04-09
+---
+
+# [Toggle Icon directive](../../../lib/content-services/upload/directives/toggle-icon.directive.ts 'Defined in toggle-icon.directive.ts')
+
+Toggle icon on mouse or keyboard event for a selectable element.
+
+## Example Usage
+
+```html
+<button mat-icon-button adf-toggle-icon #toggle="toggleIcon">
+    <mat-icon *ngIf="!toggle.isToggled">
+        check_circle
+    </mat-icon>
+
+    <mat-icon *ngIf="toggle.isToggled">
+        remove_circle
+    </mat-icon>
+    <button></button>
+</button>
+```
+
+## Class members
+
+### Properties
+
+| Name      | Type      | Default value | Description                                     |
+| --------- | --------- | ------------- | ----------------------------------------------- |
+| isToggled | `boolean` | false         | Is element active by mouseenter or focus event? |
+| isFocused | `boolean` | false         | Is element focused by keyboard navigation?      |

--- a/docs/versionIndex.md
+++ b/docs/versionIndex.md
@@ -36,6 +36,7 @@ backend services have been tested with each released version of ADF.
 -   [Identity group service](core/services/identity-group.service.md)
 -   [Local preference cloud service](process-services-cloud/services/local-preference-cloud.service.md)
 -   [User preference cloud service](process-services-cloud/services/user-preference-cloud.service.md)
+-   [Toggle icon directive](content-services/directives/toggle-icon.directive.md)
 
 <!--v340 end-->
 

--- a/e2e/content-services/upload/cancel-upload.e2e.ts
+++ b/e2e/content-services/upload/cancel-upload.e2e.ts
@@ -79,7 +79,7 @@ describe('Upload component', async () => {
     });
 
     it('[C272792] Should be possible to cancel upload of a big file using row cancel icon', async () => {
-        await browser.executeScript(' setTimeout(() => {document.querySelector(\'mat-icon[class*="adf-file-uploading-row__action"]\').click();}, 3000)');
+        await browser.executeScript('setTimeout(() => {document.querySelector("div[data-automation-id=\'cancel-upload-progress\']").click();}, 3000)');
 
         await contentServicesPage.uploadFile(largeFile.location);
 

--- a/e2e/content-services/version/version-actions.e2e.ts
+++ b/e2e/content-services/version/version-actions.e2e.ts
@@ -157,7 +157,7 @@ describe('Version component actions', () => {
     it('[C307033] Should be possible to cancel the upload of a new version', async () => {
         await browser.refresh();
         await contentServicesPage.versionManagerContent(txtFileModel.name);
-        await browser.executeScript(' setTimeout(() => {document.querySelector(\'mat-icon[class*="adf-file-uploading-row__action"]\').click();}, 1000)');
+        await browser.executeScript(' setTimeout(() => {document.querySelector("div[data-automation-id=\'cancel-upload-progress\']").click();}, 1000)');
 
         await BrowserActions.click(versionManagePage.showNewVersionButton);
 

--- a/lib/content-services/i18n/en.json
+++ b/lib/content-services/i18n/en.json
@@ -117,7 +117,8 @@
       "REMOVE_FILE": "Remove uploaded file"
     },
     "STATUS": {
-      "FILE_CANCELED_STATUS": "Canceled"
+      "FILE_CANCELED_STATUS": "Canceled",
+      "FILE_DONE_STATUS": "Uploaded"
     },
     "CONFIRMATION": {
       "BUTTON": {
@@ -130,12 +131,16 @@
       }
     },
     "ARIA-LABEL": {
-      "VERSION": "File version",
+      "VERSION": "File version {{ version }}",
       "DIALOG": "Upload list",
       "DIALOG_MAXIMIZE": "Maximize upload dialog",
       "DIALOG_MINIMIZE": "Minimize upload dialog",
       "DIALOG_CLOSE": "Close upload dialog",
       "CANCEL_ALL": "Cancel all uploading files",
+      "REMOVE_FILE": "Remove uploaded file {{ file }}",
+      "CANCEL_FILE": "Cancel scheduled file {{ file }}",
+      "CANCEL_FILE_UPLOAD": "Cancel file upload {{ file }}",
+      "UPLOAD_FILE_ERROR": "Upload error {{ error }}",
       "CONFIRMATION": {
         "CANCEL": "Confirm cancel",
         "CONTINUE": "Continue uploading"

--- a/lib/content-services/upload/components/file-uploading-dialog.component.html
+++ b/lib/content-services/upload/components/file-uploading-dialog.component.html
@@ -23,6 +23,7 @@
         </button>
 
         <span
+            tabindex="0"
             class="adf-upload-dialog__title"
             *ngIf="!uploadList.isUploadCancelled()">
             {{ 'FILE_UPLOAD.MESSAGES.UPLOAD_PROGRESS'
@@ -34,6 +35,7 @@
         </span>
 
         <span
+            tabindex="0"
             class="adf-upload-dialog__title"
             *ngIf="uploadList.isUploadCancelled()">
             {{ 'FILE_UPLOAD.MESSAGES.UPLOAD_CANCELED' | translate }}
@@ -41,6 +43,7 @@
     </header>
 
     <section class="adf-upload-dialog__info"
+        tabindex="0"
         *ngIf="totalErrors">
         {{
             (totalErrors > 1

--- a/lib/content-services/upload/components/file-uploading-list-row.component.html
+++ b/lib/content-services/upload/components/file-uploading-list-row.component.html
@@ -27,6 +27,7 @@
         adf-toggle-icon
         (keyup.enter)="onCancel(file)"
         (click)="onCancel(file)"
+        data-automation-id="cancel-upload-progress"
         *ngIf="file.status === FileUploadStatus.Progress || file.status === FileUploadStatus.Starting"
         [attr.aria-label]="'ADF_FILE_UPLOAD.ARIA-LABEL.CANCEL_FILE_UPLOAD' | translate: { file: file.name }"
         class="adf-file-uploading-row__group adf-file-uploading-row__group--toggle"

--- a/lib/content-services/upload/components/file-uploading-list-row.component.html
+++ b/lib/content-services/upload/components/file-uploading-list-row.component.html
@@ -6,54 +6,68 @@
     <adf-icon *ngIf="mimeType !== 'default'" value="adf:{{ mimeType }}"></adf-icon>
 
     <span
+        tabindex="0"
         class="adf-file-uploading-row__name"
         title="{{ file.name }}">
         {{ file.name }}
     </span>
 
-    <span *ngIf="isUploadVersion()" class="adf-file-uploading-row__version">
-        <mat-chip color="primary" [attr.aria-label]="'ADF_FILE_UPLOAD.ARIA-LABEL.VERSION' | translate" [title]="'version' + versionNumber" disabled>{{
-            versionNumber
+    <span *ngIf="isUploadVersion()" class="adf-file-uploading-row__version" tabindex="0" >
+        <mat-chip color="primary"
+            [attr.aria-label]="'ADF_FILE_UPLOAD.ARIA-LABEL.VERSION' | translate: { version:  versionNumber }"
+            [title]="'version' + versionNumber" disabled>{{
+                versionNumber
         }}</mat-chip>
     </span>
 
     <div
-        *ngIf="file.status === FileUploadStatus.Progress || file.status === FileUploadStatus.Starting"
+        tabindex="0"
+        role="button"
+        #toggleIcon="toggleIcon"
+        adf-toggle-icon
+        (keyup.enter)="onCancel(file)"
         (click)="onCancel(file)"
+        *ngIf="file.status === FileUploadStatus.Progress || file.status === FileUploadStatus.Starting"
+        [attr.aria-label]="'ADF_FILE_UPLOAD.ARIA-LABEL.CANCEL_FILE_UPLOAD' | translate: { file: file.name }"
         class="adf-file-uploading-row__group adf-file-uploading-row__group--toggle"
         title="{{ 'ADF_FILE_UPLOAD.BUTTON.CANCEL_FILE' | translate }}">
-        <span class="adf-file-uploading-row__status">
+
+        <span class="adf-file-uploading-row__status" *ngIf="!toggleIcon.isToggled">
             {{ file.progress.loaded | adfFileSize }} / {{ file.progress.total | adfFileSize }}
         </span>
 
-        <mat-icon
-            mat-list-icon
+        <mat-icon *ngIf="toggleIcon.isToggled"
             class="adf-file-uploading-row__action adf-file-uploading-row__action--cancel">
             clear
         </mat-icon>
     </div>
 
-    <div
+    <button mat-icon-button
+        adf-toggle-icon
+        #toggleIcon="toggleIcon"
         *ngIf="file.status === FileUploadStatus.Complete && !isUploadVersion()"
         (click)="onRemove(file)"
-        class="adf-file-uploading-row__group adf-file-uploading-row__group--toggle"
+        class="adf-file-uploading-row__group"
+        [attr.aria-label]="'ADF_FILE_UPLOAD.ARIA-LABEL.REMOVE_FILE' | translate: { file: file.name }"
         title="{{ 'ADF_FILE_UPLOAD.BUTTON.REMOVE_FILE' | translate }}">
-        <mat-icon
-            mat-list-icon
+
+        <mat-icon *ngIf="!toggleIcon.isToggled"
             class="adf-file-uploading-row__status adf-file-uploading-row__status--done">
             check_circle
         </mat-icon>
 
-        <mat-icon
-            mat-list-icon
+        <mat-icon *ngIf="toggleIcon.isToggled"
             class="adf-file-uploading-row__action adf-file-uploading-row__action--remove">
             remove_circle
         </mat-icon>
-    </div>
+    </button>
 
     <div
         *ngIf="file.status === FileUploadStatus.Complete && isUploadVersion()"
-        class="adf-file-uploading-row__file-version">
+        class="adf-file-uploading-row__file-version"
+        [attr.aria-label]="'ADF_FILE_UPLOAD.STATUS.FILE_DONE_STATUS' | translate"
+        role="status"
+        >
         <mat-icon
             mat-list-icon
             class="adf-file-uploading-row__status--done">
@@ -61,34 +75,44 @@
         </mat-icon>
     </div>
 
-    <div
+    <button
+        adf-toggle-icon
+        #toggleIconCancel="toggleIcon"
+        mat-icon-button
         *ngIf="file.status === FileUploadStatus.Pending"
         (click)="onCancel(file)"
-        class="adf-file-uploading-row__group adf-file-uploading-row__group--toggle">
+        class="adf-file-uploading-row__group"
+        title="{{ 'ADF_FILE_UPLOAD.BUTTON.CANCEL_FILE' | translate }}"
+        [attr.aria-label]="'ADF_FILE_UPLOAD.ARIA-LABEL.CANCEL_FILE' | translate: { file: file.name }">
         <mat-icon
-            mat-list-icon
+            *ngIf="!toggleIconCancel.isToggled"
             class="adf-file-uploading-row__status adf-file-uploading-row__status--pending">
             schedule
         </mat-icon>
 
         <mat-icon
-            mat-list-icon
+            *ngIf="toggleIconCancel.isToggled"
             class="adf-file-uploading-row__action adf-file-uploading-row__action--remove">
             remove_circle
         </mat-icon>
-    </div>
+    </button>
 
     <div
+        tabindex="0"
+        role="status"
         *ngIf="file.status === FileUploadStatus.Error"
         class="adf-file-uploading-row__block adf-file-uploading-row__status--error">
         <mat-icon mat-list-icon
-            [attr.aria-label]="'ADF_FILE_UPLOAD.ARIA-LABEL.ERROR' | translate"
+            [attr.aria-label]="'ADF_FILE_UPLOAD.ARIA-LABEL.UPLOAD_FILE_ERROR' | translate: { error: file.errorCode | adfFileUploadError }"
             [matTooltip]="file.errorCode | adfFileUploadError">
             report_problem
         </mat-icon>
     </div>
 
     <div
+        tabindex="0"
+        [attr.aria-label]="'ADF_FILE_UPLOAD.STATUS.FILE_CANCELED_STATUS' | translate"
+        role="status"
         *ngIf="showCancelledStatus()"
         class="adf-file-uploading-row__block adf-file-uploading-row__status--cancelled">
         {{ 'ADF_FILE_UPLOAD.STATUS.FILE_CANCELED_STATUS' | translate }}

--- a/lib/content-services/upload/components/file-uploading-list-row.component.scss
+++ b/lib/content-services/upload/components/file-uploading-list-row.component.scss
@@ -15,7 +15,7 @@
     .adf-file-uploading-row {
         display: flex;
         align-items: center;
-        padding: 0.5em 1em;
+        padding: 0.3em 1em;
         cursor: default;
 
         &:hover {
@@ -34,28 +34,15 @@
             min-width: 100px;
             display: flex;
             justify-content: flex-end;
+            line-height: 40px;
         }
 
         &__group--toggle {
             cursor: pointer;
-
-            .adf-file-uploading-row__status {
-                display: flex;
-            }
-
-            .adf-file-uploading-row__action {
-                display: none;
-            }
-
-            &:hover {
-                .adf-file-uploading-row__status {
-                    display: none;
-                }
-
-                .adf-file-uploading-row__action {
-                    display: flex;
-                }
-            }
+            display:flex;
+            align-items: center;
+            height: 40px;
+            line-height: 40px;
         }
 
         &__status--done {

--- a/lib/content-services/upload/directives/toggle-icon.directive.spec.ts
+++ b/lib/content-services/upload/directives/toggle-icon.directive.spec.ts
@@ -1,0 +1,91 @@
+/*!
+ * @license
+ * Copyright 2019 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, ViewChild } from '@angular/core';
+import { ToggleIconDirective } from './toggle-icon.directive';
+import { setupTestBed } from '@alfresco/adf-core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+@Component({
+    selector: 'adf-test-component',
+    template: `
+       <button id="testButton" adf-toggle-icon>test</button>
+    `
+})
+class TestComponent {
+    @ViewChild(ToggleIconDirective) directive: ToggleIconDirective;
+}
+
+describe('ToggleIconDirective', () => {
+    let fixture: ComponentFixture<TestComponent>;
+    let component: TestComponent;
+
+    setupTestBed({
+        declarations: [
+            TestComponent,
+            ToggleIconDirective
+        ]
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(TestComponent);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+    });
+
+    it('should set toggle to true on mouseenter', () => {
+        const button: HTMLElement = fixture.nativeElement.querySelector('#testButton');
+        button.dispatchEvent(new MouseEvent('mouseenter'));
+
+        expect(component.directive.isToggled).toBe(true);
+    });
+
+    it('should set toggle to false on mouseleave if element is not focused', () => {
+        const button: HTMLElement = fixture.nativeElement.querySelector('#testButton');
+        button.dispatchEvent(new MouseEvent('mouseleave'));
+
+        expect(component.directive.isToggled).toBe(false);
+    });
+
+    it('should set toggle and focus to false on mouseleave when element is focused', () => {
+        const button: HTMLElement = fixture.nativeElement.querySelector('#testButton');
+        button.dispatchEvent(new Event('focus'));
+        expect(component.directive.isToggled).toBe(true);
+
+        button.dispatchEvent(new MouseEvent('mouseleave'));
+
+        expect(component.directive.isToggled).toBe(false);
+        expect(component.directive.isFocused).toBe(false);
+    });
+
+    it('should set toggle and focus to true when element is focused', () => {
+        const button: HTMLElement = fixture.nativeElement.querySelector('#testButton');
+        button.dispatchEvent(new Event('focus'));
+
+        expect(component.directive.isToggled).toBe(true);
+        expect(component.directive.isFocused).toBe(true);
+    });
+
+    it('should set toggle and focus to true when element blur event', () => {
+        const button: HTMLElement = fixture.nativeElement.querySelector('#testButton');
+        button.dispatchEvent(new Event('focus'));
+        button.dispatchEvent(new Event('blur'));
+
+        expect(component.directive.isToggled).toBe(false);
+        expect(component.directive.isFocused).toBe(false);
+    });
+});

--- a/lib/content-services/upload/directives/toggle-icon.directive.ts
+++ b/lib/content-services/upload/directives/toggle-icon.directive.ts
@@ -1,0 +1,62 @@
+/*!
+ * @license
+ * Copyright 2019 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Directive, HostListener } from '@angular/core';
+
+@Directive({
+    selector: '[adf-toggle-icon]',
+    exportAs: 'toggleIcon'
+})
+export class ToggleIconDirective {
+    private isFocus: boolean = false;
+    private toggle: boolean = false;
+
+    @HostListener('mouseenter') onMouseEnter() {
+        if (!this.isFocus) {
+            this.toggle = true;
+        }
+    }
+
+    @HostListener('mouseleave') onMouseLeave() {
+        if (!this.isFocus) {
+            this.toggle = false;
+        }
+
+        if (this.isFocus && this.toggle) {
+            this.isFocus = false;
+            this.toggle = false;
+        }
+    }
+
+    @HostListener('focus') onFocus() {
+        this.isFocus = true;
+        this.toggle = true;
+    }
+
+    @HostListener('blur') onBlur() {
+        this.isFocus = false;
+        this.toggle = false;
+    }
+
+    get isToggled(): boolean {
+        return this.toggle;
+    }
+
+    get isFocused(): boolean {
+        return this.isFocus;
+    }
+}

--- a/lib/content-services/upload/public-api.ts
+++ b/lib/content-services/upload/public-api.ts
@@ -24,6 +24,7 @@ export * from './components/file-uploading-list-row.component';
 export * from './components/upload-files.event';
 
 export * from './directives/file-draggable.directive';
+export * from './directives/toggle-icon.directive';
 
 export * from './pipes/file-upload-error.pipe';
 

--- a/lib/content-services/upload/upload.module.ts
+++ b/lib/content-services/upload/upload.module.ts
@@ -27,6 +27,7 @@ import { UploadDragAreaComponent } from './components/upload-drag-area.component
 import { FileUploadErrorPipe } from './pipes/file-upload-error.pipe';
 import { CoreModule } from '@alfresco/adf-core';
 import { FileDraggableDirective } from './directives/file-draggable.directive';
+import { ToggleIconDirective } from './directives/toggle-icon.directive';
 
 @NgModule({
     imports: [
@@ -42,7 +43,8 @@ import { FileDraggableDirective } from './directives/file-draggable.directive';
         FileUploadingDialogComponent,
         FileUploadingListComponent,
         FileUploadingListRowComponent,
-        FileUploadErrorPipe
+        FileUploadErrorPipe,
+        ToggleIconDirective
     ],
     exports: [
         FileDraggableDirective,
@@ -52,7 +54,8 @@ import { FileDraggableDirective } from './directives/file-draggable.directive';
         FileUploadingDialogComponent,
         FileUploadingListComponent,
         FileUploadingListRowComponent,
-        FileUploadErrorPipe
+        FileUploadErrorPipe,
+        ToggleIconDirective
     ]
 })
 export class UploadModule {}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
[ADF-4865](https://issues.alfresco.com/jira/browse/ADF-4865)


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
