### PR TITLE
ACA-2567 - Data Table - SR Text Refactor

### DIFF
--- a/lib/core/datatable/components/datatable/datatable.component.html
+++ b/lib/core/datatable/components/datatable/datatable.component.html
@@ -33,7 +33,7 @@
                  [attr.aria-sort]="col.sortable ? (getAriaSort(col) | translate) : null"
                  adf-drop-zone dropTarget="header" [dropColumn]="col">
                 <span *ngIf="col.title" class="adf-datatable-cell-value">{{ col.title | translate}}</span>
-                <span class="adf-sr-only" aria-live="polite">{{ getSortLiveAnnouncement(col) | translate: {string: col.title} }}</span>
+                <span *ngIf="col.title" class="adf-sr-only" aria-live="polite">{{ getSortLiveAnnouncement(col) | translate: {string: col.title} }}</span>
             </div>
             <!-- Actions (right) -->
             <div *ngIf="actions && actionsPosition === 'right'" class="adf-actions-column adf-datatable-cell-header adf-datatable__actions-cell">


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ x] Tests for the changes have been added (for bug fixes / features)
> - [x ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Reading 'sortable' for all column headers regardless of text being present


**What is the new behaviour?**
Will only read sortable live function when column header text is present


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
