### PR TITLE
[ADA-2474] adding instructions to the calendar for use

### DIFF
--- a/lib/core/card-view/components/card-view-dateitem/card-view-dateitem.component.html
+++ b/lib/core/card-view/components/card-view-dateitem/card-view-dateitem.component.html
@@ -1,5 +1,6 @@
 <div [attr.data-automation-id]="'card-dateitem-label-' + property.key" class="adf-property-label" *ngIf="showProperty() || isEditable()">{{ property.label | translate }}</div>
 <div class="adf-property-value">
+<div class="adf-sr-only" id="{{uniqueId}}">{{'CORE.METADATA.ACCESSIBILITY.DATEPICKER' | translate}}</div>
     <span *ngIf="!isEditable()" [attr.data-automation-id]="'card-' + property.type + '-value-' + property.key">
         <span [attr.data-automation-id]="'card-dateitem-' + property.key">
             <span *ngIf="showProperty()">{{ property.displayValue }}</span>
@@ -32,7 +33,8 @@
         <input class="adf-invisible-date-input"
             [matDatetimepicker]="datetimePicker"
             [value]="valueDate"
-            (dateChange)="onDateChanged($event)">
+            (dateChange)="onDateChanged($event)"
+            [attr.aria-describedby]="uniqueId">
 
         <mat-datetimepicker #datetimePicker
             [type]="property.type"

--- a/lib/core/card-view/components/card-view-dateitem/card-view-dateitem.component.ts
+++ b/lib/core/card-view/components/card-view-dateitem/card-view-dateitem.component.ts
@@ -29,6 +29,7 @@ import { MOMENT_DATE_FORMATS } from '../../../utils/moment-date-formats.model';
 import { AppConfigService } from '../../../app-config/app-config.service';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
+import { UUID } from 'angular2-uuid';
 
 @Component({
     providers: [
@@ -60,6 +61,7 @@ export class CardViewDateItemComponent implements OnInit, OnDestroy {
 
     valueDate: Moment;
     dateFormat: string;
+    uniqueId: string;
 
     private onDestroy$ = new Subject<boolean>();
 
@@ -84,6 +86,8 @@ export class CardViewDateItemComponent implements OnInit, OnDestroy {
         if (this.property.value) {
             this.valueDate = moment(this.property.value, this.dateFormat);
         }
+
+        this.generateUuid();
     }
 
     ngOnDestroy() {
@@ -123,6 +127,10 @@ export class CardViewDateItemComponent implements OnInit, OnDestroy {
         this.cardViewUpdateService.update(this.property, null);
         this.property.value = null;
         this.property.default = null;
+    }
+
+    private generateUuid() {
+        this.uniqueId = UUID.UUID();
     }
 
 }

--- a/lib/core/i18n/en.json
+++ b/lib/core/i18n/en.json
@@ -199,6 +199,9 @@
         "CANCEL": "Cancel",
         "CLEAR": "Clear",
         "TOGGLE": "Toggle value"
+      },
+      "ACCESSIBILITY": {
+        "DATEPICKER": "Use the arrow keys to navigate between dates. Up and down moves to the same day of the week in the previous or next week respectively. Left and right move to the previous and next day respectively. Press Enter or Return to select a date."
       }
     }
   },

--- a/lib/core/styles/_a11y.scss
+++ b/lib/core/styles/_a11y.scss
@@ -1,0 +1,8 @@
+.adf-sr-only {
+    display: block;
+    height: 1px;
+    width: 1px;
+    clip: rect(1 1 1 1);
+    clip: rect(1px 1px 1px 1px);
+    overflow: hidden;
+}

--- a/lib/core/styles/_index.scss
+++ b/lib/core/styles/_index.scss
@@ -35,6 +35,7 @@
 @import '../../core/clipboard/clipboard.component';
 @import '../../core/search-text/search-text-input.component';
 @import './snackbar';
+@import './a11y';
 
 @mixin adf-core-theme($theme) {
     @include adf-colors-theme($theme);

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@alfresco/adf-cli": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@alfresco/adf-cli/-/adf-cli-3.6.0.tgz",
-      "integrity": "sha512-HewDSVxz+BGqSTlooOj2jgnX5g5lNSXwsI8K+eqr55s12ku7AeX0JRFxrvVz20v/2efGMnwHHXGfF8tbdCChnA==",
+      "version": "3.7.0-beta6",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/@alfresco/adf-cli/-/adf-cli-3.7.0-beta6.tgz",
+      "integrity": "sha1-UuoPgtyE94lwyN2krKwMBI22wdc=",
       "requires": {
         "@angular-devkit/core": "^7.2.15",
         "commander": "^4.0.0",
@@ -20,69 +20,69 @@
       }
     },
     "@alfresco/adf-content-services": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@alfresco/adf-content-services/-/adf-content-services-3.6.0.tgz",
-      "integrity": "sha512-npEPJ4eAIalIWd4lmTltYiS3XyLdagzfqDUfC9oHwFz8QfX7y8mUtaSDBVYqTGRm3lZ7vElczfsbuKlknLaxog==",
+      "version": "3.7.0-beta6",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/@alfresco/adf-content-services/-/adf-content-services-3.7.0-beta6.tgz",
+      "integrity": "sha1-JILEgilHYaUSb2BruJnb4QK7Sc0=",
       "requires": {
         "tslib": "^1.9.0"
       }
     },
     "@alfresco/adf-core": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@alfresco/adf-core/-/adf-core-3.6.0.tgz",
