### PR TITLE
[#5352] Fix broken pagination if totalItems is missing

### DIFF
--- a/lib/core/pagination/pagination.component.html
+++ b/lib/core/pagination/pagination.component.html
@@ -1,12 +1,7 @@
 <ng-container *ngIf="hasItems">
     <div class="adf-pagination__block adf-pagination__range-block">
         <span class="adf-pagination__range">
-            {{
-                'CORE.PAGINATION.ITEMS_RANGE' | translate: {
-                    range: range.join('-'),
-                    total: pagination.totalItems
-                }
-            }}
+            {{ itemRangeText }}
         </span>
     </div>
 
@@ -50,9 +45,11 @@
             <mat-icon>arrow_drop_down</mat-icon>
         </button>
 
-        <span class="adf-pagination__total-pages">
-            {{ 'CORE.PAGINATION.TOTAL_PAGES' | translate: { total: pages.length } }}
-        </span>
+        <div *ngIf="pagination.totalItems">
+            <span class="adf-pagination__total-pages">
+                {{ 'CORE.PAGINATION.TOTAL_PAGES' | translate: { total: pages.length } }}
+            </span>
+        </div>
 
         <mat-menu #pagesMenu="matMenu" class="adf-pagination__page-selector">
             <button

--- a/lib/core/pagination/pagination.component.spec.ts
+++ b/lib/core/pagination/pagination.component.spec.ts
@@ -333,4 +333,27 @@ describe('PaginationComponent', () => {
             expect(component.current).toBe(1);
         });
     });
+
+    describe('without total items', () => {
+        beforeEach(() => {
+            component.pagination = new FakePaginationInput(3, 2, 5);
+            component.pagination.hasMoreItems = true;
+            component.pagination.totalItems = undefined;
+        });
+
+        it('has the same, previous page', () => {
+            expect(component.previous).toBe(1);
+        });
+
+        it('has next page', () => {
+            expect(component.next).toBe(3);
+        });
+
+        it('has range', () => {
+            expect(component.range).toEqual([ 26, 50 ]);
+        });
+        it('cannot calculate number of pages', () => {
+            expect(component.pages).toEqual([1])
+        });
+    });
 });

--- a/lib/core/pagination/pagination.component.ts
+++ b/lib/core/pagination/pagination.component.ts
@@ -27,6 +27,7 @@ import { Subject } from 'rxjs';
 import { PaginationModel } from '../models/pagination.model';
 import { UserPreferencesService, UserPreferenceValues } from '../services/user-preferences.service';
 import { takeUntil } from 'rxjs/operators';
+import {TranslateService} from '@ngx-translate/core';
 
 @Component({
     selector: 'adf-pagination',
@@ -85,7 +86,7 @@ export class PaginationComponent implements OnInit, OnDestroy, PaginationCompone
 
     private onDestroy$ = new Subject<boolean>();
 
-    constructor(private cdr: ChangeDetectorRef, private userPreferencesService: UserPreferencesService) {
+    constructor(private cdr: ChangeDetectorRef, private userPreferencesService: UserPreferencesService, private translate: TranslateService) {
     }
 
     ngOnInit() {
@@ -133,6 +134,9 @@ export class PaginationComponent implements OnInit, OnDestroy, PaginationCompone
     }
 
     get isLastPage(): boolean {
+        if (!this.pagination.totalItems && this.pagination.hasMoreItems) {
+            return false;
+        }
         return this.current === this.lastPage;
     }
 
@@ -161,7 +165,11 @@ export class PaginationComponent implements OnInit, OnDestroy, PaginationCompone
         const { skipCount, maxItems, totalItems } = this.pagination;
         const { isLastPage } = this;
 
-        const start = totalItems ? skipCount + 1 : 0;
+        let start = 0;
+        if (totalItems || totalItems !== 0) {
+           start = skipCount + 1;
+        } 
+        
         const end = isLastPage ? totalItems : skipCount + maxItems;
 
         return [start, end];
@@ -171,6 +179,18 @@ export class PaginationComponent implements OnInit, OnDestroy, PaginationCompone
         return Array(this.lastPage)
             .fill('n')
             .map((_, index) => (index + 1));
+    }
+
+    get itemRangeText(): string {
+        const rangeString = this.range.join('-');
+        let translation = this.translate.instant('CORE.PAGINATION.ITEMS_RANGE', {
+            range: rangeString,
+            total: this.pagination.totalItems
+        });
+        if (!this.pagination.totalItems) {
+            translation = translation.substr(0, translation.indexOf(rangeString) + rangeString.length)
+        }
+        return translation;
     }
 
     goNext() {


### PR DESCRIPTION
This happens when a search query is executed against Solr and not the DB.

**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

> - [ x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** 

Described in #5352 

**What is the new behaviour?**
If totalItems param is missing, the pagination now looks as follows:
<img width="1416" alt="image" src="https://user-images.githubusercontent.com/15780097/74339601-b54e3c00-4da4-11ea-8ed2-dd7df03bb96d.png">

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ x] No
