### PR TITLE
[ADF-4966] Keep table headers - visually hidden when showHeader false

### DIFF
--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.html
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.html
@@ -56,7 +56,7 @@
             #documentList
             [adf-highlight]="searchTerm"
             adf-highlight-selector=".adf-name-location-cell-name"
-            [showHeader]="false"
+            [showHeader]="true"
             [node]="nodePaging"
             [maxItems]="pageSize"
             [rowFilter]="_rowFilter"
@@ -78,14 +78,14 @@
 
             <data-columns>
                 <data-column key="$thumbnail" type="image"></data-column>
-                <data-column key="name" type="text" class="adf-full-width adf-ellipsis-cell">
+                <data-column key="name" type="text" title="{{ 'ADF-DOCUMENT-LIST.LAYOUT.NAME' | translate }}" class="adf-full-width adf-ellipsis-cell">
                     <ng-template let-context>
                         <adf-name-location-cell [row]="context.row"></adf-name-location-cell>
                     </ng-template>
                 </data-column>
-                <data-column key="modifiedAt" type="date" format="timeAgo" class="adf-content-selector-modified-cell"></data-column>
-                <data-column key="createdByUser.displayName" type="text" class="adf-content-selector-modifier-cell"></data-column>
-                <data-column key="visibility" type="text" class="adf-content-selector-visibility-cell"></data-column>
+                <data-column key="modifiedAt" type="date" title="{{ 'ADF-DOCUMENT-LIST.LAYOUT.MODIFIED_ON' | translate }}" format="timeAgo" class="adf-content-selector-modified-cell"></data-column>
+                <data-column key="createdByUser.displayName" type="text" title="{{ 'ADF-DOCUMENT-LIST.LAYOUT.CREATED_BY' | translate }}" class="adf-content-selector-modifier-cell"></data-column>
+                <data-column key="visibility" type="text" title="{{ 'ADF-DOCUMENT-LIST.LAYOUT.STATUS' | translate }}" class="adf-content-selector-visibility-cell"></data-column>
             </data-columns>
 
         </adf-document-list>

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.html
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.html
@@ -56,7 +56,7 @@
             #documentList
             [adf-highlight]="searchTerm"
             adf-highlight-selector=".adf-name-location-cell-name"
-            [showHeader]="true"
+            [showHeader]="false"
             [node]="nodePaging"
             [maxItems]="pageSize"
             [rowFilter]="_rowFilter"

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.html
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.html
@@ -78,14 +78,14 @@
 
             <data-columns>
                 <data-column key="$thumbnail" type="image"></data-column>
-                <data-column key="name" type="text" title="{{ 'ADF-DOCUMENT-LIST.LAYOUT.NAME' | translate }}" class="adf-full-width adf-ellipsis-cell">
+                <data-column key="name" type="text" title="ADF-DOCUMENT-LIST.LAYOUT.NAME" class="adf-full-width adf-ellipsis-cell">
                     <ng-template let-context>
                         <adf-name-location-cell [row]="context.row"></adf-name-location-cell>
                     </ng-template>
                 </data-column>
-                <data-column key="modifiedAt" type="date" title="{{ 'ADF-DOCUMENT-LIST.LAYOUT.MODIFIED_ON' | translate }}" format="timeAgo" class="adf-content-selector-modified-cell"></data-column>
-                <data-column key="createdByUser.displayName" type="text" title="{{ 'ADF-DOCUMENT-LIST.LAYOUT.CREATED_BY' | translate }}" class="adf-content-selector-modifier-cell"></data-column>
-                <data-column key="visibility" type="text" title="{{ 'ADF-DOCUMENT-LIST.LAYOUT.STATUS' | translate }}" class="adf-content-selector-visibility-cell"></data-column>
+                <data-column key="modifiedAt" type="date" title="ADF-DOCUMENT-LIST.LAYOUT.MODIFIED_ON" format="timeAgo" class="adf-content-selector-modified-cell"></data-column>
+                <data-column key="createdByUser.displayName" type="text" title="ADF-DOCUMENT-LIST.LAYOUT.CREATED_BY" class="adf-content-selector-modifier-cell"></data-column>
+                <data-column key="visibility" type="text" title="ADF-DOCUMENT-LIST.LAYOUT.STATUS" class="adf-content-selector-visibility-cell"></data-column>
             </data-columns>
 
         </adf-document-list>

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.scss
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.scss
@@ -183,6 +183,14 @@
                         }
                     }
                 }
