### PR TITLE
[AAE-726] Add new return await rule

### DIFF
--- a/e2e/actions/APS/apps.actions.ts
+++ b/e2e/actions/APS/apps.actions.ts
@@ -65,7 +65,7 @@ export class AppsActions {
         const pathFile = path.join(browser.params.testConfig.main.rootPath + appFileLocation);
         const file = fs.createReadStream(pathFile);
 
-        return await alfrescoJsApi.activiti.appsApi.importAppDefinition(file);
+        return alfrescoJsApi.activiti.appsApi.importAppDefinition(file);
     }
 
     async publishDeployApp(alfrescoJsApi, appId) {
@@ -116,7 +116,7 @@ export class AppsActions {
             startProcessOptions.name = processName;
         }
 
-        return await alfrescoJsApi.activiti.processApi.startNewProcessInstance(startProcessOptions);
+        return alfrescoJsApi.activiti.processApi.startNewProcessInstance(startProcessOptions);
 
     }
 

--- a/e2e/actions/APS/appsRuntime.actions.ts
+++ b/e2e/actions/APS/appsRuntime.actions.ts
@@ -33,7 +33,7 @@ export class AppsRuntimeActions {
 
     async getRuntimeAppDefinitions(alfrescoJsApi) {
 
-        return await alfrescoJsApi.activiti.appsRuntimeApi.getAppDefinitions();
+        return alfrescoJsApi.activiti.appsRuntimeApi.getAppDefinitions();
     }
 
 }

--- a/e2e/actions/APS/models.actions.ts
+++ b/e2e/actions/APS/models.actions.ts
@@ -19,12 +19,12 @@ export class ModelsActions {
 
     async deleteVersionModel(alfrescoJsApi, modelId) {
 
-       return await alfrescoJsApi.activiti.modelsApi.deleteModel(modelId, { cascade: false, deleteRuntimeApp : true });
+       return alfrescoJsApi.activiti.modelsApi.deleteModel(modelId, { cascade: false, deleteRuntimeApp : true });
     }
 
     async deleteEntireModel(alfrescoJsApi, modelId) {
 
-        return await alfrescoJsApi.activiti.modelsApi.deleteModel(modelId, { cascade: true, deleteRuntimeApp : true });
+        return alfrescoJsApi.activiti.modelsApi.deleteModel(modelId, { cascade: true, deleteRuntimeApp : true });
     }
 
 }

--- a/e2e/actions/drop.actions.ts
+++ b/e2e/actions/drop.actions.ts
@@ -84,7 +84,7 @@ export class DropActions {
         fs.accessSync(absolutePath, fs.constants.F_OK);
         const elem = await dropArea.getWebElement();
         const input: any = await browser.executeScript(JS_BIND_INPUT, elem);
-        return await input.sendKeys(absolutePath);
+        return input.sendKeys(absolutePath);
     }
 
     async dropFolder(dropArea, folderPath) {
@@ -95,6 +95,6 @@ export class DropActions {
 
         const elem = await dropArea.getWebElement();
         const input: any = await browser.executeScript(JS_BIND_INPUT_FOLDER, elem);
-        return await input.sendKeys(absolutePath);
+        return input.sendKeys(absolutePath);
     }
 }

