### PR TITLE
[ADF-4954] Notification history persist

### DIFF
--- a/e2e/content-services/directives/create-folder-directive.e2e.ts
+++ b/e2e/content-services/directives/create-folder-directive.e2e.ts
@@ -127,7 +127,6 @@ describe('Create folder directive', () => {
     });
 
     it('[C260159] Should not be possible create a folder with banned character', async () => {
-        await browser.refresh();
         await contentServicesPage.clickOnCreateNewFolder();
 
         await createFolderDialog.addFolderName('*');

--- a/lib/core/notifications/components/notification-history.component.ts
+++ b/lib/core/notifications/components/notification-history.component.ts
@@ -55,10 +55,10 @@ export class NotificationHistoryComponent implements OnDestroy {
             .subscribe((message) => {
                 this.notifications.push(message);
 
-                if(this.notifications.length > this.MAX_NOTIFICATION_STACK_LENGTH) {
+                if (this.notifications.length > this.MAX_NOTIFICATION_STACK_LENGTH) {
                     this.notifications.shift();
                 }
-                
+
                 storageService.setItem('notifications', JSON.stringify(this.notifications));
             });
     }

--- a/lib/core/notifications/components/notification-history.component.ts
+++ b/lib/core/notifications/components/notification-history.component.ts
@@ -34,6 +34,8 @@ export class NotificationHistoryComponent implements OnDestroy {
 
     notifications: NotificationModel[] = [];
 
+    MAX_NOTIFICATION_STACK_LENGTH = 100;
+
     @ViewChild(MatMenuTrigger)
     trigger: MatMenuTrigger;
 
@@ -52,6 +54,11 @@ export class NotificationHistoryComponent implements OnDestroy {
             .pipe(takeUntil(this.onDestroy$))
             .subscribe((message) => {
                 this.notifications.push(message);
+
+                if(this.notifications.length > this.MAX_NOTIFICATION_STACK_LENGTH) {
+                    this.notifications.shift();
+                }
+                
                 storageService.setItem('notifications', JSON.stringify(this.notifications));
             });
     }

--- a/lib/core/notifications/components/notification-history.component.ts
+++ b/lib/core/notifications/components/notification-history.component.ts
@@ -21,6 +21,7 @@ import { NotificationModel } from '../models/notification.model';
 import { MatMenuTrigger } from '@angular/material';
 import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
+import { StorageService } from '../../services/storage.service';
 
 @Component({
     selector: 'adf-notification-history',
@@ -45,12 +46,14 @@ export class NotificationHistoryComponent implements OnDestroy {
     menuPositionY: string = 'below';
 
     constructor(
-        private notificationService: NotificationService) {
+        private notificationService: NotificationService, public storageService: StorageService) {
+        this.notifications = JSON.parse(storageService.getItem('notifications')) || [];
         this.notificationService.notifications$
             .pipe(takeUntil(this.onDestroy$))
             .subscribe((message) => {
-            this.notifications.push(message);
-        });
+                this.notifications.push(message);
+                storageService.setItem('notifications', JSON.stringify(this.notifications));
+            });
     }
 
     isEmptyNotification(): boolean {
@@ -62,6 +65,7 @@ export class NotificationHistoryComponent implements OnDestroy {
     }
 
     markAsRead() {
+        this.storageService.setItem('notifications', '');
         this.notifications = [];
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
As a user, I want to be able to check the notification history after that I refresh the page.


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
