### PR TITLE
[AAE-1881] Add E2E tests for document list actions

### DIFF
--- a/e2e/content-services/document-list/document-list-copy-move-actions.e2e.ts
+++ b/e2e/content-services/document-list/document-list-copy-move-actions.e2e.ts
@@ -261,7 +261,6 @@ describe('Document List Component', () => {
             await expect(await contentNodeSelector.checkCopyMoveButtonIsEnabled()).toBe(false);
             await contentNodeSelector.typeIntoNodeSelectorSearchField(site.entry.title);
             await contentNodeSelector.doubleClickContentNodeSelectorResult(site.entry.id);
-            await contentNodeSelector.doubleClickContentNodeFolder(site.entry.id);
             await contentNodeSelector.clickContentNodeSelectorResult('documentLibrary');
             await expect(await contentNodeSelector.checkCopyMoveButtonIsEnabled()).toBe(true);
             await contentNodeSelector.clickCancelButton();

--- a/e2e/content-services/document-list/document-list-copy-move-actions.e2e.ts
+++ b/e2e/content-services/document-list/document-list-copy-move-actions.e2e.ts
@@ -254,7 +254,7 @@ describe('Document List Component', () => {
             await contentServicesPage.checkContentIsDisplayed(pdfFileModel.name);
         });
 
-        it('[C261160] should enable copy/move button when user selects own site\'s documentLibrary', async () => {
+        it('[C261990] should enable copy/move button when user selects own site\'s documentLibrary', async () => {
             await contentServicesPage.checkContentIsDisplayed(pdfFileModel.name);
             await contentServicesPage.copyContent(pdfFileModel.name);
             await contentNodeSelector.checkDialogIsDisplayed();

--- a/e2e/content-services/document-list/document-list-copy-move-actions.e2e.ts
+++ b/e2e/content-services/document-list/document-list-copy-move-actions.e2e.ts
@@ -28,6 +28,7 @@ import { NavigationBarPage } from '../../pages/adf/navigation-bar.page';
 import { AcsUserModel } from '../../models/ACS/acs-user.model';
 import { AlfrescoApiCompatibility as AlfrescoApi } from '@alfresco/js-api';
 import { FileModel } from '../../models/ACS/file.model';
+import CONSTANTS = require('../../util/constants');
 
 describe('Document List Component', () => {
 
@@ -46,7 +47,7 @@ describe('Document List Component', () => {
     let uploadedFolder, uploadedFile, sourceFolder, destinationFolder, subFolder, subFolder2, copyFolder, subFile,
         duplicateFolderName;
     let acsUser = null, anotherAcsUser: AcsUserModel;
-    let folderName, sameNameFolder;
+    let folderName, sameNameFolder, site;
 
     const pdfFileModel = new FileModel({
         name: browser.params.resources.Files.ADF_DOCUMENTS.PDF.file_name,
@@ -66,6 +67,14 @@ describe('Document List Component', () => {
         await this.alfrescoJsApi.login(browser.params.testConfig.adf.adminEmail, browser.params.testConfig.adf.adminPassword);
         await this.alfrescoJsApi.core.peopleApi.addPerson(acsUser);
         await this.alfrescoJsApi.core.peopleApi.addPerson(anotherAcsUser);
+        site = await this.alfrescoJsApi.core.sitesApi.createSite({
+            title: StringUtil.generateRandomString(8),
+            visibility: 'PUBLIC'
+        });
+        await this.alfrescoJsApi.core.sitesApi.addSiteMember(site.entry.id, {
+            id: anotherAcsUser.getId(),
+            role: CONSTANTS.CS_USER_ROLES.COLLABORATOR
+        });
         await this.alfrescoJsApi.login(acsUser.id, acsUser.password);
         uploadedFolder = await uploadActions.createFolder(folderName, '-my-');
         destinationFolder = await uploadActions.createFolder(StringUtil.generateRandomString(5), '-my-');
@@ -76,9 +85,9 @@ describe('Document List Component', () => {
         duplicateFolderName = await uploadActions.createFolder(sameNameFolder, '-my-');
         subFile = await uploadActions.uploadFile(testFileModel.location, testFileModel.name, subFolder.entry.id);
         await uploadActions.uploadFile(pdfFileModel.location, pdfFileModel.name, uploadedFolder.entry.id);
+        await uploadActions.uploadFile(pdfFileModel.location, pdfFileModel.name, sourceFolder.entry.id);
         uploadedFile = await uploadActions.uploadFile(pdfFileModel.location, pdfFileModel.name, '-my-');
         await this.alfrescoJsApi.core.nodesApi.updateNode(sourceFolder.entry.id,
-
             {
                 permissions: {
                     locallySet: [{
@@ -90,7 +99,7 @@ describe('Document List Component', () => {
             });
 
         await browser.driver.sleep(12000);
-   });
+    });
 
     afterAll(async () => {
         await navigationBarPage.clickLogoutButton();
@@ -100,7 +109,8 @@ describe('Document List Component', () => {
         await uploadActions.deleteFileOrFolder(uploadedFile.entry.id);
         await uploadActions.deleteFileOrFolder(sourceFolder.entry.id);
         await uploadActions.deleteFileOrFolder(destinationFolder.entry.id);
-   });
+        await this.alfrescoJsApi.core.sitesApi.deleteSite(site.entry.id);
+    });
 
     describe('Document List Component - Actions Move and Copy', () => {
 
@@ -175,7 +185,28 @@ describe('Document List Component', () => {
             await contentNodeSelector.clickMoveCopyButton();
             await notificationHistoryPage.checkNotifyContains('This name is already in use, try a different name.');
         });
-   });
+
+        it('[C260124] should be able to move file using action menu and content node selector', async () => {
+            await contentServicesPage.checkContentIsDisplayed(pdfFileModel.name);
+            await contentServicesPage.moveContent(pdfFileModel.name);
+            await contentNodeSelector.checkDialogIsDisplayed();
+            await expect(await contentNodeSelector.getDialogHeaderText()).toBe(`Move '${pdfFileModel.name}' to...`);
+            await contentNodeSelector.clickContentNodeSelectorResult(destinationFolder.entry.name);
+            await contentNodeSelector.checkSelectedFolder(destinationFolder.entry.name);
+            await contentNodeSelector.checkCopyMoveButtonIsEnabled();
+            await contentNodeSelector.clickCancelButton();
+            await contentNodeSelector.checkDialogIsNotDisplayed();
+            await contentServicesPage.checkContentIsDisplayed(pdfFileModel.name);
+
+            await contentServicesPage.moveContent(pdfFileModel.name);
+            await contentNodeSelector.clickContentNodeSelectorResult(destinationFolder.entry.name);
+            await contentNodeSelector.checkSelectedFolder(destinationFolder.entry.name);
+            await contentNodeSelector.checkCopyMoveButtonIsEnabled();
+            await contentNodeSelector.clickMoveCopyButton();
+            await contentNodeSelector.checkDialogIsNotDisplayed();
+            await contentServicesPage.checkContentIsNotDisplayed(pdfFileModel.name);
+        });
+    });
 
     describe('Document List actionns - Move, Copy on no permission folder', () => {
 
@@ -210,5 +241,45 @@ describe('Document List Component', () => {
             await contentNodeSelector.contentListPage().dataTablePage().waitTillContentLoaded();
             await contentNodeSelector.contentListPage().dataTablePage().checkRowContentIsDisplayed(subFolder2.entry.name);
         });
-   });
+
+        it('[C261160] should disable copy/move button when user is not allowed in a specific folder', async () => {
+            await contentServicesPage.checkContentIsDisplayed(pdfFileModel.name);
+            await contentServicesPage.copyContent(pdfFileModel.name);
+            await contentNodeSelector.checkDialogIsDisplayed();
+            await contentNodeSelector.clickContentNodeSelectorResult(subFolder.entry.name);
+            await contentNodeSelector.checkSelectedFolder(subFolder.entry.name);
+            await expect(await contentNodeSelector.checkCopyMoveButtonIsEnabled()).toBe(false);
+            await contentNodeSelector.clickCancelButton();
+            await contentNodeSelector.checkDialogIsNotDisplayed();
+            await contentServicesPage.checkContentIsDisplayed(pdfFileModel.name);
+        });
+
+        it('[C261160] should enable copy/move button when user selects own site\'s documentLibrary', async () => {
+            await contentServicesPage.checkContentIsDisplayed(pdfFileModel.name);
+            await contentServicesPage.copyContent(pdfFileModel.name);
+            await contentNodeSelector.checkDialogIsDisplayed();
+            await expect(await contentNodeSelector.checkCopyMoveButtonIsEnabled()).toBe(false);
+            await contentNodeSelector.typeIntoNodeSelectorSearchField(site.entry.title);
+            await contentNodeSelector.doubleClickContentNodeSelectorResult(site.entry.id);
+            await contentNodeSelector.doubleClickContentNodeFolder(site.entry.id);
+            await contentNodeSelector.clickContentNodeSelectorResult('documentLibrary');
+            await expect(await contentNodeSelector.checkCopyMoveButtonIsEnabled()).toBe(true);
+            await contentNodeSelector.clickCancelButton();
+            await contentNodeSelector.checkDialogIsNotDisplayed();
+            await contentServicesPage.checkContentIsDisplayed(pdfFileModel.name);
+        });
+
+        it('[C260137] should disable delete action when user has no permission', async () => {
+            await contentServicesPage.checkContentIsDisplayed(pdfFileModel.name);
+            await contentServicesPage.checkDeleteIsDisabled(pdfFileModel.name);
+
+            await loginPage.loginToContentServicesUsingUserModel(acsUser);
+            await BrowserActions.getUrl(`${browser.params.testConfig.adf.url}/files/${sourceFolder.entry.id}`);
+            await contentServicesPage.getDocumentList().dataTablePage().waitTillContentLoaded();
+
+            await contentServicesPage.checkContentIsDisplayed(pdfFileModel.name);
+            await contentServicesPage.deleteContent(pdfFileModel.name);
+            await contentServicesPage.checkContentIsNotDisplayed(pdfFileModel.name);
+        });
+    });
 });

--- a/e2e/pages/adf/content-services.page.ts
+++ b/e2e/pages/adf/content-services.page.ts
@@ -149,6 +149,11 @@ export class ContentServicesPage {
         await BrowserActions.click(this.copyContentElement);
     }
 
+    async moveContent(content): Promise<void> {
+        await this.contentList.clickOnActionMenu(content);
+        await BrowserActions.click(this.moveContentElement);
+    }
+
     async lockContent(content): Promise<void> {
         await this.contentList.clickOnActionMenu(content);
         await BrowserActions.click(this.lockContentElement);

--- a/lib/testing/src/lib/content-services/dialog/content-node-selector-dialog.page.ts
+++ b/lib/testing/src/lib/content-services/dialog/content-node-selector-dialog.page.ts
@@ -101,11 +101,9 @@ export class ContentNodeSelectorDialogPage {
     }
 
     async doubleClickContentNodeSelectorResult(name): Promise<void> {
+        // First click to select from search mode and second click to actually open node
         await this.contentList.dataTablePage().doubleClickRowByContent(name);
-    }
-
-    async doubleClickContentNodeFolder(name): Promise<void> {
-        await this.doubleClickContentNodeSelectorResult(name);
+        await this.contentList.dataTablePage().doubleClickRowByContent(name);
     }
 
     contentListPage(): DocumentListPage {

--- a/lib/testing/src/lib/content-services/dialog/content-node-selector-dialog.page.ts
+++ b/lib/testing/src/lib/content-services/dialog/content-node-selector-dialog.page.ts
@@ -26,6 +26,7 @@ export class ContentNodeSelectorDialogPage {
     searchInputElement: ElementFinder = this.dialog.element(by.css(`input[data-automation-id='content-node-selector-search-input']`));
     searchLabel: ElementFinder = this.searchInputElement.element(by.xpath("ancestor::div[@class='mat-form-field-infix']/span/label"));
     siteListDropdown: ElementFinder = this.dialog.element(by.css(`mat-select[data-automation-id='site-my-files-option']`));
+    selectedRow: ElementFinder = this.dialog.element(by.css(`adf-datatable-row[class*="adf-is-selected"]`));
     cancelButton: ElementFinder = element(by.css(`button[data-automation-id='content-node-selector-actions-cancel']`));
     moveCopyButton: ElementFinder = element(by.css(`button[data-automation-id='content-node-selector-actions-choose']`));
     contentList: DocumentListPage = new DocumentListPage(this.dialog);
@@ -52,6 +53,10 @@ export class ContentNodeSelectorDialogPage {
 
     async checkSelectedSiteIsDisplayed(siteName): Promise<void> {
         await BrowserVisibility.waitUntilElementIsVisible(this.siteListDropdown.element(by.cssContainingText('.mat-select-value-text span', siteName)));
+    }
+
+    async checkSelectedFolder(folderName: string): Promise<void> {
+        await BrowserVisibility.waitUntilElementIsVisible(this.selectedRow.element(by.cssContainingText('adf-name-location-cell', folderName)));
     }
 
     async checkCancelButtonIsDisplayed(): Promise<void> {
@@ -93,6 +98,14 @@ export class ContentNodeSelectorDialogPage {
 
     async clickContentNodeSelectorResult(name): Promise<void> {
         await this.contentList.dataTablePage().clickRowByContent(name);
+    }
+
+    async doubleClickContentNodeSelectorResult(name): Promise<void> {
+        await this.contentList.dataTablePage().doubleClickRowByContent(name);
+    }
+
+    async doubleClickContentNodeFolder(name): Promise<void> {
+        await this.doubleClickContentNodeSelectorResult(name);
     }
 
     contentListPage(): DocumentListPage {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/AAE-1881


**What is the new behaviour?**
The following tests have been automated (e2e):
- C260124 Move - Dropdown Menu No
- C261160 Copy / Move - consumer user No
- C261990 Copy / Move - button enable/disable No
- C260137 Upload


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/AAE-1881