### PR TITLE
#1256 Fix Icon alignment mismatch and the rows to have the same height.

### DIFF
--- a/lib/content-services/src/lib/upload/components/file-uploading-list-row.component.scss
+++ b/lib/content-services/src/lib/upload/components/file-uploading-list-row.component.scss
@@ -32,9 +32,11 @@
 
         &__group, &__block, &__file-version {
             min-width: 100px;
-            display: flex;
+            display: flex !important;
             justify-content: flex-end;
             line-height: 40px;
+            height: 40px;
+            align-items: center;
         }
 
         &__group--toggle {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
