### PR TITLE
[ADF-4949] Add SUSPENDED state to the edit task filter

### DIFF
--- a/e2e/process-services-cloud/tasks-custom-filters.e2e.ts
+++ b/e2e/process-services-cloud/tasks-custom-filters.e2e.ts
@@ -171,5 +171,23 @@ describe('Task filters cloud', () => {
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsNotDisplayedByName(completedTaskName);
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsNotDisplayedByName(createdTaskName);
         });
+
+        it('[C317658] Should display only tasks with Suspended status when SUSPENDED is selected from status dropdown', async () => {
+            const processDefinition = await processDefinitionService
+                .getProcessDefinitionByName(browser.params.resources.ACTIVITI7_APPS.SIMPLE_APP.processes.dropdownrestprocess, simpleApp);
+
+            const processInstance = await processInstancesService.createProcessInstance(processDefinition.entry.key, simpleApp);
+
+            const taskAssigned = await queryService.getProcessInstanceTasks(processInstance.entry.id,simpleApp);
+
+            await processInstancesService.suspendProcessInstance(processInstance.entry.id, simpleApp);
+
+            await tasksCloudDemoPage.editTaskFilterCloudComponent().openFilter();
+            await tasksCloudDemoPage.editTaskFilterCloudComponent().clearAssignee();
+            await tasksCloudDemoPage.editTaskFilterCloudComponent().setStatusFilterDropDown('SUSPENDED');
+
+            await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(taskAssigned.list.entries[0].entry.name);
+
+        });
     });
 });

--- a/e2e/process-services-cloud/tasks-custom-filters.e2e.ts
+++ b/e2e/process-services-cloud/tasks-custom-filters.e2e.ts
@@ -178,7 +178,7 @@ describe('Task filters cloud', () => {
 
             const processInstance = await processInstancesService.createProcessInstance(processDefinition.entry.key, simpleApp);
 
-            const taskAssigned = await queryService.getProcessInstanceTasks(processInstance.entry.id,simpleApp);
+            const taskAssigned = await queryService.getProcessInstanceTasks(processInstance.entry.id, simpleApp);
 
             await processInstancesService.suspendProcessInstance(processInstance.entry.id, simpleApp);
 

--- a/lib/process-services-cloud/src/lib/task/task-filters/components/edit-task-filter-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/task/task-filters/components/edit-task-filter-cloud.component.spec.ts
@@ -242,10 +242,10 @@ describe('EditTaskFilterCloudComponent', () => {
 
             expect(statusOptions[0].nativeElement.textContent.trim()).toBe('ALL');
             expect(statusOptions[1].nativeElement.textContent.trim()).toBe('CREATED');
-            expect(statusOptions[2].nativeElement.textContent.trim()).toBe('CANCELLED');
-            expect(statusOptions[3].nativeElement.textContent.trim()).toBe('ASSIGNED');
-            expect(statusOptions[4].nativeElement.textContent.trim()).toBe('COMPLETED');
-            expect(statusOptions[5].nativeElement.textContent.trim()).toBe('SUSPENDED');
+            expect(statusOptions[2].nativeElement.textContent.trim()).toBe('SUSPENDED');
+            expect(statusOptions[3].nativeElement.textContent.trim()).toBe('CANCELLED');
+            expect(statusOptions[4].nativeElement.textContent.trim()).toBe('ASSIGNED');
+            expect(statusOptions[5].nativeElement.textContent.trim()).toBe('COMPLETED');
         }));
 
         it('should display sort drop down', async(() => {

--- a/lib/process-services-cloud/src/lib/task/task-filters/components/edit-task-filter-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/task/task-filters/components/edit-task-filter-cloud.component.spec.ts
@@ -242,9 +242,9 @@ describe('EditTaskFilterCloudComponent', () => {
 
             expect(statusOptions[0].nativeElement.textContent.trim()).toBe('ALL');
             expect(statusOptions[1].nativeElement.textContent.trim()).toBe('CREATED');
-            expect(statusOptions[2].nativeElement.textContent.trim()).toBe('SUSPENDED');
-            expect(statusOptions[3].nativeElement.textContent.trim()).toBe('CANCELLED');
-            expect(statusOptions[4].nativeElement.textContent.trim()).toBe('ASSIGNED');
+            expect(statusOptions[2].nativeElement.textContent.trim()).toBe('ASSIGNED');
+            expect(statusOptions[3].nativeElement.textContent.trim()).toBe('SUSPENDED');
+            expect(statusOptions[4].nativeElement.textContent.trim()).toBe('CANCELLED');
             expect(statusOptions[5].nativeElement.textContent.trim()).toBe('COMPLETED');
         }));
 

--- a/lib/process-services-cloud/src/lib/task/task-filters/components/edit-task-filter-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/task/task-filters/components/edit-task-filter-cloud.component.spec.ts
@@ -214,20 +214,6 @@ describe('EditTaskFilterCloudComponent', () => {
             });
         }));
 
