### PR TITLE
[ADF-5101] Change empty folder text display colors

### DIFF
--- a/lib/content-services/src/lib/document-list/components/document-list.component.scss
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.scss
@@ -126,20 +126,18 @@
 
         &-this-space-is-empty {
             height: 32px;
-            opacity: 0.26;
             font-size: 24px;
             line-height: 1.33;
             letter-spacing: -1px;
-            color: mat-color($foreground, text);
+            color: mat-color($foreground, text, 0.54);
         }
 
         &-drag-drop {
             min-height: 56px;
-            opacity: 0.54;
             font-size: 53px;
             line-height: 1;
             letter-spacing: -2px;
-            color: mat-color($foreground, text);
+            color: mat-color($foreground, text, 0.72);
             margin-top: 40px;
             word-break: break-all;
             white-space: pre-line;
@@ -151,11 +149,10 @@
 
         &-any-files-here-to-add {
             min-height: 24px;
-            opacity: 0.54;
             font-size: 16px;
             line-height: 1.5;
             letter-spacing: -0.4px;
-            color: mat-color($foreground, text);
+            color: mat-color($foreground, text, 0.72);
             margin-top: 17px;
             word-break: break-all;
             white-space: pre-line;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe: Styling


**What is the current behaviour?** (You can also link to an open issue here)
Some texts in the empty folder element displayed in the document-list component when the current folder is empty are laking of contrast with their background for AA accessibility.


**What is the new behaviour?**
New colors (Cf primary and secondary black in Design System) of text meet AA accessibility.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-5101