### PR TITLE
add missing DataColumn module to DataTable

### DIFF
--- a/lib/core/about/about-application-modules/about-application-modules.component.spec.ts
+++ b/lib/core/about/about-application-modules/about-application-modules.component.spec.ts
@@ -20,7 +20,6 @@ import { CoreTestingModule } from '../../testing/core.testing.module';
 import { setupTestBed } from '../../testing/setup-test-bed';
 import { AboutApplicationModulesComponent } from './about-application-modules.component';
 import { MatTableModule } from '@angular/material/table';
-import { DataColumnModule } from '../../data-column/data-column.module';
 import { DataTableModule } from '../../datatable/datatable.module';
 import { mockDependencies, mockPlugins } from '../about.mock';
 
@@ -29,7 +28,7 @@ describe('AboutApplicationModulesComponent', () => {
     let component: AboutApplicationModulesComponent;
 
     setupTestBed({
-        imports: [CoreTestingModule, MatTableModule, DataColumnModule, DataTableModule]
+        imports: [CoreTestingModule, MatTableModule, DataTableModule]
     });
 
     beforeEach(() => {

--- a/lib/core/about/about-product-version/about-product-version.component.spec.ts
+++ b/lib/core/about/about-product-version/about-product-version.component.spec.ts
@@ -22,7 +22,6 @@ import { AboutProductVersionComponent } from './about-product-version.component'
 import { DiscoveryApiService } from '../../services/discovery-api.service';
 import { AuthenticationService } from '../../services/authentication.service';
 import { of } from 'rxjs';
-import { DataColumnModule } from '../../data-column/data-column.module';
 import { DataTableModule } from '../../datatable/datatable.module';
 import { MatCardModule } from '@angular/material';
 import { aboutAPSMockDetails, mockModules } from '../about.mock';
@@ -33,7 +32,7 @@ describe('AboutProductVersionComponent', () => {
     let discoveryApiService:  DiscoveryApiService;
 
     setupTestBed({
-        imports: [CoreTestingModule, DataColumnModule, DataTableModule, MatCardModule]
+        imports: [CoreTestingModule, DataTableModule, MatCardModule]
     });
 
     beforeEach(() => {

--- a/lib/core/about/about.module.ts
+++ b/lib/core/about/about.module.ts
@@ -20,7 +20,6 @@ import { NgModule } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { MaterialModule } from '../material.module';
 import { DataTableModule } from '../datatable/datatable.module';
-import { DataColumnModule } from '../data-column/data-column.module';
 import { AboutApplicationModulesComponent } from './about-application-modules/about-application-modules.component';
 import { AboutProductVersionComponent } from './about-product-version/about-product-version.component';
 import { AboutGithubLinkComponent } from './about-github-link/about-github-link.component';
@@ -29,9 +28,8 @@ import { AboutGithubLinkComponent } from './about-github-link/about-github-link.
     imports: [
         CommonModule,
         MaterialModule,
-        TranslateModule.forChild(),
-        DataTableModule,
-        DataColumnModule
+        TranslateModule,
+        DataTableModule
     ],
     declarations: [
         AboutApplicationModulesComponent,

--- a/lib/core/datatable/datatable.module.ts
+++ b/lib/core/datatable/datatable.module.ts
@@ -44,13 +44,15 @@ import { CustomNoPermissionTemplateDirective } from './directives/custom-no-perm
 import { JsonCellComponent } from './components/datatable/json-cell.component';
 import { ClipboardModule } from '../clipboard/clipboard.module';
 import { DropZoneDirective } from './components/datatable/drop-zone.directive';
+import { DataColumnModule } from '../data-column';
 
 @NgModule({
     imports: [
         RouterModule,
         MaterialModule,
         CommonModule,
-        TranslateModule.forChild(),
+        TranslateModule,
+        DataColumnModule,
         ContextMenuModule,
         PipeModule,
         DirectiveModule,

--- a/lib/core/datatable/datatable.module.ts
+++ b/lib/core/datatable/datatable.module.ts
@@ -44,7 +44,7 @@ import { CustomNoPermissionTemplateDirective } from './directives/custom-no-perm
 import { JsonCellComponent } from './components/datatable/json-cell.component';
 import { ClipboardModule } from '../clipboard/clipboard.module';
 import { DropZoneDirective } from './components/datatable/drop-zone.directive';
-import { DataColumnModule } from '../data-column';
+import { DataColumnModule } from '../data-column/data-column.module';
 
 @NgModule({
     imports: [


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

Add the missing `DataColumnModule` reference to the `DataTableModule`.
That will reduce the amount of modules needed for unit testing in the ADF and applications.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
