### PR TITLE
[ADF-4984] Focus indicator is not clearly visible- mat-expansion-panel

### DIFF
--- a/lib/content-services/src/lib/search/components/search-filter/search-filter.component.scss
+++ b/lib/content-services/src/lib/search/components/search-filter/search-filter.component.scss
@@ -1,5 +1,7 @@
 @mixin adf-search-filter-theme($theme) {
     $foreground: map-get($theme, foreground);
+    $background: map-get($theme, background);
+    $panel-header-hover: mat-color($background, hover);
 
     .adf-search-filter {
 
@@ -50,6 +52,12 @@
 
             &--topSpace {
                 padding-top: 15px;
+            }
+        }
+
+        .mat-expansion-panel-header.mat-expanded {
+            &:focus, &:hover {
+                background: $panel-header-hover;
             }
         }
 

--- a/lib/content-services/src/lib/search/components/search-filter/search-filter.component.scss
+++ b/lib/content-services/src/lib/search/components/search-filter/search-filter.component.scss
@@ -1,7 +1,5 @@
 @mixin adf-search-filter-theme($theme) {
     $foreground: map-get($theme, foreground);
-    $background: map-get($theme, background);
-    $panel-header-hover: mat-color($background, hover);
 
     .adf-search-filter {
 
@@ -52,12 +50,6 @@
 
             &--topSpace {
                 padding-top: 15px;
-            }
-        }
-
-        .mat-expansion-panel-header.mat-expanded {
-            &:focus, &:hover {
-                background: $panel-header-hover;
             }
         }
 

--- a/lib/core/styles/_index.scss
+++ b/lib/core/styles/_index.scss
@@ -70,4 +70,5 @@
     @include adf-sidenav-layout-theme($theme);
     @include adf-clipboard-theme($theme);
     @include adf-snackbar-theme($theme);
+    @include mat-expansion-panel-theme-get-823-fix($theme);
 }

--- a/lib/core/styles/_index.scss
+++ b/lib/core/styles/_index.scss
@@ -70,5 +70,5 @@
     @include adf-sidenav-layout-theme($theme);
     @include adf-clipboard-theme($theme);
     @include adf-snackbar-theme($theme);
-    @include mat-expansion-panel-theme-get-823-fix($theme);
+    @include mat-expansion-panel-theme--fix($theme);
 }

--- a/lib/core/styles/_mixins.scss
+++ b/lib/core/styles/_mixins.scss
@@ -66,7 +66,7 @@
     overflow: hidden;
 }
 
-@mixin mat-expansion-panel-theme-get-823-fix($theme) {
+@mixin mat-expansion-panel-theme--fix($theme) {
     $background: map-get($theme, background);
 
     .mat-expansion-panel {

--- a/lib/core/styles/_mixins.scss
+++ b/lib/core/styles/_mixins.scss
@@ -65,3 +65,17 @@
     height: 100%;
     overflow: hidden;
 }
+
+@mixin mat-expansion-panel-theme-get-823-fix($theme) {
+    $background: map-get($theme, background);
+
+    .mat-expansion-panel {
+        & .mat-expansion-panel-header.cdk-keyboard-focused,
+        & .mat-expansion-panel-header.cdk-program-focused,
+        &:not(.mat-expanded) .mat-expansion-panel-header:hover {
+            &:not([aria-disabled='true']) {
+                background: mat-color($background, hover);
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe: improve accessibility


**What is the current behaviour?** (You can also link to an open issue here)
Please check Jira issue https://issues.alfresco.com/jira/browse/ADF-4984

**What is the new behaviour?**
Make focused mat-expansion-panel items visible
- get fix from @angular/material 8.2.3


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
