### PR TITLE
[AAE-1594] Fix partial group name of a valid group should not be vali…

### DIFF
--- a/lib/process-services-cloud/src/lib/group/components/group-cloud.component.html
+++ b/lib/process-services-cloud/src/lib/group/components/group-cloud.component.html
@@ -1,6 +1,6 @@
 <form>
     <mat-form-field class="adf-cloud-group">
-        <mat-label
+        <mat-label *ngIf="!isReadonly()"
             id="adf-group-cloud-title-id">{{ (title || 'ADF_CLOUD_GROUPS.SEARCH-GROUP') | translate }}</mat-label>
         <mat-chip-list #groupChipList [disabled]="isReadonly() || isValidationLoading()" data-automation-id="adf-cloud-group-chip-list" class="apa-group-chip-list">
             <mat-chip
@@ -16,7 +16,7 @@
                     cancel
                 </mat-icon>
             </mat-chip>
-            <input matInput
+            <input *ngIf="!isReadonly()" matInput
                    [formControl]="searchGroupsControl"
                    [matAutocomplete]="auto"
                    [matChipInputFor]="groupChipList"

--- a/lib/process-services-cloud/src/lib/group/components/group-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/group/components/group-cloud.component.spec.ts
@@ -119,7 +119,6 @@ describe('GroupCloudComponent', () => {
         it('should selectedGroup  and groupsChanged emit, update selected groups when a group is selected', (done) => {
             const group = { name: 'groupname' };
             fixture.detectChanges();
-            spyOn(component, 'hasGroupIdOrName').and.returnValue(true);
             const selectEmitSpy = spyOn(component.selectGroup, 'emit');
             const changedGroupsSpy = spyOn(component.changedGroups, 'emit');
             component.onSelect(group);
@@ -540,7 +539,6 @@ describe('GroupCloudComponent', () => {
 
             it('should check validation only for the first group and emit warning when group is invalid - single mode', (done) => {
                 spyOn(identityGroupService, 'findGroupsByName').and.returnValue(Promise.resolve([]));
-                spyOn(component, 'hasGroupIdOrName').and.returnValue(false);
 
                 const expectedWarning = {
                     message: 'INVALID_PRESELECTED_GROUPS',

--- a/lib/process-services-cloud/src/lib/group/components/group-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/group/components/group-cloud.component.ts
@@ -265,7 +265,7 @@ export class GroupCloudComponent implements OnInit, OnChanges, OnDestroy {
         await Promise.all(preselectedGroupsToValidate.map(async (group: IdentityGroupModel) => {
             try {
                 const validationResult = await this.searchGroup(group.name);
-                if (!this.hasGroupIdOrName(validationResult)) {
+                if (this.isPreselectedGroupInvalid(group, validationResult)) {
                     this.invalidGroups.push(group);
                 }
             } catch (error) {
@@ -379,8 +379,12 @@ export class GroupCloudComponent implements OnInit, OnChanges, OnDestroy {
         this.searchGroupsSubject.next(this.searchGroups);
     }
 
-    hasGroupIdOrName(group: IdentityGroupModel): boolean {
-        return group && (group.id !== undefined || group.name !== undefined);
+    isPreselectedGroupInvalid(preselectedGroup: IdentityGroupModel, validatedGroup: IdentityGroupModel): boolean {
+        if (validatedGroup && validatedGroup.name !== undefined) {
+            return preselectedGroup.name !== validatedGroup.name;
+        } else {
+            return true;
+        }
     }
 
     isSingleMode(): boolean {

--- a/lib/process-services-cloud/src/lib/people/components/people-cloud.component.html
+++ b/lib/process-services-cloud/src/lib/people/components/people-cloud.component.html
@@ -1,6 +1,6 @@
 <form>
     <mat-form-field class="adf-people-cloud">
-        <mat-label id="adf-people-cloud-title-id">{{ title | translate }}</mat-label>
+        <mat-label *ngIf="!isReadonly()" id="adf-people-cloud-title-id">{{ title | translate }}</mat-label>
         <mat-chip-list #userMultipleChipList [disabled]="isReadonly() || isValidationLoading()" data-automation-id="adf-cloud-people-chip-list">
             <mat-chip
                 *ngFor="let user of selectedUsers"
@@ -16,7 +16,7 @@
                     cancel
                 </mat-icon>
             </mat-chip>
-            <input matInput
+            <input *ngIf="!isReadonly()" matInput
                    [formControl]="searchUserCtrl"
                    [matAutocomplete]="auto"
                    [matChipInputFor]="userMultipleChipList"


### PR DESCRIPTION
…d, fix form-cloud able to search when people/group widget is readonly

**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
- https://issues.alfresco.com/jira/browse/AAE-1594
- Able to search for users/groups in form-cloud when using readonly prople/group widgets.


**What is the new behaviour?**
- user/group names of a valid user/group matches entirely and not partially
- Not able to search for users/groups when people/group widgets in a form are set to readonly


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
