### PR TITLE
[ADF-5006] Datatable - custom cell template focus not working

### DIFF
--- a/demo-shell/src/app/components/files/files.component.html
+++ b/demo-shell/src/app/components/files/files.component.html
@@ -318,6 +318,7 @@
                     <data-column
                         title="{{'DOCUMENT_LIST.COLUMNS.IS_LOCKED' | translate}}"
                         key="id"
+                        [focus]="false"
                         class="app-desktop-only adf-ellipsis-cell">
                         <ng-template let-entry="$implicit">
                             <button mat-icon-button [adf-node-lock]="entry.row.node.entry" class="app-lock-button">

--- a/docs/core/components/data-column.component.md
+++ b/docs/core/components/data-column.component.md
@@ -53,6 +53,7 @@ Defines column properties for DataTable, Tasklist, Document List and other compo
 | srTitle | `string` |  | Title to be used for screen readers. |
 | title | `string` | "" | Display title of the column, typically used for column headers. You can use the i18n resource key to get it translated automatically. |
 | type | `string` | "text" | Value type for the column. Possible settings are 'text', 'image', 'date', 'fileSize', 'location', and 'json'. |
+| focus | `boolean` | "true" | Toggles keyboard focus for a column. This should be use for custom template columns that contain actions elements   |
 
 ## Details
 

--- a/docs/core/interfaces/datatable-adapter.interface.md
+++ b/docs/core/interfaces/datatable-adapter.interface.md
@@ -70,6 +70,7 @@ interface DataColumn {
     cssClass?: string;
     template?: TemplateRef<any>;
     formatTooltip?: Function;
+    focus?: boolean;
 }
 ```
 

--- a/lib/core/data-column/data-column.component.ts
+++ b/lib/core/data-column/data-column.component.ts
@@ -74,6 +74,10 @@ export class DataColumnComponent implements OnInit {
     @Input()
     editable: boolean = false;
 
+    /**  Enable or disable cell focus */
+    @Input()
+    focus: boolean = true;
+
     ngOnInit() {
         if (!this.srTitle && this.key === '$thumbnail') {
             this.srTitle = 'Thumbnail';

--- a/lib/core/datatable/components/datatable/datatable.component.html
+++ b/lib/core/datatable/components/datatable/datatable.component.html
@@ -197,7 +197,7 @@
                         </ng-container>
                     </div>
                     <div *ngIf="col.template" class="adf-datatable-cell-container">
-                        <div class="adf-cell-value">
+                        <div class="adf-cell-value" [attr.tabindex]="col.focus ? 0 : null">
                             <ng-container
                                 [ngTemplateOutlet]="col.template"
                                 [ngTemplateOutletContext]="{ $implicit: { data: data, row: row, col: col }, value: data.getValue(row, col, resolverFn) }">

--- a/lib/core/datatable/data/data-column.model.ts
+++ b/lib/core/datatable/data/data-column.model.ts
@@ -41,4 +41,5 @@ export interface DataColumn {
     formatTooltip?: Function;
     copyContent?: boolean;
     editable?: boolean;
+    focus?: boolean;
 }

--- a/lib/core/datatable/data/object-datacolumn.model.ts
+++ b/lib/core/datatable/data/object-datacolumn.model.ts
@@ -30,6 +30,7 @@ export class ObjectDataColumn implements DataColumn {
     cssClass: string;
     template?: TemplateRef<any>;
     copyContent?: boolean;
+    focus?: boolean;
 
     constructor(input: any) {
         this.key = input.key;
@@ -41,5 +42,6 @@ export class ObjectDataColumn implements DataColumn {
         this.cssClass = input.cssClass;
         this.template = input.template;
         this.copyContent = input.copyContent;
+        this.focus = input.focus;
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
[ADF-5006](https://issues.alfresco.com/jira/browse/ADF-5006)


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
