### PR TITLE
[ADF-5092] Change card view label color

### DIFF
--- a/lib/core/card-view/components/card-view/card-view.component.scss
+++ b/lib/core/card-view/components/card-view/card-view.component.scss
@@ -10,7 +10,7 @@
 
             .adf-property-label {
                 font-size: 12px;
-                color: mat-color($foreground, text, 0.4);
+                color: mat-color($foreground, text, 0.54);
                 word-wrap: break-word;
             }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe: Styling


**What is the current behaviour?** (You can also link to an open issue here)
Color of card view labels is slightly too light (black with 0.4 opacity).


**What is the new behaviour?**
Color of card view label now balck with 0.54 opacity (2nd grey of design spec) . 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-5092