### PR TITLE
[ACA-2561] Datatable- Hiding Decorative Icons in table

### DIFF
--- a/lib/core/datatable/components/datatable/datatable.component.html
+++ b/lib/core/datatable/components/datatable/datatable.component.html
@@ -132,13 +132,7 @@
                                     </ng-template>
                                 </ng-template>
                             </div>
-                            <div *ngSwitchCase="'icon'" class="adf-cell-value" tabindex="0">
-                                <span class="adf-sr-only">
-                                    {{ 'ADF-DATATABLE.ACCESSIBILITY.ICON_ALT_TEXT' | translate:{
-                                            type: 'ADF-DATATABLE.FILE_TYPE.' + (data.getValue(row, col) | fileType | uppercase) | translate
-                                        }
-                                    }}
-                                </span>
+                            <div *ngSwitchCase="'icon'" class="adf-cell-value">
                                 <mat-icon>{{ data.getValue(row, col) }}</mat-icon>
                             </div>
                             <div *ngSwitchCase="'date'" class="adf-cell-value" [attr.tabindex]="data.getValue(row, col)? 0 : -1"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ x] Tests for the changes have been added (for bug fixes / features)
> - [x ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Currently the icon is trying to read with Alt text behind the scenes, while having tabindex="0" so it is focusable. 


**What is the new behaviour?**
After verifying with an accessibility SME, FOR ICONS ONLY, the content can be hidden from screen reader users. Removal of the screen reader only text and tabindex="0" on the cell. When a SR user uses this the table it will simply ignore the icon, and the user will continue on.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
