### PR TITLE
[ADF-5072] Permission panel shows first and last name of users

### DIFF
--- a/lib/content-services/src/lib/mock/add-permission.component.mock.ts
+++ b/lib/content-services/src/lib/mock/add-permission.component.mock.ts
@@ -141,15 +141,91 @@ export const fakeAuthorityResults: any[] = [{
 }];
 
 export const fakeAuthorityListResult: any = {
-'list': {
-'pagination': {
-    'count': 0,
-    'hasMoreItems': false,
-    'totalItems': 0,
-    'skipCount': 0,
-    'maxItems': 100
-},
-'context': {},
-'entries': fakeAuthorityResults
-}
+    'list': {
+        'pagination': {
+            'count': 0,
+            'hasMoreItems': false,
+            'totalItems': 0,
+            'skipCount': 0,
+            'maxItems': 100
+        },
+        'context': {},
+        'entries': fakeAuthorityResults
+    }
+};
+
+export const fakeNameListResult: any = {
+    'list': {
+        'pagination': {
+            'count': 2,
+            'hasMoreItems': false,
+            'totalItems': 2,
+            'skipCount': 0,
+            'maxItems': 20
+        },
+        'context': {
+            'consistency': {
+                'lastTxId': 5496
+            }
+        },
+        'entries': [{
+            'entry': {
+                'aspectNames': ['cm:ownable'],
+                'isFolder': false,
+                'search': {
+                    'score': 1.0
+                },
+                'isFile': false,
+                'name': '730cd9b0-5617-4865-aee8-90de1d596997',
+                'location': 'nodes',
+                'id': '730cd9b0-5617-4865-aee8-90de1d596997',
+                'nodeType': 'cm:person',
+                'properties': {
+                    'cm:homeFolderProvider': 'userHomesHomeFolderProvider',
+                    'cm:authorizationStatus': 'NEVER_AUTHORIZED',
+                    'cm:homeFolder': '277f505d-6526-45b1-a7b3-c9bdd66f17f6',
+                    'cm:userName': 'test1',
+                    'cm:lastName': 'lastName1',
+                    'cm:sizeCurrent': 0,
+                    'cm:email': 'test1@gmail.com',
+                    'cm:sizeQuota': 1073741824,
+                    'cm:firstName': 'firstName',
+                    'cm:owner': {
+                        'id': 'test1',
+                        'displayName': 'firstName lastName1'
+                    }
+                },
+                'parentId': '3e9ce910-a4a0-4531-8f80-7734bece6342'
+            }
+        }, {
+            'entry': {
+                'aspectNames': ['cm:ownable'],
+                'isFolder': false,
+                'search': {
+                    'score': 1.0
+                },
+                'isFile': false,
+                'name': '3d1e9e57-505f-431e-bb2b-38ad8d5d2d15',
+                'location': 'nodes',
+                'id': '3d1e9e57-505f-431e-bb2b-38ad8d5d2d15',
+                'nodeType': 'cm:person',
+                'properties': {
+                    'cm:homeFolderProvider': 'userHomesHomeFolderProvider',
+                    'cm:authorizationStatus': 'NEVER_AUTHORIZED',
+                    'cm:homeFolder': '81a07ff0-82fb-4bbb-b869-d5fd92e71e17',
+                    'cm:userName': 'test11',
+                    'cm:lastName': 'lastName2',
+                    'cm:sizeCurrent': 0,
+                    'cm:email': 'test2@gmail.com',
+                    'cm:sizeQuota': -1,
+                    'cm:firstName': 'firstName',
+                    'cm:owner': {
+                        'id': 'test11',
+                        'displayName': 'firstName lastName2'
+                    }
+                },
+                'parentId': '3e9ce910-a4a0-4531-8f80-7734bece6342'
+            }
+        }]
+    }
 };

--- a/lib/content-services/src/lib/permission-manager/components/add-permission/add-permission-panel.component.html
+++ b/lib/content-services/src/lib/permission-manager/components/add-permission/add-permission-panel.component.html
@@ -56,7 +56,7 @@
             <p>
              {{item.entry?.properties['cm:authorityName']?
                                     item.entry?.properties['cm:authorityName'] :
-                                    item.entry?.properties['cm:firstName']}}</p>
+                                    item.entry?.properties['cm:owner']?.displayName}}</p>
         </mat-list-option>
     </mat-selection-list>
 </ng-template>

--- a/lib/content-services/src/lib/permission-manager/components/add-permission/add-permission-panel.component.spec.ts
+++ b/lib/content-services/src/lib/permission-manager/components/add-permission/add-permission-panel.component.spec.ts
@@ -20,7 +20,7 @@ import { AddPermissionPanelComponent } from './add-permission-panel.component';
 import { By } from '@angular/platform-browser';
 import { SearchService, setupTestBed, SearchConfigurationService } from '@alfresco/adf-core';
 import { of } from 'rxjs';
-import { fakeAuthorityListResult } from '../../../mock/add-permission.component.mock';
+import { fakeAuthorityListResult, fakeNameListResult } from '../../../mock/add-permission.component.mock';
 import { ContentTestingModule } from '../../../testing/content.testing.module';
 import { DebugElement } from '@angular/core';
 
@@ -184,6 +184,24 @@ describe('AddPermissionPanelComponent', () => {
             expect(element.querySelector('#adf-add-permission-authority-results')).not.toBeNull();
             expect(element.querySelector('#adf-add-permission-group-everyone')).toBeDefined();
             expect(element.querySelector('#adf-add-permission-group-everyone')).not.toBeNull();
+        });
+    }));
+
+    it('should show first and last name of users', async(() => {
+        searchApiService = fixture.componentRef.injector.get(SearchService);
+        spyOn(searchApiService, 'search').and.returnValue(of(fakeNameListResult));
+        component.selectedItems.push(fakeNameListResult.list.entries[0]);
+        component.selectedItems.push(fakeNameListResult.list.entries[1]);
+
+        typeWordIntoSearchInput('a');
+        fixture.detectChanges();
+        fixture.whenStable().then(() => {
+            fixture.detectChanges();
+            expect(element.querySelector('#result_option_0 .mat-list-text')).not.toBeNull();
+            expect(element.querySelector('#result_option_0 .mat-list-text')).toBeDefined();
+            expect(element.querySelector('#result_option_1 .mat-list-text')).not.toBeNull();
+            expect(element.querySelector('#result_option_1 .mat-list-text')).toBeDefined();
+            expect(element.querySelector('#result_option_0 .mat-list-text').innerHTML).not.toEqual(element.querySelector('#result_option_1 .mat-list-text').innerHTML);
         });
     }));
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
When looking for users to add permissions on a file only the first name of the users is displayed.
https://issues.alfresco.com/jira/browse/ADF-5072

**What is the new behaviour?**
Now the first and last name (if existing) is displayed when looking for a user in the add-permission-panel component. 
Also, I implemented a new test in the spec that checks that 2 users with the same first name aren't displayed the same way.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://github.com/Alfresco/alfresco-ng2-components/issues/5419