-      "integrity": "sha512-WlYvxuBpJ6sug5iPfJprdWDZcDtJ7Y6/SFzEchEhan30O4Efb/MgWY+3s1nCsIwX0eYhyv8pj9NHQjHNjPotLw==",
+      "version": "3.7.0-beta6",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/@alfresco/adf-core/-/adf-core-3.7.0-beta6.tgz",
+      "integrity": "sha1-+0wo/FrW9fY0eqkWrgV8MpJX2f4=",
       "requires": {
         "tslib": "^1.9.0"
       }
     },
     "@alfresco/adf-extensions": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@alfresco/adf-extensions/-/adf-extensions-3.6.0.tgz",
-      "integrity": "sha512-/B2+TKrjQswXsTkkuU7qgK9Ud8Wn02bZRgRuKZiPwUxIo8s4wSMZpgWkfrIw58WDNDiL/MDgDeNiCrpxxrzdow==",
+      "version": "3.7.0-beta6",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/@alfresco/adf-extensions/-/adf-extensions-3.7.0-beta6.tgz",
+      "integrity": "sha1-Ahwqym3IU96isigouInwsuzySvg=",
       "requires": {
         "tslib": "^1.9.0"
       }
     },
     "@alfresco/adf-insights": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@alfresco/adf-insights/-/adf-insights-3.6.0.tgz",
-      "integrity": "sha512-MnrunA1KpM+B5NBRhY1yxcm/51l331JhEn5+5F3UEw4X+MjYLpAdgwTmYLdmO5LHkG76NjLiLDLlzJxMV7ITjA==",
+      "version": "3.7.0-beta6",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/@alfresco/adf-insights/-/adf-insights-3.7.0-beta6.tgz",
+      "integrity": "sha1-kV02HNKte71KpcTqeyNDbI4sgW8=",
       "requires": {
         "tslib": "^1.9.0"
       }
     },
     "@alfresco/adf-process-services": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@alfresco/adf-process-services/-/adf-process-services-3.6.0.tgz",
-      "integrity": "sha512-Q57YvCpWlLmcKd4Mjrd9oRqSEImO/lDDDMxT9JpIueGq9xgsYOApN6C6fKxzy/+VFYiFEuBNCICmNkK51wUz/A==",
+      "version": "3.7.0-beta6",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/@alfresco/adf-process-services/-/adf-process-services-3.7.0-beta6.tgz",
+      "integrity": "sha1-NHiCadIq0cVdRKHhEvNnnE3u4EA=",
       "requires": {
         "tslib": "^1.9.0"
       }
     },
     "@alfresco/adf-process-services-cloud": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@alfresco/adf-process-services-cloud/-/adf-process-services-cloud-3.6.0.tgz",
