### PR TITLE
[ADF-5064] Info Drawer - More and Less Information buttons are reversed

### DIFF
--- a/e2e/content-services/metadata/metadata-smoke-tests.e2e.ts
+++ b/e2e/content-services/metadata/metadata-smoke-tests.e2e.ts
@@ -120,7 +120,7 @@ describe('Metadata component', () => {
             await metadataViewPage.editIconIsDisplayed();
             await metadataViewPage.informationButtonIsDisplayed();
             await expect(await metadataViewPage.getInformationButtonText()).toEqual(METADATA.MORE_INFO_BUTTON);
-            await expect(await metadataViewPage.getInformationIconText()).toEqual(METADATA.ARROW_UP);
+            await expect(await metadataViewPage.getInformationIconText()).toEqual(METADATA.ARROW_DOWN);
         });
 
         it('[C272769] Should be possible to display more details when clicking on More Information button', async () => {
@@ -129,8 +129,8 @@ describe('Metadata component', () => {
             await metadataViewPage.clickOnPropertiesTab();
             await metadataViewPage.informationButtonIsDisplayed();
             await metadataViewPage.clickOnInformationButton();
-            await expect(await metadataViewPage.getInformationButtonText()).toEqual(METADATA.MORE_INFO_BUTTON);
-            await expect(await metadataViewPage.getInformationIconText()).toEqual(METADATA.ARROW_DOWN);
+            await expect(await metadataViewPage.getInformationButtonText()).toEqual(METADATA.LESS_INFO_BUTTON);
+            await expect(await metadataViewPage.getInformationIconText()).toEqual(METADATA.ARROW_UP);
         });
 
         it('[C270952] Should be possible to open/close properties using info icon', async () => {

--- a/e2e/content-services/metadata/metadata-smoke-tests.e2e.ts
+++ b/e2e/content-services/metadata/metadata-smoke-tests.e2e.ts
@@ -119,7 +119,7 @@ describe('Metadata component', () => {
 
             await metadataViewPage.editIconIsDisplayed();
             await metadataViewPage.informationButtonIsDisplayed();
-            await expect(await metadataViewPage.getInformationButtonText()).toEqual(METADATA.LESS_INFO_BUTTON);
+            await expect(await metadataViewPage.getInformationButtonText()).toEqual(METADATA.MORE_INFO_BUTTON);
             await expect(await metadataViewPage.getInformationIconText()).toEqual(METADATA.ARROW_UP);
         });
 

--- a/lib/content-services/src/lib/content-metadata/components/content-metadata-card/content-metadata-card.component.html
+++ b/lib/content-services/src/lib/content-metadata/components/content-metadata-card/content-metadata-card.component.html
@@ -23,11 +23,11 @@
             </button>
         </div>
         <button *ngIf="displayDefaultProperties" mat-button (click)="toggleExpanded()" data-automation-id="meta-data-card-toggle-expand">
-            <ng-container *ngIf="expanded">
+            <ng-container *ngIf="!expanded">
                 <span data-automation-id="meta-data-card-toggle-expand-label">{{ 'ADF_VIEWER.SIDEBAR.METADATA.MORE_INFORMATION' | translate }}</span>
                 <mat-icon>keyboard_arrow_down</mat-icon>
             </ng-container>
-            <ng-container *ngIf="!expanded">
+            <ng-container *ngIf="expanded">
                 <span data-automation-id="meta-data-card-toggle-expand-label">{{ 'ADF_VIEWER.SIDEBAR.METADATA.LESS_INFORMATION' | translate }}</span>
                 <mat-icon>keyboard_arrow_up</mat-icon>
             </ng-container>

--- a/lib/content-services/src/lib/content-metadata/components/content-metadata-card/content-metadata-card.component.spec.ts
+++ b/lib/content-services/src/lib/content-metadata/components/content-metadata-card/content-metadata-card.component.spec.ts
@@ -153,7 +153,7 @@ describe('ContentMetadataCardComponent', () => {
 
         const buttonLabel = fixture.debugElement.query(By.css('[data-automation-id="meta-data-card-toggle-expand-label"]'));
 
-        expect(buttonLabel.nativeElement.innerText.trim()).toBe('ADF_VIEWER.SIDEBAR.METADATA.LESS_INFORMATION');
+        expect(buttonLabel.nativeElement.innerText.trim()).toBe('ADF_VIEWER.SIDEBAR.METADATA.MORE_INFORMATION');
     });
 
     it('should have the proper text on button while collapsed', () => {
@@ -162,7 +162,7 @@ describe('ContentMetadataCardComponent', () => {
 
         const buttonLabel = fixture.debugElement.query(By.css('[data-automation-id="meta-data-card-toggle-expand-label"]'));
 
-        expect(buttonLabel.nativeElement.innerText.trim()).toBe('ADF_VIEWER.SIDEBAR.METADATA.MORE_INFORMATION');
+        expect(buttonLabel.nativeElement.innerText.trim()).toBe('ADF_VIEWER.SIDEBAR.METADATA.LESS_INFORMATION');
     });
 
     it('should hide the edit button in readOnly is true', () => {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
[ADF-5064](https://issues.alfresco.com/jira/browse/ADF-5064)


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
