### PR TITLE
[AAE-1977] Fix file uploaded after cancelling upload

### DIFF
--- a/lib/content-services/src/lib/upload/components/file-uploading-dialog.component.ts
+++ b/lib/content-services/src/lib/upload/components/file-uploading-dialog.component.ts
@@ -73,8 +73,7 @@ export class FileUploadingDialogComponent implements OnInit, OnDestroy {
         private uploadService: UploadService,
         private changeDetector: ChangeDetectorRef,
         private userPreferencesService: UserPreferencesService,
-        private elementRef: ElementRef
-        ) {
+        private elementRef: ElementRef) {
     }
 
     ngOnInit() {
@@ -104,9 +103,9 @@ export class FileUploadingDialogComponent implements OnInit, OnDestroy {
             });
 
         this.counterSubscription = merge(
-                this.uploadService.fileUploadComplete,
-                this.uploadService.fileUploadDeleted
-            )
+            this.uploadService.fileUploadComplete,
+            this.uploadService.fileUploadDeleted
+        )
             .pipe(takeUntil(this.onDestroy$))
             .subscribe(event => {
                 this.totalCompleted = event.totalComplete;
@@ -130,11 +129,11 @@ export class FileUploadingDialogComponent implements OnInit, OnDestroy {
             .pipe(takeUntil(this.onDestroy$))
             .subscribe(objId => {
                 if (this.filesUploadingList) {
-                    const file = this.filesUploadingList.find((item) => {
-                        return item.data.entry.id === objId;
+                    const uploadedFile = this.filesUploadingList.find((file) => {
+                        return file.data ? file.data.entry.id === objId : false;
                     });
-                    if (file) {
-                        file.status = FileUploadStatus.Cancelled;
+                    if (uploadedFile) {
+                        uploadedFile.status = FileUploadStatus.Cancelled;
                         this.changeDetector.detectChanges();
                     }
                 }

--- a/lib/core/services/upload.service.ts
+++ b/lib/core/services/upload.service.ts
@@ -39,6 +39,7 @@ export class UploadService {
     private totalError: number = 0;
     private excludedFileList: string[] = [];
     private matchingOptions: any = null;
+    private abortedFile: string;
 
     activeTask: Promise<any> = null;
     queue: FileModel[] = [];
@@ -113,7 +114,7 @@ export class UploadService {
 
                 const promise = this.beginUpload(file, emitter);
                 this.activeTask = promise;
-                this.cache[file.id] = promise;
+                this.cache[file.name] = promise;
 
                 const next = () => {
                     this.activeTask = null;
@@ -132,15 +133,21 @@ export class UploadService {
 
     /**
      * Cancels uploading of files.
+     * If the file is smaller than 1 MB the file will be uploaded and then the node deleted
+     * to prevent having files that were aborted but still uploaded.
      * @param files One or more separate parameters or an array of files specifying uploads to cancel
      */
     cancelUpload(...files: FileModel[]) {
         files.forEach((file) => {
-            const promise = this.cache[file.id];
-
+            const promise = this.cache[file.name];
             if (promise) {
-                promise.abort();
-                delete this.cache[file.id];
+                if (this.isSaveToAbortFile(file)) {
+                    promise.abort();
+                }
+                this.abortedFile = file.name;
+                delete this.cache[file.name];
+                promise.next();
+
             } else {
                 const performAction = this.getAction(file);
                 performAction();
@@ -200,7 +207,6 @@ export class UploadService {
     private beginUpload(file: FileModel, emitter: EventEmitter<any>): any {
 
         const promise = this.getUploadPromise(file);
-
         promise.on('progress', (progress: FileUploadProgress) => {
             this.onUploadProgress(file, progress);
         })
@@ -217,12 +223,20 @@ export class UploadService {
                 }
             })
             .on('success', (data) => {
-                this.onUploadComplete(file, data);
-                if (emitter) {
-                    emitter.emit({ value: data });
+                if (this.abortedFile === file.name) {
+                    this.onUploadAborted(file);
+                    this.deleteAbortedNode(data.entry.id);
+                    if (emitter) {
+                        emitter.emit({ value: 'File deleted' });
+                    }
+                } else {
+                    this.onUploadComplete(file, data);
+                    if (emitter) {
+                        emitter.emit({ value: data });
+                    }
                 }
             })
-            .catch(() => {});
+            .catch(() => { });
 
         return promise;
     }
@@ -249,13 +263,13 @@ export class UploadService {
 
     private onUploadError(file: FileModel, error: any): void {
         if (file) {
-            file.errorCode = ( error || {} ).status;
+            file.errorCode = (error || {}).status;
             file.status = FileUploadStatus.Error;
             this.totalError++;
 
-            const promise = this.cache[file.id];
+            const promise = this.cache[file.name];
             if (promise) {
-                delete this.cache[file.id];
+                delete this.cache[file.name];
             }
 
             const event = new FileUploadErrorEvent(file, error, this.totalError);
@@ -269,10 +283,9 @@ export class UploadService {
             file.status = FileUploadStatus.Complete;
             file.data = data;
             this.totalComplete++;
-
-            const promise = this.cache[file.id];
+            const promise = this.cache[file.name];
             if (promise) {
-                delete this.cache[file.id];
+                delete this.cache[file.name];
             }
 
             const event = new FileUploadCompleteEvent(file, this.totalComplete, data, this.totalAborted);
@@ -286,15 +299,9 @@ export class UploadService {
             file.status = FileUploadStatus.Aborted;
             this.totalAborted++;
 
-            const promise = this.cache[file.id];
-            if (promise) {
-                delete this.cache[file.id];
-            }
-
             const event = new FileUploadEvent(file, FileUploadStatus.Aborted);
             this.fileUpload.next(event);
             this.fileUploadAborted.next(event);
-            promise.next();
         }
     }
 
@@ -319,7 +326,7 @@ export class UploadService {
         }
     }
 
-    private getAction(file) {
+    private getAction(file: FileModel) {
         const actions = {
             [FileUploadStatus.Pending]: () => this.onUploadCancelled(file),
             [FileUploadStatus.Deleted]: () => this.onUploadDeleted(file),
@@ -327,5 +334,15 @@ export class UploadService {
         };
 
         return actions[file.status];
+    }
+
+    private deleteAbortedNode(nodeId: string) {
+        this.apiService.getInstance().core.nodesApi.deleteNode(nodeId, { permanent: true })
+            .then(() => this.abortedFile = undefined);
+
+    }
+
+    private isSaveToAbortFile(file: FileModel): boolean {
+        return file.size > 1000000 && file.progress.percent < 50;
     }
 }

--- a/lib/core/services/upload.service.ts
+++ b/lib/core/services/upload.service.ts
@@ -28,6 +28,9 @@ import {
 import { FileModel, FileUploadProgress, FileUploadStatus } from '../models/file.model';
 import { AlfrescoApiService } from './alfresco-api.service';
 
+const MIN_CANCELLABLE_FILE_SIZE = 1000000;
+const MAX_CANCELLABLE_FILE_PERCENTAGE = 50;
+
 @Injectable({
     providedIn: 'root'
 })
@@ -343,6 +346,6 @@ export class UploadService {
     }
 
     private isSaveToAbortFile(file: FileModel): boolean {
-        return file.size > 1000000 && file.progress.percent < 50;
+        return file.size > MIN_CANCELLABLE_FILE_SIZE && file.progress.percent < MAX_CANCELLABLE_FILE_PERCENTAGE;
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/AAE-1977
File is still uploaded after upload is cancelled.

**What is the new behaviour?**
Beccause we were canceling the promise but not the actual upload, when the file size is really small there was no time and before we could safely cancel it the file was already uploaded.
This is something that we have to deal with as there is no solution to this problem. What this PR does is detecting whether the file was uploaded after been cancelled and delete the node in that case. 

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/AAE-1977