-      "integrity": "sha512-AZJMrWxH0ldT5QBTl/5eObQX94j7ydJvaWxrXs0p9WDZdzl5A7VTds7zYueveQV2lDSO3cBo6wq2/lgrhZPnJw==",
+      "version": "3.7.0-beta6",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/@alfresco/adf-process-services-cloud/-/adf-process-services-cloud-3.7.0-beta6.tgz",
+      "integrity": "sha1-jK7r6eTweMCI9cJ1VpVIE+c1bD0=",
       "requires": {
         "tslib": "^1.9.0"
       }
     },
     "@alfresco/adf-testing": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@alfresco/adf-testing/-/adf-testing-3.6.0.tgz",
-      "integrity": "sha512-9m/EZCi2sQbxbl1HAmgW8ZKfaLPLOhhHOaklToWcJLmyWeREmln10Y5jemUvU8FfBsQ0C+5lTZ35J/Q46XKFpA==",
+      "version": "3.7.0-beta6",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/@alfresco/adf-testing/-/adf-testing-3.7.0-beta6.tgz",
+      "integrity": "sha1-jTZUiBoFkPtOzeVIkrbGXoi6pmY=",
       "requires": {
         "tslib": "^1.9.0"
       }
     },
     "@alfresco/js-api": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@alfresco/js-api/-/js-api-3.6.0.tgz",
-      "integrity": "sha512-aXc4twC3jDTZqyyhrlQX5DvyuSAnsfmZ7LT03itm/II9EqFEHcpXGWzyOA2VyZSyfuYz5e13KuM6v1VqBZxCwQ==",
+      "version": "3.7.0-beta6",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/@alfresco/js-api/-/js-api-3.7.0-beta6.tgz",
+      "integrity": "sha1-Ry6bRS9+WoQTC/nK6T1tA3EyQhU=",
       "requires": {
         "event-emitter": "^0.3.5",
         "minimatch": "3.0.4",
-        "superagent": "^3.8.2"
+        "superagent": "^5.1.2"
       }
     },
     "@angular-devkit/architect": {
@@ -2160,6 +2160,11 @@
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
       "dev": true
+    },
+    "angular2-uuid": {
+      "version": "1.1.1",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/angular2-uuid/-/angular2-uuid-1.1.1.tgz",
+      "integrity": "sha1-cvA81TK39AAy6x7PufhFc4S+lW4="
     },
     "ansi-align": {
       "version": "2.0.0",
@@ -4456,8 +4461,8 @@
     },
     "cookiejar": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
-      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/cookiejar/-/cookiejar-2.1.2.tgz",
+      "integrity": "sha1-3YojVTB1L5iPmghE8/xYnjERElw="
     },
     "copy-concurrently": {
       "version": "1.0.5",
@@ -4939,8 +4944,8 @@
     },
     "d": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/d/-/d-1.0.1.tgz",
+      "integrity": "sha1-hpgJU3LVjb7jRv/Qxwk/mfj561o=",
       "requires": {
         "es5-ext": "^0.10.50",
         "type": "^1.0.1"
@@ -5732,8 +5737,8 @@
     },
     "es5-ext": {
       "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/es5-ext/-/es5-ext-0.10.53.tgz",
+      "integrity": "sha1-k8WjrP2+8nUiCtcmRK0C7hg2jeE=",
       "requires": {
         "es6-iterator": "~2.0.3",
         "es6-symbol": "~3.1.3",
@@ -5742,7 +5747,7 @@
     },
     "es6-iterator": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "requires": {
         "d": "1",
@@ -5765,8 +5770,8 @@
     },
     "es6-symbol": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha1-utXTwbzawoJp9MszHkMceKxwXRg=",
       "requires": {
         "d": "^1.0.1",
         "ext": "^1.1.2"
@@ -5870,7 +5875,7 @@
     },
     "event-emitter": {
       "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "requires": {
         "d": "1",
@@ -6076,16 +6081,16 @@
     },
     "ext": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
-      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/ext/-/ext-1.4.0.tgz",
+      "integrity": "sha1-ia56BxWPedNVF4gpBDJAd+Q3kkQ=",
       "requires": {
         "type": "^2.0.0"
       },
       "dependencies": {
         "type": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
-          "integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow=="
+          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/type/-/type-2.0.0.tgz",
+          "integrity": "sha1-Xxb/bvLrRPJgSU2uJxAzspwJqcM="
         }
       }
     },
