### PR TITLE
[AAE-174]  Show radio box in text box when read only

### DIFF
--- a/lib/core/form/components/widgets/radio-buttons/radio-buttons.widget.html
+++ b/lib/core/form/components/widgets/radio-buttons/radio-buttons.widget.html
@@ -2,12 +2,11 @@
      [class.adf-invalid]="!field.isValid" [class.adf-readonly]="field.readOnly" [id]="field.id">
     <div class="adf-radio-button-container">
         <label class="adf-label" [attr.for]="field.id">{{field.name | translate }}<span *ngIf="isRequired()">*</span></label>
-        <mat-radio-group class="adf-radio-group" [(ngModel)]="field.value">
+        <mat-radio-group class="adf-radio-group" [(ngModel)]="field.value" *ngIf="!field.readOnly">
             <mat-radio-button
                 [id]="field.id + '-' + opt.id"
                 [name]="field.id"
                 [value]="opt.id"
-                [disabled]="field.readOnly"
                 [checked]="field.value === opt.id"
                 (change)="onOptionClick(opt.id)"
                 color="primary"
@@ -15,6 +14,7 @@
                 {{opt.name}}
             </mat-radio-button>
         </mat-radio-group>
+        <display-text-widget *ngIf="field.readOnly" [field]="field"></display-text-widget>
     </div>
     <error-widget [error]="field.validationSummary" ></error-widget>
     <error-widget *ngIf="isInvalidFieldRequired()" required="{{ 'FORM.FIELD.REQUIRED' | translate }}"></error-widget>

--- a/lib/core/form/components/widgets/radio-buttons/radio-buttons.widget.spec.ts
+++ b/lib/core/form/components/widgets/radio-buttons/radio-buttons.widget.spec.ts
@@ -174,7 +174,6 @@ describe('RadioButtonsWidgetComponent', () => {
                 expect(element.querySelector('display-text-widget')).toBeDefined();
             }));
 
-
         });
 
         describe('and radioButton is populated via taskId', () => {

--- a/lib/core/form/components/widgets/radio-buttons/radio-buttons.widget.spec.ts
+++ b/lib/core/form/components/widgets/radio-buttons/radio-buttons.widget.spec.ts
@@ -134,10 +134,15 @@ describe('RadioButtonsWidgetComponent', () => {
         let fixture: ComponentFixture<RadioButtonsWidgetComponent>;
         let element: HTMLElement;
         let stubFormService: FormService;
-        const restOption: FormFieldOption[] = [{ id: 'opt-1', name: 'opt-name-1' }, {
-            id: 'opt-2',
-            name: 'opt-name-2'
-        }];
+        const restOption: FormFieldOption[] = [
+            {
+                id: 'opt-1',
+                name: 'opt-name-1'
+            },
+            {
+                id: 'opt-2',
+                name: 'opt-name-2'
+            }];
 
         beforeEach(async(() => {
             fixture = TestBed.createComponent(RadioButtonsWidgetComponent);
@@ -147,6 +152,29 @@ describe('RadioButtonsWidgetComponent', () => {
 
         afterEach(() => {
             fixture.destroy();
+        });
+
+        describe('and radioButton is readonly', () => {
+
+            beforeEach(async(() => {
+                stubFormService = fixture.debugElement.injector.get(FormService);
+                radioButtonWidget.field = new FormFieldModel(new FormModel({ taskId: 'task-id' }), {
+                    id: 'radio-id',
+                    name: 'radio-name',
+                    type: FormFieldTypes.RADIO_BUTTONS,
+                    readOnly: true
+                });
+                radioButtonWidget.field.isVisible = true;
+                const fakeContainer = new ContainerModel(radioButtonWidget.field);
+                radioButtonWidget.field.form.fields.push(fakeContainer);
+                fixture.detectChanges();
+            }));
+
+            it('should show radio buttons as text when is readonly', async(() => {
+                expect(element.querySelector('display-text-widget')).toBeDefined();
+            }));
+
+
         });
 
         describe('and radioButton is populated via taskId', () => {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Upload and deploy the attached app
Create a new process
Navigate to active task
Select a radio button
Complete task
Navigate to active task
Current behaviour:
No value is displayed in the form.

Expected behavior:
The value selected in the previous task is displayed.

Note: Please find below the question raised by the community.

https://hub.alfresco.com/t5/application-development/radio-buttons-values-are-not-displayed/m-p/268210


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
