### PR TITLE
[ADF-4968 ] [TaskHeaderCloudComponent] Allow Assignee property to be clickable if the task in CREATED, ASSIGNED, SUSPENDED states

### DIFF
--- a/lib/process-services-cloud/src/lib/task/start-task/models/task-details-cloud.model.ts
+++ b/lib/process-services-cloud/src/lib/task/start-task/models/task-details-cloud.model.ts
@@ -85,6 +85,11 @@ export class TaskDetailsCloudModel {
         return this.status === TaskStatusEnum.ASSIGNED;
     }
 
+    clickAble(): boolean {
+        const states = [TaskStatusEnum.ASSIGNED, TaskStatusEnum.CREATED, TaskStatusEnum.SUSPENDED];
+        return states.includes(this.status);
+    }
+
     canClaimTask(): boolean {
         return this.status === TaskStatusEnum.CREATED;
     }

--- a/lib/process-services-cloud/src/lib/task/start-task/models/task-details-cloud.model.ts
+++ b/lib/process-services-cloud/src/lib/task/start-task/models/task-details-cloud.model.ts
@@ -85,11 +85,6 @@ export class TaskDetailsCloudModel {
         return this.status === TaskStatusEnum.ASSIGNED;
     }
 
-    clickAble(): boolean {
-        const states = [TaskStatusEnum.ASSIGNED, TaskStatusEnum.CREATED, TaskStatusEnum.SUSPENDED];
-        return states.includes(this.status);
-    }
-
     canClaimTask(): boolean {
         return this.status === TaskStatusEnum.CREATED;
     }

--- a/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.ts
@@ -160,14 +160,16 @@ export class TaskHeaderCloudComponent implements OnInit, OnDestroy {
                     label: 'ADF_CLOUD_TASK_HEADER.PROPERTIES.PARENT_NAME',
                     value: this.parentTaskName,
                     default: this.translationService.instant('ADF_CLOUD_TASK_HEADER.PROPERTIES.PARENT_NAME_DEFAULT'),
-                    key: 'parentName'
+                    key: 'parentName',
+                    clickable: true
                 }
             ),
             new CardViewTextItemModel(
                 {
                     label: 'ADF_CLOUD_TASK_HEADER.PROPERTIES.PARENT_TASK_ID',
                     value: this.taskDetails.parentTaskId,
-                    key: 'parentTaskId'
+                    key: 'parentTaskId',
+                    clickable: true
                 }
             ),
             new CardViewDateItemModel(

--- a/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.ts
@@ -106,7 +106,7 @@ export class TaskHeaderCloudComponent implements OnInit, OnDestroy {
                     label: 'ADF_CLOUD_TASK_HEADER.PROPERTIES.ASSIGNEE',
                     value: this.taskDetails.assignee,
                     key: 'assignee',
-                    clickable: this.taskDetails.clickAble(),
+                    clickable: this.isClickable(),
                     default: this.translationService.instant('ADF_CLOUD_TASK_HEADER.PROPERTIES.ASSIGNEE_DEFAULT'),
                     icon: 'create'
                 }
@@ -255,6 +255,11 @@ export class TaskHeaderCloudComponent implements OnInit, OnDestroy {
 
     isTaskEditable(): boolean {
         return this.taskCloudService.isTaskEditable(this.taskDetails);
+    }
+
+    isClickable(): boolean {
+        const states = [TaskStatusEnum.ASSIGNED, TaskStatusEnum.CREATED, TaskStatusEnum.SUSPENDED];
+        return states.includes(this.taskDetails.status);
     }
 
     private isValidSelection(filteredProperties: string[], cardItem: CardViewBaseItemModel): boolean {

--- a/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.ts
@@ -106,6 +106,7 @@ export class TaskHeaderCloudComponent implements OnInit, OnDestroy {
                     label: 'ADF_CLOUD_TASK_HEADER.PROPERTIES.ASSIGNEE',
                     value: this.taskDetails.assignee,
                     key: 'assignee',
+                    clickable: this.taskDetails.clickAble(),
                     default: this.translationService.instant('ADF_CLOUD_TASK_HEADER.PROPERTIES.ASSIGNEE_DEFAULT'),
                     icon: 'create'
                 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://issues.alfresco.com/jira/browse/ADF-4968,
Assignee property of taskCloudHeader is not clickable.

**What is the new behaviour?**

Now assignee property of taskCloudHeader is clickable if the task in CREATED, ASSIGNED, SUSPENDED states.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
