### PR TITLE
ADF-5024 add wait for task list page in dt component

### DIFF
--- a/lib/testing/src/lib/core/pages/data-table-component.page.ts
+++ b/lib/testing/src/lib/core/pages/data-table-component.page.ts
@@ -68,7 +68,7 @@ export class DataTableComponentPage {
     }
 
     async checkListIsDisplayed(): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsNotVisible(this.list.first());
+        await BrowserVisibility.waitUntilElementIsVisible(this.list.first());
     }
 
     async checkRowIsChecked(columnName: string, columnValue: string): Promise<void> {

--- a/lib/testing/src/lib/core/pages/data-table-component.page.ts
+++ b/lib/testing/src/lib/core/pages/data-table-component.page.ts
@@ -67,6 +67,10 @@ export class DataTableComponentPage {
         await BrowserVisibility.waitUntilElementIsNotVisible(this.getRowCheckbox(columnName, columnValue).element(by.css('input[aria-checked="true"]')));
     }
 
+    async checkListIsDisplayed(): Promise<void> {
+        await BrowserVisibility.waitUntilElementIsNotVisible(this.list.first());
+    }
+
     async checkRowIsChecked(columnName: string, columnValue: string): Promise<void> {
         const rowCheckbox = this.getRowCheckbox(columnName, columnValue);
         await BrowserVisibility.waitUntilElementIsVisible(rowCheckbox.element(by.css('input[aria-checked="true"]')));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
A new method aded to wait for the list to load in datatable component page


**What is the new behaviour?**
No method to wait for the list to load in datatable component page



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
