### PR TITLE
[ADF-5007] Comments - textarea Escape event cannot be canceled

### DIFF
--- a/lib/core/comments/comments.component.html
+++ b/lib/core/comments/comments.component.html
@@ -4,7 +4,7 @@
     </div>
     <div class="adf-comments-input-container" *ngIf="!isReadOnly()">
             <mat-form-field class="adf-full-width">
-                <textarea (keyup.escape)="clear()" matInput id="comment-input" placeholder="{{'COMMENTS.ADD' | translate}}" [(ngModel)]="message"></textarea>
+                <textarea (keydown.escape)="clear($event)" matInput id="comment-input" placeholder="{{'COMMENTS.ADD' | translate}}" [(ngModel)]="message"></textarea>
             </mat-form-field>
 
             <div class="adf-comments-input-actions">

--- a/lib/core/comments/comments.component.spec.ts
+++ b/lib/core/comments/comments.component.spec.ts
@@ -277,7 +277,7 @@ describe('CommentsComponent', () => {
         }));
 
         it('should clear comment when escape key is pressed', async(() => {
-            const event = new KeyboardEvent('keyup', {'key': 'Escape'});
+            const event = new KeyboardEvent('keydown', {'key': 'Escape'});
             let element = fixture.nativeElement.querySelector('#comment-input');
             element.dispatchEvent(event);
             fixture.detectChanges();
@@ -365,7 +365,7 @@ describe('CommentsComponent', () => {
         }));
 
         it('should clear comment when escape key is pressed', async(() => {
-            const event = new KeyboardEvent('keyup', {'key': 'Escape'});
+            const event = new KeyboardEvent('keydown', {'key': 'Escape'});
             let element = fixture.nativeElement.querySelector('#comment-input');
             element.dispatchEvent(event);
             fixture.detectChanges();

--- a/lib/core/comments/comments.component.ts
+++ b/lib/core/comments/comments.component.ts
@@ -165,7 +165,8 @@ export class CommentsComponent implements OnChanges {
         }
     }
 
-    clear(): void {
+    clear(event: KeyboardEvent): void {
+        event.stopPropagation();
         this.message = '';
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
[ADF-5007](https://issues.alfresco.com/jira/browse/ADF-5007)


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
