### PR TITLE
[AAE-1729] Move task-process filters methods into adf-testing, refactor dropdowns to use dropdown material testing page

### DIFF
--- a/demo-shell/src/app/components/datatable/datatable.component.html
+++ b/demo-shell/src/app/components/datatable/datatable.component.html
@@ -49,7 +49,7 @@
 <div>
     <p>{{ 'DATATABLE.MULTISELECT_DESCRIPTION'| translate }}</p>
     <mat-form-field>
-        <mat-select placeholder="Selection Mode" [(ngModel)]="selectionMode" name="food">
+        <mat-select placeholder="Selection Mode" [(ngModel)]="selectionMode" name="food" data-automation-id="datatable-selection-mode">
             <mat-option *ngFor="let mode of selectionModes" [value]="mode.value">
                 {{mode.viewValue}}
             </mat-option>

--- a/e2e/content-services/upload/cancel-upload.e2e.ts
+++ b/e2e/content-services/upload/cancel-upload.e2e.ts
@@ -95,6 +95,14 @@ describe('Upload component', async () => {
     });
 
     it('[C272793] Should be able to cancel multiple files upload', async () => {
+
+        (browser.driver as any).setNetworkConditions({
+            offline: false,
+            latency: 150,
+            download_throughput: 450 * 1024,
+            upload_throughput: 100 * 1024
+        });
+
         await uploadToggles.enableMultipleFileUpload();
 
         await browser.executeScript(' setTimeout(() => {document.querySelector("#adf-upload-dialog-cancel-all").click();' +

--- a/e2e/content-services/upload/cancel-upload.e2e.ts
+++ b/e2e/content-services/upload/cancel-upload.e2e.ts
@@ -95,14 +95,6 @@ describe('Upload component', async () => {
     });
 
     it('[C272793] Should be able to cancel multiple files upload', async () => {
-
-        (browser.driver as any).setNetworkConditions({
-            offline: false,
-            latency: 150,
-            download_throughput: 450 * 1024,
-            upload_throughput: 100 * 1024
-        });
-
         await uploadToggles.enableMultipleFileUpload();
 
         await browser.executeScript(' setTimeout(() => {document.querySelector("#adf-upload-dialog-cancel-all").click();' +

--- a/e2e/core/settings-component.e2e.ts
+++ b/e2e/core/settings-component.e2e.ts
@@ -57,7 +57,6 @@ describe('Settings component', () => {
             await expect(await settingsPage.getSelectedOptionText()).toEqual('ALL', 'The Settings changes are not saved');
             await expect(await settingsPage.getBpmHostUrl()).toEqual(browser.params.testConfig.adf_aps.host, 'The BPM Settings changes are not saved');
             await expect(await settingsPage.getEcmHostUrl()).toEqual(browser.params.testConfig.adf_acs.host, 'The ECM Settings changes are not saved');
-
         });
 
         it('[C291949] Should have field validation for Content Services Url', async () => {

--- a/e2e/core/settings-component.e2e.ts
+++ b/e2e/core/settings-component.e2e.ts
@@ -61,7 +61,7 @@ describe('Settings component', () => {
         });
 
         it('[C291949] Should have field validation for Content Services Url', async () => {
-            await settingsPage.setProvider(settingsPage.getEcmAndBpmOption(), 'ALL');
+            await settingsPage.setProvider('ALL');
             await settingsPage.clearContentServicesURL();
             await settingsPage.ecmText.sendKeys(protractor.Key.TAB);
             await settingsPage.checkValidationMessageIsDisplayed();
@@ -69,7 +69,7 @@ describe('Settings component', () => {
         });
 
         it('[C291950] Should have field validation for Process Services Url', async () => {
-            await settingsPage.setProvider(settingsPage.getEcmAndBpmOption(), 'ALL');
+            await settingsPage.setProvider('ALL');
             await settingsPage.clearProcessServicesURL();
             await settingsPage.bpmText.sendKeys(protractor.Key.TAB);
             await settingsPage.checkValidationMessageIsDisplayed();
@@ -77,7 +77,7 @@ describe('Settings component', () => {
         });
 
         it('[C291951] Should not be able to sign in with invalid Content Services Url', async () => {
-            await settingsPage.setProvider(settingsPage.getEcmOption(), 'ECM');
+            await settingsPage.setProvider('ECM');
             await settingsPage.setContentServicesURL('http://localhost:7070');
             await settingsPage.clickApply();
             await loginPage.waitForElements();
@@ -88,7 +88,7 @@ describe('Settings component', () => {
         });
 
         it('[C291952] Should not be able to sign in with invalid Process Services Url', async () => {
-            await settingsPage.setProvider(settingsPage.getBpmOption(), 'BPM');
+            await settingsPage.setProvider('BPM');
             await settingsPage.setProcessServicesURL('http://localhost:7070');
             await settingsPage.clickApply();
             await loginPage.waitForElements();
@@ -102,7 +102,7 @@ describe('Settings component', () => {
     describe('Settings Component - Basic Authentication', () => {
         beforeAll(async () => {
             await settingsPage.goToSettingsPage();
-            await settingsPage.setProvider(settingsPage.getEcmAndBpmOption(), 'ALL');
+            await settingsPage.setProvider('ALL');
             await settingsPage.setContentServicesURL(browser.params.testConfig.adf_acs.host);
             await settingsPage.setProcessServicesURL(browser.params.testConfig.adf_aps.host);
             await settingsPage.clickApply();
@@ -126,7 +126,7 @@ describe('Settings component', () => {
             await loginPage.goToLoginPage();
             await loginPage.clickSettingsIcon();
             await settingsPage.checkProviderDropdownIsDisplayed();
-            await settingsPage.setProvider(settingsPage.getBpmOption(), 'BPM');
+            await settingsPage.setProvider('BPM');
             await settingsPage.clickBackButton();
             await loginPage.waitForElements();
             await loginPage.clickSettingsIcon();
@@ -156,7 +156,7 @@ describe('Settings component', () => {
         });
 
         it('[C277752] Should allow the User to login to Content Services using the ECM selection on Settings page', async () => {
-            await settingsPage.setProvider(settingsPage.getEcmOption(), 'ECM');
+            await settingsPage.setProvider('ECM');
             await settingsPage.clickBackButton();
             await loginPage.waitForElements();
             await loginPage.clickSettingsIcon();
@@ -183,7 +183,7 @@ describe('Settings component', () => {
         });
 
         it('[C277753] Should allow the User to login to both Process Services and Content Services using the ALL selection on Settings Page', async () => {
-            await settingsPage.setProvider(settingsPage.getEcmAndBpmOption(), 'ALL');
+            await settingsPage.setProvider('ALL');
             await settingsPage.clickBackButton();
             await loginPage.waitForElements();
             await loginPage.clickSettingsIcon();

--- a/e2e/pages/adf/card-view-component.page.ts
+++ b/e2e/pages/adf/card-view-component.page.ts
@@ -16,12 +16,11 @@
  */
 
 import { by, element, ElementFinder } from 'protractor';
-import { BrowserVisibility, BrowserActions, CardTextItemPage } from '@alfresco/adf-testing';
+import { BrowserVisibility, BrowserActions, CardTextItemPage, DropdownPage } from '@alfresco/adf-testing';
 
 export class CardViewComponentPage {
 
     addButton: ElementFinder = element(by.className('adf-card-view__key-value-pairs__add-btn'));
-    selectValue = 'mat-option';
     nameCardTextItem: CardTextItemPage = new CardTextItemPage('name');
     intField: ElementFinder = element(by.css(`input[data-automation-id='card-textitem-editinput-int']`));
     floatField: ElementFinder = element(by.css(`input[data-automation-id='card-textitem-editinput-float']`));
@@ -29,14 +28,14 @@ export class CardViewComponentPage {
     nameInputField: ElementFinder = element(by.xpath(`//*[contains(@id,'input') and @placeholder='Name']`));
     consoleLog: ElementFinder = element(by.className('app-console'));
     deleteButton: ElementFinder = element.all(by.className('adf-card-view__key-value-pairs__remove-btn')).first();
-    select: ElementFinder = element(by.css('mat-select[data-automation-class="select-box"]'));
     checkbox: ElementFinder = element(by.css(`mat-checkbox[data-automation-id='card-boolean-boolean']`));
     resetButton: ElementFinder = element(by.css(`#adf-reset-card-log`));
-    listContent: ElementFinder = element(by.css('.mat-select-panel'));
     editableSwitch: ElementFinder = element(by.id('app-toggle-editable'));
     clearDateSwitch: ElementFinder = element(by.id('app-toggle-clear-date'));
     noneOptionSwitch: ElementFinder = element(by.id('app-toggle-none-option'));
     clickableField: ElementFinder = element(by.css(`[data-automation-id="card-textitem-toggle-click"]`));
+
+    selectDropdown = new DropdownPage(element(by.css('mat-select[data-automation-class="select-box"]')));
 
     async clickOnAddButton(): Promise<void> {
         await BrowserActions.click(this.addButton);
@@ -151,8 +150,8 @@ export class CardViewComponentPage {
     }
 
     async clickSelectBox(): Promise<void> {
-        await BrowserActions.click(this.select);
-        await BrowserVisibility.waitUntilElementIsVisible(this.listContent);
+        await this.selectDropdown.clickDropdown();
+        await this.selectDropdown.checkOptionsPanelIsDisplayed();
     }
 
     async checkboxClick(): Promise<void> {
@@ -160,8 +159,7 @@ export class CardViewComponentPage {
     }
 
     async selectValueFromComboBox(index): Promise<void> {
-        const value: ElementFinder = element.all(by.className(this.selectValue)).get(index);
-        await BrowserActions.click(value);
+        await this.selectDropdown.selectOptionFromIndex(index);
     }
 
     async disableEdit(): Promise<void> {

--- a/e2e/pages/adf/content-services.page.ts
+++ b/e2e/pages/adf/content-services.page.ts
@@ -580,8 +580,7 @@ export class ContentServicesPage {
     }
 
     async selectGridSortingFromDropdown(sortingOption): Promise<void> {
-        await this.sortingDropdown.clickDropdown();
-        await this.sortingDropdown.selectOption(sortingOption);
+        await this.sortingDropdown.clickDropdownWithOption(sortingOption);
     }
 
     async checkRowIsDisplayed(rowName): Promise<void> {

--- a/e2e/pages/adf/content-services.page.ts
+++ b/e2e/pages/adf/content-services.page.ts
@@ -81,12 +81,14 @@ export class ContentServicesPage {
     copyContentElement: ElementFinder = element(by.css('button[data-automation-id*="COPY"]'));
     lockContentElement: ElementFinder = element(by.css('button[data-automation-id="DOCUMENT_LIST.ACTIONS.LOCK"]'));
     downloadContent: ElementFinder = element(by.css('button[data-automation-id*="DOWNLOAD"]'));
-    siteListDropdown: ElementFinder = element(by.css(`mat-select[data-automation-id='site-my-files-option']`));
     downloadButton: ElementFinder = element(by.css('button[title="Download"]'));
     favoriteButton: ElementFinder = element(by.css('button[data-automation-id="favorite"]'));
     markedFavorite: ElementFinder = element(by.cssContainingText('button[data-automation-id="favorite"] mat-icon', 'star'));
     notMarkedFavorite: ElementFinder = element(by.cssContainingText('button[data-automation-id="favorite"] mat-icon', 'star_border'));
     multiSelectToggle: ElementFinder = element(by.cssContainingText('span.mat-slide-toggle-content', ' Multiselect (with checkboxes) '));
+
+    siteListDropdown = new DropdownPage(element(by.css(`mat-select[data-automation-id='site-my-files-option']`)));
+    sortingDropdown = new DropdownPage(element(by.css('mat-select[data-automation-id="grid-view-sorting"]')));
 
     async pressContextMenuActionNamed(actionName): Promise<void> {
         await BrowserActions.clickExecuteScript(`button[data-automation-id="context-${actionName}"]`);
@@ -577,11 +579,9 @@ export class ContentServicesPage {
         await browser.actions().sendKeys(protractor.Key.ENTER).perform();
     }
 
-    async selectGridSortingFromDropdown(sortingChosen): Promise<void> {
-        const sortingDropdown: ElementFinder = element(by.css('mat-select[data-automation-id="grid-view-sorting"]'));
-        await BrowserActions.click(sortingDropdown);
-        const optionToClick: ElementFinder = element(by.css(`mat-option[data-automation-id="grid-view-sorting-${sortingChosen}"]`));
-        await BrowserActions.click(optionToClick);
+    async selectGridSortingFromDropdown(sortingOption): Promise<void> {
+        await this.sortingDropdown.clickDropdown();
+        await this.sortingDropdown.selectOption(sortingOption);
     }
 
     async checkRowIsDisplayed(rowName): Promise<void> {
@@ -595,13 +595,11 @@ export class ContentServicesPage {
     }
 
     async checkSelectedSiteIsDisplayed(siteName): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.siteListDropdown.element(by.cssContainingText('.mat-select-value-text span', siteName)));
+        await this.siteListDropdown.checkSelectedOptionIsDisplayed(siteName);
     }
 
     async selectSite(siteName: string): Promise<void> {
-        const dropdownPage = new DropdownPage(this.siteListDropdown);
-        await dropdownPage.clickDropdown();
-        await dropdownPage.selectOption(siteName);
+        await this.siteListDropdown.selectOption(siteName);
     }
 
     async clickDownloadButton(): Promise<void> {

--- a/e2e/pages/adf/content-services.page.ts
+++ b/e2e/pages/adf/content-services.page.ts
@@ -595,7 +595,7 @@ export class ContentServicesPage {
     }
 
     async checkSelectedSiteIsDisplayed(siteName): Promise<void> {
-        await this.siteListDropdown.checkSelectedOptionIsDisplayed(siteName);
+        await this.siteListDropdown.checkOptionIsSelected(siteName);
     }
 
     async selectSite(siteName: string): Promise<void> {

--- a/e2e/pages/adf/content-services.page.ts
+++ b/e2e/pages/adf/content-services.page.ts
@@ -598,7 +598,7 @@ export class ContentServicesPage {
     }
 
     async selectSite(siteName: string): Promise<void> {
-        await this.siteListDropdown.selectOption(siteName);
+        await this.siteListDropdown.clickDropdownWithOption(siteName);
     }
 
     async clickDownloadButton(): Promise<void> {

--- a/e2e/pages/adf/content-services/breadcrumb/bread-crumb-dropdown.page.ts
+++ b/e2e/pages/adf/content-services/breadcrumb/bread-crumb-dropdown.page.ts
@@ -16,19 +16,18 @@
  */
 
 import { element, by, ElementFinder } from 'protractor';
-import { BrowserVisibility, BrowserActions } from '@alfresco/adf-testing';
+import { BrowserActions, DropdownPage } from '@alfresco/adf-testing';
 
 export class BreadCrumbDropdownPage {
 
     breadCrumb: ElementFinder = element(by.css(`adf-dropdown-breadcrumb[data-automation-id='content-node-selector-content-breadcrumb']`));
     parentFolder = this.breadCrumb.element(by.css(`button[data-automation-id='dropdown-breadcrumb-trigger']`));
-    breadCrumbDropdown: ElementFinder = element.all(by.css(`div[class*='mat-select-panel']`)).first();
     currentFolder = this.breadCrumb.element(by.css(`div span[data-automation-id="current-folder"]`));
 
+    breadCrumbDropdown = new DropdownPage(element.all(by.css(`div[class*='mat-select-panel']`)).first());
+
     async choosePath(pathName): Promise<void> {
-        const path = this.breadCrumbDropdown.element(by.cssContainingText(`mat-option[data-automation-class='dropdown-breadcrumb-path-option'] span[class='mat-option-text']`,
-            pathName));
-        await BrowserActions.click(path);
+        await this.breadCrumbDropdown.selectOption(pathName);
     }
 
     async clickParentFolder(): Promise<void> {
@@ -36,7 +35,7 @@ export class BreadCrumbDropdownPage {
     }
 
     async checkBreadCrumbDropdownIsDisplayed(): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.breadCrumbDropdown);
+        await this.breadCrumbDropdown.checkDropdownIsVisible();
     }
 
     async getTextOfCurrentFolder(): Promise<string> {

--- a/e2e/pages/adf/demo-shell/data-table.page.ts
+++ b/e2e/pages/adf/demo-shell/data-table.page.ts
@@ -129,8 +129,7 @@ export class DataTablePage {
     }
 
     async selectSelectionMode(selectionMode): Promise<void> {
-        await this.selectModeDropdown.clickDropdown();
-        await this.selectModeDropdown.selectOption(selectionMode);
+        await this.selectModeDropdown.clickDropdownWithOption(selectionMode);
     }
 
     getRowCheckbox(rowNumber: string): ElementFinder {

--- a/e2e/pages/adf/demo-shell/data-table.page.ts
+++ b/e2e/pages/adf/demo-shell/data-table.page.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { BrowserActions, BrowserVisibility, DataTableComponentPage } from '@alfresco/adf-testing';
+import { BrowserActions, BrowserVisibility, DataTableComponentPage, DropdownPage } from '@alfresco/adf-testing';
 import { browser, by, element, ElementArrayFinder, ElementFinder, protractor } from 'protractor';
 
 export class DataTablePage {
@@ -44,6 +44,8 @@ export class DataTablePage {
     createdOnColumn: ElementFinder = element(by.css(`div[data-automation-id='auto_id_createdOn']`));
     idColumnHeader: ElementFinder = element(by.css(`div[data-automation-id='auto_id_id']`));
     pasteClipboardInput: ElementFinder = element(by.css(`input[data-automation-id='paste clipboard input']`));
+
+    selectModeDropdown = new DropdownPage(element(by.css(`mat-select[data-automation-id='datatable-selection-mode']`)));
 
     constructor(data?) {
         if (this.data[data]) {
@@ -127,9 +129,8 @@ export class DataTablePage {
     }
 
     async selectSelectionMode(selectionMode): Promise<void> {
-        const selectMode: ElementFinder = element(by.cssContainingText(`span[class='mat-option-text']`, selectionMode));
-        await BrowserActions.clickExecuteScript('div[class="mat-select-arrow"]');
-        await BrowserActions.click(selectMode);
+        await this.selectModeDropdown.clickDropdown();
+        await this.selectModeDropdown.selectOption(selectionMode);
     }
 
     getRowCheckbox(rowNumber: string): ElementFinder {

--- a/e2e/pages/adf/demo-shell/process-services/process-cloud-demo.page.ts
+++ b/e2e/pages/adf/demo-shell/process-services/process-cloud-demo.page.ts
@@ -20,18 +20,12 @@ import { by, element, ElementFinder } from 'protractor';
 
 export class ProcessCloudDemoPage {
 
-    allProcesses: ElementFinder = element(by.css('span[data-automation-id="all-processes_filter"]'));
-    runningProcesses: ElementFinder = element(by.css('span[data-automation-id="running-processes_filter"]'));
-    completedProcesses: ElementFinder = element(by.css('span[data-automation-id="completed-processes_filter"]'));
-    activeFilter: ElementFinder = element(by.css("mat-list-item[class*='active'] span"));
-    processFilters: ElementFinder = element(by.css("mat-expansion-panel[data-automation-id='Process Filters']"));
-    processFiltersList: ElementFinder = element(by.css('adf-cloud-process-filters'));
-
     createButton: ElementFinder = element(by.css('button[data-automation-id="create-button"'));
     newProcessButton: ElementFinder = element(by.css('button[data-automation-id="btn-start-process"]'));
 
     processListCloud = new ProcessListCloudComponentPage();
     editProcessFilterCloud = new EditProcessFilterCloudComponentPage();
+    processFilterCloudComponent = new ProcessFiltersCloudComponentPage();
 
     editProcessFilterCloudComponent(): EditProcessFilterCloudComponentPage {
         return this.editProcessFilterCloud;
@@ -45,31 +39,6 @@ export class ProcessCloudDemoPage {
         return this.processListCloud.getAllRowsByColumn('Id');
     }
 
-    allProcessesFilter(): ProcessFiltersCloudComponentPage {
-        return new ProcessFiltersCloudComponentPage(this.allProcesses);
-    }
-
-    runningProcessesFilter(): ProcessFiltersCloudComponentPage {
-        return new ProcessFiltersCloudComponentPage(this.runningProcesses);
-    }
-
-    completedProcessesFilter(): ProcessFiltersCloudComponentPage {
-        return new ProcessFiltersCloudComponentPage(this.completedProcesses);
-    }
-
-    customProcessFilter(filterName): ProcessFiltersCloudComponentPage {
-        return new ProcessFiltersCloudComponentPage(element(by.css(`span[data-automation-id="${filterName}_filter"]`)));
-    }
-
-    async getActiveFilterName(): Promise<string> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.activeFilter);
-        return BrowserActions.getText(this.activeFilter);
-    }
-
-    async clickOnProcessFilters(): Promise<void> {
-        await BrowserActions.click(this.processFilters);
-    }
-
     async openNewProcessForm(): Promise<void> {
         await this.clickOnCreateButton();
         await this.newProcessButtonIsDisplayed();
@@ -78,10 +47,6 @@ export class ProcessCloudDemoPage {
 
     async newProcessButtonIsDisplayed(): Promise<void> {
         await BrowserVisibility.waitUntilElementIsClickable(this.newProcessButton);
-    }
-
-    async isProcessFiltersListVisible(): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.processFiltersList);
     }
 
     async clickOnCreateButton(): Promise<void> {

--- a/e2e/pages/adf/demo-shell/process-services/process-list-demo.page.ts
+++ b/e2e/pages/adf/demo-shell/process-services/process-list-demo.page.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { BrowserActions, BrowserVisibility, DataTableComponentPage } from '@alfresco/adf-testing';
+import { BrowserActions, BrowserVisibility, DataTableComponentPage, DropdownPage } from '@alfresco/adf-testing';
 import { by, element, ElementFinder, protractor } from 'protractor';
 
 export class ProcessListDemoPage {
@@ -25,8 +25,9 @@ export class ProcessListDemoPage {
     emptyProcessContent: ElementFinder = element(by.css('div[class="adf-empty-content"]'));
     processDefinitionInput: ElementFinder = element(by.css('input[data-automation-id="process-definition-id"]'));
     processInstanceInput: ElementFinder = element(by.css('input[data-automation-id="process-instance-id"]'));
-    stateSelector: ElementFinder = element(by.css('mat-select[data-automation-id="state"'));
-    sortSelector: ElementFinder = element(by.css('mat-select[data-automation-id="sort"'));
+
+    stateDropdown = new DropdownPage(element(by.css('mat-select[data-automation-id="state"')));
+    sortDropdown = new DropdownPage(element(by.css('mat-select[data-automation-id="sort"')));
 
     dataTable: DataTableComponentPage = new DataTableComponentPage();
 
@@ -34,16 +35,14 @@ export class ProcessListDemoPage {
         return this.dataTable.getAllRowsColumnValues('Name');
     }
 
-    async selectSorting(sort): Promise<void> {
-        await BrowserActions.click(this.sortSelector);
-        const sortLocator: ElementFinder = element(by.cssContainingText('mat-option span', sort));
-        await BrowserActions.click(sortLocator);
+    async selectSorting(sortingOption: string): Promise<void> {
+        await this.sortDropdown.clickDropdown();
+        await this.sortDropdown.selectOption(sortingOption);
     }
 
-    async selectStateFilter(state): Promise<void> {
-        await BrowserActions.click(this.stateSelector);
-        const stateLocator: ElementFinder = element(by.cssContainingText('mat-option span', state));
-        await BrowserActions.click(stateLocator);
+    async selectStateFilter(stateOption: string): Promise<void> {
+        await this.stateDropdown.clickDropdown();
+        await this.stateDropdown.selectOption(stateOption);
     }
 
     async addAppId(appId): Promise<void> {
@@ -82,12 +81,12 @@ export class ProcessListDemoPage {
         await BrowserVisibility.waitUntilElementIsVisible(this.processInstanceInput);
     }
 
-    async checkStateFieldIsDisplayed(): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.stateSelector);
+    async checkStateDropdownIsDisplayed(): Promise<void> {
+        await this.stateDropdown.checkDropdownIsVisible();
     }
 
-    async checkSortFieldIsDisplayed(): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.sortSelector);
+    async checkSortDropdownIsDisplayed(): Promise<void> {
+        await this.sortDropdown.checkDropdownIsVisible();
     }
 
     async addProcessDefinitionId(procDefinitionId): Promise<void> {

--- a/e2e/pages/adf/demo-shell/process-services/process-list-demo.page.ts
+++ b/e2e/pages/adf/demo-shell/process-services/process-list-demo.page.ts
@@ -36,13 +36,11 @@ export class ProcessListDemoPage {
     }
 
     async selectSorting(sortingOption: string): Promise<void> {
-        await this.sortDropdown.clickDropdown();
-        await this.sortDropdown.selectOption(sortingOption);
+        await this.sortDropdown.clickDropdownWithOption(sortingOption);
     }
 
     async selectStateFilter(stateOption: string): Promise<void> {
-        await this.stateDropdown.clickDropdown();
-        await this.stateDropdown.selectOption(stateOption);
+        await this.stateDropdown.clickDropdownWithOption(stateOption);
     }
 
     async addAppId(appId): Promise<void> {

--- a/e2e/pages/adf/demo-shell/process-services/task-list-demo.page.ts
+++ b/e2e/pages/adf/demo-shell/process-services/task-list-demo.page.ts
@@ -139,9 +139,7 @@ export class TaskListDemoPage {
     }
 
     async selectState(state): Promise<void> {
-        await this.stateDropdown.clickDropdown();
-        await this.stateDropdown.checkOptionsPanelIsDisplayed();
-        await this.stateDropdown.selectOption(state);
+        await this.stateDropdown.clickDropdownWithOption(state);
     }
 
     getAllProcessDefinitionIds(): Promise<any> {

--- a/e2e/pages/adf/demo-shell/process-services/task-list-demo.page.ts
+++ b/e2e/pages/adf/demo-shell/process-services/task-list-demo.page.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { BrowserActions, BrowserVisibility, PaginationPage } from '@alfresco/adf-testing';
+import { BrowserActions, BrowserVisibility, DropdownPage, PaginationPage } from '@alfresco/adf-testing';
 import { by, element, ElementFinder } from 'protractor';
 import { TasksListPage } from '../../process-services/tasks-list.page';
 
@@ -34,8 +34,9 @@ export class TaskListDemoPage {
     dueBefore: ElementFinder = element(by.css("input[data-automation-id='due before']"));
     dueAfter: ElementFinder = element(by.css("input[data-automation-id='due after']"));
     taskId: ElementFinder = element(by.css("input[data-automation-id='task id']"));
+
     stateDropDownArrow: ElementFinder = element(by.css("mat-form-field[data-automation-id='state'] div[class*='arrow']"));
-    stateSelector: ElementFinder = element(by.css("div[class*='mat-select-panel']"));
+    stateDropdown = new DropdownPage(this.stateDropDownArrow);
 
     taskList(): TasksListPage {
         return this.taskListPage;
@@ -138,15 +139,9 @@ export class TaskListDemoPage {
     }
 
     async selectState(state): Promise<void> {
-        await this.clickOnStateDropDownArrow();
-
-        const stateElement: ElementFinder = element.all(by.cssContainingText('mat-option span', state)).first();
-        await BrowserActions.click(stateElement);
-    }
-
-    async clickOnStateDropDownArrow(): Promise<void> {
-        await BrowserActions.click(this.stateDropDownArrow);
-        await BrowserVisibility.waitUntilElementIsVisible(this.stateSelector);
+        await this.stateDropdown.clickDropdown();
+        await this.stateDropdown.checkOptionsPanelIsDisplayed();
+        await this.stateDropdown.selectOption(state);
     }
 
     getAllProcessDefinitionIds(): Promise<any> {

--- a/e2e/pages/adf/demo-shell/process-services/task-list-demo.page.ts
+++ b/e2e/pages/adf/demo-shell/process-services/task-list-demo.page.ts
@@ -35,7 +35,7 @@ export class TaskListDemoPage {
     dueAfter: ElementFinder = element(by.css("input[data-automation-id='due after']"));
     taskId: ElementFinder = element(by.css("input[data-automation-id='task id']"));
 
-    stateDropDownArrow: ElementFinder = element(by.css("mat-form-field[data-automation-id='state'] div[class*='arrow']"));
+    stateDropDownArrow: ElementFinder = element(by.css("mat-form-field[data-automation-id='state']"));
     stateDropdown = new DropdownPage(this.stateDropDownArrow);
 
     taskList(): TasksListPage {

--- a/e2e/pages/adf/demo-shell/process-services/tasks-cloud-demo.page.ts
+++ b/e2e/pages/adf/demo-shell/process-services/tasks-cloud-demo.page.ts
@@ -27,12 +27,6 @@ import {
 
 export class TasksCloudDemoPage {
 
-    myTasks: ElementFinder = element(by.css('span[data-automation-id="my-tasks-filter"]'));
-    completedTasks: ElementFinder = element(by.css('span[data-automation-id="completed-tasks-filter"]'));
-    activeFilter: ElementFinder = element(by.css("mat-list-item[class*='active'] span"));
-
-    defaultActiveFilter: ElementFinder = element.all(by.css('.adf-filters__entry')).first();
-
     createButton: ElementFinder = element(by.css('button[data-automation-id="create-button"'));
     newTaskButton: ElementFinder = element(by.css('button[data-automation-id="btn-start-task"]'));
     settingsButton: ElementFinder = element.all(by.cssContainingText('div[class*="mat-tab-label"] .mat-tab-labels div', 'Settings')).first();
@@ -54,11 +48,12 @@ export class TasksCloudDemoPage {
     addActionButton: ElementFinder = element(by.cssContainingText('button span', 'Add'));
     disableCheckbox: ElementFinder = element(by.css(`mat-checkbox[formcontrolname='disabled']`));
     visibleCheckbox: ElementFinder = element(by.css(`mat-checkbox[formcontrolname='visible']`));
-    filter: ElementFinder = element(by.css(`mat-expansion-panel[data-automation-id='Task Filters']`));
 
     formControllersPage: FormControllersPage = new FormControllersPage();
 
     editTaskFilterCloud: EditTaskFilterCloudComponentPage = new EditTaskFilterCloudComponentPage();
+
+    taskFilterCloudComponent = new TaskFiltersCloudComponentPage();
 
     async disableDisplayTaskDetails(): Promise<void> {
         await this.formControllersPage.disableToggle(this.displayTaskDetailsToggle);
@@ -84,10 +79,6 @@ export class TasksCloudDemoPage {
         await this.formControllersPage.enableToggle(this.testingModeToggle);
     }
 
-    async clickOnTaskFilter(): Promise<void> {
-        await BrowserActions.click(this.filter);
-    }
-
     taskListCloudComponent(): TaskListCloudComponentPage {
         return new TaskListCloudComponentPage();
     }
@@ -96,31 +87,9 @@ export class TasksCloudDemoPage {
         return this.editTaskFilterCloud;
     }
 
-    myTasksFilter(): TaskFiltersCloudComponentPage {
-        return new TaskFiltersCloudComponentPage(this.myTasks);
-    }
-
-    completedTasksFilter(): TaskFiltersCloudComponentPage {
-        return new TaskFiltersCloudComponentPage(this.completedTasks);
-    }
-
-    async getActiveFilterName(): Promise<string> {
-        await browser.sleep(500);
-        return BrowserActions.getText(this.activeFilter);
-    }
-
-    customTaskFilter(filterName): TaskFiltersCloudComponentPage {
-        return new TaskFiltersCloudComponentPage(element(by.css(`span[data-automation-id="${filterName}-filter"]`)));
-    }
-
     async openNewTaskForm(): Promise<void> {
         await BrowserActions.click(this.createButton);
         await BrowserActions.clickExecuteScript('button[data-automation-id="btn-start-task"]');
-    }
-
-    async firstFilterIsActive(): Promise<boolean> {
-        const value = await this.defaultActiveFilter.getAttribute('class');
-        return value.includes('adf-active');
     }
 
     async clickSettingsButton(): Promise<void> {

--- a/e2e/pages/adf/demo-shell/process-services/tasks-cloud-demo.page.ts
+++ b/e2e/pages/adf/demo-shell/process-services/tasks-cloud-demo.page.ts
@@ -22,7 +22,7 @@ import {
     EditTaskFilterCloudComponentPage,
     BrowserVisibility,
     TaskListCloudComponentPage,
-    BrowserActions
+    BrowserActions, DropdownPage
 } from '@alfresco/adf-testing';
 
 export class TasksCloudDemoPage {
@@ -31,8 +31,6 @@ export class TasksCloudDemoPage {
     newTaskButton: ElementFinder = element(by.css('button[data-automation-id="btn-start-task"]'));
     settingsButton: ElementFinder = element.all(by.cssContainingText('div[class*="mat-tab-label"] .mat-tab-labels div', 'Settings')).first();
     appButton: ElementFinder = element.all(by.cssContainingText('div[class*="mat-tab-label"] .mat-tab-labels div', 'App')).first();
-    modeDropDownArrow: ElementFinder = element(by.css('mat-form-field[data-automation-id="selectionMode"] div[class*="arrow-wrapper"]'));
-    modeSelector: ElementFinder = element(by.css("div[class*='mat-select-panel']"));
     displayTaskDetailsToggle: ElementFinder = element(by.css('mat-slide-toggle[data-automation-id="taskDetailsRedirection"]'));
     displayProcessDetailsToggle: ElementFinder = element(by.css('mat-slide-toggle[data-automation-id="processDetailsRedirection"]'));
     actionMenuToggle: ElementFinder = element(by.css('mat-slide-toggle[data-automation-id="actionmenu"]'));
@@ -48,6 +46,8 @@ export class TasksCloudDemoPage {
     addActionButton: ElementFinder = element(by.cssContainingText('button span', 'Add'));
     disableCheckbox: ElementFinder = element(by.css(`mat-checkbox[formcontrolname='disabled']`));
     visibleCheckbox: ElementFinder = element(by.css(`mat-checkbox[formcontrolname='visible']`));
+
+    modeDropdown = new DropdownPage(element(by.css('mat-form-field[data-automation-id="selectionMode"] div[class*="arrow-wrapper"]')));
 
     formControllersPage: FormControllersPage = new FormControllersPage();
 
@@ -96,7 +96,7 @@ export class TasksCloudDemoPage {
         await BrowserActions.click(this.settingsButton);
         await browser.sleep(400);
         await BrowserVisibility.waitUntilElementIsVisible(this.multiSelectionToggle);
-        await BrowserVisibility.waitUntilElementIsClickable(this.modeDropDownArrow);
+        await this.modeDropdown.checkDropdownIsClickable();
     }
 
     async clickAppButton(): Promise<void> {
@@ -104,15 +104,8 @@ export class TasksCloudDemoPage {
     }
 
     async selectSelectionMode(mode): Promise<void> {
-        await this.clickOnSelectionModeDropDownArrow();
-
-        const modeElement: ElementFinder = element.all(by.cssContainingText('mat-option span', mode)).first();
-        await BrowserActions.click(modeElement);
-    }
-
-    async clickOnSelectionModeDropDownArrow(): Promise<void> {
-        await BrowserActions.click(this.modeDropDownArrow);
-        await BrowserVisibility.waitUntilElementIsVisible(this.modeSelector);
+        await this.modeDropdown.clickDropdown();
+        await this.modeDropdown.selectOption(mode);
     }
 
     async checkSelectedRowsIsDisplayed(): Promise<void> {

--- a/e2e/pages/adf/demo-shell/process-services/tasks-cloud-demo.page.ts
+++ b/e2e/pages/adf/demo-shell/process-services/tasks-cloud-demo.page.ts
@@ -47,7 +47,7 @@ export class TasksCloudDemoPage {
     disableCheckbox: ElementFinder = element(by.css(`mat-checkbox[formcontrolname='disabled']`));
     visibleCheckbox: ElementFinder = element(by.css(`mat-checkbox[formcontrolname='visible']`));
 
-    modeDropdown = new DropdownPage(element(by.css('mat-form-field[data-automation-id="selectionMode"] div[class*="arrow-wrapper"]')));
+    modeDropdown = new DropdownPage(element(by.css('mat-form-field[data-automation-id="selectionMode"]')));
 
     formControllersPage: FormControllersPage = new FormControllersPage();
 

--- a/e2e/pages/adf/notification.page.ts
+++ b/e2e/pages/adf/notification.page.ts
@@ -66,18 +66,15 @@ export class NotificationPage {
     }
 
     async selectHorizontalPosition(selectItem): Promise<void> {
-        await this.horizontalPositionDropdown.clickDropdown();
-        await this.horizontalPositionDropdown.selectOption(selectItem);
+        await this.horizontalPositionDropdown.clickDropdownWithOption(selectItem);
     }
 
     async selectVerticalPosition(selectItem): Promise<void> {
-        await this.verticalPositionDropdown.clickDropdown();
-        await this.verticalPositionDropdown.selectOption(selectItem);
+        await this.verticalPositionDropdown.clickDropdownWithOption(selectItem);
     }
 
     async selectDirection(selectItem): Promise<void> {
-        await this.directionDropdown.clickDropdown();
-        await this.directionDropdown.selectOption(selectItem);
+        await this.directionDropdown.clickDropdownWithOption(selectItem);
     }
 
     async clickNotificationButton(): Promise<void> {

--- a/e2e/pages/adf/notification.page.ts
+++ b/e2e/pages/adf/notification.page.ts
@@ -16,21 +16,21 @@
  */
 
 import { element, by, browser, ElementFinder } from 'protractor';
-import { BrowserVisibility, BrowserActions } from '@alfresco/adf-testing';
+import { BrowserVisibility, BrowserActions, DropdownPage } from '@alfresco/adf-testing';
 
 export class NotificationPage {
 
     messageField: ElementFinder = element(by.css('input[data-automation-id="notification-message"]'));
-    horizontalPosition: ElementFinder = element(by.css('mat-select[data-automation-id="notification-horizontal-position"]'));
-    verticalPosition: ElementFinder = element(by.css('mat-select[data-automation-id="notification-vertical-position"]'));
     durationField: ElementFinder = element(by.css('input[data-automation-id="notification-duration"]'));
-    direction: ElementFinder = element(by.css('mat-select[data-automation-id="notification-direction"]'));
     actionToggle: ElementFinder = element(by.css('mat-slide-toggle[data-automation-id="notification-action-toggle"]'));
     notificationSnackBar: ElementFinder = element.all(by.css('simple-snack-bar')).first();
     actionOutput: ElementFinder = element(by.css('div[data-automation-id="notification-action-output"]'));
-    selectionDropDown: ElementFinder = element.all(by.css('.mat-select-panel')).first();
     notificationsPage: ElementFinder = element(by.css('.app-sidenav-link[data-automation-id="Notifications"]'));
     notificationConfig: ElementFinder = element(by.css('p[data-automation-id="notification-custom-object"]'));
+
+    horizontalPositionDropdown = new DropdownPage(element(by.css('mat-select[data-automation-id="notification-horizontal-position"]')));
+    verticalPositionDropdown = new DropdownPage(element(by.css('mat-select[data-automation-id="notification-vertical-position"]')));
+    directionDropdown = new DropdownPage(element(by.css('mat-select[data-automation-id="notification-direction"]')));
 
     async checkNotifyContains(message): Promise<void> {
         await BrowserVisibility.waitUntilElementIsVisible(element.all(by.cssContainingText('simple-snack-bar', message)).first());
@@ -65,25 +65,19 @@ export class NotificationPage {
         await BrowserActions.clearSendKeys(this.durationField, time);
     }
 
-    async selectHorizontalPosition(selectedItem): Promise<void> {
-        const selectItem: ElementFinder = element(by.cssContainingText('span[class="mat-option-text"]', selectedItem));
-        await BrowserActions.click(this.horizontalPosition);
-        await BrowserVisibility.waitUntilElementIsVisible(this.selectionDropDown);
-        await BrowserActions.click(selectItem);
+    async selectHorizontalPosition(selectItem): Promise<void> {
+        await this.horizontalPositionDropdown.clickDropdown();
+        await this.horizontalPositionDropdown.selectOption(selectItem);
     }
 
-    async selectVerticalPosition(selectedItem): Promise<void> {
-        const selectItem: ElementFinder = element(by.cssContainingText('span[class="mat-option-text"]', selectedItem));
-        await BrowserActions.click(this.verticalPosition);
-        await BrowserVisibility.waitUntilElementIsVisible(this.selectionDropDown);
-        await BrowserActions.click(selectItem);
+    async selectVerticalPosition(selectItem): Promise<void> {
+        await this.verticalPositionDropdown.clickDropdown();
+        await this.verticalPositionDropdown.selectOption(selectItem);
     }
 
-    async selectDirection(selectedItem): Promise<void> {
-        const selectItem: ElementFinder = element(by.cssContainingText('span[class="mat-option-text"]', selectedItem));
-        await BrowserActions.click(this.direction);
-        await BrowserVisibility.waitUntilElementIsVisible(this.selectionDropDown);
-        await BrowserActions.click(selectItem);
+    async selectDirection(selectItem): Promise<void> {
+        await this.directionDropdown.clickDropdown();
+        await this.directionDropdown.selectOption(selectItem);
     }
 
     async clickNotificationButton(): Promise<void> {

--- a/e2e/pages/adf/permissions.page.ts
+++ b/e2e/pages/adf/permissions.page.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { BrowserActions, BrowserVisibility, DataTableComponentPage } from '@alfresco/adf-testing';
+import { BrowserActions, BrowserVisibility, DataTableComponentPage, DropdownPage } from '@alfresco/adf-testing';
 import { by, element, ElementFinder } from 'protractor';
 
 const column = {
@@ -120,8 +120,7 @@ export class PermissionsPage {
     }
 
     async selectOption(name): Promise<void> {
-        const selectProcessDropdown = element(by.cssContainingText('.mat-option-text', name));
-        await BrowserActions.click(selectProcessDropdown);
+        await new DropdownPage().selectOption(name);
     }
 
     async checkPermissionContainerIsDisplayed(): Promise<void> {

--- a/e2e/pages/adf/process-services/attach-form.page.ts
+++ b/e2e/pages/adf/process-services/attach-form.page.ts
@@ -16,7 +16,7 @@
  */
 
 import { element, by, ElementFinder } from 'protractor';
-import { BrowserVisibility, BrowserActions } from '@alfresco/adf-testing';
+import { BrowserVisibility, BrowserActions, DropdownPage } from '@alfresco/adf-testing';
 
 export class AttachFormPage {
 
@@ -26,7 +26,7 @@ export class AttachFormPage {
     formDropdown: ElementFinder = element(by.id('form_id'));
     cancelButton: ElementFinder = element(by.id('adf-no-form-cancel-button'));
     defaultTitle: ElementFinder = element(by.css('mat-card-title[class="mat-card-title mat-card-title"]'));
-    attachFormDropdown: ElementFinder = element(by.css("div[class='adf-attach-form-row']"));
+    attachFormDropdown = new DropdownPage(element(by.css("div[class='adf-attach-form-row']")));
 
     async checkNoFormMessageIsDisplayed(): Promise<void> {
         await BrowserVisibility.waitUntilElementIsVisible(this.noFormMessage);
@@ -58,11 +58,11 @@ export class AttachFormPage {
     }
 
     async clickAttachFormDropdown(): Promise<void> {
-        await BrowserActions.click(this.attachFormDropdown);
+        await this.attachFormDropdown.clickDropdown();
     }
 
     async selectAttachFormOption(option): Promise<void> {
-        await BrowserActions.click(element(by.cssContainingText("mat-option[role='option']", option)));
+        await this.attachFormDropdown.selectOption(option);
     }
 
     async clickCancelButton(): Promise<void> {

--- a/e2e/pages/adf/process-services/attach-form.page.ts
+++ b/e2e/pages/adf/process-services/attach-form.page.ts
@@ -57,12 +57,8 @@ export class AttachFormPage {
         await BrowserVisibility.waitUntilElementIsVisible(this.cancelButton);
     }
 
-    async clickAttachFormDropdown(): Promise<void> {
-        await this.attachFormDropdown.clickDropdown();
-    }
-
     async selectAttachFormOption(option): Promise<void> {
-        await this.attachFormDropdown.selectOption(option);
+        await this.attachFormDropdown.clickDropdownWithOption(option);
     }
 
     async clickCancelButton(): Promise<void> {

--- a/e2e/pages/adf/process-services/dialog/start-task-dialog.page.ts
+++ b/e2e/pages/adf/process-services/dialog/start-task-dialog.page.ts
@@ -16,7 +16,7 @@
  */
 
 import { element, by, Key, ElementFinder } from 'protractor';
-import { BrowserVisibility, BrowserActions } from '@alfresco/adf-testing';
+import { BrowserVisibility, BrowserActions, DropdownPage } from '@alfresco/adf-testing';
 
 export class StartTaskDialogPage {
 
@@ -27,7 +27,9 @@ export class StartTaskDialogPage {
     startButton: ElementFinder = element(by.css('button[id="button-start"]'));
     startButtonEnabled: ElementFinder = element(by.css('button[id="button-start"]:not(disabled)'));
     cancelButton: ElementFinder = element(by.css('button[id="button-cancel"]'));
-    formDropDown: ElementFinder = element(by.css('mat-select[id="form_id"]'));
+
+    selectFormDropdown = new DropdownPage(element(by.css('mat-select[id="form_id"]')));
+    selectAssigneeDropdown = new DropdownPage();
 
     async addName(userName): Promise<void> {
         await BrowserVisibility.waitUntilElementIsVisible(this.name);
@@ -52,9 +54,7 @@ export class StartTaskDialogPage {
     }
 
     async selectAssigneeFromList(name): Promise<void> {
-        const assigneeRow: ElementFinder = element(by.cssContainingText('mat-option span.adf-people-label-name', name));
-        await BrowserActions.click(assigneeRow);
-        await BrowserVisibility.waitUntilElementIsNotVisible(assigneeRow);
+        await this.selectAssigneeDropdown.selectOption(name);
     }
 
     async getAssignee(): Promise<string> {
@@ -62,14 +62,9 @@ export class StartTaskDialogPage {
         return this.assignee.getAttribute('placeholder');
     }
 
-    async addForm(form): Promise<void> {
-        await BrowserActions.click(this.formDropDown);
-        return this.selectForm(form);
-    }
-
     async selectForm(form): Promise<void> {
-        const option: ElementFinder = element(by.cssContainingText('span[class*="mat-option-text"]', form));
-        await BrowserActions.click(option);
+        await this.selectFormDropdown.clickDropdown();
+        await this.selectFormDropdown.selectOption(form);
     }
 
     async clickStartButton(): Promise<void> {

--- a/e2e/pages/adf/process-services/dialog/start-task-dialog.page.ts
+++ b/e2e/pages/adf/process-services/dialog/start-task-dialog.page.ts
@@ -63,8 +63,7 @@ export class StartTaskDialogPage {
     }
 
     async selectForm(form): Promise<void> {
-        await this.selectFormDropdown.clickDropdown();
-        await this.selectFormDropdown.selectOption(form);
+        await this.selectFormDropdown.clickDropdownWithOption(form);
     }
 
     async clickStartButton(): Promise<void> {

--- a/e2e/pages/adf/process-services/start-process.page.ts
+++ b/e2e/pages/adf/process-services/start-process.page.ts
@@ -16,7 +16,7 @@
  */
 
 import { by, element, Key, protractor, browser, ElementFinder } from 'protractor';
-import { BrowserVisibility, BrowserActions, FormFields } from '@alfresco/adf-testing';
+import { BrowserVisibility, BrowserActions, FormFields, DropdownPage } from '@alfresco/adf-testing';
 
 export class StartProcessPage {
 
@@ -29,6 +29,8 @@ export class StartProcessPage {
     noProcess: ElementFinder = element(by.id('no-process-message'));
     processDefinition: ElementFinder = element(by.css('input[id="processDefinitionName"]'));
     processDefinitionOptionsPanel: ElementFinder = element(by.css('div[class*="processDefinitionOptions"]'));
+
+    dropdownPage = new DropdownPage();
 
     async checkNoProcessMessage(): Promise<void> {
         await BrowserVisibility.waitUntilElementIsVisible(this.noProcess);
@@ -67,19 +69,15 @@ export class StartProcessPage {
     }
 
     async checkOptionIsDisplayed(name): Promise<void> {
-        const selectProcessDropdown: ElementFinder = element(by.cssContainingText('.mat-option-text', name));
-        await BrowserVisibility.waitUntilElementIsVisible(selectProcessDropdown);
-        await BrowserVisibility.waitUntilElementIsClickable(selectProcessDropdown);
+        await this.dropdownPage.checkOptionIsDisplayed(name);
     }
 
     async checkOptionIsNotDisplayed(name): Promise<void> {
-        const selectProcessDropdown: ElementFinder = element(by.cssContainingText('.mat-option-text', name));
-        await BrowserVisibility.waitUntilElementIsNotVisible(selectProcessDropdown);
+        await this.dropdownPage.checkOptionIsNotDisplayed(name);
     }
 
     async selectOption(name): Promise<void> {
-        const selectProcessDropdown: ElementFinder = element(by.xpath(`//mat-option/child::span [text() = ' ${name} ']`));
-        await BrowserActions.click(selectProcessDropdown);
+        await this.dropdownPage.selectOption(name);
     }
 
     async typeProcessDefinition(name): Promise<void> {

--- a/e2e/pages/adf/process-services/task-details.page.ts
+++ b/e2e/pages/adf/process-services/task-details.page.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { BrowserActions, BrowserVisibility, TabsPage } from '@alfresco/adf-testing';
+import { BrowserActions, BrowserVisibility, DropdownPage, TabsPage } from '@alfresco/adf-testing';
 import { browser, by, element, ElementFinder } from 'protractor';
 import { AppSettingsTogglesPage } from './dialog/app-settings-toggles.page';
 
@@ -55,7 +55,6 @@ export class TaskDetailsPage {
     involvePeopleHeader: ElementFinder = element(by.css('div[class="adf-search-text-header"]'));
     removeInvolvedPeople: ElementFinder = element(by.css('button[data-automation-id="Remove"]'));
     peopleTitle: ElementFinder = element(by.id('people-title'));
-    attachFormDropdown: ElementFinder = element(by.css('div[class="adf-attach-form-row"]'));
     cancelAttachForm: ElementFinder = element(by.id('adf-no-form-cancel-button'));
     attachFormButton: ElementFinder = element(by.id('adf-no-form-attach-form-button'));
     disabledAttachFormButton: ElementFinder = element(by.css('button[id="adf-no-form-attach-form-button"][disabled]'));
@@ -66,6 +65,8 @@ export class TaskDetailsPage {
     editableAssignee = element(by.css('span[data-automation-id="card-textitem-value-assignee"][class*="clickable"]'));
     claimElement = element(by.css('[data-automation-id="header-claim-button"]'));
     releaseElement = element(by.css('[data-automation-id="header-unclaim-button"]'));
+
+    attachFormDropdown = new DropdownPage(element(by.css('div[class="adf-attach-form-row"]')));
 
     async checkEditableAssigneeIsNotDisplayed(): Promise<void> {
         await BrowserVisibility.waitUntilElementIsNotVisible(this.editableAssignee);
@@ -109,16 +110,15 @@ export class TaskDetailsPage {
     }
 
     async checkAttachFormDropdownIsDisplayed(): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.attachFormDropdown);
+        await this.attachFormDropdown.checkDropdownIsVisible();
     }
 
     async clickAttachFormDropdown(): Promise<void> {
-        await BrowserActions.click(this.attachFormDropdown);
+        await this.attachFormDropdown.clickDropdown();
     }
 
     async selectAttachFormOption(option): Promise<void> {
-        const selectedOption: ElementFinder = element(by.cssContainingText('mat-option[role="option"]', option));
-        await BrowserActions.click(selectedOption);
+        await this.attachFormDropdown.selectOption(option);
     }
 
     async checkCancelAttachFormIsDisplayed(): Promise<void> {

--- a/e2e/pages/adf/process-services/task-details.page.ts
+++ b/e2e/pages/adf/process-services/task-details.page.ts
@@ -97,8 +97,7 @@ export class TaskDetailsPage {
     }
 
     async checkSelectedForm(formName): Promise<void> {
-        const text = await BrowserActions.getText(this.attachFormName);
-        await expect(formName).toEqual(text);
+        await this.attachFormDropdown.checkOptionIsSelected(formName);
     }
 
     async checkAttachFormButtonIsDisabled(): Promise<void> {
@@ -113,12 +112,8 @@ export class TaskDetailsPage {
         await this.attachFormDropdown.checkDropdownIsVisible();
     }
 
-    async clickAttachFormDropdown(): Promise<void> {
-        await this.attachFormDropdown.clickDropdown();
-    }
-
     async selectAttachFormOption(option): Promise<void> {
-        await this.attachFormDropdown.selectOption(option);
+        await this.attachFormDropdown.clickDropdownWithOption(option);
     }
 
     async checkCancelAttachFormIsDisplayed(): Promise<void> {

--- a/e2e/pages/adf/process-services/tasks.page.ts
+++ b/e2e/pages/adf/process-services/tasks.page.ts
@@ -52,7 +52,7 @@ export class TasksPage {
         await dialog.addName(name);
         await dialog.addDescription(description);
         await dialog.addDueDate(dueDate);
-        await dialog.addForm(formName);
+        await dialog.selectForm(formName);
         await dialog.clickStartButton();
     }
 

--- a/e2e/process-services-cloud/edit-process-filters-component.e2e.ts
+++ b/e2e/process-services-cloud/edit-process-filters-component.e2e.ts
@@ -36,11 +36,6 @@ describe('Edit process filters cloud', () => {
         let testUser, groupInfo;
         const apiService = new ApiService(browser.params.config.oauth2.clientId, browser.params.config.bpmHost, browser.params.config.oauth2.host, 'BPM');
 
-        const enum PROCESS_FILTERS {
-            ALL_PROCESSES = 'all-processes',
-            RUNNING_PROCESSES = 'running-processes'
-        }
-
         beforeAll(async () => {
             await apiService.login(browser.params.identityAdmin.email, browser.params.identityAdmin.password);
             identityService = new IdentityService(apiService);
@@ -67,11 +62,11 @@ describe('Edit process filters cloud', () => {
             const editProcessFilterCloud = processCloudDemoPage.editProcessFilterCloudComponent();
             await editProcessFilterCloud.openFilter();
             await editProcessFilterCloud.checkCustomiseFilterHeaderIsExpanded();
-            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter(PROCESS_FILTERS.ALL_PROCESSES);
+            await processCloudDemoPage.processFilterCloudComponent.clickAllProcessesFilter();
         });
 
         it('[C291804] Delete Save and Save as actions should be displayed when clicking on custom filter header', async () => {
-            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed(PROCESS_FILTERS.ALL_PROCESSES);
+            await processCloudDemoPage.processFilterCloudComponent.clickAllProcessesFilter();
             await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('All Processes');
             await processCloudDemoPage.editProcessFilterCloudComponent().checkSaveButtonIsDisplayed();
             await processCloudDemoPage.editProcessFilterCloudComponent().checkSaveAsButtonIsDisplayed();
@@ -84,7 +79,7 @@ describe('Edit process filters cloud', () => {
 
         it('[C291805] New process filter is added when clicking Save As button', async () => {
             await processCloudDemoPage.editProcessFilterCloudComponent().setSortFilterDropDown('Id');
-            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed(PROCESS_FILTERS.ALL_PROCESSES);
+            await processCloudDemoPage.processFilterCloudComponent.clickAllProcessesFilter();
 
             await processCloudDemoPage.editProcessFilterCloudComponent().clickSaveAsButton();
             await processCloudDemoPage.editProcessFilterCloudComponent().editProcessFilterDialog().setFilterName('New');
@@ -98,7 +93,7 @@ describe('Edit process filters cloud', () => {
             await expect(await processCloudDemoPage.editProcessFilterCloudComponent().getSortFilterDropDownValue()).toEqual('Id');
             await expect(await processCloudDemoPage.editProcessFilterCloudComponent().checkSaveAsButtonIsEnabled()).toEqual(false);
             await expect(await processCloudDemoPage.editProcessFilterCloudComponent().checkDeleteButtonIsEnabled()).toEqual(true);
-            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter(PROCESS_FILTERS.ALL_PROCESSES);
+            await processCloudDemoPage.processFilterCloudComponent.clickAllProcessesFilter();
             await expect(await processCloudDemoPage.editProcessFilterCloudComponent().getSortFilterDropDownValue()).toEqual('StartDate');
             await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter('custom-new');
             await expect(await processCloudDemoPage.editProcessFilterCloudComponent().getSortFilterDropDownValue()).toEqual('Id');
@@ -143,7 +138,7 @@ describe('Edit process filters cloud', () => {
 
         it('[C291807] A process filter is overrided when clicking on save button', async () => {
             await processCloudDemoPage.editProcessFilterCloudComponent().setSortFilterDropDown('Id');
-            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed(PROCESS_FILTERS.ALL_PROCESSES);
+            await processCloudDemoPage.processFilterCloudComponent.clickAllProcessesFilter();
             await processCloudDemoPage.editProcessFilterCloudComponent().clickSaveAsButton();
             await processCloudDemoPage.editProcessFilterCloudComponent().editProcessFilterDialog().setFilterName('New');
             await processCloudDemoPage.editProcessFilterCloudComponent().editProcessFilterDialog().clickOnSaveButton();
@@ -169,7 +164,7 @@ describe('Edit process filters cloud', () => {
 
         it('[C291808] A process filter is deleted when clicking on delete button', async () => {
             await processCloudDemoPage.editProcessFilterCloudComponent().setSortFilterDropDown('Id');
-            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed(PROCESS_FILTERS.ALL_PROCESSES);
+            await processCloudDemoPage.processFilterCloudComponent.clickAllProcessesFilter();
             await processCloudDemoPage.editProcessFilterCloudComponent().clickSaveAsButton();
             await processCloudDemoPage.editProcessFilterCloudComponent().editProcessFilterDialog().setFilterName('New');
 
@@ -189,17 +184,17 @@ describe('Edit process filters cloud', () => {
 
         it('[C291810] Process filter should not be created when process filter dialog is closed', async () => {
             await processCloudDemoPage.editProcessFilterCloudComponent().setSortFilterDropDown('Id');
-            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed(PROCESS_FILTERS.ALL_PROCESSES);
+            await processCloudDemoPage.processFilterCloudComponent.clickAllProcessesFilter();
             await processCloudDemoPage.editProcessFilterCloudComponent().clickSaveAsButton();
             await processCloudDemoPage.editProcessFilterCloudComponent().editProcessFilterDialog().setFilterName('Cancel');
             await expect(await processCloudDemoPage.editProcessFilterCloudComponent().editProcessFilterDialog().getFilterName()).toEqual('Cancel');
             await processCloudDemoPage.editProcessFilterCloudComponent().editProcessFilterDialog().clickOnCancelButton();
             await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterNotDisplayed('Cancel');
             await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toEqual('All Processes');
-            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter(PROCESS_FILTERS.RUNNING_PROCESSES);
+            await processCloudDemoPage.processFilterCloudComponent.clickRunningProcessesFilter();
             await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toEqual('Running Processes');
             await processCloudDemoPage.editProcessFilterCloudComponent().openFilter();
-            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter(PROCESS_FILTERS.ALL_PROCESSES);
+            await processCloudDemoPage.processFilterCloudComponent.clickAllProcessesFilter();
             await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toEqual('All Processes');
             await expect(await processCloudDemoPage.editProcessFilterCloudComponent().getSortFilterDropDownValue()).toEqual('StartDate');
             await processCloudDemoPage.editProcessFilterCloudComponent().openFilter();
@@ -207,7 +202,7 @@ describe('Edit process filters cloud', () => {
 
         it('[C291811] Save button of process filter dialog should be disabled when process name is empty', async () => {
             await processCloudDemoPage.editProcessFilterCloudComponent().setSortFilterDropDown('Id');
-            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed(PROCESS_FILTERS.ALL_PROCESSES);
+            await processCloudDemoPage.processFilterCloudComponent.clickAllProcessesFilter();
             await processCloudDemoPage.editProcessFilterCloudComponent().clickSaveAsButton();
             await processCloudDemoPage.editProcessFilterCloudComponent().editProcessFilterDialog().clearFilterName();
 
@@ -225,7 +220,7 @@ describe('Edit process filters cloud', () => {
 
         it('[C291809] Process filter dialog is displayed when clicking on Save As button', async () => {
             await processCloudDemoPage.editProcessFilterCloudComponent().setSortFilterDropDown('Name');
-            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed(PROCESS_FILTERS.ALL_PROCESSES);
+            await processCloudDemoPage.processFilterCloudComponent.clickAllProcessesFilter();
             await processCloudDemoPage.editProcessFilterCloudComponent().clickSaveAsButton();
             await expect(await processCloudDemoPage.editProcessFilterCloudComponent().editProcessFilterDialog().checkCancelButtonIsEnabled()).toEqual(true);
             await expect(await processCloudDemoPage.editProcessFilterCloudComponent().editProcessFilterDialog().checkSaveButtonIsEnabled()).toEqual(true);

--- a/e2e/process-services-cloud/edit-process-filters-component.e2e.ts
+++ b/e2e/process-services-cloud/edit-process-filters-component.e2e.ts
@@ -36,6 +36,11 @@ describe('Edit process filters cloud', () => {
         let testUser, groupInfo;
         const apiService = new ApiService(browser.params.config.oauth2.clientId, browser.params.config.bpmHost, browser.params.config.oauth2.host, 'BPM');
 
+        const enum PROCESS_FILTERS {
+            ALL_PROCESSES = 'all-processes',
+            RUNNING_PROCESSES = 'running-processes'
+        }
+
         beforeAll(async () => {
             await apiService.login(browser.params.identityAdmin.email, browser.params.identityAdmin.password);
             identityService = new IdentityService(apiService);
@@ -58,16 +63,16 @@ describe('Edit process filters cloud', () => {
             await appListCloudComponent.checkApsContainer();
             await appListCloudComponent.goToApp(simpleApp);
             await tasksCloudDemoPage.taskListCloudComponent().checkTaskListIsLoaded();
-            await processCloudDemoPage.clickOnProcessFilters();
+            await processCloudDemoPage.processFilterCloudComponent.clickOnProcessFilters();
             const editProcessFilterCloud = processCloudDemoPage.editProcessFilterCloudComponent();
             await editProcessFilterCloud.openFilter();
             await editProcessFilterCloud.checkCustomiseFilterHeaderIsExpanded();
-            await processCloudDemoPage.allProcessesFilter().clickProcessFilter();
+            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter(PROCESS_FILTERS.ALL_PROCESSES);
         });
 
         it('[C291804] Delete Save and Save as actions should be displayed when clicking on custom filter header', async () => {
-            await processCloudDemoPage.allProcessesFilter().checkProcessFilterIsDisplayed();
-            await expect(await processCloudDemoPage.getActiveFilterName()).toBe('All Processes');
+            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed(PROCESS_FILTERS.ALL_PROCESSES);
+            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('All Processes');
             await processCloudDemoPage.editProcessFilterCloudComponent().checkSaveButtonIsDisplayed();
             await processCloudDemoPage.editProcessFilterCloudComponent().checkSaveAsButtonIsDisplayed();
             await processCloudDemoPage.editProcessFilterCloudComponent().checkDeleteButtonIsDisplayed();
@@ -79,7 +84,7 @@ describe('Edit process filters cloud', () => {
 
         it('[C291805] New process filter is added when clicking Save As button', async () => {
             await processCloudDemoPage.editProcessFilterCloudComponent().setSortFilterDropDown('Id');
-            await processCloudDemoPage.allProcessesFilter().checkProcessFilterIsDisplayed();
+            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed(PROCESS_FILTERS.ALL_PROCESSES);
 
             await processCloudDemoPage.editProcessFilterCloudComponent().clickSaveAsButton();
             await processCloudDemoPage.editProcessFilterCloudComponent().editProcessFilterDialog().setFilterName('New');
@@ -87,15 +92,15 @@ describe('Edit process filters cloud', () => {
 
             await browser.driver.sleep(1000);
 
-            await expect(await processCloudDemoPage.getActiveFilterName()).toBe('New');
+            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('New');
             await processCloudDemoPage.editProcessFilterCloudComponent().openFilter();
             await expect(await processCloudDemoPage.editProcessFilterCloudComponent().checkSaveButtonIsEnabled()).toEqual(false);
             await expect(await processCloudDemoPage.editProcessFilterCloudComponent().getSortFilterDropDownValue()).toEqual('Id');
             await expect(await processCloudDemoPage.editProcessFilterCloudComponent().checkSaveAsButtonIsEnabled()).toEqual(false);
             await expect(await processCloudDemoPage.editProcessFilterCloudComponent().checkDeleteButtonIsEnabled()).toEqual(true);
-            await processCloudDemoPage.allProcessesFilter().clickProcessFilter();
+            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter(PROCESS_FILTERS.ALL_PROCESSES);
             await expect(await processCloudDemoPage.editProcessFilterCloudComponent().getSortFilterDropDownValue()).toEqual('StartDate');
-            await processCloudDemoPage.customProcessFilter('custom-new').clickProcessFilter();
+            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter('custom-new');
             await expect(await processCloudDemoPage.editProcessFilterCloudComponent().getSortFilterDropDownValue()).toEqual('Id');
             await processCloudDemoPage.editProcessFilterCloudComponent().clickDeleteButton();
         });
@@ -110,7 +115,7 @@ describe('Edit process filters cloud', () => {
 
             await processCloudDemoPage.editProcessFilterCloudComponent().openFilter();
             await processCloudDemoPage.editProcessFilterCloudComponent().checkCustomiseFilterHeaderIsExpanded();
-            await expect(await processCloudDemoPage.getActiveFilterName()).toBe('New');
+            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('New');
             await expect(await processCloudDemoPage.editProcessFilterCloudComponent().getSortFilterDropDownValue()).toEqual('Id');
             await processCloudDemoPage.editProcessFilterCloudComponent().setSortFilterDropDown('Name');
             await expect(await processCloudDemoPage.editProcessFilterCloudComponent().getSortFilterDropDownValue()).toEqual('Name');
@@ -123,13 +128,13 @@ describe('Edit process filters cloud', () => {
 
             await browser.driver.sleep(1000);
 
-            await expect(await processCloudDemoPage.getActiveFilterName()).toBe('New');
+            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('New');
             await expect(await processCloudDemoPage.editProcessFilterCloudComponent().getSortFilterDropDownValue()).toEqual('Name');
             await processCloudDemoPage.editProcessFilterCloudComponent().clickDeleteButton();
 
             await browser.driver.sleep(1000);
 
-            await processCloudDemoPage.customProcessFilter('custom-new').clickProcessFilter();
+            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter('custom-new');
             await processCloudDemoPage.editProcessFilterCloudComponent().openFilter();
             await processCloudDemoPage.editProcessFilterCloudComponent().checkCustomiseFilterHeaderIsExpanded();
             await expect(await processCloudDemoPage.editProcessFilterCloudComponent().getSortFilterDropDownValue()).toEqual('Id');
@@ -138,14 +143,14 @@ describe('Edit process filters cloud', () => {
 
         it('[C291807] A process filter is overrided when clicking on save button', async () => {
             await processCloudDemoPage.editProcessFilterCloudComponent().setSortFilterDropDown('Id');
-            await processCloudDemoPage.allProcessesFilter().checkProcessFilterIsDisplayed();
+            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed(PROCESS_FILTERS.ALL_PROCESSES);
             await processCloudDemoPage.editProcessFilterCloudComponent().clickSaveAsButton();
             await processCloudDemoPage.editProcessFilterCloudComponent().editProcessFilterDialog().setFilterName('New');
             await processCloudDemoPage.editProcessFilterCloudComponent().editProcessFilterDialog().clickOnSaveButton();
 
             await browser.driver.sleep(1000);
 
-            await expect(await processCloudDemoPage.getActiveFilterName()).toBe('New');
+            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('New');
             await processCloudDemoPage.editProcessFilterCloudComponent().openFilter();
             await processCloudDemoPage.editProcessFilterCloudComponent().checkCustomiseFilterHeaderIsExpanded();
             await expect(await processCloudDemoPage.editProcessFilterCloudComponent().getSortFilterDropDownValue()).toEqual('Id');
@@ -157,14 +162,14 @@ describe('Edit process filters cloud', () => {
 
             await browser.driver.sleep(1000);
 
-            await expect(await processCloudDemoPage.getActiveFilterName()).toBe('New');
+            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('New');
             await expect(await processCloudDemoPage.editProcessFilterCloudComponent().getSortFilterDropDownValue()).toEqual('Name');
             await processCloudDemoPage.editProcessFilterCloudComponent().clickDeleteButton();
         });
 
         it('[C291808] A process filter is deleted when clicking on delete button', async () => {
             await processCloudDemoPage.editProcessFilterCloudComponent().setSortFilterDropDown('Id');
-            await processCloudDemoPage.allProcessesFilter().checkProcessFilterIsDisplayed();
+            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed(PROCESS_FILTERS.ALL_PROCESSES);
             await processCloudDemoPage.editProcessFilterCloudComponent().clickSaveAsButton();
             await processCloudDemoPage.editProcessFilterCloudComponent().editProcessFilterDialog().setFilterName('New');
 
@@ -172,37 +177,37 @@ describe('Edit process filters cloud', () => {
 
             await processCloudDemoPage.editProcessFilterCloudComponent().editProcessFilterDialog().clickOnSaveButton();
             await processCloudDemoPage.editProcessFilterCloudComponent().openFilter();
-            await expect(await processCloudDemoPage.getActiveFilterName()).toBe('New');
+            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('New');
             await expect(await processCloudDemoPage.editProcessFilterCloudComponent().getSortFilterDropDownValue()).toEqual('Id');
             await processCloudDemoPage.editProcessFilterCloudComponent().clickDeleteButton();
 
             await browser.driver.sleep(1000);
 
-            await expect(await processCloudDemoPage.getActiveFilterName()).toBe('All Processes');
-            await processCloudDemoPage.customProcessFilter('New').checkProcessFilterNotDisplayed();
+            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('All Processes');
+            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterNotDisplayed('New');
         });
 
         it('[C291810] Process filter should not be created when process filter dialog is closed', async () => {
             await processCloudDemoPage.editProcessFilterCloudComponent().setSortFilterDropDown('Id');
-            await processCloudDemoPage.allProcessesFilter().checkProcessFilterIsDisplayed();
+            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed(PROCESS_FILTERS.ALL_PROCESSES);
             await processCloudDemoPage.editProcessFilterCloudComponent().clickSaveAsButton();
             await processCloudDemoPage.editProcessFilterCloudComponent().editProcessFilterDialog().setFilterName('Cancel');
             await expect(await processCloudDemoPage.editProcessFilterCloudComponent().editProcessFilterDialog().getFilterName()).toEqual('Cancel');
             await processCloudDemoPage.editProcessFilterCloudComponent().editProcessFilterDialog().clickOnCancelButton();
-            await processCloudDemoPage.customProcessFilter('Cancel').checkProcessFilterNotDisplayed();
-            await expect(await processCloudDemoPage.getActiveFilterName()).toEqual('All Processes');
-            await processCloudDemoPage.runningProcessesFilter().clickProcessFilter();
-            await expect(await processCloudDemoPage.getActiveFilterName()).toEqual('Running Processes');
+            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterNotDisplayed('Cancel');
+            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toEqual('All Processes');
+            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter(PROCESS_FILTERS.RUNNING_PROCESSES);
+            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toEqual('Running Processes');
             await processCloudDemoPage.editProcessFilterCloudComponent().openFilter();
-            await processCloudDemoPage.allProcessesFilter().clickProcessFilter();
-            await expect(await processCloudDemoPage.getActiveFilterName()).toEqual('All Processes');
+            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter(PROCESS_FILTERS.ALL_PROCESSES);
+            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toEqual('All Processes');
             await expect(await processCloudDemoPage.editProcessFilterCloudComponent().getSortFilterDropDownValue()).toEqual('StartDate');
             await processCloudDemoPage.editProcessFilterCloudComponent().openFilter();
         });
 
         it('[C291811] Save button of process filter dialog should be disabled when process name is empty', async () => {
             await processCloudDemoPage.editProcessFilterCloudComponent().setSortFilterDropDown('Id');
-            await processCloudDemoPage.allProcessesFilter().checkProcessFilterIsDisplayed();
+            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed(PROCESS_FILTERS.ALL_PROCESSES);
             await processCloudDemoPage.editProcessFilterCloudComponent().clickSaveAsButton();
             await processCloudDemoPage.editProcessFilterCloudComponent().editProcessFilterDialog().clearFilterName();
 
@@ -220,7 +225,7 @@ describe('Edit process filters cloud', () => {
 
         it('[C291809] Process filter dialog is displayed when clicking on Save As button', async () => {
             await processCloudDemoPage.editProcessFilterCloudComponent().setSortFilterDropDown('Name');
-            await processCloudDemoPage.allProcessesFilter().checkProcessFilterIsDisplayed();
+            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed(PROCESS_FILTERS.ALL_PROCESSES);
             await processCloudDemoPage.editProcessFilterCloudComponent().clickSaveAsButton();
             await expect(await processCloudDemoPage.editProcessFilterCloudComponent().editProcessFilterDialog().checkCancelButtonIsEnabled()).toEqual(true);
             await expect(await processCloudDemoPage.editProcessFilterCloudComponent().editProcessFilterDialog().checkSaveButtonIsEnabled()).toEqual(true);

--- a/e2e/process-services-cloud/edit-task-filters-component.e2e.ts
+++ b/e2e/process-services-cloud/edit-task-filters-component.e2e.ts
@@ -41,11 +41,6 @@ describe('Edit task filters cloud', () => {
         let testUser, groupInfo;
         const apiService = new ApiService(browser.params.config.oauth2.clientId, browser.params.config.bpmHost, browser.params.config.oauth2.host, 'BPM');
 
-        const enum TASK_FILTERS {
-            MY_TASKS = 'my-tasks',
-            COMPLETED_TASKS = 'completed-tasks'
-        }
-
         const simpleApp = browser.params.resources.ACTIVITI_CLOUD_APPS.SIMPLE_APP.name;
         const completedTaskName = StringUtil.generateRandomString(),
             assignedTaskName = StringUtil.generateRandomString();
@@ -79,12 +74,12 @@ describe('Edit task filters cloud', () => {
         });
 
         afterEach(async () => {
-            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
         });
 
         it('[C291785] All the filters property should be set up accordingly with the Query Param', async () => {
             await tasksCloudDemoPage.editTaskFilterCloudComponent().openFilter();
-            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(TASK_FILTERS.MY_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
             await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().getStatusFilterDropDownValue()).toEqual('ASSIGNED');
             await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().getSortFilterDropDownValue()).toEqual('CreatedDate');
@@ -92,7 +87,7 @@ describe('Edit task filters cloud', () => {
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(assignedTaskName);
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsNotDisplayedByName(completedTaskName);
 
-            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.COMPLETED_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickCompletedTasksFilter();
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('Completed Tasks');
             await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().getStatusFilterDropDownValue()).toEqual('COMPLETED');
             await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().getSortFilterDropDownValue()).toEqual('CreatedDate');
@@ -103,9 +98,9 @@ describe('Edit task filters cloud', () => {
         });
 
         it('[C306896] Delete Save and Save as actions should be displayed when clicking on custom filter header', async () => {
-            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
             await tasksCloudDemoPage.editTaskFilterCloudComponent().openFilter();
-            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(TASK_FILTERS.MY_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
             const editTaskFilterCloudComponent = tasksCloudDemoPage.editTaskFilterCloudComponent();
 
@@ -120,13 +115,13 @@ describe('Edit task filters cloud', () => {
         });
 
         it('[C291795] New filter is added when clicking Save As button', async () => {
-            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
 
             const editTaskFilterCloudComponent = tasksCloudDemoPage.editTaskFilterCloudComponent();
             await editTaskFilterCloudComponent.openFilter();
             await editTaskFilterCloudComponent.setSortFilterDropDown('Id');
 
-            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(TASK_FILTERS.MY_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().clickSaveAsButton();
 
@@ -140,7 +135,7 @@ describe('Edit task filters cloud', () => {
             await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().getSortFilterDropDownValue()).toEqual('Id');
             await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().checkSaveAsButtonIsEnabled()).toEqual(false);
             await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().checkDeleteButtonIsEnabled()).toEqual(true);
-            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
             await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().getSortFilterDropDownValue()).toEqual('CreatedDate');
             await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter('custom-new');
             await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().getSortFilterDropDownValue()).toEqual('Id');
@@ -148,13 +143,13 @@ describe('Edit task filters cloud', () => {
         });
 
         it('[C291796] Two filters with same name can be created when clicking the Save As button', async () => {
-            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
 
             const editTaskFilterCloudComponent = tasksCloudDemoPage.editTaskFilterCloudComponent();
             await editTaskFilterCloudComponent.openFilter();
             await editTaskFilterCloudComponent.setSortFilterDropDown('Id');
 
-            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(TASK_FILTERS.MY_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().clickSaveAsButton();
 
@@ -183,13 +178,13 @@ describe('Edit task filters cloud', () => {
         });
 
         it('[C291797] A filter is overrided when clicking on save button', async () => {
-            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
 
             const editTaskFilterCloudComponent = tasksCloudDemoPage.editTaskFilterCloudComponent();
             await editTaskFilterCloudComponent.openFilter();
             await editTaskFilterCloudComponent.setSortFilterDropDown('Id');
 
-            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(TASK_FILTERS.MY_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
             await tasksCloudDemoPage.editTaskFilterCloudComponent().clickSaveAsButton();
 
             const editTaskFilterDialog = await tasksCloudDemoPage.editTaskFilterCloudComponent().editTaskFilterDialog();
@@ -209,13 +204,13 @@ describe('Edit task filters cloud', () => {
         });
 
         it('[C291798] A filter is deleted when clicking on delete button', async () => {
-            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
 
             const editTaskFilterCloudComponent = tasksCloudDemoPage.editTaskFilterCloudComponent();
             await editTaskFilterCloudComponent.openFilter();
             await editTaskFilterCloudComponent.setSortFilterDropDown('Id');
 
-            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(TASK_FILTERS.MY_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
             await tasksCloudDemoPage.editTaskFilterCloudComponent().clickSaveAsButton();
 
             const editTaskFilterDialog = await tasksCloudDemoPage.editTaskFilterCloudComponent().editTaskFilterDialog();
@@ -232,7 +227,7 @@ describe('Edit task filters cloud', () => {
         });
 
         it('[C291800] Task filter should not be created when task filter dialog is closed', async () => {
-            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
 
             const editTaskFilterCloudComponent = tasksCloudDemoPage.editTaskFilterCloudComponent();
             await editTaskFilterCloudComponent.openFilter();
@@ -246,8 +241,8 @@ describe('Edit task filters cloud', () => {
             await tasksCloudDemoPage.editTaskFilterCloudComponent().editTaskFilterDialog().clickOnCancelButton();
             await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterNotDisplayed('Cancel');
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toEqual('My Tasks');
-            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.COMPLETED_TASKS);
-            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickCompletedTasksFilter();
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
             await tasksCloudDemoPage.editTaskFilterCloudComponent().openFilter();
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
             await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().getSortFilterDropDownValue()).toEqual('CreatedDate');
@@ -255,7 +250,7 @@ describe('Edit task filters cloud', () => {
         });
 
         it('[C291801] Save button of task filter dialog should be disabled when task name is empty', async () => {
-            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
 
             const editTaskFilterCloudComponent = tasksCloudDemoPage.editTaskFilterCloudComponent();
             await editTaskFilterCloudComponent.openFilter();
@@ -277,7 +272,7 @@ describe('Edit task filters cloud', () => {
         });
 
         it('[C291799] Task filter dialog is displayed when clicking on Save As button', async () => {
-            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
             const tasksCloud = tasksCloudDemoPage.editTaskFilterCloudComponent();
             await tasksCloud.openFilter();
             await tasksCloud.setSortFilterDropDown('Id');

--- a/e2e/process-services-cloud/edit-task-filters-component.e2e.ts
+++ b/e2e/process-services-cloud/edit-task-filters-component.e2e.ts
@@ -41,6 +41,11 @@ describe('Edit task filters cloud', () => {
         let testUser, groupInfo;
         const apiService = new ApiService(browser.params.config.oauth2.clientId, browser.params.config.bpmHost, browser.params.config.oauth2.host, 'BPM');
 
+        const enum TASK_FILTERS {
+            MY_TASKS = 'my-tasks',
+            COMPLETED_TASKS = 'completed-tasks'
+        }
+
         const simpleApp = browser.params.resources.ACTIVITI_CLOUD_APPS.SIMPLE_APP.name;
         const completedTaskName = StringUtil.generateRandomString(),
             assignedTaskName = StringUtil.generateRandomString();
@@ -74,21 +79,21 @@ describe('Edit task filters cloud', () => {
         });
 
         afterEach(async () => {
-            await tasksCloudDemoPage.myTasksFilter().clickTaskFilter();
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
         });
 
         it('[C291785] All the filters property should be set up accordingly with the Query Param', async () => {
             await tasksCloudDemoPage.editTaskFilterCloudComponent().openFilter();
-            await tasksCloudDemoPage.myTasksFilter().checkTaskFilterIsDisplayed();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(TASK_FILTERS.MY_TASKS);
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
             await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().getStatusFilterDropDownValue()).toEqual('ASSIGNED');
             await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().getSortFilterDropDownValue()).toEqual('CreatedDate');
             await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().getOrderFilterDropDownValue()).toEqual('DESC');
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(assignedTaskName);
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsNotDisplayedByName(completedTaskName);
 
-            await tasksCloudDemoPage.completedTasksFilter().clickTaskFilter();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('Completed Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.COMPLETED_TASKS);
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('Completed Tasks');
             await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().getStatusFilterDropDownValue()).toEqual('COMPLETED');
             await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().getSortFilterDropDownValue()).toEqual('CreatedDate');
             await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().getOrderFilterDropDownValue()).toEqual('DESC');
@@ -98,10 +103,10 @@ describe('Edit task filters cloud', () => {
         });
 
         it('[C306896] Delete Save and Save as actions should be displayed when clicking on custom filter header', async () => {
-            await tasksCloudDemoPage.myTasksFilter().clickTaskFilter();
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
             await tasksCloudDemoPage.editTaskFilterCloudComponent().openFilter();
-            await tasksCloudDemoPage.myTasksFilter().checkTaskFilterIsDisplayed();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(TASK_FILTERS.MY_TASKS);
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
             const editTaskFilterCloudComponent = tasksCloudDemoPage.editTaskFilterCloudComponent();
 
             await editTaskFilterCloudComponent.checkSaveButtonIsDisplayed();
@@ -115,13 +120,13 @@ describe('Edit task filters cloud', () => {
         });
 
         it('[C291795] New filter is added when clicking Save As button', async () => {
-            await tasksCloudDemoPage.myTasksFilter().clickTaskFilter();
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
 
             const editTaskFilterCloudComponent = tasksCloudDemoPage.editTaskFilterCloudComponent();
             await editTaskFilterCloudComponent.openFilter();
             await editTaskFilterCloudComponent.setSortFilterDropDown('Id');
 
-            await tasksCloudDemoPage.myTasksFilter().checkTaskFilterIsDisplayed();
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(TASK_FILTERS.MY_TASKS);
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().clickSaveAsButton();
 
@@ -129,27 +134,27 @@ describe('Edit task filters cloud', () => {
             await editTaskFilterDialog.setFilterName('New');
             await editTaskFilterDialog.clickOnSaveButton();
 
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('New');
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('New');
             await tasksCloudDemoPage.editTaskFilterCloudComponent().openFilter();
             await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().checkSaveButtonIsEnabled()).toEqual(false);
             await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().getSortFilterDropDownValue()).toEqual('Id');
             await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().checkSaveAsButtonIsEnabled()).toEqual(false);
             await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().checkDeleteButtonIsEnabled()).toEqual(true);
-            await tasksCloudDemoPage.myTasksFilter().clickTaskFilter();
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
             await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().getSortFilterDropDownValue()).toEqual('CreatedDate');
-            await tasksCloudDemoPage.customTaskFilter('custom-new').clickTaskFilter();
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter('custom-new');
             await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().getSortFilterDropDownValue()).toEqual('Id');
             await tasksCloudDemoPage.editTaskFilterCloudComponent().clickDeleteButton();
         });
 
         it('[C291796] Two filters with same name can be created when clicking the Save As button', async () => {
-            await tasksCloudDemoPage.myTasksFilter().clickTaskFilter();
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
 
             const editTaskFilterCloudComponent = tasksCloudDemoPage.editTaskFilterCloudComponent();
             await editTaskFilterCloudComponent.openFilter();
             await editTaskFilterCloudComponent.setSortFilterDropDown('Id');
 
-            await tasksCloudDemoPage.myTasksFilter().checkTaskFilterIsDisplayed();
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(TASK_FILTERS.MY_TASKS);
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().clickSaveAsButton();
 
@@ -157,7 +162,7 @@ describe('Edit task filters cloud', () => {
             await editTaskFilterDialog.setFilterName('New');
             await editTaskFilterDialog.clickOnSaveButton();
 
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('New');
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('New');
             await tasksCloudDemoPage.editTaskFilterCloudComponent().openFilter();
 
             await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().getSortFilterDropDownValue()).toEqual('Id');
@@ -166,11 +171,11 @@ describe('Edit task filters cloud', () => {
             await tasksCloudDemoPage.editTaskFilterCloudComponent().editTaskFilterDialog().setFilterName('New');
             await tasksCloudDemoPage.editTaskFilterCloudComponent().editTaskFilterDialog().clickOnSaveButton();
 
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('New');
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('New');
             await tasksCloudDemoPage.editTaskFilterCloudComponent().openFilter();
             await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().getSortFilterDropDownValue()).toEqual('Priority');
             await tasksCloudDemoPage.editTaskFilterCloudComponent().clickDeleteButton();
-            await tasksCloudDemoPage.customTaskFilter('custom-new').clickTaskFilter();
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter('custom-new');
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().openFilter();
             await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().getSortFilterDropDownValue()).toEqual('Id');
@@ -178,56 +183,56 @@ describe('Edit task filters cloud', () => {
         });
 
         it('[C291797] A filter is overrided when clicking on save button', async () => {
-            await tasksCloudDemoPage.myTasksFilter().clickTaskFilter();
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
 
             const editTaskFilterCloudComponent = tasksCloudDemoPage.editTaskFilterCloudComponent();
             await editTaskFilterCloudComponent.openFilter();
             await editTaskFilterCloudComponent.setSortFilterDropDown('Id');
 
-            await tasksCloudDemoPage.myTasksFilter().checkTaskFilterIsDisplayed();
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(TASK_FILTERS.MY_TASKS);
             await tasksCloudDemoPage.editTaskFilterCloudComponent().clickSaveAsButton();
 
             const editTaskFilterDialog = await tasksCloudDemoPage.editTaskFilterCloudComponent().editTaskFilterDialog();
             await editTaskFilterDialog.setFilterName('New');
             await editTaskFilterDialog.clickOnSaveButton();
 
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('New');
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('New');
             await tasksCloudDemoPage.editTaskFilterCloudComponent().openFilter();
             await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().getSortFilterDropDownValue()).toEqual('Id');
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setSortFilterDropDown('Name');
             await tasksCloudDemoPage.editTaskFilterCloudComponent().clickSaveButton();
             await tasksCloudDemoPage.editTaskFilterCloudComponent().openFilter();
 
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('New');
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('New');
             await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().getSortFilterDropDownValue()).toEqual('Name');
             await tasksCloudDemoPage.editTaskFilterCloudComponent().clickDeleteButton();
         });
 
         it('[C291798] A filter is deleted when clicking on delete button', async () => {
-            await tasksCloudDemoPage.myTasksFilter().clickTaskFilter();
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
 
             const editTaskFilterCloudComponent = tasksCloudDemoPage.editTaskFilterCloudComponent();
             await editTaskFilterCloudComponent.openFilter();
             await editTaskFilterCloudComponent.setSortFilterDropDown('Id');
 
-            await tasksCloudDemoPage.myTasksFilter().checkTaskFilterIsDisplayed();
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(TASK_FILTERS.MY_TASKS);
             await tasksCloudDemoPage.editTaskFilterCloudComponent().clickSaveAsButton();
 
             const editTaskFilterDialog = await tasksCloudDemoPage.editTaskFilterCloudComponent().editTaskFilterDialog();
             await editTaskFilterDialog.setFilterName('New');
             await editTaskFilterDialog.clickOnSaveButton();
 
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('New');
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('New');
             await tasksCloudDemoPage.editTaskFilterCloudComponent().openFilter();
             await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().getSortFilterDropDownValue()).toEqual('Id');
             await tasksCloudDemoPage.editTaskFilterCloudComponent().clickDeleteButton();
 
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
-            await tasksCloudDemoPage.customTaskFilter('New').checkTaskFilterNotDisplayed();
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterNotDisplayed('New');
         });
 
         it('[C291800] Task filter should not be created when task filter dialog is closed', async () => {
-            await tasksCloudDemoPage.myTasksFilter().clickTaskFilter();
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
 
             const editTaskFilterCloudComponent = tasksCloudDemoPage.editTaskFilterCloudComponent();
             await editTaskFilterCloudComponent.openFilter();
@@ -239,18 +244,18 @@ describe('Edit task filters cloud', () => {
             await tasksCloudDemoPage.editTaskFilterCloudComponent().editTaskFilterDialog().setFilterName('Cancel');
             await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().editTaskFilterDialog().getFilterName()).toEqual('Cancel');
             await tasksCloudDemoPage.editTaskFilterCloudComponent().editTaskFilterDialog().clickOnCancelButton();
-            await tasksCloudDemoPage.customTaskFilter('Cancel').checkTaskFilterNotDisplayed();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toEqual('My Tasks');
-            await tasksCloudDemoPage.completedTasksFilter().clickTaskFilter();
-            await tasksCloudDemoPage.myTasksFilter().clickTaskFilter();
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterNotDisplayed('Cancel');
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toEqual('My Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.COMPLETED_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
             await tasksCloudDemoPage.editTaskFilterCloudComponent().openFilter();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
             await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().getSortFilterDropDownValue()).toEqual('CreatedDate');
             await tasksCloudDemoPage.editTaskFilterCloudComponent().openFilter();
         });
 
         it('[C291801] Save button of task filter dialog should be disabled when task name is empty', async () => {
-            await tasksCloudDemoPage.myTasksFilter().clickTaskFilter();
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
 
             const editTaskFilterCloudComponent = tasksCloudDemoPage.editTaskFilterCloudComponent();
             await editTaskFilterCloudComponent.openFilter();
@@ -272,7 +277,7 @@ describe('Edit task filters cloud', () => {
         });
 
         it('[C291799] Task filter dialog is displayed when clicking on Save As button', async () => {
-            await tasksCloudDemoPage.myTasksFilter().clickTaskFilter();
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
             const tasksCloud = tasksCloudDemoPage.editTaskFilterCloudComponent();
             await tasksCloud.openFilter();
             await tasksCloud.setSortFilterDropDown('Id');

--- a/e2e/process-services-cloud/form-field/dropdown-widget.e2e.ts
+++ b/e2e/process-services-cloud/form-field/dropdown-widget.e2e.ts
@@ -92,7 +92,7 @@ describe('Form Field Component - Dropdown Widget', () => {
     });
 
     it('[C290069] Should be able to read rest service dropdown options, save and complete the task form', async () => {
-        await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter('my-tasks');
+        await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
         await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(task.entry.name);
         await tasksCloudDemoPage.taskListCloudComponent().selectRow(task.entry.name);
         await taskHeaderCloudPage.checkTaskPropertyListIsDisplayed();
@@ -109,7 +109,7 @@ describe('Form Field Component - Dropdown Widget', () => {
         await tasksCloudDemoPage.taskListCloudComponent().checkContentIsNotDisplayedByName(task.entry.name);
         await notificationHistoryPage.checkNotifyContains('Task has been saved successfully');
 
-        await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter('completed-tasks');
+        await tasksCloudDemoPage.taskFilterCloudComponent.clickCompletedTasksFilter();
         await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(task.entry.name);
         await tasksCloudDemoPage.taskListCloudComponent().selectRow(task.entry.name);
         await taskFormCloudComponent.formFields().checkFormIsDisplayed();

--- a/e2e/process-services-cloud/form-field/dropdown-widget.e2e.ts
+++ b/e2e/process-services-cloud/form-field/dropdown-widget.e2e.ts
@@ -92,7 +92,7 @@ describe('Form Field Component - Dropdown Widget', () => {
     });
 
     it('[C290069] Should be able to read rest service dropdown options, save and complete the task form', async () => {
-        await tasksCloudDemoPage.myTasksFilter().clickTaskFilter();
+        await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter('my-tasks');
         await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(task.entry.name);
         await tasksCloudDemoPage.taskListCloudComponent().selectRow(task.entry.name);
         await taskHeaderCloudPage.checkTaskPropertyListIsDisplayed();
@@ -105,11 +105,11 @@ describe('Form Field Component - Dropdown Widget', () => {
         await expect(await dropdown.getSelectedOptionText('Dropdown097maj')).toBe('Clementine Bauch');
         await taskFormCloudComponent.checkCompleteButtonIsDisplayed();
         await taskFormCloudComponent.clickCompleteButton();
-        await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+        await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
         await tasksCloudDemoPage.taskListCloudComponent().checkContentIsNotDisplayedByName(task.entry.name);
         await notificationHistoryPage.checkNotifyContains('Task has been saved successfully');
 
-        await tasksCloudDemoPage.completedTasksFilter().clickTaskFilter();
+        await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter('completed-tasks');
         await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(task.entry.name);
         await tasksCloudDemoPage.taskListCloudComponent().selectRow(task.entry.name);
         await taskFormCloudComponent.formFields().checkFormIsDisplayed();

--- a/e2e/process-services-cloud/process-custom-filters.e2e.ts
+++ b/e2e/process-services-cloud/process-custom-filters.e2e.ts
@@ -228,8 +228,7 @@ describe('Process list cloud', () => {
         });
 
         it('[C305054] Should display the actions filters Save, SaveAs and Delete', async () => {
-            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter('all-processes');
-            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed('all-processes');
+            await processCloudDemoPage.processFilterCloudComponent.clickAllProcessesFilter();
             await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('All Processes');
             await processCloudDemoPage.editProcessFilterCloudComponent().openFilter();
 
@@ -316,8 +315,7 @@ describe('Process list cloud', () => {
             });
 
             it('[C305054] Should display the actions filters Save and SaveAs, Delete button is not displayed', async () => {
-                await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter('all-processes');
-                await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed('all-processes');
+                await processCloudDemoPage.processFilterCloudComponent.clickAllProcessesFilter();
                 await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('All Processes');
                 await processCloudDemoPage.editProcessFilterCloudComponent().openFilter();
                 await processCloudDemoPage.editProcessFilterCloudComponent().checkSaveButtonIsDisplayed();

--- a/e2e/process-services-cloud/process-custom-filters.e2e.ts
+++ b/e2e/process-services-cloud/process-custom-filters.e2e.ts
@@ -117,7 +117,7 @@ describe('Process list cloud', () => {
             await appListCloudComponent.checkApsContainer();
             await appListCloudComponent.goToApp(candidateBaseApp);
             await tasksCloudDemoPage.taskListCloudComponent().checkTaskListIsLoaded();
-            await processCloudDemoPage.clickOnProcessFilters();
+            await processCloudDemoPage.processFilterCloudComponent.clickOnProcessFilters();
         });
 
         it('[C290069] Should display processes ordered by name when Name is selected from sort dropdown', async () => {
@@ -228,9 +228,9 @@ describe('Process list cloud', () => {
         });
 
         it('[C305054] Should display the actions filters Save, SaveAs and Delete', async () => {
-            await processCloudDemoPage.allProcessesFilter().clickProcessFilter();
-            await processCloudDemoPage.allProcessesFilter().checkProcessFilterIsDisplayed();
-            await expect(await processCloudDemoPage.getActiveFilterName()).toBe('All Processes');
+            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter('all-processes');
+            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed('all-processes');
+            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('All Processes');
             await processCloudDemoPage.editProcessFilterCloudComponent().openFilter();
 
             const editProcessFilterCloudComponent = processCloudDemoPage.editProcessFilterCloudComponent();
@@ -248,7 +248,7 @@ describe('Process list cloud', () => {
             await processCloudDemoPage.editProcessFilterCloudComponent().editProcessFilterDialog().setFilterName('New');
             await processCloudDemoPage.editProcessFilterCloudComponent().editProcessFilterDialog().clickOnSaveButton();
 
-            await expect(await processCloudDemoPage.getActiveFilterName()).toBe('New');
+            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('New');
 
             await processCloudDemoPage.processListCloudComponent().checkContentIsDisplayedById(completedProcess.entry.id);
             await expect(await processCloudDemoPage.processListCloudComponent().getDataTable().numberOfRows()).toBe(1);
@@ -276,7 +276,7 @@ describe('Process list cloud', () => {
             await processCloudDemoPage.editProcessFilterCloudComponent().clickSaveAsButton();
             await processCloudDemoPage.editProcessFilterCloudComponent().editProcessFilterDialog().setFilterName('SavedFilter');
             await processCloudDemoPage.editProcessFilterCloudComponent().editProcessFilterDialog().clickOnSaveButton();
-            await expect(await processCloudDemoPage.getActiveFilterName()).toBe('SavedFilter');
+            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('SavedFilter');
 
             await processCloudDemoPage.editProcessFilterCloudComponent().openFilter();
             await expect(await processCloudDemoPage.editProcessFilterCloudComponent().getProcessInstanceId()).toEqual(runningProcessInstance.entry.id);
@@ -289,7 +289,7 @@ describe('Process list cloud', () => {
             await processCloudDemoPage.editProcessFilterCloudComponent().clickSaveAsButton();
             await processCloudDemoPage.editProcessFilterCloudComponent().editProcessFilterDialog().setFilterName('SwitchFilter');
             await processCloudDemoPage.editProcessFilterCloudComponent().editProcessFilterDialog().clickOnSaveButton();
-            await expect(await processCloudDemoPage.getActiveFilterName()).toBe('SwitchFilter');
+            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('SwitchFilter');
 
             await processCloudDemoPage.editProcessFilterCloudComponent().openFilter();
             await expect(await processCloudDemoPage.editProcessFilterCloudComponent().getProcessInstanceId()).toEqual(switchProcessInstance.entry.id);
@@ -311,14 +311,14 @@ describe('Process list cloud', () => {
                 await appListCloudComponent.checkApsContainer();
                 await appListCloudComponent.goToApp(candidateBaseApp);
                 await tasksCloudDemoPage.taskListCloudComponent().checkTaskListIsLoaded();
-                await processCloudDemoPage.clickOnProcessFilters();
+                await processCloudDemoPage.processFilterCloudComponent.clickOnProcessFilters();
 
             });
 
             it('[C305054] Should display the actions filters Save and SaveAs, Delete button is not displayed', async () => {
-                await processCloudDemoPage.allProcessesFilter().clickProcessFilter();
-                await processCloudDemoPage.allProcessesFilter().checkProcessFilterIsDisplayed();
-                await expect(await processCloudDemoPage.getActiveFilterName()).toBe('All Processes');
+                await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter('all-processes');
+                await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed('all-processes');
+                await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('All Processes');
                 await processCloudDemoPage.editProcessFilterCloudComponent().openFilter();
                 await processCloudDemoPage.editProcessFilterCloudComponent().checkSaveButtonIsDisplayed();
                 await processCloudDemoPage.editProcessFilterCloudComponent().checkSaveAsButtonIsDisplayed();

--- a/e2e/process-services-cloud/process-filter-results.e2e.ts
+++ b/e2e/process-services-cloud/process-filter-results.e2e.ts
@@ -153,7 +153,7 @@ describe('Process filters cloud', () => {
         await appListCloudComponent.checkApsContainer();
         await appListCloudComponent.goToApp(candidateBaseApp);
         await tasksCloudDemoPage.taskListCloudComponent().checkTaskListIsLoaded();
-        await processCloudDemoPage.clickOnProcessFilters();
+        await processCloudDemoPage.processFilterCloudComponent.clickOnProcessFilters();
     });
 
     it('[C306887] Should be able to filter by appName', async () => {

--- a/e2e/process-services-cloud/process-filter-task.e2e.ts
+++ b/e2e/process-services-cloud/process-filter-task.e2e.ts
@@ -85,7 +85,7 @@ describe('Process filters cloud', () => {
         await appListCloudComponent.checkApsContainer();
         await appListCloudComponent.goToApp(simpleApp);
         await tasksCloudDemoPage.taskListCloudComponent().checkTaskListIsLoaded();
-        await processCloudDemoPage.clickOnProcessFilters();
+        await processCloudDemoPage.processFilterCloudComponent.clickOnProcessFilters();
     });
 
     it('[C290041] Should be displayed the "No Process Found" message when the process list is empty', async () => {
@@ -124,7 +124,7 @@ describe('Process filters cloud', () => {
         await processDetailsCloudDemoPage.checkTaskIsDisplayed(taskName);
         await browser.navigate().back();
 
-        await tasksCloudDemoPage.clickOnTaskFilter();
+        await tasksCloudDemoPage.taskFilterCloudComponent.clickOnTaskFilters();
         await tasksCloudDemoPage.editTaskFilterCloudComponent().openFilter();
         await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(taskAssigned[0].entry.name);
         await tasksCloudDemoPage.taskListCloudComponent().selectRow(taskAssigned[0].entry.name);

--- a/e2e/process-services-cloud/process-filters-cloud.e2e.ts
+++ b/e2e/process-services-cloud/process-filters-cloud.e2e.ts
@@ -34,12 +34,6 @@ describe('Process filters cloud', () => {
             browser.params.config.bpmHost, browser.params.config.oauth2.host, browser.params.config.providers
         );
 
-        const enum PROCESS_FILTERS {
-            COMPLETED = 'completed-processes',
-            RUNNING = 'running-processes',
-            ALL = 'all-processes'
-        }
-
         let tasksService: TasksService;
         let identityService: IdentityService;
         let groupIdentityService: GroupIdentityService;
@@ -96,41 +90,35 @@ describe('Process filters cloud', () => {
         });
 
         it('[C290021] Should be able to view default filters', async () => {
-            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed(PROCESS_FILTERS.COMPLETED);
-            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed(PROCESS_FILTERS.RUNNING);
-            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed(PROCESS_FILTERS.ALL);
+            await processCloudDemoPage.processFilterCloudComponent.checkCompletedProcessesFilterIsDisplayed();
+            await processCloudDemoPage.processFilterCloudComponent.checkRunningProcessesFilterIsDisplayed();
+            await processCloudDemoPage.processFilterCloudComponent.checkAllProcessesFilterIsDisplayed();
         });
 
         it('[C290043] Should display process in Running Processes List when process is started', async () => {
-            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed(PROCESS_FILTERS.RUNNING);
-            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter(PROCESS_FILTERS.RUNNING);
+            await processCloudDemoPage.processFilterCloudComponent.clickRunningProcessesFilter();
             await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('Running Processes');
             await processCloudDemoPage.processListCloudComponent().checkContentIsDisplayedById(runningProcess.entry.id);
 
-            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed(PROCESS_FILTERS.COMPLETED);
-            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter(PROCESS_FILTERS.COMPLETED);
+            await processCloudDemoPage.processFilterCloudComponent.clickCompletedProcessesFilter();
             await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('Completed Processes');
             await processCloudDemoPage.processListCloudComponent().checkContentIsNotDisplayedById(runningProcess.entry.id);
 
-            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed(PROCESS_FILTERS.ALL);
-            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter(PROCESS_FILTERS.ALL);
+            await processCloudDemoPage.processFilterCloudComponent.clickAllProcessesFilter();
             await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('All Processes');
             await processCloudDemoPage.processListCloudComponent().checkContentIsDisplayedById(runningProcess.entry.id);
         });
 
         it('[C290044] Should display process in Completed Processes List when process is completed', async () => {
-            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed(PROCESS_FILTERS.RUNNING);
-            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter(PROCESS_FILTERS.RUNNING);
+            await processCloudDemoPage.processFilterCloudComponent.clickRunningProcessesFilter();
             await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('Running Processes');
             await processCloudDemoPage.processListCloudComponent().checkContentIsNotDisplayedById(completedProcess.entry.id);
 
-            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed(PROCESS_FILTERS.COMPLETED);
-            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter(PROCESS_FILTERS.COMPLETED);
+            await processCloudDemoPage.processFilterCloudComponent.clickCompletedProcessesFilter();
             await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('Completed Processes');
             await processCloudDemoPage.processListCloudComponent().checkContentIsDisplayedById(completedProcess.entry.id);
 
-            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed(PROCESS_FILTERS.ALL);
-            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter(PROCESS_FILTERS.ALL);
+            await processCloudDemoPage.processFilterCloudComponent.clickAllProcessesFilter();
             await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('All Processes');
             await processCloudDemoPage.processListCloudComponent().checkContentIsDisplayedById(completedProcess.entry.id);
         });

--- a/e2e/process-services-cloud/process-filters-cloud.e2e.ts
+++ b/e2e/process-services-cloud/process-filters-cloud.e2e.ts
@@ -34,6 +34,12 @@ describe('Process filters cloud', () => {
             browser.params.config.bpmHost, browser.params.config.oauth2.host, browser.params.config.providers
         );
 
+        const enum PROCESS_FILTERS {
+            COMPLETED = 'completed-processes',
+            RUNNING = 'running-processes',
+            ALL = 'all-processes'
+        }
+
         let tasksService: TasksService;
         let identityService: IdentityService;
         let groupIdentityService: GroupIdentityService;
@@ -85,47 +91,47 @@ describe('Process filters cloud', () => {
             await appListCloudComponent.checkApsContainer();
             await appListCloudComponent.goToApp(candidateBaseApp);
             await tasksCloudDemoPage.taskListCloudComponent().checkTaskListIsLoaded();
-            await processCloudDemoPage.clickOnProcessFilters();
+            await processCloudDemoPage.processFilterCloudComponent.clickOnProcessFilters();
 
         });
 
         it('[C290021] Should be able to view default filters', async () => {
-            await processCloudDemoPage.completedProcessesFilter().checkProcessFilterIsDisplayed();
-            await processCloudDemoPage.runningProcessesFilter().checkProcessFilterIsDisplayed();
-            await processCloudDemoPage.allProcessesFilter().checkProcessFilterIsDisplayed();
+            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed(PROCESS_FILTERS.COMPLETED);
+            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed(PROCESS_FILTERS.RUNNING);
+            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed(PROCESS_FILTERS.ALL);
         });
 
         it('[C290043] Should display process in Running Processes List when process is started', async () => {
-            await processCloudDemoPage.runningProcessesFilter().clickProcessFilter();
-            await processCloudDemoPage.runningProcessesFilter().checkProcessFilterIsDisplayed();
-            await expect(await processCloudDemoPage.getActiveFilterName()).toBe('Running Processes');
+            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed(PROCESS_FILTERS.RUNNING);
+            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter(PROCESS_FILTERS.RUNNING);
+            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('Running Processes');
             await processCloudDemoPage.processListCloudComponent().checkContentIsDisplayedById(runningProcess.entry.id);
 
-            await processCloudDemoPage.completedProcessesFilter().clickProcessFilter();
-            await processCloudDemoPage.completedProcessesFilter().checkProcessFilterIsDisplayed();
-            await expect(await processCloudDemoPage.getActiveFilterName()).toBe('Completed Processes');
+            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed(PROCESS_FILTERS.COMPLETED);
+            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter(PROCESS_FILTERS.COMPLETED);
+            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('Completed Processes');
             await processCloudDemoPage.processListCloudComponent().checkContentIsNotDisplayedById(runningProcess.entry.id);
 
-            await processCloudDemoPage.allProcessesFilter().clickProcessFilter();
-            await processCloudDemoPage.allProcessesFilter().checkProcessFilterIsDisplayed();
-            await expect(await processCloudDemoPage.getActiveFilterName()).toBe('All Processes');
+            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed(PROCESS_FILTERS.ALL);
+            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter(PROCESS_FILTERS.ALL);
+            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('All Processes');
             await processCloudDemoPage.processListCloudComponent().checkContentIsDisplayedById(runningProcess.entry.id);
         });
 
         it('[C290044] Should display process in Completed Processes List when process is completed', async () => {
-            await processCloudDemoPage.runningProcessesFilter().clickProcessFilter();
-            await processCloudDemoPage.runningProcessesFilter().checkProcessFilterIsDisplayed();
-            await expect(await processCloudDemoPage.getActiveFilterName()).toBe('Running Processes');
+            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed(PROCESS_FILTERS.RUNNING);
+            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter(PROCESS_FILTERS.RUNNING);
+            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('Running Processes');
             await processCloudDemoPage.processListCloudComponent().checkContentIsNotDisplayedById(completedProcess.entry.id);
 
-            await processCloudDemoPage.completedProcessesFilter().clickProcessFilter();
-            await processCloudDemoPage.completedProcessesFilter().checkProcessFilterIsDisplayed();
-            await expect(await processCloudDemoPage.getActiveFilterName()).toBe('Completed Processes');
+            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed(PROCESS_FILTERS.COMPLETED);
+            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter(PROCESS_FILTERS.COMPLETED);
+            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('Completed Processes');
             await processCloudDemoPage.processListCloudComponent().checkContentIsDisplayedById(completedProcess.entry.id);
 
-            await processCloudDemoPage.allProcessesFilter().clickProcessFilter();
-            await processCloudDemoPage.allProcessesFilter().checkProcessFilterIsDisplayed();
-            await expect(await processCloudDemoPage.getActiveFilterName()).toBe('All Processes');
+            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed(PROCESS_FILTERS.ALL);
+            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter(PROCESS_FILTERS.ALL);
+            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('All Processes');
             await processCloudDemoPage.processListCloudComponent().checkContentIsDisplayedById(completedProcess.entry.id);
         });
     });

--- a/e2e/process-services-cloud/process-header-cloud.e2e.ts
+++ b/e2e/process-services-cloud/process-header-cloud.e2e.ts
@@ -105,8 +105,7 @@ describe('Process Header cloud component', () => {
             await tasksCloudDemoPage.taskListCloudComponent().checkTaskListIsLoaded();
             await processCloudDemoPage.processFilterCloudComponent.clickOnProcessFilters();
 
-            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed('running-processes');
-            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter('running-processes');
+            await processCloudDemoPage.processFilterCloudComponent.clickRunningProcessesFilter();
             await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('Running Processes');
             await processCloudDemoPage.processListCloudComponent().checkContentIsDisplayedByName(runningProcess.entry.name);
 
@@ -127,8 +126,7 @@ describe('Process Header cloud component', () => {
             await tasksCloudDemoPage.taskListCloudComponent().checkTaskListIsLoaded();
             await processCloudDemoPage.processFilterCloudComponent.clickOnProcessFilters();
 
-            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed('completed-processes');
-            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter('completed-processes');
+            await processCloudDemoPage.processFilterCloudComponent.clickCompletedProcessesFilter();
             await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('Completed Processes');
             await processCloudDemoPage.processListCloudComponent().checkContentIsDisplayedByName(childCompleteProcess.entry.name);
 

--- a/e2e/process-services-cloud/process-header-cloud.e2e.ts
+++ b/e2e/process-services-cloud/process-header-cloud.e2e.ts
@@ -103,11 +103,11 @@ describe('Process Header cloud component', () => {
         it('[C305010] Should display process details for running process', async () => {
             await appListCloudComponent.goToApp(simpleApp);
             await tasksCloudDemoPage.taskListCloudComponent().checkTaskListIsLoaded();
-            await processCloudDemoPage.clickOnProcessFilters();
+            await processCloudDemoPage.processFilterCloudComponent.clickOnProcessFilters();
 
-            await processCloudDemoPage.runningProcessesFilter().checkProcessFilterIsDisplayed();
-            await processCloudDemoPage.runningProcessesFilter().clickProcessFilter();
-            await expect(await processCloudDemoPage.getActiveFilterName()).toBe('Running Processes');
+            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed('running-processes');
+            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter('running-processes');
+            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('Running Processes');
             await processCloudDemoPage.processListCloudComponent().checkContentIsDisplayedByName(runningProcess.entry.name);
 
             await processCloudDemoPage.processListCloudComponent().checkProcessListIsLoaded();
@@ -125,11 +125,11 @@ describe('Process Header cloud component', () => {
         it('[C305008] Should display process details for completed process', async () => {
             await appListCloudComponent.goToApp(subProcessApp);
             await tasksCloudDemoPage.taskListCloudComponent().checkTaskListIsLoaded();
-            await processCloudDemoPage.clickOnProcessFilters();
+            await processCloudDemoPage.processFilterCloudComponent.clickOnProcessFilters();
 
-            await processCloudDemoPage.completedProcessesFilter().checkProcessFilterIsDisplayed();
-            await processCloudDemoPage.completedProcessesFilter().clickProcessFilter();
-            await expect(await processCloudDemoPage.getActiveFilterName()).toBe('Completed Processes');
+            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed('completed-processes');
+            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter('completed-processes');
+            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('Completed Processes');
             await processCloudDemoPage.processListCloudComponent().checkContentIsDisplayedByName(childCompleteProcess.entry.name);
 
             await processCloudDemoPage.processListCloudComponent().checkProcessListIsLoaded();

--- a/e2e/process-services-cloud/process-list-cloud-action-menu.e2e.ts
+++ b/e2e/process-services-cloud/process-list-cloud-action-menu.e2e.ts
@@ -85,7 +85,7 @@ describe('Process list cloud', () => {
             await tasksCloudDemoPage.actionAdded('invisibleaction');
             await tasksCloudDemoPage.clickAppButton();
             await processCloudDemoPage.processFilterCloudComponent.clickOnProcessFilters();
-            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter('running-processes');
+            await processCloudDemoPage.processFilterCloudComponent.clickRunningProcessesFilter();
         });
 
         it('[C315236] Should be able to see and execute custom action menu', async () => {

--- a/e2e/process-services-cloud/process-list-cloud-action-menu.e2e.ts
+++ b/e2e/process-services-cloud/process-list-cloud-action-menu.e2e.ts
@@ -84,12 +84,12 @@ describe('Process list cloud', () => {
             await tasksCloudDemoPage.addInvisibleAction('invisibleaction');
             await tasksCloudDemoPage.actionAdded('invisibleaction');
             await tasksCloudDemoPage.clickAppButton();
-            await processCloudDemoPage.clickOnProcessFilters();
-            await processCloudDemoPage.runningProcessesFilter().clickProcessFilter();
+            await processCloudDemoPage.processFilterCloudComponent.clickOnProcessFilters();
+            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter('running-processes');
         });
 
         it('[C315236] Should be able to see and execute custom action menu', async () => {
-            await expect(await processCloudDemoPage.getActiveFilterName()).toBe('Running Processes');
+            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('Running Processes');
             await processCloudDemoPage.processListCloudComponent().checkProcessListIsLoaded();
             await processCloudDemoPage.processListCloudComponent().checkContentIsDisplayedById(editProcess.entry.id);
             await processCloudDemoPage.processListCloudComponent().clickOptionsButton(editProcess.entry.id);

--- a/e2e/process-services-cloud/process-list-cloud-component.e2e.ts
+++ b/e2e/process-services-cloud/process-list-cloud-component.e2e.ts
@@ -75,10 +75,10 @@ describe('Process list cloud', () => {
             await navigationBarPage.navigateToProcessServicesCloudPage();
             await appListCloudComponent.checkApsContainer();
             await appListCloudComponent.goToApp(candidateBaseApp);
-            await processCloudDemoPage.clickOnProcessFilters();
-            await processCloudDemoPage.runningProcessesFilter().checkProcessFilterIsDisplayed();
-            await processCloudDemoPage.runningProcessesFilter().clickProcessFilter();
-            await expect(await processCloudDemoPage.getActiveFilterName()).toBe('Running Processes');
+            await processCloudDemoPage.processFilterCloudComponent.clickOnProcessFilters();
+            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed('running-processes');
+            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter('running-processes');
+            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('Running Processes');
             await processCloudDemoPage.processListCloudComponent().checkProcessListIsLoaded();
             await processCloudDemoPage.processListCloudComponent().checkContentIsDisplayedById(runningProcess.entry.id);
 

--- a/e2e/process-services-cloud/process-list-cloud-component.e2e.ts
+++ b/e2e/process-services-cloud/process-list-cloud-component.e2e.ts
@@ -76,8 +76,7 @@ describe('Process list cloud', () => {
             await appListCloudComponent.checkApsContainer();
             await appListCloudComponent.goToApp(candidateBaseApp);
             await processCloudDemoPage.processFilterCloudComponent.clickOnProcessFilters();
-            await processCloudDemoPage.processFilterCloudComponent.checkProcessFilterIsDisplayed('running-processes');
-            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter('running-processes');
+            await processCloudDemoPage.processFilterCloudComponent.clickRunningProcessesFilter();
             await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('Running Processes');
             await processCloudDemoPage.processListCloudComponent().checkProcessListIsLoaded();
             await processCloudDemoPage.processListCloudComponent().checkContentIsDisplayedById(runningProcess.entry.id);

--- a/e2e/process-services-cloud/process-list-selection-cloud.e2e.ts
+++ b/e2e/process-services-cloud/process-list-selection-cloud.e2e.ts
@@ -78,9 +78,9 @@ describe('Process list cloud', () => {
             await expect(processInstances.length).toEqual(noOfProcesses, 'Wrong preconditions');
             await appListCloudComponent.checkApsContainer();
             await appListCloudComponent.goToApp(simpleApp);
-            await processCloudDemoPage.clickOnProcessFilters();
-            await processCloudDemoPage.runningProcessesFilter().clickProcessFilter();
-            await expect(await processCloudDemoPage.getActiveFilterName()).toBe('Running Processes');
+            await processCloudDemoPage.processFilterCloudComponent.clickOnProcessFilters();
+            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter('running-processes');
+            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('Running Processes');
             await tasksCloudDemoPage.clickSettingsButton();
             await tasksCloudDemoPage.disableDisplayProcessDetails();
             await tasksCloudDemoPage.clickAppButton();
@@ -90,8 +90,8 @@ describe('Process list cloud', () => {
             await tasksCloudDemoPage.clickSettingsButton();
             await tasksCloudDemoPage.selectSelectionMode('None');
             await tasksCloudDemoPage.clickAppButton();
-            await processCloudDemoPage.isProcessFiltersListVisible();
-            await expect(await processCloudDemoPage.getActiveFilterName()).toEqual('Running Processes');
+            await processCloudDemoPage.processFilterCloudComponent.isProcessFiltersListVisible();
+            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toEqual('Running Processes');
 
             await processCloudDemoPage.processListCloudComponent().selectRowById(processInstances[0]);
             await processCloudDemoPage.processListCloudComponent().getDataTable().checkNoRowIsSelected();
@@ -101,8 +101,8 @@ describe('Process list cloud', () => {
             await tasksCloudDemoPage.clickSettingsButton();
             await tasksCloudDemoPage.selectSelectionMode('Single');
             await tasksCloudDemoPage.clickAppButton();
-            await processCloudDemoPage.isProcessFiltersListVisible();
-            await expect(await processCloudDemoPage.getActiveFilterName()).toEqual('Running Processes');
+            await processCloudDemoPage.processFilterCloudComponent.isProcessFiltersListVisible();
+            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toEqual('Running Processes');
 
             await processCloudDemoPage.processListCloudComponent().selectRowById(processInstances[0]);
             await processCloudDemoPage.processListCloudComponent().checkRowIsSelectedById(processInstances[0]);
@@ -116,8 +116,8 @@ describe('Process list cloud', () => {
             await tasksCloudDemoPage.clickSettingsButton();
             await tasksCloudDemoPage.selectSelectionMode('Multiple');
             await tasksCloudDemoPage.clickAppButton();
-            await processCloudDemoPage.isProcessFiltersListVisible();
-            await expect(await processCloudDemoPage.getActiveFilterName()).toEqual('Running Processes');
+            await processCloudDemoPage.processFilterCloudComponent.isProcessFiltersListVisible();
+            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toEqual('Running Processes');
 
             await processCloudDemoPage.processListCloudComponent().selectRowById(processInstances[0]);
             await processCloudDemoPage.processListCloudComponent().checkRowIsSelectedById(processInstances[0]);
@@ -132,8 +132,8 @@ describe('Process list cloud', () => {
             await tasksCloudDemoPage.clickSettingsButton();
             await tasksCloudDemoPage.enableMultiSelection();
             await tasksCloudDemoPage.clickAppButton();
-            await processCloudDemoPage.isProcessFiltersListVisible();
-            await expect(await processCloudDemoPage.getActiveFilterName()).toEqual('Running Processes');
+            await processCloudDemoPage.processFilterCloudComponent.isProcessFiltersListVisible();
+            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toEqual('Running Processes');
 
             await processCloudDemoPage.processListCloudComponent().checkCheckboxById(processInstances[0]);
             await processCloudDemoPage.processListCloudComponent().checkRowIsCheckedById(processInstances[0]);
@@ -149,8 +149,8 @@ describe('Process list cloud', () => {
             await tasksCloudDemoPage.clickSettingsButton();
             await tasksCloudDemoPage.enableMultiSelection();
             await tasksCloudDemoPage.clickAppButton();
-            await processCloudDemoPage.isProcessFiltersListVisible();
-            await expect(await processCloudDemoPage.getActiveFilterName()).toEqual('Running Processes');
+            await processCloudDemoPage.processFilterCloudComponent.isProcessFiltersListVisible();
+            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toEqual('Running Processes');
 
             await processCloudDemoPage.processListCloudComponent().getDataTable().checkAllRowsButtonIsDisplayed();
             await processCloudDemoPage.processListCloudComponent().getDataTable().checkAllRows();
@@ -171,8 +171,8 @@ describe('Process list cloud', () => {
             await tasksCloudDemoPage.enableMultiSelection();
             await tasksCloudDemoPage.enableTestingMode();
             await tasksCloudDemoPage.clickAppButton();
-            await processCloudDemoPage.isProcessFiltersListVisible();
-            await expect(await processCloudDemoPage.getActiveFilterName()).toEqual('Running Processes');
+            await processCloudDemoPage.processFilterCloudComponent.isProcessFiltersListVisible();
+            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toEqual('Running Processes');
 
             await processCloudDemoPage.processListCloudComponent().checkCheckboxById(processInstances[0]);
             await processCloudDemoPage.processListCloudComponent().checkRowIsCheckedById(processInstances[0]);

--- a/e2e/process-services-cloud/process-list-selection-cloud.e2e.ts
+++ b/e2e/process-services-cloud/process-list-selection-cloud.e2e.ts
@@ -79,7 +79,7 @@ describe('Process list cloud', () => {
             await appListCloudComponent.checkApsContainer();
             await appListCloudComponent.goToApp(simpleApp);
             await processCloudDemoPage.processFilterCloudComponent.clickOnProcessFilters();
-            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter('running-processes');
+            await processCloudDemoPage.processFilterCloudComponent.clickRunningProcessesFilter();
             await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('Running Processes');
             await tasksCloudDemoPage.clickSettingsButton();
             await tasksCloudDemoPage.disableDisplayProcessDetails();

--- a/e2e/process-services-cloud/start-process-cloud.e2e.ts
+++ b/e2e/process-services-cloud/start-process-cloud.e2e.ts
@@ -104,10 +104,10 @@ describe('Start Process', () => {
         await startProcessPage.enterProcessName(processName);
         await expect(await startProcessPage.checkStartProcessButtonIsEnabled()).toBe(true);
         await startProcessPage.clickStartProcessButton();
-        await processCloudDemoPage.clickOnProcessFilters();
+        await processCloudDemoPage.processFilterCloudComponent.clickOnProcessFilters();
 
-        await processCloudDemoPage.runningProcessesFilter().clickProcessFilter();
-        await expect(await processCloudDemoPage.getActiveFilterName()).toBe('Running Processes');
+        await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter('running-processes');
+        await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('Running Processes');
         await processCloudDemoPage.processListCloudComponent().checkContentIsDisplayedByName(processName);
    });
 });

--- a/e2e/process-services-cloud/start-process-cloud.e2e.ts
+++ b/e2e/process-services-cloud/start-process-cloud.e2e.ts
@@ -106,7 +106,7 @@ describe('Start Process', () => {
         await startProcessPage.clickStartProcessButton();
         await processCloudDemoPage.processFilterCloudComponent.clickOnProcessFilters();
 
-        await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter('running-processes');
+        await processCloudDemoPage.processFilterCloudComponent.clickRunningProcessesFilter();
         await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('Running Processes');
         await processCloudDemoPage.processListCloudComponent().checkContentIsDisplayedByName(processName);
    });

--- a/e2e/process-services-cloud/start-task-form-cloud.e2e.ts
+++ b/e2e/process-services-cloud/start-task-form-cloud.e2e.ts
@@ -95,6 +95,11 @@ describe('Start Task Form', () => {
         'location': browser.params.resources.Files.ADF_DOCUMENTS.TEST.file_location
     });
 
+    const enum PROCESS_FILTERS {
+        COMPLETED = 'completed-processes',
+        RUNNING = 'running-processes'
+    }
+
     let identityService: IdentityService;
     let groupIdentityService: GroupIdentityService;
     const folderName = StringUtil.generateRandomString(5);
@@ -219,7 +224,7 @@ describe('Start Task Form', () => {
             await appListCloudComponent.goToApp(candidateBaseApp);
             await tasksCloudDemoPage.taskListCloudComponent().getDataTable().waitForTableBody();
 
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(standaloneTaskName);
             await tasksCloudDemoPage.taskListCloudComponent().selectRow(standaloneTaskName);
             await taskFormCloudComponent.formFields().checkFormIsDisplayed();
@@ -277,8 +282,8 @@ describe('Start Task Form', () => {
             await widget.numberWidget().setFieldValue('Number07vyx9', 100);
             await expect(await startProcessPage.checkStartProcessButtonIsEnabled()).toBe(true);
             await startProcessPage.clickStartProcessButton();
-            await processCloudDemoPage.runningProcessesFilter().clickProcessFilter();
-            await expect(await processCloudDemoPage.getActiveFilterName()).toBe('Running Processes');
+            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter(PROCESS_FILTERS.RUNNING);
+            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('Running Processes');
             await processCloudDemoPage.editProcessFilterCloudComponent().openFilter();
             await processCloudDemoPage.editProcessFilterCloudComponent().setProperty('processName', startEventFormProcess);
 
@@ -297,14 +302,14 @@ describe('Start Task Form', () => {
             const taskId = await taskHeaderCloudPage.getId();
             await taskFormCloudComponent.checkCompleteButtonIsDisplayed();
             await taskFormCloudComponent.clickCompleteButton();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsNotDisplayedById(taskId);
 
-            await tasksCloudDemoPage.completedTasksFilter().clickTaskFilter();
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter('completed-tasks');
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedById(taskId);
 
-            await processCloudDemoPage.clickOnProcessFilters();
-            await processCloudDemoPage.completedProcessesFilter().clickProcessFilter();
+            await processCloudDemoPage.processFilterCloudComponent.clickOnProcessFilters();
+            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter(PROCESS_FILTERS.COMPLETED);
             await processCloudDemoPage.processListCloudComponent().checkContentIsDisplayedById(processId);
 
         });
@@ -317,8 +322,8 @@ describe('Start Task Form', () => {
             await appListCloudComponent.checkApsContainer();
             await appListCloudComponent.checkAppIsDisplayed(candidateBaseApp);
             await appListCloudComponent.goToApp(candidateBaseApp);
-            await processCloudDemoPage.clickOnProcessFilters();
-            await processCloudDemoPage.runningProcessesFilter().clickProcessFilter();
+            await processCloudDemoPage.processFilterCloudComponent.clickOnProcessFilters();
+            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter(PROCESS_FILTERS.RUNNING);
             await processCloudDemoPage.processListCloudComponent().checkProcessListIsLoaded();
         });
 
@@ -498,10 +503,10 @@ describe('Start Task Form', () => {
             const taskId = await taskHeaderCloudPage.getId();
             await taskFormCloudComponent.checkCompleteButtonIsDisplayed();
             await taskFormCloudComponent.clickCompleteButton();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsNotDisplayedById(taskId);
 
-            await tasksCloudDemoPage.completedTasksFilter().clickTaskFilter();
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter('completed-tasks');
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedById(taskId);
             await tasksCloudDemoPage.taskListCloudComponent().selectRowByTaskId(taskId);
             await contentFileWidget.checkFileIsAttached(testFileModel.name);
@@ -532,10 +537,10 @@ describe('Start Task Form', () => {
 
             const taskId = await taskHeaderCloudPage.getId();
             await taskFormCloudComponent.clickCompleteButton();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsNotDisplayedById(taskId);
 
-            await tasksCloudDemoPage.completedTasksFilter().clickTaskFilter();
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter('completed-tasks');
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedById(taskId);
             await tasksCloudDemoPage.taskListCloudComponent().selectRowByTaskId(taskId);
             await contentFileWidget.checkFileIsAttached(testFileModel.name);

--- a/e2e/process-services-cloud/start-task-form-cloud.e2e.ts
+++ b/e2e/process-services-cloud/start-task-form-cloud.e2e.ts
@@ -95,11 +95,6 @@ describe('Start Task Form', () => {
         'location': browser.params.resources.Files.ADF_DOCUMENTS.TEST.file_location
     });
 
-    const enum PROCESS_FILTERS {
-        COMPLETED = 'completed-processes',
-        RUNNING = 'running-processes'
-    }
-
     let identityService: IdentityService;
     let groupIdentityService: GroupIdentityService;
     const folderName = StringUtil.generateRandomString(5);
@@ -282,7 +277,7 @@ describe('Start Task Form', () => {
             await widget.numberWidget().setFieldValue('Number07vyx9', 100);
             await expect(await startProcessPage.checkStartProcessButtonIsEnabled()).toBe(true);
             await startProcessPage.clickStartProcessButton();
-            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter(PROCESS_FILTERS.RUNNING);
+            await processCloudDemoPage.processFilterCloudComponent.clickRunningProcessesFilter();
             await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('Running Processes');
             await processCloudDemoPage.editProcessFilterCloudComponent().openFilter();
             await processCloudDemoPage.editProcessFilterCloudComponent().setProperty('processName', startEventFormProcess);
@@ -305,11 +300,11 @@ describe('Start Task Form', () => {
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsNotDisplayedById(taskId);
 
-            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter('completed-tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickCompletedTasksFilter();
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedById(taskId);
 
             await processCloudDemoPage.processFilterCloudComponent.clickOnProcessFilters();
-            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter(PROCESS_FILTERS.COMPLETED);
+            await processCloudDemoPage.processFilterCloudComponent.clickCompletedProcessesFilter();
             await processCloudDemoPage.processListCloudComponent().checkContentIsDisplayedById(processId);
 
         });
@@ -323,7 +318,7 @@ describe('Start Task Form', () => {
             await appListCloudComponent.checkAppIsDisplayed(candidateBaseApp);
             await appListCloudComponent.goToApp(candidateBaseApp);
             await processCloudDemoPage.processFilterCloudComponent.clickOnProcessFilters();
-            await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter(PROCESS_FILTERS.RUNNING);
+            await processCloudDemoPage.processFilterCloudComponent.clickRunningProcessesFilter();
             await processCloudDemoPage.processListCloudComponent().checkProcessListIsLoaded();
         });
 
@@ -506,7 +501,7 @@ describe('Start Task Form', () => {
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsNotDisplayedById(taskId);
 
-            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter('completed-tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickCompletedTasksFilter();
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedById(taskId);
             await tasksCloudDemoPage.taskListCloudComponent().selectRowByTaskId(taskId);
             await contentFileWidget.checkFileIsAttached(testFileModel.name);
@@ -540,7 +535,7 @@ describe('Start Task Form', () => {
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsNotDisplayedById(taskId);
 
-            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter('completed-tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickCompletedTasksFilter();
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedById(taskId);
             await tasksCloudDemoPage.taskListCloudComponent().selectRowByTaskId(taskId);
             await contentFileWidget.checkFileIsAttached(testFileModel.name);

--- a/e2e/process-services-cloud/start-task/start-task-custom-app-cloud.e2e.ts
+++ b/e2e/process-services-cloud/start-task/start-task-custom-app-cloud.e2e.ts
@@ -194,9 +194,9 @@ describe('Start Task', () => {
 
         await browser.driver.sleep(1000);
 
-        await tasksCloudDemoPage.myTasksFilter().clickTaskFilter();
+        await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter('my-tasks');
 
-        await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+        await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
     });
 
     it('[C291953] Assignee field should display the logged user as default', async () => {

--- a/e2e/process-services-cloud/start-task/start-task-custom-app-cloud.e2e.ts
+++ b/e2e/process-services-cloud/start-task/start-task-custom-app-cloud.e2e.ts
@@ -194,7 +194,7 @@ describe('Start Task', () => {
 
         await browser.driver.sleep(1000);
 
-        await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter('my-tasks');
+        await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
 
         await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
     });

--- a/e2e/process-services-cloud/task-filters-cloud.e2e.ts
+++ b/e2e/process-services-cloud/task-filters-cloud.e2e.ts
@@ -33,11 +33,6 @@ describe('Task filters cloud', () => {
         let testUser, groupInfo;
         const apiService = new ApiService(browser.params.config.oauth2.clientId, browser.params.config.bpmHost, browser.params.config.oauth2.host, 'BPM');
 
-        const enum TASK_FILTERS {
-            COMPLETED_TASKS = 'completed-tasks',
-            MY_TASKS = 'my-tasks'
-        }
-
         const newTask = StringUtil.generateRandomString(5), completedTask = StringUtil.generateRandomString(5);
         const simpleApp = browser.params.resources.ACTIVITI_CLOUD_APPS.SIMPLE_APP.name;
 
@@ -69,8 +64,8 @@ describe('Task filters cloud', () => {
         });
 
         it('[C290011] Should display default filters when an app is deployed', async () => {
-            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(TASK_FILTERS.MY_TASKS);
-            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(TASK_FILTERS.COMPLETED_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkMyTasksFilterIsDisplayed();
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkCompletedTasksFilterIsDisplayed();
         });
 
         it('[C290009] Should display default filters and created task', async () => {
@@ -79,13 +74,11 @@ describe('Task filters cloud', () => {
             const task = await tasksService.createStandaloneTask(newTask, simpleApp);
             await tasksService.claimTask(task.entry.id, simpleApp);
 
-            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(TASK_FILTERS.COMPLETED_TASKS);
-            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.COMPLETED_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickCompletedTasksFilter();
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('Completed Tasks');
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsNotDisplayedByName(newTask);
 
-            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(TASK_FILTERS.MY_TASKS);
-            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(newTask);
@@ -98,13 +91,11 @@ describe('Task filters cloud', () => {
             await tasksService.claimTask(toBeCompletedTask.entry.id, simpleApp);
             await tasksService.completeTask(toBeCompletedTask.entry.id, simpleApp);
 
-            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(TASK_FILTERS.MY_TASKS);
-            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsNotDisplayedByName(completedTask);
 
-            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(TASK_FILTERS.COMPLETED_TASKS);
-            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.COMPLETED_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickCompletedTasksFilter();
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('Completed Tasks');
 
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(completedTask);

--- a/e2e/process-services-cloud/task-filters-cloud.e2e.ts
+++ b/e2e/process-services-cloud/task-filters-cloud.e2e.ts
@@ -33,6 +33,11 @@ describe('Task filters cloud', () => {
         let testUser, groupInfo;
         const apiService = new ApiService(browser.params.config.oauth2.clientId, browser.params.config.bpmHost, browser.params.config.oauth2.host, 'BPM');
 
+        const enum TASK_FILTERS {
+            COMPLETED_TASKS = 'completed-tasks',
+            MY_TASKS = 'my-tasks'
+        }
+
         const newTask = StringUtil.generateRandomString(5), completedTask = StringUtil.generateRandomString(5);
         const simpleApp = browser.params.resources.ACTIVITI_CLOUD_APPS.SIMPLE_APP.name;
 
@@ -64,8 +69,8 @@ describe('Task filters cloud', () => {
         });
 
         it('[C290011] Should display default filters when an app is deployed', async () => {
-            await tasksCloudDemoPage.myTasksFilter().checkTaskFilterIsDisplayed();
-            await tasksCloudDemoPage.completedTasksFilter().checkTaskFilterIsDisplayed();
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(TASK_FILTERS.MY_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(TASK_FILTERS.COMPLETED_TASKS);
         });
 
         it('[C290009] Should display default filters and created task', async () => {
@@ -74,12 +79,14 @@ describe('Task filters cloud', () => {
             const task = await tasksService.createStandaloneTask(newTask, simpleApp);
             await tasksService.claimTask(task.entry.id, simpleApp);
 
-            await tasksCloudDemoPage.completedTasksFilter().clickTaskFilter();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('Completed Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(TASK_FILTERS.COMPLETED_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.COMPLETED_TASKS);
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('Completed Tasks');
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsNotDisplayedByName(newTask);
 
-            await tasksCloudDemoPage.myTasksFilter().clickTaskFilter();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(TASK_FILTERS.MY_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(newTask);
         });
@@ -91,19 +98,21 @@ describe('Task filters cloud', () => {
             await tasksService.claimTask(toBeCompletedTask.entry.id, simpleApp);
             await tasksService.completeTask(toBeCompletedTask.entry.id, simpleApp);
 
-            await tasksCloudDemoPage.myTasksFilter().clickTaskFilter();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(TASK_FILTERS.MY_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsNotDisplayedByName(completedTask);
 
-            await tasksCloudDemoPage.completedTasksFilter().clickTaskFilter();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('Completed Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(TASK_FILTERS.COMPLETED_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.COMPLETED_TASKS);
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('Completed Tasks');
 
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(completedTask);
         });
 
         it('[C291792] Should select the first task filter from the list as default', async () => {
 
-            await expect(await tasksCloudDemoPage.firstFilterIsActive()).toBe(true);
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.firstFilterIsActive()).toBe(true);
         });
    });
 });

--- a/e2e/process-services-cloud/task-form-cloud-component-tab.e2e.ts
+++ b/e2e/process-services-cloud/task-form-cloud-component-tab.e2e.ts
@@ -53,6 +53,11 @@ describe('Task form cloud component', () => {
     const apiService = new ApiService(browser.params.config.oauth2.clientId, browser.params.config.bpmHost, browser.params.config.oauth2.host, browser.params.config.providers);
     const apiServiceHrUser = new ApiService(browser.params.config.oauth2.clientId, browser.params.config.bpmHost, browser.params.config.oauth2.host, browser.params.config.providers);
 
+    const enum TASK_FILTERS {
+        MY_TASKS = 'my-tasks',
+        COMPLETED_TASKS = 'completed-tasks'
+    }
+
     const visibilityConditionTasks = [];
 
     const tab = {
@@ -158,8 +163,8 @@ describe('Task form cloud component', () => {
     describe('Complete task with form - cloud directive', () => {
 
         it('[C315174] Should be able to complete a standalone task with visible tab with empty value for field', async () => {
-            await tasksCloudDemoPage.myTasksFilter().clickTaskFilter();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(visibilityConditionTasks[0].entry.name);
             await tasksCloudDemoPage.taskListCloudComponent().selectRow(visibilityConditionTasks[0].entry.name);
@@ -177,10 +182,10 @@ describe('Task form cloud component', () => {
             await browser.sleep(1000);
             await browser.refresh();
 
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsNotDisplayedByName(visibilityConditionTasks[0].entry.name);
 
-            await tasksCloudDemoPage.completedTasksFilter().clickTaskFilter();
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.COMPLETED_TASKS);
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(visibilityConditionTasks[0].entry.name);
             await tasksCloudDemoPage.taskListCloudComponent().selectRow(visibilityConditionTasks[0].entry.name);
             await widget.tab().checkTabIsDisplayedByLabel(tab.tabWithFields);
@@ -188,8 +193,8 @@ describe('Task form cloud component', () => {
         });
 
         it('[C315177] Should be able to complete a standalone task with invisible tab with invalid value for field', async () => {
-            await tasksCloudDemoPage.myTasksFilter().clickTaskFilter();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(visibilityConditionTasks[1].entry.name);
             await tasksCloudDemoPage.taskListCloudComponent().selectRow(visibilityConditionTasks[1].entry.name);
@@ -215,10 +220,10 @@ describe('Task form cloud component', () => {
             await browser.sleep(1000);
             await browser.refresh();
 
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsNotDisplayedByName(visibilityConditionTasks[1].entry.name);
 
-            await tasksCloudDemoPage.completedTasksFilter().clickTaskFilter();
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.COMPLETED_TASKS);
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(visibilityConditionTasks[1].entry.name);
             await tasksCloudDemoPage.taskListCloudComponent().selectRow(visibilityConditionTasks[1].entry.name);
             await widget.tab().checkTabIsDisplayedByLabel(tab.tabWithFields);
@@ -226,8 +231,8 @@ describe('Task form cloud component', () => {
         });
 
         it('[C315178] Should be able to complete a standalone task with invisible tab with valid value', async () => {
-            await tasksCloudDemoPage.myTasksFilter().clickTaskFilter();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(visibilityConditionTasks[2].entry.name);
 
@@ -253,11 +258,11 @@ describe('Task form cloud component', () => {
             await browser.sleep(1000);
             await browser.refresh();
 
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsNotDisplayedByName(visibilityConditionTasks[2].entry.name);
 
-            await tasksCloudDemoPage.completedTasksFilter().clickTaskFilter();
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.COMPLETED_TASKS);
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(visibilityConditionTasks[2].entry.name);
             await tasksCloudDemoPage.taskListCloudComponent().selectRow(visibilityConditionTasks[2].entry.name);
 
@@ -266,8 +271,8 @@ describe('Task form cloud component', () => {
         });
 
         it('[C315175] Should be able to complete a standalone task with invisible tab with empty value for field', async () => {
-            await tasksCloudDemoPage.myTasksFilter().clickTaskFilter();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(visibilityConditionTasks[3].entry.name);
             await tasksCloudDemoPage.taskListCloudComponent().selectRow(visibilityConditionTasks[3].entry.name);
@@ -282,10 +287,10 @@ describe('Task form cloud component', () => {
             await browser.sleep(1000);
             await browser.refresh();
 
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsNotDisplayedByName(visibilityConditionTasks[3].entry.name);
 
-            await tasksCloudDemoPage.completedTasksFilter().clickTaskFilter();
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.COMPLETED_TASKS);
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(visibilityConditionTasks[3].entry.name);
             await tasksCloudDemoPage.taskListCloudComponent().selectRow(visibilityConditionTasks[3].entry.name);
             await widget.tab().checkTabIsDisplayedByLabel(tab.tabWithFields);
@@ -293,8 +298,8 @@ describe('Task form cloud component', () => {
         });
 
         it('[C315176] Should not be able to complete a standalone task with visible tab with invalid value for field', async () => {
-            await tasksCloudDemoPage.myTasksFilter().clickTaskFilter();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(visibilityConditionTasks[4].entry.name);
             await tasksCloudDemoPage.taskListCloudComponent().selectRow(visibilityConditionTasks[4].entry.name);
@@ -315,8 +320,8 @@ describe('Task form cloud component', () => {
         });
 
         it('[C315179] Should be able to complete a standalone task with visible tab with valid value for field', async () => {
-            await tasksCloudDemoPage.myTasksFilter().clickTaskFilter();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(visibilityConditionTasks[5].entry.name);
             await tasksCloudDemoPage.taskListCloudComponent().selectRow(visibilityConditionTasks[5].entry.name);
@@ -333,10 +338,10 @@ describe('Task form cloud component', () => {
             await browser.sleep(1000);
             await browser.refresh();
 
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsNotDisplayedByName(visibilityConditionTasks[5].entry.name);
 
-            await tasksCloudDemoPage.completedTasksFilter().clickTaskFilter();
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.COMPLETED_TASKS);
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(visibilityConditionTasks[5].entry.name);
             await tasksCloudDemoPage.taskListCloudComponent().selectRow(visibilityConditionTasks[5].entry.name);
             await widget.tab().checkTabIsDisplayedByLabel(tab.tabWithFields);

--- a/e2e/process-services-cloud/task-form-cloud-component-tab.e2e.ts
+++ b/e2e/process-services-cloud/task-form-cloud-component-tab.e2e.ts
@@ -53,11 +53,6 @@ describe('Task form cloud component', () => {
     const apiService = new ApiService(browser.params.config.oauth2.clientId, browser.params.config.bpmHost, browser.params.config.oauth2.host, browser.params.config.providers);
     const apiServiceHrUser = new ApiService(browser.params.config.oauth2.clientId, browser.params.config.bpmHost, browser.params.config.oauth2.host, browser.params.config.providers);
 
-    const enum TASK_FILTERS {
-        MY_TASKS = 'my-tasks',
-        COMPLETED_TASKS = 'completed-tasks'
-    }
-
     const visibilityConditionTasks = [];
 
     const tab = {
@@ -163,7 +158,7 @@ describe('Task form cloud component', () => {
     describe('Complete task with form - cloud directive', () => {
 
         it('[C315174] Should be able to complete a standalone task with visible tab with empty value for field', async () => {
-            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(visibilityConditionTasks[0].entry.name);
@@ -185,7 +180,7 @@ describe('Task form cloud component', () => {
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsNotDisplayedByName(visibilityConditionTasks[0].entry.name);
 
-            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.COMPLETED_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickCompletedTasksFilter();
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(visibilityConditionTasks[0].entry.name);
             await tasksCloudDemoPage.taskListCloudComponent().selectRow(visibilityConditionTasks[0].entry.name);
             await widget.tab().checkTabIsDisplayedByLabel(tab.tabWithFields);
@@ -193,7 +188,7 @@ describe('Task form cloud component', () => {
         });
 
         it('[C315177] Should be able to complete a standalone task with invisible tab with invalid value for field', async () => {
-            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(visibilityConditionTasks[1].entry.name);
@@ -205,6 +200,7 @@ describe('Task form cloud component', () => {
             await widget.textWidget().isWidgetVisible(widgets.textOneId);
 
             await widget.textWidget().setValue(widgets.textOneId, value.displayTab);
+            await widget.textWidget().setValue(widgets.textThreeId, value.displayTab);
             await widget.textWidget().setValue(widgets.textThreeId, value.displayTab);
             await widget.tab().checkTabIsDisplayedByLabel(tab.tabWithFields);
             await widget.tab().checkTabIsDisplayedByLabel(tab.tabFieldField);
@@ -223,7 +219,7 @@ describe('Task form cloud component', () => {
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsNotDisplayedByName(visibilityConditionTasks[1].entry.name);
 
-            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.COMPLETED_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickCompletedTasksFilter();
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(visibilityConditionTasks[1].entry.name);
             await tasksCloudDemoPage.taskListCloudComponent().selectRow(visibilityConditionTasks[1].entry.name);
             await widget.tab().checkTabIsDisplayedByLabel(tab.tabWithFields);
@@ -231,7 +227,7 @@ describe('Task form cloud component', () => {
         });
 
         it('[C315178] Should be able to complete a standalone task with invisible tab with valid value', async () => {
-            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(visibilityConditionTasks[2].entry.name);
@@ -262,7 +258,7 @@ describe('Task form cloud component', () => {
 
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsNotDisplayedByName(visibilityConditionTasks[2].entry.name);
 
-            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.COMPLETED_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickCompletedTasksFilter();
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(visibilityConditionTasks[2].entry.name);
             await tasksCloudDemoPage.taskListCloudComponent().selectRow(visibilityConditionTasks[2].entry.name);
 
@@ -271,7 +267,7 @@ describe('Task form cloud component', () => {
         });
 
         it('[C315175] Should be able to complete a standalone task with invisible tab with empty value for field', async () => {
-            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(visibilityConditionTasks[3].entry.name);
@@ -290,7 +286,7 @@ describe('Task form cloud component', () => {
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsNotDisplayedByName(visibilityConditionTasks[3].entry.name);
 
-            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.COMPLETED_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickCompletedTasksFilter();
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(visibilityConditionTasks[3].entry.name);
             await tasksCloudDemoPage.taskListCloudComponent().selectRow(visibilityConditionTasks[3].entry.name);
             await widget.tab().checkTabIsDisplayedByLabel(tab.tabWithFields);
@@ -298,7 +294,7 @@ describe('Task form cloud component', () => {
         });
 
         it('[C315176] Should not be able to complete a standalone task with visible tab with invalid value for field', async () => {
-            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(visibilityConditionTasks[4].entry.name);
@@ -320,7 +316,7 @@ describe('Task form cloud component', () => {
         });
 
         it('[C315179] Should be able to complete a standalone task with visible tab with valid value for field', async () => {
-            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(visibilityConditionTasks[5].entry.name);
@@ -341,7 +337,7 @@ describe('Task form cloud component', () => {
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsNotDisplayedByName(visibilityConditionTasks[5].entry.name);
 
-            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.COMPLETED_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickCompletedTasksFilter();
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(visibilityConditionTasks[5].entry.name);
             await tasksCloudDemoPage.taskListCloudComponent().selectRow(visibilityConditionTasks[5].entry.name);
             await widget.tab().checkTabIsDisplayedByLabel(tab.tabWithFields);

--- a/e2e/process-services-cloud/task-form-cloud-component.e2e.ts
+++ b/e2e/process-services-cloud/task-form-cloud-component.e2e.ts
@@ -119,8 +119,8 @@ describe('Task form cloud component', () => {
 
     it('[C310366] Should refresh buttons and form after an action is complete', async () => {
         await appListCloudComponent.goToApp(simpleApp);
-        await tasksCloudDemoPage.myTasksFilter().clickTaskFilter();
-        await expect(tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+        await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
+        await expect(tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
         await tasksCloudDemoPage.editTaskFilterCloudComponent().openFilter();
         await tasksCloudDemoPage.editTaskFilterCloudComponent().clearAssignee();
         await tasksCloudDemoPage.editTaskFilterCloudComponent().setStatusFilterDropDown('CREATED');
@@ -142,7 +142,7 @@ describe('Task form cloud component', () => {
         await taskFormCloudComponent.checkReleaseButtonIsDisplayed();
 
         await taskFormCloudComponent.clickCompleteButton();
-        await tasksCloudDemoPage.completedTasksFilter().clickTaskFilter();
+        await tasksCloudDemoPage.taskFilterCloudComponent.clickCompletedTasksFilter();
         await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedById(formTaskId);
         await tasksCloudDemoPage.taskListCloudComponent().selectRowByTaskId(formTaskId);
 
@@ -155,7 +155,7 @@ describe('Task form cloud component', () => {
 
     it('[C306872] Should not be able to Release a process task which has only assignee', async () => {
         await appListCloudComponent.goToApp(simpleApp);
-        await tasksCloudDemoPage.myTasksFilter().clickTaskFilter();
+        await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
         await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedById(assigneeTaskId);
         await tasksCloudDemoPage.taskListCloudComponent().selectRowByTaskId(assigneeTaskId);
 
@@ -171,14 +171,14 @@ describe('Task form cloud component', () => {
         });
 
         it('[C307032] Should display the appropriate title for the unclaim option of a Task', async () => {
-            await tasksCloudDemoPage.myTasksFilter().clickTaskFilter();
-            await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedById(candidateUsersTask.entry.id);
-            await tasksCloudDemoPage.taskListCloudComponent().selectRowByTaskId(candidateUsersTask.entry.id);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
+            await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(assigneeTask.entry.name);
+            await tasksCloudDemoPage.taskListCloudComponent().selectRow(assigneeTask.entry.name);
             await expect(await taskFormCloudComponent.getReleaseButtonText()).toBe('RELEASE');
         });
 
         it('[C310142] Empty content is displayed when having a task without form', async () => {
-            await tasksCloudDemoPage.myTasksFilter().clickTaskFilter();
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(assigneeTask.entry.name);
             await tasksCloudDemoPage.taskListCloudComponent().selectRow(assigneeTask.entry.name);
             await taskFormCloudComponent.checkFormIsNotDisplayed();
@@ -189,7 +189,7 @@ describe('Task form cloud component', () => {
         });
 
         it('[C310199] Should not be able to complete a task when required field is empty or invalid data is added to a field', async () => {
-            await tasksCloudDemoPage.myTasksFilter().clickTaskFilter();
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(formValidationsTask.entry.name);
             await tasksCloudDemoPage.taskListCloudComponent().selectRow(formValidationsTask.entry.name);
             await taskFormCloudComponent.checkFormIsDisplayed();
@@ -225,8 +225,8 @@ describe('Task form cloud component', () => {
         });
 
         it('[C307093] Complete button is not displayed when the task is already completed', async () => {
-            await tasksCloudDemoPage.completedTasksFilter().clickTaskFilter();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('Completed Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickCompletedTasksFilter();
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('Completed Tasks');
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(completedTaskName);
             await tasksCloudDemoPage.taskListCloudComponent().selectRow(completedTaskName);
             await taskHeaderCloudPage.checkTaskPropertyListIsDisplayed();
@@ -234,8 +234,8 @@ describe('Task form cloud component', () => {
         });
 
         it('[C307095] Task can not be completed by owner user', async () => {
-            await tasksCloudDemoPage.myTasksFilter().clickTaskFilter();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
             await tasksCloudDemoPage.editTaskFilterCloudComponent().openFilter();
 
             await browser.driver.sleep(1000);
@@ -250,21 +250,21 @@ describe('Task form cloud component', () => {
         });
 
         it('[C307110] Task list is displayed after clicking on Cancel button', async () => {
-            await tasksCloudDemoPage.myTasksFilter().clickTaskFilter();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(assigneeTask.entry.name);
             await tasksCloudDemoPage.taskListCloudComponent().selectRow(assigneeTask.entry.name);
             await taskHeaderCloudPage.checkTaskPropertyListIsDisplayed();
             await taskFormCloudComponent.clickCancelButton();
 
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(assigneeTask.entry.name);
         });
 
         it('[C307094] Standalone Task can be completed by a user that is owner and assignee', async () => {
-            await tasksCloudDemoPage.myTasksFilter().clickTaskFilter();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(toBeCompletedTask.entry.name);
             await tasksCloudDemoPage.taskListCloudComponent().selectRow(toBeCompletedTask.entry.name);
@@ -273,14 +273,14 @@ describe('Task form cloud component', () => {
             await taskFormCloudComponent.clickCompleteButton();
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsNotDisplayedByName(toBeCompletedTask.entry.name);
 
-            await tasksCloudDemoPage.completedTasksFilter().clickTaskFilter();
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickCompletedTasksFilter();
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(toBeCompletedTask.entry.name);
             await taskFormCloudComponent.checkCompleteButtonIsNotDisplayed();
         });
 
         it('[C307111] Task of a process can be completed by a user that is owner and assignee', async () => {
-            await tasksCloudDemoPage.myTasksFilter().clickTaskFilter();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(completedTask.entry.name);
             await tasksCloudDemoPage.taskListCloudComponent().selectRow(completedTask.entry.name);
@@ -289,7 +289,7 @@ describe('Task form cloud component', () => {
             await taskFormCloudComponent.clickCompleteButton();
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsNotDisplayedByName(completedTask.entry.name);
 
-            await tasksCloudDemoPage.completedTasksFilter().clickTaskFilter();
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickCompletedTasksFilter();
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(completedTask.entry.name);
             await taskFormCloudComponent.checkCompleteButtonIsNotDisplayed();
         });

--- a/e2e/process-services-cloud/task-form-cloud-component.e2e.ts
+++ b/e2e/process-services-cloud/task-form-cloud-component.e2e.ts
@@ -172,8 +172,8 @@ describe('Task form cloud component', () => {
 
         it('[C307032] Should display the appropriate title for the unclaim option of a Task', async () => {
             await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
-            await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(assigneeTask.entry.name);
-            await tasksCloudDemoPage.taskListCloudComponent().selectRow(assigneeTask.entry.name);
+            await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(candidateUsersTask.entry.name);
+            await tasksCloudDemoPage.taskListCloudComponent().selectRow(candidateUsersTask.entry.name);
             await expect(await taskFormCloudComponent.getReleaseButtonText()).toBe('RELEASE');
         });
 

--- a/e2e/process-services-cloud/task-form-cloud-component.e2e.ts
+++ b/e2e/process-services-cloud/task-form-cloud-component.e2e.ts
@@ -172,8 +172,8 @@ describe('Task form cloud component', () => {
 
         it('[C307032] Should display the appropriate title for the unclaim option of a Task', async () => {
             await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
-            await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(candidateUsersTask.entry.name);
-            await tasksCloudDemoPage.taskListCloudComponent().selectRow(candidateUsersTask.entry.name);
+            await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedById(candidateUsersTask.entry.id);
+            await tasksCloudDemoPage.taskListCloudComponent().selectRowByTaskId(candidateUsersTask.entry.id);
             await expect(await taskFormCloudComponent.getReleaseButtonText()).toBe('RELEASE');
         });
 

--- a/e2e/process-services-cloud/task-header-cloud.e2e.ts
+++ b/e2e/process-services-cloud/task-header-cloud.e2e.ts
@@ -64,6 +64,11 @@ describe('Task Header cloud component', () => {
     let identityService: IdentityService;
     let groupIdentityService: GroupIdentityService;
 
+    const enum TASK_FILTERS {
+        MY_TASKS = 'my-tasks',
+        COMPLETED_TASKS = 'completed-tasks'
+    }
+
     beforeAll(async () => {
 
         await apiService.login(browser.params.identityAdmin.email, browser.params.identityAdmin.password);
@@ -115,7 +120,7 @@ describe('Task Header cloud component', () => {
     });
 
     it('[C291943] Should display task details for assigned task', async () => {
-        await tasksCloudDemoPage.myTasksFilter().clickTaskFilter();
+        await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
         await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(basicCreatedTaskName);
         await tasksCloudDemoPage.taskListCloudComponent().selectRow(basicCreatedTaskName);
         await expect(await taskHeaderCloudPage.getId()).toEqual(basicCreatedTask.entry.id);
@@ -134,8 +139,8 @@ describe('Task Header cloud component', () => {
     });
 
     it('[C291944] Should display task details for completed task', async () => {
-        await tasksCloudDemoPage.myTasksFilter().clickTaskFilter();
-        await tasksCloudDemoPage.completedTasksFilter().clickTaskFilter();
+        await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
+        await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.COMPLETED_TASKS);
         await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(completedTaskName);
         await tasksCloudDemoPage.taskListCloudComponent().selectRow(completedTaskName);
         await expect(await taskHeaderCloudPage.getId()).toEqual(completedTask.entry.id);
@@ -154,7 +159,7 @@ describe('Task Header cloud component', () => {
     });
 
     it('[C291945] Should Parent Name and Parent Id not be empty in task details for sub task', async () => {
-        await tasksCloudDemoPage.myTasksFilter().clickTaskFilter();
+        await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
         await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(subTask.entry.name);
         await tasksCloudDemoPage.taskListCloudComponent().selectRow(subTask.entry.name);
         await expect(await taskHeaderCloudPage.getId()).toEqual(subTask.entry.id);
@@ -187,8 +192,8 @@ describe('Task Header cloud component', () => {
         });
 
         it('[C311280] Should pick up the default date format from the app configuration', async () => {
-            await tasksCloudDemoPage.myTasksFilter().clickTaskFilter();
-            await tasksCloudDemoPage.completedTasksFilter().clickTaskFilter();
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.COMPLETED_TASKS);
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(completedTaskName);
             await tasksCloudDemoPage.taskListCloudComponent().selectRow(completedTaskName);
             await taskHeaderCloudPage.checkTaskPropertyListIsDisplayed();

--- a/e2e/process-services-cloud/task-header-cloud.e2e.ts
+++ b/e2e/process-services-cloud/task-header-cloud.e2e.ts
@@ -64,11 +64,6 @@ describe('Task Header cloud component', () => {
     let identityService: IdentityService;
     let groupIdentityService: GroupIdentityService;
 
-    const enum TASK_FILTERS {
-        MY_TASKS = 'my-tasks',
-        COMPLETED_TASKS = 'completed-tasks'
-    }
-
     beforeAll(async () => {
 
         await apiService.login(browser.params.identityAdmin.email, browser.params.identityAdmin.password);
@@ -120,7 +115,7 @@ describe('Task Header cloud component', () => {
     });
 
     it('[C291943] Should display task details for assigned task', async () => {
-        await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
+        await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
         await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(basicCreatedTaskName);
         await tasksCloudDemoPage.taskListCloudComponent().selectRow(basicCreatedTaskName);
         await expect(await taskHeaderCloudPage.getId()).toEqual(basicCreatedTask.entry.id);
@@ -139,8 +134,7 @@ describe('Task Header cloud component', () => {
     });
 
     it('[C291944] Should display task details for completed task', async () => {
-        await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
-        await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.COMPLETED_TASKS);
+        await tasksCloudDemoPage.taskFilterCloudComponent.clickCompletedTasksFilter();
         await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(completedTaskName);
         await tasksCloudDemoPage.taskListCloudComponent().selectRow(completedTaskName);
         await expect(await taskHeaderCloudPage.getId()).toEqual(completedTask.entry.id);
@@ -159,7 +153,7 @@ describe('Task Header cloud component', () => {
     });
 
     it('[C291945] Should Parent Name and Parent Id not be empty in task details for sub task', async () => {
-        await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
+        await tasksCloudDemoPage.taskFilterCloudComponent.clickMyTasksFilter();
         await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(subTask.entry.name);
         await tasksCloudDemoPage.taskListCloudComponent().selectRow(subTask.entry.name);
         await expect(await taskHeaderCloudPage.getId()).toEqual(subTask.entry.id);
@@ -192,8 +186,7 @@ describe('Task Header cloud component', () => {
         });
 
         it('[C311280] Should pick up the default date format from the app configuration', async () => {
-            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.MY_TASKS);
-            await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter(TASK_FILTERS.COMPLETED_TASKS);
+            await tasksCloudDemoPage.taskFilterCloudComponent.clickCompletedTasksFilter();
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(completedTaskName);
             await tasksCloudDemoPage.taskListCloudComponent().selectRow(completedTaskName);
             await taskHeaderCloudPage.checkTaskPropertyListIsDisplayed();

--- a/e2e/process-services-cloud/task-list-cloud-action-menu.e2e.ts
+++ b/e2e/process-services-cloud/task-list-cloud-action-menu.e2e.ts
@@ -93,7 +93,7 @@ describe('Process list cloud', () => {
             await tasksCloudDemoPage.actionAdded('invisibleaction');
             await tasksCloudDemoPage.clickAppButton();
             await tasksCloudDemoPage.editTaskFilterCloudComponent().openFilter();
-            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed('my-tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkMyTasksFilterIsDisplayed();
         });
 
         it('[C315723] Should be able to see and execute custom action menu', async () => {

--- a/e2e/process-services-cloud/task-list-cloud-action-menu.e2e.ts
+++ b/e2e/process-services-cloud/task-list-cloud-action-menu.e2e.ts
@@ -93,11 +93,11 @@ describe('Process list cloud', () => {
             await tasksCloudDemoPage.actionAdded('invisibleaction');
             await tasksCloudDemoPage.clickAppButton();
             await tasksCloudDemoPage.editTaskFilterCloudComponent().openFilter();
-            await tasksCloudDemoPage.myTasksFilter().checkTaskFilterIsDisplayed();
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed('my-tasks');
         });
 
         it('[C315723] Should be able to see and execute custom action menu', async () => {
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
             await tasksCloudDemoPage.taskListCloudComponent().checkTaskListIsLoaded();
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedById(editTask.list.entries[0].entry.id);
             await tasksCloudDemoPage.taskListCloudComponent().clickOptionsButton(editTask.list.entries[0].entry.id);

--- a/e2e/process-services-cloud/task-list-properties-sort.e2e.ts
+++ b/e2e/process-services-cloud/task-list-properties-sort.e2e.ts
@@ -128,8 +128,7 @@ describe('Edit task filters and task list properties', () => {
             await appListCloudComponent.checkApsContainer();
             await appListCloudComponent.goToApp(simpleApp);
             await tasksCloudDemoPage.editTaskFilterCloudComponent().openFilter();
-            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed('my-tasks');
-
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkMyTasksFilterIsDisplayed();
         });
 
         it('[C306901] Should display tasks sorted by task name when taskName is selected from sort dropdown', async () => {
@@ -141,7 +140,6 @@ describe('Edit task filters and task list properties', () => {
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setOrderFilterDropDown('DESC');
             await expect(await tasksCloudDemoPage.taskListCloudComponent().getDataTable().checkListIsSorted('DESC', 'Name')).toBe(true);
-
         });
 
         it('[C290156] Should display tasks ordered by id when Id is selected from sort dropdown', async () => {
@@ -153,7 +151,6 @@ describe('Edit task filters and task list properties', () => {
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setOrderFilterDropDown('DESC');
             await expect(await tasksCloudDemoPage.taskListCloudComponent().getDataTable().checkListIsSorted('DESC', 'Id')).toBe(true);
-
         });
 
         it('[C306903] Should display tasks sorted by processDefinitionId when processDefinitionId is selected from sort dropdown', async () => {
@@ -211,7 +208,6 @@ describe('Edit task filters and task list properties', () => {
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setOrderFilterDropDown('DESC');
             await expect(await tasksCloudDemoPage.taskListCloudComponent().getDataTable().checkListIsSorted('DESC', 'Priority')).toBe(true);
-
         });
 
         it('[C307115] Should display tasks sorted by owner when owner is selected from sort dropdown', async () => {

--- a/e2e/process-services-cloud/task-list-properties-sort.e2e.ts
+++ b/e2e/process-services-cloud/task-list-properties-sort.e2e.ts
@@ -128,7 +128,7 @@ describe('Edit task filters and task list properties', () => {
             await appListCloudComponent.checkApsContainer();
             await appListCloudComponent.goToApp(simpleApp);
             await tasksCloudDemoPage.editTaskFilterCloudComponent().openFilter();
-            await tasksCloudDemoPage.myTasksFilter().checkTaskFilterIsDisplayed();
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed('my-tasks');
 
         });
 

--- a/e2e/process-services-cloud/task-list-properties.e2e.ts
+++ b/e2e/process-services-cloud/task-list-properties.e2e.ts
@@ -53,8 +53,6 @@ describe('Edit task filters and task list properties', () => {
     const currentDate = DateUtil.formatDate('DD/MM/YYYY');
     const afterDate = moment().add(1, 'days').format('DD/MM/YYYY');
 
-    const myTasksFilter = 'my-tasks';
-
     beforeAll(async () => {
 
         await apiService.login(browser.params.identityAdmin.email, browser.params.identityAdmin.password);
@@ -147,11 +145,11 @@ describe('Edit task filters and task list properties', () => {
             await appListCloudComponent.checkApsContainer();
             await appListCloudComponent.goToApp(simpleApp);
             await tasksCloudDemoPage.editTaskFilterCloudComponent().openFilter();
-            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkMyTasksFilterIsDisplayed();
         });
 
         it('[C292004] Filter by appName', async () => {
-            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkMyTasksFilterIsDisplayed();
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().getAppNameDropDownValue()).toEqual(simpleApp);
@@ -167,7 +165,7 @@ describe('Edit task filters and task list properties', () => {
         });
 
         it('[C291906] Should be able to see only the task with specific taskId when typing it in the task Id field', async () => {
-            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkMyTasksFilterIsDisplayed();
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setId(createdTask.entry.id);
@@ -179,7 +177,7 @@ describe('Edit task filters and task list properties', () => {
         });
 
         it('[C291907] Should be able to see No tasks found when typing an invalid task id', async () => {
-            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkMyTasksFilterIsDisplayed();
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setId('invalidId');
@@ -189,7 +187,7 @@ describe('Edit task filters and task list properties', () => {
         });
 
         it('[C297476] Filter by taskName', async () => {
-            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkMyTasksFilterIsDisplayed();
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setTaskName(createdTask.entry.name);
@@ -201,7 +199,7 @@ describe('Edit task filters and task list properties', () => {
         });
 
         it('[C297613] Should be able to see No tasks found when typing a task name that does not exist', async () => {
-            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkMyTasksFilterIsDisplayed();
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setTaskName('invalidName');
@@ -211,7 +209,7 @@ describe('Edit task filters and task list properties', () => {
         });
 
         it('[C297480] Should be able to see only tasks that are part of a specific process when processInstanceId is set', async () => {
-            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkMyTasksFilterIsDisplayed();
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setProcessInstanceId(processInstance.entry.id);
@@ -223,7 +221,7 @@ describe('Edit task filters and task list properties', () => {
         });
 
         it('[C297684] Should be able to see No tasks found when typing an invalid processInstanceId', async () => {
-            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkMyTasksFilterIsDisplayed();
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setProcessInstanceId('invalidTaskId');
@@ -232,7 +230,7 @@ describe('Edit task filters and task list properties', () => {
         });
 
         it('[C297478] Should be able to see only tasks that are assigned to a specific user when assignee is set', async () => {
-            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkMyTasksFilterIsDisplayed();
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setAssignee('admin.adf');
@@ -242,7 +240,7 @@ describe('Edit task filters and task list properties', () => {
         });
 
         it('[C297686] Should be able to see No tasks found when typing an invalid user to assignee field', async () => {
-            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkMyTasksFilterIsDisplayed();
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setAssignee('invalid');
@@ -251,7 +249,7 @@ describe('Edit task filters and task list properties', () => {
         });
 
         it('[C297482] Should be able to see only tasks with specific priority when priority is set', async () => {
-            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkMyTasksFilterIsDisplayed();
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setPriority(priority);
@@ -261,7 +259,7 @@ describe('Edit task filters and task list properties', () => {
         });
 
         it('[C297687] Should be able to see No tasks found when typing unused value for priority field', async () => {
-            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkMyTasksFilterIsDisplayed();
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setPriority('87650');
 
@@ -269,7 +267,7 @@ describe('Edit task filters and task list properties', () => {
         });
 
         it('[C297481] Should be able to see only tasks with specific parentTaskId when parentTaskId is set', async () => {
-            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkMyTasksFilterIsDisplayed();
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setParentTaskId(subTask.entry.parentTaskId);
@@ -279,7 +277,7 @@ describe('Edit task filters and task list properties', () => {
         });
 
         it('[C297486] Filter by Owner', async () => {
-            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkMyTasksFilterIsDisplayed();
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setStatusFilterDropDown('ALL');
@@ -295,7 +293,7 @@ describe('Edit task filters and task list properties', () => {
         });
 
         it('[C297484] Task is displayed when typing into lastModifiedFrom field a date before the task CreatedDate', async() => {
-            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkMyTasksFilterIsDisplayed();
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setLastModifiedFrom(beforeDate);
@@ -306,7 +304,7 @@ describe('Edit task filters and task list properties', () => {
         });
 
         it('[C297689] Task is not displayed when typing into lastModifiedFrom field the same date as tasks CreatedDate', async () => {
-            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkMyTasksFilterIsDisplayed();
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setLastModifiedFrom(currentDate);
@@ -314,7 +312,7 @@ describe('Edit task filters and task list properties', () => {
         });
 
         it('[C297485] Task is displayed when typing into lastModifiedTo field a date after the task CreatedDate', async () => {
-            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkMyTasksFilterIsDisplayed();
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setLastModifiedFrom(afterDate);
@@ -325,7 +323,7 @@ describe('Edit task filters and task list properties', () => {
         });
 
         it('[C297690] Task is not displayed when typing into lastModifiedTo field the same date as tasks CreatedDate', async () => {
-            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkMyTasksFilterIsDisplayed();
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setLastModifiedTo(currentDate);
@@ -335,7 +333,7 @@ describe('Edit task filters and task list properties', () => {
         it('[C297691] Task is not displayed when typing into lastModifiedFrom field a date before the task due date  ' +
             'and into lastModifiedTo a date before task due date', async () => {
 
-            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkMyTasksFilterIsDisplayed();
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setLastModifiedFrom(beforeDate);
@@ -347,7 +345,7 @@ describe('Edit task filters and task list properties', () => {
         it('[C297692] Task is displayed when typing into lastModifiedFrom field a date before the tasks due date ' +
             'and into lastModifiedTo a date after', async () => {
 
-            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkMyTasksFilterIsDisplayed();
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setLastModifiedFrom(beforeDate);
@@ -359,7 +357,7 @@ describe('Edit task filters and task list properties', () => {
         it('[C297693] Task is not displayed when typing into lastModifiedFrom field a date after the tasks due date ' +
             'and into lastModifiedTo a date after', async () => {
 
-            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkMyTasksFilterIsDisplayed();
             await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setLastModifiedFrom(afterDate);

--- a/e2e/process-services-cloud/task-list-properties.e2e.ts
+++ b/e2e/process-services-cloud/task-list-properties.e2e.ts
@@ -53,6 +53,8 @@ describe('Edit task filters and task list properties', () => {
     const currentDate = DateUtil.formatDate('DD/MM/YYYY');
     const afterDate = moment().add(1, 'days').format('DD/MM/YYYY');
 
+    const myTasksFilter = 'my-tasks';
+
     beforeAll(async () => {
 
         await apiService.login(browser.params.identityAdmin.email, browser.params.identityAdmin.password);
@@ -145,12 +147,12 @@ describe('Edit task filters and task list properties', () => {
             await appListCloudComponent.checkApsContainer();
             await appListCloudComponent.goToApp(simpleApp);
             await tasksCloudDemoPage.editTaskFilterCloudComponent().openFilter();
-            await tasksCloudDemoPage.myTasksFilter().checkTaskFilterIsDisplayed();
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
         });
 
         it('[C292004] Filter by appName', async () => {
-            await tasksCloudDemoPage.myTasksFilter().checkTaskFilterIsDisplayed();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().getAppNameDropDownValue()).toEqual(simpleApp);
 
@@ -165,8 +167,8 @@ describe('Edit task filters and task list properties', () => {
         });
 
         it('[C291906] Should be able to see only the task with specific taskId when typing it in the task Id field', async () => {
-            await tasksCloudDemoPage.myTasksFilter().checkTaskFilterIsDisplayed();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setId(createdTask.entry.id);
             await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().getId()).toEqual(createdTask.entry.id);
@@ -177,8 +179,8 @@ describe('Edit task filters and task list properties', () => {
         });
 
         it('[C291907] Should be able to see No tasks found when typing an invalid task id', async () => {
-            await tasksCloudDemoPage.myTasksFilter().checkTaskFilterIsDisplayed();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setId('invalidId');
             await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().getId()).toEqual('invalidId');
@@ -187,8 +189,8 @@ describe('Edit task filters and task list properties', () => {
         });
 
         it('[C297476] Filter by taskName', async () => {
-            await tasksCloudDemoPage.myTasksFilter().checkTaskFilterIsDisplayed();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setTaskName(createdTask.entry.name);
             await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().getTaskName()).toEqual(createdTask.entry.name);
@@ -199,8 +201,8 @@ describe('Edit task filters and task list properties', () => {
         });
 
         it('[C297613] Should be able to see No tasks found when typing a task name that does not exist', async () => {
-            await tasksCloudDemoPage.myTasksFilter().checkTaskFilterIsDisplayed();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setTaskName('invalidName');
             await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().getTaskName()).toEqual('invalidName');
@@ -209,8 +211,8 @@ describe('Edit task filters and task list properties', () => {
         });
 
         it('[C297480] Should be able to see only tasks that are part of a specific process when processInstanceId is set', async () => {
-            await tasksCloudDemoPage.myTasksFilter().checkTaskFilterIsDisplayed();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setProcessInstanceId(processInstance.entry.id);
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setStatusFilterDropDown('ALL');
@@ -221,8 +223,8 @@ describe('Edit task filters and task list properties', () => {
         });
 
         it('[C297684] Should be able to see No tasks found when typing an invalid processInstanceId', async () => {
-            await tasksCloudDemoPage.myTasksFilter().checkTaskFilterIsDisplayed();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setProcessInstanceId('invalidTaskId');
 
@@ -230,8 +232,8 @@ describe('Edit task filters and task list properties', () => {
         });
 
         it('[C297478] Should be able to see only tasks that are assigned to a specific user when assignee is set', async () => {
-            await tasksCloudDemoPage.myTasksFilter().checkTaskFilterIsDisplayed();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setAssignee('admin.adf');
 
@@ -240,8 +242,8 @@ describe('Edit task filters and task list properties', () => {
         });
 
         it('[C297686] Should be able to see No tasks found when typing an invalid user to assignee field', async () => {
-            await tasksCloudDemoPage.myTasksFilter().checkTaskFilterIsDisplayed();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setAssignee('invalid');
 
@@ -249,8 +251,8 @@ describe('Edit task filters and task list properties', () => {
         });
 
         it('[C297482] Should be able to see only tasks with specific priority when priority is set', async () => {
-            await tasksCloudDemoPage.myTasksFilter().checkTaskFilterIsDisplayed();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setPriority(priority);
 
@@ -259,16 +261,16 @@ describe('Edit task filters and task list properties', () => {
         });
 
         it('[C297687] Should be able to see No tasks found when typing unused value for priority field', async () => {
-            await tasksCloudDemoPage.myTasksFilter().checkTaskFilterIsDisplayed();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setPriority('87650');
 
             await expect(await tasksCloudDemoPage.taskListCloudComponent().getNoTasksFoundMessage()).toEqual(noTasksFoundMessage);
         });
 
         it('[C297481] Should be able to see only tasks with specific parentTaskId when parentTaskId is set', async () => {
-            await tasksCloudDemoPage.myTasksFilter().checkTaskFilterIsDisplayed();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setParentTaskId(subTask.entry.parentTaskId);
 
@@ -277,8 +279,8 @@ describe('Edit task filters and task list properties', () => {
         });
 
         it('[C297486] Filter by Owner', async () => {
-            await tasksCloudDemoPage.myTasksFilter().checkTaskFilterIsDisplayed();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setStatusFilterDropDown('ALL');
             await tasksCloudDemoPage.editTaskFilterCloudComponent().clearAssignee();
@@ -293,8 +295,8 @@ describe('Edit task filters and task list properties', () => {
         });
 
         it('[C297484] Task is displayed when typing into lastModifiedFrom field a date before the task CreatedDate', async() => {
-            await tasksCloudDemoPage.myTasksFilter().checkTaskFilterIsDisplayed();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setLastModifiedFrom(beforeDate);
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(createdTask.entry.name);
@@ -304,16 +306,16 @@ describe('Edit task filters and task list properties', () => {
         });
 
         it('[C297689] Task is not displayed when typing into lastModifiedFrom field the same date as tasks CreatedDate', async () => {
-            await tasksCloudDemoPage.myTasksFilter().checkTaskFilterIsDisplayed();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setLastModifiedFrom(currentDate);
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsNotDisplayedByName(createdTask.entry.name);
         });
 
         it('[C297485] Task is displayed when typing into lastModifiedTo field a date after the task CreatedDate', async () => {
-            await tasksCloudDemoPage.myTasksFilter().checkTaskFilterIsDisplayed();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setLastModifiedFrom(afterDate);
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(createdTask.entry.name);
@@ -323,8 +325,8 @@ describe('Edit task filters and task list properties', () => {
         });
 
         it('[C297690] Task is not displayed when typing into lastModifiedTo field the same date as tasks CreatedDate', async () => {
-            await tasksCloudDemoPage.myTasksFilter().checkTaskFilterIsDisplayed();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setLastModifiedTo(currentDate);
             await tasksCloudDemoPage.taskListCloudComponent().checkContentIsNotDisplayedByName(createdTask.entry.name);
@@ -333,8 +335,8 @@ describe('Edit task filters and task list properties', () => {
         it('[C297691] Task is not displayed when typing into lastModifiedFrom field a date before the task due date  ' +
             'and into lastModifiedTo a date before task due date', async () => {
 
-            await tasksCloudDemoPage.myTasksFilter().checkTaskFilterIsDisplayed();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setLastModifiedFrom(beforeDate);
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setLastModifiedTo(beforeDate);
@@ -345,8 +347,8 @@ describe('Edit task filters and task list properties', () => {
         it('[C297692] Task is displayed when typing into lastModifiedFrom field a date before the tasks due date ' +
             'and into lastModifiedTo a date after', async () => {
 
-            await tasksCloudDemoPage.myTasksFilter().checkTaskFilterIsDisplayed();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setLastModifiedFrom(beforeDate);
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setLastModifiedTo(afterDate);
@@ -357,8 +359,8 @@ describe('Edit task filters and task list properties', () => {
         it('[C297693] Task is not displayed when typing into lastModifiedFrom field a date after the tasks due date ' +
             'and into lastModifiedTo a date after', async () => {
 
-            await tasksCloudDemoPage.myTasksFilter().checkTaskFilterIsDisplayed();
-            await expect(await tasksCloudDemoPage.getActiveFilterName()).toBe('My Tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed(myTasksFilter);
+            await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('My Tasks');
 
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setLastModifiedFrom(afterDate);
             await tasksCloudDemoPage.editTaskFilterCloudComponent().setLastModifiedTo(afterDate);

--- a/e2e/process-services-cloud/task-list-selection.e2e.ts
+++ b/e2e/process-services-cloud/task-list-selection.e2e.ts
@@ -73,7 +73,7 @@ describe('Task list cloud - selection', () => {
             await navigationBarPage.navigateToProcessServicesCloudPage();
             await appListCloudComponent.checkApsContainer();
             await appListCloudComponent.goToApp(simpleApp);
-            await tasksCloudDemoPage.myTasksFilter().checkTaskFilterIsDisplayed();
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed('my-tasks');
             await tasksCloudDemoPage.clickSettingsButton();
             await tasksCloudDemoPage.disableDisplayTaskDetails();
             await tasksCloudDemoPage.clickAppButton();

--- a/e2e/process-services-cloud/task-list-selection.e2e.ts
+++ b/e2e/process-services-cloud/task-list-selection.e2e.ts
@@ -73,7 +73,7 @@ describe('Task list cloud - selection', () => {
             await navigationBarPage.navigateToProcessServicesCloudPage();
             await appListCloudComponent.checkApsContainer();
             await appListCloudComponent.goToApp(simpleApp);
-            await tasksCloudDemoPage.taskFilterCloudComponent.checkTaskFilterIsDisplayed('my-tasks');
+            await tasksCloudDemoPage.taskFilterCloudComponent.checkMyTasksFilterIsDisplayed();
             await tasksCloudDemoPage.clickSettingsButton();
             await tasksCloudDemoPage.disableDisplayTaskDetails();
             await tasksCloudDemoPage.clickAppButton();

--- a/e2e/process-services/attach-file-widget.e2e.ts
+++ b/e2e/process-services/attach-file-widget.e2e.ts
@@ -76,7 +76,7 @@ describe('Start Task - Task App', () => {
 
         const newTask = await taskPage.createNewTask();
         await newTask.addName('View file');
-        await newTask.addForm(app.formName);
+        await newTask.selectForm(app.formName);
         await newTask.clickStartButton();
 
         await widget.attachFileWidget().attachFile(appFields.attachFile_id, browser.params.testConfig.main.rootPath + pdfFile.location);

--- a/e2e/process-services/attach-form-component.e2e.ts
+++ b/e2e/process-services/attach-form-component.e2e.ts
@@ -100,7 +100,6 @@ describe('Attach Form Component', () => {
         await attachFormPage.checkFormDropdownIsDisplayed();
         await attachFormPage.checkCancelButtonIsDisplayed();
         await attachFormPage.checkAttachFormButtonIsDisabled();
-        await attachFormPage.clickAttachFormDropdown();
         await attachFormPage.selectAttachFormOption(testNames.formName);
 
         await formFields.checkWidgetIsReadOnlyMode(testNames.widgetTitle);
@@ -116,7 +115,6 @@ describe('Attach Form Component', () => {
         await taskPage.tasksListPage().selectRow(testNames.taskName);
 
         await attachFormPage.clickAttachFormButton();
-        await attachFormPage.clickAttachFormDropdown();
         await attachFormPage.selectAttachFormOption(testNames.formName);
         await attachFormPage.clickAttachFormButton();
 

--- a/e2e/process-services/form-widgets-component.e2e.ts
+++ b/e2e/process-services/form-widgets-component.e2e.ts
@@ -65,7 +65,7 @@ describe('Form widgets', () => {
             const task = await taskPage.createNewTask();
             await task.addName(newTask);
             await task.addDescription('Description');
-            await task.addForm(app.formName);
+            await task.selectForm(app.formName);
             await task.clickStartButton();
 
             await taskPage.tasksListPage().checkContentIsDisplayed(newTask);

--- a/e2e/process-services/process-list-component.e2e.ts
+++ b/e2e/process-services/process-list-component.e2e.ts
@@ -101,8 +101,8 @@ describe('Process List Test', () => {
         await processListDemoPage.checkAppIdFieldIsDisplayed();
         await processListDemoPage.checkProcessInstanceIdFieldIsDisplayed();
         await processListDemoPage.checkProcessInstanceIdFieldIsDisplayed();
-        await processListDemoPage.checkSortFieldIsDisplayed();
-        await processListDemoPage.checkStateFieldIsDisplayed();
+        await processListDemoPage.checkSortDropdownIsDisplayed();
+        await processListDemoPage.checkStateDropdownIsDisplayed();
     });
 
     it('[C282006] Should be able to filter processes with App ID', async () => {

--- a/e2e/process-services/standalone-task.e2e.ts
+++ b/e2e/process-services/standalone-task.e2e.ts
@@ -119,7 +119,7 @@ describe('Start Task - Task App', () => {
     it('[C268912] Should a standalone task be displayed when removing the form from APS', async () => {
         const task = await taskPage.createNewTask();
         await task.addName(tasks[3]);
-        await task.addForm(app.formName);
+        await task.selectForm(app.formName);
         await task.clickStartButton();
 
         await taskPage.tasksListPage().checkContentIsDisplayed(tasks[3]);

--- a/e2e/process-services/start-task-custom-app.e2e.ts
+++ b/e2e/process-services/start-task-custom-app.e2e.ts
@@ -80,7 +80,7 @@ describe('Start Task - Custom App', () => {
 
         const task = await taskPage.createNewTask();
         await task.addName(tasks[0]);
-        await task.addForm(app.formName);
+        await task.selectForm(app.formName);
         await task.clickStartButton();
 
         await taskPage.tasksListPage().checkContentIsDisplayed(tasks[0]);
@@ -150,7 +150,7 @@ describe('Start Task - Custom App', () => {
 
         const task = await taskPage.createNewTask();
 
-        await task.addForm(app.formName);
+        await task.selectForm(app.formName);
         await task.addName(tasks[4]);
         await task.clickStartButton();
 

--- a/e2e/process-services/start-task-task-app.e2e.ts
+++ b/e2e/process-services/start-task-task-app.e2e.ts
@@ -89,7 +89,7 @@ describe('Start Task - Task App', () => {
     it('[C260383] Should be possible to modify a task', async () => {
         const task = await taskPage.createNewTask();
         await task.addName(tasks[0]);
-        await task.addForm(app.formName);
+        await task.selectForm(app.formName);
         await task.clickStartButton();
         await taskPage.tasksListPage().checkContentIsDisplayed(tasks[0]);
         const taskDetails = await taskPage.taskDetails();
@@ -129,7 +129,7 @@ describe('Start Task - Task App', () => {
 
     it('[C260423] Should be possible to save filled form', async () => {
         const task = await taskPage.createNewTask();
-        await task.addForm(app.formName);
+        await task.selectForm(app.formName);
         await task.addName(tasks[4]);
         await task.clickStartButton();
 

--- a/e2e/process-services/task-details-form.e2e.ts
+++ b/e2e/process-services/task-details-form.e2e.ts
@@ -103,8 +103,6 @@ describe('Task Details - Form', () => {
         await taskDetailsPage.checkAttachFormDropdownIsDisplayed();
         await taskDetailsPage.checkAttachFormButtonIsDisabled();
 
-        await taskDetailsPage.clickAttachFormDropdown();
-
         await taskDetailsPage.selectAttachFormOption(newForm.name);
         await taskDetailsPage.checkSelectedForm(newForm.name);
         await taskDetailsPage.checkAttachFormButtonIsEnabled();
@@ -117,8 +115,6 @@ describe('Task Details - Form', () => {
         await taskDetailsPage.clickForm();
 
         await taskDetailsPage.checkAttachFormDropdownIsDisplayed();
-        await taskDetailsPage.clickAttachFormDropdown();
-
         await taskDetailsPage.selectAttachFormOption(newForm.name);
 
         await taskDetailsPage.checkAttachFormButtonIsDisplayed();

--- a/e2e/search/components/search-sorting-picker.e2e.ts
+++ b/e2e/search/components/search-sorting-picker.e2e.ts
@@ -93,7 +93,7 @@ describe('Search Sorting Picker', () => {
     });
 
     it(`[C277269] Should see the "sort by" option when search results are displayed in search results page`, async () => {
-        await searchSortingPicker.checkSortingSelectorIsDisplayed();
+        await searchSortingPicker.checkSortingDropdownIsDisplayed();
     });
 
     it(`[C277270] Should see the icon for ASC and DESC sort when search results are displayed in the search results page`, async () => {
@@ -116,8 +116,8 @@ describe('Search Sorting Picker', () => {
         await searchDialog.clickOnSearchIcon();
         await searchDialog.enterTextAndPressEnter(search);
 
-        await searchSortingPicker.checkSortingSelectorIsDisplayed();
-        await searchSortingPicker.clickSortingSelector();
+        await searchSortingPicker.checkSortingDropdownIsDisplayed();
+        await searchSortingPicker.clickSortingDropdown();
         await searchSortingPicker.checkOptionsDropdownIsDisplayed();
         await searchSortingPicker.checkOptionIsDisplayed('Modifier');
     });
@@ -132,8 +132,8 @@ describe('Search Sorting Picker', () => {
         await searchDialog.clickOnSearchIcon();
         await searchDialog.enterTextAndPressEnter(search);
 
-        await searchSortingPicker.checkSortingSelectorIsDisplayed();
-        await searchSortingPicker.clickSortingSelector();
+        await searchSortingPicker.checkSortingDropdownIsDisplayed();
+        await searchSortingPicker.clickSortingDropdown();
         await searchSortingPicker.checkOptionsDropdownIsDisplayed();
         await searchSortingPicker.checkOptionIsNotDisplayed(removedOption[0].label);
     });
@@ -157,8 +157,8 @@ describe('Search Sorting Picker', () => {
         await searchDialog.clickOnSearchIcon();
         await searchDialog.enterTextAndPressEnter(search);
 
-        await searchSortingPicker.checkSortingSelectorIsDisplayed();
-        await searchSortingPicker.clickSortingSelector();
+        await searchSortingPicker.checkSortingDropdownIsDisplayed();
+        await searchSortingPicker.clickSortingDropdown();
         await searchSortingPicker.checkOptionIsDisplayed('Name');
         await searchSortingPicker.clickSortingOption('Name');
         await expect(await searchSortingPicker.checkOrderArrowIsDownward()).toBe(true);
@@ -208,7 +208,7 @@ describe('Search Sorting Picker', () => {
         await searchDialog.clickOnSearchIcon();
         await searchDialog.enterTextAndPressEnter(search);
 
-        await searchSortingPicker.checkSortingSelectorIsDisplayed();
+        await searchSortingPicker.checkSortingDropdownIsDisplayed();
         await searchSortingPicker.sortBy('ASC', 'Modified Date');
 
         const idList = await contentServices.getElementsDisplayedId();

--- a/lib/testing/src/lib/content-services/dialog/content-node-selector-dialog.page.ts
+++ b/lib/testing/src/lib/content-services/dialog/content-node-selector-dialog.page.ts
@@ -19,17 +19,19 @@ import { by, element, ElementFinder } from 'protractor';
 import { DocumentListPage } from '../pages/document-list.page';
 import { BrowserVisibility } from '../../core/utils/browser-visibility';
 import { BrowserActions } from '../../core/utils/browser-actions';
+import { DropdownPage } from '../../material/pages/dropdown.page';
 
 export class ContentNodeSelectorDialogPage {
     dialog: ElementFinder = element(by.css(`adf-content-node-selector`));
     header: ElementFinder = this.dialog.element(by.css(`header[data-automation-id='content-node-selector-title']`));
     searchInputElement: ElementFinder = this.dialog.element(by.css(`input[data-automation-id='content-node-selector-search-input']`));
     searchLabel: ElementFinder = this.searchInputElement.element(by.xpath("ancestor::div[@class='mat-form-field-infix']/span/label"));
-    siteListDropdown: ElementFinder = this.dialog.element(by.css(`mat-select[data-automation-id='site-my-files-option']`));
     selectedRow: ElementFinder = this.dialog.element(by.css(`adf-datatable-row[class*="adf-is-selected"]`));
     cancelButton: ElementFinder = element(by.css(`button[data-automation-id='content-node-selector-actions-cancel']`));
     moveCopyButton: ElementFinder = element(by.css(`button[data-automation-id='content-node-selector-actions-choose']`));
+
     contentList: DocumentListPage = new DocumentListPage(this.dialog);
+    siteListDropdown = new DropdownPage(this.dialog.element(by.css(`mat-select[data-automation-id='site-my-files-option']`)));
 
     async checkDialogIsDisplayed(): Promise<void> {
         await BrowserVisibility.waitUntilElementIsVisible(this.dialog);
@@ -52,7 +54,7 @@ export class ContentNodeSelectorDialogPage {
     }
 
     async checkSelectedSiteIsDisplayed(siteName): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.siteListDropdown.element(by.cssContainingText('.mat-select-value-text span', siteName)));
+        await this.siteListDropdown.checkSelectedOptionIsDisplayed(siteName);
     }
 
     async checkSelectedFolder(folderName: string): Promise<void> {

--- a/lib/testing/src/lib/content-services/dialog/content-node-selector-dialog.page.ts
+++ b/lib/testing/src/lib/content-services/dialog/content-node-selector-dialog.page.ts
@@ -54,7 +54,7 @@ export class ContentNodeSelectorDialogPage {
     }
 
     async checkSelectedSiteIsDisplayed(siteName): Promise<void> {
-        await this.siteListDropdown.checkSelectedOptionIsDisplayed(siteName);
+        await this.siteListDropdown.checkOptionIsSelected(siteName);
     }
 
     async checkSelectedFolder(folderName: string): Promise<void> {

--- a/lib/testing/src/lib/content-services/pages/search/search-sorting-picker.page.ts
+++ b/lib/testing/src/lib/content-services/pages/search/search-sorting-picker.page.ts
@@ -18,15 +18,15 @@
 import { browser, by, element, ElementFinder } from 'protractor';
 import { BrowserActions } from '../../../core/utils/browser-actions';
 import { BrowserVisibility } from '../../../core/utils/browser-visibility';
+import { DropdownPage } from '../../../material/pages/dropdown.page';
 
 export class SearchSortingPickerPage {
 
-    sortingSelector: ElementFinder = element(by.css('adf-sorting-picker div[class="mat-select-arrow"]'));
+    sortingDropdown = new DropdownPage(element(by.css('adf-sorting-picker div[class="mat-select-arrow"]')));
     orderArrow: ElementFinder = element(by.css('adf-sorting-picker button mat-icon'));
-    optionsDropdown: ElementFinder = element(by.css('div .mat-select-panel'));
 
     async sortBy(sortOrder: string, sortType: string | RegExp): Promise<void> {
-        await BrowserActions.click(this.sortingSelector);
+        await this.sortingDropdown.clickDropdown();
         const selectedSortingOption = element(by.cssContainingText('span[class="mat-option-text"]', sortType));
         await BrowserActions.click(selectedSortingOption);
         await this.sortByOrder(sortOrder);
@@ -52,31 +52,29 @@ export class SearchSortingPickerPage {
         }
     }
 
-    async clickSortingOption(option): Promise<void> {
+    async clickSortingOption(option: string): Promise<void> {
         const selectedSortingOption = element(by.cssContainingText('span[class="mat-option-text"]', option));
         await BrowserActions.click(selectedSortingOption);
     }
 
-    async clickSortingSelector(): Promise<void> {
-        await BrowserActions.click(this.sortingSelector);
+    async checkOptionIsDisplayed(option: string): Promise<void> {
+        await this.sortingDropdown.checkOptionIsDisplayed(option);
     }
 
-    async checkOptionIsDisplayed(option): Promise<void> {
-        const optionSelector = this.optionsDropdown.element(by.cssContainingText('span[class="mat-option-text"]', option));
-        await BrowserVisibility.waitUntilElementIsVisible(optionSelector);
-    }
-
-    async checkOptionIsNotDisplayed(option): Promise<void> {
-        const optionSelector = this.optionsDropdown.element(by.cssContainingText('span[class="mat-option-text"]', option));
-        await BrowserVisibility.waitUntilElementIsNotVisible(optionSelector);
+    async checkOptionIsNotDisplayed(option: string): Promise<void> {
+        await this.sortingDropdown.checkOptionIsNotDisplayed(option);
     }
 
     async checkOptionsDropdownIsDisplayed(): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.optionsDropdown);
+        await this.sortingDropdown.checkOptionsPanelIsDisplayed();
     }
 
-    async checkSortingSelectorIsDisplayed(): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.sortingSelector);
+    async checkSortingDropdownIsDisplayed(): Promise<void> {
+        await this.sortingDropdown.checkDropdownIsVisible();
+    }
+
+    async clickSortingDropdown(): Promise<void> {
+        await this.sortingDropdown.clickDropdown();
     }
 
     async checkOrderArrowIsDownward(): Promise<boolean> {

--- a/lib/testing/src/lib/core/pages/form/form-fields.ts
+++ b/lib/testing/src/lib/core/pages/form/form-fields.ts
@@ -125,9 +125,7 @@ export class FormFields {
     }
 
     async selectForm(formName): Promise<void> {
-        await this.selectFormDropdown.clickDropdown();
-        await this.selectFormDropdown.checkOptionsPanelIsDisplayed();
-        await this.selectFormDropdown.selectOption(formName);
+        await this.selectFormDropdown.clickDropdownWithOption(formName);
     }
 
     async selectFormFromDropDown(formName): Promise<void> {

--- a/lib/testing/src/lib/core/pages/form/form-fields.ts
+++ b/lib/testing/src/lib/core/pages/form/form-fields.ts
@@ -17,6 +17,7 @@
 
 import { by, element, Locator, ElementFinder } from 'protractor';
 import { BrowserVisibility, BrowserActions } from '../../utils/public-api';
+import { DropdownPage } from '../../../material/pages/dropdown.page';
 
 export class FormFields {
 
@@ -28,10 +29,10 @@ export class FormFields {
     noFormMessage: ElementFinder = element(by.css('span[id*="no-form-message"]'));
     completedTaskNoFormMessage: ElementFinder = element(by.css('div[id*="completed-form-message"] p'));
     attachFormButton: ElementFinder = element(by.id('adf-no-form-attach-form-button'));
-    selectFormDropDownArrow: ElementFinder = element.all(by.css('adf-attach-form div[class*="mat-select-arrow"]')).first();
-    selectFormContent: ElementFinder = element(by.css('div[class*="mat-select-panel"]'));
     completeButton: ElementFinder = element(by.id('adf-form-complete'));
     errorMessage: Locator = by.css('.adf-error-text-container .adf-error-text');
+
+    selectFormDropdown = new DropdownPage(element.all(by.css('adf-attach-form div[class*="mat-select-arrow"]')).first());
 
     async setFieldValue(locator, field, value): Promise<void> {
         const fieldElement = element(locator(field));
@@ -124,9 +125,9 @@ export class FormFields {
     }
 
     async selectForm(formName): Promise<void> {
-        await BrowserActions.click(this.selectFormDropDownArrow);
-        await BrowserVisibility.waitUntilElementIsVisible(this.selectFormContent);
-        await this.selectFormFromDropDown(formName);
+        await this.selectFormDropdown.clickDropdown();
+        await this.selectFormDropdown.checkOptionsPanelIsDisplayed();
+        await this.selectFormDropdown.selectOption(formName);
     }
 
     async selectFormFromDropDown(formName): Promise<void> {

--- a/lib/testing/src/lib/core/pages/settings.page.ts
+++ b/lib/testing/src/lib/core/pages/settings.page.ts
@@ -49,7 +49,7 @@ export class SettingsPage {
     async setProvider(option): Promise<void> {
         await this.providerDropdown.clickDropdown();
         await this.providerDropdown.selectOption(option);
-        await this.providerDropdown.checkSelectedOptionIsDisplayed(option);
+        await this.providerDropdown.checkOptionIsSelected(option);
     }
 
     async getSelectedOptionText(): Promise<string> {

--- a/lib/testing/src/lib/core/pages/settings.page.ts
+++ b/lib/testing/src/lib/core/pages/settings.page.ts
@@ -39,7 +39,7 @@ export class SettingsPage {
     backButton: ElementFinder = element(by.cssContainingText('button span[class="mat-button-wrapper"]', 'Back'));
     validationMessage: ElementFinder = element(by.cssContainingText('mat-error', 'This field is required'));
 
-    providerDropdown = new DropdownPage(element(by.css('mat-select[id="adf-provider-selector"] div[class="mat-select-arrow-wrapper"]')));
+    providerDropdown = new DropdownPage(element(by.css('mat-select[id="adf-provider-selector"]')));
 
     async goToSettingsPage(): Promise<void> {
         await browser.get(this.settingsURL);

--- a/lib/testing/src/lib/core/pages/settings.page.ts
+++ b/lib/testing/src/lib/core/pages/settings.page.ts
@@ -47,8 +47,7 @@ export class SettingsPage {
     }
 
     async setProvider(option): Promise<void> {
-        await this.providerDropdown.clickDropdown();
-        await this.providerDropdown.selectOption(option);
+        await this.providerDropdown.clickDropdownWithOption(option);
         await this.providerDropdown.checkOptionIsSelected(option);
     }
 

--- a/lib/testing/src/lib/material/pages/dropdown.page.ts
+++ b/lib/testing/src/lib/material/pages/dropdown.page.ts
@@ -54,7 +54,7 @@ export class DropdownPage {
         await BrowserVisibility.waitUntilElementIsClickable(this.dropDownElement);
     }
 
-    async checkSelectedOptionIsDisplayed(option: string): Promise<void> {
+    async checkOptionIsSelected(option: string): Promise<void> {
         const selectedOption = element(by.cssContainingText('.mat-select-value-text span', option));
         await BrowserVisibility.waitUntilElementIsVisible(selectedOption);
     }

--- a/lib/testing/src/lib/material/pages/dropdown.page.ts
+++ b/lib/testing/src/lib/material/pages/dropdown.page.ts
@@ -22,7 +22,6 @@ import { BrowserActions } from '../../core/utils/browser-actions';
 export class DropdownPage {
 
     dropDownElement: ElementFinder;
-    private selectedOption: ElementFinder = element(by.css('span[class*="mat-select-value-text"]'));
 
     constructor(dropDownElement: ElementFinder = element.all(by.css('div[class="mat-select-arrow-wrapper"]')).first()) {
         this.dropDownElement = dropDownElement;
@@ -55,7 +54,7 @@ export class DropdownPage {
     }
 
     async checkOptionIsSelected(option: string): Promise<void> {
-        const selectedOption = element(by.cssContainingText('.mat-select-value-text span', option));
+        const selectedOption = this.dropDownElement.element(by.cssContainingText('.mat-select-value-text span', option));
         await BrowserVisibility.waitUntilElementIsVisible(selectedOption);
     }
 
@@ -69,7 +68,8 @@ export class DropdownPage {
     }
 
     async getSelectedOptionText(): Promise<string> {
-        return BrowserActions.getText(this.selectedOption);
+        const selectedOption = this.dropDownElement.element(by.css('.mat-select-value-text span'));
+        return BrowserActions.getText(selectedOption);
     }
 
     async checkOptionIsDisplayed(option: string): Promise <void> {
@@ -78,5 +78,10 @@ export class DropdownPage {
 
     async checkOptionIsNotDisplayed(option: string): Promise <void> {
         await BrowserVisibility.waitUntilElementIsNotVisible(element(by.cssContainingText('mat-option span.mat-option-text', option)));
+    }
+
+    async clickDropdownWithOption(option: string): Promise<void> {
+        await this.clickDropdown();
+        await this.selectOption(option);
     }
 }

--- a/lib/testing/src/lib/material/pages/dropdown.page.ts
+++ b/lib/testing/src/lib/material/pages/dropdown.page.ts
@@ -22,17 +22,10 @@ import { BrowserActions } from '../../core/utils/browser-actions';
 export class DropdownPage {
 
     dropDownElement: ElementFinder;
+    private selectedOption: ElementFinder = element(by.css('span[class*="mat-select-value-text"]'));
 
     constructor(dropDownElement: ElementFinder = element.all(by.css('div[class="mat-select-arrow-wrapper"]')).first()) {
         this.dropDownElement = dropDownElement;
-    }
-
-    async checkOptionIsVisibleInDropdown(option: string): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(element(by.cssContainingText('mat-option span', option)), 5000);
-    }
-
-    async checkOptionIsNotVisible(option: string): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsNotVisible(element(by.cssContainingText('mat-option span', option)), 5000);
     }
 
     async clickDropdown(): Promise<void> {
@@ -46,5 +39,44 @@ export class DropdownPage {
 
     async getValue(): Promise<string> {
         return BrowserActions.getText(element(by.css('mat-form-field span')));
+    }
+
+    async getNumberOfOptions(): Promise<number> {
+        const dropdownOptions = element.all(by.css('.mat-select-panel mat-option'));
+        return dropdownOptions.count();
+    }
+
+    async checkDropdownIsVisible(): Promise<void> {
+        await BrowserVisibility.waitUntilElementIsVisible(this.dropDownElement);
+    }
+
+    async checkDropdownIsClickable(): Promise<void> {
+        await BrowserVisibility.waitUntilElementIsClickable(this.dropDownElement);
+    }
+
+    async checkSelectedOptionIsDisplayed(option: string): Promise<void> {
+        const selectedOption = element(by.cssContainingText('.mat-select-value-text span', option));
+        await BrowserVisibility.waitUntilElementIsVisible(selectedOption);
+    }
+
+    async selectOptionFromIndex(index): Promise<void> {
+        const value: ElementFinder = element.all(by.className('mat-option')).get(index);
+        await BrowserActions.click(value);
+    }
+
+    async checkOptionsPanelIsDisplayed(): Promise<void> {
+        await BrowserVisibility.waitUntilElementIsVisible(element(by.css('.mat-select-panel')));
+    }
+
+    async getSelectedOptionText(): Promise<string> {
+        return BrowserActions.getText(this.selectedOption);
+    }
+
+    async checkOptionIsDisplayed(option: string): Promise <void> {
+        await BrowserVisibility.waitUntilElementIsVisible(element(by.cssContainingText('mat-option span.mat-option-text', option)));
+    }
+
+    async checkOptionIsNotDisplayed(option: string): Promise <void> {
+        await BrowserVisibility.waitUntilElementIsNotVisible(element(by.cssContainingText('mat-option span.mat-option-text', option)));
     }
 }

--- a/lib/testing/src/lib/process-services-cloud/pages/edit-process-filter-cloud-component.page.ts
+++ b/lib/testing/src/lib/process-services-cloud/pages/edit-process-filter-cloud-component.page.ts
@@ -18,15 +18,25 @@ import { browser, by, element, protractor, ElementFinder } from 'protractor';
 import { EditProcessFilterDialogPage } from './dialog/edit-process-filter-dialog.page';
 import { BrowserVisibility } from '../../core/utils/browser-visibility';
 import { BrowserActions } from '../../core/utils/browser-actions';
+import { DropdownPage } from '../../material/pages/dropdown.page';
 
 export class EditProcessFilterCloudComponentPage {
 
     customiseFilter: ElementFinder = element(by.id('adf-edit-process-filter-title-id'));
-    selectedOption: ElementFinder = element.all(by.css('mat-option[class*="mat-selected"]')).first();
     saveButton: ElementFinder = element(by.css('button[data-automation-id="adf-filter-action-save"]'));
     saveAsButton: ElementFinder = element(by.css('button[data-automation-id="adf-filter-action-saveAs"]'));
     deleteButton: ElementFinder = element(by.css('button[data-automation-id="adf-filter-action-delete"]'));
     filter: ElementFinder = element(by.css(`adf-cloud-edit-process-filter mat-expansion-panel-header`));
+
+    private locatorAppNameDropdown = element(by.css(`mat-select[data-automation-id='adf-cloud-edit-process-property-appName']`));
+    private locatorStatusDropdown = element(by.css(`mat-select[data-automation-id='adf-cloud-edit-process-property-status']`));
+    private locatorSortDropdown = element(by.css(`mat-select[data-automation-id='adf-cloud-edit-process-property-sort']`));
+    private locatorOrderDropdown = element(by.css(`mat-select[data-automation-id='adf-cloud-edit-process-property-order']`));
+
+    private appNameDropdown = new DropdownPage(this.locatorAppNameDropdown);
+    private statusDropdown = new DropdownPage(this.locatorStatusDropdown);
+    private sortDropdown = new DropdownPage(this.locatorSortDropdown);
+    private orderDropdown = new DropdownPage(this.locatorOrderDropdown);
 
     editProcessFilterDialogPage = new EditProcessFilterDialogPage();
 
@@ -51,10 +61,8 @@ export class EditProcessFilterCloudComponentPage {
     }
 
     async setStatusFilterDropDown(option: string): Promise<void> {
-        await this.clickOnDropDownArrow('status');
-
-        const statusElement = element.all(by.cssContainingText('mat-option span', option)).first();
-        await BrowserActions.click(statusElement);
+        await this.statusDropdown.clickDropdown();
+        await this.statusDropdown.selectOption(option);
     }
 
     async getStateFilterDropDownValue(): Promise<string> {
@@ -62,10 +70,8 @@ export class EditProcessFilterCloudComponentPage {
     }
 
     async setSortFilterDropDown(option): Promise<void> {
-        await this.clickOnDropDownArrow('sort');
-
-        const sortElement = element.all(by.cssContainingText('mat-option span', option)).first();
-        await BrowserActions.click(sortElement);
+        await this.sortDropdown.clickDropdown();
+        await this.sortDropdown.selectOption(option);
     }
 
     async getSortFilterDropDownValue(): Promise<string> {
@@ -74,10 +80,8 @@ export class EditProcessFilterCloudComponentPage {
     }
 
     async setOrderFilterDropDown(option): Promise<void> {
-        await this.clickOnDropDownArrow('order');
-
-        const orderElement = element.all(by.cssContainingText('mat-option span', option)).first();
-        await BrowserActions.click(orderElement);
+        await this.orderDropdown.clickDropdown();
+        await this.orderDropdown.selectOption(option);
         await browser.sleep(1500);
     }
 
@@ -85,16 +89,9 @@ export class EditProcessFilterCloudComponentPage {
         return BrowserActions.getText(element(by.css("mat-form-field[data-automation-id='order'] span")));
     }
 
-    async clickOnDropDownArrow(option): Promise<void> {
-        const dropDownArrow = element.all(by.css("mat-form-field[data-automation-id='" + option + "'] div[class='mat-select-arrow-wrapper']")).first();
-        await BrowserActions.click(dropDownArrow);
-    }
-
     async setAppNameDropDown(option: string): Promise<void> {
-        await this.clickOnDropDownArrow('appName');
-
-        const appNameElement = element.all(by.cssContainingText('mat-option span', option)).first();
-        await BrowserActions.click(appNameElement);
+        await this.appNameDropdown.clickDropdown();
+        await this.appNameDropdown.selectOption(option);
     }
 
     async getApplicationSelected(): Promise<string> {
@@ -113,9 +110,8 @@ export class EditProcessFilterCloudComponentPage {
     }
 
     async getNumberOfAppNameOptions(): Promise<number> {
-        await this.clickOnDropDownArrow('appName');
-        const dropdownOptions = element.all(by.css('.mat-select-panel mat-option'));
-        return dropdownOptions.count();
+        await this.appNameDropdown.clickDropdown();
+        return this.appNameDropdown.getNumberOfOptions();
     }
 
     async isApplicationListLoaded(): Promise<boolean> {

--- a/lib/testing/src/lib/process-services-cloud/pages/edit-process-filter-cloud-component.page.ts
+++ b/lib/testing/src/lib/process-services-cloud/pages/edit-process-filter-cloud-component.page.ts
@@ -33,10 +33,10 @@ export class EditProcessFilterCloudComponentPage {
     private locatorSortDropdown = element(by.css(`mat-select[data-automation-id='adf-cloud-edit-process-property-sort']`));
     private locatorOrderDropdown = element(by.css(`mat-select[data-automation-id='adf-cloud-edit-process-property-order']`));
 
-    private appNameDropdown = new DropdownPage(this.locatorAppNameDropdown);
-    private statusDropdown = new DropdownPage(this.locatorStatusDropdown);
-    private sortDropdown = new DropdownPage(this.locatorSortDropdown);
-    private orderDropdown = new DropdownPage(this.locatorOrderDropdown);
+    appNameDropdown = new DropdownPage(this.locatorAppNameDropdown);
+    statusDropdown = new DropdownPage(this.locatorStatusDropdown);
+    sortDropdown = new DropdownPage(this.locatorSortDropdown);
+    orderDropdown = new DropdownPage(this.locatorOrderDropdown);
 
     editProcessFilterDialogPage = new EditProcessFilterDialogPage();
 
@@ -61,8 +61,7 @@ export class EditProcessFilterCloudComponentPage {
     }
 
     async setStatusFilterDropDown(option: string): Promise<void> {
-        await this.statusDropdown.clickDropdown();
-        await this.statusDropdown.selectOption(option);
+        await this.statusDropdown.clickDropdownWithOption(option);
     }
 
     async getStateFilterDropDownValue(): Promise<string> {
@@ -70,8 +69,7 @@ export class EditProcessFilterCloudComponentPage {
     }
 
     async setSortFilterDropDown(option): Promise<void> {
-        await this.sortDropdown.clickDropdown();
-        await this.sortDropdown.selectOption(option);
+        await this.sortDropdown.clickDropdownWithOption(option);
     }
 
     async getSortFilterDropDownValue(): Promise<string> {
@@ -80,8 +78,7 @@ export class EditProcessFilterCloudComponentPage {
     }
 
     async setOrderFilterDropDown(option): Promise<void> {
-        await this.orderDropdown.clickDropdown();
-        await this.orderDropdown.selectOption(option);
+        await this.orderDropdown.clickDropdownWithOption(option);
         await browser.sleep(1500);
     }
 
@@ -90,8 +87,7 @@ export class EditProcessFilterCloudComponentPage {
     }
 
     async setAppNameDropDown(option: string): Promise<void> {
-        await this.appNameDropdown.clickDropdown();
-        await this.appNameDropdown.selectOption(option);
+        await this.appNameDropdown.clickDropdownWithOption(option);
     }
 
     async getApplicationSelected(): Promise<string> {

--- a/lib/testing/src/lib/process-services-cloud/pages/edit-task-filter-cloud-component.page.ts
+++ b/lib/testing/src/lib/process-services-cloud/pages/edit-task-filter-cloud-component.page.ts
@@ -44,10 +44,10 @@ export class EditTaskFilterCloudComponentPage {
     private locatorSortDropdown = element(by.css(`mat-select[data-automation-id='adf-cloud-edit-task-property-sort']`));
     private locatorOrderDropdown = element(by.css(`mat-select[data-automation-id='adf-cloud-edit-task-property-order']`));
 
-    private appNameDropdown = new DropdownPage(this.locatorAppNameDropdown);
-    private statusDropdown = new DropdownPage(this.locatorStatusDropdown);
-    private sortDropdown = new DropdownPage(this.locatorSortDropdown);
-    private orderDropdown = new DropdownPage(this.locatorOrderDropdown);
+    appNameDropdown = new DropdownPage(this.locatorAppNameDropdown);
+    statusDropdown = new DropdownPage(this.locatorStatusDropdown);
+    sortDropdown = new DropdownPage(this.locatorSortDropdown);
+    orderDropdown = new DropdownPage(this.locatorOrderDropdown);
 
     editTaskFilterDialogPage = new EditTaskFilterDialogPage();
 
@@ -65,8 +65,7 @@ export class EditTaskFilterCloudComponentPage {
     }
 
     async setStatusFilterDropDown(option: string): Promise<void> {
-        await this.statusDropdown.clickDropdown();
-        await this.statusDropdown.selectOption(option);
+        await this.statusDropdown.clickDropdownWithOption(option);
     }
 
     async getStatusFilterDropDownValue(): Promise<string> {
@@ -74,8 +73,7 @@ export class EditTaskFilterCloudComponentPage {
     }
 
     async setSortFilterDropDown(option: string): Promise<void> {
-        await this.sortDropdown.clickDropdown();
-        await this.sortDropdown.selectOption(option);
+        await this.sortDropdown.clickDropdownWithOption(option);
     }
 
     async getSortFilterDropDownValue(): Promise<string> {
@@ -83,8 +81,7 @@ export class EditTaskFilterCloudComponentPage {
     }
 
     async setOrderFilterDropDown(option: string): Promise<void> {
-        await this.orderDropdown.clickDropdown();
-        await this.orderDropdown.selectOption(option);
+        await this.orderDropdown.clickDropdownWithOption(option);
         await browser.sleep(1500);
     }
 
@@ -196,8 +193,7 @@ export class EditTaskFilterCloudComponentPage {
     }
 
     async setAppNameDropDown(option: string): Promise<void> {
-        await this.appNameDropdown.clickDropdown();
-        await this.appNameDropdown.selectOption(option);
+        await this.appNameDropdown.clickDropdownWithOption(option);
     }
 
     async getAppNameDropDownValue(): Promise<string> {

--- a/lib/testing/src/lib/process-services-cloud/pages/edit-task-filter-cloud-component.page.ts
+++ b/lib/testing/src/lib/process-services-cloud/pages/edit-task-filter-cloud-component.page.ts
@@ -19,11 +19,11 @@ import { browser, by, element, protractor, ElementFinder } from 'protractor';
 import { EditTaskFilterDialogPage } from './dialog/edit-task-filter-dialog.page';
 import { BrowserVisibility } from '../../core/utils/browser-visibility';
 import { BrowserActions } from '../../core/utils/browser-actions';
+import { DropdownPage } from '../../material/pages/dropdown.page';
 
 export class EditTaskFilterCloudComponentPage {
 
     customiseFilter: ElementFinder = element(by.id('adf-edit-task-filter-title-id'));
-    selectedOption: ElementFinder = element.all(by.css('mat-option[class*="mat-selected"]')).first();
     assignee: ElementFinder = element(by.css('input[data-automation-id="adf-cloud-edit-task-property-assignee"]'));
     priority: ElementFinder = element(by.css('input[data-automation-id="adf-cloud-edit-task-property-priority"]'));
     taskName: ElementFinder = element(by.css('input[data-automation-id="adf-cloud-edit-task-property-taskName"]'));
@@ -38,6 +38,16 @@ export class EditTaskFilterCloudComponentPage {
     saveAsButton: ElementFinder = element(by.css('[data-automation-id="adf-filter-action-saveAs"]'));
     deleteButton: ElementFinder = element(by.css('[data-automation-id="adf-filter-action-delete"]'));
     filter: ElementFinder = element(by.css(`adf-cloud-edit-task-filter mat-expansion-panel-header`));
+
+    private locatorAppNameDropdown = element(by.css(`mat-select[data-automation-id='adf-cloud-edit-task-property-appName']`));
+    private locatorStatusDropdown = element(by.css(`mat-select[data-automation-id='adf-cloud-edit-task-property-status']`));
+    private locatorSortDropdown = element(by.css(`mat-select[data-automation-id='adf-cloud-edit-task-property-sort']`));
+    private locatorOrderDropdown = element(by.css(`mat-select[data-automation-id='adf-cloud-edit-task-property-order']`));
+
+    private appNameDropdown = new DropdownPage(this.locatorAppNameDropdown);
+    private statusDropdown = new DropdownPage(this.locatorStatusDropdown);
+    private sortDropdown = new DropdownPage(this.locatorSortDropdown);
+    private orderDropdown = new DropdownPage(this.locatorOrderDropdown);
 
     editTaskFilterDialogPage = new EditTaskFilterDialogPage();
 
@@ -55,44 +65,31 @@ export class EditTaskFilterCloudComponentPage {
     }
 
     async setStatusFilterDropDown(option: string): Promise<void> {
-        await this.clickOnDropDownArrow('status');
-
-        const statusElement = element.all(by.cssContainingText('mat-option span', option)).first();
-        await BrowserActions.click(statusElement);
+        await this.statusDropdown.clickDropdown();
+        await this.statusDropdown.selectOption(option);
     }
 
     async getStatusFilterDropDownValue(): Promise<string> {
-        return BrowserActions.getText(element.all(by.css("mat-select[data-automation-id='adf-cloud-edit-task-property-status'] span")).first());
+        return this.statusDropdown.getSelectedOptionText();
     }
 
-    async setSortFilterDropDown(option): Promise<void> {
-        await this.clickOnDropDownArrow('sort');
-
-        const sortElement = element.all(by.cssContainingText('mat-option span', option)).first();
-        await BrowserActions.click(sortElement);
+    async setSortFilterDropDown(option: string): Promise<void> {
+        await this.sortDropdown.clickDropdown();
+        await this.sortDropdown.selectOption(option);
     }
 
     async getSortFilterDropDownValue(): Promise<string> {
-        const elementSort = element.all(by.css("mat-select[data-automation-id='adf-cloud-edit-task-property-sort'] span")).first();
-        return BrowserActions.getText(elementSort);
+        return this.sortDropdown.getSelectedOptionText();
     }
 
     async setOrderFilterDropDown(option: string): Promise<void> {
-        await this.clickOnDropDownArrow('order');
-
-        const orderElement = element.all(by.cssContainingText('mat-option span', option)).first();
-        await BrowserActions.click(orderElement);
+        await this.orderDropdown.clickDropdown();
+        await this.orderDropdown.selectOption(option);
         await browser.sleep(1500);
     }
 
-    getOrderFilterDropDownValue(): Promise<string> {
-        return BrowserActions.getText(element.all(by.css("mat-select[data-automation-id='adf-cloud-edit-task-property-order'] span")).first());
-    }
-
-    async clickOnDropDownArrow(option: string): Promise<void> {
-        const dropDownArrow = element.all(by.css("mat-form-field[data-automation-id='" + option + "'] div[class*='arrow']")).first();
-        await BrowserActions.click(dropDownArrow);
-        await BrowserVisibility.waitUntilElementIsVisible(this.selectedOption);
+    async getOrderFilterDropDownValue(): Promise<string> {
+        return this.orderDropdown.getSelectedOptionText();
     }
 
     async setAssignee(option: string): Promise<void> {
@@ -199,15 +196,12 @@ export class EditTaskFilterCloudComponentPage {
     }
 
     async setAppNameDropDown(option: string): Promise<void> {
-        await this.clickOnDropDownArrow('appName');
-
-        const appNameElement = element.all(by.cssContainingText('mat-option span', option)).first();
-        await BrowserActions.click(appNameElement);
+        await this.appNameDropdown.clickDropdown();
+        await this.appNameDropdown.selectOption(option);
     }
 
     async getAppNameDropDownValue(): Promise<string> {
-        const locator = element.all(by.css("mat-select[data-automation-id='adf-cloud-edit-task-property-appName'] span")).first();
-        return BrowserActions.getText(locator);
+        return this.appNameDropdown.getSelectedOptionText();
     }
 
     async setId(option): Promise<void> {

--- a/lib/testing/src/lib/process-services-cloud/pages/process-filters-cloud-component.page.ts
+++ b/lib/testing/src/lib/process-services-cloud/pages/process-filters-cloud-component.page.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { by, ElementFinder, Locator } from 'protractor';
+import { by, element, ElementFinder, Locator } from 'protractor';
 import { BrowserVisibility } from '../../core/utils/browser-visibility';
 import { BrowserActions } from '../../core/utils/browser-actions';
 
@@ -24,32 +24,54 @@ export class ProcessFiltersCloudComponentPage {
     filter: ElementFinder;
     filterIcon: Locator = by.xpath("ancestor::div[@class='mat-list-item-content']/mat-icon");
 
-    constructor(filter: ElementFinder) {
-        this.filter = filter;
-    }
+    processFilters: ElementFinder = element(by.css("mat-expansion-panel[data-automation-id='Process Filters']"));
 
-    async checkProcessFilterIsDisplayed(): Promise<void> {
+    activeFilter: ElementFinder = element(by.css("mat-list-item[class*='active'] span"));
+    processFiltersList: ElementFinder = element(by.css('adf-cloud-process-filters'));
+
+    async checkProcessFilterIsDisplayed(filterName: string): Promise<void> {
+        this.filter = this.getProcessFilterLocatorByFilterName(filterName);
         await BrowserVisibility.waitUntilElementIsVisible(this.filter);
     }
 
-    async getProcessFilterIcon(): Promise<string> {
+    async getProcessFilterIcon(filterName: string): Promise<string> {
+        this.filter = this.getProcessFilterLocatorByFilterName(filterName);
         await BrowserVisibility.waitUntilElementIsVisible(this.filter);
         const icon = this.filter.element(this.filterIcon);
         await BrowserVisibility.waitUntilElementIsVisible(icon);
         return BrowserActions.getText(icon);
     }
 
-    async checkProcessFilterHasNoIcon(): Promise<void> {
+    async checkProcessFilterHasNoIcon(filterName: string): Promise<void> {
+        this.filter = this.getProcessFilterLocatorByFilterName(filterName);
         await BrowserVisibility.waitUntilElementIsVisible(this.filter);
         await BrowserVisibility.waitUntilElementIsNotVisible(this.filter.element(this.filterIcon));
     }
 
-    async clickProcessFilter(): Promise<void> {
+    async clickProcessFilter(filterName: string): Promise<void> {
+        this.filter = this.getProcessFilterLocatorByFilterName(filterName);
         await BrowserActions.click(this.filter);
     }
 
-    async checkProcessFilterNotDisplayed(): Promise<void> {
+    async checkProcessFilterNotDisplayed(filterName: string): Promise<void> {
+        this.filter = this.getProcessFilterLocatorByFilterName(filterName);
         await BrowserVisibility.waitUntilElementIsNotVisible(this.filter);
     }
 
+    async clickOnProcessFilters(): Promise<void> {
+        await BrowserActions.click(this.processFilters);
+    }
+
+    async getActiveFilterName(): Promise<string> {
+        await BrowserVisibility.waitUntilElementIsVisible(this.activeFilter);
+        return BrowserActions.getText(this.activeFilter);
+    }
+
+    async isProcessFiltersListVisible(): Promise<void> {
+        await BrowserVisibility.waitUntilElementIsVisible(this.processFiltersList);
+    }
+
+    getProcessFilterLocatorByFilterName(filterName: string): ElementFinder {
+        return element(by.css(`span[data-automation-id="${filterName}_filter"]`));
+    }
 }

--- a/lib/testing/src/lib/process-services-cloud/pages/process-filters-cloud-component.page.ts
+++ b/lib/testing/src/lib/process-services-cloud/pages/process-filters-cloud-component.page.ts
@@ -50,7 +50,41 @@ export class ProcessFiltersCloudComponentPage {
 
     async clickProcessFilter(filterName: string): Promise<void> {
         this.filter = this.getProcessFilterLocatorByFilterName(filterName);
+        await BrowserVisibility.waitUntilElementIsClickable(this.filter);
         await BrowserActions.click(this.filter);
+    }
+
+    async clickAllProcessesFilter(): Promise<void> {
+        this.filter = this.getProcessFilterLocatorByFilterName('all-processes');
+        await BrowserVisibility.waitUntilElementIsClickable(this.filter);
+        await BrowserActions.click(this.filter);
+    }
+
+    async clickCompletedProcessesFilter(): Promise<void> {
+        this.filter = this.getProcessFilterLocatorByFilterName('completed-processes');
+        await BrowserVisibility.waitUntilElementIsClickable(this.filter);
+        await BrowserActions.click(this.filter);
+    }
+
+    async clickRunningProcessesFilter(): Promise<void> {
+        this.filter = this.getProcessFilterLocatorByFilterName('running-processes');
+        await BrowserVisibility.waitUntilElementIsClickable(this.filter);
+        await BrowserActions.click(this.filter);
+    }
+
+    async checkAllProcessesFilterIsDisplayed(): Promise<void> {
+        this.filter = this.getProcessFilterLocatorByFilterName('all-processes');
+        await BrowserVisibility.waitUntilElementIsVisible(this.filter);
+    }
+
+    async checkCompletedProcessesFilterIsDisplayed(): Promise<void> {
+        this.filter = this.getProcessFilterLocatorByFilterName('completed-processes');
+        await BrowserVisibility.waitUntilElementIsVisible(this.filter);
+    }
+
+    async checkRunningProcessesFilterIsDisplayed(): Promise<void> {
+        this.filter = this.getProcessFilterLocatorByFilterName('running-processes');
+        await BrowserVisibility.waitUntilElementIsVisible(this.filter);
     }
 
     async checkProcessFilterNotDisplayed(filterName: string): Promise<void> {

--- a/lib/testing/src/lib/process-services-cloud/pages/task-filters-cloud-component.page.ts
+++ b/lib/testing/src/lib/process-services-cloud/pages/task-filters-cloud-component.page.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { browser, by, ElementFinder, Locator } from 'protractor';
+import { by, element, ElementFinder, Locator } from 'protractor';
 import { BrowserVisibility } from '../../core/utils/browser-visibility';
 import { BrowserActions } from '../../core/utils/browser-actions';
 
@@ -23,33 +23,54 @@ export class TaskFiltersCloudComponentPage {
 
     filter: ElementFinder;
     taskIcon: Locator = by.xpath("ancestor::div[@class='mat-list-item-content']/mat-icon");
+    taskFilters: ElementFinder = element(by.css(`mat-expansion-panel[data-automation-id='Task Filters']`));
 
-    constructor(filter: ElementFinder) {
-        this.filter = filter;
-    }
+    activeFilter: ElementFinder = element(by.css("mat-list-item[class*='active'] span"));
+    defaultActiveFilter: ElementFinder = element.all(by.css('.adf-filters__entry')).first();
 
-    async checkTaskFilterIsDisplayed(): Promise<void> {
+    async checkTaskFilterIsDisplayed(filterName: string): Promise<void> {
+        this.filter = this.getTaskFilterLocatorByFilterName(filterName);
         await BrowserVisibility.waitUntilElementIsVisible(this.filter);
     }
 
-    async getTaskFilterIcon(): Promise<string> {
+    async getTaskFilterIcon(filterName: string): Promise<string> {
+        this.filter = this.getTaskFilterLocatorByFilterName(filterName);
         await BrowserVisibility.waitUntilElementIsVisible(this.filter);
         const icon = this.filter.element(this.taskIcon);
         return BrowserActions.getText(icon);
     }
 
-    async checkTaskFilterHasNoIcon(): Promise<void> {
+    async checkTaskFilterHasNoIcon(filterName: string): Promise<void> {
+        this.filter = this.getTaskFilterLocatorByFilterName(filterName);
         await BrowserVisibility.waitUntilElementIsVisible(this.filter);
         await BrowserVisibility.waitUntilElementIsNotVisible(this.filter.element(this.taskIcon));
     }
 
-    async clickTaskFilter(): Promise<void> {
+    async clickTaskFilter(filterName): Promise<void> {
+        this.filter = this.getTaskFilterLocatorByFilterName(filterName);
         await BrowserActions.click(this.filter);
-        await browser.driver.sleep(1000);
     }
 
-    async checkTaskFilterNotDisplayed(): Promise<void> {
+    async checkTaskFilterNotDisplayed(filterName: string): Promise<void> {
+        this.filter = this.getTaskFilterLocatorByFilterName(filterName);
         await BrowserVisibility.waitUntilElementIsNotVisible(this.filter);
+    }
+
+    async clickOnTaskFilters(): Promise<void> {
+        await BrowserActions.click(this.taskFilters);
+    }
+
+    async getActiveFilterName(): Promise<string> {
+        return BrowserActions.getText(this.activeFilter);
+    }
+
+    async firstFilterIsActive(): Promise<boolean> {
+        const value = await this.defaultActiveFilter.getAttribute('class');
+        return value.includes('adf-active');
+    }
+
+    getTaskFilterLocatorByFilterName(filterName: string): ElementFinder {
+        return element(by.css(`span[data-automation-id="${filterName}-filter"]`));
     }
 
 }

--- a/lib/testing/src/lib/process-services-cloud/pages/task-filters-cloud-component.page.ts
+++ b/lib/testing/src/lib/process-services-cloud/pages/task-filters-cloud-component.page.ts
@@ -48,7 +48,30 @@ export class TaskFiltersCloudComponentPage {
 
     async clickTaskFilter(filterName): Promise<void> {
         this.filter = this.getTaskFilterLocatorByFilterName(filterName);
+        await BrowserVisibility.waitUntilElementIsClickable(this.filter);
         await BrowserActions.click(this.filter);
+    }
+
+    async clickMyTasksFilter(): Promise<void> {
+        this.filter = this.getTaskFilterLocatorByFilterName('my-tasks');
+        await BrowserVisibility.waitUntilElementIsClickable(this.filter);
+        await BrowserActions.click(this.filter);
+    }
+
+    async clickCompletedTasksFilter(): Promise<void> {
+        this.filter = this.getTaskFilterLocatorByFilterName('completed-tasks');
+        await BrowserVisibility.waitUntilElementIsClickable(this.filter);
+        await BrowserActions.click(this.filter);
+    }
+
+    async checkMyTasksFilterIsDisplayed(): Promise<void> {
+        this.filter = this.getTaskFilterLocatorByFilterName('my-tasks');
+        await BrowserVisibility.waitUntilElementIsVisible(this.filter);
+    }
+
+    async checkCompletedTasksFilterIsDisplayed(): Promise<void> {
+        this.filter = this.getTaskFilterLocatorByFilterName('completed-tasks');
+        await BrowserVisibility.waitUntilElementIsVisible(this.filter);
     }
 
     async checkTaskFilterNotDisplayed(filterName: string): Promise<void> {

--- a/lib/testing/src/lib/process-services/pages/form-fields.page.ts
+++ b/lib/testing/src/lib/process-services/pages/form-fields.page.ts
@@ -19,6 +19,7 @@ import { BrowserVisibility } from '../../core/utils/browser-visibility';
 import { by, element, ElementFinder, Locator } from 'protractor';
 import { BrowserActions } from '../../core/utils/browser-actions';
 import { By } from 'selenium-webdriver';
+import { DropdownPage } from '../../material/pages/dropdown.page';
 
 export class FormFieldsPage {
 
@@ -30,10 +31,10 @@ export class FormFieldsPage {
     noFormMessage: ElementFinder = element(by.css('span[id*="no-form-message"]'));
     completedTaskNoFormMessage: ElementFinder = element(by.css('div[id*="completed-form-message"] p'));
     attachFormButton: ElementFinder = element(by.id('adf-no-form-attach-form-button'));
-    selectFormDropDownArrow: ElementFinder = element.all(by.css('adf-attach-form div[class*="mat-select-arrow"]')).first();
-    selectFormContent: ElementFinder = element(by.css('div[class*="mat-select-panel"]'));
     completeButton: ElementFinder = element(by.id('adf-form-complete'));
     errorMessage: Locator = by.css('.adf-error-text-container .adf-error-text');
+
+    selectFormDropdown = new DropdownPage(element.all(by.css('adf-attach-form div[class*="mat-select-arrow"]')).first());
 
     async setFieldValue(locator: (id: string) => By, field: string, value: string): Promise<void> {
         const fieldElement = element(locator(field));
@@ -121,9 +122,9 @@ export class FormFieldsPage {
     }
 
     async selectForm(formName: string): Promise<void> {
-        await BrowserActions.click(this.selectFormDropDownArrow);
-        await BrowserVisibility.waitUntilElementIsVisible(this.selectFormContent);
-        await this.selectFormFromDropDown(formName);
+        await this.selectFormDropdown.clickDropdown();
+        await this.selectFormDropdown.checkOptionsPanelIsDisplayed();
+        await this.selectFormDropdown.selectOption(formName);
     }
 
     async selectFormFromDropDown(formName: string): Promise<void> {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [X] Other... Please describe:
e2e refactoring

**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/AAE-1729


**What is the new behaviour?**
Task/Process filters methods are moved from demo-shell pages into adf-testing


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
