### PR TITLE
Should not redirect if is SilentLogin on

### DIFF
--- a/lib/core/services/auth-guard-base.ts
+++ b/lib/core/services/auth-guard-base.ts
@@ -64,12 +64,14 @@ export abstract class AuthGuardBase implements CanActivate, CanActivateChild {
     }
 
     protected redirectToUrl(provider: string, url: string) {
-        this.authenticationService.setRedirect({ provider, url });
+        if(!this.isSilentLogin()) {
+            this.authenticationService.setRedirect({ provider, url });
 
-        const pathToLogin = this.getLoginRoute();
-        const urlToRedirect = `/${pathToLogin}?redirectUrl=${url}`;
+            const pathToLogin = this.getLoginRoute();
+            const urlToRedirect = `/${pathToLogin}?redirectUrl=${url}`;
 
-        this.router.navigateByUrl(urlToRedirect);
+            this.router.navigateByUrl(urlToRedirect);
+        }
     }
 
     protected getLoginRoute(): string {
@@ -90,5 +92,14 @@ export abstract class AuthGuardBase implements CanActivate, CanActivateChild {
         return (
             this.authenticationService.isOauth() && !!oauth && !oauth.silentLogin
         );
+    }
+
+    protected isSilentLogin(): boolean {
+        const oauth = this.appConfigService.get<OauthConfigModel>(
+            AppConfigValues.OAUTHCONFIG,
+            null
+        );
+
+        return oauth && oauth.silentLogin;
     }
 }

--- a/lib/core/services/auth-guard-base.ts
+++ b/lib/core/services/auth-guard-base.ts
@@ -64,7 +64,7 @@ export abstract class AuthGuardBase implements CanActivate, CanActivateChild {
     }
 
     protected redirectToUrl(provider: string, url: string) {
-        if(!this.isSilentLogin()) {
+        if (!this.isSilentLogin()) {
             this.authenticationService.setRedirect({ provider, url });
 
             const pathToLogin = this.getLoginRoute();

--- a/lib/core/services/auth-guard-base.ts
+++ b/lib/core/services/auth-guard-base.ts
@@ -100,6 +100,6 @@ export abstract class AuthGuardBase implements CanActivate, CanActivateChild {
             null
         );
 
-        return oauth && oauth.silentLogin;
+        return this.authenticationService.isOauth() && oauth && oauth.silentLogin;
     }
 }

--- a/lib/core/services/auth-guard-bpm.service.spec.ts
+++ b/lib/core/services/auth-guard-bpm.service.spec.ts
@@ -92,17 +92,6 @@ describe('AuthGuardService BPM', () => {
         expect(router.navigateByUrl).toHaveBeenCalled();
     }));
 