--- a/e2e/pages/adf/content-services/treeViewPage.ts
+++ b/e2e/pages/adf/content-services/treeViewPage.ts
@@ -31,7 +31,7 @@ export class TreeViewPage {
 
     async getNodeId(): Promise<string> {
         await BrowserVisibility.waitUntilElementIsVisible(this.nodeIdInput);
-        return await this.nodeIdInput.getAttribute('value');
+        return this.nodeIdInput.getAttribute('value');
     }
 
     async clickNode(nodeName): Promise<void> {
@@ -81,6 +81,6 @@ export class TreeViewPage {
     }
 
     async getTotalNodes() {
-        return await this.nodesOnPage.count();
+        return this.nodesOnPage.count();
     }
 }

--- a/e2e/pages/adf/contentServicesPage.ts
+++ b/e2e/pages/adf/contentServicesPage.ts
@@ -112,11 +112,11 @@ export class ContentServicesPage {
     }
 
     async checkLockedIcon(content): Promise<void> {
-        return await this.contentList.checkLockedIcon(content);
+        return this.contentList.checkLockedIcon(content);
     }
 
     async checkUnlockedIcon(content): Promise<void> {
-        return await this.contentList.checkUnlockedIcon(content);
+        return this.contentList.checkUnlockedIcon(content);
     }
 
     async checkDeleteIsDisabled(content): Promise<void> {
@@ -186,7 +186,7 @@ export class ContentServicesPage {
     }
 
     async getElementsDisplayedId() {
-        return await this.contentList.dataTablePage().getAllRowsColumnValues(this.columns.nodeId);
+        return this.contentList.dataTablePage().getAllRowsColumnValues(this.columns.nodeId);
     }
 
     checkElementsDateSortedAsc(elements) {
@@ -248,7 +248,7 @@ export class ContentServicesPage {
     }
 
     async getRecentFileIcon(): Promise<string> {
-        return await BrowserActions.getText(this.recentFileIcon);
+        return BrowserActions.getText(this.recentFileIcon);
     }
 
     async checkAcsContainer(): Promise<void> {
@@ -269,15 +269,15 @@ export class ContentServicesPage {
     }
 
     async numberOfResultsDisplayed(): Promise<number> {
-        return await this.contentList.dataTablePage().numberOfRows();
+        return this.contentList.dataTablePage().numberOfRows();
     }
 
     async currentFolderName(): Promise<string> {
-        return await BrowserActions.getText(this.currentFolder);
+        return BrowserActions.getText(this.currentFolder);
     }
 
     async getAllRowsNameColumn(): Promise<any> {
-        return await this.contentList.getAllRowsColumnValues(this.columns.name);
+        return this.contentList.getAllRowsColumnValues(this.columns.name);
     }
 
     async sortByName(sortOrder: string): Promise<any> {
@@ -294,33 +294,33 @@ export class ContentServicesPage {
 
     async sortAndCheckListIsOrderedByName(sortOrder: string): Promise<any> {
         await this.sortByName(sortOrder);
-        return await this.checkListIsSortedByNameColumn(sortOrder);
+        return this.checkListIsSortedByNameColumn(sortOrder);
     }
 
     async checkListIsSortedByNameColumn(sortOrder: string): Promise<any> {
-        return await this.contentList.dataTablePage().checkListIsSorted(sortOrder, this.columns.name);
+        return this.contentList.dataTablePage().checkListIsSorted(sortOrder, this.columns.name);
     }
 
     async checkListIsSortedByCreatedColumn(sortOrder: string): Promise<any> {
-        return await this.contentList.dataTablePage().checkListIsSorted(sortOrder, this.columns.created);
+        return this.contentList.dataTablePage().checkListIsSorted(sortOrder, this.columns.created);
     }
 
     async checkListIsSortedByAuthorColumn(sortOrder: string): Promise<any> {
-        return await this.contentList.dataTablePage().checkListIsSorted(sortOrder, this.columns.createdBy);
+        return this.contentList.dataTablePage().checkListIsSorted(sortOrder, this.columns.createdBy);
     }
 
     async checkListIsSortedBySizeColumn(sortOrder: string): Promise<any> {
-        return await this.contentList.dataTablePage().checkListIsSorted(sortOrder, this.columns.size);
+        return this.contentList.dataTablePage().checkListIsSorted(sortOrder, this.columns.size);
     }
 
     async sortAndCheckListIsOrderedByAuthor(sortOrder: string): Promise<any> {
         await this.sortByAuthor(sortOrder);
-        return await this.checkListIsSortedByAuthorColumn(sortOrder);
+        return this.checkListIsSortedByAuthorColumn(sortOrder);
     }
 
     async sortAndCheckListIsOrderedByCreated(sortOrder: string): Promise<any> {
         await this.sortByCreated(sortOrder);
-        return await this.checkListIsSortedByCreatedColumn(sortOrder);
+        return this.checkListIsSortedByCreatedColumn(sortOrder);
     }
 
     async doubleClickRow(nodeName): Promise<void> {
@@ -378,7 +378,7 @@ export class ContentServicesPage {
 
     async getActiveBreadcrumb(): Promise<string> {
         await BrowserVisibility.waitUntilElementIsVisible(this.activeBreadcrumb);
-        return await this.activeBreadcrumb.getAttribute('title');
+        return this.activeBreadcrumb.getAttribute('title');
     }
 
     async uploadFile(fileLocation): Promise<void> {
@@ -405,17 +405,17 @@ export class ContentServicesPage {
 
     async getSingleFileButtonTooltip(): Promise<string> {
         await BrowserVisibility.waitUntilElementIsPresent(this.uploadFileButton);
-        return await this.uploadFileButtonInput.getAttribute('title');
+        return this.uploadFileButtonInput.getAttribute('title');
     }
 
     async getMultipleFileButtonTooltip(): Promise<string> {
         await BrowserVisibility.waitUntilElementIsPresent(this.uploadMultipleFileButton);
-        return await this.uploadMultipleFileButton.getAttribute('title');
+        return this.uploadMultipleFileButton.getAttribute('title');
     }
 
     async getFolderButtonTooltip(): Promise<string> {
         await BrowserVisibility.waitUntilElementIsPresent(this.uploadFolderButton);
-        return await this.uploadFolderButton.getAttribute('title');
+        return this.uploadFolderButton.getAttribute('title');
     }
 
     async checkUploadButton(): Promise<void> {
@@ -423,7 +423,7 @@ export class ContentServicesPage {
     }
 
     async uploadButtonIsEnabled(): Promise<boolean> {
-        return await this.uploadFileButton.isEnabled();
+        return this.uploadFileButton.isEnabled();
     }
 
     async getErrorMessage(): Promise<string> {
@@ -457,7 +457,7 @@ export class ContentServicesPage {
     async getDocumentListRowNumber(): Promise<number> {
         const documentList: ElementFinder = element(by.css('adf-upload-drag-area adf-document-list'));
         await BrowserVisibility.waitUntilElementIsVisible(documentList);
-        return await $$('adf-upload-drag-area adf-document-list .adf-datatable-row').count();
+        return $$('adf-upload-drag-area adf-document-list .adf-datatable-row').count();
     }
 
     async checkColumnNameHeader(): Promise<void> {
@@ -496,13 +496,13 @@ export class ContentServicesPage {
     }
 
     async getColumnValueForRow(file, columnName): Promise<string> {
-        return await this.contentList.dataTablePage().getColumnValueForRow(this.columns.name, file, columnName);
+        return this.contentList.dataTablePage().getColumnValueForRow(this.columns.name, file, columnName);
     }
 
     async getStyleValueForRowText(rowName, styleName): Promise<string> {
         const row: ElementFinder = element(by.css(`div.adf-datatable-cell[data-automation-id="${rowName}"] span.adf-datatable-cell-value[title="${rowName}"]`));
         await BrowserVisibility.waitUntilElementIsVisible(row);
-        return await row.getCssValue(styleName);
+        return row.getCssValue(styleName);
     }
 
     async checkEmptyFolderTextToBe(text): Promise<void> {
@@ -522,7 +522,7 @@ export class ContentServicesPage {
     async getRowIconImageUrl(fileName): Promise<string> {
         const iconRow: ElementFinder = element(by.css(`.app-document-list-container div.adf-datatable-cell[data-automation-id="${fileName}"] img`));
         await BrowserVisibility.waitUntilElementIsVisible(iconRow);
-        return await iconRow.getAttribute('src');
+        return iconRow.getAttribute('src');
     }
 
     async checkGridViewButtonIsVisible(): Promise<void> {
@@ -545,7 +545,7 @@ export class ContentServicesPage {
 
     async getDocumentCardIconForElement(elementName): Promise<string> {
         const elementIcon: ElementFinder = element(by.css(`.app-document-list-container div.adf-datatable-cell[data-automation-id="${elementName}"] img`));
-        return await elementIcon.getAttribute('src');
+        return elementIcon.getAttribute('src');
     }
 
     async checkDocumentCardPropertyIsShowed(elementName, propertyName): Promise<void> {
@@ -555,7 +555,7 @@ export class ContentServicesPage {
 
     async getAttributeValueForElement(elementName, propertyName): Promise<string> {
         const elementSize = element(by.css(`.app-document-list-container div.adf-datatable-cell[data-automation-id="${elementName}"][title="${propertyName}"] span`));
-        return await BrowserActions.getText(elementSize);
+        return BrowserActions.getText(elementSize);
     }
 
     async checkMenuIsShowedForElementIndex(elementIndex): Promise<void> {

--- a/e2e/pages/adf/demo-shell/dataTablePage.ts
+++ b/e2e/pages/adf/demo-shell/dataTablePage.ts
@@ -138,7 +138,7 @@ export class DataTablePage {
     }
 
     async getCopyContentTooltip(): Promise<string> {
-        return await this.dataTable.getCopyContentTooltip();
+        return this.dataTable.getCopyContentTooltip();
     }
 
     async mouseOverNameColumn(name: string): Promise<void> {
@@ -191,6 +191,6 @@ export class DataTablePage {
 
     async getClipboardInputText(): Promise<string> {
         await BrowserVisibility.waitUntilElementIsVisible(this.pasteClipboardInput);
-        return await this.pasteClipboardInput.getAttribute('value');
+        return this.pasteClipboardInput.getAttribute('value');
     }
 }

--- a/e2e/pages/adf/demo-shell/process-services/tasksCloudDemoPage.ts
+++ b/e2e/pages/adf/demo-shell/process-services/tasksCloudDemoPage.ts
@@ -100,7 +100,7 @@ export class TasksCloudDemoPage {
     }
 
     async getActiveFilterName(): Promise<string> {
-        return await BrowserActions.getText(this.activeFilter);
+        return BrowserActions.getText(this.activeFilter);
     }
 
     customTaskFilter(filterName): TaskFiltersCloudComponentPage {
@@ -146,13 +146,13 @@ export class TasksCloudDemoPage {
 
     async getNoOfSelectedRows(): Promise<number> {
         await this.checkSelectedRowsIsDisplayed();
-        return await this.noOfSelectedRows.count();
+        return this.noOfSelectedRows.count();
     }
 
     async getSelectedTaskRowText(rowNo: string): Promise<string> {
         await this.checkSelectedRowsIsDisplayed();
         const row: ElementFinder = element(by.xpath(`//div[text()=' Selected Rows: ']//li[${rowNo}]`));
-        return await BrowserActions.getText(row);
+        return BrowserActions.getText(row);
     }
 
     async addActionIsDisplayed(): Promise<void> {

--- a/e2e/pages/adf/dialog/createLibraryDialog.ts
+++ b/e2e/pages/adf/dialog/createLibraryDialog.ts
@@ -35,7 +35,7 @@ export class CreateLibraryDialog {
 
     async getSelectedRadio(): Promise<string> {
         const radio: ElementFinder = element(by.css('.mat-radio-button[class*="checked"]'));
-        return await BrowserActions.getText(radio);
+        return BrowserActions.getText(radio);
     }
 
     async waitForDialogToOpen(): Promise<void> {
@@ -47,27 +47,27 @@ export class CreateLibraryDialog {
     }
 
     async isDialogOpen(): Promise<any> {
-        return await browser.isElementPresent(this.libraryDialog);
+        return browser.isElementPresent(this.libraryDialog);
     }
 
     async getTitle(): Promise<string> {
-        return await BrowserActions.getText(this.libraryTitle);
+        return BrowserActions.getText(this.libraryTitle);
     }
 
     async getLibraryIdText(): Promise<string> {
-        return await this.libraryIdField.getAttribute('value');
+        return this.libraryIdField.getAttribute('value');
     }
 
     async isErrorMessageDisplayed(): Promise<boolean> {
-        return await this.errorMessage.isDisplayed();
+        return this.errorMessage.isDisplayed();
     }
 
     async getErrorMessage(): Promise<string> {
-        return await BrowserActions.getText(this.errorMessage);
+        return BrowserActions.getText(this.errorMessage);
     }
 
     async getErrorMessages(position): Promise<string> {
-        return await BrowserActions.getText(this.errorMessages.get(position));
+        return BrowserActions.getText(this.errorMessages.get(position));
     }
 
     async waitForLibraryNameHint(): Promise<void> {
@@ -75,39 +75,39 @@ export class CreateLibraryDialog {
     }
 
     async getLibraryNameHint(): Promise<string> {
-        return await BrowserActions.getText(this.libraryNameHint);
+        return BrowserActions.getText(this.libraryNameHint);
     }
 
     async isNameDisplayed(): Promise<boolean> {
-        return await this.libraryNameField.isDisplayed();
+        return this.libraryNameField.isDisplayed();
     }
 
     async isLibraryIdDisplayed(): Promise<boolean> {
-        return await this.libraryIdField.isDisplayed();
+        return this.libraryIdField.isDisplayed();
     }
 
     async isDescriptionDisplayed(): Promise<boolean> {
-        return await this.libraryDescriptionField.isDisplayed();
+        return this.libraryDescriptionField.isDisplayed();
     }
 
     async isPublicDisplayed(): Promise<boolean> {
-        return await this.publicRadioButton.isDisplayed();
+        return this.publicRadioButton.isDisplayed();
     }
 
     async isModeratedDisplayed(): Promise<boolean> {
-        return await this.moderatedRadioButton.isDisplayed();
+        return this.moderatedRadioButton.isDisplayed();
     }
 
     async isPrivateDisplayed(): Promise<boolean> {
-        return await this.privateRadioButton.isDisplayed();
+        return this.privateRadioButton.isDisplayed();
     }
 
     async isCreateEnabled(): Promise<boolean> {
-        return await this.createButton.isEnabled();
+        return this.createButton.isEnabled();
     }
 
     async isCancelEnabled(): Promise<boolean> {
-        return await this.cancelButton.isEnabled();
+        return this.cancelButton.isEnabled();
     }
 
     async clickCreate(): Promise<void> {

--- a/e2e/pages/adf/dialog/folderDialog.ts
+++ b/e2e/pages/adf/dialog/folderDialog.ts
@@ -28,7 +28,7 @@ export class FolderDialog {
     validationMessage: ElementFinder = this.folderDialog.element(by.css('div.mat-form-field-subscript-wrapper mat-hint span'));
 
     async getDialogTitle(): Promise<string> {
-        return await BrowserActions.getText(this.folderTitle);
+        return BrowserActions.getText(this.folderTitle);
     }
 
     async checkFolderDialogIsDisplayed(): Promise<void> {
@@ -62,11 +62,11 @@ export class FolderDialog {
     }
 
     async getFolderName(): Promise<string> {
-        return await this.folderNameField.getAttribute('value');
+        return this.folderNameField.getAttribute('value');
     }
 
     async getValidationMessage(): Promise<string> {
-        return await BrowserActions.getText(this.validationMessage);
+        return BrowserActions.getText(this.validationMessage);
     }
 
     async checkValidationMessageIsNotDisplayed(): Promise<void> {

--- a/e2e/pages/adf/dialog/searchDialog.ts
+++ b/e2e/pages/adf/dialog/searchDialog.ts
@@ -84,15 +84,15 @@ export class SearchDialog {
     }
 
     async getSpecificRowsHighlightName(name): Promise<string> {
-        return await BrowserActions.getText(this.getRowByRowName(name).element(this.highlightName));
+        return BrowserActions.getText(this.getRowByRowName(name).element(this.highlightName));
     }
 
     async getSpecificRowsCompleteName(name): Promise<string> {
-        return await BrowserActions.getText(this.getRowByRowName(name).element(this.completeName));
+        return BrowserActions.getText(this.getRowByRowName(name).element(this.completeName));
     }
 
     async getSpecificRowsAuthor(name): Promise<string> {
-        return await BrowserActions.getText(this.getRowByRowName(name).element(this.rowsAuthor));
+        return BrowserActions.getText(this.getRowByRowName(name).element(this.rowsAuthor));
     }
 
     async clearText(): Promise<void> {

--- a/e2e/pages/adf/dialog/shareDialog.ts
+++ b/e2e/pages/adf/dialog/shareDialog.ts
@@ -61,7 +61,7 @@ export class ShareDialog {
 
     async getShareLink(): Promise<string> {
         await BrowserVisibility.waitUntilElementIsVisible(this.shareLink);
-        return await this.shareLink.getAttribute('value');
+        return this.shareLink.getAttribute('value');
     }
 
     async clickCloseButton(): Promise<void> {
@@ -120,7 +120,7 @@ export class ShareDialog {
     }
 
     async getExpirationDate(): Promise<string> {
-        return await this.expirationDateInput.getAttribute('value');
+        return this.expirationDateInput.getAttribute('value');
     }
 
     async expirationDateInputHasValue(value): Promise<void> {

--- a/e2e/pages/adf/dialog/uploadDialog.ts
+++ b/e2e/pages/adf/dialog/uploadDialog.ts
@@ -107,7 +107,7 @@ export class UploadDialog {
 
     async getTitleText(): Promise<string> {
         await BrowserVisibility.waitUntilElementIsVisible(this.title);
-        return await this.title.getText();
+        return this.title.getText();
     }
 
     async getConfirmationDialogTitleText(): Promise<string> {
@@ -152,7 +152,7 @@ export class UploadDialog {
     }
 
     async getTooltip(): Promise<string> {
-        return await BrowserActions.getText(this.errorTooltip);
+        return BrowserActions.getText(this.errorTooltip);
     }
 
 }

--- a/e2e/pages/adf/iconsPage.ts
+++ b/e2e/pages/adf/iconsPage.ts
@@ -30,7 +30,7 @@ export class IconsPage {
     async isCustomIconDisplayed(name) {
         const present = await browser.isElementPresent(this.locateCustomIcon(name));
         if (present) {
-          return await this.locateCustomIcon(name).isDisplayed();
+          return this.locateCustomIcon(name).isDisplayed();
         } else {
           return false;
         }
@@ -39,7 +39,7 @@ export class IconsPage {
     async isLigatureIconDisplayed(name) {
         const present = await browser.isElementPresent(this.locateLigatureIcon(name));
         if (present) {
-          return await this.locateLigatureIcon(name).isDisplayed();
+          return this.locateLigatureIcon(name).isDisplayed();
         } else {
           return false;
         }

--- a/e2e/pages/adf/metadataViewPage.ts
+++ b/e2e/pages/adf/metadataViewPage.ts
@@ -47,51 +47,51 @@ export class MetadataViewPage {
     applyAspect: ElementFinder = element(by.cssContainingText(`button span.mat-button-wrapper`, 'Apply Aspect'));
 
     async getTitle(): Promise<string> {
-        return await BrowserActions.getText(this.title);
+        return BrowserActions.getText(this.title);
     }
 
     async getExpandedAspectName(): Promise<string> {
-        return await BrowserActions.getText(this.expandedAspect.element(this.aspectTitle));
+        return BrowserActions.getText(this.expandedAspect.element(this.aspectTitle));
     }
 
     async getName(): Promise<string> {
-        return await BrowserActions.getText(this.name);
+        return BrowserActions.getText(this.name);
     }
 
     async getCreator(): Promise<string> {
-        return await BrowserActions.getText(this.creator);
+        return BrowserActions.getText(this.creator);
     }
 
     async getCreatedDate(): Promise<string> {
-        return await BrowserActions.getText(this.createdDate);
+        return BrowserActions.getText(this.createdDate);
     }
 
     async getModifier(): Promise<string> {
-        return await BrowserActions.getText(this.modifier);
+        return BrowserActions.getText(this.modifier);
     }
 
     async getModifiedDate(): Promise<string> {
-        return await BrowserActions.getText(this.modifiedDate);
+        return BrowserActions.getText(this.modifiedDate);
     }
 
     async getMimetypeName(): Promise<string> {
-        return await BrowserActions.getText(this.mimetypeName);
+        return BrowserActions.getText(this.mimetypeName);
     }
 
     async getSize(): Promise<string> {
-        return await BrowserActions.getText(this.size);
+        return BrowserActions.getText(this.size);
     }
 
     async getDescription(): Promise<string> {
-        return await BrowserActions.getText(this.description);
+        return BrowserActions.getText(this.description);
     }
 
     async getAuthor(): Promise<string> {
-        return await BrowserActions.getText(this.author);
+        return BrowserActions.getText(this.author);
     }
 
     async getTitleProperty(): Promise<string> {
-        return await BrowserActions.getText(this.titleProperty);
+        return BrowserActions.getText(this.titleProperty);
     }
 
     async editIconIsDisplayed(): Promise<void> {
@@ -119,11 +119,11 @@ export class MetadataViewPage {
     }
 
     async getInformationButtonText(): Promise<string> {
-        return await BrowserActions.getText(this.informationSpan);
+        return BrowserActions.getText(this.informationSpan);
     }
 
     async getInformationIconText(): Promise<string> {
-        return await BrowserActions.getText(this.informationIcon);
+        return BrowserActions.getText(this.informationIcon);
     }
 
     async clickOnPropertiesTab(): Promise<void> {
@@ -132,7 +132,7 @@ export class MetadataViewPage {
     }
 
     async getEditIconTooltip(): Promise<string> {
-        return await this.editIcon.getAttribute('title');
+        return this.editIcon.getAttribute('title');
     }
 
     async editPropertyIconIsDisplayed(propertyName: string) {
@@ -179,7 +179,7 @@ export class MetadataViewPage {
         const propertyType = type || 'textitem';
         const textField: ElementFinder = element(by.css('span[data-automation-id="card-' + propertyType + '-value-' + propertyName + '"]'));
 
-        return await BrowserActions.getText(textField);
+        return BrowserActions.getText(textField);
     }
 
     async clearPropertyIconIsDisplayed(propertyName: string): Promise<void> {
@@ -194,7 +194,7 @@ export class MetadataViewPage {
 
     async getPropertyIconTooltip(propertyName: string): Promise<string> {
         const editPropertyIcon: ElementFinder = element(by.css('button[data-automation-id="card-textitem-edit-icon-' + propertyName + '"]'));
-        return await editPropertyIcon.getAttribute('title');
+        return editPropertyIcon.getAttribute('title');
     }
 
     async clickMetadataGroup(groupName: string): Promise<void> {
@@ -226,7 +226,7 @@ export class MetadataViewPage {
 
     async getMetadataGroupTitle(groupName: string): Promise<string> {
         const group = element(by.css('mat-expansion-panel[data-automation-id="adf-metadata-group-' + groupName + '"] > mat-expansion-panel-header > span > mat-panel-title'));
-        return await BrowserActions.getText(group);
+        return BrowserActions.getText(group);
     }
 
     async checkPropertyIsVisible(propertyName: string, type: string): Promise<void> {

--- a/e2e/pages/adf/permissionsPage.ts
+++ b/e2e/pages/adf/permissionsPage.ts
@@ -100,7 +100,7 @@ export class PermissionsPage {
     }
 
     async getPermissionInheritedButtonText(): Promise<string> {
-        return await BrowserActions.getText(this.permissionInheritedButton);
+        return BrowserActions.getText(this.permissionInheritedButton);
     }
 
     async checkPermissionsDatatableIsDisplayed(): Promise<void> {
@@ -109,7 +109,7 @@ export class PermissionsPage {
 
     async getRoleCellValue(rowName): Promise<string> {
         const locator = this.dataTableComponentPage.getCellByRowContentAndColumn('Authority ID', rowName, column.role);
-        return await BrowserActions.getText(locator);
+        return BrowserActions.getText(locator);
     }
 
     async clickRoleDropdownByUserOrGroupName(name): Promise<void> {

--- a/e2e/pages/adf/process-services/filtersPage.ts
+++ b/e2e/pages/adf/process-services/filtersPage.ts
@@ -38,7 +38,7 @@ export class FiltersPage {
     }
 
     async getAllRowsNameColumn() {
-        return await this.dataTable.getAllRowsColumnValues('Name');
+        return this.dataTable.getAllRowsColumnValues('Name');
     }
 
 }

--- a/e2e/pages/adf/process-services/processFiltersPage.ts
+++ b/e2e/pages/adf/process-services/processFiltersPage.ts
@@ -85,7 +85,7 @@ export class ProcessFiltersPage {
     }
 
     async numberOfProcessRows(): Promise<number> {
-        return await element.all(this.rows).count();
+        return element.all(this.rows).count();
     }
 
     async waitForTableBody(): Promise<void> {
@@ -102,7 +102,7 @@ export class ProcessFiltersPage {
     }
 
     async getAllRowsNameColumn() {
-        return await this.dataTable.getAllRowsColumnValues('Name');
+        return this.dataTable.getAllRowsColumnValues('Name');
     }
 
     async checkFilterIsDisplayed(name): Promise<void> {
@@ -120,7 +120,7 @@ export class ProcessFiltersPage {
         const filterName: ElementFinder = element(by.css(`span[data-automation-id='${name}_filter']`));
         await BrowserVisibility.waitUntilElementIsVisible(filterName);
         const icon = filterName.element(this.processIcon);
-        return await BrowserActions.getText(icon);
+        return BrowserActions.getText(icon);
     }
 
     async checkFilterIsNotDisplayed(name): Promise<void> {

--- a/e2e/pages/adf/process-services/taskDetailsPage.ts
+++ b/e2e/pages/adf/process-services/taskDetailsPage.ts
@@ -372,7 +372,7 @@ export class TaskDetailsPage {
     }
 
     async isCompleteButtonWithFormEnabled(): Promise<boolean> {
-        return await this.completeFormTask.isEnabled();
+        return this.completeFormTask.isEnabled();
     }
 
 }

--- a/e2e/pages/adf/process-services/tasksPage.ts
+++ b/e2e/pages/adf/process-services/tasksPage.ts
@@ -141,11 +141,11 @@ export class TasksPage {
     }
 
     async clickSortByNameAsc(): Promise<any> {
-        return await this.tasksListPage().getDataTable().sortByColumn('ASC', 'name');
+        return this.tasksListPage().getDataTable().sortByColumn('ASC', 'name');
     }
 
     async clickSortByNameDesc(): Promise<any> {
-        return await this.tasksListPage().getDataTable().sortByColumn('DESC', 'name');
+        return this.tasksListPage().getDataTable().sortByColumn('DESC', 'name');
     }
 
 }

--- a/e2e/pages/adf/searchFiltersPage.ts
+++ b/e2e/pages/adf/searchFiltersPage.ts
@@ -120,11 +120,11 @@ export class SearchFiltersPage {
     }
 
     async isTypeFacetQueryGroupPresent(): Promise<boolean> {
-        return await this.facetQueriesTypeGroup.isPresent();
+        return this.facetQueriesTypeGroup.isPresent();
     }
 
     async isSizeFacetQueryGroupPresent(): Promise<boolean> {
-        return await this.facetQueriesSizeGroup.isPresent();
+        return this.facetQueriesSizeGroup.isPresent();
     }
 
     async clickCheckListFilter(): Promise<void> {

--- a/e2e/pages/adf/searchResultsPage.ts
+++ b/e2e/pages/adf/searchResultsPage.ts
@@ -40,7 +40,7 @@ export class SearchResultsPage {
     }
 
     async numberOfResultsDisplayed(): Promise<number> {
-        return await this.dataTable.numberOfRows();
+        return this.dataTable.numberOfRows();
     }
 
     async checkContentIsNotDisplayed(content): Promise<void> {

--- a/e2e/pages/adf/tagPage.ts
+++ b/e2e/pages/adf/tagPage.ts
@@ -37,7 +37,7 @@ export class TagPage {
 
     async getNodeId(): Promise<string> {
         await BrowserVisibility.waitUntilElementIsVisible(this.insertNodeIdElement);
-        return await this.insertNodeIdElement.getAttribute('value');
+        return this.insertNodeIdElement.getAttribute('value');
     }
 
     async insertNodeId(nodeId) {
@@ -72,17 +72,17 @@ export class TagPage {
 
     async getNewTagInput(): Promise<string> {
         await BrowserVisibility.waitUntilElementIsVisible(this.newTagInput);
-        return await this.newTagInput.getAttribute('value');
+        return this.newTagInput.getAttribute('value');
     }
 
     async getNewTagPlaceholder(): Promise<string> {
         await BrowserVisibility.waitUntilElementIsVisible(this.newTagInput);
-        return await this.newTagInput.getAttribute('placeholder');
+        return this.newTagInput.getAttribute('placeholder');
     }
 
     async addTagButtonIsEnabled(): Promise<boolean> {
         await BrowserVisibility.waitUntilElementIsVisible(this.addTagButton);
-        return await this.addTagButton.isEnabled();
+        return this.addTagButton.isEnabled();
     }
 
     async checkTagIsDisplayedInTagList(tagName): Promise<void> {
@@ -119,7 +119,7 @@ export class TagPage {
     }
 
     async getErrorMessage(): Promise<string> {
-        return await BrowserActions.getText(this.errorMessage);
+        return BrowserActions.getText(this.errorMessage);
     }
 
     async checkTagListIsOrderedAscending(): Promise<any> {
@@ -181,7 +181,7 @@ export class TagPage {
     }
 
     async checkTagsOnList(): Promise<number> {
-        return await this.tagsOnPage.count();
+        return this.tagsOnPage.count();
     }
 
     async checkShowLessButtonIsDisplayed(): Promise<void> {

--- a/e2e/pages/adf/trashcanPage.ts
+++ b/e2e/pages/adf/trashcanPage.ts
@@ -29,7 +29,7 @@ export class TrashcanPage {
     restoreButton: ElementFinder = element(by.css(`button[title='Restore']`));
 
     async numberOfResultsDisplayed(): Promise<number> {
-        return await element.all(this.rows).count();
+        return element.all(this.rows).count();
     }
 
     async waitForTableBody(): Promise<void> {

--- a/e2e/pages/adf/versionManagerPage.ts
+++ b/e2e/pages/adf/versionManagerPage.ts
@@ -52,7 +52,7 @@ export class VersionManagePage {
 
     async getFileVersionName(version): Promise<string> {
         const fileElement: ElementFinder = element(by.css(`[id="adf-version-list-item-name-${version}"]`));
-        return await BrowserActions.getText(fileElement);
+        return BrowserActions.getText(fileElement);
     }
 
     async checkFileVersionExist(version): Promise<void> {
@@ -67,12 +67,12 @@ export class VersionManagePage {
 
     async getFileVersionComment(version): Promise<string> {
         const fileComment: ElementFinder = element(by.id(`adf-version-list-item-comment-${version}`));
-        return await BrowserActions.getText(fileComment);
+        return BrowserActions.getText(fileComment);
     }
 
     async getFileVersionDate(version): Promise<string> {
         const fileDate: ElementFinder = element(by.id(`adf-version-list-item-date-${version}`));
-        return await BrowserActions.getText(fileDate);
+        return BrowserActions.getText(fileDate);
     }
 
     async enterCommentText(text): Promise<void> {

--- a/lib/core/services/log.service.spec.ts
+++ b/lib/core/services/log.service.spec.ts
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+/* tslint:disable:no-console */
+
 import { HttpClientModule } from '@angular/common/http';
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
@@ -23,168 +25,168 @@ import { LogService } from './log.service';
 import { setupTestBed } from '../testing/setupTestBed';
 
 @Component({
-    template: '',
-    providers: [LogService]
+   template: '',
+   providers: [LogService]
 })
 class ProvidesLogComponent {
-    constructor(public logService: LogService) {
+   constructor(public logService: LogService) {
 
-    }
+   }
 
-    error() {
-        this.logService.error('Test message');
-    }
+   error() {
+       this.logService.error('Test message');
+   }
 
-    info() {
-        this.logService.info('Test message');
-    }
+   info() {
+       this.logService.info('Test message');
+   }
 
-    warn() {
-        this.logService.warn('Test message');
-    }
+   warn() {
+       this.logService.warn('Test message');
+   }
 
-    log() {
-        this.logService.log('Test message');
-    }
+   log() {
+       this.logService.log('Test message');
+   }
 
-    debug() {
-        this.logService.debug('Test message');
-    }
+   debug() {
+       this.logService.debug('Test message');
+   }
 
-    trace() {
-        this.logService.trace('Test message');
-    }
+   trace() {
+       this.logService.trace('Test message');
+   }
 
 }
 
 describe('Log Service', () => {
 
-    let providesLogComponent: ComponentFixture<ProvidesLogComponent>;
-    let appConfigService: AppConfigService;
+   let providesLogComponent: ComponentFixture<ProvidesLogComponent>;
+   let appConfigService: AppConfigService;
 
-    setupTestBed({
-        imports: [
-            HttpClientModule
-        ],
-        declarations: [ProvidesLogComponent],
-        providers: [
-            LogService,
-            AppConfigService
-        ]
-    });
+   setupTestBed({
+       imports: [
+           HttpClientModule
+       ],
+       declarations: [ProvidesLogComponent],
+       providers: [
+           LogService,
+           AppConfigService
+       ]
+   });
 
-    beforeEach(() => {
-        appConfigService = TestBed.get(AppConfigService);
-    });
+   beforeEach(() => {
+       appConfigService = TestBed.get(AppConfigService);
+   });
 
-    it('should not log anything if is silent', () => {
-        appConfigService.config['logLevel'] = 'silent';
-        providesLogComponent = TestBed.createComponent(ProvidesLogComponent);
+   it('should not log anything if is silent', () => {
+       appConfigService.config['logLevel'] = 'silent';
+       providesLogComponent = TestBed.createComponent(ProvidesLogComponent);
 
-        spyOn(console, 'log');
-        spyOn(console, 'trace');
-        spyOn(console, 'debug');
-        spyOn(console, 'info');
-        spyOn(console, 'warn');
-        spyOn(console, 'error');
+       spyOn(console, 'log');
+       spyOn(console, 'trace');
+       spyOn(console, 'debug');
+       spyOn(console, 'info');
+       spyOn(console, 'warn');
+       spyOn(console, 'error');
 
-        providesLogComponent.componentInstance.log();
-        providesLogComponent.componentInstance.trace();
-        providesLogComponent.componentInstance.debug();
-        providesLogComponent.componentInstance.info();
-        providesLogComponent.componentInstance.warn();
-        providesLogComponent.componentInstance.error();
+       providesLogComponent.componentInstance.log();
+       providesLogComponent.componentInstance.trace();
+       providesLogComponent.componentInstance.debug();
+       providesLogComponent.componentInstance.info();
+       providesLogComponent.componentInstance.warn();
+       providesLogComponent.componentInstance.error();
 
-        expect(console.log).not.toHaveBeenCalled();
-        expect(console.trace).not.toHaveBeenCalled();
-        expect(console.debug).not.toHaveBeenCalled();
-        expect(console.info).not.toHaveBeenCalled();
-        expect(console.warn).not.toHaveBeenCalled();
-        expect(console.error).not.toHaveBeenCalled();
-    });
+       expect(console.log).not.toHaveBeenCalled();
+       expect(console.trace).not.toHaveBeenCalled();
+       expect(console.debug).not.toHaveBeenCalled();
+       expect(console.info).not.toHaveBeenCalled();
+       expect(console.warn).not.toHaveBeenCalled();
+       expect(console.error).not.toHaveBeenCalled();
+   });
 
-    it('should log only warning and errors if is warning level', () => {
-        appConfigService.config['logLevel'] = 'WARN';
-        providesLogComponent = TestBed.createComponent(ProvidesLogComponent);
+   it('should log only warning and errors if is warning level', () => {
+       appConfigService.config['logLevel'] = 'WARN';
+       providesLogComponent = TestBed.createComponent(ProvidesLogComponent);
 
-        spyOn(console, 'log');
-        spyOn(console, 'error');
-        spyOn(console, 'trace');
-        spyOn(console, 'warn');
+       spyOn(console, 'log');
+       spyOn(console, 'error');
+       spyOn(console, 'trace');
+       spyOn(console, 'warn');
 
-        providesLogComponent.componentInstance.log();
-        providesLogComponent.componentInstance.error();
-        providesLogComponent.componentInstance.trace();
-        providesLogComponent.componentInstance.warn();
+       providesLogComponent.componentInstance.log();
+       providesLogComponent.componentInstance.error();
+       providesLogComponent.componentInstance.trace();
+       providesLogComponent.componentInstance.warn();
 
-        expect(console.log).not.toHaveBeenCalled();
-        expect(console.error).toHaveBeenCalled();
-        expect(console.warn).toHaveBeenCalled();
-        expect(console.trace).not.toHaveBeenCalled();
-    });
+       expect(console.log).not.toHaveBeenCalled();
+       expect(console.error).toHaveBeenCalled();
+       expect(console.warn).toHaveBeenCalled();
+       expect(console.trace).not.toHaveBeenCalled();
+   });
 
-    it('should debug level not log trace and log', () => {
-        appConfigService.config['logLevel'] = 'debug';
-        providesLogComponent = TestBed.createComponent(ProvidesLogComponent);
+   it('should debug level not log trace and log', () => {
+       appConfigService.config['logLevel'] = 'debug';
+       providesLogComponent = TestBed.createComponent(ProvidesLogComponent);
 
-        spyOn(console, 'log');
-        spyOn(console, 'trace');
-        spyOn(console, 'debug');
-        spyOn(console, 'info');
-        spyOn(console, 'warn');
-        spyOn(console, 'error');
+       spyOn(console, 'log');
+       spyOn(console, 'trace');
+       spyOn(console, 'debug');
+       spyOn(console, 'info');
+       spyOn(console, 'warn');
+       spyOn(console, 'error');
 
-        providesLogComponent.componentInstance.log();
-        providesLogComponent.componentInstance.trace();
-        providesLogComponent.componentInstance.debug();
-        providesLogComponent.componentInstance.info();
-        providesLogComponent.componentInstance.warn();
-        providesLogComponent.componentInstance.error();
+       providesLogComponent.componentInstance.log();
+       providesLogComponent.componentInstance.trace();
+       providesLogComponent.componentInstance.debug();
+       providesLogComponent.componentInstance.info();
+       providesLogComponent.componentInstance.warn();
+       providesLogComponent.componentInstance.error();
 
-        expect(console.log).not.toHaveBeenCalled();
-        expect(console.trace).not.toHaveBeenCalled();
-        expect(console.debug).toHaveBeenCalled();
-        expect(console.info).toHaveBeenCalled();
-        expect(console.warn).toHaveBeenCalled();
-        expect(console.error).toHaveBeenCalled();
-    });
+       expect(console.log).not.toHaveBeenCalled();
+       expect(console.trace).not.toHaveBeenCalled();
+       expect(console.debug).toHaveBeenCalled();
+       expect(console.info).toHaveBeenCalled();
+       expect(console.warn).toHaveBeenCalled();
+       expect(console.error).toHaveBeenCalled();
+   });
 
-    it('should trace level log all', () => {
-        appConfigService.config['logLevel'] = 'trace';
-        providesLogComponent = TestBed.createComponent(ProvidesLogComponent);
+   it('should trace level log all', () => {
+       appConfigService.config['logLevel'] = 'trace';
+       providesLogComponent = TestBed.createComponent(ProvidesLogComponent);
 
-        spyOn(console, 'log');
-        spyOn(console, 'trace');
-        spyOn(console, 'debug');
-        spyOn(console, 'info');
-        spyOn(console, 'warn');
-        spyOn(console, 'error');
+       spyOn(console, 'log');
+       spyOn(console, 'trace');
+       spyOn(console, 'debug');
+       spyOn(console, 'info');
+       spyOn(console, 'warn');
+       spyOn(console, 'error');
 
-        providesLogComponent.componentInstance.log();
-        providesLogComponent.componentInstance.trace();
-        providesLogComponent.componentInstance.debug();
-        providesLogComponent.componentInstance.info();
-        providesLogComponent.componentInstance.warn();
-        providesLogComponent.componentInstance.error();
+       providesLogComponent.componentInstance.log();
+       providesLogComponent.componentInstance.trace();
+       providesLogComponent.componentInstance.debug();
+       providesLogComponent.componentInstance.info();
+       providesLogComponent.componentInstance.warn();
+       providesLogComponent.componentInstance.error();
 
-        expect(console.log).toHaveBeenCalled();
-        expect(console.trace).toHaveBeenCalled();
-        expect(console.debug).toHaveBeenCalled();
-        expect(console.info).toHaveBeenCalled();
-        expect(console.warn).toHaveBeenCalled();
-        expect(console.error).toHaveBeenCalled();
-    });
+       expect(console.log).toHaveBeenCalled();
+       expect(console.trace).toHaveBeenCalled();
+       expect(console.debug).toHaveBeenCalled();
+       expect(console.info).toHaveBeenCalled();
+       expect(console.warn).toHaveBeenCalled();
+       expect(console.error).toHaveBeenCalled();
+   });
 
-    it('message Observable', (done) => {
-        appConfigService.config['logLevel'] = 'trace';
-        providesLogComponent = TestBed.createComponent(ProvidesLogComponent);
+   it('message Observable', (done) => {
+       appConfigService.config['logLevel'] = 'trace';
+       providesLogComponent = TestBed.createComponent(ProvidesLogComponent);
 
-        providesLogComponent.componentInstance.logService.onMessage.subscribe(() => {
-            done();
-        });
+       providesLogComponent.componentInstance.logService.onMessage.subscribe(() => {
+           done();
+       });
 
-        providesLogComponent.componentInstance.log();
+       providesLogComponent.componentInstance.log();
 
-    });
+   });
 
 });

--- a/lib/core/viewer/services/view-util.service.ts
+++ b/lib/core/viewer/services/view-util.service.ts
@@ -123,7 +123,7 @@ export class ViewUtilService {
             } else {
                 retries += 1;
                 await this.wait(1000);
-                return await this.waitRendition(nodeId, renditionId, retries);
+                return this.waitRendition(nodeId, renditionId, retries);
             }
         }
 

--- a/lib/process-services-cloud/src/lib/task/start-task/components/people-cloud/people-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/start-task/components/people-cloud/people-cloud.component.ts
@@ -216,7 +216,7 @@ export class PeopleCloudComponent implements OnInit, OnChanges, OnDestroy {
             const isUserValid: boolean = this.userExists(result);
             return isUserValid ? result : null;
         });
-        return await Promise.all(promiseBatch);
+        return Promise.all(promiseBatch);
     }
 
     async searchUser(user: IdentityUserModel) {
@@ -231,7 +231,7 @@ export class PeopleCloudComponent implements OnInit, OnChanges, OnDestroy {
         }
 
         switch (key) {
-            case 'id': return await this.identityUserService.findUserById(user[key]).toPromise();
+            case 'id': return this.identityUserService.findUserById(user[key]).toPromise();
             case 'username': return (await this.identityUserService.findUserByUsername(user[key]).toPromise())[0];
             case 'email': return (await this.identityUserService.findUserByEmail(user[key]).toPromise())[0];
             default: return of([]);

--- a/lib/testing/src/lib/content-services/dialog/content-node-selector-dialog.page.ts
+++ b/lib/testing/src/lib/content-services/dialog/content-node-selector-dialog.page.ts
@@ -39,7 +39,7 @@ export class ContentNodeSelectorDialogPage {
     }
 
     async getDialogHeaderText(): Promise<string> {
-        return await BrowserActions.getText(this.header);
+        return BrowserActions.getText(this.header);
     }
 
     async checkSearchInputIsDisplayed(): Promise<void> {
@@ -47,7 +47,7 @@ export class ContentNodeSelectorDialogPage {
     }
 
     async getSearchLabel(): Promise<string> {
-        return await BrowserActions.getText(this.searchLabel);
+        return BrowserActions.getText(this.searchLabel);
     }
 
     async checkSelectedSiteIsDisplayed(siteName): Promise<void> {
@@ -63,11 +63,11 @@ export class ContentNodeSelectorDialogPage {
     }
 
     async checkCancelButtonIsEnabled(): Promise<boolean> {
-        return await this.cancelButton.isEnabled();
+        return this.cancelButton.isEnabled();
     }
 
     async checkCopyMoveButtonIsEnabled(): Promise<boolean> {
-        return await this.moveCopyButton.isEnabled();
+        return this.moveCopyButton.isEnabled();
     }
 
     async checkMoveCopyButtonIsDisplayed(): Promise<void> {
@@ -75,7 +75,7 @@ export class ContentNodeSelectorDialogPage {
     }
 
     async getMoveCopyButtonText(): Promise<string> {
-        return await BrowserActions.getText(this.moveCopyButton);
+        return BrowserActions.getText(this.moveCopyButton);
     }
 
     async clickMoveCopyButton(): Promise<void> {
@@ -83,7 +83,7 @@ export class ContentNodeSelectorDialogPage {
     }
 
     async numberOfResultsDisplayed(): Promise<number> {
-        return await this.contentList.dataTablePage().numberOfRows();
+        return this.contentList.dataTablePage().numberOfRows();
     }
 
     async typeIntoNodeSelectorSearchField(text): Promise<void> {

--- a/lib/testing/src/lib/content-services/pages/document-list.page.ts
+++ b/lib/testing/src/lib/content-services/pages/document-list.page.ts
@@ -50,7 +50,7 @@ export class DocumentListPage {
     }
 
     async getTooltip(nodeName: string): Promise<string> {
-        return await this.dataTable.getTooltip('Display name', nodeName);
+        return this.dataTable.getTooltip('Display name', nodeName);
     }
 
     async selectRow(nodeName: string): Promise<void> {
@@ -78,7 +78,7 @@ export class DocumentListPage {
     }
 
     async getAllRowsColumnValues(column: string) {
-        return await this.dataTable.getAllRowsColumnValues(column);
+        return this.dataTable.getAllRowsColumnValues(column);
     }
 
     async doubleClickRow(nodeName: string): Promise<void> {

--- a/lib/testing/src/lib/content-services/pages/search/date-range-filter.page.ts
+++ b/lib/testing/src/lib/content-services/pages/search/date-range-filter.page.ts
@@ -37,7 +37,7 @@ export class DateRangeFilterPage {
     }
 
     async getFromDate(): Promise<string> {
-        return await this.filter.element(this.fromField).getAttribute('value');
+        return this.filter.element(this.fromField).getAttribute('value');
     }
 
     async putFromDate(date): Promise<void> {
@@ -91,7 +91,7 @@ export class DateRangeFilterPage {
     }
 
     async getToDate(): Promise<string> {
-        return await this.filter.element(this.toField).getAttribute('value');
+        return this.filter.element(this.toField).getAttribute('value');
     }
 
     async putToDate(date): Promise<void> {

--- a/lib/testing/src/lib/content-services/pages/search/number-range-filter.page.ts
+++ b/lib/testing/src/lib/content-services/pages/search/number-range-filter.page.ts
@@ -40,7 +40,7 @@ export class NumberRangeFilterPage {
     }
 
     async getFromNumber(): Promise<string> {
-        return await this.filter.element(this.fromInput).getAttribute('value');
+        return this.filter.element(this.fromInput).getAttribute('value');
     }
 
     async putFromNumber(value): Promise<void> {
@@ -50,7 +50,7 @@ export class NumberRangeFilterPage {
     }
 
     async getFromErrorRequired(): Promise<string> {
-        return await BrowserActions.getText(this.filter.element(this.fromErrorRequired));
+        return BrowserActions.getText(this.filter.element(this.fromErrorRequired));
     }
 
     async checkFromErrorRequiredIsDisplayed(): Promise<void> {
@@ -58,7 +58,7 @@ export class NumberRangeFilterPage {
     }
 
     async getFromErrorInvalid(): Promise<string> {
-        return await BrowserActions.getText(this.filter.element(this.fromErrorInvalid));
+        return BrowserActions.getText(this.filter.element(this.fromErrorInvalid));
     }
 
     async checkFromErrorInvalidIsDisplayed(): Promise<void> {
@@ -75,7 +75,7 @@ export class NumberRangeFilterPage {
     }
 
     async getToNumber(): Promise<string> {
-        return await this.filter.element(this.toInput).getAttribute('value');
+        return this.filter.element(this.toInput).getAttribute('value');
     }
 
     async putToNumber(value): Promise<void> {
@@ -85,7 +85,7 @@ export class NumberRangeFilterPage {
     }
 
     async getToErrorRequired(): Promise<string> {
-        return await BrowserActions.getText(this.filter.element(this.toErrorRequired));
+        return BrowserActions.getText(this.filter.element(this.toErrorRequired));
     }
 
     async checkToErrorRequiredIsDisplayed(): Promise<void> {
@@ -93,7 +93,7 @@ export class NumberRangeFilterPage {
     }
 
     async getToErrorInvalid(): Promise<string> {
-        return await BrowserActions.getText(this.filter.element(this.toErrorInvalid));
+        return BrowserActions.getText(this.filter.element(this.toErrorInvalid));
     }
 
     async checkToErrorInvalidIsDisplayed(): Promise<void> {
@@ -113,7 +113,7 @@ export class NumberRangeFilterPage {
     }
 
     async checkApplyButtonIsEnabled(): Promise<boolean> {
-        return await this.filter.element(this.applyButton).isEnabled();
+        return this.filter.element(this.applyButton).isEnabled();
     }
 
     async clickClearButton(): Promise<void> {

--- a/lib/testing/src/lib/content-services/pages/search/search-slider.page.ts
+++ b/lib/testing/src/lib/content-services/pages/search/search-slider.page.ts
@@ -31,15 +31,15 @@ export class SearchSliderPage {
     }
 
     async getMaxValue() {
-        return await this.filter.element(this.slider).getAttribute('aria-valuemax');
+        return this.filter.element(this.slider).getAttribute('aria-valuemax');
     }
 
     async getMinValue() {
-        return await this.filter.element(this.slider).getAttribute('aria-valuemin');
+        return this.filter.element(this.slider).getAttribute('aria-valuemin');
     }
 
     async getValue() {
-        return await this.filter.element(this.slider).getAttribute('aria-valuenow');
+        return this.filter.element(this.slider).getAttribute('aria-valuenow');
     }
 
     async setValue(value: number): Promise<void> {
@@ -65,7 +65,7 @@ export class SearchSliderPage {
     }
 
     async checkClearButtonIsEnabled() {
-        return await this.filter.element(this.clearButton).isEnabled();
+        return this.filter.element(this.clearButton).isEnabled();
     }
 
     async checkClearButtonIsDisplayed(): Promise<void> {

--- a/lib/testing/src/lib/core/pages/data-table-component.page.ts
+++ b/lib/testing/src/lib/core/pages/data-table-component.page.ts
@@ -81,7 +81,7 @@ export class DataTableComponentPage {
     }
 
     async getNumberOfSelectedRows(): Promise<number> {
-        return await this.allSelectedRows.count();
+        return this.allSelectedRows.count();
     }
 
     async selectRow(columnName, columnValue): Promise<void> {
@@ -110,7 +110,7 @@ export class DataTableComponentPage {
         const row = this.getRow(identifyingColumn, identifyingValue);
         await BrowserVisibility.waitUntilElementIsVisible(row);
         const rowColumn = row.element(by.css(`div[title="${columnName}"] span`));
-        return await BrowserActions.getText(rowColumn);
+        return BrowserActions.getText(rowColumn);
     }
 
     /**
@@ -146,7 +146,7 @@ export class DataTableComponentPage {
     }
 
     async getTooltip(columnName, columnValue): Promise<string> {
-        return await this.getCellElementByValue(columnName, columnValue).getAttribute('title');
+        return this.getCellElementByValue(columnName, columnValue).getAttribute('title');
     }
 
     async rightClickOnRowByIndex(index: number): Promise<void> {
@@ -160,15 +160,15 @@ export class DataTableComponentPage {
     }
 
     async numberOfRows(): Promise<number> {
-        return await this.rootElement.all(this.rows).count();
+        return this.rootElement.all(this.rows).count();
     }
 
     async getAllRowsColumnValues(column: string) {
         const columnLocator = by.css("adf-datatable div[class*='adf-datatable-body'] div[class*='adf-datatable-row'] div[title='" + column + "'] span");
         await BrowserVisibility.waitUntilElementIsPresent(element.all(columnLocator).first());
-        return await element.all(columnLocator)
-            .filter(async (el) => await el.isPresent())
-            .map(async (el) => await el.getText());
+        return element.all(columnLocator)
+            .filter(async (el) => el.isPresent())
+            .map(async (el) => el.getText());
     }
 
     async getRowsWithSameColumnValues(columnName: string, columnValue) {
@@ -189,7 +189,7 @@ export class DataTableComponentPage {
 
     async getFirstElementDetail(detail: string): Promise<string> {
         const firstNode = element.all(by.css(`adf-datatable div[title="${detail}"] span`)).first();
-        return await BrowserActions.getText(firstNode);
+        return BrowserActions.getText(firstNode);
     }
 
     geCellElementDetail(detail: string): ElementArrayFinder {
@@ -241,7 +241,7 @@ export class DataTableComponentPage {
 
     async contentInPosition(position: number): Promise<string> {
         await BrowserVisibility.waitUntilElementIsVisible(this.contents.first());
-        return await BrowserActions.getText(this.contents.get(position - 1));
+        return BrowserActions.getText(this.contents.get(position - 1));
     }
 
     getCellElementByValue(columnName: string, columnValue: string): ElementFinder {
@@ -261,11 +261,11 @@ export class DataTableComponentPage {
     }
 
     async getNumberOfColumns(): Promise<number> {
-        return await this.allColumns.count();
+        return this.allColumns.count();
     }
 
     async getNumberOfRows(): Promise<number> {
-        return await this.list.count();
+        return this.list.count();
     }
 
     getCellByRowNumberAndColumnName(rowNumber, columnName): ElementFinder {
@@ -333,7 +333,7 @@ export class DataTableComponentPage {
     }
 
     async getCopyContentTooltip(): Promise<string> {
-        return await BrowserActions.getText(this.copyColumnTooltip);
+        return BrowserActions.getText(this.copyColumnTooltip);
     }
 
     async copyContentTooltipIsNotDisplayed(): Promise<void> {

--- a/lib/testing/src/lib/core/pages/form/widgets/amountWidget.ts
+++ b/lib/testing/src/lib/core/pages/form/widgets/amountWidget.ts
@@ -31,7 +31,7 @@ export class AmountWidget {
 
     async getAmountFieldCurrency(fieldId): Promise<string> {
         const widget = await this.formFields.getWidget(fieldId);
-        return await BrowserActions.getText(widget.element(this.currency));
+        return BrowserActions.getText(widget.element(this.currency));
     }
 
     async setFieldValue(fieldId, value): Promise<void> {

--- a/lib/testing/src/lib/core/pages/login.page.ts
+++ b/lib/testing/src/lib/core/pages/login.page.ts
@@ -127,7 +127,7 @@ export class LoginPage {
 
     async getSignInButtonIsEnabled(): Promise<boolean> {
         await BrowserVisibility.waitUntilElementIsVisible(this.signInButton);
-        return await this.signInButton.isEnabled();
+        return this.signInButton.isEnabled();
     }
 
     async loginToAllUsingUserModel(userModel): Promise<void> {

--- a/lib/testing/src/lib/core/pages/settings.page.ts
+++ b/lib/testing/src/lib/core/pages/settings.page.ts
@@ -73,11 +73,11 @@ export class SettingsPage {
     }
 
     async getBpmHostUrl() {
-        return await this.bpmText.getAttribute('value');
+        return this.bpmText.getAttribute('value');
     }
 
     async getEcmHostUrl() {
-        return await this.ecmText.getAttribute('value');
+        return this.ecmText.getAttribute('value');
     }
 
     getBpmOption() {

--- a/lib/testing/src/lib/core/pages/viewerPage.ts
+++ b/lib/testing/src/lib/core/pages/viewerPage.ts
@@ -118,20 +118,20 @@ export class ViewerPage {
     }
 
     async getZoom(): Promise<string> {
-        return await BrowserActions.getText(this.percentage);
+        return BrowserActions.getText(this.percentage);
     }
 
     async getCanvasWidth(): Promise<string> {
-        return await this.canvasLayer.getAttribute(`width`);
+        return this.canvasLayer.getAttribute(`width`);
     }
 
     async getCanvasHeight(): Promise<string> {
-        return await this.canvasLayer.getAttribute(`height`);
+        return this.canvasLayer.getAttribute(`height`);
     }
 
     async getDisplayedFileName(): Promise<string> {
         await BrowserVisibility.waitUntilElementIsVisible(this.fileName);
-        return await BrowserActions.getText(this.fileName);
+        return BrowserActions.getText(this.fileName);
     }
 
     async exitFullScreen(): Promise<void> {
@@ -209,11 +209,11 @@ export class ViewerPage {
     }
 
     async getLastButtonTitle(): Promise<string> {
-        return await this.lastButton.getAttribute('title');
+        return this.lastButton.getAttribute('title');
     }
 
     async getMoreActionsMenuTitle(): Promise<string> {
-        return await this.moreActionsMenu.getAttribute('title');
+        return this.moreActionsMenu.getAttribute('title');
     }
 
     async checkDownloadButtonIsDisplayed(): Promise<void> {
@@ -428,7 +428,7 @@ export class ViewerPage {
     }
 
     async getActiveTab(): Promise<string> {
-        return await BrowserActions.getText(this.activeTab);
+        return BrowserActions.getText(this.activeTab);
     }
 
     async clickOnCommentsTab(): Promise<void> {
@@ -617,12 +617,12 @@ export class ViewerPage {
 
     async getTabLabelById(index: number): Promise<string> {
         const tab: ElementFinder = element(by.css(`div[id="mat-tab-label-1-${index}"] div[class="mat-tab-label-content"] span`));
-        return await BrowserActions.getText(tab);
+        return BrowserActions.getText(tab);
     }
 
     async getTabIconById(index: number): Promise<string> {
         const tab: ElementFinder = element(by.css(`div[id="mat-tab-label-1-${index}"] div[class="mat-tab-label-content"] mat-icon`));
-        return await BrowserActions.getText(tab);
+        return BrowserActions.getText(tab);
     }
 
     async checkUnknownFormatIsDisplayed(): Promise<void> {
@@ -631,6 +631,6 @@ export class ViewerPage {
 
     async getUnknownFormatMessage(): Promise<string> {
         const unknownFormatLabel = this.unknownFormat.element(by.css(`.label`));
-        return await BrowserActions.getText(unknownFormatLabel);
+        return BrowserActions.getText(unknownFormatLabel);
     }
 }

--- a/lib/testing/src/lib/core/utils/browser-actions.ts
+++ b/lib/testing/src/lib/core/utils/browser-actions.ts
@@ -72,7 +72,7 @@ export class BrowserActions {
     static async getColor(elementFinder: ElementFinder): Promise<string> {
         await BrowserVisibility.waitUntilElementIsVisible(elementFinder);
         const webElem = await elementFinder.getWebElement();
-        return await webElem.getCssValue('color');
+        return webElem.getCssValue('color');
     }
 
     static async clearWithBackSpace(elementFinder: ElementFinder) {

--- a/lib/testing/src/lib/material/pages/date-picker.page.ts
+++ b/lib/testing/src/lib/material/pages/date-picker.page.ts
@@ -27,7 +27,7 @@ export class DatePickerPage {
     previousMonthButton: ElementFinder = element(by.css('button[class*="mat-calendar-previous-button"]'));
 
     async getSelectedDate(): Promise<string> {
-        return await element(by.css('td[class*="mat-calendar-body-active"]')).getAttribute('aria-label');
+        return element(by.css('td[class*="mat-calendar-body-active"]')).getAttribute('aria-label');
     }
 
     async checkDatesAfterDateAreDisabled(date): Promise<void> {

--- a/lib/testing/src/lib/process-services-cloud/app/app-list-cloud.page.ts
+++ b/lib/testing/src/lib/process-services-cloud/app/app-list-cloud.page.ts
@@ -41,7 +41,7 @@ export class AppListCloudPage {
     }
 
     async getNameOfTheApplications(): Promise<string> {
-        return await BrowserActions.getArrayText(this.nameOfAllApps);
+        return BrowserActions.getArrayText(this.nameOfAllApps);
     }
 
     async checkAppIsNotDisplayed(applicationName): Promise<void> {

--- a/lib/testing/src/lib/process-services-cloud/pages/edit-process-filter-cloud-component.page.ts
+++ b/lib/testing/src/lib/process-services-cloud/pages/edit-process-filter-cloud-component.page.ts
@@ -36,7 +36,7 @@ export class EditProcessFilterCloudComponentPage {
     }
 
     async isFilterDisplayed(): Promise<boolean> {
-        return await BrowserVisibility.waitUntilElementIsVisible(this.filter);
+        return BrowserVisibility.waitUntilElementIsVisible(this.filter);
     }
 
     async openFilter(): Promise<void> {
@@ -71,7 +71,7 @@ export class EditProcessFilterCloudComponentPage {
 
     async getSortFilterDropDownValue(): Promise<string> {
         const sortLocator = element.all(by.css("mat-form-field[data-automation-id='sort'] span")).first();
-        return await BrowserActions.getText(sortLocator);
+        return BrowserActions.getText(sortLocator);
     }
 
     async setOrderFilterDropDown(option): Promise<void> {
@@ -100,7 +100,7 @@ export class EditProcessFilterCloudComponentPage {
 
     async getApplicationSelected(): Promise<string> {
         const applicationDropdown = element(by.css(`[data-automation-id='adf-cloud-edit-process-property-appName']`));
-        return await applicationDropdown.getText();
+        return applicationDropdown.getText();
     }
 
     async checkAppNamesAreUnique(): Promise<boolean> {
@@ -121,7 +121,7 @@ export class EditProcessFilterCloudComponentPage {
 
     async isApplicationListLoaded(): Promise<boolean> {
         const emptyList = element(by.css(`[data-automation-id='adf-cloud-edit-process-property-appName'] .mat-select-placeholder`));
-        return await BrowserVisibility.waitUntilElementIsNotVisible(emptyList);
+        return BrowserVisibility.waitUntilElementIsNotVisible(emptyList);
     }
 
     async setProcessInstanceId(option): Promise<void> {

--- a/lib/testing/src/lib/process-services-cloud/pages/edit-task-filter-cloud-component.page.ts
+++ b/lib/testing/src/lib/process-services-cloud/pages/edit-task-filter-cloud-component.page.ts
@@ -47,7 +47,7 @@ export class EditTaskFilterCloudComponentPage {
     }
 
     async isFilterDisplayed(): Promise<boolean> {
-        return await BrowserVisibility.waitUntilElementIsVisible(this.filter);
+        return BrowserVisibility.waitUntilElementIsVisible(this.filter);
     }
 
     async openFilter(): Promise<void> {

--- a/lib/testing/src/lib/process-services-cloud/pages/process-list-cloud-component.page.ts
+++ b/lib/testing/src/lib/process-services-cloud/pages/process-list-cloud-component.page.ts
@@ -87,7 +87,7 @@ export class ProcessListCloudComponentPage {
     }
 
     async getAllRowsNameColumn() {
-        return await this.dataTable.getAllRowsColumnValues(this.columns.name);
+        return this.dataTable.getAllRowsColumnValues(this.columns.name);
     }
 
     async checkProcessListIsLoaded(): Promise<void> {

--- a/lib/testing/src/lib/process-services-cloud/pages/task-list-cloud-component.page.ts
+++ b/lib/testing/src/lib/process-services-cloud/pages/task-list-cloud-component.page.ts
@@ -118,39 +118,39 @@ export class TaskListCloudComponentPage {
     }
 
     async getAllRowsNameColumn() {
-        return await this.dataTable.getAllRowsColumnValues(column.name);
+        return this.dataTable.getAllRowsColumnValues(column.name);
     }
 
     async getAllRowsByIdColumn() {
-        return await this.dataTable.getAllRowsColumnValues(column.id);
+        return this.dataTable.getAllRowsColumnValues(column.id);
     }
 
     async getAllRowsByProcessDefIdColumn() {
-        return await this.dataTable.getAllRowsColumnValues(column.processDefinitionId);
+        return this.dataTable.getAllRowsColumnValues(column.processDefinitionId);
     }
 
     async getAllRowsByProcessInstanceIdColumn() {
-        return await this.dataTable.getAllRowsColumnValues(column.processInstanceId);
+        return this.dataTable.getAllRowsColumnValues(column.processInstanceId);
     }
 
     async getAllRowsByAssigneeColumn() {
-        return await this.dataTable.getAllRowsColumnValues(column.assignee);
+        return this.dataTable.getAllRowsColumnValues(column.assignee);
     }
 
     async getAllRowsByParentTaskIdColumn() {
-        return await this.dataTable.getAllRowsColumnValues(column.parentTaskId);
+        return this.dataTable.getAllRowsColumnValues(column.parentTaskId);
     }
 
     async getAllRowsByPriorityColumn() {
-        return await this.dataTable.getAllRowsColumnValues(column.priority);
+        return this.dataTable.getAllRowsColumnValues(column.priority);
     }
 
     async getAllRowsByStandAloneColumn() {
-        return await this.dataTable.getAllRowsColumnValues(column.standAlone);
+        return this.dataTable.getAllRowsColumnValues(column.standAlone);
     }
 
     async getAllRowsByOwnerColumn() {
-        return await this.dataTable.getAllRowsColumnValues(column.owner);
+        return this.dataTable.getAllRowsColumnValues(column.owner);
     }
 
     async getIdCellValue(rowName): Promise<string> {

--- a/lib/testing/src/lib/process-services/pages/form-fields.page.ts
+++ b/lib/testing/src/lib/process-services/pages/form-fields.page.ts
@@ -60,13 +60,13 @@ export class FormFieldsPage {
         const widget: ElementFinder = await this.getWidget(fieldId);
         const value = widget.element(valueLocatorParam || this.valueLocator);
         await BrowserVisibility.waitUntilElementIsVisible(value);
-        return await value.getAttribute('value');
+        return value.getAttribute('value');
     }
 
     async getFieldLabel(fieldId, labelLocatorParam): Promise<string> {
         const widget = await this.getWidget(fieldId);
         const label = widget.all(labelLocatorParam || this.labelLocator).first();
-        return await BrowserActions.getText(label);
+        return BrowserActions.getText(label);
     }
 
     async getFieldErrorMessage(fieldId): Promise<string> {

--- a/package.json
+++ b/package.json
@@ -198,7 +198,7 @@
     "tsconfig-paths": "^3.8.0",
     "tsickle": "^0.34.0",
     "tslib": "^1.9.0",
-    "tslint": "5.9.1",
+    "tslint": "5.20.0",
     "tslint-consistent-codestyle": "^1.15.1",
     "typedoc": "^0.15.0",
     "typescript": "3.1.6",

--- a/tslint.json
+++ b/tslint.json
@@ -87,6 +87,7 @@
     "no-var-keyword": true,
     "no-var-requires": true,
     "object-literal-sort-keys": false,
+    "no-return-await": true,
     "one-line": [
       true,
       "check-open-brace",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [X] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [] Bugfix
> - [ ] Feature
> - [X] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Disallows unnecessary return await.

Rationale
An async function always wraps the return value in a Promise. Using return await just adds extra time before the overreaching promise is resolved without changing the semantics.


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
