### PR TITLE
[ACA-2599] added always visible label to sort, i18n

### DIFF
--- a/lib/core/i18n/en.json
+++ b/lib/core/i18n/en.json
@@ -205,7 +205,8 @@
       }
     },
     "SEARCH": {
-      "TOGGLE_ASC_DESC_ORDER": "Toggle results between ascending and descending order"
+      "TOGGLE_ASC_DESC_ORDER": "Toggle results between ascending and descending order",
+      "SORT_BY": "Sort by"
     }
   },
   "COMMENTS": {

--- a/lib/core/sorting-picker/sorting-picker.component.html
+++ b/lib/core/sorting-picker/sorting-picker.component.html
@@ -1,4 +1,5 @@
-<mat-form-field>
+<mat-form-field floatLabel="always">
+    <mat-label>{{'CORE.SEARCH.SORT_BY' | translate}}</mat-label>
     <mat-select [(value)]="selected" (selectionChange)="onOptionChanged($event)">
         <mat-option *ngFor="let option of options" [value]="option.key">
             {{ option.label | translate }}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [X] Other... Please describe: accessibility


**What is the current behaviour?** (You can also link to an open issue here)

There is no persistent, visible label for the search sort dropdown

**What is the new behaviour?**

this adds an always visible label along with i18n for the visible text string

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