-        it('should display status drop down', async(() => {
-            fixture.detectChanges();
-            const expansionPanel = fixture.debugElement.nativeElement.querySelector('mat-expansion-panel-header');
-            expansionPanel.click();
-            fixture.detectChanges();
-            const stateElement = fixture.debugElement.nativeElement.querySelector('[data-automation-id="adf-cloud-edit-task-property-status"] .mat-select-trigger');
-            stateElement.click();
-            fixture.detectChanges();
-            fixture.whenStable().then(() => {
-                const statusOptions = fixture.debugElement.queryAll(By.css('.mat-option-text'));
-                expect(statusOptions.length).toEqual(5);
-            });
-        }));
-
         it('should display all the statuses that are defined in the task filter', async(() => {
 
             const expansionPanel = fixture.debugElement.nativeElement.querySelector('mat-expansion-panel-header');

--- a/lib/process-services-cloud/src/lib/task/task-filters/components/edit-task-filter-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/task/task-filters/components/edit-task-filter-cloud.component.spec.ts
@@ -31,7 +31,7 @@ import { TaskFiltersCloudModule } from '../task-filters-cloud.module';
 import { EditTaskFilterCloudComponent } from './edit-task-filter-cloud.component';
 import { TaskFilterCloudService } from '../services/task-filter-cloud.service';
 import { TaskFilterDialogCloudComponent } from './task-filter-dialog-cloud.component';
-import { fakeFilter, fakeAllTaskFilter } from '../mock/task-filters-cloud.mock';
+import { fakeFilter } from '../mock/task-filters-cloud.mock';
 import { AbstractControl } from '@angular/forms';
 import moment from 'moment-es6';
 
@@ -74,7 +74,7 @@ describe('EditTaskFilterCloudComponent', () => {
 
     it('should fetch task filter by taskId', () => {
         const taskFilterIdChange = new SimpleChange(undefined, 'mock-task-filter-id', true);
-        component.ngOnChanges({ 'id': taskFilterIdChange});
+        component.ngOnChanges({ 'id': taskFilterIdChange });
         fixture.detectChanges();
         fixture.whenStable().then(() => {
             expect(getTaskFilterSpy).toHaveBeenCalled();
@@ -88,7 +88,7 @@ describe('EditTaskFilterCloudComponent', () => {
 
     it('should display filter name as title', async(() => {
         const taskFilterIdChange = new SimpleChange(undefined, 'mock-task-filter-id', true);
-        component.ngOnChanges({ 'id': taskFilterIdChange});
+        component.ngOnChanges({ 'id': taskFilterIdChange });
         fixture.detectChanges();
         const title = fixture.debugElement.nativeElement.querySelector('#adf-edit-task-filter-title-id');
         const subTitle = fixture.debugElement.nativeElement.querySelector('#adf-edit-task-filter-sub-title-id');
@@ -132,12 +132,12 @@ describe('EditTaskFilterCloudComponent', () => {
 
         beforeEach(() => {
             const taskFilterIdChange = new SimpleChange(undefined, 'mock-task-filter-id', true);
-            component.ngOnChanges({'id': taskFilterIdChange});
+            component.ngOnChanges({ 'id': taskFilterIdChange });
             fixture.detectChanges();
         });
 
         it('should defined editTaskFilter form ', () => {
-             expect(component.editTaskFilterForm).toBeDefined();
+            expect(component.editTaskFilterForm).toBeDefined();
         });
 
         it('should create editTaskFilter form with default properties', async(() => {
@@ -228,13 +228,7 @@ describe('EditTaskFilterCloudComponent', () => {
             });
         }));
 
-        it('should select \'All\' option in Task Status if All filter is set', async(() => {
-
-            getTaskFilterSpy.and.returnValue(of(fakeAllTaskFilter));
-
-            const taskFilterIdChange = new SimpleChange(undefined, 'mock-task-filter-id', true);
-            component.ngOnChanges({ 'id': taskFilterIdChange});
-            fixture.detectChanges();
+        it('should display all the statuses that are defined in the task filter', async(() => {
 
             const expansionPanel = fixture.debugElement.nativeElement.querySelector('mat-expansion-panel-header');
             expansionPanel.click();
@@ -244,9 +238,14 @@ describe('EditTaskFilterCloudComponent', () => {
             stateElement.click();
             fixture.detectChanges();
 
-            fixture.whenStable().then(() => {
-                expect(stateElement.textContent.trim()).toBe('ALL');
-            });
+            const statusOptions = fixture.debugElement.queryAll(By.css('[data-automation-id="adf-cloud-edit-task-property-options-status"]'));
+
+            expect(statusOptions[0].nativeElement.textContent.trim()).toBe('ALL');
+            expect(statusOptions[1].nativeElement.textContent.trim()).toBe('CREATED');
+            expect(statusOptions[2].nativeElement.textContent.trim()).toBe('CANCELLED');
+            expect(statusOptions[3].nativeElement.textContent.trim()).toBe('ASSIGNED');
+            expect(statusOptions[4].nativeElement.textContent.trim()).toBe('COMPLETED');
+            expect(statusOptions[5].nativeElement.textContent.trim()).toBe('SUSPENDED');
         }));
 
         it('should display sort drop down', async(() => {
@@ -279,7 +278,7 @@ describe('EditTaskFilterCloudComponent', () => {
 
         it('should able to build a editTaskFilter form with default properties if input is empty', async(() => {
             const taskFilterIdChange = new SimpleChange(undefined, 'mock-task-filter-id', true);
-            component.ngOnChanges({ 'id': taskFilterIdChange});
+            component.ngOnChanges({ 'id': taskFilterIdChange });
             component.filterProperties = [];
             fixture.detectChanges();
             const stateController = component.editTaskFilterForm.get('status');
@@ -303,7 +302,7 @@ describe('EditTaskFilterCloudComponent', () => {
             component.filterProperties = ['appName', 'processInstanceId', 'priority'];
             fixture.detectChanges();
             const taskFilterIdChange = new SimpleChange(undefined, 'mock-task-filter-id', true);
-            component.ngOnChanges({ 'id': taskFilterIdChange});
+            component.ngOnChanges({ 'id': taskFilterIdChange });
             const appController = component.editTaskFilterForm.get('appName');
             fixture.detectChanges();
             fixture.whenStable().then(() => {
@@ -318,7 +317,7 @@ describe('EditTaskFilterCloudComponent', () => {
 
         it('should display default sort properties', async(() => {
             const taskFilterIdChange = new SimpleChange(undefined, 'mock-task-filter-id', true);
-            component.ngOnChanges({ 'id': taskFilterIdChange});
+            component.ngOnChanges({ 'id': taskFilterIdChange });
             fixture.detectChanges();
             const expansionPanel = fixture.debugElement.nativeElement.querySelector('mat-expansion-panel-header');
             expansionPanel.click();
@@ -344,7 +343,7 @@ describe('EditTaskFilterCloudComponent', () => {
             }));
             fixture.detectChanges();
             const taskFilterIdChange = new SimpleChange(undefined, 'mock-task-filter-id', true);
-            component.ngOnChanges({ 'id': taskFilterIdChange});
+            component.ngOnChanges({ 'id': taskFilterIdChange });
             fixture.detectChanges();
             const expansionPanel = fixture.debugElement.nativeElement.querySelector('mat-expansion-panel-header');
             expansionPanel.click();
@@ -365,7 +364,7 @@ describe('EditTaskFilterCloudComponent', () => {
 
         it('should display default sort properties if input is empty', async(() => {
             const taskFilterIdChange = new SimpleChange(undefined, 'mock-task-filter-id', true);
-            component.ngOnChanges({ 'id': taskFilterIdChange});
+            component.ngOnChanges({ 'id': taskFilterIdChange });
             fixture.detectChanges();
             component.sortProperties = [];
             fixture.detectChanges();
@@ -390,7 +389,7 @@ describe('EditTaskFilterCloudComponent', () => {
         it('should display default filter actions', async(() => {
             component.toggleFilterActions = true;
             const taskFilterIdChange = new SimpleChange(undefined, 'mock-task-filter-id', true);
-            component.ngOnChanges({ 'id': taskFilterIdChange});
+            component.ngOnChanges({ 'id': taskFilterIdChange });
             fixture.detectChanges();
             const expansionPanel = fixture.debugElement.nativeElement.querySelector('mat-expansion-panel-header');
             expansionPanel.click();
@@ -414,7 +413,7 @@ describe('EditTaskFilterCloudComponent', () => {
             component.actions = ['save'];
             fixture.detectChanges();
             const taskFilterIdChange = new SimpleChange(undefined, 'mock-task-filter-id', true);
-            component.ngOnChanges({ 'id': taskFilterIdChange});
+            component.ngOnChanges({ 'id': taskFilterIdChange });
             fixture.detectChanges();
             component.toggleFilterActions = true;
             fixture.detectChanges();
@@ -434,7 +433,7 @@ describe('EditTaskFilterCloudComponent', () => {
             component.toggleFilterActions = true;
             component.actions = [];
             const taskFilterIdChange = new SimpleChange(undefined, 'mock-task-filter-id', true);
-            component.ngOnChanges({ 'id': taskFilterIdChange});
+            component.ngOnChanges({ 'id': taskFilterIdChange });
             fixture.detectChanges();
             const expansionPanel = fixture.debugElement.nativeElement.querySelector('mat-expansion-panel-header');
             expansionPanel.click();
@@ -458,7 +457,7 @@ describe('EditTaskFilterCloudComponent', () => {
             component.appName = 'fake';
             component.filterProperties = ['appName', 'processInstanceId', 'priority', 'lastModified'];
             const taskFilterIdChange = new SimpleChange(undefined, 'mock-task-filter-id', true);
-            component.ngOnChanges({ 'id': taskFilterIdChange});
+            component.ngOnChanges({ 'id': taskFilterIdChange });
             fixture.detectChanges();
 
             const lastModifiedToControl: AbstractControl = component.editTaskFilterForm.get('lastModifiedTo');
@@ -482,7 +481,7 @@ describe('EditTaskFilterCloudComponent', () => {
 
         beforeEach(() => {
             const taskFilterIdChange = new SimpleChange(undefined, 'mock-task-filter-id', true);
-            component.ngOnChanges({ 'id': taskFilterIdChange});
+            component.ngOnChanges({ 'id': taskFilterIdChange });
             fixture.detectChanges();
 
         });

--- a/lib/process-services-cloud/src/lib/task/task-filters/components/edit-task-filter-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-filters/components/edit-task-filter-cloud.component.ts
@@ -92,9 +92,9 @@ export class EditTaskFilterCloudComponent implements OnInit, OnChanges, OnDestro
     status = [
         { label: 'ALL', value: '' },
         { label: 'CREATED', value: 'CREATED' },
+        { label: 'ASSIGNED', value: 'ASSIGNED' },
         { label: 'SUSPENDED', value: 'SUSPENDED' },
         { label: 'CANCELLED', value: 'CANCELLED' },
-        { label: 'ASSIGNED', value: 'ASSIGNED' },
         { label: 'COMPLETED', value: 'COMPLETED' }
     ];
 

--- a/lib/process-services-cloud/src/lib/task/task-filters/components/edit-task-filter-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-filters/components/edit-task-filter-cloud.component.ts
@@ -92,10 +92,10 @@ export class EditTaskFilterCloudComponent implements OnInit, OnChanges, OnDestro
     status = [
         { label: 'ALL', value: '' },
         { label: 'CREATED', value: 'CREATED' },
+        { label: 'SUSPENDED', value: 'SUSPENDED' },
         { label: 'CANCELLED', value: 'CANCELLED' },
         { label: 'ASSIGNED', value: 'ASSIGNED' },
-        { label: 'COMPLETED', value: 'COMPLETED' },
-        { label: 'SUSPENDED', value: 'SUSPENDED' }
+        { label: 'COMPLETED', value: 'COMPLETED' }
     ];
 
     directions = [

--- a/lib/process-services-cloud/src/lib/task/task-filters/components/edit-task-filter-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-filters/components/edit-task-filter-cloud.component.ts
@@ -94,7 +94,8 @@ export class EditTaskFilterCloudComponent implements OnInit, OnChanges, OnDestro
         { label: 'CREATED', value: 'CREATED' },
         { label: 'CANCELLED', value: 'CANCELLED' },
         { label: 'ASSIGNED', value: 'ASSIGNED' },
-        { label: 'COMPLETED', value: 'COMPLETED' }
+        { label: 'COMPLETED', value: 'COMPLETED' },
+        { label: 'SUSPENDED', value: 'SUSPENDED' }
     ];
 
     directions = [


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-4949


**What is the new behaviour?**
SUSPENDED filter has been added.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
A unit test that was checking that ALL filter is selected if we select ALL from the dropdown (which is wrong because we don't want to test the behaviour of the dropdown) has been replaced by a test that is checking that the statuses that we have inside the edit-task-filters component are shown in the dropdown. 