### PR TITLE
[ACA-2609] removes calendar popup on focus

### DIFF
--- a/lib/content-services/src/lib/content-node-share/content-node-share.dialog.html
+++ b/lib/content-services/src/lib/content-node-share/content-node-share.dialog.html
@@ -7,7 +7,7 @@
         <p class="adf-share-link__info">{{ 'SHARE.DESCRIPTION' | translate }}</p>
 
         <div class="adf-share-link--row">
-            <h1 class="adf-share-link__label">{{ 'SHARE.TITLE' | translate }}</h1>
+            <label for="mat-input-1" class="adf-share-link__label">{{ 'SHARE.TITLE' | translate }}</label>
 
             <mat-slide-toggle color="primary" data-automation-id="adf-share-toggle" [checked]="isFileShared"
                 [disabled]="!canUpdate || isDisabled" (change)="onSlideShareChange($event)">
@@ -27,7 +27,7 @@
             </mat-form-field>
 
             <div class="adf-share-link--row">
-            <h1 class="adf-share-link__label">{{ 'SHARE.EXPIRES' | translate }}</h1>
+            <label for="mat-input-2" class="adf-share-link__label">{{ 'SHARE.EXPIRES' | translate }}</label>
             <mat-slide-toggle [disabled]="!canUpdate" #slideToggleExpirationDate color="primary"
                 data-automation-id="adf-expire-toggle" [checked]="form.controls['time'].value"
                 (change)="onToggleExpirationDate($event)">
@@ -36,7 +36,7 @@
 
             <mat-form-field class="adf-full-width">
                 <mat-datetimepicker-toggle #matDatetimepickerToggle="matDatetimepickerToggle" [for]="datetimePicker" matSuffix></mat-datetimepicker-toggle>
-                <mat-datetimepicker #datetimePicker (closed)="onDatetimepickerClosed()" [type]="type" openOnFocus="true" timeInterval="1"></mat-datetimepicker>
+                <mat-datetimepicker #datetimePicker (closed)="onDatetimepickerClosed()" [type]="type" timeInterval="1"></mat-datetimepicker>
                 <input class="adf-share-link__input"
                     #dateTimePickerInput
                     matInput


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

when focus enters the date-picker input, the calendar pops up causing a major change in content.

**What is the new behaviour?**

i've removed the onfocus behavior so now only the calendar tigger button opens the field.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

I did notice there weren't any programmatic IDs tying the labels to the inputs so I added some, but we may need to make them dynamic if there is ever more than one share modal on a page.
