### PR TITLE
[ADF-5087] Document List - custom sources 'where' clause not passed

### DIFF
--- a/docs/content-services/services/custom-resources.service.md
+++ b/docs/content-services/services/custom-resources.service.md
@@ -41,29 +41,34 @@ Manages Document List information that is specific to a user.
     Is the folder ID a "-my", "-root-", or "-shared-" alias?
     -   _folderId:_ `string`  - Folder ID name to check
     -   **Returns** `boolean` - True if the ID is one of the supported sources, false otherwise
--   **loadFavorites**(pagination: [`PaginationModel`](../../../lib/core/models/pagination.model.ts), includeFields: `string[]` = `[]`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`NodePaging`](https://github.com/Alfresco/alfresco-js-api/blob/development/src/api/content-rest-api/docs/NodePaging.md)`>`<br/>
+-   **loadFavorites**(pagination: [`PaginationModel`](../../../lib/core/models/pagination.model.ts), includeFields: `string[]` = `[]`, where? string): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`NodePaging`](https://github.com/Alfresco/alfresco-js-api/blob/development/src/api/content-rest-api/docs/NodePaging.md)`>`<br/>
     Gets favorite files for the current user.
     -   _pagination:_ [`PaginationModel`](../../../lib/core/models/pagination.model.ts)  - Specifies how to paginate the results
     -   _includeFields:_ `string[]`  - List of data field names to include in the results
+    -   _where:_ (Optional) `string`  - A string to restrict the returned objects by using a predicate
     -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`NodePaging`](https://github.com/Alfresco/alfresco-js-api/blob/development/src/api/content-rest-api/docs/NodePaging.md)`>` - List of favorite files
--   **loadFolderByNodeId**(nodeId: `string`, pagination: [`PaginationModel`](../../../lib/core/models/pagination.model.ts), includeFields: `string[]` = `[]`): `any`<br/>
+-   **loadFolderByNodeId**(nodeId: `string`, pagination: [`PaginationModel`](../../../lib/core/models/pagination.model.ts), includeFields: `string[]` = `[]`, where?: string): `any`<br/>
     Gets a folder's contents.
     -   _nodeId:_ `string`  - ID of the target folder node
     -   _pagination:_ [`PaginationModel`](../../../lib/core/models/pagination.model.ts)  - Specifies how to paginate the results
     -   _includeFields:_ `string[]`  - List of data field names to include in the results
+    -   _where:_ (Optional) `string`  - A string to restrict the returned objects by using a predicate
     -   **Returns** `any` - List of items contained in the folder
--   **loadMemberSites**(pagination: [`PaginationModel`](../../../lib/core/models/pagination.model.ts)): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`SiteMemberPaging`](https://github.com/Alfresco/alfresco-js-api/blob/development/src/api/content-rest-api/docs/SiteMemberPaging.md)`>`<br/>
+-   **loadMemberSites**(pagination: [`PaginationModel`](../../../lib/core/models/pagination.model.ts), where?: string): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`SiteMemberPaging`](https://github.com/Alfresco/alfresco-js-api/blob/development/src/api/content-rest-api/docs/SiteMemberPaging.md)`>`<br/>
     Gets sites that the current user is a member of.
     -   _pagination:_ [`PaginationModel`](../../../lib/core/models/pagination.model.ts)  - Specifies how to paginate the results
+    -   _where:_ (Optional) `string`  - A string to restrict the returned objects by using a predicate
     -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`SiteMemberPaging`](https://github.com/Alfresco/alfresco-js-api/blob/development/src/api/content-rest-api/docs/SiteMemberPaging.md)`>` - List of sites
--   **loadSharedLinks**(pagination: [`PaginationModel`](../../../lib/core/models/pagination.model.ts), includeFields: `string[]` = `[]`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`SharedLinkPaging`](https://github.com/Alfresco/alfresco-js-api/blob/development/src/api/content-rest-api/docs/SharedLinkPaging.md)`>`<br/>
+-   **loadSharedLinks**(pagination: [`PaginationModel`](../../../lib/core/models/pagination.model.ts), includeFields: `string[]` = `[]`, where?: string): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`SharedLinkPaging`](https://github.com/Alfresco/alfresco-js-api/blob/development/src/api/content-rest-api/docs/SharedLinkPaging.md)`>`<br/>
     Gets shared links for the current user.
     -   _pagination:_ [`PaginationModel`](../../../lib/core/models/pagination.model.ts)  - Specifies how to paginate the results
     -   _includeFields:_ `string[]`  - List of data field names to include in the results
+    -   _where:_ (Optional)`string`  - A string to restrict the returned objects by using a predicate
     -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`SharedLinkPaging`](https://github.com/Alfresco/alfresco-js-api/blob/development/src/api/content-rest-api/docs/SharedLinkPaging.md)`>` - List of shared links
--   **loadSites**(pagination: [`PaginationModel`](../../../lib/core/models/pagination.model.ts)): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`NodePaging`](https://github.com/Alfresco/alfresco-js-api/blob/development/src/api/content-rest-api/docs/NodePaging.md)`>`<br/>
+-   **loadSites**(pagination: [`PaginationModel`](../../../lib/core/models/pagination.model.ts), where?: string): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`NodePaging`](https://github.com/Alfresco/alfresco-js-api/blob/development/src/api/content-rest-api/docs/NodePaging.md)`>`<br/>
     Gets all sites in the repository.
     -   _pagination:_ [`PaginationModel`](../../../lib/core/models/pagination.model.ts)  - Specifies how to paginate the results
+    -   _where:_ (Optional)`string`  - A string to restrict the returned objects by using a predicate
     -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`NodePaging`](https://github.com/Alfresco/alfresco-js-api/blob/development/src/api/content-rest-api/docs/NodePaging.md)`>` - List of sites
 -   **loadTrashcan**(pagination: [`PaginationModel`](../../../lib/core/models/pagination.model.ts), includeFields: `string[]` = `[]`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`DeletedNodesPaging`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/DeletedNodesPaging.md)`>`<br/>
     Gets all items currently in the trash.

--- a/lib/content-services/src/lib/document-list/services/custom-resources.service.ts
+++ b/lib/content-services/src/lib/document-list/services/custom-resources.service.ts
@@ -132,15 +132,17 @@ export class CustomResourcesService {
      * Gets favorite files for the current user.
      * @param pagination Specifies how to paginate the results
      * @param includeFields List of data field names to include in the results
+     * @param where A string to restrict the returned objects by using a predicate
      * @returns List of favorite files
      */
-    loadFavorites(pagination: PaginationModel, includeFields: string[] = []): Observable<NodePaging> {
+    loadFavorites(pagination: PaginationModel, includeFields: string[] = [], where?: string): Observable<NodePaging> {
         const includeFieldsRequest = this.getIncludesFields(includeFields);
+        const defaultPredicate = '(EXISTS(target/file) OR EXISTS(target/folder))';
 
         const options = {
             maxItems: pagination.maxItems,
             skipCount: pagination.skipCount,
-            where: '(EXISTS(target/file) OR EXISTS(target/folder))',
+            where: where ? `${where} AND ${defaultPredicate}` : defaultPredicate ,
             include: includeFieldsRequest
         };
 
@@ -181,13 +183,15 @@ export class CustomResourcesService {
     /**
      * Gets sites that the current user is a member of.
      * @param pagination Specifies how to paginate the results
+     * @param where A string to restrict the returned objects by using a predicate
      * @returns List of sites
      */
-    loadMemberSites(pagination: PaginationModel): Observable<SiteMemberPaging> {
+    loadMemberSites(pagination: PaginationModel, where?: string): Observable<SiteMemberPaging> {
         const options = {
             include: ['properties'],
             maxItems: pagination.maxItems,
-            skipCount: pagination.skipCount
+            skipCount: pagination.skipCount,
+            where
         };
 
         return new Observable((observer) => {
@@ -220,13 +224,15 @@ export class CustomResourcesService {
     /**
      * Gets all sites in the repository.
      * @param pagination Specifies how to paginate the results
+     * @param where A string to restrict the returned objects by using a predicate
      * @returns List of sites
      */
-    loadSites(pagination: PaginationModel): Observable<NodePaging> {
+    loadSites(pagination: PaginationModel, where?: string): Observable<NodePaging> {
         const options = {
             include: ['properties', 'aspectNames'],
             maxItems: pagination.maxItems,
-            skipCount: pagination.skipCount
+            skipCount: pagination.skipCount,
+            where
         };
 
         return new Observable((observer) => {
@@ -272,15 +278,17 @@ export class CustomResourcesService {
      * Gets shared links for the current user.
      * @param pagination Specifies how to paginate the results
      * @param includeFields List of data field names to include in the results
+     * @param where A string to restrict the returned objects by using a predicate
      * @returns List of shared links
      */
-    loadSharedLinks(pagination: PaginationModel, includeFields: string[] = []): Observable<SharedLinkPaging> {
+    loadSharedLinks(pagination: PaginationModel, includeFields: string[] = [], where?: string): Observable<SharedLinkPaging> {
         const includeFieldsRequest = this.getIncludesFields(includeFields);
 
         const options = {
             include: includeFieldsRequest,
             maxItems: pagination.maxItems,
-            skipCount: pagination.skipCount
+            skipCount: pagination.skipCount,
+            where
         };
 
         return from(this.apiService.sharedLinksApi.findSharedLinks(options))
@@ -326,17 +334,17 @@ export class CustomResourcesService {
      * @param includeFields List of data field names to include in the results
      * @returns List of items contained in the folder
      */
-    loadFolderByNodeId(nodeId: string, pagination: PaginationModel, includeFields: string[] = []): any {
+    loadFolderByNodeId(nodeId: string, pagination: PaginationModel, includeFields: string[] = [], where?: string): any {
         if (nodeId === '-trashcan-') {
             return this.loadTrashcan(pagination, includeFields);
         } else if (nodeId === '-sharedlinks-') {
-            return this.loadSharedLinks(pagination, includeFields);
+            return this.loadSharedLinks(pagination, includeFields, where);
         } else if (nodeId === '-sites-') {
-            return this.loadSites(pagination);
+            return this.loadSites(pagination, where);
         } else if (nodeId === '-mysites-') {
-            return this.loadMemberSites(pagination);
+            return this.loadMemberSites(pagination, where);
         } else if (nodeId === '-favorites-') {
-            return this.loadFavorites(pagination, includeFields);
+            return this.loadFavorites(pagination, includeFields, where);
         } else if (nodeId === '-recent-') {
             return this.getRecentFiles('-me-', pagination);
         }

--- a/lib/content-services/src/lib/document-list/services/document-list.service.ts
+++ b/lib/content-services/src/lib/document-list/services/document-list.service.ts
@@ -171,7 +171,7 @@ export class DocumentListService implements DocumentListLoader {
      */
     loadFolderByNodeId(nodeId: string, pagination: PaginationModel, includeFields: string[], where?: string): Observable<DocumentLoaderNode> {
         if (this.customResourcesService.isCustomSource(nodeId)) {
-            return this.customResourcesService.loadFolderByNodeId(nodeId, pagination, includeFields).pipe(
+            return this.customResourcesService.loadFolderByNodeId(nodeId, pagination, includeFields, where).pipe(
                 map((result: any) => new DocumentLoaderNode(null, result))
             );
         } else {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
[ADF-5087](https://issues.alfresco.com/jira/browse/ADF-5087)


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
