### PR TITLE
[ACA-2619][ACA-2616] a11y fixes for Share Link dialog

### DIFF
--- a/e2e/content-services/share-file/share-file.e2e.ts
+++ b/e2e/content-services/share-file/share-file.e2e.ts
@@ -121,6 +121,7 @@ describe('Share file', () => {
         it('[C286578] Should disable today option in expiration day calendar', async () => {
             await contentServicesPage.clickShareButton();
             await shareDialog.checkDialogIsDisplayed();
+            await shareDialog.clickExpireToggle();
             await shareDialog.clickDateTimePickerButton();
             await shareDialog.calendarTodayDayIsDisabled();
             await BrowserActions.closeMenuAndDialogs();
@@ -129,6 +130,7 @@ describe('Share file', () => {
         it('[C286548] Should be possible to set expiry date for link', async () => {
             await contentServicesPage.clickShareButton();
             await shareDialog.checkDialogIsDisplayed();
+            await shareDialog.clickExpireToggle();
             await shareDialog.setDefaultDay();
             await shareDialog.setDefaultHour();
             await shareDialog.setDefaultMinutes();
@@ -142,18 +144,11 @@ describe('Share file', () => {
             await BrowserActions.closeMenuAndDialogs();
         });
 
-        it('[C286578] Should disable today option in expiration day calendar', async () => {
-            await contentServicesPage.clickShareButton();
-            await shareDialog.checkDialogIsDisplayed();
-            await shareDialog.clickDateTimePickerButton();
-            await shareDialog.calendarTodayDayIsDisabled();
-            await BrowserActions.closeMenuAndDialogs();
-        });
-
         it('[C310329] Should be possible to set expiry date only for link', async () => {
             await LocalStorageUtil.setConfigField('sharedLinkDateTimePickerType', JSON.stringify('date'));
             await contentServicesPage.clickShareButton();
             await shareDialog.checkDialogIsDisplayed();
+            await shareDialog.clickExpireToggle();
             await shareDialog.setDefaultDay();
             await shareDialog.dateTimePickerDialogIsClosed();
             const value = await shareDialog.getExpirationDate();

--- a/e2e/pages/adf/dialog/share-dialog.page.ts
+++ b/e2e/pages/adf/dialog/share-dialog.page.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { element, by, ElementFinder } from 'protractor';
+import { element, by } from 'protractor';
 import { BrowserVisibility, TogglePage, BrowserActions, DateTimePickerPage } from '@alfresco/adf-testing';
 import moment = require('moment');
 
@@ -23,17 +23,18 @@ export class ShareDialogPage {
 
     togglePage = new TogglePage();
     dateTimePickerPage = new DateTimePickerPage();
-    shareDialog: ElementFinder = element(by.css('adf-share-dialog'));
-    dialogTitle: ElementFinder = element(by.css('[data-automation-id="adf-share-dialog-title"]'));
-    shareToggle: ElementFinder = element(by.css('[data-automation-id="adf-share-toggle"] label'));
-    shareToggleChecked: ElementFinder = element(by.css('mat-dialog-container mat-slide-toggle.mat-checked'));
-    shareLink: ElementFinder = element(by.css('[data-automation-id="adf-share-link"]'));
-    closeButton: ElementFinder = element(by.css('button[data-automation-id="adf-share-dialog-close"]'));
-    copySharedLinkButton: ElementFinder = element(by.css('.adf-input-action'));
-    expirationDateInput: ElementFinder = element(by.css('input[formcontrolname="time"]'));
-    confirmationDialog: ElementFinder = element(by.css('adf-confirm-dialog'));
-    confirmationCancelButton: ElementFinder = element(by.id('adf-confirm-cancel'));
-    confirmationRemoveButton: ElementFinder = element(by.id('adf-confirm-accept'));
+    shareDialog = element(by.css('adf-share-dialog'));
+    dialogTitle = element(by.css('[data-automation-id="adf-share-dialog-title"]'));
+    shareToggle = element(by.css('[data-automation-id="adf-share-toggle"] label'));
+    expireToggle = element(by.css(`[data-automation-id="adf-expire-toggle"] label`));
+    shareToggleChecked = element(by.css('mat-dialog-container mat-slide-toggle.mat-checked'));
+    shareLink = element(by.css('[data-automation-id="adf-share-link"]'));
+    closeButton = element(by.css('button[data-automation-id="adf-share-dialog-close"]'));
+    copySharedLinkButton = element(by.css('.adf-input-action'));
+    expirationDateInput = element(by.css('input[formcontrolname="time"]'));
+    confirmationDialog = element(by.css('adf-confirm-dialog'));
+    confirmationCancelButton = element(by.id('adf-confirm-cancel'));
+    confirmationRemoveButton = element(by.id('adf-confirm-accept'));
 
     async checkDialogIsDisplayed(): Promise<void> {
         await BrowserVisibility.waitUntilElementIsVisible(this.dialogTitle);
@@ -41,6 +42,10 @@ export class ShareDialogPage {
 
     async clickUnShareFile() {
         await this.togglePage.enableToggle(this.shareToggle);
+    }
+
+    async clickExpireToggle() {
+        await this.togglePage.enableToggle(this.expireToggle);
     }
 
     async clickConfirmationDialogCancelButton(): Promise<void> {

--- a/lib/content-services/src/lib/content-node-share/content-node-share.dialog.html
+++ b/lib/content-services/src/lib/content-node-share/content-node-share.dialog.html
@@ -7,12 +7,12 @@
         <p class="adf-share-link__info">{{ 'SHARE.DESCRIPTION' | translate }}</p>
 
         <div class="adf-share-link--row">
-            <label id="share-toggle-label" class="adf-share-link__label">{{ 'SHARE.TITLE' | translate }}</label>
+            <label class="adf-share-link__label">{{ 'SHARE.TITLE' | translate }}</label>
 
             <mat-slide-toggle
                 color="primary"
                 data-automation-id="adf-share-toggle"
-                aria-labelledby="share-toggle-label"
+                aria-label="{{ 'SHARE.TITLE' | translate }}"
                 [checked]="isFileShared"
                 [disabled]="!canUpdate || isDisabled"
                 (change)="onSlideShareChange($event)">
@@ -40,13 +40,13 @@
             </mat-form-field>
 
             <div class="adf-share-link--row">
-                <label id="expire-toggle-label" class="adf-share-link__label">{{ 'SHARE.EXPIRES' | translate }}</label>
+                <label class="adf-share-link__label">{{ 'SHARE.EXPIRES' | translate }}</label>
                 <mat-slide-toggle
                     #slideToggleExpirationDate
                     [disabled]="!canUpdate"
                     color="primary"
                     data-automation-id="adf-expire-toggle"
-                    aria-labelledby="expire-toggle-label"
+                    aria-label="{{ 'SHARE.EXPIRES' | translate }}"
                     [checked]="time.value"
                     (change)="onToggleExpirationDate($event)">
                 </mat-slide-toggle>

--- a/lib/content-services/src/lib/content-node-share/content-node-share.dialog.html
+++ b/lib/content-services/src/lib/content-node-share/content-node-share.dialog.html
@@ -7,11 +7,12 @@
         <p class="adf-share-link__info">{{ 'SHARE.DESCRIPTION' | translate }}</p>
 
         <div class="adf-share-link--row">
-            <label for="mat-input-1" class="adf-share-link__label">{{ 'SHARE.TITLE' | translate }}</label>
+            <label id="share-toggle-label" class="adf-share-link__label">{{ 'SHARE.TITLE' | translate }}</label>
 
             <mat-slide-toggle
                 color="primary"
                 data-automation-id="adf-share-toggle"
+                aria-labelledby="share-toggle-label"
                 [checked]="isFileShared"
                 [disabled]="!canUpdate || isDisabled"
                 (change)="onSlideShareChange($event)">
@@ -39,15 +40,16 @@
             </mat-form-field>
 
             <div class="adf-share-link--row">
-            <label for="mat-input-2" class="adf-share-link__label">{{ 'SHARE.EXPIRES' | translate }}</label>
-            <mat-slide-toggle
-                #slideToggleExpirationDate
-                [disabled]="!canUpdate"
-                color="primary"
-                data-automation-id="adf-expire-toggle"
-                [checked]="time.value"
-                (change)="onToggleExpirationDate($event)">
-            </mat-slide-toggle>
+                <label id="expire-toggle-label" class="adf-share-link__label">{{ 'SHARE.EXPIRES' | translate }}</label>
+                <mat-slide-toggle
+                    #slideToggleExpirationDate
+                    [disabled]="!canUpdate"
+                    color="primary"
+                    data-automation-id="adf-expire-toggle"
+                    aria-labelledby="expire-toggle-label"
+                    [checked]="time.value"
+                    (change)="onToggleExpirationDate($event)">
+                </mat-slide-toggle>
             </div>
 
             <mat-form-field class="adf-full-width">

--- a/lib/content-services/src/lib/content-node-share/content-node-share.dialog.html
+++ b/lib/content-services/src/lib/content-node-share/content-node-share.dialog.html
@@ -9,17 +9,29 @@
         <div class="adf-share-link--row">
             <label for="mat-input-1" class="adf-share-link__label">{{ 'SHARE.TITLE' | translate }}</label>
 
-            <mat-slide-toggle color="primary" data-automation-id="adf-share-toggle" [checked]="isFileShared"
-                [disabled]="!canUpdate || isDisabled" (change)="onSlideShareChange($event)">
+            <mat-slide-toggle
+                color="primary"
+                data-automation-id="adf-share-toggle"
+                [checked]="isFileShared"
+                [disabled]="!canUpdate || isDisabled"
+                (change)="onSlideShareChange($event)">
             </mat-slide-toggle>
         </div>
 
         <form [formGroup]="form">
             <mat-form-field class="adf-full-width adf-float-label" floatLabel='always'>
-                <input #sharedLinkInput data-automation-id="adf-share-link" class="adf-share-link__input" matInput
-                    cdkFocusInitial placeholder="{{ 'SHARE.PUBLIC-LINK' | translate }}" formControlName="sharedUrl"
+                <input
+                    #sharedLinkInput
+                    data-automation-id="adf-share-link"
+                    class="adf-share-link__input"
+                    matInput
+                    cdkFocusInitial
+                    placeholder="{{ 'SHARE.PUBLIC-LINK' | translate }}"
+                    formControlName="sharedUrl"
                     readonly="readonly">
-                <mat-icon class="adf-input-action" matSuffix
+                <mat-icon
+                    class="adf-input-action"
+                    matSuffix
                     [clipboard-notification]="'SHARE.CLIPBOARD-MESSAGE' | translate" [adf-clipboard]
                     [target]="sharedLinkInput">
                     link
@@ -28,16 +40,29 @@
 
             <div class="adf-share-link--row">
             <label for="mat-input-2" class="adf-share-link__label">{{ 'SHARE.EXPIRES' | translate }}</label>
-            <mat-slide-toggle [disabled]="!canUpdate" #slideToggleExpirationDate color="primary"
-                data-automation-id="adf-expire-toggle" [checked]="form.controls['time'].value"
-                (change)="onToggleExpirationDate($event)"
-                >
+            <mat-slide-toggle
+                #slideToggleExpirationDate
+                [disabled]="!canUpdate"
+                color="primary"
+                data-automation-id="adf-expire-toggle"
+                [checked]="time.value"
+                (change)="onToggleExpirationDate($event)">
             </mat-slide-toggle>
             </div>
 
             <mat-form-field class="adf-full-width">
-                <mat-datetimepicker-toggle #matDatetimepickerToggle="matDatetimepickerToggle" [disabled]="form.controls['time'].disabled" [for]="datetimePicker" matSuffix></mat-datetimepicker-toggle>
-                <mat-datetimepicker #datetimePicker  (closed)="onDatetimepickerClosed()" [type]="type" timeInterval="1"></mat-datetimepicker>
+                <mat-datetimepicker-toggle
+                    #matDatetimepickerToggle="matDatetimepickerToggle"
+                    [disabled]="time.disabled"
+                    [for]="datetimePicker"
+                    matSuffix>
+                </mat-datetimepicker-toggle>
+                <mat-datetimepicker
+                    #datetimePicker
+                    (closed)="onDatetimepickerClosed()"
+                    [type]="type"
+                    timeInterval="1">
+                </mat-datetimepicker>
                 <input class="adf-share-link__input"
                     #dateTimePickerInput
                     matInput

--- a/lib/content-services/src/lib/content-node-share/content-node-share.dialog.html
+++ b/lib/content-services/src/lib/content-node-share/content-node-share.dialog.html
@@ -30,13 +30,14 @@
             <label for="mat-input-2" class="adf-share-link__label">{{ 'SHARE.EXPIRES' | translate }}</label>
             <mat-slide-toggle [disabled]="!canUpdate" #slideToggleExpirationDate color="primary"
                 data-automation-id="adf-expire-toggle" [checked]="form.controls['time'].value"
-                (change)="onToggleExpirationDate($event)">
+                (change)="onToggleExpirationDate($event)"
+                >
             </mat-slide-toggle>
             </div>
 
-            <mat-form-field class="adf-full-width adf-float-label" floatLabel='always'>
-                <mat-datetimepicker-toggle #matDatetimepickerToggle="matDatetimepickerToggle" [for]="datetimePicker" matSuffix></mat-datetimepicker-toggle>
-                <mat-datetimepicker #datetimePicker (closed)="onDatetimepickerClosed()" [type]="type" timeInterval="1"></mat-datetimepicker>
+            <mat-form-field class="adf-full-width">
+                <mat-datetimepicker-toggle #matDatetimepickerToggle="matDatetimepickerToggle" [disabled]="form.controls['time'].disabled" [for]="datetimePicker" matSuffix></mat-datetimepicker-toggle>
+                <mat-datetimepicker #datetimePicker  (closed)="onDatetimepickerClosed()" [type]="type" timeInterval="1"></mat-datetimepicker>
                 <input class="adf-share-link__input"
                     #dateTimePickerInput
                     matInput

--- a/lib/content-services/src/lib/content-node-share/content-node-share.dialog.html
+++ b/lib/content-services/src/lib/content-node-share/content-node-share.dialog.html
@@ -7,7 +7,7 @@
         <p class="adf-share-link__info">{{ 'SHARE.DESCRIPTION' | translate }}</p>
 
         <div class="adf-share-link--row">
-            <label class="adf-share-link__label">{{ 'SHARE.TITLE' | translate }}</label>
+            <div class="adf-share-link__label">{{ 'SHARE.TITLE' | translate }}</div>
 
             <mat-slide-toggle
                 color="primary"
@@ -40,7 +40,7 @@
             </mat-form-field>
 
             <div class="adf-share-link--row">
-                <label class="adf-share-link__label">{{ 'SHARE.EXPIRES' | translate }}</label>
+                <div class="adf-share-link__label">{{ 'SHARE.EXPIRES' | translate }}</div>
                 <mat-slide-toggle
                     #slideToggleExpirationDate
                     [disabled]="!canUpdate"

--- a/lib/content-services/src/lib/content-node-share/content-node-share.dialog.spec.ts
+++ b/lib/content-services/src/lib/content-node-share/content-node-share.dialog.spec.ts
@@ -80,6 +80,8 @@ describe('ShareDialogComponent', () => {
                 properties: {}
             }
         };
+
+        spyOn(nodesApiService, 'updateNode').and.returnValue(of({}));
     });
 
     afterEach(() => {
@@ -138,7 +140,9 @@ describe('ShareDialogComponent', () => {
     });
 
     it(`should not toggle share action when file has 'sharedId' property`, async () => {
-        spyOn(sharedLinksApiService, 'createSharedLinks');
+        spyOn(sharedLinksApiService, 'createSharedLinks').and.returnValue(of({
+            entry: { id: 'sharedId', sharedId: 'sharedId' }
+        }));
         spyOn(renditionService, 'generateRenditionForNode').and.returnValue(empty());
 
         node.entry.properties['qshare:sharedId'] = 'sharedId';
@@ -161,7 +165,6 @@ describe('ShareDialogComponent', () => {
     it('should open a confirmation dialog when unshare button is triggered', () => {
         spyOn(matDialog, 'open').and.returnValue({ beforeClose: () => of(false) });
         spyOn(sharedLinksApiService, 'deleteSharedLink').and.callThrough();
-        spyOn(nodesApiService, 'updateNode').and.returnValue(of({}));
 
         node.entry.properties['qshare:sharedId'] = 'sharedId';
 
@@ -182,7 +185,7 @@ describe('ShareDialogComponent', () => {
 
     it('should unshare file when confirmation dialog returns true', fakeAsync(() => {
         spyOn(matDialog, 'open').and.returnValue({ beforeClose: () => of(true) });
-        spyOn(sharedLinksApiService, 'deleteSharedLink').and.callThrough();
+        spyOn(sharedLinksApiService, 'deleteSharedLink').and.returnValue(of({}));
         node.entry.properties['qshare:sharedId'] = 'sharedId';
 
         component.data = {
@@ -237,7 +240,6 @@ describe('ShareDialogComponent', () => {
     });
 
     it('should reset expiration date when toggle is unchecked', () => {
-        spyOn(nodesApiService, 'updateNode').and.returnValue(of({}));
         node.entry.properties['qshare:sharedId'] = 'sharedId';
         node.entry.properties['qshare:sharedId'] = '2017-04-15T18:31:37+00:00';
         node.entry.allowableOperations = ['update'];
@@ -289,7 +291,6 @@ describe('ShareDialogComponent', () => {
         const date = moment();
         node.entry.allowableOperations = ['update'];
         node.entry.properties['qshare:sharedId'] = 'sharedId';
-        spyOn(nodesApiService, 'updateNode').and.returnValue(of({}));
         fixture.componentInstance.form.controls['time'].setValue(null);
 
         component.data = {
@@ -315,7 +316,6 @@ describe('ShareDialogComponent', () => {
 
     describe('datetimepicker type', () => {
         beforeEach(() => {
-            spyOn(nodesApiService, 'updateNode').and.returnValue(of({}));
             spyOn(sharedLinksApiService, 'createSharedLinks').and.returnValue(of({}));
             node.entry.allowableOperations = ['update'];
             component.data = {

--- a/lib/content-services/src/lib/content-node-share/content-node-share.dialog.ts
+++ b/lib/content-services/src/lib/content-node-share/content-node-share.dialog.ts
@@ -62,7 +62,7 @@ export class ShareDialogComponent implements OnInit, OnDestroy {
     isDisabled: boolean = false;
     form: FormGroup = new FormGroup({
         sharedUrl: new FormControl(''),
-        time: new FormControl({ value: '', disabled: false })
+        time: new FormControl({ value: '', disabled: true })
     });
     type = 'datetime';
 
@@ -92,7 +92,7 @@ export class ShareDialogComponent implements OnInit, OnDestroy {
         this.type = this.appConfigService.get<string>('sharedLinkDateTimePickerType', 'datetime');
 
         if (!this.canUpdate) {
-            this.form.controls['time'].disable();
+           this.form.controls['time'].disable();
         }
 
         this.form.controls.time.valueChanges
@@ -126,6 +126,12 @@ export class ShareDialogComponent implements OnInit, OnDestroy {
         }
     }
 
+    ngAfterViewInit() {
+        if (this.slideToggleExpirationDate.checked === true) {
+            this.form.controls['time'].enable();
+        }
+    }
+
     ngOnDestroy() {
         this.onDestroy$.next(true);
         this.onDestroy$.complete();
@@ -155,10 +161,9 @@ export class ShareDialogComponent implements OnInit, OnDestroy {
 
     onToggleExpirationDate(slideToggle: MatSlideToggleChange) {
         if (slideToggle.checked) {
-            this.matDatetimepickerToggle.datetimepicker.open();
+            this.form.controls['time'].enable();
         } else {
-            this.matDatetimepickerToggle.datetimepicker.close();
-            this.form.controls.time.setValue(null);
+            this.form.controls['time'].disable();
         }
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
After switching on the expiration toggle, the calendar appears. This is not proper from an accessibility standpoint. 


**What is the new behaviour?**
The field will be disabled if there is not date added into it. and when the switch toggle is turned on the field will become enabled. The action of the calendar appearing on click has been removed. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
