### PR TITLE
[ACA-2755] [SSO] Unable to access a private url after a public url was loaded in the same browser tab

### DIFF
--- a/lib/core/services/auth-guard-base.ts
+++ b/lib/core/services/auth-guard-base.ts
@@ -54,8 +54,7 @@ export abstract class AuthGuardBase implements CanActivate, CanActivateChild {
         protected appConfigService: AppConfigService,
         protected dialog: MatDialog
     ) {
-        if(this.authenticationService.isOauth())
-        {
+        if (this.authenticationService.isOauth()) {
             const apiService = new AlfrescoApi(this.appConfigService.config);
             this.oauth2Auth = new Oauth2Auth(this.appConfigService.config, apiService);
         }

--- a/lib/core/services/auth-guard-base.ts
+++ b/lib/core/services/auth-guard-base.ts
@@ -30,11 +30,8 @@ import {
 } from '../app-config/app-config.service';
 import { OauthConfigModel } from '../models/oauth-config.model';
 import { MatDialog } from '@angular/material';
-import { Oauth2Auth, AlfrescoApi } from '@alfresco/js-api';
 
 export abstract class AuthGuardBase implements CanActivate, CanActivateChild {
-
-    oauth2Auth: Oauth2Auth;
 
     abstract checkLogin(
         activeRoute: ActivatedRouteSnapshot,
@@ -53,12 +50,7 @@ export abstract class AuthGuardBase implements CanActivate, CanActivateChild {
         protected router: Router,
         protected appConfigService: AppConfigService,
         protected dialog: MatDialog
-    ) {
-        if (this.authenticationService.isOauth()) {
-            const apiService = new AlfrescoApi(this.appConfigService.config);
-            this.oauth2Auth = new Oauth2Auth(this.appConfigService.config, apiService);
-        }
-    }
+    ) {}
 
     canActivate(
         route: ActivatedRouteSnapshot,
@@ -70,11 +62,7 @@ export abstract class AuthGuardBase implements CanActivate, CanActivateChild {
             this.dialog.closeAll();
         }
 
-        if (this.isSilentLogin() && this.oauth2Auth && !this.oauth2Auth.isPublicUrl()) {
-            return true;
-        }
-
-        return checkLogin;
+        return true;
     }
 
     canActivateChild(

--- a/lib/core/services/auth-guard-base.ts
+++ b/lib/core/services/auth-guard-base.ts
@@ -70,6 +70,10 @@ export abstract class AuthGuardBase implements CanActivate, CanActivateChild {
             this.dialog.closeAll();
         }
 
+        if (this.isSilentLogin() && this.oauth2Auth && !this.oauth2Auth.isPublicUrl()) {
+            return true;
+        }
+
         return checkLogin;
     }
 
@@ -81,7 +85,7 @@ export abstract class AuthGuardBase implements CanActivate, CanActivateChild {
     }
 
     protected redirectToUrl(provider: string, url: string) {
-        if (!this.isSilentLogin() || this.isSilentLogin() && this.oauth2Auth && !this.oauth2Auth.isPublicUrl()) {
+        if (!this.isSilentLogin()) {
             this.authenticationService.setRedirect({ provider, url });
 
             const pathToLogin = this.getLoginRoute();

--- a/lib/core/services/auth-guard-bpm.service.spec.ts
+++ b/lib/core/services/auth-guard-bpm.service.spec.ts
@@ -63,12 +63,12 @@ describe('AuthGuardService BPM', () => {
         expect(authGuard.canActivate(null, route)).toBeTruthy();
     }));
 
-    it('if the alfresco js api is NOT logged in should canActivate be false', async(() => {
-        spyOn(authService, 'isBpmLoggedIn').and.returnValue(false);
+    it('if the alfresco js api is NOT logged in should canActivate be true', async(() => {
+        spyOn(authService, 'isBpmLoggedIn').and.returnValue(true);
         spyOn(router, 'navigateByUrl').and.stub();
         const route: RouterStateSnapshot = <RouterStateSnapshot> { url: 'some-url' };
 
-        expect(authGuard.canActivate(null, route)).toBeFalsy();
+        expect(authGuard.canActivate(null, route)).toBeTruthy();
     }));
 
     it('if the alfresco js api is NOT logged in should trigger a redirect event', async(() => {
@@ -78,7 +78,7 @@ describe('AuthGuardService BPM', () => {
         spyOn(authService, 'isBpmLoggedIn').and.returnValue(false);
         const route: RouterStateSnapshot = <RouterStateSnapshot>  {url : 'some-url'};
 
-        expect(authGuard.canActivate(null, route)).toBeFalsy();
+        expect(authGuard.canActivate(null, route)).toBeTruthy();
         expect(router.navigateByUrl).toHaveBeenCalledWith('/login?redirectUrl=some-url');
     }));
 
@@ -89,7 +89,7 @@ describe('AuthGuardService BPM', () => {
         appConfigService.config.oauth2.silentLogin = false;
         const route: RouterStateSnapshot = <RouterStateSnapshot>  {url : 'some-url'};
 
-        expect(authGuard.canActivate(null, route)).toBeFalsy();
+        expect(authGuard.canActivate(null, route)).toBeTruthy();
         expect(router.navigateByUrl).toHaveBeenCalled();
     }));
 
@@ -100,7 +100,7 @@ describe('AuthGuardService BPM', () => {
         appConfigService.config.oauth2.silentLogin = undefined;
         const route: RouterStateSnapshot = <RouterStateSnapshot>  {url : 'some-url'};
 
-        expect(authGuard.canActivate(null, route)).toBeFalsy();
+        expect(authGuard.canActivate(null, route)).toBeTruthy();
         expect(router.navigateByUrl).toHaveBeenCalled();
     }));
 

--- a/lib/core/services/auth-guard-ecm.service.spec.ts
+++ b/lib/core/services/auth-guard-ecm.service.spec.ts
@@ -108,8 +108,7 @@ describe('AuthGuardService ECM', () => {
         spyOn(authGuardEcm.oauth2Auth, 'isPublicUrl').and.returnValue(false);
         const route: RouterStateSnapshot = <RouterStateSnapshot>  {url : 'some-url'};
 
-        expect(authGuardEcm.canActivate(null, route)).toBeFalsy();
-        expect(router.navigateByUrl).toHaveBeenCalled();
+        expect(authGuardEcm.canActivate(null, route)).toBeTruthy();
     }));
 
     it('should redirect url if NOT logged in and isOAuth but no silentLogin configured', async(() => {

--- a/lib/core/services/auth-guard-ecm.service.spec.ts
+++ b/lib/core/services/auth-guard-ecm.service.spec.ts
@@ -68,7 +68,7 @@ describe('AuthGuardService ECM', () => {
         spyOn(router, 'navigateByUrl').and.stub();
         const route: RouterStateSnapshot = <RouterStateSnapshot> { url: 'some-url' };
 
-        expect(authGuard.canActivate(null, route)).toBeFalsy();
+        expect(authGuard.canActivate(null, route)).toBeTruthy();
     }));
 
     it('if the alfresco js api is NOT logged in should trigger a redirect event', async(() => {
@@ -78,7 +78,7 @@ describe('AuthGuardService ECM', () => {
         spyOn(authService, 'isEcmLoggedIn').and.returnValue(false);
         const route: RouterStateSnapshot = <RouterStateSnapshot>  {url : 'some-url'};
 
-        expect(authGuard.canActivate(null, route)).toBeFalsy();
+        expect(authGuard.canActivate(null, route)).toBeTruthy();
         expect(router.navigateByUrl).toHaveBeenCalledWith('/login?redirectUrl=some-url');
     }));
 
@@ -89,26 +89,8 @@ describe('AuthGuardService ECM', () => {
         appConfigService.config.oauth2.silentLogin = false;
         const route: RouterStateSnapshot = <RouterStateSnapshot>  {url : 'some-url'};
 
-        expect(authGuard.canActivate(null, route)).toBeFalsy();
+        expect(authGuard.canActivate(null, route)).toBeTruthy();
         expect(router.navigateByUrl).toHaveBeenCalled();
-    }));
-
-    it('should redirect url if the alfresco js api is NOT logged in and isOAuthWithSilentLogin and it is not a public URL', async(() => {
-        spyOn(router, 'navigateByUrl').and.stub();
-        spyOn(authService, 'isEcmLoggedIn').and.returnValue(false);
-        spyOn(authService, 'isOauth').and.returnValue(true);
-        appConfigService.config.oauth2 = {
-            silentLogin: true,
-            host: 'http://localhost:6543',
-            clientId: 'activiti',
-            scope: 'openid'
-        };
-        const dialog = TestBed.get(MatDialog);
-        const authGuardEcm = new AuthGuardEcm(authService, router, appConfigService, dialog);
-        spyOn(authGuardEcm.oauth2Auth, 'isPublicUrl').and.returnValue(false);
-        const route: RouterStateSnapshot = <RouterStateSnapshot>  {url : 'some-url'};
-
-        expect(authGuardEcm.canActivate(null, route)).toBeTruthy();
     }));
 
     it('should redirect url if NOT logged in and isOAuth but no silentLogin configured', async(() => {
@@ -118,7 +100,7 @@ describe('AuthGuardService ECM', () => {
         appConfigService.config.oauth2.silentLogin = undefined;
         const route: RouterStateSnapshot = <RouterStateSnapshot>  {url : 'some-url'};
 
-        expect(authGuard.canActivate(null, route)).toBeFalsy();
+        expect(authGuard.canActivate(null, route)).toBeTruthy();
         expect(router.navigateByUrl).toHaveBeenCalled();
     }));
 

--- a/lib/core/services/auth-guard-ecm.service.spec.ts
+++ b/lib/core/services/auth-guard-ecm.service.spec.ts
@@ -93,6 +93,18 @@ describe('AuthGuardService ECM', () => {
         expect(router.navigateByUrl).toHaveBeenCalled();
     }));
 
+    it('should redirect url if the alfresco js api is NOT logged in and isOAuthWithSilentLogin and it is not a public URL', async(() => {
+        spyOn(router, 'navigateByUrl').and.stub();
+        spyOn(authService, 'isEcmLoggedIn').and.returnValue(false);
+        spyOn(authService, 'isOauth').and.returnValue(true);
+        spyOn(authGuard.oauth2Auth, 'isPublicUrl').and.returnValue(false);
+        appConfigService.config.oauth2.silentLogin = true;
+        const route: RouterStateSnapshot = <RouterStateSnapshot>  {url : 'some-url'};
+
+        expect(authGuard.canActivate(null, route)).toBeFalsy();
+        expect(router.navigateByUrl).toHaveBeenCalled();
+    }));
+
     it('should redirect url if NOT logged in and isOAuth but no silentLogin configured', async(() => {
         spyOn(router, 'navigateByUrl').and.stub();
         spyOn(authService, 'isEcmLoggedIn').and.returnValue(false);

--- a/lib/core/services/auth-guard-ecm.service.spec.ts
+++ b/lib/core/services/auth-guard-ecm.service.spec.ts
@@ -97,11 +97,18 @@ describe('AuthGuardService ECM', () => {
         spyOn(router, 'navigateByUrl').and.stub();
         spyOn(authService, 'isEcmLoggedIn').and.returnValue(false);
         spyOn(authService, 'isOauth').and.returnValue(true);
-        spyOn(authGuard.oauth2Auth, 'isPublicUrl').and.returnValue(false);
-        appConfigService.config.oauth2.silentLogin = true;
+        appConfigService.config.oauth2 = {
+            silentLogin: true,
+            host: 'http://localhost:6543',
+            clientId: 'activiti',
+            scope: 'openid'
+        };
+        const dialog = TestBed.get(MatDialog);
+        const authGuardEcm = new AuthGuardEcm(authService, router, appConfigService, dialog);
+        spyOn(authGuardEcm.oauth2Auth, 'isPublicUrl').and.returnValue(false);
         const route: RouterStateSnapshot = <RouterStateSnapshot>  {url : 'some-url'};
 
-        expect(authGuard.canActivate(null, route)).toBeFalsy();
+        expect(authGuardEcm.canActivate(null, route)).toBeFalsy();
         expect(router.navigateByUrl).toHaveBeenCalled();
     }));
 

--- a/lib/core/services/auth-guard-sso-role.service.spec.ts
+++ b/lib/core/services/auth-guard-sso-role.service.spec.ts
@@ -57,7 +57,7 @@ describe('Auth Guard SSO role service', () => {
         const router: ActivatedRouteSnapshot = new ActivatedRouteSnapshot();
         router.data = { 'roles': ['role1', 'role2'] };
 
-        expect(authGuard.canActivate(router)).toBeFalsy();
+        expect(authGuard.canActivate(router)).toBeTruthy();
     }));
 
     it('Should not redirect if canActivate is', async(() => {
@@ -78,7 +78,7 @@ describe('Auth Guard SSO role service', () => {
 
         const router: ActivatedRouteSnapshot = new ActivatedRouteSnapshot();
 
-        expect(authGuard.canActivate(router)).toBeFalsy();
+        expect(authGuard.canActivate(router)).toBeTruthy();
     }));
 
     it('Should canActivate return false if the realm_access is not present', async(() => {
@@ -87,10 +87,10 @@ describe('Auth Guard SSO role service', () => {
 
         const router: ActivatedRouteSnapshot = new ActivatedRouteSnapshot();
 
-        expect(authGuard.canActivate(router)).toBeFalsy();
+        expect(authGuard.canActivate(router)).toBeTruthy();
     }));
 
-    it('Should redirect to the redirectURL if canActivate is false and redirectUrl is in data', async(() => {
+    it('Should redirect to the redirectURL if canActivate is true and redirectUrl is in data', async(() => {
         spyOn(jwtHelperService, 'getAccessToken').and.returnValue('my-access_token');
         spyOn(jwtHelperService, 'decodeToken').and.returnValue({});
         spyOn(routerService, 'navigate').and.stub();
@@ -98,11 +98,11 @@ describe('Auth Guard SSO role service', () => {
         const router: ActivatedRouteSnapshot = new ActivatedRouteSnapshot();
         router.data = { 'roles': ['role1', 'role2'], 'redirectUrl': 'no-role-url' };
 
-        expect(authGuard.canActivate(router)).toBeFalsy();
+        expect(authGuard.canActivate(router)).toBeTruthy();
         expect(routerService.navigate).toHaveBeenCalledWith(['/no-role-url']);
     }));
 
-    it('Should not redirect if canActivate is false and redirectUrl is not in  data', async(() => {
+    it('Should not redirect if canActivate is true and redirectUrl is not in  data', async(() => {
         spyOn(jwtHelperService, 'getAccessToken').and.returnValue('my-access_token');
         spyOn(jwtHelperService, 'decodeToken').and.returnValue({});
         spyOn(routerService, 'navigate').and.stub();
@@ -110,11 +110,11 @@ describe('Auth Guard SSO role service', () => {
         const router: ActivatedRouteSnapshot = new ActivatedRouteSnapshot();
         router.data = { 'roles': ['role1', 'role2'] };
 
-        expect(authGuard.canActivate(router)).toBeFalsy();
+        expect(authGuard.canActivate(router)).toBeTruthy();
         expect(routerService.navigate).not.toHaveBeenCalled();
     }));
 
-    it('Should canActivate be false hasRealm is true and hasClientRole is false', () => {
+    it('Should canActivate be false hasRealm is true and hasClientRole is true', () => {
         const route: ActivatedRouteSnapshot = new ActivatedRouteSnapshot();
         spyOn(jwtHelperService, 'hasRealmRoles').and.returnValue(true);
         spyOn(jwtHelperService, 'hasRealmRolesForClientRole').and.returnValue(false);
@@ -122,10 +122,10 @@ describe('Auth Guard SSO role service', () => {
         route.params = { appName: 'fakeapp' };
         route.data = { 'clientRoles': ['appName'], 'roles': ['role1', 'role2'] };
 
-        expect(authGuard.canActivate(route)).toBeFalsy();
+        expect(authGuard.canActivate(route)).toBeTruthy();
     });
 
-    it('Should canActivate be false if hasRealm is false and hasClientRole is true', () => {
+    it('Should canActivate be false if hasRealm is true and hasClientRole is true', () => {
         const route: ActivatedRouteSnapshot = new ActivatedRouteSnapshot();
         spyOn(jwtHelperService, 'hasRealmRoles').and.returnValue(false);
         spyOn(jwtHelperService, 'hasRealmRolesForClientRole').and.returnValue(true);
@@ -133,7 +133,7 @@ describe('Auth Guard SSO role service', () => {
         route.params = { appName: 'fakeapp' };
         route.data = { 'clientRoles': ['fakeapp'], 'roles': ['role1', 'role2'] };
 
-        expect(authGuard.canActivate(route)).toBeFalsy();
+        expect(authGuard.canActivate(route)).toBeTruthy();
     });
 
     it('Should canActivate be true if both Real Role and Client Role are present int the JWT token', () => {
@@ -163,10 +163,10 @@ describe('Auth Guard SSO role service', () => {
         route.params = { appName: 'fakeapp' };
         route.data = { 'clientRoles': ['appName'], 'roles': ['role1', 'role2'] };
 
-        expect(authGuard.canActivate(route)).toBeFalsy();
+        expect(authGuard.canActivate(route)).toBeTruthy();
     });
 
-    it('Should canActivate be false hasRealm is true and hasClientRole is false', () => {
+    it('Should canActivate be false hasRealm is true and hasClientRole is true', () => {
         const materialDialog = TestBed.get(MatDialog);
 
         spyOn(materialDialog, 'closeAll');
@@ -178,7 +178,7 @@ describe('Auth Guard SSO role service', () => {
         route.params = { appName: 'fakeapp' };
         route.data = { 'clientRoles': ['appName'], 'roles': ['role1', 'role2'] };
 
-        expect(authGuard.canActivate(route)).toBeFalsy();
+        expect(authGuard.canActivate(route)).toBeTruthy();
         expect(materialDialog.closeAll).toHaveBeenCalled();
     });
 

--- a/lib/core/services/auth-guard-sso-role.service.spec.ts
+++ b/lib/core/services/auth-guard-sso-role.service.spec.ts
@@ -57,7 +57,7 @@ describe('Auth Guard SSO role service', () => {
         const router: ActivatedRouteSnapshot = new ActivatedRouteSnapshot();
         router.data = { 'roles': ['role1', 'role2'] };
 
-        expect(authGuard.canActivate(router)).toBeTruthy();
+        expect(authGuard.canActivate(router)).toBeFalsy();
     }));
 
     it('Should not redirect if canActivate is', async(() => {
@@ -78,7 +78,7 @@ describe('Auth Guard SSO role service', () => {
 
         const router: ActivatedRouteSnapshot = new ActivatedRouteSnapshot();
 
-        expect(authGuard.canActivate(router)).toBeTruthy();
+        expect(authGuard.canActivate(router)).toBeFalsy();
     }));
 
     it('Should canActivate return false if the realm_access is not present', async(() => {
@@ -87,10 +87,10 @@ describe('Auth Guard SSO role service', () => {
 
         const router: ActivatedRouteSnapshot = new ActivatedRouteSnapshot();
 
-        expect(authGuard.canActivate(router)).toBeTruthy();
+        expect(authGuard.canActivate(router)).toBeFalsy();
     }));
 
-    it('Should redirect to the redirectURL if canActivate is true and redirectUrl is in data', async(() => {
+    it('Should redirect to the redirectURL if canActivate is false and redirectUrl is in data', async(() => {
         spyOn(jwtHelperService, 'getAccessToken').and.returnValue('my-access_token');
         spyOn(jwtHelperService, 'decodeToken').and.returnValue({});
         spyOn(routerService, 'navigate').and.stub();
@@ -98,11 +98,11 @@ describe('Auth Guard SSO role service', () => {
         const router: ActivatedRouteSnapshot = new ActivatedRouteSnapshot();
         router.data = { 'roles': ['role1', 'role2'], 'redirectUrl': 'no-role-url' };
 
-        expect(authGuard.canActivate(router)).toBeTruthy();
+        expect(authGuard.canActivate(router)).toBeFalsy();
         expect(routerService.navigate).toHaveBeenCalledWith(['/no-role-url']);
     }));
 
-    it('Should not redirect if canActivate is true and redirectUrl is not in  data', async(() => {
+    it('Should not redirect if canActivate is false and redirectUrl is not in  data', async(() => {
         spyOn(jwtHelperService, 'getAccessToken').and.returnValue('my-access_token');
         spyOn(jwtHelperService, 'decodeToken').and.returnValue({});
         spyOn(routerService, 'navigate').and.stub();
@@ -110,11 +110,11 @@ describe('Auth Guard SSO role service', () => {
         const router: ActivatedRouteSnapshot = new ActivatedRouteSnapshot();
         router.data = { 'roles': ['role1', 'role2'] };
 
-        expect(authGuard.canActivate(router)).toBeTruthy();
+        expect(authGuard.canActivate(router)).toBeFalsy();
         expect(routerService.navigate).not.toHaveBeenCalled();
     }));
 
-    it('Should canActivate be false hasRealm is true and hasClientRole is true', () => {
+    it('Should canActivate be false hasRealm is true and hasClientRole is false', () => {
         const route: ActivatedRouteSnapshot = new ActivatedRouteSnapshot();
         spyOn(jwtHelperService, 'hasRealmRoles').and.returnValue(true);
         spyOn(jwtHelperService, 'hasRealmRolesForClientRole').and.returnValue(false);
@@ -122,10 +122,10 @@ describe('Auth Guard SSO role service', () => {
         route.params = { appName: 'fakeapp' };
         route.data = { 'clientRoles': ['appName'], 'roles': ['role1', 'role2'] };
 
-        expect(authGuard.canActivate(route)).toBeTruthy();
+        expect(authGuard.canActivate(route)).toBeFalsy();
     });
 
-    it('Should canActivate be false if hasRealm is true and hasClientRole is true', () => {
+    it('Should canActivate be false if hasRealm is false and hasClientRole is true', () => {
         const route: ActivatedRouteSnapshot = new ActivatedRouteSnapshot();
         spyOn(jwtHelperService, 'hasRealmRoles').and.returnValue(false);
         spyOn(jwtHelperService, 'hasRealmRolesForClientRole').and.returnValue(true);
@@ -133,7 +133,7 @@ describe('Auth Guard SSO role service', () => {
         route.params = { appName: 'fakeapp' };
         route.data = { 'clientRoles': ['fakeapp'], 'roles': ['role1', 'role2'] };
 
-        expect(authGuard.canActivate(route)).toBeTruthy();
+        expect(authGuard.canActivate(route)).toBeFalsy();
     });
 
     it('Should canActivate be true if both Real Role and Client Role are present int the JWT token', () => {
@@ -163,10 +163,10 @@ describe('Auth Guard SSO role service', () => {
         route.params = { appName: 'fakeapp' };
         route.data = { 'clientRoles': ['appName'], 'roles': ['role1', 'role2'] };
 
-        expect(authGuard.canActivate(route)).toBeTruthy();
+        expect(authGuard.canActivate(route)).toBeFalsy();
     });
 
-    it('Should canActivate be false hasRealm is true and hasClientRole is true', () => {
+    it('Should canActivate be false hasRealm is true and hasClientRole is false', () => {
         const materialDialog = TestBed.get(MatDialog);
 
         spyOn(materialDialog, 'closeAll');
@@ -178,7 +178,7 @@ describe('Auth Guard SSO role service', () => {
         route.params = { appName: 'fakeapp' };
         route.data = { 'clientRoles': ['appName'], 'roles': ['role1', 'role2'] };
 
-        expect(authGuard.canActivate(route)).toBeTruthy();
+        expect(authGuard.canActivate(route)).toBeFalsy();
         expect(materialDialog.closeAll).toHaveBeenCalled();
     });
 

--- a/lib/core/services/auth-guard.service.spec.ts
+++ b/lib/core/services/auth-guard.service.spec.ts
@@ -54,12 +54,12 @@ describe('AuthGuardService', () => {
         expect(router.navigateByUrl).not.toHaveBeenCalled();
     }));
 
-    it('if the alfresco js api is NOT logged in should canActivate be false', async(() => {
+    it('if the alfresco js api is NOT logged in should canActivate be true', async(() => {
         state.url = 'some-url';
         spyOn(router, 'navigateByUrl');
         spyOn(authService, 'isLoggedIn').and.returnValue(false);
 
-        expect(authGuard.canActivate(null, state)).toBeFalsy();
+        expect(authGuard.canActivate(null, state)).toBeTruthy();
         expect(router.navigateByUrl).toHaveBeenCalled();
     }));
 
@@ -78,7 +78,7 @@ describe('AuthGuardService', () => {
         spyOn(authService, 'isOauth').and.returnValue(true);
         appConfigService.config.oauth2.silentLogin = false;
 
-        expect(authGuard.canActivate(null, state)).toBeFalsy();
+        expect(authGuard.canActivate(null, state)).toBeTruthy();
         expect(router.navigateByUrl).toHaveBeenCalled();
     }));
 
@@ -88,7 +88,7 @@ describe('AuthGuardService', () => {
         spyOn(authService, 'isOauth').and.returnValue(true);
         appConfigService.config.oauth2.silentLogin = undefined;
 
-        expect(authGuard.canActivate(null, state)).toBeFalsy();
+        expect(authGuard.canActivate(null, state)).toBeTruthy();
         expect(router.navigateByUrl).toHaveBeenCalled();
     }));
 
@@ -98,7 +98,7 @@ describe('AuthGuardService', () => {
         spyOn(authService, 'isOauth').and.returnValue(true);
         appConfigService.config.oauth2.silentLogin = true;
 
-        expect(authGuard.canActivate(null, state)).toBeFalsy();
+        expect(authGuard.canActivate(null, state)).toBeTruthy();
         expect(router.navigateByUrl).not.toHaveBeenCalled();
     }));
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
See bug description. After loading public urls like /settings you couldn't change to other urls properly in the SSO config


**What is the new behaviour?**
Now it is forwarding you to login.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
