### PR TITLE
[ADF-5095] Update text color of share dialog

### DIFF
--- a/lib/content-services/src/lib/content-node-share/content-node-share.dialog.scss
+++ b/lib/content-services/src/lib/content-node-share/content-node-share.dialog.scss
@@ -1,71 +1,75 @@
-@mixin adf-share-link-typography {
+@mixin adf-share-link-typography($foreground) {
     letter-spacing: -0.4px;
     line-height: 2;
     font-weight: normal;
     font-style: normal;
     font-stretch: normal;
     font-size: 16px;
-    opacity: 0.87;
+    color: mat-color($foreground, text, 0.87);
 }
-.adf-float-label {
-   padding-top: 20px;
-}
-.adf-share-link-dialog {
+@mixin adf-content-node-share-theme($theme) {
+    $foreground: map-get($theme, foreground);
 
-    .adf-share-link {
-        &__dialog-content {
-            display: flex;
-            flex-direction: column;
+    .adf-float-label {
+       padding-top: 20px;
+    }
+    .adf-share-link-dialog {
+
+        .adf-share-link {
+            &__dialog-content {
+                display: flex;
+                flex-direction: column;
+            }
+
+            &__label {
+                @include adf-share-link-typography($foreground);
+                flex: 1 1 auto;
+            }
+
+            &__title {
+                @include adf-share-link-typography($foreground);
+            }
+
+            &__info {
+                @include adf-share-link-typography($foreground);
+                color: mat-color($foreground, text, 0.54);
+                font-size: 13px;
+            }
+
+            &--row {
+                display: flex;
+                flex-direction: row;
+                flex-wrap: wrap;
+                align-items: center;
+            }
+
+            &__input {
+                color: mat-color($foreground, text, 0.87);
+            }
         }
 
-        &__label {
-            @include adf-share-link-typography;
-            flex: 1 1 auto;
+        .adf-input-action {
+            cursor: pointer;
         }
 
-        &__title {
-            @include adf-share-link-typography;
+        .adf-full-width {
+            width: 100%;
         }
 
-        &__info {
-            @include adf-share-link-typography;
-            opacity: 0.54;
-            font-size: 13px;
+        .mat-form-field-infix {
+            border-top: unset;
         }
 
-        &--row {
-            display: flex;
-            flex-direction: row;
-            flex-wrap: wrap;
+        .mat-dialog-actions {
+            justify-content: flex-end;
+
+            & > button {
+                text-transform: uppercase;
+            }
+        }
+
+        .mat-form-field-flex {
             align-items: center;
         }
-
-        &__input {
-            opacity: 0.54;
-        }
-    }
-
-    .adf-input-action {
-        cursor: pointer;
-    }
-
-    .adf-full-width {
-        width: 100%;
-    }
-
-    .mat-form-field-infix {
-        border-top: unset;
-    }
-
-    .mat-dialog-actions {
-        justify-content: flex-end;
-
-        & > button {
-            text-transform: uppercase;
-        }
-    }
-
-    .mat-form-field-flex {
-        align-items: center;
     }
 }

--- a/lib/content-services/src/lib/styles/_index.scss
+++ b/lib/content-services/src/lib/styles/_index.scss
@@ -16,6 +16,7 @@
 @import '../dialogs/folder.dialog';
 
 @import '../content-node-selector/content-node-selector.component';
+@import '../content-node-share/content-node-share.dialog';
 @import '../content-metadata/content-metadata.module';
 @import '../permission-manager/components/permission-list/permission-list.component';
 @import '../permission-manager/components/add-permission/add-permission.component';
@@ -26,7 +27,8 @@
 @mixin adf-content-services-theme($theme) {
     @include adf-breadcrumb-theme($theme);
     @include adf-breadcrumb-dropdown-theme($theme);
-    @include adf-content-node-selector-theme($theme) ;
+    @include adf-content-node-selector-theme($theme);
+    @include adf-content-node-share-theme($theme);
     @include adf-name-location-cell-theme($theme);
     @include adf-document-list-theme($theme) ;
     @include adf-file-uploading-row-theme($theme);
@@ -36,7 +38,7 @@
     @include adf-search-autocomplete-theme($theme);
     @include adf-search-sorting-picker-theme($theme);
     @include adf-dialog-theme($theme);
-    @include adf-content-node-selector-dialog-theme($theme) ;
+    @include adf-content-node-selector-dialog-theme($theme);
     @include adf-content-metadata-module-theme($theme);
     @include adf-permission-list-theme($theme);
     @include adf-add-permission-theme($theme);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe: Styling


**What is the current behaviour?** (You can also link to an open issue here)
Share dialog texts are too light for AA accesibility.


**What is the new behaviour?**
Share dialog texts are darker (.54 or .87 opacity) and refactor for consistency.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-5095