### PR TITLE
[AAE-485] Fix card view int item validator when value is empty

### DIFF
--- a/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.html
+++ b/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.html
@@ -59,7 +59,6 @@
                 <button mat-icon-button class="adf-textitem-action" (click)="update()"
                     [attr.aria-label]="'CORE.METADATA.ACTIONS.SAVE' | translate"
                     [attr.title]="'CORE.METADATA.ACTIONS.SAVE' | translate"
-                    [disabled]="hasErrors()"
                     [attr.data-automation-id]="'card-textitem-update-' + property.key">
 
                     <mat-icon class="adf-textitem-icon">done</mat-icon>

--- a/lib/core/card-view/validators/card-view-item-float.validator.ts
+++ b/lib/core/card-view/validators/card-view-item-float.validator.ts
@@ -22,6 +22,8 @@ export class CardViewItemFloatValidator implements CardViewItemValidator {
     message = 'CORE.CARDVIEW.VALIDATORS.FLOAT_VALIDATION_ERROR';
 
     isValid(value: any): boolean {
-        return !isNaN(parseFloat(value)) && isFinite(value);
+        return value === ''
+            || !isNaN(parseFloat(value))
+            && isFinite(value);
     }
 }

--- a/lib/core/card-view/validators/card-view-item-int.validator.ts
+++ b/lib/core/card-view/validators/card-view-item-int.validator.ts
@@ -24,6 +24,11 @@ export class CardViewItemIntValidator implements CardViewItemValidator {
     isValid(value: any): boolean {
         return value === ''
             || !isNaN(value)
-            && (function (x) { return (x | 0) === x; })(parseFloat(value));
+            && this.isIntegerNumber(value);
+    }
+
+    isIntegerNumber(value: any) {
+        const parsedNumber = parseFloat(value);
+        return (parsedNumber | 0) === parsedNumber;
     }
 }

--- a/lib/core/card-view/validators/card-view-item-int.validator.ts
+++ b/lib/core/card-view/validators/card-view-item-int.validator.ts
@@ -22,6 +22,8 @@ export class CardViewItemIntValidator implements CardViewItemValidator {
     message = 'CORE.CARDVIEW.VALIDATORS.INT_VALIDATION_ERROR';
 
     isValid(value: any): boolean {
-        return !isNaN(value) && (function(x) { return (x | 0) === x; })(parseFloat(value));
+        return value === ''
+            || !isNaN(value)
+            && (function (x) { return (x | 0) === x; })(parseFloat(value));
     }
 }

--- a/lib/core/card-view/validators/card-view-item-int.validator.ts
+++ b/lib/core/card-view/validators/card-view-item-int.validator.ts
@@ -27,7 +27,7 @@ export class CardViewItemIntValidator implements CardViewItemValidator {
             && this.isIntegerNumber(value);
     }
 
-    isIntegerNumber(value: any) {
+    isIntegerNumber(value: any): boolean {
         const parsedNumber = parseFloat(value);
         return (parsedNumber | 0) === parsedNumber;
     }


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Validator fails when removing value from int/float card view item. It's not possible to remove it =


**What is the new behaviour?**
The validator does not fail when setting field back to empty
<img width="316" alt="Screen Shot 2019-10-30 at 17 47 40" src="https://user-images.githubusercontent.com/18293044/67884253-6eae3c00-fb3d-11e9-888f-8bafd509a84b.png">


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
