### PR TITLE
[AAE-207] support aps 1.x for upload reset

### DIFF
--- a/demo-shell/src/app/components/files/files.component.ts
+++ b/demo-shell/src/app/components/files/files.component.ts
@@ -373,8 +373,8 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
         });
     }
 
-    openSnackMessage(event: any) {
-        this.notificationService.openSnackMessage(event);
+    openSnackMessage(message: string) {
+        this.notificationService.showError(message);
     }
 
     emitReadyEvent(event: NodePaging) {

--- a/lib/content-services/src/lib/i18n/en.json
+++ b/lib/content-services/src/lib/i18n/en.json
@@ -151,7 +151,8 @@
   "FILE_UPLOAD": {
     "BUTTON": {
       "UPLOAD_FILE": "Upload file",
-      "UPLOAD_FOLDER": "Upload folder"
+      "UPLOAD_FOLDER": "Upload folder",
+      "PERMISSION_CHECK_ERROR": "Error checking permission."
     },
     "VERSION": {
       "MESSAGES": {

--- a/lib/content-services/src/lib/upload/components/upload-button.component.spec.ts
+++ b/lib/content-services/src/lib/upload/components/upload-button.component.spec.ts
@@ -384,7 +384,7 @@ describe('UploadButtonComponent', () => {
             spyOn(contentService, 'getNode').and.returnValue(throwError('error'));
 
             component.error.subscribe((value) => {
-                expect(value).toBe('error');
+                expect(value).toBe('FILE_UPLOAD.BUTTON.PERMISSION_CHECK_ERROR');
                 done();
             });
 

--- a/lib/content-services/src/lib/upload/components/upload-button.component.ts
+++ b/lib/content-services/src/lib/upload/components/upload-button.component.ts
@@ -124,7 +124,7 @@ export class UploadButtonComponent extends UploadBase implements OnInit, OnChang
                     if (error && error.error) {
                         this.error.emit(error.error.message);
                     } else {
-                        this.error.emit('Error checking permission');
+                        this.error.emit('FILE_UPLOAD.BUTTON.PERMISSION_CHECK_ERROR');
                     }
                 }
             );

--- a/lib/content-services/src/lib/upload/components/upload-button.component.ts
+++ b/lib/content-services/src/lib/upload/components/upload-button.component.ts
@@ -120,7 +120,13 @@ export class UploadButtonComponent extends UploadBase implements OnInit, OnChang
 
             this.contentService.getNode(this.rootFolderId, opts).subscribe(
                 (res) => this.permissionValue.next(this.nodeHasPermission(res.entry, AllowableOperationsEnum.CREATE)),
-                (error) => this.error.emit(error)
+                (error: { error: Error }) => {
+                    if (error && error.error) {
+                        this.error.emit(error.error.message);
+                    } else {
+                        this.error.emit('Error checking permission');
+                    }
+                }
             );
         }
     }

--- a/lib/core/form/components/widgets/upload/upload.widget.spec.ts
+++ b/lib/core/form/components/widgets/upload/upload.widget.spec.ts
@@ -134,8 +134,8 @@ describe('UploadWidgetComponent', () => {
             });
 
             uploadWidgetComponent.removeFile(uploadWidgetComponent.field.value[0]);
-            expect(uploadWidgetComponent.field.value.length).toBe(0);
-            expect(uploadWidgetComponent.field.json.value.length).toBe(0);
+            expect(uploadWidgetComponent.field.value).toBeNull();
+            expect(uploadWidgetComponent.field.json.value).toBeNull();
             expect(uploadWidgetComponent.hasFile).toBeFalsy();
         });
 

--- a/lib/core/form/components/widgets/upload/upload.widget.ts
+++ b/lib/core/form/components/widgets/upload/upload.widget.ts
@@ -108,7 +108,7 @@ export class UploadWidgetComponent extends WidgetComponent implements OnInit {
         }
     }
 
-    private removeElementFromList(file) {
+    private removeElementFromList(file: any) {
         const index = this.field.value.indexOf(file);
 
         if (index !== -1) {
@@ -119,17 +119,13 @@ export class UploadWidgetComponent extends WidgetComponent implements OnInit {
 
         this.hasFile = this.field.value.length > 0;
 
-        this.resetFormValueWithNoFiles();
-    }
-
-    private resetFormValueWithNoFiles() {
-        if (this.field.value.length === 0) {
-            this.field.value = [];
-            this.field.json.value = [];
+        if (!this.hasFile) {
+            this.field.value = null;
+            this.field.json.value = null;
         }
     }
 
-    getIcon(mimeType) {
+    getIcon(mimeType: string): string {
         return this.thumbnailService.getMimeTypeIcon(mimeType);
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12753,12 +12753,12 @@
       }
     },
     "pdfjs-dist": {
-      "version": "2.0.943",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.0.943.tgz",
-      "integrity": "sha512-iLhNcm4XceTHRaSU5o22ZGCm4YpuW5+rf4+BJFH/feBhMQLbCGBry+Jet8Q419QDI4qgARaIQzXuiNrsNWS8Yw==",
+      "version": "2.0.489",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-2.0.489.tgz",
+      "integrity": "sha1-Y+VLKSqGeQpFRpfrRNQ0e4+/rSc=",
       "requires": {
         "node-ensure": "^0.0.0",
-        "worker-loader": "^2.0.0"
+        "worker-loader": "^1.1.1"
       }
     },
     "pend": {
@@ -19517,9 +19517,9 @@
       }
     },
     "worker-loader": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/worker-loader/-/worker-loader-2.0.0.tgz",
-      "integrity": "sha512-tnvNp4K3KQOpfRnD20m8xltE3eWh89Ye+5oj7wXEEHKac1P4oZ6p9oTj8/8ExqoSBnk9nu5Pr4nKfQ1hn2APJw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/worker-loader/-/worker-loader-1.1.1.tgz",
+      "integrity": "sha512-qJZLVS/jMCBITDzPo/RuweYSIG8VJP5P67mP/71alGyTZRe1LYJFdwLjLalY3T5ifx0bMDRD3OB6P2p1escvlg==",
       "requires": {
         "loader-utils": "^1.0.0",
         "schema-utils": "^0.4.0"

--- a/package.json
+++ b/package.json
@@ -114,15 +114,15 @@
     "moment-es6": "^1.0.0",
     "ng2-charts": "1.6.0",
     "ngx-monaco-editor": "7.0.0",
-    "pdfjs-dist": "2.0.943",
+    "pdfjs-dist": "2.0.489",
     "raphael": "2.2.7",
     "reflect-metadata": "0.1.13",
     "remark-validate-links": "^8.0.0",
     "rxjs": "^6.2.2",
+    "snyk": "^1.250.0",
     "systemjs": "0.19.27",
     "web-animations-js": "2.3.1",
-    "zone.js": "~0.8.26",
-    "snyk": "^1.250.0"
+    "zone.js": "~0.8.26"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^0.13.4",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

provide `null` value for UploadWidget to support APS 1.x scenarios
note that UploadCloudWidget still supports empty arrays for APS 2.x

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/AAE-207