### PR TITLE
[ADF-4909] Hide about-plugins and about-product-versions sections whe…

### DIFF
--- a/lib/core/about/about-application-modules/about-application-modules.component.html
+++ b/lib/core/about/about-application-modules/about-application-modules.component.html
@@ -3,9 +3,9 @@
     <small>{{ 'ABOUT.PACKAGES.DESCRIPTION' | translate }}</small>
     <adf-datatable [data]="dependencyEntries"></adf-datatable>
 
-    <div class="adf-extension-details-container" *ngIf="showExtensions && extensions$">
+    <div class="adf-extension-details-container" *ngIf="showExtensions && extensions.length">
         <h3>{{ 'ABOUT.EXTENSIONS.TITLE' | translate }}</h3>
-        <mat-table [dataSource]="extensions$ | async">
+        <mat-table [dataSource]="extensions">
             <!-- $id Column -->
             <ng-container matColumnDef="$id">
                 <mat-header-cell

--- a/lib/core/about/about-application-modules/about-application-modules.component.ts
+++ b/lib/core/about/about-application-modules/about-application-modules.component.ts
@@ -17,7 +17,6 @@
 
 import { Component, Input, OnInit, ViewEncapsulation } from '@angular/core';
 import { ObjectDataTableAdapter } from '../../datatable/data/object-datatable-adapter';
-import { Observable } from 'rxjs';
 import { AppExtensionService, ExtensionRef } from '@alfresco/adf-extensions';
 
 @Component({
@@ -30,7 +29,7 @@ export class AboutApplicationModulesComponent implements OnInit {
     extensionColumns: string[] = ['$id', '$name', '$version', '$vendor', '$license', '$runtime', '$description'];
 
     dependencyEntries: ObjectDataTableAdapter;
-    extensions$: Observable<ExtensionRef[]>;
+    extensions: ExtensionRef[];
 
     /** Toggles showing/hiding of extensions block. */
     @Input()
@@ -43,7 +42,7 @@ export class AboutApplicationModulesComponent implements OnInit {
     @Input() dependencies: any;
 
     constructor(appExtensions: AppExtensionService) {
-        this.extensions$ = appExtensions.references$;
+        appExtensions.references$.subscribe((extensions) => this.extensions = extensions);
     }
 
     ngOnInit() {

--- a/lib/core/about/about-product-version/about-product-version.component.html
+++ b/lib/core/about/about-product-version/about-product-version.component.html
@@ -1,4 +1,4 @@
-<div class="adf-about-container">
+<div class="adf-about-container" *ngIf="bpmVersion || ecmVersion">
     <h3>{{ 'ABOUT.VERSIONS.TITLE' | translate }}</h3>
     <div *ngIf="bpmVersion">
         <mat-card>


### PR DESCRIPTION
…n they are empty

**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-4909


**What is the new behaviour?**
The about-plugins section and about-product-versions section is not visible when they are empty


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
