### PR TITLE
[ACA-2956] Add event emitter when processDefinition selection changes…

### DIFF
--- a/docs/process-services-cloud/components/start-process-cloud.component.md
+++ b/docs/process-services-cloud/components/start-process-cloud.component.md
@@ -52,6 +52,7 @@ Starts a process.
 | error | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`ProcessInstanceCloud`](../../../lib/process-services-cloud/src/lib/process/start-process/models/process-instance-cloud.model.ts)`>` | Emitted when an error occurs. |
 | formContentClicked | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`ContentLinkModel`](../../../lib/core/form/components/widgets/core/content-link.model.ts)`>` | Emitted when form content is clicked. |
 | success | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`ProcessInstanceCloud`](../../../lib/process-services-cloud/src/lib/process/start-process/models/process-instance-cloud.model.ts)`>` | Emitted when the process is successfully started. |
+| processDefinitionSelection | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`ProcessDefinitionCloud`](../../../lib/process-services-cloud/src/lib/process/start-process/models/process-definition-cloud.model.ts)`>` |  Emitted when process definition selection changes. |
 
 ## Details
 

--- a/docs/process-services/components/start-process.component.md
+++ b/docs/process-services/components/start-process.component.md
@@ -53,6 +53,7 @@ Starts a process.
 | cancel | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`ProcessInstance`](../../../lib/process-services/src/lib/process-list/models/process-instance.model.ts)`>` | Emitted when the process is canceled. |
 | error | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`ProcessInstance`](../../../lib/process-services/src/lib/process-list/models/process-instance.model.ts)`>` | Emitted when an error occurs. |
 | start | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`ProcessInstance`](../../../lib/process-services/src/lib/process-list/models/process-instance.model.ts)`>` | Emitted when the process starts. |
+| processDefinitionSelection | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`ProcessDefinitionRepresentation`](../../../lib/process-services/src/lib/process-list/models/process-definition.model.ts)`>` |  Emitted when process definition selection changes. |
 
 ## Details
 

--- a/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.html
+++ b/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.html
@@ -33,7 +33,8 @@
                     id="processDefinitionName">
                 <div class="adf-process-input-autocomplete">
                     <mat-autocomplete #auto="matAutocomplete" id="processDefinitionOptions" [displayWith]="displayProcessNameOnDropdown" (optionSelected)="setProcessDefinitionOnForm($event.option.value)">
-                        <mat-option *ngFor="let processDef of filteredProcesses" [value]="getProcessDefinitionValue(processDef)">
+                        <mat-option *ngFor="let processDef of filteredProcesses" [value]="getProcessDefinitionValue(processDef)"
+                                    (click)="processDefinitionSelectionChanged(processDef)">
                             {{ getProcessDefinitionValue(processDef) }}
                         </mat-option>
                     </mat-autocomplete>

--- a/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.spec.ts
@@ -534,5 +534,14 @@ describe('StartProcessCloudComponent', () => {
             fixture.detectChanges();
             expect(processInstanceName.valid).toBeTruthy();
         });
+
+        it('should emit processDefinitionSelection event when a process definition is selected', (done) => {
+            component.processDefinitionSelection.subscribe((processDefinition) => {
+                expect(processDefinition).toEqual(fakeProcessDefinitions[0]);
+                done();
+            });
+            fixture.detectChanges();
+            selectOptionByName(fakeProcessDefinitions[0].name);
+        });
     });
 });

--- a/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.ts
@@ -88,6 +88,10 @@ export class StartProcessCloudComponent implements OnChanges, OnInit, OnDestroy 
     @Output()
     formContentClicked: EventEmitter<ContentLinkModel> = new EventEmitter();
 
+    /** Emitted when process definition selection changes. */
+    @Output()
+    processDefinitionSelection: EventEmitter<ProcessDefinitionCloud> = new EventEmitter<ProcessDefinitionCloud>();
+
     processDefinitionList: ProcessDefinitionCloud[] = [];
     processDefinitionCurrent: ProcessDefinitionCloud;
     errorMessageId: string = '';
