### PR TITLE
[AAE-1579] Fixing the style of the prefix of amount widget

### DIFF
--- a/lib/core/form/components/widgets/amount/amount.widget.scss
+++ b/lib/core/form/components/widgets/amount/amount.widget.scss
@@ -28,7 +28,7 @@
 
             &:not(.mat-focused) {
                 .adf-amount-widget__prefix-spacing {
-                    color: mat-color($foreground, disabled-text);
+                    color: mat-color($foreground, secondary-text);
                 }
             }
         }

--- a/lib/core/form/components/widgets/amount/amount.widget.scss
+++ b/lib/core/form/components/widgets/amount/amount.widget.scss
@@ -16,13 +16,22 @@
         right: 12px;
     }
 
-    &-amount-widget__input .mat-focused {
-        transition: none;
+    &-amount-widget__input {
+
+        .mat-focused {
+            transition: none;
+        }
+
+        &:not(.mat-focused) {
+            .adf-amount-widget__prefix-spacing {
+                color: rgba(0, 0, 0, 0.54);
+            }
+        }
     }
 
     &-amount-widget__prefix-spacing {
         position: absolute;
-        top: 12px;
+        top: 11px;
     }
 }
 

--- a/lib/core/form/components/widgets/amount/amount.widget.scss
+++ b/lib/core/form/components/widgets/amount/amount.widget.scss
@@ -1,5 +1,4 @@
 @import '../form';
-@import '~@angular/material/theming';
 
 @mixin adf-amount-widget-theme($theme) {
     $foreground: map-get($theme, foreground);
@@ -26,7 +25,7 @@
                 transition: none;
             }
 
-            &:not(.mat-focused) {
+            &:not(.mat-focused):not(.mat-form-field-invalid) {
                 .adf-amount-widget__prefix-spacing {
                     color: mat-color($foreground, secondary-text);
                 }

--- a/lib/core/form/components/widgets/amount/amount.widget.scss
+++ b/lib/core/form/components/widgets/amount/amount.widget.scss
@@ -31,7 +31,7 @@
 
     &-amount-widget__prefix-spacing {
         position: absolute;
-        top: 11px;
+        top: 12px;
     }
 }
 

--- a/lib/core/form/components/widgets/amount/amount.widget.scss
+++ b/lib/core/form/components/widgets/amount/amount.widget.scss
@@ -1,37 +1,41 @@
 @import '../form';
+@import '~@angular/material/theming';
 
-.adf {
-    &-amount-widget {
-        width: 100%;
+@mixin adf-amount-widget-theme($theme) {
+    $foreground: map-get($theme, foreground);
 
-        .mat-input-element {
-            margin-left: 13px;
-            margin-right: 13px;
-        }
-    }
+    .adf {
+        &-amount-widget {
+            width: 100%;
 
-    &-amount-widget__container .mat-form-field-label-wrapper {
-        top: 17px;
-        left: 12px;
-        right: 12px;
-    }
-
-    &-amount-widget__input {
-
-        .mat-focused {
-            transition: none;
-        }
-
-        &:not(.mat-focused) {
-            .adf-amount-widget__prefix-spacing {
-                color: rgba(0, 0, 0, 0.54);
+            .mat-input-element {
+                margin-left: 13px;
+                margin-right: 13px;
             }
         }
-    }
 
-    &-amount-widget__prefix-spacing {
-        position: absolute;
-        top: 12px;
+        &-amount-widget__container .mat-form-field-label-wrapper {
+            top: 17px;
+            left: 12px;
+            right: 12px;
+        }
+
+        &-amount-widget__input {
+
+            .mat-focused {
+                transition: none;
+            }
+
+            &:not(.mat-focused) {
+                .adf-amount-widget__prefix-spacing {
+                    color: mat-color($foreground, disabled-text);
+                }
+            }
+        }
+
+        &-amount-widget__prefix-spacing {
+            position: absolute;
+            top: 12px;
+        }
     }
 }
-

--- a/lib/core/form/components/widgets/form.scss
+++ b/lib/core/form/components/widgets/form.scss
@@ -6,6 +6,7 @@
     $warn: map-get($theme, warn);
 
     @include adf-hyperlink-widget-theme($theme);
+    @include adf-amount-widget-theme($theme);
 
     ul > li > form-field > .adf-focus {
         .adf-label {

--- a/lib/core/form/components/widgets/form.scss
+++ b/lib/core/form/components/widgets/form.scss
@@ -6,7 +6,6 @@
     $warn: map-get($theme, warn);
 
     @include adf-hyperlink-widget-theme($theme);
-    @include adf-amount-widget-theme($theme);
 
     ul > li > form-field > .adf-focus {
         .adf-label {

--- a/lib/core/styles/_index.scss
+++ b/lib/core/styles/_index.scss
@@ -8,6 +8,7 @@
 @import '../form/components/widgets/dynamic-table/dynamic-table.widget';
 @import '../form/components/widgets/form';
 @import '../form/components/widgets/hyperlink/hyperlink.widget';
+@import '../form/components/widgets/amount/amount.widget';
 @import '../form/components/widgets/people/people.widget';
 @import '../info-drawer/info-drawer-layout.component';
 @import '../login/components/login.component';
@@ -45,6 +46,7 @@
     @include adf-dynamic-table-theme($theme);
     @include adf-form-theme($theme);
     @include adf-hyperlink-widget-theme($theme);
+    @include adf-amount-widget-theme($theme);
     @include adf-form-people-widget-theme($theme);
     @include adf-info-drawer-theme($theme);
     @include adf-login-theme($theme);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Prefix is black when widget's input is not focused. (and orange otherwise)


**What is the new behaviour?**
Prefix is the same color as the placeholder. (and still orange when input focused)


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
This PR is in the context of that Jira issue : https://issues.alfresco.com/jira/browse/AAE-1579