### PR TITLE
[ADF-4522] Metadata value is not rolled back upon error

### DIFF
--- a/demo-shell/src/app/components/card-view/card-view.component.ts
+++ b/demo-shell/src/app/components/card-view/card-view.component.ts
@@ -167,6 +167,7 @@ export class CardViewComponent implements OnInit, OnDestroy {
     }
 
     onItemChange(notification: UpdateNotification) {
+        this.cardViewUpdateService.updateElement(notification);
         let value = notification.changed[notification.target.key];
 
         if (notification.target.type === 'keyvaluepairs') {

--- a/demo-shell/src/app/components/card-view/card-view.component.ts
+++ b/demo-shell/src/app/components/card-view/card-view.component.ts
@@ -167,7 +167,6 @@ export class CardViewComponent implements OnInit, OnDestroy {
     }
 
     onItemChange(notification: UpdateNotification) {
-        this.cardViewUpdateService.updateElement(notification);
         let value = notification.changed[notification.target.key];
 
         if (notification.target.type === 'keyvaluepairs') {

--- a/docs/core/services/card-view-update.service.md
+++ b/docs/core/services/card-view-update.service.md
@@ -126,6 +126,16 @@ respondToCardClick(cn: ClickNotification) {
 
 Note that this function will only be called if the `clickable` property of the model object is set to true for this item.
 
+## Update cardview update item
+
+[`updateElement`](../../../lib/core/card-view/services/card-view-update.service.ts)  function helps to update the card view item. It takes the [`UpdateNotification`](../../../lib/core/card-view/services/card-view-update.service.ts)  type object as parameter.
+
+Example
+
+```javascript
+   this.cardViewUpdateService.updateElement(updateNotification)
+```
+
 ## See also
 
 -   [Card view component](../components/card-view.component.md)

--- a/docs/core/services/card-view-update.service.md
+++ b/docs/core/services/card-view-update.service.md
@@ -128,12 +128,12 @@ Note that this function will only be called if the `clickable` property of the m
 
 ## Update cardview update item
 
-[`updateElement`](../../../lib/core/card-view/services/card-view-update.service.ts)  function helps to update the card view item. It takes the [`UpdateNotification`](../../../lib/core/card-view/services/card-view-update.service.ts)  type object as parameter.
+[`updateElement`](../../../lib/core/card-view/services/card-view-update.service.ts)  function helps to update the card view item. It takes the [`CardViewBaseItemModel`](../../../lib/core/card-view/models/card-view-baseitem.model.ts)  type object as parameter.
 
 Example
 
 ```javascript
-   this.cardViewUpdateService.updateElement(updateNotification)
+   this.cardViewUpdateService.updateElement(cardViewBaseItemModel)
 ```
 
 ## See also

--- a/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.spec.ts
+++ b/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.spec.ts
@@ -147,12 +147,10 @@ describe('ContentMetadataComponent', () => {
             expect(logService.error).toHaveBeenCalledWith(new Error('My bad'));
         });
 
-        it('should raise error message and reload the properties', (done) => {
-            spyOn(contentMetadataService, 'getBasicProperties');
+        it('should raise error message', (done) => {
             const property = <CardViewBaseItemModel> { key: 'property-key', value: 'original-value' };
 
             const sub = contentMetadataService.error.subscribe((err) => {
-                expect(contentMetadataService.getBasicProperties).toHaveBeenCalledWith(node);
                 expect(err.statusCode).toBe(0);
                 expect(err.message).toBe('METADATA.ERRORS.GENERIC');
                 sub.unsubscribe();

--- a/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.ts
+++ b/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.ts
@@ -28,7 +28,7 @@ import {
 } from '@alfresco/adf-core';
 import { ContentMetadataService } from '../../services/content-metadata.service';
 import { CardViewGroup } from '../../interfaces/content-metadata.interfaces';
-import { switchMap, takeUntil, catchError } from 'rxjs/operators';
+import { switchMap, takeUntil, catchError, tap } from 'rxjs/operators';
 
 @Component({
     selector: 'adf-content-metadata',
@@ -93,8 +93,8 @@ export class ContentMetadataComponent implements OnChanges, OnInit, OnDestroy {
             .pipe(
                 switchMap((changes) =>
                     this.saveNode(changes).pipe(
+                        tap(() => this.cardViewUpdateService.updateElement(changes)),
                         catchError((err) => {
-                            this.loadProperties(this.node);
                             this.handleUpdateError(err);
                             return of(null);
                         })

--- a/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.ts
+++ b/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.ts
@@ -94,7 +94,7 @@ export class ContentMetadataComponent implements OnChanges, OnInit, OnDestroy {
                 switchMap((changes) =>
                     this.saveNode(changes).pipe(
                         catchError((err) => {
-                            this.cardViewUpdateService.updateElement(changes);
+                            this.cardViewUpdateService.updateElement(changes.target);
                             this.handleUpdateError(err);
                             return of(null);
                         })

--- a/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.ts
+++ b/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.ts
@@ -28,7 +28,7 @@ import {
 } from '@alfresco/adf-core';
 import { ContentMetadataService } from '../../services/content-metadata.service';
 import { CardViewGroup } from '../../interfaces/content-metadata.interfaces';
-import { switchMap, takeUntil, catchError, tap } from 'rxjs/operators';
+import { switchMap, takeUntil, catchError } from 'rxjs/operators';
 
 @Component({
     selector: 'adf-content-metadata',
@@ -93,8 +93,8 @@ export class ContentMetadataComponent implements OnChanges, OnInit, OnDestroy {
             .pipe(
                 switchMap((changes) =>
                     this.saveNode(changes).pipe(
-                        tap(() => this.cardViewUpdateService.updateElement(changes)),
                         catchError((err) => {
+                            this.cardViewUpdateService.updateElement(changes);
                             this.handleUpdateError(err);
                             return of(null);
                         })

--- a/lib/core/card-view/components/base-card-view.ts
+++ b/lib/core/card-view/components/base-card-view.ts
@@ -33,7 +33,7 @@ export abstract class BaseCardView<T extends CardViewItem> implements OnDestroy 
             .pipe(takeUntil(this.destroy$))
             .subscribe((notification: UpdateNotification) => {
             if (this.property.key === notification.target.key) {
-                this.property.value =  notification.target && notification.target.property && notification.target.property.value;
+                this.property.value = notification.target.value;
             }
         });
     }

--- a/lib/core/card-view/components/base-card-view.ts
+++ b/lib/core/card-view/components/base-card-view.ts
@@ -1,0 +1,46 @@
+/*!
+ * @license
+ * Copyright 2019 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Input, OnDestroy } from '@angular/core';
+import { CardViewUpdateService, UpdateNotification } from '../services/card-view.services';
+import { CardViewItem } from '../interfaces/card-view.interfaces';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+
+export abstract class BaseCardView<T extends CardViewItem> implements OnDestroy {
+
+    @Input()
+    property: T;
+
+    protected destroy$ = new Subject<boolean>();
+
+    constructor(protected cardViewUpdateService: CardViewUpdateService) {
+        this.cardViewUpdateService.updateItem$
+            .pipe(takeUntil(this.destroy$))
+            .subscribe((notification: UpdateNotification) => {
+            if (this.property.key === notification.target.key) {
+                this.property.value =  notification.value;
+            }
+        });
+    }
+
+    ngOnDestroy(): void {
+        this.destroy$.next(true);
+        this.destroy$.complete();
+    }
+
+}

--- a/lib/core/card-view/components/base-card-view.ts
+++ b/lib/core/card-view/components/base-card-view.ts
@@ -16,8 +16,9 @@
  */
 
 import { Input, OnDestroy } from '@angular/core';
-import { CardViewUpdateService, UpdateNotification } from '../services/card-view.services';
+import { CardViewUpdateService } from '../services/card-view.services';
 import { CardViewItem } from '../interfaces/card-view.interfaces';
+import { CardViewBaseItemModel } from '../models/card-view-baseitem.model';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
@@ -31,9 +32,9 @@ export abstract class BaseCardView<T extends CardViewItem> implements OnDestroy 
     constructor(protected cardViewUpdateService: CardViewUpdateService) {
         this.cardViewUpdateService.updateItem$
             .pipe(takeUntil(this.destroy$))
-            .subscribe((notification: UpdateNotification) => {
-            if (this.property.key === notification.target.key) {
-                this.property.value = notification.target.value;
+            .subscribe((itemModel: CardViewBaseItemModel) => {
+            if (this.property.key === itemModel.key) {
+                this.property.value = itemModel.value;
             }
         });
     }

--- a/lib/core/card-view/components/base-card-view.ts
+++ b/lib/core/card-view/components/base-card-view.ts
@@ -33,7 +33,7 @@ export abstract class BaseCardView<T extends CardViewItem> implements OnDestroy 
             .pipe(takeUntil(this.destroy$))
             .subscribe((notification: UpdateNotification) => {
             if (this.property.key === notification.target.key) {
-                this.property.value =  notification.value;
+                this.property.value =  notification.target && notification.target.property && notification.target.property.value;
             }
         });
     }

--- a/lib/core/card-view/components/card-view-arrayitem/card-view-arrayitem.component.ts
+++ b/lib/core/card-view/components/card-view-arrayitem/card-view-arrayitem.component.ts
@@ -15,22 +15,21 @@
  * limitations under the License.
  */
 
-import { Component, Input } from '@angular/core';
+import { Component } from '@angular/core';
 import { CardViewArrayItemModel } from '../../models/card-view-arrayitem.model';
 import { CardViewUpdateService } from '../../services/card-view-update.service';
+import { BaseCardView } from '../base-card-view';
 
 @Component({
   selector: 'adf-card-view-arrayitem',
   templateUrl: './card-view-arrayitem.component.html',
   styleUrls: ['./card-view-arrayitem.component.scss']
 })
-export class CardViewArrayItemComponent {
+export class CardViewArrayItemComponent extends BaseCardView<CardViewArrayItemModel> {
 
-    /** The CardViewArrayItemModel of data used to populate the cardView array items. */
-    @Input()
-    property: CardViewArrayItemModel;
-
-    constructor(private cardViewUpdateService: CardViewUpdateService) {}
+    constructor(cardViewUpdateService: CardViewUpdateService) {
+        super(cardViewUpdateService);
+    }
 
     clicked(): void {
         if (this.isClickable()) {

--- a/lib/core/card-view/components/card-view-boolitem/card-view-boolitem.component.spec.ts
+++ b/lib/core/card-view/components/card-view-boolitem/card-view-boolitem.component.spec.ts
@@ -178,10 +178,11 @@ describe('CardViewBoolItemComponent', () => {
         it('should trigger the update event when changing the checkbox', () => {
             const cardViewUpdateService = TestBed.get(CardViewUpdateService);
             spyOn(cardViewUpdateService, 'update');
+            const property = { ... component.property };
 
             component.changed(<MatCheckboxChange> { checked: true });
 
-            expect(cardViewUpdateService.update).toHaveBeenCalledWith(component.property, true);
+            expect(cardViewUpdateService.update).toHaveBeenCalledWith(property, true);
         });
 
         it('should update the property value after a changed', async(() => {
@@ -198,10 +199,11 @@ describe('CardViewBoolItemComponent', () => {
             const cardViewUpdateService = TestBed.get(CardViewUpdateService);
             component.property.value = false;
             fixture.detectChanges();
+            const property = { ...component.property };
 
             const disposableUpdate = cardViewUpdateService.itemUpdated$.subscribe(
                 (updateNotification) => {
-                    expect(updateNotification.target).toBe(component.property);
+                    expect(updateNotification.target).toEqual(property);
                     expect(updateNotification.changed).toEqual({ boolkey: true });
                     disposableUpdate.unsubscribe();
                     done();

--- a/lib/core/card-view/components/card-view-boolitem/card-view-boolitem.component.ts
+++ b/lib/core/card-view/components/card-view-boolitem/card-view-boolitem.component.ts
@@ -19,6 +19,7 @@ import { Component, Input } from '@angular/core';
 import { MatCheckboxChange } from '@angular/material';
 import { CardViewBoolItemModel } from '../../models/card-view-boolitem.model';
 import { CardViewUpdateService } from '../../services/card-view-update.service';
+import { BaseCardView } from '../base-card-view';
 
 @Component({
     selector: 'adf-card-view-boolitem',
@@ -26,15 +27,14 @@ import { CardViewUpdateService } from '../../services/card-view-update.service';
     styleUrls: ['./card-view-boolitem.component.scss']
 })
 
-export class CardViewBoolItemComponent {
-
-    @Input()
-    property: CardViewBoolItemModel;
+export class CardViewBoolItemComponent extends BaseCardView<CardViewBoolItemModel> {
 
     @Input()
     editable: boolean;
 
-    constructor(private cardViewUpdateService: CardViewUpdateService) {}
+    constructor(cardViewUpdateService: CardViewUpdateService) {
+        super(cardViewUpdateService);
+    }
 
     isEditable() {
         return this.editable && this.property.editable;
@@ -42,6 +42,6 @@ export class CardViewBoolItemComponent {
 
     changed(change: MatCheckboxChange) {
         this.cardViewUpdateService.update(this.property, change.checked );
-        this.property.value = change.checked;
+        // this.property.value = change.checked;
     }
 }

--- a/lib/core/card-view/components/card-view-boolitem/card-view-boolitem.component.ts
+++ b/lib/core/card-view/components/card-view-boolitem/card-view-boolitem.component.ts
@@ -41,7 +41,7 @@ export class CardViewBoolItemComponent extends BaseCardView<CardViewBoolItemMode
     }
 
     changed(change: MatCheckboxChange) {
-        this.cardViewUpdateService.update(<any> { ...this.property }, change.checked );
+        this.cardViewUpdateService.update(<CardViewBoolItemModel> { ...this.property }, change.checked );
         this.property.value = change.checked;
     }
 }

--- a/lib/core/card-view/components/card-view-boolitem/card-view-boolitem.component.ts
+++ b/lib/core/card-view/components/card-view-boolitem/card-view-boolitem.component.ts
@@ -41,7 +41,7 @@ export class CardViewBoolItemComponent extends BaseCardView<CardViewBoolItemMode
     }
 
     changed(change: MatCheckboxChange) {
-        this.cardViewUpdateService.update(this.property, change.checked );
-        // this.property.value = change.checked;
+        this.cardViewUpdateService.update(<any> { ...this.property }, change.checked );
+        this.property.value = change.checked;
     }
 }

--- a/lib/core/card-view/components/card-view-dateitem/card-view-dateitem.component.spec.ts
+++ b/lib/core/card-view/components/card-view-dateitem/card-view-dateitem.component.spec.ts
@@ -189,10 +189,11 @@ describe('CardViewDateItemComponent', () => {
         const cardViewUpdateService = TestBed.get(CardViewUpdateService);
         const expectedDate = moment('Jul 10 2017', 'MMM DD YY');
         fixture.detectChanges();
+        const property = { ...component.property };
 
         const disposableUpdate = cardViewUpdateService.itemUpdated$.subscribe(
             (updateNotification) => {
-                expect(updateNotification.target).toBe(component.property);
+                expect(updateNotification.target).toEqual(property);
                 expect(updateNotification.changed).toEqual({ dateKey: expectedDate.toDate() });
                 disposableUpdate.unsubscribe();
                 done();

--- a/lib/core/card-view/components/card-view-dateitem/card-view-dateitem.component.spec.ts
+++ b/lib/core/card-view/components/card-view-dateitem/card-view-dateitem.component.spec.ts
@@ -288,10 +288,11 @@ describe('CardViewDateItemComponent', () => {
             component.property.value = 'Jul 10 2017';
             fixture.detectChanges();
             const cardViewUpdateService = TestBed.get(CardViewUpdateService);
+            const property = { ...component.property };
 
             const disposableUpdate = cardViewUpdateService.itemUpdated$.subscribe(
                 (updateNotification) => {
-                    expect(updateNotification.target).toBe(component.property);
+                    expect(updateNotification.target).toEqual(property);
                     expect(updateNotification.changed).toEqual({ dateKey: null });
                     disposableUpdate.unsubscribe();
                 }

--- a/lib/core/card-view/components/card-view-dateitem/card-view-dateitem.component.ts
+++ b/lib/core/card-view/components/card-view-dateitem/card-view-dateitem.component.ts
@@ -114,8 +114,8 @@ export class CardViewDateItemComponent extends BaseCardView<CardViewDateItemMode
             const momentDate = moment(newDateValue.value, this.dateFormat, true);
             if (momentDate.isValid()) {
                 this.valueDate = momentDate;
-                this.cardViewUpdateService.update(this.property, momentDate.toDate());
-                // this.property.value = momentDate.toDate();
+                this.cardViewUpdateService.update(<any> {...this.property }, momentDate.toDate());
+                this.property.value = momentDate.toDate();
             }
         }
     }

--- a/lib/core/card-view/components/card-view-dateitem/card-view-dateitem.component.ts
+++ b/lib/core/card-view/components/card-view-dateitem/card-view-dateitem.component.ts
@@ -122,7 +122,7 @@ export class CardViewDateItemComponent extends BaseCardView<CardViewDateItemMode
 
     onDateClear() {
         this.valueDate = null;
-        this.cardViewUpdateService.update(this.property, null);
+        this.cardViewUpdateService.update(<CardViewDateItemModel> { ...this.property }, null);
         this.property.value = null;
         this.property.default = null;
     }

--- a/lib/core/card-view/components/card-view-dateitem/card-view-dateitem.component.ts
+++ b/lib/core/card-view/components/card-view-dateitem/card-view-dateitem.component.ts
@@ -114,7 +114,7 @@ export class CardViewDateItemComponent extends BaseCardView<CardViewDateItemMode
             const momentDate = moment(newDateValue.value, this.dateFormat, true);
             if (momentDate.isValid()) {
                 this.valueDate = momentDate;
-                this.cardViewUpdateService.update(<any> {...this.property }, momentDate.toDate());
+                this.cardViewUpdateService.update(<CardViewDateItemModel> { ...this.property }, momentDate.toDate());
                 this.property.value = momentDate.toDate();
             }
         }

--- a/lib/core/card-view/components/card-view-dateitem/card-view-dateitem.component.ts
+++ b/lib/core/card-view/components/card-view-dateitem/card-view-dateitem.component.ts
@@ -15,10 +15,10 @@
  * limitations under the License.
  */
 
-import { Component, Input, OnInit, ViewChild, OnDestroy } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { DateAdapter, MAT_DATE_FORMATS } from '@angular/material';
-import { MatDatetimepicker, DatetimeAdapter, MAT_DATETIME_FORMATS } from '@mat-datetimepicker/core';
-import { MomentDatetimeAdapter, MAT_MOMENT_DATETIME_FORMATS } from '@mat-datetimepicker/moment';
+import { DatetimeAdapter, MAT_DATETIME_FORMATS, MatDatetimepicker } from '@mat-datetimepicker/core';
+import { MAT_MOMENT_DATETIME_FORMATS, MomentDatetimeAdapter } from '@mat-datetimepicker/moment';
 import moment from 'moment-es6';
 import { Moment } from 'moment';
 import { CardViewDateItemModel } from '../../models/card-view-dateitem.model';
@@ -29,6 +29,7 @@ import { MOMENT_DATE_FORMATS } from '../../../utils/moment-date-formats.model';
 import { AppConfigService } from '../../../app-config/app-config.service';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
+import { BaseCardView } from '../base-card-view';
 
 @Component({
     providers: [
@@ -41,7 +42,7 @@ import { takeUntil } from 'rxjs/operators';
     templateUrl: './card-view-dateitem.component.html',
     styleUrls: ['./card-view-dateitem.component.scss']
 })
-export class CardViewDateItemComponent implements OnInit, OnDestroy {
+export class CardViewDateItemComponent extends BaseCardView<CardViewDateItemModel> implements OnInit, OnDestroy {
 
     @Input()
     property: CardViewDateItemModel;
@@ -63,10 +64,11 @@ export class CardViewDateItemComponent implements OnInit, OnDestroy {
 
     private onDestroy$ = new Subject<boolean>();
 
-    constructor(private cardViewUpdateService: CardViewUpdateService,
+    constructor(cardViewUpdateService: CardViewUpdateService,
                 private dateAdapter: DateAdapter<Moment>,
                 private userPreferencesService: UserPreferencesService,
                 private appConfig: AppConfigService) {
+        super(cardViewUpdateService);
         this.dateFormat = this.appConfig.get('dateValues.defaultDateFormat');
     }
 
@@ -113,7 +115,7 @@ export class CardViewDateItemComponent implements OnInit, OnDestroy {
             if (momentDate.isValid()) {
                 this.valueDate = momentDate;
                 this.cardViewUpdateService.update(this.property, momentDate.toDate());
-                this.property.value = momentDate.toDate();
+                // this.property.value = momentDate.toDate();
             }
         }
     }

--- a/lib/core/card-view/components/card-view-keyvaluepairsitem/card-view-keyvaluepairsitem.component.ts
+++ b/lib/core/card-view/components/card-view-keyvaluepairsitem/card-view-keyvaluepairsitem.component.ts
@@ -68,8 +68,8 @@ export class CardViewKeyValuePairsItemComponent extends BaseCardView<CardViewKey
         const validValues = this.values.filter((i) => i.name.length && i.value.length);
 
         if (remove || validValues.length) {
-            this.cardViewUpdateService.update(this.property, validValues);
-            // this.property.value = validValues;
+            this.cardViewUpdateService.update(<any>{ ...this.property }, validValues);
+            this.property.value = validValues;
         }
     }
 }

--- a/lib/core/card-view/components/card-view-keyvaluepairsitem/card-view-keyvaluepairsitem.component.ts
+++ b/lib/core/card-view/components/card-view-keyvaluepairsitem/card-view-keyvaluepairsitem.component.ts
@@ -20,6 +20,7 @@ import { CardViewUpdateService } from '../../services/card-view-update.service';
 import { CardViewKeyValuePairsItemModel } from '../../models/card-view.models';
 import { CardViewKeyValuePairsItemType } from '../../interfaces/card-view.interfaces';
 import { MatTableDataSource } from '@angular/material';
+import { BaseCardView } from '../base-card-view';
 
 @Component({
     selector: 'adf-card-view-boolitem',
@@ -27,10 +28,7 @@ import { MatTableDataSource } from '@angular/material';
     styleUrls: ['./card-view-keyvaluepairsitem.component.scss']
 })
 
-export class CardViewKeyValuePairsItemComponent implements OnChanges {
-
-    @Input()
-    property: CardViewKeyValuePairsItemModel;
+export class CardViewKeyValuePairsItemComponent extends BaseCardView<CardViewKeyValuePairsItemModel> implements OnChanges {
 
     @Input()
     editable: boolean = false;
@@ -38,7 +36,9 @@ export class CardViewKeyValuePairsItemComponent implements OnChanges {
     values: CardViewKeyValuePairsItemType[];
     matTableValues: MatTableDataSource<CardViewKeyValuePairsItemType>;
 
-    constructor(private cardViewUpdateService: CardViewUpdateService) {}
+    constructor(cardViewUpdateService: CardViewUpdateService) {
+        super(cardViewUpdateService);
+    }
 
     ngOnChanges() {
         this.values = this.property.value || [];
@@ -69,7 +69,7 @@ export class CardViewKeyValuePairsItemComponent implements OnChanges {
 
         if (remove || validValues.length) {
             this.cardViewUpdateService.update(this.property, validValues);
-            this.property.value = validValues;
+            // this.property.value = validValues;
         }
     }
 }

--- a/lib/core/card-view/components/card-view-keyvaluepairsitem/card-view-keyvaluepairsitem.component.ts
+++ b/lib/core/card-view/components/card-view-keyvaluepairsitem/card-view-keyvaluepairsitem.component.ts
@@ -68,7 +68,7 @@ export class CardViewKeyValuePairsItemComponent extends BaseCardView<CardViewKey
         const validValues = this.values.filter((i) => i.name.length && i.value.length);
 
         if (remove || validValues.length) {
-            this.cardViewUpdateService.update(<any>{ ...this.property }, validValues);
+            this.cardViewUpdateService.update(<CardViewKeyValuePairsItemModel> { ...this.property }, validValues);
             this.property.value = validValues;
         }
     }

--- a/lib/core/card-view/components/card-view-mapitem/card-view-mapitem.component.ts
+++ b/lib/core/card-view/components/card-view-mapitem/card-view-mapitem.component.ts
@@ -18,6 +18,7 @@
 import { Component, Input } from '@angular/core';
 import { CardViewMapItemModel } from '../../models/card-view-mapitem.model';
 import { CardViewUpdateService } from '../../services/card-view-update.service';
+import { BaseCardView } from '../base-card-view';
 
 @Component({
     selector: 'adf-card-view-mapitem',
@@ -25,14 +26,16 @@ import { CardViewUpdateService } from '../../services/card-view-update.service';
     styleUrls: ['./card-view-mapitem.component.scss']
 })
 
-export class CardViewMapItemComponent {
+export class CardViewMapItemComponent extends BaseCardView<CardViewMapItemModel> {
     @Input()
     property: CardViewMapItemModel;
 
     @Input()
     displayEmpty: boolean = true;
 
-    constructor(private cardViewUpdateService: CardViewUpdateService) {}
+    constructor(cardViewUpdateService: CardViewUpdateService) {
+        super(cardViewUpdateService);
+    }
 
     showProperty() {
         return this.displayEmpty || !this.property.isEmpty();

--- a/lib/core/card-view/components/card-view-selectitem/card-view-selectitem.component.ts
+++ b/lib/core/card-view/components/card-view-selectitem/card-view-selectitem.component.ts
@@ -57,8 +57,8 @@ export class CardViewSelectItemComponent extends BaseCardView<CardViewSelectItem
 
     onChange(event: MatSelectChange): void {
         const selectedOption = event.value !== undefined ? event.value : null;
-        this.cardViewUpdateService.update(this.property, selectedOption);
-        // this.property.value = selectedOption;
+        this.cardViewUpdateService.update(<any> { ...this.property }, selectedOption);
+        this.property.value = selectedOption;
     }
 
     showNoneOption() {

--- a/lib/core/card-view/components/card-view-selectitem/card-view-selectitem.component.ts
+++ b/lib/core/card-view/components/card-view-selectitem/card-view-selectitem.component.ts
@@ -44,14 +44,10 @@ export class CardViewSelectItemComponent extends BaseCardView<CardViewSelectItem
     }
 
     ngOnChanges(): void {
-        this.refreshValue();
-    }
-
-    refreshValue() {
         this.value = this.property.value;
     }
 
-        isEditable(): boolean {
+    isEditable(): boolean {
         return this.editable && this.property.editable;
     }
 

--- a/lib/core/card-view/components/card-view-selectitem/card-view-selectitem.component.ts
+++ b/lib/core/card-view/components/card-view-selectitem/card-view-selectitem.component.ts
@@ -44,10 +44,14 @@ export class CardViewSelectItemComponent extends BaseCardView<CardViewSelectItem
     }
 
     ngOnChanges(): void {
+        this.refreshValue();
+    }
+
+    refreshValue() {
         this.value = this.property.value;
     }
 
-    isEditable(): boolean {
+        isEditable(): boolean {
         return this.editable && this.property.editable;
     }
 
@@ -57,7 +61,7 @@ export class CardViewSelectItemComponent extends BaseCardView<CardViewSelectItem
 
     onChange(event: MatSelectChange): void {
         const selectedOption = event.value !== undefined ? event.value : null;
-        this.cardViewUpdateService.update(<any> { ...this.property }, selectedOption);
+        this.cardViewUpdateService.update(<CardViewSelectItemModel<string>> { ...this.property }, selectedOption);
         this.property.value = selectedOption;
     }
 

--- a/lib/core/card-view/components/card-view-selectitem/card-view-selectitem.component.ts
+++ b/lib/core/card-view/components/card-view-selectitem/card-view-selectitem.component.ts
@@ -21,14 +21,14 @@ import { CardViewUpdateService } from '../../services/card-view-update.service';
 import { Observable } from 'rxjs';
 import { CardViewSelectItemOption } from '../../interfaces/card-view.interfaces';
 import { MatSelectChange } from '@angular/material';
+import { BaseCardView } from '../base-card-view';
 
 @Component({
     selector: 'adf-card-view-selectitem',
     templateUrl: './card-view-selectitem.component.html',
     styleUrls: ['./card-view-selectitem.component.scss']
 })
-export class CardViewSelectItemComponent implements OnChanges {
-    @Input() property: CardViewSelectItemModel<string>;
+export class CardViewSelectItemComponent extends BaseCardView<CardViewSelectItemModel<string>> implements OnChanges {
 
     @Input() editable: boolean = false;
 
@@ -39,7 +39,9 @@ export class CardViewSelectItemComponent implements OnChanges {
 
     value: string;
 
-    constructor(private cardViewUpdateService: CardViewUpdateService) {}
+    constructor(cardViewUpdateService: CardViewUpdateService) {
+        super(cardViewUpdateService);
+    }
 
     ngOnChanges(): void {
         this.value = this.property.value;
@@ -56,7 +58,7 @@ export class CardViewSelectItemComponent implements OnChanges {
     onChange(event: MatSelectChange): void {
         const selectedOption = event.value !== undefined ? event.value : null;
         this.cardViewUpdateService.update(this.property, selectedOption);
-        this.property.value = selectedOption;
+        // this.property.value = selectedOption;
     }
 
     showNoneOption() {

--- a/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
+++ b/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
@@ -437,6 +437,24 @@ describe('CardViewTextItemComponent', () => {
             expect(component.property.value).toBe(expectedText);
         }));
 
+        it('should update the value using the updateItem$ subject', async(() => {
+            component.inEdit = false;
+            component.property.isValid = () => true;
+            const cardViewUpdateService = TestBed.get(CardViewUpdateService);
+            const expectedText = 'changed text';
+            fixture.detectChanges();
+
+            let textItemReadOnly = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-value-${component.property.key}"]`));
+            expect(textItemReadOnly.nativeElement.textContent).toEqual('Lorem ipsum');
+            expect(component.property.value).toBe('Lorem ipsum');
+
+            cardViewUpdateService.updateElement({ target: { key: component.property.key, value: expectedText  } });
+            fixture.detectChanges();
+
+            expect(textItemReadOnly.nativeElement.textContent).toEqual(expectedText);
+            expect(component.property.value).toBe(expectedText);
+        }));
+
         it('should reset the value using the escape key', async(() => {
             component.inEdit = false;
             component.property.isValid = () => true;

--- a/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
+++ b/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
@@ -265,7 +265,7 @@ describe('CardViewTextItemComponent', () => {
             fixture.detectChanges();
 
             const disposableUpdate = cardViewUpdateService.itemUpdated$.subscribe((updateNotification) => {
-                expect(updateNotification.target).toBe(component.property);
+                expect(updateNotification.target).toEqual({ ...component.property });
                 expect(updateNotification.changed).toEqual({ textkey: expectedText });
                 disposableUpdate.unsubscribe();
             });
@@ -309,10 +309,11 @@ describe('CardViewTextItemComponent', () => {
             const cardViewUpdateService = TestBed.get(CardViewUpdateService);
             spyOn(cardViewUpdateService, 'update');
             component.editedValue = 'updated-value';
+            const property = { ...component.property };
 
             component.update(event);
 
-            expect(cardViewUpdateService.update).toHaveBeenCalledWith(component.property, 'updated-value');
+            expect(cardViewUpdateService.update).toHaveBeenCalledWith(property, 'updated-value');
         });
 
         it('should NOT trigger the update event if the editedValue is invalid', () => {
@@ -384,7 +385,7 @@ describe('CardViewTextItemComponent', () => {
 
             const disposableUpdate = cardViewUpdateService.itemUpdated$.subscribe(
                 (updateNotification) => {
-                    expect(updateNotification.target).toBe(component.property);
+                    expect(updateNotification.target).toEqual({ ...component.property });
                     expect(updateNotification.changed).toEqual({ textkey: expectedText });
                     disposableUpdate.unsubscribe();
                     done();
@@ -413,7 +414,7 @@ describe('CardViewTextItemComponent', () => {
 
             const disposableUpdate = cardViewUpdateService.itemUpdated$.subscribe(
                 (updateNotification) => {
-                    expect(updateNotification.target).toBe(component.property);
+                    expect(updateNotification.target).toEqual({ ...component.property });
                     expect(updateNotification.changed).toEqual({ textkey: expectedText });
                     disposableUpdate.unsubscribe();
                 }
@@ -506,7 +507,7 @@ describe('CardViewTextItemComponent', () => {
             fixture.detectChanges();
 
             const disposableUpdate = cardViewUpdateService.itemUpdated$.subscribe((updateNotification) => {
-                expect(updateNotification.target).toBe(component.property);
+                expect(updateNotification.target).toEqual({ ...component.property });
                 expect(updateNotification.changed).toEqual({ textkey: expectedText });
                 disposableUpdate.unsubscribe();
             });
@@ -643,7 +644,7 @@ describe('CardViewTextItemComponent', () => {
             expect(component.property.value).not.toEqual(expectedNumber);
 
             const disposableUpdate = cardViewUpdateService.itemUpdated$.subscribe((updateNotification) => {
-                expect(updateNotification.target).toBe(component.property);
+                expect(updateNotification.target).toEqual({ ...component.property });
                 expect(updateNotification.changed).toEqual({ textkey: expectedNumber.toString() });
                 disposableUpdate.unsubscribe();
             });
@@ -717,7 +718,7 @@ describe('CardViewTextItemComponent', () => {
             fixture.detectChanges();
 
             const disposableUpdate = cardViewUpdateService.itemUpdated$.subscribe((updateNotification) => {
-                expect(updateNotification.target).toBe(component.property);
+                expect(updateNotification.target).toEqual({ ...component.property });
                 expect(updateNotification.changed).toEqual({ textkey: expectedFloat.toString() });
                 disposableUpdate.unsubscribe();
             });

--- a/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
+++ b/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
@@ -444,7 +444,7 @@ describe('CardViewTextItemComponent', () => {
             const expectedText = 'changed text';
             fixture.detectChanges();
 
-            let textItemReadOnly = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-value-${component.property.key}"]`));
+            const textItemReadOnly = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-value-${component.property.key}"]`));
             expect(textItemReadOnly.nativeElement.textContent).toEqual('Lorem ipsum');
             expect(component.property.value).toBe('Lorem ipsum');
 

--- a/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
+++ b/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
@@ -449,7 +449,7 @@ describe('CardViewTextItemComponent', () => {
             expect(textItemReadOnly.nativeElement.textContent).toEqual('Lorem ipsum');
             expect(component.property.value).toBe('Lorem ipsum');
 
-            cardViewUpdateService.updateElement({ target: { key: component.property.key, value: expectedText  } });
+            cardViewUpdateService.updateElement({ key: component.property.key, value: expectedText  });
             fixture.detectChanges();
 
             expect(textItemReadOnly.nativeElement.textContent).toEqual(expectedText);

--- a/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.ts
+++ b/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.ts
@@ -104,7 +104,7 @@ export class CardViewTextItemComponent extends BaseCardView<CardViewTextItemMode
 
         if (this.property.isValid(this.editedValue)) {
             const updatedValue = this.prepareValueForUpload(this.property, this.editedValue);
-            this.cardViewUpdateService.update(<any> {...this.property}, updatedValue);
+            this.cardViewUpdateService.update(<CardViewTextItemModel> {...this.property}, updatedValue);
             this.property.value = updatedValue;
             this.setEditMode(false);
             this.resetErrorMessages();

--- a/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.ts
+++ b/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.ts
@@ -104,8 +104,8 @@ export class CardViewTextItemComponent extends BaseCardView<CardViewTextItemMode
 
         if (this.property.isValid(this.editedValue)) {
             const updatedValue = this.prepareValueForUpload(this.property, this.editedValue);
-            this.cardViewUpdateService.update(this.property, updatedValue);
-            // this.property.value = updatedValue;
+            this.cardViewUpdateService.update(<any> {...this.property}, updatedValue);
+            this.property.value = updatedValue;
             this.setEditMode(false);
             this.resetErrorMessages();
         } else {

--- a/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.ts
+++ b/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.ts
@@ -104,7 +104,7 @@ export class CardViewTextItemComponent extends BaseCardView<CardViewTextItemMode
 
         if (this.property.isValid(this.editedValue)) {
             const updatedValue = this.prepareValueForUpload(this.property, this.editedValue);
-            this.cardViewUpdateService.update(<CardViewTextItemModel> {...this.property}, updatedValue);
+            this.cardViewUpdateService.update(<CardViewTextItemModel> { ...this.property }, updatedValue);
             this.property.value = updatedValue;
             this.setEditMode(false);
             this.resetErrorMessages();

--- a/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.ts
+++ b/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.ts
@@ -19,18 +19,16 @@ import { Component, Input, OnChanges, ViewChild } from '@angular/core';
 import { CardViewTextItemModel } from '../../models/card-view-textitem.model';
 import { CardViewUpdateService } from '../../services/card-view-update.service';
 import { AppConfigService } from '../../../app-config/app-config.service';
+import { BaseCardView } from '../base-card-view';
 
 @Component({
     selector: 'adf-card-view-textitem',
     templateUrl: './card-view-textitem.component.html',
     styleUrls: ['./card-view-textitem.component.scss']
 })
-export class CardViewTextItemComponent implements OnChanges {
+export class CardViewTextItemComponent extends BaseCardView<CardViewTextItemModel> implements OnChanges {
 
     static DEFAULT_SEPARATOR = ', ';
-
-    @Input()
-    property: CardViewTextItemModel;
 
     @Input()
     editable: boolean = false;
@@ -46,8 +44,9 @@ export class CardViewTextItemComponent implements OnChanges {
     errorMessages: string[];
     valueSeparator: string;
 
-    constructor(private cardViewUpdateService: CardViewUpdateService,
+    constructor(cardViewUpdateService: CardViewUpdateService,
                 private appConfig: AppConfigService) {
+        super(cardViewUpdateService);
         this.valueSeparator = this.appConfig.get<string>('content-metadata.multi-value-pipe-separator') || CardViewTextItemComponent.DEFAULT_SEPARATOR;
     }
 
@@ -106,7 +105,7 @@ export class CardViewTextItemComponent implements OnChanges {
         if (this.property.isValid(this.editedValue)) {
             const updatedValue = this.prepareValueForUpload(this.property, this.editedValue);
             this.cardViewUpdateService.update(this.property, updatedValue);
-            this.property.value = updatedValue;
+            // this.property.value = updatedValue;
             this.setEditMode(false);
             this.resetErrorMessages();
         } else {

--- a/lib/core/card-view/services/card-view-update.service.ts
+++ b/lib/core/card-view/services/card-view-update.service.ts
@@ -43,7 +43,7 @@ export class CardViewUpdateService {
 
     itemUpdated$ = new Subject<UpdateNotification>();
     itemClicked$ = new Subject<ClickNotification>();
-    updateItem$ = new Subject<UpdateNotification>();
+    updateItem$ = new Subject<CardViewBaseItemModel>();
 
     update(property: CardViewBaseItemModel, newValue: any) {
         this.itemUpdated$.next({
@@ -60,9 +60,9 @@ export class CardViewUpdateService {
 
     /**
      * Updates the cardview items property
-     * @Input UpdateNotification
+     * @param CardViewBaseItemModel
      */
-    updateElement(notification: UpdateNotification) {
+    updateElement(notification: CardViewBaseItemModel) {
         this.updateItem$.next(notification);
     }
 

--- a/lib/core/card-view/services/card-view-update.service.ts
+++ b/lib/core/card-view/services/card-view-update.service.ts
@@ -48,7 +48,7 @@ export class CardViewUpdateService {
     update(property: CardViewBaseItemModel, newValue: any) {
         this.itemUpdated$.next({
             target: property,
-            changed: transformKeyToObject(property.key, newValue),
+            changed: transformKeyToObject(property.key, newValue)
         });
     }
 

--- a/lib/core/card-view/services/card-view-update.service.ts
+++ b/lib/core/card-view/services/card-view-update.service.ts
@@ -22,7 +22,6 @@ import { CardViewBaseItemModel } from '../models/card-view-baseitem.model';
 export interface UpdateNotification {
     target: any;
     changed: any;
-    value: any;
 }
 
 export interface ClickNotification {
@@ -50,7 +49,6 @@ export class CardViewUpdateService {
         this.itemUpdated$.next({
             target: property,
             changed: transformKeyToObject(property.key, newValue),
-            value: newValue
         });
     }
 

--- a/lib/core/card-view/services/card-view-update.service.ts
+++ b/lib/core/card-view/services/card-view-update.service.ts
@@ -58,6 +58,10 @@ export class CardViewUpdateService {
         });
     }
 
+    /**
+     * Updates the cardview items property
+     * @Input UpdateNotification
+     */
     updateElement(notification: UpdateNotification) {
         this.updateItem$.next(notification);
     }

--- a/lib/core/card-view/services/card-view-update.service.ts
+++ b/lib/core/card-view/services/card-view-update.service.ts
@@ -22,6 +22,7 @@ import { CardViewBaseItemModel } from '../models/card-view-baseitem.model';
 export interface UpdateNotification {
     target: any;
     changed: any;
+    value: any;
 }
 
 export interface ClickNotification {
@@ -43,11 +44,13 @@ export class CardViewUpdateService {
 
     itemUpdated$ = new Subject<UpdateNotification>();
     itemClicked$ = new Subject<ClickNotification>();
+    updateItem$ = new Subject<UpdateNotification>();
 
     update(property: CardViewBaseItemModel, newValue: any) {
         this.itemUpdated$.next({
             target: property,
-            changed: transformKeyToObject(property.key, newValue)
+            changed: transformKeyToObject(property.key, newValue),
+            value: newValue
         });
     }
 
@@ -56,4 +59,9 @@ export class CardViewUpdateService {
             target: property
         });
     }
+
+    updateElement(notification: UpdateNotification) {
+        this.updateItem$.next(notification);
+    }
+
 }

--- a/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.ts
@@ -278,12 +278,12 @@ export class TaskHeaderCloudComponent implements OnInit, OnDestroy, OnChanges {
                 this.cardViewUpdateService.updateElement(updateNotification);
                 return of(null);
             }))
-            .subscribe(
-                (taskDetails) => {
-                    this.taskDetails = taskDetails;
+            .subscribe((taskDetails) => {
+                    if (taskDetails) {
+                        this.taskDetails = taskDetails;
+                    }
                     this.refreshData();
-                }
-            );
+                });
     }
 
     private loadParentName(taskId: string) {

--- a/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.ts
@@ -16,7 +16,7 @@
  */
 
 import { Component, Input, EventEmitter, Output, OnDestroy, OnChanges, OnInit } from '@angular/core';
-import { takeUntil, concatMap } from 'rxjs/operators';
+import { takeUntil, concatMap, tap } from 'rxjs/operators';
 import { Subject, of, forkJoin } from 'rxjs';
 import {
     CardViewDateItemModel,
@@ -274,6 +274,7 @@ export class TaskHeaderCloudComponent implements OnInit, OnDestroy, OnChanges {
      */
     private updateTaskDetails(updateNotification: UpdateNotification) {
         this.taskCloudService.updateTask(this.appName, this.taskId, updateNotification.changed)
+            .pipe(tap(() => this.cardViewUpdateService.updateElement(updateNotification)))
             .subscribe(
                 (taskDetails) => {
                     this.taskDetails = taskDetails;

--- a/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.ts
@@ -275,7 +275,7 @@ export class TaskHeaderCloudComponent implements OnInit, OnDestroy, OnChanges {
     private updateTaskDetails(updateNotification: UpdateNotification) {
         this.taskCloudService.updateTask(this.appName, this.taskId, updateNotification.changed)
             .pipe(catchError(() => {
-                this.cardViewUpdateService.updateElement(updateNotification);
+                this.cardViewUpdateService.updateElement(updateNotification.target);
                 return of(null);
             }))
             .subscribe((taskDetails) => {

--- a/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.ts
@@ -16,7 +16,7 @@
  */
 
 import { Component, Input, EventEmitter, Output, OnDestroy, OnChanges, OnInit } from '@angular/core';
-import { takeUntil, concatMap, tap } from 'rxjs/operators';
+import { takeUntil, concatMap, catchError } from 'rxjs/operators';
 import { Subject, of, forkJoin } from 'rxjs';
 import {
     CardViewDateItemModel,
@@ -274,7 +274,10 @@ export class TaskHeaderCloudComponent implements OnInit, OnDestroy, OnChanges {
      */
     private updateTaskDetails(updateNotification: UpdateNotification) {
         this.taskCloudService.updateTask(this.appName, this.taskId, updateNotification.changed)
-            .pipe(tap(() => this.cardViewUpdateService.updateElement(updateNotification)))
+            .pipe(catchError(() => {
+                this.cardViewUpdateService.updateElement(updateNotification);
+                return of(null);
+            }))
             .subscribe(
                 (taskDetails) => {
                     this.taskDetails = taskDetails;

--- a/lib/process-services/src/lib/task-list/components/task-details.component.ts
+++ b/lib/process-services/src/lib/task-list/components/task-details.component.ts
@@ -276,7 +276,7 @@ export class TaskDetailsComponent implements OnInit, OnChanges, OnDestroy {
         this.taskListService
             .updateTask(this.taskId, updateNotification.changed)
             .pipe(catchError(() => {
-                this.cardViewUpdateService.updateElement(updateNotification);
+                this.cardViewUpdateService.updateElement(updateNotification.target);
                 return of(null);
             }))
             .subscribe(() => this.loadDetails(this.taskId));

--- a/lib/process-services/src/lib/task-list/components/task-details.component.ts
+++ b/lib/process-services/src/lib/task-list/components/task-details.component.ts
@@ -38,12 +38,12 @@ import {
     OnDestroy
 } from '@angular/core';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
-import { Observable, Observer, Subject } from 'rxjs';
+import { Observable, Observer, of, Subject } from 'rxjs';
 import { TaskQueryRequestRepresentationModel } from '../models/filter.model';
 import { TaskDetailsModel } from '../models/task-details.model';
 import { TaskListService } from './../services/tasklist.service';
 import { UserRepresentation } from '@alfresco/js-api';
-import { share, takeUntil, tap } from 'rxjs/operators';
+import { catchError, share, takeUntil } from 'rxjs/operators';
 
 @Component({
     selector: 'adf-task-details',
@@ -275,7 +275,10 @@ export class TaskDetailsComponent implements OnInit, OnChanges, OnDestroy {
     private updateTaskDetails(updateNotification: UpdateNotification) {
         this.taskListService
             .updateTask(this.taskId, updateNotification.changed)
-            .pipe(tap(() => this.cardViewUpdateService.updateElement(updateNotification)))
+            .pipe(catchError(() => {
+                this.cardViewUpdateService.updateElement(updateNotification);
+                return of(null);
+            }))
             .subscribe(() => this.loadDetails(this.taskId));
     }
 

--- a/lib/process-services/src/lib/task-list/components/task-details.component.ts
+++ b/lib/process-services/src/lib/task-list/components/task-details.component.ts
@@ -43,7 +43,7 @@ import { TaskQueryRequestRepresentationModel } from '../models/filter.model';
 import { TaskDetailsModel } from '../models/task-details.model';
 import { TaskListService } from './../services/tasklist.service';
 import { UserRepresentation } from '@alfresco/js-api';
-import { share, takeUntil } from 'rxjs/operators';
+import { share, takeUntil, tap } from 'rxjs/operators';
 
 @Component({
     selector: 'adf-task-details',
@@ -275,6 +275,7 @@ export class TaskDetailsComponent implements OnInit, OnChanges, OnDestroy {
     private updateTaskDetails(updateNotification: UpdateNotification) {
         this.taskListService
             .updateTask(this.taskId, updateNotification.changed)
+            .pipe(tap(() => this.cardViewUpdateService.updateElement(updateNotification)))
             .subscribe(() => this.loadDetails(this.taskId));
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://issues.alfresco.com/jira/browse/ADF-4522

Metadata value is not rolling back on error

**What is the new behaviour?**
 
#5545 -> this pr doesn't address all the scenarios as expected. (it is reloading unnecessarily when  updating failed)

Solution: Introducing hook to update the card view item.

New method as below will be added to update the card view item property

    updateElement(notification: CardViewBaseItemModel) {
        this.updateItem$.next(notification);
    }

So, all consumer should call this method to update the expected value in the card view

consumer-like content-meta-data service, Task header cloud, and task details components are updated as well

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
