### PR TITLE
[ADF- 4871][TaskHeaderCloudComponent] Add Candidate Users/Groups properties

### DIFF
--- a/demo-shell/src/app/components/card-view/card-view.component.ts
+++ b/demo-shell/src/app/components/card-view/card-view.component.ts
@@ -157,7 +157,6 @@ export class CardViewComponent implements OnInit, OnDestroy {
                 key: 'array',
                 icon: 'directions_bike',
                 default: 'Empty',
-                editable: false,
                 noOfItemsToDisplay: 2
             })
         ];

--- a/demo-shell/src/app/components/card-view/card-view.component.ts
+++ b/demo-shell/src/app/components/card-view/card-view.component.ts
@@ -28,7 +28,8 @@ import {
     CardViewUpdateService,
     CardViewMapItemModel,
     UpdateNotification,
-    DecimalNumberPipe
+    DecimalNumberPipe,
+    CardViewArrayItemModel
 } from '@alfresco/adf-core';
 import { of, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -148,6 +149,16 @@ export class CardViewComponent implements OnInit, OnDestroy {
                 clickCallBack: () => {
                     this.respondToCardClick();
                 }
+            }),
+            new CardViewArrayItemModel({
+                label: 'CardView Array of items',
+                value: '',
+                items$: of(['Zlatan', 'Lionel Messi', 'Mohamed', 'Ronaldo']),
+                key: 'array',
+                icon: 'directions_bike',
+                default: 'Empty',
+                editable: false,
+                noOfItemsToDisplay: 2
             })
         ];
     }

