### PR TITLE
[AAE-1725] ADF Task/Process filters - default filters should be recreated when they all get deleted

### DIFF
--- a/lib/process-services-cloud/src/lib/process/process-filters/components/edit-process-filter-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/process/process-filters/components/edit-process-filter-cloud.component.spec.ts
@@ -561,5 +561,61 @@ describe('EditProcessFilterCloudComponent', () => {
             });
             component.onFilterChange();
         });
+
+        it('should call restore default filters service on deletion of last filter', (done) => {
+            component.toggleFilterActions = true;
+            const deleteFilterSpy = spyOn(service, 'deleteFilter').and.returnValue(of([]));
+            const restoreFiltersSpy = spyOn(component, 'restoreDefaultProcessFilters').and.returnValue(of([]));
+            const deleteSpy: jasmine.Spy = spyOn(component.action, 'emit');
+            fixture.detectChanges();
+
+            const expansionPanel = fixture.debugElement.nativeElement.querySelector('mat-expansion-panel-header');
+            expansionPanel.click();
+            fixture.detectChanges();
+            const stateElement = fixture.debugElement.nativeElement.querySelector('[data-automation-id="adf-cloud-edit-process-property-status"] .mat-select-trigger');
+            stateElement.click();
+            fixture.detectChanges();
+            const deleteButton = fixture.debugElement.nativeElement.querySelector('[data-automation-id="adf-filter-action-delete"]');
+            deleteButton.click();
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+                expect(deleteFilterSpy).toHaveBeenCalled();
+                fixture.detectChanges();
+                fixture.whenStable().then(() => {
+                    expect(deleteSpy).toHaveBeenCalled();
+                    expect(restoreFiltersSpy).toHaveBeenCalled();
+                    done();
+                });
+
+            });
+        });
+
+        it('should not call restore default filters service on deletion first filter', (done) => {
+            component.toggleFilterActions = true;
+            const deleteFilterSpy = spyOn(service, 'deleteFilter').and.returnValue(of([{ name: 'mock-filter-name'}]));
+            const restoreFiltersSpy = spyOn(component, 'restoreDefaultProcessFilters').and.returnValue(of([]));
+            const deleteSpy: jasmine.Spy = spyOn(component.action, 'emit');
+            fixture.detectChanges();
+
+            const expansionPanel = fixture.debugElement.nativeElement.querySelector('mat-expansion-panel-header');
+            expansionPanel.click();
+            fixture.detectChanges();
+            const stateElement = fixture.debugElement.nativeElement.querySelector('[data-automation-id="adf-cloud-edit-process-property-status"] .mat-select-trigger');
+            stateElement.click();
+            fixture.detectChanges();
+            const deleteButton = fixture.debugElement.nativeElement.querySelector('[data-automation-id="adf-filter-action-delete"]');
+            deleteButton.click();
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+                expect(deleteFilterSpy).toHaveBeenCalled();
+                fixture.detectChanges();
+                fixture.whenStable().then(() => {
+                    expect(deleteSpy).toHaveBeenCalled();
+                    expect(restoreFiltersSpy).not.toHaveBeenCalled();
+                    done();
+                });
+
+            });
+        });
     });
 });

--- a/lib/process-services-cloud/src/lib/process/process-filters/services/process-filter-cloud.service.ts
+++ b/lib/process-services-cloud/src/lib/process/process-filters/services/process-filter-cloud.service.ts
@@ -159,7 +159,7 @@ export class ProcessFilterCloudService {
                     filters = filters.filter(filter => filter.id !== deletedFilter.id);
                     return this.updateProcessFilters(deletedFilter.appName, key, filters);
                 } else {
-                    return [];
+                    return of([]);
                 }
             }),
             map((filters: ProcessFilterCloudModel[]) => {

--- a/lib/process-services-cloud/src/lib/task/task-filters/components/edit-task-filter-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/task/task-filters/components/edit-task-filter-cloud.component.spec.ts
@@ -493,5 +493,49 @@ describe('EditTaskFilterCloudComponent', () => {
                 expect(dialog.open).toHaveBeenCalled();
             });
         }));
+
+        it('should call restore default filters service on deletion of last filter', async(() => {
+            component.toggleFilterActions = true;
+            spyOn(service, 'deleteFilter').and.returnValue(of([]));
+            const restoreDefaultFiltersSpy = spyOn(component, 'restoreDefaultTaskFilters').and.returnValue(of([]));
+            fixture.detectChanges();
+            const expansionPanel = fixture.debugElement.nativeElement.querySelector('mat-expansion-panel-header');
+            expansionPanel.click();
+            fixture.detectChanges();
+            const stateElement = fixture.debugElement.nativeElement.querySelector('[data-automation-id="adf-cloud-edit-task-property-sort"] .mat-select-trigger');
+            stateElement.click();
+            fixture.detectChanges();
+            const deleteButton = fixture.debugElement.nativeElement.querySelector('[data-automation-id="adf-filter-action-delete"]');
+            fixture.whenStable().then(() => {
+                fixture.detectChanges();
+                expect(deleteButton.disabled).toBe(false);
+                deleteButton.click();
+                expect(service.deleteFilter).toHaveBeenCalled();
+                expect(component.action.emit).toHaveBeenCalled();
+                expect(restoreDefaultFiltersSpy).toHaveBeenCalled();
+            });
+        }));
+
+        it('should not call restore default filters service on deletion of first filter', async(() => {
+            component.toggleFilterActions = true;
+            spyOn(service, 'deleteFilter').and.returnValue(of([{ name: 'mock-filter-name'}]));
+            const restoreDefaultFiltersSpy = spyOn(component, 'restoreDefaultTaskFilters').and.returnValue(of([]));
+            fixture.detectChanges();
+            const expansionPanel = fixture.debugElement.nativeElement.querySelector('mat-expansion-panel-header');
+            expansionPanel.click();
+            fixture.detectChanges();
+            const stateElement = fixture.debugElement.nativeElement.querySelector('[data-automation-id="adf-cloud-edit-task-property-sort"] .mat-select-trigger');
+            stateElement.click();
+            fixture.detectChanges();
+            const deleteButton = fixture.debugElement.nativeElement.querySelector('[data-automation-id="adf-filter-action-delete"]');
+            fixture.whenStable().then(() => {
+                fixture.detectChanges();
+                expect(deleteButton.disabled).toBe(false);
+                deleteButton.click();
+                expect(service.deleteFilter).toHaveBeenCalled();
+                expect(component.action.emit).toHaveBeenCalled();
+                expect(restoreDefaultFiltersSpy).not.toHaveBeenCalled();
+            });
+        }));
     });
 });

--- a/lib/process-services-cloud/src/lib/task/task-filters/services/task-filter-cloud.service.ts
+++ b/lib/process-services-cloud/src/lib/task/task-filters/services/task-filter-cloud.service.ts
@@ -206,7 +206,7 @@ export class TaskFilterCloudService {
                     filters = filters.filter(filter => filter.id !== deletedFilter.id);
                     return this.updateTaskFilters(deletedFilter.appName, key, filters);
                 }
-                return [];
+                return of([]);
             }),
             map(filters => {
                 this.addFiltersToStream(filters);


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://issues.alfresco.com/jira/browse/AAE-1725

**What is the new behaviour?**

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/25585550/76743162-3334a700-6798-11ea-9988-5f1d0b767310.gif)


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
