### PR TITLE
[AAE-2034] Display disabled radio button in read-only mode

### DIFF
--- a/lib/core/form/components/widgets/radio-buttons/radio-buttons.widget.html
+++ b/lib/core/form/components/widgets/radio-buttons/radio-buttons.widget.html
@@ -2,9 +2,8 @@
      [class.adf-invalid]="!field.isValid" [class.adf-readonly]="field.readOnly" [id]="field.id">
     <div class="adf-radio-button-container">
         <label class="adf-label" [attr.for]="field.id">{{field.name | translate }}<span *ngIf="isRequired()">*</span></label>
-        <mat-radio-group class="adf-radio-group" [(ngModel)]="field.value">
+        <mat-radio-group class="adf-radio-group" [(ngModel)]="field.value" [disabled]="field.readOnly">
             <mat-radio-button
-                [disabled]="field.readOnly"
                 [id]="field.id + '-' + opt.id"
                 [name]="field.id"
                 [value]="opt.id"

--- a/lib/core/form/components/widgets/radio-buttons/radio-buttons.widget.html
+++ b/lib/core/form/components/widgets/radio-buttons/radio-buttons.widget.html
@@ -2,8 +2,9 @@
      [class.adf-invalid]="!field.isValid" [class.adf-readonly]="field.readOnly" [id]="field.id">
     <div class="adf-radio-button-container">
         <label class="adf-label" [attr.for]="field.id">{{field.name | translate }}<span *ngIf="isRequired()">*</span></label>
-        <mat-radio-group class="adf-radio-group" [(ngModel)]="field.value" *ngIf="!field.readOnly">
+        <mat-radio-group class="adf-radio-group" [(ngModel)]="field.value">
             <mat-radio-button
+                [disabled]="field.readOnly"
                 [id]="field.id + '-' + opt.id"
                 [name]="field.id"
                 [value]="opt.id"
@@ -14,10 +15,7 @@
                 {{opt.name}}
             </mat-radio-button>
         </mat-radio-group>
-        <display-text-widget *ngIf="field.readOnly" [field]="field"></display-text-widget>
     </div>
     <error-widget [error]="field.validationSummary" ></error-widget>
     <error-widget *ngIf="isInvalidFieldRequired()" required="{{ 'FORM.FIELD.REQUIRED' | translate }}"></error-widget>
 </div>
-
-

--- a/lib/core/form/components/widgets/radio-buttons/radio-buttons.widget.spec.ts
+++ b/lib/core/form/components/widgets/radio-buttons/radio-buttons.widget.spec.ts
@@ -154,28 +154,6 @@ describe('RadioButtonsWidgetComponent', () => {
             fixture.destroy();
         });
 
-        describe('and radioButton is readonly', () => {
-
-            beforeEach(async(() => {
-                stubFormService = fixture.debugElement.injector.get(FormService);
-                radioButtonWidget.field = new FormFieldModel(new FormModel({ taskId: 'task-id' }), {
-                    id: 'radio-id',
-                    name: 'radio-name',
-                    type: FormFieldTypes.RADIO_BUTTONS,
-                    readOnly: true
-                });
-                radioButtonWidget.field.isVisible = true;
-                const fakeContainer = new ContainerModel(radioButtonWidget.field);
-                radioButtonWidget.field.form.fields.push(fakeContainer);
-                fixture.detectChanges();
-            }));
-
-            it('should show radio buttons as text when is readonly', async(() => {
-                expect(element.querySelector('display-text-widget')).toBeDefined();
-            }));
-
-        });
-
         describe('and radioButton is populated via taskId', () => {
 
             beforeEach(async(() => {
@@ -211,6 +189,33 @@ describe('RadioButtonsWidgetComponent', () => {
                     expect(element.querySelector('#radio-id-opt-1-input')).toBeNull();
                 });
             }));
+
+            describe('and radioButton is readonly', () => {
+
+                beforeEach(async(() => {
+                    radioButtonWidget.field.readOnly = true;
+                    fixture.detectChanges();
+                }));
+
+                it('should show radio buttons disabled', async(() => {
+                    expect(element.querySelector('.adf-readonly')).toBeDefined();
+                    expect(element.querySelector('.adf-readonly')).not.toBeNull();
+                }));
+
+                describe('and a value is selected', () => {
+
+                    beforeEach(async(() => {
+                        radioButtonWidget.field.value = restOption[0].id;
+                        fixture.detectChanges();
+                    }));
+
+                    it('should check the selected value', async(() => {
+                        expect(element.querySelector('.mat-radio-checked')).toBeDefined();
+                        expect(element.querySelector('.mat-radio-checked')).not.toBeNull();
+                        expect(element.querySelector('.mat-radio-checked')).toBe(element.querySelector('mat-radio-button[ng-reflect-id="radio-id-opt-1"]'));
+                    }));
+                });
+            });
         });
 
         describe('and radioButton is populated via processDefinitionId', () => {

--- a/lib/core/form/components/widgets/radio-buttons/radio-buttons.widget.spec.ts
+++ b/lib/core/form/components/widgets/radio-buttons/radio-buttons.widget.spec.ts
@@ -198,8 +198,10 @@ describe('RadioButtonsWidgetComponent', () => {
                 }));
 
                 it('should show radio buttons disabled', async(() => {
-                    expect(element.querySelector('.adf-readonly')).toBeDefined();
-                    expect(element.querySelector('.adf-readonly')).not.toBeNull();
+                    expect(element.querySelector('.mat-radio-disabled[ng-reflect-id="radio-id-opt-1"]')).toBeDefined();
+                    expect(element.querySelector('.mat-radio-disabled[ng-reflect-id="radio-id-opt-1"]')).not.toBeNull();
+                    expect(element.querySelector('.mat-radio-disabled[ng-reflect-id="radio-id-opt-2"]')).toBeDefined();
+                    expect(element.querySelector('.mat-radio-disabled[ng-reflect-id="radio-id-opt-2"]')).not.toBeNull();
                 }));
 
                 describe('and a value is selected', () => {
@@ -210,8 +212,6 @@ describe('RadioButtonsWidgetComponent', () => {
                     }));
 
                     it('should check the selected value', async(() => {
-                        expect(element.querySelector('.mat-radio-checked')).toBeDefined();
-                        expect(element.querySelector('.mat-radio-checked')).not.toBeNull();
                         expect(element.querySelector('.mat-radio-checked')).toBe(element.querySelector('mat-radio-button[ng-reflect-id="radio-id-opt-1"]'));
                     }));
                 });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
When on readOnly mode the radio-button-widget is displaying its "value" (which is by default the string "empty") in a display-text-widget which makes no sense.

**What is the new behaviour?**
Display disabled radio buttons with default value selected when on read-only mode.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/AAE-2034