### PR TITLE
[AAE-936] injecting external settings for amount widget

### DIFF
--- a/demo-shell/src/app/components/form/form.component.html
+++ b/demo-shell/src/app/components/form/form.component.html
@@ -4,7 +4,6 @@
         <mat-tab label="Form">
             <div class="app-form-container">
                 <adf-form
-                    [readOnly]="true"
                     [showRefreshButton]="false"
                     [form]="form"
                     (formError)="logErrors($event)">

--- a/demo-shell/src/app/components/form/form.component.html
+++ b/demo-shell/src/app/components/form/form.component.html
@@ -4,6 +4,7 @@
         <mat-tab label="Form">
             <div class="app-form-container">
                 <adf-form
+                    [readOnly]="true"
                     [showRefreshButton]="false"
                     [form]="form"
                     (formError)="logErrors($event)">

--- a/lib/core/form/components/widgets/amount/amount.widget.spec.ts
+++ b/lib/core/form/components/widgets/amount/amount.widget.spec.ts
@@ -17,7 +17,7 @@
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormFieldModel } from './../core/form-field.model';
-import { AmountWidgetComponent } from './amount.widget';
+import { AmountWidgetComponent, ADF_AMOUNT_SETTINGS } from './amount.widget';
 import { setupTestBed } from '../../../../testing/setupTestBed';
 import { CoreModule } from '../../../../core.module';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -76,4 +76,39 @@ describe('AmountWidgetComponent', () => {
         expect(widget.placeholder).toBe('1234');
     });
 
+});
+
+describe('AmountWidgetComponent settings', () => {
+    let widget: AmountWidgetComponent;
+    let fixture: ComponentFixture<AmountWidgetComponent>;
+
+    setupTestBed({
+        imports: [
+            NoopAnimationsModule,
+            CoreModule.forRoot()
+        ],
+        providers: [
+            {
+                provide: ADF_AMOUNT_SETTINGS,
+                useValue: {
+                    showReadonlyPlaceholder: true
+                }
+            }
+        ]
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(AmountWidgetComponent);
+
+        widget = fixture.componentInstance;
+    });
+
+    it('should display placeholder via injected settings', () => {
+        const field: any = {
+            readOnly: true,
+            placeholder: 'some placeholder'
+        };
+        widget.field = field;
+        expect(widget.placeholder).toBe('some placeholder');
+    });
 });

--- a/lib/core/form/components/widgets/amount/amount.widget.ts
+++ b/lib/core/form/components/widgets/amount/amount.widget.ts
@@ -17,9 +17,15 @@
 
  /* tslint:disable:component-selector  */
 
-import { Component, OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, OnInit, ViewEncapsulation, InjectionToken, Inject, Optional } from '@angular/core';
 import { FormService } from './../../../services/form.service';
 import { baseHost , WidgetComponent } from './../widget.component';
+
+export interface AmountWidgetSettings {
+    showReadonlyPlaceholder: boolean;
+}
+
+export const ADF_AMOUNT_SETTINGS = new InjectionToken<AmountWidgetSettings>('adf-amount-settings');
 
 @Component({
     selector: 'amount-widget',
@@ -31,20 +37,32 @@ import { baseHost , WidgetComponent } from './../widget.component';
 export class AmountWidgetComponent extends WidgetComponent implements OnInit {
 
     static DEFAULT_CURRENCY: string = '$';
+    private showPlaceholder = true;
 
     currency: string = AmountWidgetComponent.DEFAULT_CURRENCY;
 
     get placeholder(): string {
-        return !this.field.readOnly ? this.field.placeholder : '';
+        return this.showPlaceholder ? this.field.placeholder : '';
     }
 
-    constructor(public formService: FormService) {
+    constructor(
+        public formService: FormService,
+        @Inject(ADF_AMOUNT_SETTINGS)
+        @Optional()
+        private settings: AmountWidgetSettings
+    ) {
         super(formService);
     }
 
     ngOnInit() {
-        if (this.field && this.field.currency) {
-            this.currency = this.field.currency;
+        if (this.field) {
+            if (this.field.currency) {
+                this.currency = this.field.currency;
+            }
+
+            if (this.field.readOnly) {
+                this.showPlaceholder = this.settings && this.settings.showReadonlyPlaceholder;
+            }
         }
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

the Modeler application needs to display readonly amount widgets but with the placeholders,
right now, the placeholders are hidden for readonly amount one

**What is the new behaviour?**

similar to the material components, provide support for injecting custom configuration for the Amount widget:

```ts
providers: [
  {
     provide: ADF_AMOUNT_SETTINGS,
     useValue: {
         showReadonlyPlaceholder: true
      }
   }
]
```

Note that Modeler will need to upgrade to latest and enable corresponding flags before closing the Jira ticket

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/AAE-936