@@ -6263,6 +6268,11 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+    },
+    "fast-safe-stringify": {
+      "version": "2.0.7",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+      "integrity": "sha1-EkqohYmSYfaK7bQqfAgN6dpgh0M="
     },
     "fastparse": {
       "version": "1.1.2",
@@ -6548,8 +6558,8 @@
     },
     "formidable": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
-      "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/formidable/-/formidable-1.2.1.tgz",
+      "integrity": "sha1-cPt8oCkO5v+WEJBBX0s989IIJlk="
     },
     "forwarded": {
       "version": "0.1.2",
@@ -10716,7 +10726,8 @@
     "mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true
     },
     "mime-db": {
       "version": "1.40.0",
@@ -11076,7 +11087,7 @@
     },
     "next-tick": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "ng-packagr": {
@@ -13624,7 +13635,8 @@
     "qs": {
       "version": "6.7.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+      "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+      "dev": true
     },
     "querystring": {
       "version": "0.2.0",
@@ -16795,20 +16807,66 @@
       }
     },
     "superagent": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
-      "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
+      "version": "5.2.1",
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/superagent/-/superagent-5.2.1.tgz",
+      "integrity": "sha1-n1+GtwW+CGWowbm83lM6t3c/9jo=",
       "requires": {
-        "component-emitter": "^1.2.0",
-        "cookiejar": "^2.1.0",
-        "debug": "^3.1.0",
-        "extend": "^3.0.0",
-        "form-data": "^2.3.1",
-        "formidable": "^1.2.0",
-        "methods": "^1.1.1",
-        "mime": "^1.4.1",
-        "qs": "^6.5.1",
-        "readable-stream": "^2.3.5"
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.2",
+        "debug": "^4.1.1",
+        "fast-safe-stringify": "^2.0.7",
+        "form-data": "^3.0.0",
+        "formidable": "^1.2.1",
+        "methods": "^1.1.2",
+        "mime": "^2.4.4",
+        "qs": "^6.9.1",
+        "readable-stream": "^3.4.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha1-MbfjnIXxNVtxOe4MZHzw3n+DxoI=",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "mime": {
+          "version": "2.4.4",
+          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/mime/-/mime-2.4.4.tgz",
+          "integrity": "sha1-vXuRE1/GsBzePpuuM9ZZtj2IV+U="
+        },
+        "qs": {
+          "version": "6.9.1",
+          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/qs/-/qs-6.9.1.tgz",
+          "integrity": "sha1-IAgsZct4IjY1qxqerKiHWim/jsk="
+        },
+        "readable-stream": {
+          "version": "3.5.0",
+          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/readable-stream/-/readable-stream-3.5.0.tgz",
+          "integrity": "sha1-Rl1w5tEIf2Fi0HnNC123++v9FgY=",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0="
+        }
       }
     },
     "supports-color": {
@@ -17695,8 +17753,8 @@
     },
     "type": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg=="
+      "resolved": "https://agora.dequecloud.com/artifactory/api/npm/dequelabs/type/-/type-1.2.0.tgz",
+      "integrity": "sha1-hI3XaY2vo+VKbEeedZxLw/GIR6A="
     },
     "type-check": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "@types/request": "^2.48.3",
     "adf-monaco-extension": "0.0.8",
     "adf-tslint-rules": "0.0.6",
+    "angular2-uuid": "^1.1.1",
     "chart.js": "2.5.0",
     "classlist.js": "1.1.20150312",
     "core-js": "^2.5.4",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [X] Other... accessibility enhancement


**What is the current behaviour?** (You can also link to an open issue here)

While the Material Design calendar/datepicker is keyboard accessible, the elements aren't announced as functional. This creates a block of text providing instructions for screen reader users on how to interact with the control.

**What is the new behaviour?**

The text instructions will be announced when the user controls the datepicker.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