@@ -310,6 +314,10 @@ export class StartProcessCloudComponent implements OnChanges, OnInit, OnDestroy 
 
     onFormContentClicked(content: ContentLinkModel) {
         this.formContentClicked.emit(content);
+    }
+
+    processDefinitionSelectionChanged(processDefinition) {
+        this.processDefinitionSelection.emit(processDefinition);
     }
 
     ngOnDestroy() {

--- a/lib/process-services/src/lib/process-list/components/start-process.component.html
+++ b/lib/process-services/src/lib/process-list/components/start-process.component.html
@@ -30,7 +30,8 @@
                     #auto="matAutocomplete"
                     id="processDefinitionOptions"
                     [displayWith]="displayFn">
-                    <mat-option *ngFor="let processDef of filteredProcesses | async" [value]="processDef.name">
+                    <mat-option *ngFor="let processDef of filteredProcesses | async" [value]="processDef.name"
+                    (click)="processDefinitionSelectionChanged(processDef)">
                         {{ processDef.name }}
                     </mat-option>
                 </mat-autocomplete>

--- a/lib/process-services/src/lib/process-list/components/start-process.component.spec.ts
+++ b/lib/process-services/src/lib/process-list/components/start-process.component.spec.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { SimpleChange } from '@angular/core';
+import { DebugElement, SimpleChange } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivitiContentService, AppConfigService, FormService, setupTestBed } from '@alfresco/adf-core';
 import { of, throwError } from 'rxjs';
@@ -32,6 +32,7 @@ import {
 } from '../../mock';
 import { StartProcessInstanceComponent } from './start-process.component';
 import { ProcessTestingModule } from '../../testing/process.testing.module';
+import { By } from '@angular/platform-browser';
 
 describe('StartFormComponent', () => {
 
@@ -51,6 +52,19 @@ describe('StartFormComponent', () => {
             ProcessTestingModule
         ]
     });
+
+    const selectOptionByName = (name: string) => {
+
+        const selectElement = fixture.nativeElement.querySelector('button#adf-select-process-dropdown');
+        selectElement.click();
+        fixture.detectChanges();
+        const options: any = fixture.debugElement.queryAll(By.css('.mat-option-text'));
+        const currentOption = options.find( (option: DebugElement) => option.nativeElement.innerHTML.trim() === name );
+
+        if (currentOption) {
+            currentOption.nativeElement.click();
+        }
+    };
 
     beforeEach(() => {
         appConfig = TestBed.get(AppConfigService);
@@ -488,6 +502,15 @@ describe('StartFormComponent', () => {
             component.name = 'my:Process';
             component.startProcess();
             fixture.detectChanges();
+        });
+
+        it('should emit processDefinitionSelection event when a process definition is selected', (done) => {
+            component.processDefinitionSelection.subscribe((processDefinition) => {
+                expect(processDefinition).toEqual(testProcessDef);
+                done();
+            });
+            fixture.detectChanges();
+            selectOptionByName(testProcessDef.name);
         });
 
         it('should not emit start event when start the process without select a process and name', () => {

--- a/lib/process-services/src/lib/process-list/components/start-process.component.ts
+++ b/lib/process-services/src/lib/process-list/components/start-process.component.ts
@@ -88,6 +88,10 @@ export class StartProcessInstanceComponent implements OnChanges, OnInit, OnDestr
     @Output()
     error: EventEmitter<ProcessInstance> = new EventEmitter<ProcessInstance>();
 
+    /** Emitted when process definition selection changes. */
+    @Output()
+    processDefinitionSelection: EventEmitter<ProcessDefinitionRepresentation> = new EventEmitter<ProcessDefinitionRepresentation>();
+
     @ViewChild('startForm')
     startForm: StartFormComponent;
 
@@ -316,5 +320,9 @@ export class StartProcessInstanceComponent implements OnChanges, OnInit, OnDestr
 
     get nameController(): AbstractControl {
         return this.processNameInput;
+    }
+
+    processDefinitionSelectionChanged(processDefinition) {
+        this.processDefinitionSelection.emit(processDefinition);
     }
 }


### PR DESCRIPTION
… (for both APS and CLOUD)

**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [X] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [X] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
For the needs of this ticket https://issues.alfresco.com/jira/browse/ACA-2956 we need to expose the process definition selection when it changes.

**What is the new behaviour?**
Event emitters for both APS and Process Services Cloud have been added on the start-process components.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
