### PR TITLE
[ADF-5074] Scrollable card-view-textitem when value too long for display

### DIFF
--- a/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.html
+++ b/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.html
@@ -2,9 +2,9 @@
 <div class="adf-property-value">
     <span *ngIf="!isEditable()">
         <span *ngIf="!isClickable(); else elseBlock" [attr.data-automation-id]="'card-textitem-value-' + property.key">
-            <div id="parent" *ngIf="showProperty()">
-                <span [ngClass]="property.multiline?'adf-textitem-multiline':'adf-textitem-scroll'">{{ property.displayValue }}</span>
-            </div>
+            <span *ngIf="showProperty()"
+                [ngClass]="property.multiline?'adf-textitem-multiline':'adf-textitem-scroll'">
+                {{ property.displayValue }}</span>
         </span>
         <ng-template #elseBlock>
             <div role="button" class="adf-textitem-clickable" [attr.data-automation-id]="'card-textitem-toggle-' + property.key" (click)="clicked()" fxLayout="row" fxLayoutAlign="space-between center">

--- a/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.html
+++ b/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.html
@@ -2,7 +2,9 @@
 <div class="adf-property-value">
     <span *ngIf="!isEditable()">
         <span *ngIf="!isClickable(); else elseBlock" [attr.data-automation-id]="'card-textitem-value-' + property.key">
-            <span *ngIf="showProperty()" class="adf-textitem-ellipsis">{{ property.displayValue }}</span>
+            <div id="parent" *ngIf="showProperty()">
+                <span [ngClass]="property.multiline?'adf-textitem-multiline':'adf-textitem-scroll'">{{ property.displayValue }}</span>
+            </div>
         </span>
         <ng-template #elseBlock>
             <div role="button" class="adf-textitem-clickable" [attr.data-automation-id]="'card-textitem-toggle-' + property.key" (click)="clicked()" fxLayout="row" fxLayoutAlign="space-between center">

--- a/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.scss
+++ b/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.scss
@@ -130,10 +130,9 @@
         }
 
         &-textitem-scroll {
-            overflow-x: scroll;
+            overflow-x: auto;
             white-space: nowrap;
             display: block;
-            margin-bottom: -5px;
 
             &::-webkit-scrollbar {
                 height: 5px;

--- a/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.scss
+++ b/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.scss
@@ -52,7 +52,7 @@
 
                 mat-icon:not(.adf-button-disabled):hover {
                     color: mat-color($foreground, text);
-                    cursor: pointer !important;;
+                    cursor: pointer !important;
                 }
 
                 mat-form-field {
@@ -129,10 +129,24 @@
             margin-bottom: -8px;
         }
 
-        &-textitem-ellipsis {
-            overflow: hidden;
-            text-overflow: ellipsis;
+        &-textitem-scroll {
+            overflow-x: scroll;
             white-space: nowrap;
+            display: block;
+            margin-bottom: -5px;
+
+            &::-webkit-scrollbar {
+                height: 5px;
+            }
+
+            &:hover::-webkit-scrollbar-thumb {
+                display: block;
+                background-color: mat-color($foreground, text, 0.25);
+                border-radius: 2px;
+            }
+        }
+
+        &-textitem-multiline {
             display: block;
         }
     }

--- a/lib/process-services/src/lib/task-list/components/task-header.component.spec.ts
+++ b/lib/process-services/src/lib/task-list/components/task-header.component.spec.ts
@@ -301,7 +301,7 @@ describe('TaskHeaderComponent', () => {
             const clickableForm = fixture.debugElement.query(By.css('[data-automation-id="header-formName"] .adf-textitem-clickable-value'));
             expect(clickableForm).toBeNull();
 
-            const readOnlyForm = fixture.debugElement.query(By.css('[data-automation-id="header-formName"] .adf-textitem-ellipsis'));
+            const readOnlyForm = fixture.debugElement.query(By.css('[data-automation-id="header-formName"] .adf-textitem-scroll'));
             expect(readOnlyForm.nativeElement.innerText).toBe('test form');
         });
     }));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Use of ellipsis when the value is non-multiline and too long for display. 
Multiline items are also affected and should be displayed as multiple lines.

**What is the new behaviour?**
No ellipsis but if the value is too long but the value is now horizontally scrollable.
For multiline items, they are now displayed on several lines.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-5074