### PR TITLE
[ADF-4964] Add enter and escape events for updating card view properties

### DIFF
--- a/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.html
+++ b/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.html
@@ -36,11 +36,10 @@
         </div>
         <div *ngIf="inEdit" class="adf-textitem-editable">
             <div class="adf-textitem-editable-controls">
-                <mat-form-field floatPlaceholder="never"
-                                class="adf-input-container"
-                                (keyup.escape)="reset()"
-                                (keyup.enter)="update()">
+                <mat-form-field floatPlaceholder="never" class="adf-input-container">
                     <input *ngIf="!property.multiline" #editorInput
+                           (keyup.escape)="reset()"
+                           (keyup.enter)="update()"
                         matInput
                         class="adf-input"
                         [placeholder]="property.default | translate"

--- a/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.html
+++ b/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.html
@@ -36,7 +36,10 @@
         </div>
         <div *ngIf="inEdit" class="adf-textitem-editable">
             <div class="adf-textitem-editable-controls">
-                <mat-form-field floatPlaceholder="never" class="adf-input-container">
+                <mat-form-field floatPlaceholder="never"
+                                class="adf-input-container"
+                                (keyup.escape)="reset()"
+                                (keyup.enter)="update()">
                     <input *ngIf="!property.multiline" #editorInput
                         matInput
                         class="adf-input"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [X] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/secure/RapidBoard.jspa?rapidView=715&projectKey=APM&view=detail&selectedIssue=ADF-4964&sprint=2576


**What is the new behaviour?**
We can now update and reset the card view properties using the enter and escape keyboard buttons 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
