### PR TITLE
[ADF-5009] close all the dialogs after false canActivate event

### DIFF
--- a/lib/core/services/auth-guard-base.ts
+++ b/lib/core/services/auth-guard-base.ts
@@ -29,6 +29,7 @@ import {
     AppConfigValues
 } from '../app-config/app-config.service';
 import { OauthConfigModel } from '../models/oauth-config.model';
+import { MatDialog } from '@angular/material';
 
 export abstract class AuthGuardBase implements CanActivate, CanActivateChild {
     abstract checkLogin(
@@ -46,14 +47,21 @@ export abstract class AuthGuardBase implements CanActivate, CanActivateChild {
     constructor(
         protected authenticationService: AuthenticationService,
         protected router: Router,
-        protected appConfigService: AppConfigService
+        protected appConfigService: AppConfigService,
+        protected dialog: MatDialog
     ) {}
 
     canActivate(
         route: ActivatedRouteSnapshot,
         state: RouterStateSnapshot
     ): Observable<boolean> | Promise<boolean> | boolean {
-        return this.checkLogin(route, state.url);
+        const checkLogin = this.checkLogin(route, state.url);
+
+        if (!checkLogin) {
+            this.dialog.closeAll();
+        }
+
+        return checkLogin;
     }
 
     canActivateChild(

--- a/lib/core/services/auth-guard-bpm.service.spec.ts
+++ b/lib/core/services/auth-guard-bpm.service.spec.ts
@@ -22,6 +22,7 @@ import { AuthenticationService } from './authentication.service';
 import { RouterStateSnapshot, Router } from '@angular/router';
 import { setupTestBed } from '../testing/setupTestBed';
 import { CoreTestingModule } from '../testing/core.testing.module';
+import { MatDialog } from '@angular/material';
 
 describe('AuthGuardService BPM', () => {
 
@@ -156,4 +157,21 @@ describe('AuthGuardService BPM', () => {
         expect(router.navigateByUrl).toHaveBeenCalledWith('/fakeLoginRoute?redirectUrl=some-url');
     }));
 
+    it('should to close the material dialog if is redirect to the login', () => {
+        const materialDialog = TestBed.get(MatDialog);
+
+        spyOn(materialDialog, 'closeAll');
+
+        spyOn(authService, 'setRedirect').and.callThrough();
+        spyOn(router, 'navigateByUrl').and.stub();
+        const route: RouterStateSnapshot = <RouterStateSnapshot> { url: 'some-url' };
+
+        authGuard.canActivate(null, route);
+
+        expect(authService.setRedirect).toHaveBeenCalledWith({
+            provider: 'ECM', url: 'some-url'
+        });
+
+        expect(materialDialog.closeAll).toHaveBeenCalled();
+    });
 });

--- a/lib/core/services/auth-guard-bpm.service.spec.ts
+++ b/lib/core/services/auth-guard-bpm.service.spec.ts
@@ -169,7 +169,7 @@ describe('AuthGuardService BPM', () => {
         authGuard.canActivate(null, route);
 
         expect(authService.setRedirect).toHaveBeenCalledWith({
-            provider: 'ECM', url: 'some-url'
+            provider: 'BPM', url: 'some-url'
         });
 
         expect(materialDialog.closeAll).toHaveBeenCalled();

--- a/lib/core/services/auth-guard-bpm.service.ts
+++ b/lib/core/services/auth-guard-bpm.service.ts
@@ -21,6 +21,7 @@ import { AppConfigService } from '../app-config/app-config.service';
 import { AuthenticationService } from './authentication.service';
 import { AuthGuardBase } from './auth-guard-base';
 import { Observable } from 'rxjs';
+import { MatDialog } from '@angular/material';
 
 @Injectable({
     providedIn: 'root'
@@ -29,8 +30,10 @@ export class AuthGuardBpm extends AuthGuardBase {
 
     constructor(authenticationService: AuthenticationService,
                 router: Router,
-                appConfigService: AppConfigService) {
-        super(authenticationService, router, appConfigService);
+                appConfigService: AppConfigService,
+                dialog: MatDialog
+    ) {
+        super(authenticationService, router, appConfigService, dialog);
     }
 
     checkLogin(_: ActivatedRouteSnapshot, redirectUrl: string): Observable<boolean> | Promise<boolean> | boolean {

--- a/lib/core/services/auth-guard-ecm.service.spec.ts
+++ b/lib/core/services/auth-guard-ecm.service.spec.ts
@@ -22,6 +22,7 @@ import { AuthenticationService } from './authentication.service';
 import { RouterStateSnapshot, Router } from '@angular/router';
 import { setupTestBed } from '../testing/setupTestBed';
 import { CoreTestingModule } from '../testing/core.testing.module';
+import { MatDialog } from '@angular/material';
 
 describe('AuthGuardService ECM', () => {
 
@@ -155,5 +156,23 @@ describe('AuthGuardService ECM', () => {
         });
         expect(router.navigateByUrl).toHaveBeenCalledWith('/fakeLoginRoute?redirectUrl=some-url');
     }));
+
+    it('should to close the material dialog if is redirect to the login', () => {
+        const materialDialog = TestBed.get(MatDialog);
+
+        spyOn(materialDialog, 'closeAll');
+
+        spyOn(authService, 'setRedirect').and.callThrough();
+        spyOn(router, 'navigateByUrl').and.stub();
+        const route: RouterStateSnapshot = <RouterStateSnapshot> { url: 'some-url' };
+
+        authGuard.canActivate(null, route);
+
+        expect(authService.setRedirect).toHaveBeenCalledWith({
+            provider: 'ECM', url: 'some-url'
+        });
+
+        expect(materialDialog.closeAll).toHaveBeenCalled();
+    });
 
 });

--- a/lib/core/services/auth-guard-ecm.service.ts
+++ b/lib/core/services/auth-guard-ecm.service.ts
@@ -23,6 +23,7 @@ import { AuthenticationService } from './authentication.service';
 import { AppConfigService } from '../app-config/app-config.service';
 import { AuthGuardBase } from './auth-guard-base';
 import { Observable } from 'rxjs';
+import { MatDialog } from '@angular/material';
 
 @Injectable({
     providedIn: 'root'
@@ -31,8 +32,9 @@ export class AuthGuardEcm extends AuthGuardBase {
 
     constructor(authenticationService: AuthenticationService,
                 router: Router,
-                appConfigService: AppConfigService) {
-        super(authenticationService, router, appConfigService);
+                appConfigService: AppConfigService,
+                dialog: MatDialog) {
+        super(authenticationService, router, appConfigService, dialog);
     }
 
     checkLogin(_: ActivatedRouteSnapshot, redirectUrl: string): Observable<boolean> | Promise<boolean> | boolean {

--- a/lib/core/services/auth-guard-sso-role.service.spec.ts
+++ b/lib/core/services/auth-guard-sso-role.service.spec.ts
@@ -21,6 +21,7 @@ import { setupTestBed } from '../testing/setupTestBed';
 import { CoreTestingModule } from '../testing/core.testing.module';
 import { AuthGuardSsoRoleService } from './auth-guard-sso-role.service';
 import { JwtHelperService } from './jwt-helper.service';
+import { MatDialog } from '@angular/material';
 
 describe('Auth Guard SSO role service', () => {
 
@@ -164,4 +165,20 @@ describe('Auth Guard SSO role service', () => {
 
         expect(authGuard.canActivate(route)).toBeFalsy();
     });
+
+    it('Should canActivate be false hasRealm is true and hasClientRole is false', () => {
+        const materialDialog = TestBed.get(MatDialog);
+
+        spyOn(materialDialog, 'closeAll');
+
+        const route: ActivatedRouteSnapshot = new ActivatedRouteSnapshot();
+        spyOn(jwtHelperService, 'hasRealmRoles').and.returnValue(true);
+        spyOn(jwtHelperService, 'hasRealmRolesForClientRole').and.returnValue(false);
+
+        route.params = { appName: 'fakeapp' };
+        route.data = { 'clientRoles': ['appName'], 'roles': ['role1', 'role2'] };
+
+        expect(materialDialog.closeAll).toHaveBeenCalled();
+    });
+
 });

--- a/lib/core/services/auth-guard-sso-role.service.spec.ts
+++ b/lib/core/services/auth-guard-sso-role.service.spec.ts
@@ -178,6 +178,8 @@ describe('Auth Guard SSO role service', () => {
         route.params = { appName: 'fakeapp' };
         route.data = { 'clientRoles': ['appName'], 'roles': ['role1', 'role2'] };
 
+
+        expect(authGuard.canActivate(route)).toBeFalsy();
         expect(materialDialog.closeAll).toHaveBeenCalled();
     });
 

--- a/lib/core/services/auth-guard-sso-role.service.spec.ts
+++ b/lib/core/services/auth-guard-sso-role.service.spec.ts
@@ -178,7 +178,6 @@ describe('Auth Guard SSO role service', () => {
         route.params = { appName: 'fakeapp' };
         route.data = { 'clientRoles': ['appName'], 'roles': ['role1', 'role2'] };
 
-
         expect(authGuard.canActivate(route)).toBeFalsy();
         expect(materialDialog.closeAll).toHaveBeenCalled();
     });

--- a/lib/core/services/auth-guard-sso-role.service.ts
+++ b/lib/core/services/auth-guard-sso-role.service.ts
@@ -59,5 +59,3 @@ export class AuthGuardSsoRoleService implements CanActivate {
         return hasRole;
     }
 }
-
-

--- a/lib/core/services/auth-guard-sso-role.service.ts
+++ b/lib/core/services/auth-guard-sso-role.service.ts
@@ -18,11 +18,15 @@
 import { Injectable } from '@angular/core';
 import { JwtHelperService } from './jwt-helper.service';
 import { ActivatedRouteSnapshot, CanActivate, Router } from '@angular/router';
+import { MatDialog } from '@angular/material';
 
 @Injectable({
     providedIn: 'root'
 })
 export class AuthGuardSsoRoleService implements CanActivate {
+
+    constructor(private jwtHelperService: JwtHelperService, private router: Router, private dialog: MatDialog) {
+    }
 
     canActivate(route: ActivatedRouteSnapshot): boolean {
         let hasRole;
@@ -48,9 +52,12 @@ export class AuthGuardSsoRoleService implements CanActivate {
             this.router.navigate(['/' + route.data['redirectUrl']]);
         }
 
+        if (!hasRole) {
+            this.dialog.closeAll();
+        }
+
         return hasRole;
     }
-
-    constructor(private jwtHelperService: JwtHelperService, private router: Router) {
-    }
 }
+
+

--- a/lib/core/services/auth-guard.service.ts
+++ b/lib/core/services/auth-guard.service.ts
@@ -22,6 +22,7 @@ import { Observable } from 'rxjs';
 import { AppConfigService } from '../app-config/app-config.service';
 import { AuthGuardBase } from './auth-guard-base';
 import { JwtHelperService } from './jwt-helper.service';
+import { MatDialog } from '@angular/material';
 
 @Injectable({
     providedIn: 'root'
@@ -33,8 +34,9 @@ export class AuthGuard extends AuthGuardBase {
     constructor(private jwtHelperService: JwtHelperService,
                 authenticationService: AuthenticationService,
                 router: Router,
-                appConfigService: AppConfigService) {
-        super(authenticationService, router, appConfigService);
+                appConfigService: AppConfigService,
+                dialog: MatDialog) {
+        super(authenticationService, router, appConfigService, dialog);
         this.ticketChangeBind = this.ticketChange.bind(this);
 
         window.addEventListener('storage', this.ticketChangeBind);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

All the open modal dialogs needs handling and closing when the user logs out.



**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
