### PR TITLE
[ADF-5025] add mp3 support mediatype viewer/thumbnail blob

### DIFF
--- a/lib/core/services/thumbnail.service.ts
+++ b/lib/core/services/thumbnail.service.ts
@@ -123,6 +123,7 @@ export class ThumbnailService {
         'audio/ogg': './assets/images/ft_ic_audio.svg',
         'audio/wav': './assets/images/ft_ic_audio.svg',
         'audio/basic': './assets/images/ft_ic_audio.svg',
+        'audio/mp3': './assets/images/ft_ic_audio.svg',
         'audio/mp4': './assets/images/ft_ic_audio.svg',
         'audio/vnd.adobe.soundbooth': './assets/images/ft_ic_audio.svg',
         'audio/vorbis': './assets/images/ft_ic_audio.svg',

--- a/lib/core/viewer/components/viewer.component.ts
+++ b/lib/core/viewer/components/viewer.component.ts
@@ -233,7 +233,7 @@ export class ViewerComponent implements OnChanges, OnInit, OnDestroy {
         text: ['text/plain', 'text/csv', 'text/xml', 'text/html', 'application/x-javascript'],
         pdf: ['application/pdf'],
         image: ['image/png', 'image/jpeg', 'image/gif', 'image/bmp', 'image/svg+xml'],
-        media: ['video/mp4', 'video/webm', 'video/ogg', 'audio/mpeg', 'audio/ogg', 'audio/wav']
+        media: ['video/mp4', 'video/webm', 'video/ogg', 'audio/mpeg', 'audio/mp3', 'audio/ogg', 'audio/wav']
     };
 
     constructor(private apiService: AlfrescoApiService,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)


**What is the new behaviour?**
With this modify is possible to open with the viewer the media type MP3 blob file and see the right icon



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
