### PR TITLE
[ADF-5001] Process Audit File Log APS1 section wrong instruction for complete processes

### DIFF
--- a/demo-shell/src/app/components/process-service/process-attachments.component.html
+++ b/demo-shell/src/app/components/process-service/process-attachments.component.html
@@ -14,7 +14,7 @@
                       <div adf-empty-list-header class="app-empty-list-header">
                           {{'ADF_PROCESS_LIST.PROCESS-ATTACHMENT.EMPTY.HEADER' | translate}}
                        </div>
-                            <div adf-empty-list-body>
+                            <div adf-empty-list-body *ngIf="!isCompletedProcess()">
                             <div fxHide.lt-md="true" class="app-empty-list-drag_drop">
                               {{'ADF_PROCESS_LIST.PROCESS-ATTACHMENT.EMPTY.DRAG-AND-DROP.TITLE' | translate}}
                             </div>

--- a/demo-shell/src/app/components/process-service/task-attachments.component.html
+++ b/demo-shell/src/app/components/process-service/task-attachments.component.html
@@ -2,7 +2,8 @@
     <div>
 
         <adf-upload-drag-area
-            [rootFolderId]="taskId">
+            [rootFolderId]="taskId"
+            [disabled]="isCompletedTask()">
 
             <adf-task-attachment-list #taskAttachList
                 [disabled]="isCompletedTask()"
@@ -11,7 +12,7 @@
                 <adf-empty-list>
                     <div adf-empty-list-header class="app-empty-list-header">{{'ADF_TASK_LIST.ATTACHMENT.EMPTY.HEADER' | translate}}
                     </div>
-                    <div adf-empty-list-body>
+                    <div adf-empty-list-body  *ngIf="!isCompletedTask()">
                         <div fxHide.lt-md="true" class="app-empty-list-drag_drop">
                             {{'ADF_TASK_LIST.ATTACHMENT.EMPTY.DRAG-AND-DROP.TITLE' | translate}}
                         </div>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-5001

The triggered process displays the Process audit log with the option to drag n drop the files that the user wishes to upload. Drag n drop a file, nothing happens, the file is not uploaded.


**What is the new behaviour?**

 Drag n drop a file is not permitted when the process is complete. The empty template should not suggest to drag and drop

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
