### PR TITLE
[ADF-4955] Info Drawer - Visual heading text is not marked as a heading

### DIFF
--- a/lib/content-services/content-metadata/components/content-metadata/content-metadata.component.html
+++ b/lib/content-services/content-metadata/components/content-metadata/content-metadata.component.html
@@ -6,7 +6,7 @@
             [hideToggle]="canExpandProperties()"
             [attr.data-automation-id]="'adf-metadata-group-properties'" >
             <mat-expansion-panel-header>
-                <mat-panel-title>
+                <mat-panel-title role="heading">
                     {{ 'CORE.METADATA.BASIC.HEADER' | translate }}
                 </mat-panel-title>
             </mat-expansion-panel-header>

--- a/lib/core/comments/comments.component.html
+++ b/lib/core/comments/comments.component.html
@@ -1,5 +1,5 @@
 <div class="adf-comments-container">
-    <div id="comment-header" class="adf-comments-header">
+    <div id="comment-header" class="adf-comments-header" role="heading">
         {{'COMMENTS.HEADER' | translate: { count: comments?.length} }}
     </div>
     <div class="adf-comments-input-container" *ngIf="!isReadOnly()">

--- a/lib/core/info-drawer/info-drawer.component.html
+++ b/lib/core/info-drawer/info-drawer.component.html
@@ -1,5 +1,5 @@
 <adf-info-drawer-layout>
-    <div *ngIf="title" info-drawer-title>{{ title | translate }}</div>
+    <div role="heading" aria-level="1" *ngIf="title" info-drawer-title>{{ title | translate }}</div>
     <ng-content *ngIf="!title" info-drawer-title select="[info-drawer-title]"></ng-content>
 
     <ng-content info-drawer-buttons select="[info-drawer-buttons]"></ng-content>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
[ADF-4955](https://issues.alfresco.com/jira/browse/ADF-4955)


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