-    it('should redirect url if the alfresco js api is NOT logged in and isOAuthWithSilentLogin', async(() => {
-        spyOn(router, 'navigateByUrl').and.stub();
-        spyOn(authService, 'isBpmLoggedIn').and.returnValue(false);
-        spyOn(authService, 'isOauth').and.returnValue(true);
-        appConfigService.config.oauth2.silentLogin = true;
-        const route: RouterStateSnapshot = <RouterStateSnapshot>  {url : 'some-url'};
-
-        expect(authGuard.canActivate(null, route)).toBeFalsy();
-        expect(router.navigateByUrl).toHaveBeenCalled();
-    }));
-
     it('should redirect url if NOT logged in and isOAuth but no silentLogin configured', async(() => {
         spyOn(router, 'navigateByUrl').and.stub();
         spyOn(authService, 'isBpmLoggedIn').and.returnValue(false);

--- a/lib/core/services/auth-guard-ecm.service.spec.ts
+++ b/lib/core/services/auth-guard-ecm.service.spec.ts
@@ -92,17 +92,6 @@ describe('AuthGuardService ECM', () => {
         expect(router.navigateByUrl).toHaveBeenCalled();
     }));
 
-    it('should redirect url if the alfresco js api is NOT logged in and isOAuthWithSilentLogin', async(() => {
-        spyOn(router, 'navigateByUrl').and.stub();
-        spyOn(authService, 'isEcmLoggedIn').and.returnValue(false);
-        spyOn(authService, 'isOauth').and.returnValue(true);
-        appConfigService.config.oauth2.silentLogin = true;
-        const route: RouterStateSnapshot = <RouterStateSnapshot>  {url : 'some-url'};
-
-        expect(authGuard.canActivate(null, route)).toBeFalsy();
-        expect(router.navigateByUrl).toHaveBeenCalled();
-    }));
-
     it('should redirect url if NOT logged in and isOAuth but no silentLogin configured', async(() => {
         spyOn(router, 'navigateByUrl').and.stub();
         spyOn(authService, 'isEcmLoggedIn').and.returnValue(false);

--- a/lib/core/services/auth-guard.service.spec.ts
+++ b/lib/core/services/auth-guard.service.spec.ts
@@ -72,7 +72,7 @@ describe('AuthGuardService', () => {
         expect(authGuard.canActivate(null, route)).toBeTruthy();
     }));
 
-    it('should redirect url if the alfresco js api is NOT logged in and isOAuthWithoutSilentLogin', async(() => {
+    it('should redirect url if the User is NOT logged in and isOAuthWithoutSilentLogin', async(() => {
         spyOn(router, 'navigateByUrl').and.stub();
         spyOn(authService, 'isLoggedIn').and.returnValue(false);
         spyOn(authService, 'isOauth').and.returnValue(true);
@@ -82,7 +82,7 @@ describe('AuthGuardService', () => {
         expect(router.navigateByUrl).toHaveBeenCalled();
     }));
 
-    it('should redirect url if the alfresco js api is NOT logged in and isOAuthWithSilentLogin', async(() => {
+    it('should redirect url if the User is NOT logged in and isOAuthWithSilentLogin', async(() => {
         spyOn(router, 'navigateByUrl').and.stub();
         spyOn(authService, 'isLoggedIn').and.returnValue(false);
         spyOn(authService, 'isOauth').and.returnValue(true);
@@ -92,7 +92,7 @@ describe('AuthGuardService', () => {
         expect(router.navigateByUrl).toHaveBeenCalled();
     }));
 
-    it('should redirect url if NOT logged in and isOAuth but no silentLogin configured', async(() => {
+    it('should redirect url if the User is NOT logged in and isOAuth but no silentLogin configured', async(() => {
         spyOn(router, 'navigateByUrl').and.stub();
         spyOn(authService, 'isLoggedIn').and.returnValue(false);
         spyOn(authService, 'isOauth').and.returnValue(true);
@@ -100,6 +100,16 @@ describe('AuthGuardService', () => {
 
         expect(authGuard.canActivate(null, state)).toBeFalsy();
         expect(router.navigateByUrl).toHaveBeenCalled();
+    }));
+
+    it('should NOT redirect url if the User is NOT logged in and isOAuth but with silentLogin configured', async(() => {
+        spyOn(router, 'navigateByUrl').and.stub();
+        spyOn(authService, 'isLoggedIn').and.returnValue(false);
+        spyOn(authService, 'isOauth').and.returnValue(true);
+        appConfigService.config.oauth2.silentLogin = true;
+
+        expect(authGuard.canActivate(null, state)).toBeFalsy();
+        expect(router.navigateByUrl).not.toHaveBeenCalled();
     }));
 
     it('should set redirect url', async(() => {

--- a/lib/core/services/auth-guard.service.spec.ts
+++ b/lib/core/services/auth-guard.service.spec.ts
@@ -82,16 +82,6 @@ describe('AuthGuardService', () => {
         expect(router.navigateByUrl).toHaveBeenCalled();
     }));
 
-    it('should redirect url if the User is NOT logged in and isOAuthWithSilentLogin', async(() => {
-        spyOn(router, 'navigateByUrl').and.stub();
-        spyOn(authService, 'isLoggedIn').and.returnValue(false);
-        spyOn(authService, 'isOauth').and.returnValue(true);
-        appConfigService.config.oauth2.silentLogin = true;
-
-        expect(authGuard.canActivate(null, state)).toBeFalsy();
-        expect(router.navigateByUrl).toHaveBeenCalled();
-    }));
-
     it('should redirect url if the User is NOT logged in and isOAuth but no silentLogin configured', async(() => {
         spyOn(router, 'navigateByUrl').and.stub();
         spyOn(authService, 'isLoggedIn').and.returnValue(false);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
The redirect URL can loop if you don't use the login component and you have silent login on

**What is the new behaviour?**
The auth guard should not redirect if silent login is on



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