--- a/demo-shell/src/app/components/card-view/card-view.component.ts
+++ b/demo-shell/src/app/components/card-view/card-view.component.ts
@@ -152,8 +152,7 @@ export class CardViewComponent implements OnInit, OnDestroy {
             }),
             new CardViewArrayItemModel({
                 label: 'CardView Array of items',
-                value: '',
-                items$: of(['Zlatan', 'Lionel Messi', 'Mohamed', 'Ronaldo']),
+                value: of(['Zlatan', 'Lionel Messi', 'Mohamed', 'Ronaldo']),
                 key: 'array',
                 icon: 'directions_bike',
                 default: 'Empty',

--- a/docs/core/components/card-view.component.md
+++ b/docs/core/components/card-view.component.md
@@ -358,8 +358,7 @@ const arrayItemProperty = new CardViewArrayItemModel(items);
 | label\* | string |  | Item label |
 | key\* | string |  | Identifying key (important when editing the item) |
 | editable | boolean | false | Toggles whether the item is editable |
-| value | string |  | The original data value for the item |
-| items$\* | [`Observable`](http://reactivex.io/documentation/observable.html)&lt;`string`\[]> |  | The original data value for the item |
+| value | [`Observable`](http://reactivex.io/documentation/observable.html)&lt;`string`\[]> |  | The original data value for the item |
 
 ## See also
 

--- a/docs/core/components/card-view.component.md
+++ b/docs/core/components/card-view.component.md
@@ -87,6 +87,14 @@ Defining properties from Typescript:
         options$: of([{ key: 'one', label: 'One' }, { key: 'two', label: 'Two' }]),
         key: 'select'
     }),
+    new CardViewArrayItemModel({
+        label: 'Array of items',
+        value: '',
+        items$: of(['One', 'Two', 'Three', 'Four']),
+        key: 'array',
+        default: 'Empty',
+        noOfItemsToDisplay: 2
+    })
     ...
 ]
 ```
@@ -116,6 +124,7 @@ You define the property list, the [`CardViewComponent`](../../core/components/ca
 -   [**CardViewFloatItemModel**](#card-float-item) - _for float items_
 -   [**CardViewKeyValuePairsItemModel**](#card-key-value-pairs-item) - _for key-value-pairs items_
 -   [**CardViewSelectItemModel**](#card-select-item) - _for select items_
+-   [**CardViewArrayItemModel**](#card-array-item) - _for array items_
 
 Each of these types implements the [Card View Item interface](../interfaces/card-view-item.interface.md):
 
@@ -335,6 +344,22 @@ const selectItemProperty = new CardViewSelectItemModel(options);
 | editable | boolean | false | Toggles whether the item is editable |
 | value | string |  | The original data value for the item |
 | options$\* | [`Observable`](http://reactivex.io/documentation/observable.html)&lt;[`CardViewSelectItemOption`](../../../lib/core/card-view/interfaces/card-view-selectitem-properties.interface.ts)\[]> |  | The original data value for the item |
+
+#### Card Array Item
+
+[`CardViewArrayItemModel`](../../../lib/core/card-view/models/card-view-arrayitem.model.ts) is a property type for array properties.
+
+```ts
+const arrayItemProperty = new CardViewArrayItemModel(items);
+```
+
+| Name | Type | Default | Description |
+| ---- | ---- | ------- | ----------- |
+| label\* | string |  | Item label |
+| key\* | string |  | Identifying key (important when editing the item) |
+| editable | boolean | false | Toggles whether the item is editable |
+| value | string |  | The original data value for the item |
+| items$\* | [`Observable`](http://reactivex.io/documentation/observable.html)&lt;`string`\[]> |  | The original data value for the item |
 
 ## See also
 

--- a/docs/process-services-cloud/components/task-header-cloud.component.md
+++ b/docs/process-services-cloud/components/task-header-cloud.component.md
@@ -43,7 +43,7 @@ The component populates an internal array of
 
 By default all properties are displayed:
 
-**_assignee_**, **_status_**, **_priority_**, **_dueDate_**, **_category_**, **_parentName_**, **_created_**, **_id_**, **_description_**, **_formName_**.
+**_assignee_**, **_status_**, **_priority_**, **_dueDate_**, **_category_**, **_parentName_**, **_created_**, **_id_**, **_description_**, **_formName_**, **_candidateUsers_**, **_candidateGroups_**.
 
 However, you can also choose which properties to show using a configuration in `app.config.json`:
 

--- a/lib/core/card-view/card-view.module.scss
+++ b/lib/core/card-view/card-view.module.scss
@@ -1,3 +1,4 @@
+@import './components/card-view-arrayitem/card-view-arrayitem.component';
 @import './components/card-view-dateitem/card-view-dateitem.component';
 @import './components/card-view-textitem/card-view-textitem.component';
 @import './components/card-view/card-view.component';
@@ -8,4 +9,5 @@
     @include adf-card-view-textitem-theme($theme);
     @include adf-card-view-theme($theme);
     @include mat-datetimepicker-theme($theme);
+    @include adf-card-view-array-item-theme($theme);
 }

--- a/lib/core/card-view/card-view.module.ts
+++ b/lib/core/card-view/card-view.module.ts
@@ -26,7 +26,10 @@ import {
     MatInputModule,
     MatCheckboxModule,
     MatNativeDateModule,
-    MatSelectModule
+    MatSelectModule,
+    MatChipsModule,
+    MatMenuModule,
+    MatCardModule
 } from '@angular/material';
 import { MatDatetimepickerModule, MatNativeDatetimeModule } from '@mat-datetimepicker/core';
 import { FlexLayoutModule } from '@angular/flex-layout';
@@ -41,6 +44,7 @@ import { CardViewMapItemComponent } from './components/card-view-mapitem/card-vi
 import { CardViewTextItemComponent } from './components/card-view-textitem/card-view-textitem.component';
 import { CardViewKeyValuePairsItemComponent } from './components/card-view-keyvaluepairsitem/card-view-keyvaluepairsitem.component';
 import { CardViewSelectItemComponent } from './components/card-view-selectitem/card-view-selectitem.component';
+import { CardViewArrayItemComponent } from './components/card-view-arrayitem/card-view-arrayitem.component';
 
 @NgModule({
     imports: [
@@ -56,6 +60,9 @@ import { CardViewSelectItemComponent } from './components/card-view-selectitem/c
         MatIconModule,
         MatSelectModule,
         MatButtonModule,
+        MatChipsModule,
+        MatMenuModule,
+        MatCardModule,
         MatDatetimepickerModule,
         MatNativeDatetimeModule
     ],
@@ -68,7 +75,8 @@ import { CardViewSelectItemComponent } from './components/card-view-selectitem/c
         CardViewKeyValuePairsItemComponent,
         CardViewSelectItemComponent,
         CardViewItemDispatcherComponent,
-        CardViewContentProxyDirective
+        CardViewContentProxyDirective,
+        CardViewArrayItemComponent
     ],
     entryComponents: [
         CardViewBoolItemComponent,
@@ -76,7 +84,8 @@ import { CardViewSelectItemComponent } from './components/card-view-selectitem/c
         CardViewMapItemComponent,
         CardViewTextItemComponent,
         CardViewSelectItemComponent,
-        CardViewKeyValuePairsItemComponent
+        CardViewKeyValuePairsItemComponent,
+        CardViewArrayItemComponent
     ],
     exports: [
         CardViewComponent,
@@ -85,7 +94,8 @@ import { CardViewSelectItemComponent } from './components/card-view-selectitem/c
         CardViewMapItemComponent,
         CardViewTextItemComponent,
         CardViewSelectItemComponent,
-        CardViewKeyValuePairsItemComponent
+        CardViewKeyValuePairsItemComponent,
+        CardViewArrayItemComponent
     ]
 })
 export class CardViewModule {}

--- a/lib/core/card-view/components/card-view-arrayitem/card-view-arrayitem.component.html
+++ b/lib/core/card-view/components/card-view-arrayitem/card-view-arrayitem.component.html
@@ -1,0 +1,52 @@
+
+<div [attr.data-automation-id]="'card-array-label-' + property.key" class="adf-property-label">{{ property.label | translate }}</div>
+<div class="adf-property-value">
+    <ng-container *ngIf="(getValues() | async) as items; else elseEmptyValueBlock">
+        <mat-chip-list *ngIf="items.length > 0; else elseEmptyValueBlock" data-automation-id="card-arrayitem-chip-list-container">
+            <ng-container *ngIf="displayCount() > 0; else withOutDisplayCount" >
+                <mat-chip
+                    *ngFor="let item of items.slice(0, displayCount())"
+                    (click)="clicked()"
+                    [disabled]="!isEditable()"
+                    [attr.data-automation-id]="'card-arrayitem-chip-' + item">
+                    <mat-icon *ngIf="hasIcon()" class="adf-array-item-icon">{{property.icon}}</mat-icon>
+                    <span>{{item}}</span>
+                </mat-chip>
+                <mat-chip
+                    *ngIf="items.length > displayCount()"
+                    data-automation-id="card-arrayitem-more-chip"
+                    [matMenuTriggerFor]="menu">
+                    <span>{{items.length - displayCount()}} {{'CORE.CARDVIEW.MORE' | translate}}</span>
+                </mat-chip>
+            </ng-container>
+            <ng-template #withOutDisplayCount>
+                <mat-chip
+                    *ngFor="let item of items"
+                    (click)="clicked()"
+                    [disabled]="!isEditable()"
+                    [attr.data-automation-id]="'card-arrayitem-chip-' + item">
+                    <mat-icon *ngIf="hasIcon()" class="adf-array-item-icon">{{property.icon}}</mat-icon>
+                    <span>{{item}}</span>
+                </mat-chip>
+            </ng-template>
+        </mat-chip-list>
+        <mat-menu #menu="matMenu">
+            <mat-card class="adf-array-item-more-chip-container">
+                <mat-card-content>
+                    <mat-chip-list (click)="clicked()">
+                        <mat-chip
+                            *ngFor="let item of items.slice(displayCount(), items.length)"
+                            [disabled]="!isEditable()"
+                            [attr.data-automation-id]="'card-arrayitem-chip-' + item">
+                        <mat-icon *ngIf="hasIcon()" class="adf-array-item-icon">{{property.icon}}</mat-icon>
+                        <span>{{item}}</span>
+                        </mat-chip>
+                    </mat-chip-list>
+                </mat-card-content>
+            </mat-card>
+        </mat-menu>
+    </ng-container>
+    <ng-template #elseEmptyValueBlock>
+        <span  data-automation-id="card-arrayitem-default">{{ property.default | translate }}</span>
+    </ng-template>
+</div>

--- a/lib/core/card-view/components/card-view-arrayitem/card-view-arrayitem.component.html
+++ b/lib/core/card-view/components/card-view-arrayitem/card-view-arrayitem.component.html
@@ -1,13 +1,12 @@
 
 <div [attr.data-automation-id]="'card-array-label-' + property.key" class="adf-property-label">{{ property.label | translate }}</div>
-<div class="adf-property-value">
+<div class="adf-property-value" (click)="clicked()">
     <ng-container *ngIf="(getValues() | async) as items; else elseEmptyValueBlock">
         <mat-chip-list *ngIf="items.length > 0; else elseEmptyValueBlock" data-automation-id="card-arrayitem-chip-list-container">
             <ng-container *ngIf="displayCount() > 0; else withOutDisplayCount" >
                 <mat-chip
                     *ngFor="let item of items.slice(0, displayCount())"
                     (click)="clicked()"
-                    [disabled]="!isEditable()"
                     [attr.data-automation-id]="'card-arrayitem-chip-' + item">
                     <mat-icon *ngIf="hasIcon()" class="adf-array-item-icon">{{property.icon}}</mat-icon>
                     <span>{{item}}</span>
@@ -23,7 +22,6 @@
                 <mat-chip
                     *ngFor="let item of items"
                     (click)="clicked()"
-                    [disabled]="!isEditable()"
                     [attr.data-automation-id]="'card-arrayitem-chip-' + item">
                     <mat-icon *ngIf="hasIcon()" class="adf-array-item-icon">{{property.icon}}</mat-icon>
                     <span>{{item}}</span>
@@ -33,10 +31,9 @@
         <mat-menu #menu="matMenu">
             <mat-card class="adf-array-item-more-chip-container">
                 <mat-card-content>
-                    <mat-chip-list (click)="clicked()">
-                        <mat-chip
+                    <mat-chip-list>
+                        <mat-chip (click)="clicked()"
                             *ngFor="let item of items.slice(displayCount(), items.length)"
-                            [disabled]="!isEditable()"
                             [attr.data-automation-id]="'card-arrayitem-chip-' + item">
                         <mat-icon *ngIf="hasIcon()" class="adf-array-item-icon">{{property.icon}}</mat-icon>
                         <span>{{item}}</span>

--- a/lib/core/card-view/components/card-view-arrayitem/card-view-arrayitem.component.html
+++ b/lib/core/card-view/components/card-view-arrayitem/card-view-arrayitem.component.html
@@ -1,7 +1,7 @@
 
 <div [attr.data-automation-id]="'card-array-label-' + property.key" class="adf-property-label">{{ property.label | translate }}</div>
 <div class="adf-property-value" (click)="clicked()">
-    <ng-container *ngIf="(getValues() | async) as items; else elseEmptyValueBlock">
+    <ng-container *ngIf="(property.displayValue | async) as items; else elseEmptyValueBlock">
         <mat-chip-list *ngIf="items.length > 0; else elseEmptyValueBlock" data-automation-id="card-arrayitem-chip-list-container">
             <ng-container *ngIf="displayCount() > 0; else withOutDisplayCount" >
                 <mat-chip

--- a/lib/core/card-view/components/card-view-arrayitem/card-view-arrayitem.component.scss
+++ b/lib/core/card-view/components/card-view-arrayitem/card-view-arrayitem.component.scss
@@ -10,6 +10,12 @@
             &.mat-card {
                 box-shadow: none;
             }
+
+            &.mat-card {
+                max-height: 300px;
+                overflow-y: auto;
+            }
+
             .mat-chip {
                 cursor: pointer;
             }

--- a/lib/core/card-view/components/card-view-arrayitem/card-view-arrayitem.component.scss
+++ b/lib/core/card-view/components/card-view-arrayitem/card-view-arrayitem.component.scss
@@ -1,6 +1,4 @@
 @mixin adf-card-view-array-item-theme($theme) {
-    $foreground: map-get($theme, foreground);
-    $outline: 1px solid mat-color($alfresco-ecm-blue, A200) !default;
 
     .adf {
         &-array-item-icon {

--- a/lib/core/card-view/components/card-view-arrayitem/card-view-arrayitem.component.scss
+++ b/lib/core/card-view/components/card-view-arrayitem/card-view-arrayitem.component.scss
@@ -1,0 +1,17 @@
+@mixin adf-card-view-array-item-theme($theme) {
+    $foreground: map-get($theme, foreground);
+    $outline: 1px solid mat-color($alfresco-ecm-blue, A200) !default;
+
+    .adf {
+        &-array-item-icon {
+            font-size: 16px;
+            padding-top: 8px;
+        }
+
+        &-array-item-more-chip-container {
+            &.mat-card {
+                box-shadow: none;
+            }
+        }
+    }
+}

--- a/lib/core/card-view/components/card-view-arrayitem/card-view-arrayitem.component.scss
+++ b/lib/core/card-view/components/card-view-arrayitem/card-view-arrayitem.component.scss
@@ -12,6 +12,18 @@
             &.mat-card {
                 box-shadow: none;
             }
+            .mat-chip {
+                cursor: pointer;
+            }
+        }
+
+        &-property-value {
+            .mat-chip-list {
+                cursor: pointer;
+            }
+            .mat-chip {
+                cursor: pointer;
+            }
         }
     }
 }

--- a/lib/core/card-view/components/card-view-arrayitem/card-view-arrayitem.component.spec.ts
+++ b/lib/core/card-view/components/card-view-arrayitem/card-view-arrayitem.component.spec.ts
@@ -102,7 +102,7 @@ describe('CardViewArrayItemComponent', () => {
 
             expect(chiplistContainer).not.toBeNull();
             expect(chip.length).toBe(3);
-            expect(chip[2].nativeElement.innerText).toBe('2 more');
+            expect(chip[2].nativeElement.innerText).toBe('2 CORE.CARDVIEW.MORE');
         });
     });
 });

--- a/lib/core/card-view/components/card-view-arrayitem/card-view-arrayitem.component.spec.ts
+++ b/lib/core/card-view/components/card-view-arrayitem/card-view-arrayitem.component.spec.ts
@@ -1,0 +1,108 @@
+/*!
+ * @license
+ * Copyright 2019 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { setupTestBed } from '../../../testing/setupTestBed';
+import { CoreTestingModule } from '../../../testing/core.testing.module';
+import { CardViewArrayItemComponent } from './card-view-arrayitem.component';
+import { CardViewArrayItemModel } from '../../models/card-view-arrayitem.model';
+import { By } from '@angular/platform-browser';
+
+describe('CardViewArrayItemComponent', () => {
+    let component: CardViewArrayItemComponent;
+    let fixture: ComponentFixture<CardViewArrayItemComponent>;
+
+    const mockData = ['Zlatan', 'Lionel Messi', 'Mohamed', 'Ronaldo'];
+    const mockDefaultProps = {
+        label: 'Array of items',
+        value: '',
+        items$: of(mockData),
+        key: 'array',
+        icon: 'person'
+    };
+    setupTestBed({
+        imports: [CoreTestingModule]
+    });
+
+    afterEach(() => {
+        fixture.destroy();
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(CardViewArrayItemComponent);
+        component = fixture.componentInstance;
+        component.property = new CardViewArrayItemModel(mockDefaultProps);
+    });
+
+    it('should create CardViewArrayItemComponent', () => {
+        expect(component instanceof CardViewArrayItemComponent).toBeTruthy();
+    });
+
+    describe('Rendering', () => {
+        it('should render the label', () => {
+            fixture.detectChanges();
+
+            const labelValue = fixture.debugElement.query(By.css('.adf-property-label'));
+            expect(labelValue).not.toBeNull();
+            expect(labelValue.nativeElement.innerText).toBe('Array of items');
+        });
+
+        it('should render chip list', () => {
+            component.property = new CardViewArrayItemModel({
+                ...mockDefaultProps,
+                editable: true
+            });
+            fixture.detectChanges();
+
+            const chiplistContainer = fixture.debugElement.query(By.css('[data-automation-id="card-arrayitem-chip-list-container"]'));
+            const chip1 = fixture.nativeElement.querySelector('[data-automation-id="card-arrayitem-chip-Zlatan"] span');
+            const chip2 = fixture.nativeElement.querySelector('[data-automation-id="card-arrayitem-chip-Lionel Messi"] span');
+
+            expect(chiplistContainer).not.toBeNull();
+            expect(chip1.innerText).toEqual('Zlatan');
+            expect(chip2.innerText).toEqual('Lionel Messi');
+        });
+
+        it('should render all values if noOfItemsToDisplay is not defined', () => {
+            fixture.detectChanges();
+
+            const chiplistContainer = fixture.debugElement.query(By.css('[data-automation-id="card-arrayitem-chip-list-container"]'));
+            const moreElement = fixture.debugElement.query(By.css('[data-automation-id="card-arrayitem-more-chip"]'));
+            const chip = fixture.nativeElement.querySelectorAll('mat-chip');
+
+            expect(chiplistContainer).not.toBeNull();
+            expect(moreElement).toBeNull();
+            expect(chip.length).toBe(4);
+        });
+
+        it('should render only two values along with more item chip if noOfItemsToDisplay is set to 2', () => {
+            component.property = new CardViewArrayItemModel({
+                ...mockDefaultProps,
+                noOfItemsToDisplay: 2
+            });
+            fixture.detectChanges();
+
+            const chiplistContainer = fixture.debugElement.query(By.css('[data-automation-id="card-arrayitem-chip-list-container"]'));
+            const chip = fixture.debugElement.queryAll(By.css('mat-chip'));
+
+            expect(chiplistContainer).not.toBeNull();
+            expect(chip.length).toBe(3);
+            expect(chip[2].nativeElement.innerText).toBe('2 more');
+        });
+    });
+});

--- a/lib/core/card-view/components/card-view-arrayitem/card-view-arrayitem.component.spec.ts
+++ b/lib/core/card-view/components/card-view-arrayitem/card-view-arrayitem.component.spec.ts
@@ -30,8 +30,7 @@ describe('CardViewArrayItemComponent', () => {
     const mockData = ['Zlatan', 'Lionel Messi', 'Mohamed', 'Ronaldo'];
     const mockDefaultProps = {
         label: 'Array of items',
-        value: '',
-        items$: of(mockData),
+        value: of(mockData),
         key: 'array',
         icon: 'person'
     };

--- a/lib/core/card-view/components/card-view-arrayitem/card-view-arrayitem.component.ts
+++ b/lib/core/card-view/components/card-view-arrayitem/card-view-arrayitem.component.ts
@@ -1,0 +1,59 @@
+/*!
+ * @license
+ * Copyright 2019 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component, Input } from '@angular/core';
+import { CardViewArrayItemModel } from '../../models/card-view-arrayitem.model';
+import { CardViewUpdateService } from '../../services/card-view-update.service';
+
+@Component({
+  selector: 'adf-card-view-arrayitem',
+  templateUrl: './card-view-arrayitem.component.html',
+  styleUrls: ['./card-view-arrayitem.component.scss']
+})
+export class CardViewArrayItemComponent {
+
+    @Input()
+    property: CardViewArrayItemModel;
+
+    @Input()
+    displayEmpty: boolean = true;
+
+    @Input()
+    editable: boolean;
+
+    constructor(private cardViewUpdateService: CardViewUpdateService) {}
+
+    getValues () {
+        return this.property.items$;
+    }
+
+    isEditable() {
+        return this.editable && this.property.editable;
+    }
+
+    clicked(): void {
+        this.cardViewUpdateService.clicked(this.property);
+    }
+
+    hasIcon(): boolean {
+        return !!this.property.icon;
+    }
+
+    displayCount() {
+        return this.property.noOfItemsToDisplay ? this.property.noOfItemsToDisplay : 0;
+    }
+}

--- a/lib/core/card-view/components/card-view-arrayitem/card-view-arrayitem.component.ts
+++ b/lib/core/card-view/components/card-view-arrayitem/card-view-arrayitem.component.ts
@@ -18,6 +18,7 @@
 import { Component, Input } from '@angular/core';
 import { CardViewArrayItemModel } from '../../models/card-view-arrayitem.model';
 import { CardViewUpdateService } from '../../services/card-view-update.service';
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'adf-card-view-arrayitem',
@@ -26,18 +27,13 @@ import { CardViewUpdateService } from '../../services/card-view-update.service';
 })
 export class CardViewArrayItemComponent {
 
+    /** The CardViewArrayItemModel of data used to populate the cardView array items. */
     @Input()
     property: CardViewArrayItemModel;
 
-    @Input()
-    displayEmpty: boolean = true;
-
-    @Input()
-    editable: boolean;
-
     constructor(private cardViewUpdateService: CardViewUpdateService) {}
 
-    getValues () {
+    getValues (): Observable<string[]> {
         return this.property.items$;
     }
 
@@ -49,7 +45,7 @@ export class CardViewArrayItemComponent {
         return !!this.property.icon;
     }
 
-    displayCount() {
+    displayCount(): number {
         return this.property.noOfItemsToDisplay ? this.property.noOfItemsToDisplay : 0;
     }
 }

--- a/lib/core/card-view/components/card-view-arrayitem/card-view-arrayitem.component.ts
+++ b/lib/core/card-view/components/card-view-arrayitem/card-view-arrayitem.component.ts
@@ -41,10 +41,6 @@ export class CardViewArrayItemComponent {
         return this.property.items$;
     }
 
-    isEditable() {
-        return this.editable && this.property.editable;
-    }
-
     clicked(): void {
         this.cardViewUpdateService.clicked(this.property);
     }

--- a/lib/core/card-view/components/card-view-arrayitem/card-view-arrayitem.component.ts
+++ b/lib/core/card-view/components/card-view-arrayitem/card-view-arrayitem.component.ts
@@ -18,7 +18,6 @@
 import { Component, Input } from '@angular/core';
 import { CardViewArrayItemModel } from '../../models/card-view-arrayitem.model';
 import { CardViewUpdateService } from '../../services/card-view-update.service';
-import { Observable } from 'rxjs';
 
 @Component({
   selector: 'adf-card-view-arrayitem',
@@ -32,10 +31,6 @@ export class CardViewArrayItemComponent {
     property: CardViewArrayItemModel;
 
     constructor(private cardViewUpdateService: CardViewUpdateService) {}
-
-    getValues (): Observable<string[]> {
-        return this.property.items$;
-    }
 
     clicked(): void {
         this.cardViewUpdateService.clicked(this.property);

--- a/lib/core/card-view/components/card-view.components.ts
+++ b/lib/core/card-view/components/card-view.components.ts
@@ -23,3 +23,4 @@ export * from './card-view-mapitem/card-view-mapitem.component';
 export * from './card-view-textitem/card-view-textitem.component';
 export * from './card-view-selectitem/card-view-selectitem.component';
 export * from './card-view-keyvaluepairsitem/card-view-keyvaluepairsitem.component';
+export * from  './card-view-arrayitem/card-view-arrayitem.component';

--- a/lib/core/card-view/interfaces/card-view-arrayitem-properties.interface.ts
+++ b/lib/core/card-view/interfaces/card-view-arrayitem-properties.interface.ts
@@ -16,9 +16,7 @@
  */
 
 import { CardViewItemProperties } from './card-view-item-properties.interface';
-import { Observable } from 'rxjs';
 
 export interface CardViewArrayItemProperties extends CardViewItemProperties {
-    items$?: Observable<string[]>;
     noOfItemsToDisplay?: number;
 }

--- a/lib/core/card-view/interfaces/card-view-arrayitem-properties.interface.ts
+++ b/lib/core/card-view/interfaces/card-view-arrayitem-properties.interface.ts
@@ -15,14 +15,11 @@
  * limitations under the License.
  */
 
-export * from './card-view-baseitem.model';
-export * from './card-view-boolitem.model';
-export * from './card-view-dateitem.model';
-export * from './card-view-datetimeitem.model';
-export * from './card-view-floatitem.model';
-export * from './card-view-intitem.model';
-export * from './card-view-mapitem.model';
-export * from './card-view-textitem.model';
-export * from './card-view-keyvaluepairs.model';
-export * from './card-view-selectitem.model';
-export * from './card-view-arrayitem.model';
+import { CardViewItemProperties } from './card-view-item-properties.interface';
+import { Observable } from 'rxjs';
+
+export interface CardViewArrayItemProperties extends CardViewItemProperties {
+    value: any;
+    items$?: Observable<string[]>;
+    noOfItemsToDisplay?: number;
+}

--- a/lib/core/card-view/interfaces/card-view-arrayitem-properties.interface.ts
+++ b/lib/core/card-view/interfaces/card-view-arrayitem-properties.interface.ts
@@ -19,7 +19,6 @@ import { CardViewItemProperties } from './card-view-item-properties.interface';
 import { Observable } from 'rxjs';
 
 export interface CardViewArrayItemProperties extends CardViewItemProperties {
-    value: any;
     items$?: Observable<string[]>;
     noOfItemsToDisplay?: number;
 }

--- a/lib/core/card-view/models/card-view-arrayitem.model.ts
+++ b/lib/core/card-view/models/card-view-arrayitem.model.ts
@@ -35,6 +35,6 @@ export class CardViewArrayItemModel extends CardViewBaseItemModel implements Car
     }
 
     get displayValue() {
-            return this.value;
+        return this.value;
     }
 }

--- a/lib/core/card-view/models/card-view-arrayitem.model.ts
+++ b/lib/core/card-view/models/card-view-arrayitem.model.ts
@@ -1,0 +1,40 @@
+/*!
+ * @license
+ * Copyright 2019 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CardViewItem } from '../interfaces/card-view-item.interface';
+import { DynamicComponentModel } from '../../services/dynamic-component-mapper.service';
+import { CardViewBaseItemModel } from './card-view-baseitem.model';
+import { Observable } from 'rxjs';
+import { CardViewArrayItemProperties } from '../interfaces/card-view-arrayitem-properties.interface';
+
+export class CardViewArrayItemModel extends CardViewBaseItemModel implements CardViewItem, DynamicComponentModel {
+
+    type: string = 'array';
+    items$: Observable<string[]>;
+    noOfItemsToDisplay: number;
+
+    constructor(cardViewArrayItemProperties: CardViewArrayItemProperties) {
+        super(cardViewArrayItemProperties);
+
+        this.items$ = cardViewArrayItemProperties.items$;
+        this.noOfItemsToDisplay = cardViewArrayItemProperties.noOfItemsToDisplay;
+    }
+
+    get displayValue() {
+            return this.value;
+    }
+}

--- a/lib/core/card-view/models/card-view-arrayitem.model.ts
+++ b/lib/core/card-view/models/card-view-arrayitem.model.ts
@@ -24,17 +24,15 @@ import { CardViewArrayItemProperties } from '../interfaces/card-view-arrayitem-p
 export class CardViewArrayItemModel extends CardViewBaseItemModel implements CardViewItem, DynamicComponentModel {
 
     type: string = 'array';
-    items$: Observable<string[]>;
+    value: Observable<string[]>;
     noOfItemsToDisplay: number;
 
     constructor(cardViewArrayItemProperties: CardViewArrayItemProperties) {
         super(cardViewArrayItemProperties);
-
-        this.items$ = cardViewArrayItemProperties.items$;
         this.noOfItemsToDisplay = cardViewArrayItemProperties.noOfItemsToDisplay;
     }
 
-    get displayValue() {
+    get displayValue(): Observable<string[]> {
         return this.value;
     }
 }

--- a/lib/core/card-view/public-api.ts
+++ b/lib/core/card-view/public-api.ts
@@ -22,7 +22,8 @@ export {
     CardViewMapItemComponent,
     CardViewTextItemComponent,
     CardViewSelectItemComponent,
-    CardViewKeyValuePairsItemComponent
+    CardViewKeyValuePairsItemComponent,
+    CardViewArrayItemComponent
 } from './components/card-view.components';
 
 export * from './interfaces/card-view.interfaces';

--- a/lib/core/card-view/services/card-item-types.service.ts
+++ b/lib/core/card-view/services/card-item-types.service.ts
@@ -23,6 +23,7 @@ import { CardViewSelectItemComponent } from '../components/card-view-selectitem/
 import { CardViewBoolItemComponent } from '../components/card-view-boolitem/card-view-boolitem.component';
 import { CardViewKeyValuePairsItemComponent } from '../components/card-view-keyvaluepairsitem/card-view-keyvaluepairsitem.component';
 import { DynamicComponentMapper, DynamicComponentResolveFunction, DynamicComponentResolver } from '../../services/dynamic-component-mapper.service';
+import { CardViewArrayItemComponent } from '../components/card-view-arrayitem/card-view-arrayitem.component';
 
 @Injectable({
     providedIn: 'root'
@@ -40,6 +41,7 @@ export class CardItemTypeService extends DynamicComponentMapper {
         'datetime': DynamicComponentResolver.fromType(CardViewDateItemComponent),
         'bool': DynamicComponentResolver.fromType(CardViewBoolItemComponent),
         'map': DynamicComponentResolver.fromType(CardViewMapItemComponent),
-        'keyvaluepairs': DynamicComponentResolver.fromType(CardViewKeyValuePairsItemComponent)
+        'keyvaluepairs': DynamicComponentResolver.fromType(CardViewKeyValuePairsItemComponent),
+        'array': DynamicComponentResolver.fromType(CardViewArrayItemComponent)
     };
 }

--- a/lib/core/i18n/en.json
+++ b/lib/core/i18n/en.json
@@ -175,7 +175,8 @@
       "VALIDATORS": {
         "FLOAT_VALIDATION_ERROR": "Use a number format",
         "INT_VALIDATION_ERROR": "Use an integer format"
-      }
+      },
+      "MORE": "More"
     },
     "METADATA": {
       "BASIC": {

--- a/lib/core/pipes/full-name.pipe.spec.ts
+++ b/lib/core/pipes/full-name.pipe.spec.ts
@@ -45,4 +45,14 @@ describe('FullNamePipe', () => {
         const user = {firstName : 'Abc', lastName : 'Xyz'};
         expect(pipe.transform(user)).toBe('Abc Xyz');
     });
+
+    it('should return username when firstName and lastName are not available', () => {
+        const user = {firstName : '', lastName : '', username: 'username'};
+        expect(pipe.transform(user)).toBe('username');
+    });
+
+    it('should return user eamil when firstName, lastName and username are not available', () => {
+        const user = {firstName : '', lastName : '', username: '', email: 'abcXyz@gmail.com'};
+        expect(pipe.transform(user)).toBe('abcXyz@gmail.com');
+    });
 });

--- a/lib/core/pipes/full-name.pipe.ts
+++ b/lib/core/pipes/full-name.pipe.ts
@@ -29,6 +29,9 @@ export class FullNamePipe implements PipeTransform {
                 fullName += fullName.length > 0 ? ' ' : '';
                 fullName += user.lastName;
             }
+            if (!fullName) {
+                fullName += user.username ? user.username : user.email ? user.email : '';
+            }
         }
         return fullName;
     }

--- a/lib/process-services-cloud/src/lib/i18n/en.json
+++ b/lib/process-services-cloud/src/lib/i18n/en.json
@@ -208,7 +208,11 @@
       "DESCRIPTION": "Description",
       "DESCRIPTION_DEFAULT": "No description",
       "FORM_NAME": "Form Name",
-      "FORM_NAME_DEFAULT": "No form"
+      "FORM_NAME_DEFAULT": "No form",
+      "CANDIDATE_USER": "Candidate Users",
+      "CANDIDATE_USERS_DEFAULT": "No Candidate Users",
+      "CANDIDATE_GROUPS": "Candidate Groups",
+      "CANDIDATE_GROUPS_DEFAULT": "No Candidate Groups"
     },
     "FORM_VALIDATION": {
         "INVALID_FIELD": "Enter a different value"

--- a/lib/process-services-cloud/src/lib/i18n/en.json
+++ b/lib/process-services-cloud/src/lib/i18n/en.json
@@ -209,7 +209,7 @@
       "DESCRIPTION_DEFAULT": "No description",
       "FORM_NAME": "Form Name",
       "FORM_NAME_DEFAULT": "No form",
-      "CANDIDATE_USER": "Candidate Users",
+      "CANDIDATE_USERS": "Candidate Users",
       "CANDIDATE_USERS_DEFAULT": "No Candidate Users",
       "CANDIDATE_GROUPS": "Candidate Groups",
       "CANDIDATE_GROUPS_DEFAULT": "No Candidate Groups"

--- a/lib/process-services-cloud/src/lib/task/services/task-cloud.service.spec.ts
+++ b/lib/process-services-cloud/src/lib/task/services/task-cloud.service.spec.ts
@@ -60,6 +60,26 @@ describe('Task Cloud Service', () => {
         };
     }
 
+    function returnFakeCandidateUsersResults() {
+        return {
+            oauth2Auth: {
+                callCustomApi : () => {
+                    return Promise.resolve(['mockuser1', 'mockuser2', 'mockuser3']);
+                }
+            }
+        };
+    }
+
+    function returnFakeCandidateGroupResults() {
+        return {
+            oauth2Auth: {
+                callCustomApi : () => {
+                    return Promise.resolve(['mockgroup1', 'mockgroup2', 'mockgroup3']);
+                }
+            }
+        };
+    }
+
     setupTestBed({
         imports: [
             CoreModule.forRoot()
@@ -306,6 +326,82 @@ describe('Task Cloud Service', () => {
         const updatePayload = { description: 'New description' };
         spyOn(alfrescoApiMock, 'getInstance').and.callFake(returnFakeTaskDetailsResults);
         service.updateTask(appName, taskId, updatePayload).subscribe(
+            () => { },
+            (error) => {
+                expect(error).toBe('AppName/TaskId not configured');
+                done();
+            });
+    });
+
+    it('should return the candidate users by appName and taskId', (done) => {
+        const appName = 'taskp-app';
+        const taskId = '68d54a8f';
+        spyOn(alfrescoApiMock, 'getInstance').and.callFake(returnFakeCandidateUsersResults);
+        service.getCandidateUsers(appName, taskId).subscribe((res: any) => {
+            expect(res).toBeDefined();
+            expect(res).not.toBeNull();
+            expect(res.length).toBe(3);
+            expect(res[0]).toBe('mockuser1');
+            expect(res[1]).toBe('mockuser2');
+            done();
+        });
+    });
+
+    it('should throw error if appName is not defined when fetching candidate users', (done) => {
+        const appName = null;
+        const taskId = '68d54a8f';
+        spyOn(alfrescoApiMock, 'getInstance').and.callFake(returnFakeCandidateUsersResults);
+        service.getCandidateUsers(appName, taskId).subscribe(
+            () => { },
+            (error) => {
+                expect(error).toBe('AppName/TaskId not configured');
+                done();
+            });
+    });
+
+    it('should throw error if taskId is not defined when fetching candidate users', (done) => {
+        const appName = 'task-app';
+        const taskId = null;
+        spyOn(alfrescoApiMock, 'getInstance').and.callFake(returnFakeCandidateUsersResults);
+        service.getCandidateUsers(appName, taskId).subscribe(
+            () => { },
+            (error) => {
+                expect(error).toBe('AppName/TaskId not configured');
+                done();
+            });
+    });
+
+    it('should return the candidate groups by appName and taskId', (done) => {
+        const appName = 'taskp-app';
+        const taskId = '68d54a8f';
+        spyOn(alfrescoApiMock, 'getInstance').and.callFake(returnFakeCandidateGroupResults);
+        service.getCandidateGroups(appName, taskId).subscribe((res: any) => {
+            expect(res).toBeDefined();
+            expect(res).not.toBeNull();
+            expect(res.length).toBe(3);
+            expect(res[0]).toBe('mockgroup1');
+            expect(res[1]).toBe('mockgroup2');
+            done();
+        });
+    });
+
+    it('should throw error if appName is not defined when fetching candidate groups', (done) => {
+        const appName = null;
+        const taskId = '68d54a8f';
+        spyOn(alfrescoApiMock, 'getInstance').and.callFake(returnFakeCandidateGroupResults);
+        service.getCandidateGroups(appName, taskId).subscribe(
+            () => { },
+            (error) => {
+                expect(error).toBe('AppName/TaskId not configured');
+                done();
+            });
+    });
+
+    it('should throw error if taskId is not defined when fetching candidate groups', (done) => {
+        const appName = 'task-app';
+        const taskId = null;
+        spyOn(alfrescoApiMock, 'getInstance').and.callFake(returnFakeCandidateGroupResults);
+        service.getCandidateGroups(appName, taskId).subscribe(
             () => { },
             (error) => {
                 expect(error).toBe('AppName/TaskId not configured');

--- a/lib/process-services-cloud/src/lib/task/services/task-cloud.service.spec.ts
+++ b/lib/process-services-cloud/src/lib/task/services/task-cloud.service.spec.ts
@@ -337,7 +337,7 @@ describe('Task Cloud Service', () => {
         const appName = 'taskp-app';
         const taskId = '68d54a8f';
         spyOn(alfrescoApiMock, 'getInstance').and.callFake(returnFakeCandidateUsersResults);
-        service.getCandidateUsers(appName, taskId).subscribe((res: any) => {
+        service.getCandidateUsers(appName, taskId).subscribe((res: string[]) => {
             expect(res).toBeDefined();
             expect(res).not.toBeNull();
             expect(res.length).toBe(3);
@@ -347,26 +347,24 @@ describe('Task Cloud Service', () => {
         });
     });
 
-    it('should throw error if appName is not defined when fetching candidate users', (done) => {
+    it('should log message and return empty array if appName is not defined when fetching candidate users', (done) => {
         const appName = null;
         const taskId = '68d54a8f';
         spyOn(alfrescoApiMock, 'getInstance').and.callFake(returnFakeCandidateUsersResults);
         service.getCandidateUsers(appName, taskId).subscribe(
-            () => { },
-            (error) => {
-                expect(error).toBe('AppName/TaskId not configured');
+            (res: any[]) => {
+                expect(res.length).toBe(0);
                 done();
             });
     });
 
-    it('should throw error if taskId is not defined when fetching candidate users', (done) => {
+    it('should log message and return empty array if taskId is not defined when fetching candidate users', (done) => {
         const appName = 'task-app';
         const taskId = null;
         spyOn(alfrescoApiMock, 'getInstance').and.callFake(returnFakeCandidateUsersResults);
         service.getCandidateUsers(appName, taskId).subscribe(
-            () => { },
-            (error) => {
-                expect(error).toBe('AppName/TaskId not configured');
+            (res: any[]) => {
+                expect(res.length).toBe(0);
                 done();
             });
     });
@@ -375,7 +373,7 @@ describe('Task Cloud Service', () => {
         const appName = 'taskp-app';
         const taskId = '68d54a8f';
         spyOn(alfrescoApiMock, 'getInstance').and.callFake(returnFakeCandidateGroupResults);
-        service.getCandidateGroups(appName, taskId).subscribe((res: any) => {
+        service.getCandidateGroups(appName, taskId).subscribe((res: string[]) => {
             expect(res).toBeDefined();
             expect(res).not.toBeNull();
             expect(res.length).toBe(3);
@@ -385,26 +383,24 @@ describe('Task Cloud Service', () => {
         });
     });
 
-    it('should throw error if appName is not defined when fetching candidate groups', (done) => {
+    it('should log message and return empty array if appName is not defined when fetching candidate groups', (done) => {
         const appName = null;
         const taskId = '68d54a8f';
         spyOn(alfrescoApiMock, 'getInstance').and.callFake(returnFakeCandidateGroupResults);
         service.getCandidateGroups(appName, taskId).subscribe(
-            () => { },
-            (error) => {
-                expect(error).toBe('AppName/TaskId not configured');
+            (res: any[]) => {
+                expect(res.length).toBe(0);
                 done();
             });
     });
 
-    it('should throw error if taskId is not defined when fetching candidate groups', (done) => {
+    it('should log message and return empty array if taskId is not defined when fetching candidate groups', (done) => {
         const appName = 'task-app';
         const taskId = null;
         spyOn(alfrescoApiMock, 'getInstance').and.callFake(returnFakeCandidateGroupResults);
         service.getCandidateGroups(appName, taskId).subscribe(
-            () => { },
-            (error) => {
-                expect(error).toBe('AppName/TaskId not configured');
+            (res: any[]) => {
+                expect(res.length).toBe(0);
                 done();
             });
     });

--- a/lib/process-services-cloud/src/lib/task/services/task-cloud.service.ts
+++ b/lib/process-services-cloud/src/lib/task/services/task-cloud.service.ts
@@ -246,6 +246,60 @@ export class TaskCloudService extends BaseCloudService {
         }
     }
 
+    /**
+     * Gets candidate users of the task.
+     * @param appName Name of the app
+     * @param taskId ID of the task
+     * @returns Candidate users
+     */
+    getCandidateUsers(appName: string, taskId: string): Observable<string[]> {
+        if ((appName || appName === '') && taskId) {
+            const queryUrl = `${this.getBasePath(appName)}/rb/v1/tasks/${taskId}/candidate-users`;
+            return from(this.apiService.getInstance()
+                .oauth2Auth.callCustomApi(queryUrl, 'GET',
+                    null, null, null,
+                    null, null,
+                    this.contentTypes, this.accepts,
+                    this.returnType, null, null)
+            ).pipe(
+                map((response: string[]) => {
+                    return response;
+                }),
+                catchError((err) => this.handleError(err))
+            );
+        } else {
+            this.logService.error('AppName and TaskId are mandatory to get candidate user');
+            return throwError('AppName/TaskId not configured');
+        }
+    }
+
+    /**
+     * Gets candidate groups of the task.
+     * @param appName Name of the app
+     * @param taskId ID of the task
+     * @returns Candidate groups
+     */
+    getCandidateGroups(appName: string, taskId: string): Observable<string[]> {
+        if ((appName || appName === '') && taskId) {
+            const queryUrl = `${this.getBasePath(appName)}/rb/v1/tasks/${taskId}/candidate-groups`;
+            return from(this.apiService.getInstance()
+                .oauth2Auth.callCustomApi(queryUrl, 'GET',
+                    null, null, null,
+                    null, null,
+                    this.contentTypes, this.accepts,
+                    this.returnType, null, null)
+            ).pipe(
+                map((response: string[]) => {
+                    return response;
+                }),
+                catchError((err) => this.handleError(err))
+            );
+        } else {
+            this.logService.error('AppName and TaskId are mandatory to get candidate groups');
+            return throwError('AppName/TaskId not configured');
+        }
+    }
+
     private isAssignedToMe(assignee: string): boolean {
         const currentUser = this.identityUserService.getCurrentUserInfo().username;
         return assignee === currentUser;

--- a/lib/process-services-cloud/src/lib/task/services/task-cloud.service.ts
+++ b/lib/process-services-cloud/src/lib/task/services/task-cloud.service.ts
@@ -17,7 +17,7 @@
 
 import { Injectable } from '@angular/core';
 import { AlfrescoApiService, LogService, AppConfigService, IdentityUserService } from '@alfresco/adf-core';
-import { from, throwError, Observable } from 'rxjs';
+import { from, throwError, Observable, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { TaskDetailsCloudModel, StartTaskCloudResponseModel } from '../start-task/models/task-details-cloud.model';
 import { BaseCloudService } from '../../services/base-cloud.service';
@@ -254,7 +254,7 @@ export class TaskCloudService extends BaseCloudService {
      */
     getCandidateUsers(appName: string, taskId: string): Observable<string[]> {
         if ((appName || appName === '') && taskId) {
-            const queryUrl = `${this.getBasePath(appName)}/rb/v1/tasks/${taskId}/candidate-users`;
+            const queryUrl = `${this.getBasePath(appName)}/query/v1/tasks/${taskId}/candidate-users`;
             return from(this.apiService.getInstance()
                 .oauth2Auth.callCustomApi(queryUrl, 'GET',
                     null, null, null,
@@ -269,7 +269,7 @@ export class TaskCloudService extends BaseCloudService {
             );
         } else {
             this.logService.error('AppName and TaskId are mandatory to get candidate user');
-            return throwError('AppName/TaskId not configured');
+            return of([]);
         }
     }
 
@@ -281,7 +281,7 @@ export class TaskCloudService extends BaseCloudService {
      */
     getCandidateGroups(appName: string, taskId: string): Observable<string[]> {
         if ((appName || appName === '') && taskId) {
-            const queryUrl = `${this.getBasePath(appName)}/rb/v1/tasks/${taskId}/candidate-groups`;
+            const queryUrl = `${this.getBasePath(appName)}/query/v1/tasks/${taskId}/candidate-groups`;
             return from(this.apiService.getInstance()
                 .oauth2Auth.callCustomApi(queryUrl, 'GET',
                     null, null, null,
@@ -296,7 +296,7 @@ export class TaskCloudService extends BaseCloudService {
             );
         } else {
             this.logService.error('AppName and TaskId are mandatory to get candidate groups');
-            return throwError('AppName/TaskId not configured');
+            return of([]);
         }
     }
 

--- a/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.spec.ts
@@ -32,8 +32,12 @@ describe('TaskHeaderCloudComponent', () => {
     let service: TaskCloudService;
     let appConfigService: AppConfigService;
     let identityUserService: IdentityUserService;
+    let getCandidateGroupsSpy: jasmine.Spy;
+    let getCandidateUsersSpy: jasmine.Spy;
 
     const identityUserMock = { username: 'testuser', firstName: 'fake-identity-first-name', lastName: 'fake-identity-last-name', email: 'fakeIdentity@email.com' };
+    const mockCandidateUsers = ['mockuser1', 'mockuser2', 'mockuser3'];
+    const mockCandidateGroups = ['mockgroup1', 'mockgroup2', 'mockgroup3'];
 
     setupTestBed({
         imports: [
@@ -53,6 +57,8 @@ describe('TaskHeaderCloudComponent', () => {
         identityUserService = TestBed.get(IdentityUserService);
         appConfigService = TestBed.get(AppConfigService);
         spyOn(service, 'getTaskById').and.returnValue(of(assignedTaskDetailsCloudMock));
+        getCandidateUsersSpy = spyOn(service, 'getCandidateUsers').and.returnValue(of(mockCandidateUsers));
+        getCandidateGroupsSpy = spyOn(service, 'getCandidateGroups').and.returnValue(of(mockCandidateGroups));
         spyOn(identityUserService, 'getCurrentUserInfo').and.returnValue(identityUserMock);
     });
 
@@ -149,6 +155,60 @@ describe('TaskHeaderCloudComponent', () => {
             const valueEl = fixture.debugElement.query(By.css('[data-automation-id="header-parentName"] .adf-property-value'));
             expect(valueEl.nativeElement.innerText.trim()).toEqual('ADF_CLOUD_TASK_HEADER.PROPERTIES.PARENT_NAME_DEFAULT');
         });
+    }));
+
+    it('should display candidate user', async(() => {
+        component.ngOnInit();
+        fixture.detectChanges();
+
+        fixture.whenStable().then(() => {
+            const candidateUser1 = fixture.nativeElement.querySelector('[data-automation-id="card-arrayitem-chip-mockuser1"] span');
+            const candidateUser2 = fixture.nativeElement.querySelector('[data-automation-id="card-arrayitem-chip-mockuser2"] span');
+            expect(getCandidateUsersSpy).toHaveBeenCalled();
+            expect(candidateUser1.innerText).toBe('mockuser1');
+            expect(candidateUser2.innerText).toBe('mockuser2');
+        });
+    }));
+
+    it('should display placeholder if no candidate users', async(() => {
+        component.ngOnInit();
+        getCandidateUsersSpy.and.returnValue(of([]));
+        fixture.detectChanges();
+
+        fixture.whenStable().then(() => {
+            const labelValue = fixture.debugElement.query(By.css('[data-automation-id="card-array-label-candidateUsers"]'));
+            const defaultElement = fixture.debugElement.query(By.css('[data-automation-id="card-arrayitem-default"]'));
+            expect(labelValue.nativeElement.innerText).toBe('ADF_CLOUD_TASK_HEADER.PROPERTIES.CANDIDATE_USERS');
+            expect(defaultElement.nativeElement.innerText).toBe('ADF_CLOUD_TASK_HEADER.PROPERTIES.CANDIDATE_USERS_DEFAULT');
+        });
+
+    }));
+
+    it('should display candidate groups', async(() => {
+        component.ngOnInit();
+        fixture.detectChanges();
+
+        fixture.whenStable().then(() => {
+            const candidateGroup1 = fixture.nativeElement.querySelector('[data-automation-id="card-arrayitem-chip-mockgroup1"] span');
+            const candidateGroup2 = fixture.nativeElement.querySelector('[data-automation-id="card-arrayitem-chip-mockgroup2"] span');
+            expect(getCandidateGroupsSpy).toHaveBeenCalled();
+            expect(candidateGroup1.innerText).toBe('mockgroup1');
+            expect(candidateGroup2.innerText).toBe('mockgroup2');
+        });
+    }));
+
+    it('should display placeholder if no candidate groups', async(() => {
+        component.ngOnInit();
+        getCandidateGroupsSpy.and.returnValue(of([]));
+        fixture.detectChanges();
+
+        fixture.whenStable().then(() => {
+            const labelValue = fixture.debugElement.query(By.css('[data-automation-id="card-array-label-candidateGroups"]'));
+            const defaultElement = fixture.debugElement.query(By.css('[data-automation-id="card-arrayitem-default"]'));
+            expect(labelValue.nativeElement.innerText).toBe('ADF_CLOUD_TASK_HEADER.PROPERTIES.CANDIDATE_GROUPS');
+            expect(defaultElement.nativeElement.innerText).toBe('ADF_CLOUD_TASK_HEADER.PROPERTIES.CANDIDATE_GROUPS_DEFAULT');
+        });
+
     }));
 
     describe('Config Filtering', () => {

--- a/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.ts
@@ -204,7 +204,6 @@ export class TaskHeaderCloudComponent implements OnInit, OnDestroy {
                     key: 'candidateUsers',
                     icon: 'person',
                     default: this.translationService.instant('ADF_CLOUD_TASK_HEADER.PROPERTIES.CANDIDATE_USERS_DEFAULT'),
-                    editable: false,
                     noOfItemsToDisplay: 2
                 }
             ),
@@ -216,7 +215,6 @@ export class TaskHeaderCloudComponent implements OnInit, OnDestroy {
                     key: 'candidateGroups',
                     icon: 'person',
                     default: this.translationService.instant('ADF_CLOUD_TASK_HEADER.PROPERTIES.CANDIDATE_GROUPS_DEFAULT'),
-                    editable: false,
                     noOfItemsToDisplay: 2
                 }
             )

--- a/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.ts
@@ -199,8 +199,7 @@ export class TaskHeaderCloudComponent implements OnInit, OnDestroy {
             new CardViewArrayItemModel(
                 {
                     label: 'ADF_CLOUD_TASK_HEADER.PROPERTIES.CANDIDATE_USERS',
-                    value: '',
-                    items$: this.getCandidateUsers(),
+                    value: this.getCandidateUsers(),
                     key: 'candidateUsers',
                     icon: 'person',
                     default: this.translationService.instant('ADF_CLOUD_TASK_HEADER.PROPERTIES.CANDIDATE_USERS_DEFAULT'),
@@ -210,8 +209,7 @@ export class TaskHeaderCloudComponent implements OnInit, OnDestroy {
             new CardViewArrayItemModel(
                 {
                     label: 'ADF_CLOUD_TASK_HEADER.PROPERTIES.CANDIDATE_GROUPS',
-                    value: '',
-                    items$: this.getCandidateGroups(),
+                    value: this.getCandidateGroups(),
                     key: 'candidateGroups',
                     icon: 'person',
                     default: this.translationService.instant('ADF_CLOUD_TASK_HEADER.PROPERTIES.CANDIDATE_GROUPS_DEFAULT'),

--- a/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.ts
@@ -31,7 +31,7 @@ import { Router } from '@angular/router';
 import { TaskCloudService } from '../../services/task-cloud.service';
 import { Subject } from 'rxjs';
 import { NumericFieldValidator } from '../../../validators/numeric-field.validator';
-import { takeUntil } from 'rxjs/operators';
+import { takeUntil, map } from 'rxjs/operators';
 
 @Component({
     selector: 'adf-cloud-task-header',
@@ -63,6 +63,8 @@ export class TaskHeaderCloudComponent implements OnInit, OnDestroy {
     dateFormat: string;
     dateLocale: string;
     displayDateClearAction = false;
+    private candidateUsers: string;
+    private candidateGroups: string;
 
     private onDestroy$ = new Subject<boolean>();
 
@@ -80,6 +82,8 @@ export class TaskHeaderCloudComponent implements OnInit, OnDestroy {
     ngOnInit() {
         if ((this.appName || this.appName === '') && this.taskId) {
             this.loadTaskDetailsById(this.appName, this.taskId);
+            this.getCandidateUsers();
+            this.getCandidateGroups();
         }
 
         this.cardViewUpdateService.itemUpdated$
@@ -194,8 +198,36 @@ export class TaskHeaderCloudComponent implements OnInit, OnDestroy {
                     multiline: true,
                     editable: true
                 }
+            ),
+            new CardViewTextItemModel(
+                {
+                    label: 'ADF_CLOUD_TASK_HEADER.PROPERTIES.CANDIDATE_USER',
+                    value: this.candidateUsers,
+                    key: 'candidateUsers',
+                    default: this.translationService.instant('ADF_CLOUD_TASK_HEADER.PROPERTIES.CANDIDATE_USERS_DEFAULT')
+                }
+            ),
+            new CardViewTextItemModel(
+                {
+                    label: 'ADF_CLOUD_TASK_HEADER.PROPERTIES.CANDIDATE_GROUPS',
+                    value: this.candidateGroups,
+                    default: this.translationService.instant('ADF_CLOUD_TASK_HEADER.PROPERTIES.CANDIDATE_GROUPS_DEFAULT'),
+                    key: 'candidateGroups'
+                }
             )
         ];
+    }
+
+    private getCandidateUsers() {
+        this.taskCloudService.getCandidateUsers(this.appName, this.taskId).pipe(
+            map((users: string[]) => users && users.length > 0 ? users.join() : ''))
+            .subscribe((res) => this.candidateUsers = res);
+    }
+
+    private getCandidateGroups() {
+        this.taskCloudService.getCandidateGroups(this.appName, this.taskId).pipe(
+            map((groups: string[]) => groups && groups.length > 0 ? groups.join() : ''))
+            .subscribe((res) => this.candidateGroups = res);
     }
 
     /**

--- a/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.ts
@@ -211,7 +211,7 @@ export class TaskHeaderCloudComponent implements OnInit, OnDestroy {
                     label: 'ADF_CLOUD_TASK_HEADER.PROPERTIES.CANDIDATE_GROUPS',
                     value: this.getCandidateGroups(),
                     key: 'candidateGroups',
-                    icon: 'person',
+                    icon: 'group',
                     default: this.translationService.instant('ADF_CLOUD_TASK_HEADER.PROPERTIES.CANDIDATE_GROUPS_DEFAULT'),
                     noOfItemsToDisplay: 2
                 }

--- a/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.ts
@@ -21,6 +21,7 @@ import {
     CardViewItem,
     CardViewTextItemModel,
     CardViewBaseItemModel,
+    CardViewArrayItemModel,
     TranslationService,
     AppConfigService,
     UpdateNotification,
@@ -31,7 +32,7 @@ import { Router } from '@angular/router';
 import { TaskCloudService } from '../../services/task-cloud.service';
 import { Subject } from 'rxjs';
 import { NumericFieldValidator } from '../../../validators/numeric-field.validator';
-import { takeUntil, map } from 'rxjs/operators';
+import { takeUntil } from 'rxjs/operators';
 
 @Component({
     selector: 'adf-cloud-task-header',
@@ -63,8 +64,6 @@ export class TaskHeaderCloudComponent implements OnInit, OnDestroy {
     dateFormat: string;
     dateLocale: string;
     displayDateClearAction = false;
-    private candidateUsers: string;
-    private candidateGroups: string;
 
     private onDestroy$ = new Subject<boolean>();
 
@@ -82,8 +81,6 @@ export class TaskHeaderCloudComponent implements OnInit, OnDestroy {
     ngOnInit() {
         if ((this.appName || this.appName === '') && this.taskId) {
             this.loadTaskDetailsById(this.appName, this.taskId);
-            this.getCandidateUsers();
-            this.getCandidateGroups();
         }
 
         this.cardViewUpdateService.itemUpdated$
@@ -199,35 +196,39 @@ export class TaskHeaderCloudComponent implements OnInit, OnDestroy {
                     editable: true
                 }
             ),
-            new CardViewTextItemModel(
+            new CardViewArrayItemModel(
                 {
-                    label: 'ADF_CLOUD_TASK_HEADER.PROPERTIES.CANDIDATE_USER',
-                    value: this.candidateUsers,
+                    label: 'ADF_CLOUD_TASK_HEADER.PROPERTIES.CANDIDATE_USERS',
+                    value: '',
+                    items$: this.getCandidateUsers(),
                     key: 'candidateUsers',
-                    default: this.translationService.instant('ADF_CLOUD_TASK_HEADER.PROPERTIES.CANDIDATE_USERS_DEFAULT')
+                    icon: 'person',
+                    default: this.translationService.instant('ADF_CLOUD_TASK_HEADER.PROPERTIES.CANDIDATE_USERS_DEFAULT'),
+                    editable: false,
+                    noOfItemsToDisplay: 2
                 }
             ),
-            new CardViewTextItemModel(
+            new CardViewArrayItemModel(
                 {
                     label: 'ADF_CLOUD_TASK_HEADER.PROPERTIES.CANDIDATE_GROUPS',
-                    value: this.candidateGroups,
+                    value: '',
+                    items$: this.getCandidateGroups(),
+                    key: 'candidateGroups',
+                    icon: 'person',
                     default: this.translationService.instant('ADF_CLOUD_TASK_HEADER.PROPERTIES.CANDIDATE_GROUPS_DEFAULT'),
-                    key: 'candidateGroups'
+                    editable: false,
+                    noOfItemsToDisplay: 2
                 }
             )
         ];
     }
 
     private getCandidateUsers() {
-        this.taskCloudService.getCandidateUsers(this.appName, this.taskId).pipe(
-            map((users: string[]) => users && users.length > 0 ? users.join() : ''))
-            .subscribe((res) => this.candidateUsers = res);
+        return this.taskCloudService.getCandidateUsers(this.appName, this.taskId);
     }
 
     private getCandidateGroups() {
-        this.taskCloudService.getCandidateGroups(this.appName, this.taskId).pipe(
-            map((groups: string[]) => groups && groups.length > 0 ? groups.join() : ''))
-            .subscribe((res) => this.candidateGroups = res);
+        return this.taskCloudService.getCandidateGroups(this.appName, this.taskId);
     }
 
     /**

--- a/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.ts
@@ -30,7 +30,7 @@ import {
 import { TaskDetailsCloudModel, TaskStatusEnum } from '../../start-task/models/task-details-cloud.model';
 import { Router } from '@angular/router';
 import { TaskCloudService } from '../../services/task-cloud.service';
-import { Subject } from 'rxjs';
+import { Subject, Observable } from 'rxjs';
 import { NumericFieldValidator } from '../../../validators/numeric-field.validator';
 import { takeUntil } from 'rxjs/operators';
 
@@ -221,11 +221,11 @@ export class TaskHeaderCloudComponent implements OnInit, OnDestroy {
         ];
     }
 
-    private getCandidateUsers() {
+    private getCandidateUsers(): Observable<string[]> {
         return this.taskCloudService.getCandidateUsers(this.appName, this.taskId);
     }
 
-    private getCandidateGroups() {
+    private getCandidateGroups(): Observable<string[]> {
         return this.taskCloudService.getCandidateGroups(this.appName, this.taskId);
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

1. TaskHeaderCloud component does not expose candidate users/groups that were added during modeling time.
2. fullName pipe to just renders first or the last name if they present, if not it just returns an empty string. 

User Header:

![image](https://user-images.githubusercontent.com/25585550/67488435-7c6f4780-f68d-11e9-90fa-17c58782fd99.png)

PeopleCloudSearch component:

![image](https://user-images.githubusercontent.com/25585550/67488607-b7717b00-f68d-11e9-8647-07b8433354a1.png)


https://issues.alfresco.com/jira/browse/ADF-4971

**What is the new behaviour?**

1. fullName pipe will render username or email in case first & the last name is missing.

User Header:
![image](https://user-images.githubusercontent.com/25585550/67489232-da505f00-f68e-11e9-91c7-c302a183ef9d.png)

PeopleCloudSearch component:
![image](https://user-images.githubusercontent.com/25585550/67489113-a07f5880-f68e-11e9-9c14-ac296848c05f.png)


2.TaskHeaderCloud component displays candidate users/groups that were added during modeling time. To achieve the above behavior we need a new CardView component, which takes an array of values and displays them using mat-chip.

3.New CardViewArrayItemComponent Type created in the card view module:

CardViewArrayItemComponent:
![card-view-array-item](https://user-images.githubusercontent.com/25585550/67485269-5050c800-f687-11e9-8f24-6b542b226bb5.png)

![card-view-array-with-more-option](https://user-images.githubusercontent.com/25585550/67485285-55ae1280-f687-11e9-8efe-97703df93574.png)

![card-view-array-with-more-info](https://user-images.githubusercontent.com/25585550/67485297-59419980-f687-11e9-805a-4069a1de8131.png)

TaskHeaderCloudComponent With Candidate Users/Groups:

![task-cloud-header-component-1](https://user-images.githubusercontent.com/25585550/67485649-2055f480-f688-11e9-89f7-6a5e6ea636a7.png)

![task-cloud-component-2](https://user-images.githubusercontent.com/25585550/67485652-22b84e80-f688-11e9-81f7-87cf382c36d8.png)

With No Candidate User/Groups

![task-cloud-header-3](https://user-images.githubusercontent.com/25585550/67485660-264bd580-f688-11e9-8368-5fcaed1201a3.png)


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
