### PR TITLE
[AAE-459] ProcessCloud - set process definition pre-filled value for one result only

### DIFF
--- a/e2e/process-services-cloud/start-process-cloud.e2e.ts
+++ b/e2e/process-services-cloud/start-process-cloud.e2e.ts
@@ -86,6 +86,8 @@ describe('Start Process', () => {
         await appListCloudComponent.checkAppIsDisplayed(simpleApp);
         await appListCloudComponent.goToApp(simpleApp);
         await processCloudDemoPage.openNewProcessForm();
+        await startProcessPage.selectFirstOptionFromProcessDropdown();
+
         await startProcessPage.enterProcessName(processName255Characters);
         await expect(await startProcessPage.checkStartProcessButtonIsEnabled()).toBe(true);
 
@@ -98,6 +100,8 @@ describe('Start Process', () => {
         await appListCloudComponent.checkAppIsDisplayed(simpleApp);
         await appListCloudComponent.goToApp(simpleApp);
         await processCloudDemoPage.openNewProcessForm();
+        await startProcessPage.selectFirstOptionFromProcessDropdown();
+
         await startProcessPage.clearField(startProcessPage.processNameInput);
         await startProcessPage.enterProcessName(processName);
         await expect(await startProcessPage.checkStartProcessButtonIsEnabled()).toBe(true);

--- a/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.spec.ts
@@ -26,7 +26,7 @@ import { StartProcessCloudComponent } from './start-process-cloud.component';
 import { ProcessServiceCloudTestingModule } from '../../../testing/process-service-cloud.testing.module';
 import { ProcessCloudModule } from '../../process-cloud.module';
 import { fakeProcessDefinitions, fakeStartForm, fakeStartFormNotValid,
-    fakeProcessInstance, fakeProcessPayload, fakeNoNameProcessDefinitions } from '../mock/start-process.component.mock';
+    fakeProcessInstance, fakeProcessPayload, fakeNoNameProcessDefinitions, fakeSingleProcessDefinition } from '../mock/start-process.component.mock';
 import { By } from '@angular/platform-browser';
 
 describe('StartProcessCloudComponent', () => {
@@ -37,6 +37,7 @@ describe('StartProcessCloudComponent', () => {
     let formCloudService: FormCloudService;
     let getDefinitionsSpy: jasmine.Spy;
     let startProcessSpy: jasmine.Spy;
+    let formDefinitionSpy: jasmine.Spy;
 
     const selectOptionByName = (name: string) => {
 
@@ -133,8 +134,9 @@ describe('StartProcessCloudComponent', () => {
 
         it('should be able to start a process with a valid form', async(() => {
             component.processDefinitionName = 'processwithform';
+            getDefinitionsSpy.and.returnValue(of(fakeSingleProcessDefinition(component.processDefinitionName)));
             fixture.detectChanges();
-            getDefinitionsSpy = spyOn(formCloudService, 'getForm').and.returnValue(of(fakeStartForm));
+            formDefinitionSpy = spyOn(formCloudService, 'getForm').and.returnValue(of(fakeStartForm));
 
             const change = new SimpleChange(null, 'MyApp', true);
             component.ngOnChanges({ 'appName': change });
@@ -153,8 +155,9 @@ describe('StartProcessCloudComponent', () => {
 
         it('should NOT be able to start a process with a form NOT valid', async(() => {
             component.processDefinitionName = 'processwithform';
+            getDefinitionsSpy.and.returnValue(of(fakeSingleProcessDefinition(component.processDefinitionName)));
             fixture.detectChanges();
-            getDefinitionsSpy = spyOn(formCloudService, 'getForm').and.returnValue(of(fakeStartFormNotValid));
+            formDefinitionSpy = spyOn(formCloudService, 'getForm').and.returnValue(of(fakeStartFormNotValid));
 
             const change = new SimpleChange(null, 'MyApp', true);
             component.ngOnChanges({ 'appName': change });
@@ -173,9 +176,10 @@ describe('StartProcessCloudComponent', () => {
 
         it('should be able to start a process with a prefilled valid form', async(() => {
             component.processDefinitionName = 'processwithform';
+            getDefinitionsSpy.and.returnValue(of(fakeSingleProcessDefinition(component.processDefinitionName)));
             component.values = [{'name': 'firstName', 'value': 'FakeName'}, {'name': 'lastName', 'value': 'FakeLastName'}];
             fixture.detectChanges();
-            getDefinitionsSpy = spyOn(formCloudService, 'getForm').and.returnValue(of(fakeStartForm));
+            formDefinitionSpy = spyOn(formCloudService, 'getForm').and.returnValue(of(fakeStartForm));
 
             const change = new SimpleChange(null, 'MyApp', true);
             component.ngOnChanges({ 'appName': change });
@@ -196,15 +200,17 @@ describe('StartProcessCloudComponent', () => {
 
         it('should NOT be able to start a process with a prefilled NOT valid form', async(() => {
             component.processDefinitionName = 'processwithform';
+            getDefinitionsSpy.and.returnValue(of(fakeSingleProcessDefinition(component.processDefinitionName)));
             component.values = [{'name': 'firstName', 'value': 'FakeName'}, {'name': 'lastName', 'value': 'FakeLastName'}];
             fixture.detectChanges();
-            getDefinitionsSpy = spyOn(formCloudService, 'getForm').and.returnValue(of(fakeStartFormNotValid));
+            formDefinitionSpy = spyOn(formCloudService, 'getForm').and.returnValue(of(fakeStartFormNotValid));
 
             const change = new SimpleChange(null, 'MyApp', true);
             component.ngOnChanges({ 'appName': change });
             fixture.detectChanges();
 
             fixture.whenStable().then(() => {
+                expect(formDefinitionSpy).toHaveBeenCalled();
                 const firstNameEl = fixture.nativeElement.querySelector('#firstName');
                 expect(firstNameEl).toBeDefined();
                 expect(firstNameEl.value).toEqual('FakeName');
@@ -292,20 +298,6 @@ describe('StartProcessCloudComponent', () => {
                 const noProcessElement = fixture.nativeElement.querySelector('#no-process-message');
                 expect(noProcessElement).not.toBeNull('Expected no available process message to be present');
                 expect(noProcessElement.innerText.trim()).toBe('ADF_CLOUD_PROCESS_LIST.ADF_CLOUD_START_PROCESS.NO_PROCESS_DEFINITIONS');
-            });
-        }));
-
-        it('should select processDefinition based on processDefinition input', async(() => {
-            component.name = 'My new process';
-            component.processDefinitionName = 'processwithoutform1';
-            fixture.detectChanges();
-
-            const change = new SimpleChange(null, 'MyApp', true);
-            component.ngOnChanges({ 'appName': change });
-            fixture.detectChanges();
-
-            fixture.whenStable().then(() => {
-                expect(component.processPayloadCloud.processDefinitionKey).toBe(JSON.parse(JSON.stringify(fakeProcessDefinitions[0])).key);
             });
         }));
 
@@ -428,6 +420,16 @@ describe('StartProcessCloudComponent', () => {
             fixture.detectChanges();
             tick(3000);
             expect(component.filteredProcesses.length).toEqual(1);
+        }));
+
+        it('should display the process definion field as empty if are more than one process definition in the list', async(() => {
+            getDefinitionsSpy.and.returnValue(of(fakeProcessDefinitions));
+            component.ngOnChanges({ appName: change });
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+                const processDefinitionInput = fixture.nativeElement.querySelector('#processDefinitionName');
+                expect(processDefinitionInput.textContent).toEqual('');
+            });
         }));
     });
 

--- a/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.ts
@@ -179,7 +179,7 @@ export class StartProcessCloudComponent implements OnChanges, OnInit, OnDestroy 
             .pipe(takeUntil(this.onDestroy$))
             .subscribe((processDefinitionRepresentations: ProcessDefinitionCloud[]) => {
                 this.processDefinitionList = processDefinitionRepresentations;
-                if (processDefinitionRepresentations.length > 0) {
+                if (processDefinitionRepresentations.length === 1) {
                     this.selectDefaultProcessDefinition();
                 }
             },

--- a/lib/process-services-cloud/src/lib/process/start-process/mock/start-process.component.mock.ts
+++ b/lib/process-services-cloud/src/lib/process/start-process/mock/start-process.component.mock.ts
@@ -64,6 +64,18 @@ export let fakeProcessDefinitions: ProcessDefinitionCloud[] = [
     })
 ];
 
+export function fakeSingleProcessDefinition(name: string): ProcessDefinitionCloud[] {
+    return [
+        new ProcessDefinitionCloud({
+            appName: 'startformwithoutupload',
+            formKey: 'form-a5d50817-5183-4850-802d-17af54b2632f',
+            id: 'd00c0237-8772-11e9-859a-428f83d5904f',
+            key: 'process-5151ad1d-f992-4ee6-9742-3a04617469fe',
+            name: name
+        })
+    ];
+}
+
 export let fakeNoNameProcessDefinitions: ProcessDefinitionCloud[] = [
     new ProcessDefinitionCloud({
         appName: 'myApp',

--- a/lib/testing/src/lib/process-services-cloud/pages/start-process-cloud-component.page.ts
+++ b/lib/testing/src/lib/process-services-cloud/pages/start-process-cloud-component.page.ts
@@ -60,6 +60,13 @@ export class StartProcessCloudPage {
         await this.selectOption(name);
     }
 
+    async selectFirstOptionFromProcessDropdown(): Promise<void> {
+        await this.clickProcessDropdownArrow();
+        const selectFirstProcessDropdown = element.all(by.css('.mat-option-text')).first();
+        await BrowserVisibility.waitUntilElementIsPresent(selectFirstProcessDropdown);
+        await BrowserActions.click(selectFirstProcessDropdown);
+    }
+
     async clickProcessDropdownArrow(): Promise<void> {
         await BrowserActions.click(this.selectProcessDropdownArrow);
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/AAE-459


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
