### PR TITLE
[AAE-1942] Automation for hyperlink widget tests 

### DIFF
--- a/lib/core/form/components/widgets/hyperlink/hyperlink.widget.spec.ts
+++ b/lib/core/form/components/widgets/hyperlink/hyperlink.widget.spec.ts
@@ -14,18 +14,43 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormFieldTypes } from '../core/form-field-types';
 import { FormFieldModel } from './../core/form-field.model';
 import { FormModel } from './../core/form.model';
+import { TranslateModule, TranslateStore, TranslateService } from '@ngx-translate/core';
 import { WidgetComponent } from './../widget.component';
+import { TranslationService } from '../../../../services';
 import { HyperlinkWidgetComponent } from './hyperlink.widget';
+import { setupTestBed } from '../../../../testing/setupTestBed';
+import { TranslationMock } from '../../../../mock/translation.service.mock';
+import { HttpClientModule } from '@angular/common/http';
 
 describe('HyperlinkWidgetComponent', () => {
 
     let widget: HyperlinkWidgetComponent;
+    let fixture: ComponentFixture<HyperlinkWidgetComponent>;
+    let element: HTMLElement;
+
+    setupTestBed({
+        imports: [
+            TranslateModule.forChild(),
+            HttpClientModule
+        ],
+        declarations: [
+            HyperlinkWidgetComponent
+        ],
+        providers: [
+            TranslateStore,
+            TranslateService,
+            { provide: TranslationService, useClass: TranslationMock }
+        ]
+    });
 
     beforeEach(() => {
-        widget = new HyperlinkWidgetComponent(null);
+        fixture = TestBed.createComponent(HyperlinkWidgetComponent);
+        widget = fixture.componentInstance;
+        element = fixture.nativeElement;
     });
 
     it('should get link text from field display text', () => {
@@ -104,4 +129,42 @@ describe('HyperlinkWidgetComponent', () => {
         expect(widget.linkUrl).toBe(url);
     });
 
+    it('should be able to set label property', () => {
+        const label = 'Label';
+        widget.field = new FormFieldModel(new FormModel(), {
+            name: label,
+            type: FormFieldTypes.HYPERLINK
+        });
+
+        fixture.detectChanges();
+        const hyperlinkWidgetLabel = element.querySelector('label');
+        expect(hyperlinkWidgetLabel.innerText).toBe(label);
+    });
+
+    it('should be able to set URL', () => {
+        const url = 'https://www.alfresco.com/';
+        widget.field = new FormFieldModel(new FormModel(), {
+            hyperlinkUrl: url,
+            type: FormFieldTypes.HYPERLINK
+        });
+
+        fixture.detectChanges();
+        const hyperlinkWidgetLink = element.querySelector('a');
+        expect(hyperlinkWidgetLink.href).toBe(url);
+    });
+
+    it('should be able to set display text', () => {
+        const displayText = 'displayText';
+        const url = 'https://www.alfresco.com/';
+        widget.field = new FormFieldModel(new FormModel(), {
+            hyperlinkUrl: url,
+            displayText: displayText,
+            type: FormFieldTypes.HYPERLINK
+        });
+
+        fixture.detectChanges();
+        const hyperlinkWidgetLink = element.querySelector('a');
+        expect(hyperlinkWidgetLink.href).toBe(url);
+        expect(hyperlinkWidgetLink.innerText).toBe(displayText);
+    });
 });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x ] Other... Please describe:
Automation for hyperlink widget tests 

**What is the current behaviour?** (You can also link to an open issue here)
Not unit tests for sting label, url, and displayText for hyperlink widget.


**What is the new behaviour?**
Created unit tests for sting label, url, and displayText for hyperlink widget.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/AAE-1942