### PR TITLE
[ADF-4794] Not able to attach a second file to a form after one has already been attached

### DIFF
--- a/lib/process-services/content-widget/attach-file-widget.component.ts
+++ b/lib/process-services/content-widget/attach-file-widget.component.ts
@@ -71,12 +71,7 @@ export class AttachFileWidgetComponent extends UploadWidgetComponent implements 
     }
 
     ngOnInit() {
-        if (this.field &&
-            this.field.value &&
-            this.field.value.length > 0) {
-            this.hasFile = true;
-        }
-        this.getMultipleFileParam();
+        super.ngOnInit();
 
         this.activitiContentService.getAlfrescoRepositories(null, true).subscribe((repoList) => {
             this.repositoryList = repoList;
@@ -229,8 +224,9 @@ export class AttachFileWidgetComponent extends UploadWidgetComponent implements 
                     this.logger.error(error);
                 },
                 () => {
-                    this.field.value = filesSaved;
-                    this.field.json.value = filesSaved;
+                    const previousFiles = this.field.value;
+                    this.field.value = [ ...previousFiles, ...filesSaved ];
+                    this.field.json.value = [ ...previousFiles, ...filesSaved ];
                     this.hasFile = true;
                 });
     }

--- a/lib/process-services/content-widget/attach-file-widget.components.spec.ts
+++ b/lib/process-services/content-widget/attach-file-widget.components.spec.ts
@@ -80,6 +80,20 @@ const fakeMinimalNode: Node = <Node> {
     }
 };
 
+const fakePngUpload = {
+    'id': 1166,
+    'name': 'fake-png.png',
+    'created': '2017-07-25T17:17:37.099Z',
+    'createdBy': {'id': 1001, 'firstName': 'Admin', 'lastName': 'admin', 'email': 'admin'},
+    'relatedContent': false,
+    'contentAvailable': true,
+    'link': false,
+    'mimeType': 'image/png',
+    'simpleType': 'image',
+    'previewStatus': 'queued',
+    'thumbnailStatus': 'queued'
+};
+
 const fakePngAnswer = {
     'id': 1155,
     'name': 'a_png_file.png',
@@ -190,6 +204,38 @@ describe('AttachFileWidgetComponent', () => {
             fixture.detectChanges();
             fixture.whenStable().then(() => {
                 expect(element.querySelector('#file-1155-icon')).not.toBeNull();
+            });
+        });
+    }));
+
+    it('should be able to upload more than one file from content node selector', async(() => {
+        const clickAttachFile = () => {
+            const attachButton: HTMLButtonElement = element.querySelector('#attach-file-attach');
+            expect(attachButton).not.toBeNull();
+            attachButton.click();
+            fixture.detectChanges();
+        };
+        spyOn(activitiContentService, 'getAlfrescoRepositories').and.returnValue(of(fakeRepositoryListAnswer));
+        spyOn(activitiContentService, 'applyAlfrescoNode').and.returnValues(of(fakePngAnswer), of(fakePngUpload));
+        spyOn(contentNodeDialogService, 'openFileBrowseDialogBySite').and.returnValue(of([fakeMinimalNode]));
+        widget.field = new FormFieldModel(new FormModel(), {
+            type: FormFieldTypes.UPLOAD,
+            value: []
+        });
+        widget.field.id = 'attach-file-attach';
+        widget.field.params = <FormFieldMetadata> allSourceParams;
+        widget.field.params.multiple = true;
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+            clickAttachFile();
+            fixture.debugElement.query(By.css('#attach-SHAREME')).nativeElement.click();
+            fixture.detectChanges();
+            clickAttachFile();
+            fixture.debugElement.query(By.css('#attach-GOKUSHARE')).nativeElement.click();
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+                expect(element.querySelector('#file-1155')).not.toBeNull();
+                expect(element.querySelector('#file-1166')).not.toBeNull();
             });
         });
     }));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://issues.alfresco.com/jira/browse/ADF-4794

**What is the new behaviour?**

We can able to upload multiple files from the content service

![multi](https://user-images.githubusercontent.com/14145706/64342673-a51d7e00-d008-11e9-9fe3-bc53d47e786f.gif)



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
