### PR TITLE
[ADF-4953] Uploader - confirmation dialog actions should return focus to the upload dialog

### DIFF
--- a/lib/content-services/upload/components/file-uploading-dialog.component.html
+++ b/lib/content-services/upload/components/file-uploading-dialog.component.html
@@ -107,7 +107,7 @@
     </footer>
 
     <footer class="adf-upload-dialog__actions"
-            *ngIf="isConfirmation">
+            *ngIf="isConfirmation" cdkTrapFocus cdkTrapFocusAutoCapture>
         <button
             id="adf-upload-dialog-cancel"
             [attr.aria-label]="'ADF_FILE_UPLOAD.ARIA-LABEL.CONFIRMATION.CANCEL' | translate"

--- a/lib/content-services/upload/components/file-uploading-dialog.component.spec.ts
+++ b/lib/content-services/upload/components/file-uploading-dialog.component.spec.ts
@@ -164,6 +164,26 @@ describe('FileUploadingDialogComponent', () => {
 
             expect(component.isDialogMinimized).toBe(false);
         });
+
+        it('should focus on dialog when coming from confirmation', fakeAsync(() => {
+            uploadService.addToQueue(...fileList);
+            uploadService.uploadFilesInTheQueue(emitter);
+
+            fixture.detectChanges();
+            tick(100);
+
+            component.toggleConfirmation();
+            fixture.detectChanges();
+            tick(100);
+
+            expect(document.activeElement.id).not.toBe('upload-dialog');
+
+            component.toggleConfirmation();
+            fixture.detectChanges();
+            tick(100);
+
+            expect(document.activeElement.id).toBe('upload-dialog');
+        }));
     });
 
     describe('cancelAllUploads()', () => {

--- a/lib/content-services/upload/components/file-uploading-dialog.component.ts
+++ b/lib/content-services/upload/components/file-uploading-dialog.component.ts
@@ -153,6 +153,10 @@ export class FileUploadingDialogComponent implements OnInit, OnDestroy {
     toggleConfirmation() {
         this.isConfirmation = !this.isConfirmation;
 
+        if (!this.isConfirmation) {
+            this.dialogActive.next();
+        }
+
         if (this.isDialogMinimized) {
             this.isDialogMinimized = false;
         }
@@ -163,7 +167,7 @@ export class FileUploadingDialogComponent implements OnInit, OnDestroy {
      */
     cancelAllUploads() {
         this.toggleConfirmation();
-
+        this.dialogActive.next();
         this.uploadList.cancelAllFiles();
     }
 

--- a/lib/content-services/upload/upload.module.ts
+++ b/lib/content-services/upload/upload.module.ts
@@ -28,12 +28,14 @@ import { FileUploadErrorPipe } from './pipes/file-upload-error.pipe';
 import { CoreModule } from '@alfresco/adf-core';
 import { FileDraggableDirective } from './directives/file-draggable.directive';
 import { ToggleIconDirective } from './directives/toggle-icon.directive';
+import { A11yModule } from '@angular/cdk/a11y';
 
 @NgModule({
     imports: [
         CoreModule.forChild(),
         CommonModule,
-        MaterialModule
+        MaterialModule,
+        A11yModule
     ],
     declarations: [
         FileDraggableDirective,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
[ADF-4953](https://issues.alfresco.com/jira/browse/ADF-4953)


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
