### PR TITLE
[ADF-4927] Document List - focus indicator on cells is not clearly visible

### DIFF
--- a/lib/core/datatable/components/datatable/datatable.component.scss
+++ b/lib/core/datatable/components/datatable/datatable.component.scss
@@ -405,11 +405,6 @@
             &--fileSize .adf-datatable-cell-value {
                 padding: 0;
             }
-
-            &:focus {
-                outline-offset: -1px;
-                outline: $data-table-cell-outline;
-            }
         }
 
         .adf-cell-value {
@@ -418,6 +413,11 @@
             align-items: center;
             word-break: break-all;
             width: 100%;
+
+            &:focus {
+                outline-offset: -1px;
+                outline: $data-table-cell-outline;
+            }
         }
 
         .adf-datatable__actions-cell, .adf-datatable-cell--image {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
[ADF-4927](https://issues.alfresco.com/jira/browse/ADF-4927)


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
