### PR TITLE
[ADF-4973] CLONE - Header - sidenav menu button expanded/collapsed state not exposed via ARIA

### DIFF
--- a/demo-shell/src/app/components/app-layout/app-layout.component.html
+++ b/demo-shell/src/app/components/app-layout/app-layout.component.html
@@ -5,7 +5,7 @@
         <ng-template let-toggleMenu="toggleMenu" let-isMenuMinimized="isMenuMinimized">
 
             <adf-layout-header id="adf-header" [title]="title | translate" [redirectUrl]="redirectUrl" [logo]="logo"
-                [tooltip]="tooltip | translate" [showSidenavToggle]="showMenu" [expandedSidenav]="isMenuMinimized() ? 'false' : 'true'"
+                [tooltip]="tooltip | translate" [showSidenavToggle]="showMenu" [expandedSidenav]="!isMenuMinimized()"
                 [color]="color" [position]="position" (clicked)=toggleMenu($event)>
 
                 <div class="app-layout-menu-spacer"></div>

--- a/demo-shell/src/app/components/app-layout/app-layout.component.html
+++ b/demo-shell/src/app/components/app-layout/app-layout.component.html
@@ -2,10 +2,10 @@
     [expandedSidenav]="expandedSidenav" (expanded)="setState($event)" [position]="position" data-automation-id="sidenav-layout">
 
     <adf-sidenav-layout-header>
-        <ng-template let-toggleMenu="toggleMenu">
+        <ng-template let-toggleMenu="toggleMenu" let-isMenuMinimized="isMenuMinimized">
 
             <adf-layout-header id="adf-header" [title]="title | translate" [redirectUrl]="redirectUrl" [logo]="logo"
-                [tooltip]="tooltip | translate" [showSidenavToggle]="showMenu" [expandedSidenav]="expandedSidenav"
+                [tooltip]="tooltip | translate" [showSidenavToggle]="showMenu" [expandedSidenav]="isMenuMinimized() ? 'false' : 'true'"
                 [color]="color" [position]="position" (clicked)=toggleMenu($event)>
 
                 <div class="app-layout-menu-spacer"></div>


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Aria-expanded wasn't calculate correct


**What is the new behaviour?**
Aria-expanded is calculate correct as in ACA the sidenav can be minimised not only through the sidenav button


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
