### PR TITLE
[ACA-2602]- Datatable - Selected state properly announced

### DIFF
--- a/lib/core/datatable/components/datatable/datatable-row.component.ts
+++ b/lib/core/datatable/components/datatable/datatable-row.component.ts
@@ -67,7 +67,11 @@ export class DataTableRowComponent implements FocusableOption {
         if (!this.row) {
             return null;
         }
-        return this.row.getValue('name') || '';
+        if (this.row.isSelected) {
+            return this.row.getValue('name') + ' selected' || '';
+        } else {
+            return this.row.getValue('name') || '';
+        }
     }
 
     @HostBinding('attr.tabindex')

--- a/lib/core/datatable/components/datatable/datatable.component.html
+++ b/lib/core/datatable/components/datatable/datatable.component.html
@@ -107,7 +107,7 @@
                      adf-drop-zone dropTarget="cell" [dropColumn]="col" [dropRow]="row">
                     <div *ngIf="!col.template" class="adf-datatable-cell-container">
                         <ng-container [ngSwitch]="col.type">
-                            <div *ngSwitchCase="'image'" class="adf-cell-value" tabindex="0">
+                            <div *ngSwitchCase="'image'" class="adf-cell-value">
                                 <mat-icon *ngIf="isIconValue(row, col); else no_iconvalue">{{ asIconValue(row, col) }}
                                 </mat-icon>
                                 <ng-template #no_iconvalue>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Selected state of items in datatable is not conveyed. And is currently reading blank SVG image.


**What is the new behaviour?**
Selected state is announced within the aria-label, and the focusable icon is now static text, as to not be read aloud to screen reader. The aria-label will take care of it. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
