### PR TITLE
[ADF-4956] Header - Focus indicator is not clearly visible

### DIFF
--- a/lib/core/layout/components/header/header.component.scss
+++ b/lib/core/layout/components/header/header.component.scss
@@ -29,7 +29,6 @@
 
         .adf-app-title {
             cursor: pointer;
-            outline: none;
             letter-spacing: -0.3px;
             font-weight: 100;
         }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
[ADF-4956](https://issues.alfresco.com/jira/browse/ADF-4956)


**What is the new behaviour?**
Box when app title get focus


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
