### PR TITLE
[AAE-898] Fix Datetime card view model custom format

### DIFF
--- a/e2e/core/card-view/card-view-component.e2e.ts
+++ b/e2e/core/card-view/card-view-component.e2e.ts
@@ -271,7 +271,7 @@ describe('CardView Component', () => {
 
         it('[C279962] Should be present a default value', async () => {
             await expect(await metadataViewPage.getPropertyText('date', 'date')).toEqual('12/24/83');
-            await expect(await metadataViewPage.getPropertyText('datetime', 'datetime')).toEqual('Dec 24, 1983, 10:00');
+            await expect(await metadataViewPage.getPropertyText('datetime', 'datetime')).toEqual('12/24/83, 10:00 AM');
         });
 
         it('[C312447] Should be able to clear the date field', async () => {

--- a/lib/core/card-view/models/card-view-datetimeitem.model.ts
+++ b/lib/core/card-view/models/card-view-datetimeitem.model.ts
@@ -18,8 +18,17 @@
 import { CardViewItem } from '../interfaces/card-view-item.interface';
 import { DynamicComponentModel } from '../../services/dynamic-component-mapper.service';
 import { CardViewDateItemModel } from './card-view-dateitem.model';
+import { CardViewDateItemProperties } from '../interfaces/card-view.interfaces';
 
 export class CardViewDatetimeItemModel extends CardViewDateItemModel implements CardViewItem, DynamicComponentModel {
     type: string = 'datetime';
     format: string = 'MMM d, y, H:mm';
+
+    constructor(cardViewDateItemProperties: CardViewDateItemProperties) {
+        super(cardViewDateItemProperties);
+
+        if (cardViewDateItemProperties.format) {
+            this.format = cardViewDateItemProperties.format;
+        }
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/AAE-898

**What is the new behaviour?**
The datetime card view model was missing the constructor. This class extends the date card view model so it allows to pass a custom format but because it didn't have a constructor this property was never been assigned. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
The datetime card view model was mi