### PR TITLE
[ADF-5034] [GroupCloudComponent] Provide a way to make pre-selected groups read-only.

### DIFF
--- a/docs/process-services-cloud/components/group-cloud.component.md
+++ b/docs/process-services-cloud/components/group-cloud.component.md
@@ -92,3 +92,35 @@ export class MyComponent {
     [preSelectGroups]="groups">
 </adf-cloud-group>
 ```
+
+### Read-only
+
+You can use `readonly` property to make preselected groups read-only in `multiple` mode.
+
+Usage example:
+
+```ts
+import { ObjectDataTableAdapter }  from '@alfresco/adf-core';
+
+@Component({...})
+export class MyComponent {
+    groups: any;
+
+    constructor() {
+        this.groups =
+            [
+                {id: 1, name: 'Group 1', readonly: true},
+                {id: 2, name: 'Group 2', readonly: false}
+            ];
+    }
+}
+```
+
+```html
+<adf-cloud-group
+    [mode]="'multiple'"
+    [preSelectGroups]="groups">
+</adf-cloud-group>
+```
+
+from above `preSelectGroups`, `Group 2` is removable from the `preSelectGroups` whereas `Group 1` is readonly you can not remove them.

--- a/lib/core/mock/identity-group.service.mock.ts
+++ b/lib/core/mock/identity-group.service.mock.ts
@@ -18,30 +18,30 @@
 import { IdentityGroupModel, IdentityGroupCountModel } from '../models/identity-group.model';
 import { IdentityRoleModel } from '../models/identity-role.model';
 
-export let mockIdentityGroup1 = new IdentityGroupModel({
+export let mockIdentityGroup1 = <IdentityGroupModel> {
     id: 'mock-group-id-1', name: 'Mock Group 1', path: '/mock', subGroups: []
-});
+};
 
-export let mockIdentityGroup2 = new IdentityGroupModel({
+export let mockIdentityGroup2 = <IdentityGroupModel> {
     id: 'mock-group-id-2', name: 'Mock Group 2', path: '', subGroups: []
-});
+};
 
-export let mockIdentityGroup3 = new IdentityGroupModel({
+export let mockIdentityGroup3 = <IdentityGroupModel> {
   id: 'mock-group-id-3', name: 'Mock Group 3', path: '', subGroups: []
-});
+};
 
-export let mockIdentityGroup4 = new IdentityGroupModel({
+export let mockIdentityGroup4 = <IdentityGroupModel> {
     id: 'mock-group-id-4', name: 'Mock Group 4', path: '', subGroups: []
-});
+};
 
-export let mockIdentityGroup5 = new IdentityGroupModel({
+export let mockIdentityGroup5 = <IdentityGroupModel> {
     id: 'mock-group-id-5', name: 'Mock Group 5', path: '', subGroups: []
-});
+};
 
 export let mockIdentityGroupsCount = <IdentityGroupCountModel> { count: 10 };
 
 export let mockIdentityGroups = [
-    mockIdentityGroup1, mockIdentityGroup2, mockIdentityGroup3, mockIdentityGroup5, mockIdentityGroup5
+    mockIdentityGroup1, mockIdentityGroup2, mockIdentityGroup3, mockIdentityGroup4, mockIdentityGroup5
 ];
 
 export let mockApplicationDetails = {id: 'mock-app-id', name: 'mock-app-name'};

--- a/lib/core/mock/identity-user.service.mock.ts
+++ b/lib/core/mock/identity-user.service.mock.ts
@@ -57,17 +57,17 @@ export const mockEffectiveRoles = [
 
 export const mockJoinGroupRequest: IdentityJoinGroupRequestModel = {userId: 'mock-hser-id', groupId: 'mock-group-id', realm: 'mock-realm-name'};
 
-export const mockGroup1 = new IdentityGroupModel({
+export const mockGroup1 = <IdentityGroupModel> {
     id: 'mock-group-id-1', name: 'Mock Group 1', path: '/mock', subGroups: []
-});
+};
 
-export const mockGroup2 = new IdentityGroupModel({
+export const mockGroup2 = <IdentityGroupModel> {
     id: 'mock-group-id-2', name: 'Mock Group 2', path: '', subGroups: []
-});
+};
 
 export const mockGroups = [
-    new IdentityGroupModel({ id: 'mock-group-id-1', name: 'Mock Group 1', path: '/mock', subGroups: [] }),
-    new IdentityGroupModel({ id: 'mock-group-id-2', name: 'Mock Group 2', path: '', subGroups: [] })
+    <IdentityGroupModel> { id: 'mock-group-id-1', name: 'Mock Group 1', path: '/mock', subGroups: [] },
+    <IdentityGroupModel> { id: 'mock-group-id-2', name: 'Mock Group 2', path: '', subGroups: [] }
 ];
 
 export const queryUsersMockApi = {

--- a/lib/core/models/identity-group.model.ts
+++ b/lib/core/models/identity-group.model.ts
@@ -17,27 +17,15 @@
 
 import { Pagination } from '@alfresco/js-api';
 
-export class IdentityGroupModel {
-
-    id: string;
-    name: string;
-    path: string;
-    realmRoles: string[];
-    clientRoles: any;
-    access: any;
-    attributes: any;
-
-    constructor(obj?: any) {
-        if (obj) {
-            this.id = obj.id || null;
-            this.name = obj.name || null;
-            this.path = obj.path || null;
-            this.realmRoles = obj.realmRoles || null;
-            this.clientRoles = obj.clientRoles || null;
-            this.access = obj.access || null;
-            this.attributes = obj.attributes || null;
-        }
-    }
+export interface IdentityGroupModel {
+    id?: string;
+    name?: string;
+    path?: string;
+    realmRoles?: string[];
+    clientRoles?: any;
+    access?: any;
+    attributes?: any;
+    readonly?: boolean;
 }
 
 export interface IdentityGroupSearchParam {
@@ -50,17 +38,9 @@ export interface IdentityGroupQueryResponse {
     pagination: Pagination;
 }
 
-export class IdentityGroupQueryCloudRequestModel {
-
+export interface IdentityGroupQueryCloudRequestModel {
     first: number;
     max: number;
-
-    constructor(obj?: any) {
-        if (obj) {
-            this.first = obj.first;
-            this.max = obj.max;
-        }
-    }
 }
 
 export interface IdentityGroupCountModel {

--- a/lib/process-services-cloud/src/lib/group/components/group-cloud.component.html
+++ b/lib/process-services-cloud/src/lib/group/components/group-cloud.component.html
@@ -4,10 +4,14 @@
     <mat-chip-list #groupChipList *ngIf="isMultipleMode()" [disabled]="isDisabled" data-automation-id="adf-cloud-group-chip-list" class="apa-group-chip-list">
       <mat-chip
         *ngFor="let group of selectedGroups$ | async"
+        [removable]="!(group.readonly)"
         (removed)="onRemove(group)"
         [attr.data-automation-id]="'adf-cloud-group-chip-' + group.name">
         {{group.name}}
-        <mat-icon matChipRemove>cancel</mat-icon>
+        <mat-icon
+            matChipRemove [attr.data-automation-id]="'adf-cloud-group-chip-remove-icon-' + group.name">
+            cancel
+        </mat-icon>
       </mat-chip>
       <input matInput
         [formControl]="searchGroupsControl"

--- a/lib/process-services-cloud/src/lib/group/pipe/group-initial.pipe.spec.ts
+++ b/lib/process-services-cloud/src/lib/group/pipe/group-initial.pipe.spec.ts
@@ -25,7 +25,7 @@ describe('InitialGroupNamePipe', () => {
 
     beforeEach(() => {
         pipe = new InitialGroupNamePipe();
-        fakeGroup = new IdentityGroupModel({name: 'mock'});
+        fakeGroup = <IdentityGroupModel> {name: 'mock'};
     });
 
     it('should return with the group initial', () => {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://issues.alfresco.com/jira/browse/ADF-5034

**What is the new behaviour?**

![ezgif com-video-to-gif (4)](https://user-images.githubusercontent.com/25585550/70047214-9e91a900-15ed-11ea-894a-d61804d273a7.gif)


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
