### PR TITLE
[DW-1491] Process instance start date incorrectly displayed

### DIFF
--- a/lib/process-services/src/lib/process-list/components/process-list.component.ts
+++ b/lib/process-services/src/lib/process-list/components/process-list.component.ts
@@ -47,17 +47,16 @@ import { processPresetsDefaultModel } from '../models/process-preset.model';
 import { ProcessService } from '../services/process.service';
 import { BehaviorSubject } from 'rxjs';
 import { ProcessListModel } from '../models/process-list.model';
-import moment from 'moment-es6';
+import { ProcessInstanceRepresentation } from '@alfresco/js-api';
 
 @Component({
     selector: 'adf-process-instance-list',
     styleUrls: ['./process-list.component.css'],
     templateUrl: './process-list.component.html'
 })
-export class ProcessInstanceListComponent extends DataTableSchema  implements OnChanges, AfterContentInit, PaginatedComponent {
+export class ProcessInstanceListComponent extends DataTableSchema implements OnChanges, AfterContentInit, PaginatedComponent {
 
     static PRESET_KEY = 'adf-process-list.presets';
-    public FORMAT_DATE: string = 'll';
 
     @ContentChild(CustomEmptyContentTemplateDirective)
     customEmptyContent: CustomEmptyContentTemplateDirective;
@@ -75,7 +74,7 @@ export class ProcessInstanceListComponent extends DataTableSchema  implements On
 
     /** The id of the process instance. */
     @Input()
-    processInstanceId: number|string;
+    processInstanceId: number | string;
 
     /** Defines the state of the processes. Possible values are `running`, `completed` and `all` */
     @Input()
@@ -290,18 +289,15 @@ export class ProcessInstanceListComponent extends DataTableSchema  implements On
      * Optimize name field
      * @param instances
      */
-    private optimizeProcessDetails(instances: any[]): any[] {
+    private optimizeProcessDetails(instances: ProcessInstanceRepresentation[]): ProcessInstanceRepresentation[] {
         instances = instances.map((instance) => {
             instance.name = this.getProcessNameOrDescription(instance, 'medium');
-            if (instance.started) {
-                instance.started = moment(instance.started).format(this.FORMAT_DATE);
-            }
             return instance;
         });
         return instances;
     }
 
-    getProcessNameOrDescription(processInstance, dateFormat: string): string {
+    getProcessNameOrDescription(processInstance: ProcessInstanceRepresentation, dateFormat: string): string {
         let name = '';
         if (processInstance) {
             name = processInstance.name ||
@@ -310,7 +306,7 @@ export class ProcessInstanceListComponent extends DataTableSchema  implements On
         return name;
     }
 
-    getFormatDate(value: any, format: string) {
+    getFormatDate(value: Date, format: string) {
         const datePipe = new DatePipe('en-US');
         try {
             return datePipe.transform(value, format);

--- a/lib/process-services/src/lib/task-list/components/task-list.component.ts
+++ b/lib/process-services/src/lib/task-list/components/task-list.component.ts
@@ -30,6 +30,7 @@ import { taskPresetsDefaultModel } from '../models/task-preset.model';
 import { TaskListService } from './../services/tasklist.service';
 import moment from 'moment-es6';
 import { takeUntil } from 'rxjs/operators';
+import { TaskDetailsModel } from '../models/task-details.model';
 
 @Component({
     selector: 'adf-tasklist',
@@ -353,7 +354,7 @@ export class TaskListComponent extends DataTableSchema implements OnChanges, Aft
      * Optimize name field
      * @param instances
      */
-    private optimizeTaskDetails(instances: any[]): any[] {
+    private optimizeTaskDetails(instances: TaskDetailsModel[]): TaskDetailsModel[] {
         instances = instances.map((task) => {
             if (!task.name) {
                 task.name = 'No name';


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


1. Make sure you have some process instances running, that were just started moments ago
2. Log in to Process Workspace as the initiator of those processes
3. Select the related application ontaining the started instances
4. In the running instances overview inspect the "created" column

Expected results
The value of "created" should just show moments/minutes ago.

Actual Results
The value of "created" dispalys as 13 hours ago (see attached screenshot startTimeWorkspace.png)

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
