### PR TITLE
[ADF-4920] Fixed checkbox dropdown style when invalid

### DIFF
--- a/lib/core/form/components/widgets/checkbox/checkbox.widget.html
+++ b/lib/core/form/components/widgets/checkbox/checkbox.widget.html
@@ -1,4 +1,5 @@
-<div [ngClass]="field.className">
+<div [ngClass]="field.className"
+     [class.adf-invalid]="!field.isValid">
     <mat-checkbox
         [id]="field.id"
         color="primary"

--- a/lib/core/form/components/widgets/checkbox/checkbox.widget.spec.ts
+++ b/lib/core/form/components/widgets/checkbox/checkbox.widget.spec.ts
@@ -65,7 +65,7 @@ describe('CheckboxWidgetComponent', () => {
             fixture.detectChanges();
         });
 
-        it('should be marked as invalid when reauired', async(() => {
+        it('should be marked as invalid when required', async(() => {
             fixture.whenStable().then(() => {
                 expect(element.querySelector('.adf-invalid')).not.toBeNull();
             });

--- a/lib/core/form/components/widgets/checkbox/checkbox.widget.spec.ts
+++ b/lib/core/form/components/widgets/checkbox/checkbox.widget.spec.ts
@@ -1,0 +1,75 @@
+/*!
+ * @license
+ * Copyright 2019 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentFixture, TestBed, async } from '@angular/core/testing';
+import { FormFieldTypes } from '../core/form-field-types';
+import { FormFieldModel } from '../core/form-field.model';
+import { FormModel } from '../core/form.model';
+import { CheckboxWidgetComponent } from './checkbox.widget';
+import { setupTestBed } from '../../../../testing/setupTestBed';
+import { FormBaseModule } from 'core/form/form-base.module';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { TranslateService, TranslateStore, TranslateLoader } from '@ngx-translate/core';
+import { TranslateLoaderService } from 'core/services';
+
+describe('CheckboxWidgetComponent', () => {
+
+    let widget: CheckboxWidgetComponent;
+    let fixture: ComponentFixture<CheckboxWidgetComponent>;
+    let element: HTMLElement;
+
+    setupTestBed({
+        imports: [
+            NoopAnimationsModule,
+            FormBaseModule
+        ],
+        providers: [
+            TranslateStore,
+            TranslateService,
+            { provide: TranslateLoader, useClass: TranslateLoaderService }
+        ]
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(CheckboxWidgetComponent);
+
+        widget = fixture.componentInstance;
+        element = fixture.nativeElement;
+    });
+
+    describe('when template is ready', () => {
+
+        beforeEach(() => {
+            widget.field = new FormFieldModel(new FormModel({taskId: 'fake-task-id'}), {
+                id: 'check-id',
+                name: 'check-name',
+                value: '',
+                type: FormFieldTypes.BOOLEAN,
+                readOnly: false,
+                required: true
+            });
+            fixture.detectChanges();
+        });
+
+        it('should be marked as invalid when reauired', async(() => {
+            fixture.whenStable().then(() => {
+                expect(element.querySelector('.adf-invalid')).not.toBeNull();
+            });
+        }));
+
+    });
+});

--- a/lib/core/form/components/widgets/form.scss
+++ b/lib/core/form/components/widgets/form.scss
@@ -43,6 +43,24 @@
                 background-color: #f44336 !important;
             }
 
+            .mat-checkbox {
+                color: mat-color($warn);
+                .mat-checkbox-frame {
+                    border-color: mat-color($warn);
+                }
+            }
+
+            .mat-select {
+
+                &-value {
+                    color: mat-color($warn);
+                }
+                &-arrow {
+                    color: mat-color($warn);
+                }
+
+            }
+
             .adf-file {
                 border-color: mat-color($warn);
             }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
The checkbox and dropdown widgets don't turn red when the form isn't valid (when it is required and not filled up). 


**What is the new behaviour?**
The checkbox's title and frame turn red when invalid as well as dropdown's arrow and value.
Also added spec file to check if required checkbox gets invalid when created and not checked.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-4920