### PR TITLE
[ACA-2567] - sortable

### DIFF
--- a/lib/core/datatable/components/datatable/datatable.component.html
+++ b/lib/core/datatable/components/datatable/datatable.component.html
@@ -31,10 +31,9 @@
                  role="columnheader"
                  [attr.tabindex]="showHeader ? 0 : null"
                  [attr.aria-sort]="col.sortable ? (getAriaSort(col) | translate) : null"
-                 title="{{ col.title | translate }}"
                  adf-drop-zone dropTarget="header" [dropColumn]="col">
-                <span *ngIf="col.srTitle" class="adf-sr-only">{{ col.srTitle | translate }}</span>
                 <span *ngIf="col.title" class="adf-datatable-cell-value">{{ col.title | translate}}</span>
+                <span class="adf-sr-only" aria-live="assertive">{{getAriaSort(col) !== 'ADF-DATATABLE.ACCESSIBILITY.SORT_NONE' ? (getAriaSort(col) | translate) + ' ' +  (col.title | translate) : ('ADF-DATATABLE.ACCESSIBILITY.SORT_DEFAULT' | translate)}}</span>
             </div>
             <!-- Actions (right) -->
             <div *ngIf="actions && actionsPosition === 'right'" class="adf-actions-column adf-datatable-cell-header adf-datatable__actions-cell">
@@ -134,7 +133,7 @@
                             </div>
                             <div *ngSwitchCase="'icon'" class="adf-cell-value" tabindex="0">
                                 <span class="adf-sr-only">
-                                    {{ 'ADF-DATATABLE.ACCESSIBILITY.ICON_ALT_TEXT' | translate:{
+                                    {{ 'ADF-DATATABLE.ACCESSIBILITY.ICON_TEXT' | translate:{
                                             type: 'ADF-DATATABLE.FILE_TYPE.' + (data.getValue(row, col) | fileType | uppercase) | translate
                                         }
                                     }}

--- a/lib/core/datatable/components/datatable/datatable.component.html
+++ b/lib/core/datatable/components/datatable/datatable.component.html
@@ -33,7 +33,7 @@
                  [attr.aria-sort]="col.sortable ? (getAriaSort(col) | translate) : null"
                  adf-drop-zone dropTarget="header" [dropColumn]="col">
                 <span *ngIf="col.title" class="adf-datatable-cell-value">{{ col.title | translate}}</span>
-                <span class="adf-sr-only" aria-live="assertive">{{getAriaSort(col) !== 'ADF-DATATABLE.ACCESSIBILITY.SORT_NONE' ? (getAriaSort(col) | translate) + ' ' +  (col.title | translate) : ('ADF-DATATABLE.ACCESSIBILITY.SORT_DEFAULT' | translate)}}</span>
+                <span class="adf-sr-only" aria-live="polite">{{ getSortLiveAnnouncement(col) | translate: {string: col.title} }}</span>
             </div>
             <!-- Actions (right) -->
             <div *ngIf="actions && actionsPosition === 'right'" class="adf-actions-column adf-datatable-cell-header adf-datatable__actions-cell">

--- a/lib/core/datatable/components/datatable/datatable.component.html
+++ b/lib/core/datatable/components/datatable/datatable.component.html
@@ -133,7 +133,7 @@
                             </div>
                             <div *ngSwitchCase="'icon'" class="adf-cell-value" tabindex="0">
                                 <span class="adf-sr-only">
-                                    {{ 'ADF-DATATABLE.ACCESSIBILITY.ICON_TEXT' | translate:{
+                                    {{ 'ADF-DATATABLE.ACCESSIBILITY.ICON_ALT_TEXT' | translate:{
                                             type: 'ADF-DATATABLE.FILE_TYPE.' + (data.getValue(row, col) | fileType | uppercase) | translate
                                         }
                                     }}

--- a/lib/core/datatable/components/datatable/datatable.component.ts
+++ b/lib/core/datatable/components/datatable/datatable.component.ts
@@ -763,6 +763,15 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck,
             'ADF-DATATABLE.ACCESSIBILITY.SORT_ASCENDING' :
             'ADF-DATATABLE.ACCESSIBILITY.SORT_DESCENDING';
     }
+
+    getSortLiveAnnouncement(column: DataColumn): string {
+        if (!this.isColumnSortActive(column)) {
+            return 'ADF-DATATABLE.ACCESSIBILITY.SORT_DEFAULT' ;
+        }
+        return this.isColumnSorted(column, 'asc') ?
+            'ADF-DATATABLE.ACCESSIBILITY.SORT_ASCENDING_BY' :
+            'ADF-DATATABLE.ACCESSIBILITY.SORT_DESCENDING_BY';
+    }
 }
 
 export interface DataTableDropEvent {

--- a/lib/core/i18n/en.json
+++ b/lib/core/i18n/en.json
@@ -275,6 +275,8 @@
       "SORT_DESCENDING": "Descending",
       "SORT_NONE": "None",
       "SORT_DEFAULT": "Sortable",
+      "SORT_ASCENDING_BY": "Ascending by {{ string }}",
+      "SORT_DESCENDING_BY": "Descending by {{ string }}",
       "ICON_TEXT": "Item type {{ type }}",
       "ICON_DISABLED": "Disabled",
       "ROW_OPTION_BUTTON": "Actions"

--- a/lib/core/i18n/en.json
+++ b/lib/core/i18n/en.json
@@ -274,6 +274,7 @@
       "SORT_ASCENDING": "Ascending",
       "SORT_DESCENDING": "Descending",
       "SORT_NONE": "None",
+      "SORT_DEFAULT": "Sortable",
       "ICON_TEXT": "Item type {{ type }}",
       "ICON_DISABLED": "Disabled",
       "ROW_OPTION_BUTTON": "Actions"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X ] Tests for the changes have been added (for bug fixes / features)
> - [X ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Currently, the aria-sort is reading the behavior to screen readers after the fact (after a user clicks the content), and the user is not made aware if it is sortable. 


**What is the new behaviour?**
When a user goes to the sortable column headers it will announce as 'sortable' with column title, and every time a user clicks on it, it will announce it is sorting the content in ascending or descending order and the column name. This will ensure this works properly with all screen readers and different types of assistive technologies



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
