### PR TITLE
filter facets : replace startsWith by includes

### DIFF
--- a/lib/content-services/src/lib/search/components/search-filter/search-filter.component.ts
+++ b/lib/content-services/src/lib/search/components/search-filter/search-filter.component.ts
@@ -397,12 +397,12 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
         });
     }
 
-    private getBucketFilterFunction(bucketList) {
+    protected getBucketFilterFunction(bucketList) {
         return (bucket: FacetFieldBucket): boolean => {
             if (bucket && bucketList.filterText) {
                 const pattern = (bucketList.filterText || '').toLowerCase();
                 const label = (this.translationService.instant(bucket.display) || this.translationService.instant(bucket.label)).toLowerCase();
-                return this.queryBuilder.config.filterWithContains ? label.indexOf(pattern) !== -1 : label.startsWith(pattern);
+                return this.queryBuilder.config.filterWithContains ? label.indexOf(pattern) !== -1 : label.includes(pattern);
             }
             return true;
         };


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
when you filter a facet, you use a "startsWith" which doesn't make sense for a search. If you have values that all start with the same word (example: Type A, Type B, Type C), you must first type "Type" before you can filter on the letter A, B or C.


**What is the new behaviour?**
Facet Type :  "Type A, Type A1, Type A2, Type B1".
If you search for "A" in the search filter, you'll get the facets "Type A, Type A1, Type A2".

And I'd like to take this opportunity to switch the function to protected. If it had been in protected, I could have overloaded this method to replace the "startsWith" by the "Includes".
Except that your private function prevents me from working and satisfying my customer! 
Your methods should all be in protected ! 

And
**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
