### PR TITLE
[ACA-2474] - Card View DateItem - Calendar Accessibility Fixes 

### DIFF
--- a/lib/core/card-view/card-view.module.ts
+++ b/lib/core/card-view/card-view.module.ts
@@ -36,6 +36,7 @@ import { FlexLayoutModule } from '@angular/flex-layout';
 import { TranslateModule } from '@ngx-translate/core';
 
 import { CardViewContentProxyDirective } from './directives/card-view-content-proxy.directive';
+import { CalendarDirective } from './directives/calendar.directive';
 import { CardViewComponent } from './components/card-view/card-view.component';
 import { CardViewBoolItemComponent } from './components/card-view-boolitem/card-view-boolitem.component';
 import { CardViewDateItemComponent } from './components/card-view-dateitem/card-view-dateitem.component';
@@ -76,6 +77,7 @@ import { CardViewArrayItemComponent } from './components/card-view-arrayitem/car
         CardViewSelectItemComponent,
         CardViewItemDispatcherComponent,
         CardViewContentProxyDirective,
+        CalendarDirective,
         CardViewArrayItemComponent
     ],
     entryComponents: [

--- a/lib/core/card-view/components/card-view-dateitem/card-view-dateitem.component.html
+++ b/lib/core/card-view/components/card-view-dateitem/card-view-dateitem.component.html
@@ -1,4 +1,3 @@
-<div class="adf-sr-only" [attr.data-automation-id]="'card-' + property.type + '-value-' + property.key">{{'CORE.METADATA.ACCESSIBILITY.DATEPICKER' | translate}}</div>
 <div [attr.data-automation-id]="'card-dateitem-label-' + property.key" class="adf-property-label" *ngIf="showProperty() || isEditable()">{{ property.label | translate }}</div>
 <div class="adf-property-value">
     <span *ngIf="!isEditable()" [attr.data-automation-id]="'card-' + property.type + '-value-' + property.key">
@@ -7,11 +6,14 @@
         </span>
     </span>
     <div *ngIf="isEditable()" class="adf-dateitem-editable">
-        <div class="adf-dateitem-editable-controls">
+        <div class="adf-dateitem-editable-controls"  >
             <span
+                adf-a11y-calendar
+                (click)="showDatePicker()" 
+                (keyup.enter)="showDatePicker()" 
                 class="adf-datepicker-toggle"
                 [attr.data-automation-id]="'datepicker-label-toggle-' + property.key"
-                (click)="showDatePicker()">
+               >
                 <span [attr.data-automation-id]="'card-' + property.type + '-value-' + property.key" *ngIf="showProperty(); else elseEmptyValueBlock">{{ property.displayValue }}</span>
             </span>
 
@@ -23,7 +25,8 @@
                 clear
             </mat-icon>
 
-            <mat-datetimepicker-toggle
+            <mat-datetimepicker-toggle 
+                [attr.tabindex]="-1"
                 [attr.title]="'CORE.METADATA.ACTIONS.EDIT' | translate"
                 [attr.data-automation-id]="'datepickertoggle-' + property.key"
                 [for]="datetimePicker">
@@ -33,8 +36,7 @@
         <input class="adf-invisible-date-input"
             [matDatetimepicker]="datetimePicker"
             [value]="valueDate"
-            (dateChange)="onDateChanged($event)"
-            [attr.aria-describedby]="'card-' + property.type + '-value-' + property.key">
+            (dateChange)="onDateChanged($event)">
 
         <mat-datetimepicker #datetimePicker
             [type]="property.type"

--- a/lib/core/card-view/components/card-view-dateitem/card-view-dateitem.component.scss
+++ b/lib/core/card-view/components/card-view-dateitem/card-view-dateitem.component.scss
@@ -1,4 +1,13 @@
 @mixin adf-card-view-dateitem-theme($theme) {
+    .mat-datetimepicker-calendar-body-cell:focus{
+        background-color: rgba(0,0,0,.12)!important;
+    }
+    .mat-datetimepicker-calendar-previous-button:focus{
+        outline: -webkit-focus-ring-color auto 5px;
+    } 
+    .mat-datetimepicker-calendar-next-button:focus{
+        outline: -webkit-focus-ring-color auto 5px;
+    }
 
     .adf {
         &-invisible-date-input {
@@ -56,14 +65,4 @@
             }
         }
     }
-
-    .adf-sr-only {
-        display: block;
-        height: 1px;
-        width: 1px;
-        clip: rect(1 1 1 1);
-        clip: rect(1px 1px 1px 1px);
-        overflow: hidden;
-    }
-
 }

