### PR TITLE
[ADF-5003] [DataTable] Selection on row is not working correctly

### DIFF
--- a/lib/core/datatable/components/datatable/datatable-row.component.spec.ts
+++ b/lib/core/datatable/components/datatable/datatable-row.component.spec.ts
@@ -120,4 +120,15 @@ describe('DataTableRowComponent', () => {
         fixture.debugElement.nativeElement.dispatchEvent(event);
         expect(component.select.emit).toHaveBeenCalledWith(event);
     });
+
+    it('should emit keyboard Enter event', () => {
+        spyOn(component.select, 'emit');
+        const event = new KeyboardEvent('keydown', {
+            key: ' ',
+            code: 'Enter'
+        });
+
+        fixture.debugElement.nativeElement.dispatchEvent(event);
+        expect(component.select.emit).toHaveBeenCalledWith(event);
+    });
 });

--- a/lib/core/datatable/components/datatable/datatable-row.component.ts
+++ b/lib/core/datatable/components/datatable/datatable-row.component.ts
@@ -76,6 +76,7 @@ export class DataTableRowComponent implements FocusableOption {
     }
 
     @HostListener('keydown.space', ['$event'])
+    @HostListener('keydown.enter', ['$event'])
     onKeyDown(event: KeyboardEvent) {
         if ((event.target as Element).tagName === this.element.nativeElement.tagName) {
             event.preventDefault();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-5003

Now row is not selected on `Enter` keypress 

**What is the new behaviour?**

Now row is selected on `Enter` keypress 

![enterkeyress](https://user-images.githubusercontent.com/14145706/69439297-adb26480-0d6c-11ea-80b5-efad7d924ce4.gif)


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