+
+                .adf-datatable-header {
+                    position: absolute;
+                    left: -10000px;
+                    top: auto;
+                    height: 0;
+                    overflow: hidden;
+                }
             }
         }
     }

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.scss
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.scss
@@ -183,14 +183,6 @@
                         }
                     }
                 }
-
-                .adf-datatable-header {
-                    position: absolute;
-                    left: -10000px;
-                    top: auto;
-                    height: 0;
-                    overflow: hidden;
-                }
             }
         }
     }

--- a/lib/content-services/src/lib/i18n/en.json
+++ b/lib/content-services/src/lib/i18n/en.json
@@ -37,6 +37,7 @@
     "NO_PERMISSION": "You don't have permission to view this file or folder.",
     "LAYOUT": {
       "CREATED": "Created",
+      "CREATED_BY": "Created by",
       "THUMBNAIL": "Thumbnail",
       "NAME": "Name",
       "LOCATION": "Location",

--- a/lib/core/datatable/components/datatable/datatable.component.html
+++ b/lib/core/datatable/components/datatable/datatable.component.html
@@ -36,7 +36,7 @@
                 <span class="adf-sr-only">Actions</span>
             </div>
         </div>
-        <mat-form-field *ngIf="display === 'gallery'">
+        <mat-form-field *ngIf="display === 'gallery' && showHeader">
             <mat-select [value]="getSortingKey()" [attr.data-automation-id]="'grid-view-sorting'">
                 <mat-option *ngFor="let col of getSortableColumns()"
                             [value]="col.key"

--- a/lib/core/datatable/components/datatable/datatable.component.html
+++ b/lib/core/datatable/components/datatable/datatable.component.html
@@ -5,7 +5,7 @@
     [class.adf-datatable-list]="display === 'list'"
     [class.adf-sticky-header]="isStickyHeaderEnabled()"
     [class.adf-datatable--empty]="!isHeaderVisible()">
-    <div *ngIf="isHeaderVisible()" class="adf-datatable-header" role="rowgroup" [ngClass]="showHeader ? '' : 'adf-sr-only'">
+    <div *ngIf="isHeaderVisible()" class="adf-datatable-header" role="rowgroup" [ngClass]="{ 'adf-sr-only': !showHeader }">
         <div class="adf-datatable-row" *ngIf="display === 'list'" role="row">
             <!-- Actions (left) -->
             <div *ngIf="actions && actionsPosition === 'left'" class="adf-actions-column adf-datatable-cell-header">

--- a/lib/core/datatable/components/datatable/datatable.component.html
+++ b/lib/core/datatable/components/datatable/datatable.component.html
@@ -5,7 +5,7 @@
     [class.adf-datatable-list]="display === 'list'"
     [class.adf-sticky-header]="isStickyHeaderEnabled()"
     [class.adf-datatable--empty]="!isHeaderVisible()">
-    <div *ngIf="showHeader && isHeaderVisible()" class="adf-datatable-header" role="rowgroup">
+    <div *ngIf="isHeaderVisible()" class="adf-datatable-header" role="rowgroup" [ngClass]="showHeader ? '' : 'adf-sr-only'">
         <div class="adf-datatable-row" *ngIf="display === 'list'" role="row">
             <!-- Actions (left) -->
             <div *ngIf="actions && actionsPosition === 'left'" class="adf-actions-column adf-datatable-cell-header">
@@ -24,7 +24,7 @@
                  (click)="onColumnHeaderClick(col)"
                  (keyup.enter)="onColumnHeaderClick(col)"
                  role="columnheader"
-                 tabindex="0"
+                 [tabindex]="showHeader ? 0 : -1"
                  [attr.aria-sort]="col.sortable ? (getAriaSort(col) | translate) : null"
                  title="{{ col.title | translate }}"
                  adf-drop-zone dropTarget="header" [dropColumn]="col">

--- a/lib/testing/src/lib/core/pages/data-table-component.page.ts
+++ b/lib/testing/src/lib/core/pages/data-table-component.page.ts
@@ -130,7 +130,7 @@ export class DataTableComponentPage {
                 initialList.push(text.toLowerCase());
             }
         });
-        let sortedList = initialList;
+        let sortedList = [...initialList];
         sortedList = sortedList.sort();
         if (sortOrder.toLocaleLowerCase() === 'desc') {
             sortedList = sortedList.reverse();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Check issue "Move or copy - column headers are not provided" https://issues.alfresco.com/jira/browse/ADF-4966

**What is the new behaviour?**
Improve the accessibility of the Datatable component by keeping the table header available for screen readers, even when it is visually hidden like in the Move/copy dialog case.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