--- a/lib/core/card-view/directives/calendar.directive.ts
+++ b/lib/core/card-view/directives/calendar.directive.ts
@@ -1,0 +1,78 @@
+/*!
+ * @license
+ * Copyright 2019 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Directive, HostListener } from '@angular/core';
+
+@Directive({
+    selector: '[adf-a11y-calendar]'
+})
+export class CalendarDirective {
+    constructor() {}
+
+    @HostListener('click') calendarClickA11yFixes() {
+        this.roleBaseButtons();
+        this.eventButtons();
+    }
+    @HostListener('document:keydown.enter') calendarKeyboardA11yFixes() {
+        this.roleBaseButtons();
+        this.eventButtons();
+    }
+
+      roleBaseButtons() {
+        setTimeout(() => {
+            const selectors = ['.mat-datetimepicker-calendar-previous-button', '.mat-datetimepicker-calendar-next-button', '.mat-datetimepicker-calendar-header-year',
+            '.mat-datetimepicker-calendar-header-date', '.mat-datetimepicker-calendar-header-time' ];
+            const calendarButtons = Array.from(document.getElementsByClassName('mat-datetimepicker-calendar-body-cell'));
+            calendarButtons.forEach(e => {
+                 e.setAttribute('role', 'button');
+                 if (e.firstElementChild.classList.contains('mat-datetimepicker-calendar-body-selected')) {
+                     e.firstElementChild.parentElement.setAttribute('aria-selected', 'true');
+                 }
+            });
+            selectors.forEach(button => {
+                  if (document.querySelector(button)) {
+                  document.querySelector(button).setAttribute('role', 'button');
+                  }
+            });
+            this.keyboardInstructions();
+        }, 1000);
+      }
+
+      eventButtons() {
+        setTimeout(() => {
+            document.querySelector('.mat-datetimepicker-calendar-previous-button, .mat-datetimepicker-calendar-next-button').addEventListener('click', () => {
+                this.roleBaseButtons();
+            });
+            document.querySelector('.mat-datetimepicker-calendar-header-year').addEventListener('click', () => {
+                this.roleBaseButtons();
+                document.querySelector('.mat-datetimepicker-calendar-previous-button').setAttribute('aria-label', 'previous year');
+                document.querySelector('.mat-datetimepicker-calendar-next-button').setAttribute('aria-label', 'next year');
+            });
+            document.querySelector('.mat-datetimepicker-calendar-header-date').addEventListener('click', () => {
+                this.roleBaseButtons();
+                document.querySelector('.mat-datetimepicker-calendar-previous-button').setAttribute('aria-label', 'previous month');
+                document.querySelector('.mat-datetimepicker-calendar-next-button').setAttribute('aria-label', 'next month');
+            });
+        }, 1000);
+      }
+
+      keyboardInstructions() {
+           document.querySelector('.mat-datetimepicker-calendar-header-date').setAttribute('aria-live', 'polite');
+           document.querySelector('.mat-datetimepicker-calendar').setAttribute('aria-label', 'Use arrow keys to navigate');
+           document.querySelector('.mat-datetimepicker-calendar').setAttribute('role', 'dialog');
+      }
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [X ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Currently the calendar is missing proper roles and multiple accessibility features


**What is the new behaviour?**
All items with calendar will now have proper roles of buttons, proper states, and addition of dynamic click events that change content for screen reader users.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
This PR includes regular JavaScript within it (directive mainly). The reason being, it was the only way currently to access the calendar dynamically on the page.

