### PR TITLE
[ADF-4264] Fixed the breadcrumb when changing to custom site in node selector

### DIFF
--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.spec.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.spec.ts
@@ -439,6 +439,12 @@ describe('ContentNodeSelectorComponent', () => {
                 expect(component.chosenNode).toBeNull();
             }));
 
+            it('should update the breadcrumb when changing to a custom site', fakeAsync(() => {
+                component.siteChanged(<SiteEntry> { entry: { guid: '-mysites-', title: 'My Sites' } });
+
+                expect(component.breadcrumbFolderTitle).toBe('My Sites');
+            }));
+
             it('should call the search api on changing the site selectBox value', fakeAsync(() => {
                 typeToSearchBox('vegeta');
 

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.ts
@@ -394,6 +394,7 @@ export class ContentNodeSelectorPanelComponent implements OnInit, OnDestroy {
     onFolderChange(): void {
         this.showingSearchResults = false;
         this.infiniteScroll = false;
+        this.breadcrumbFolderTitle = null;
         this.clearSearch();
     }
 
@@ -459,6 +460,10 @@ export class ContentNodeSelectorPanelComponent implements OnInit, OnDestroy {
     setTitleIfCustomSite(site: SiteEntry) {
         if (this.customResourcesService.isCustomSource(site.entry.guid)) {
             this.breadcrumbFolderTitle = site.entry.title;
+            if (this.documentList.folderNode.path.elements) {
+                this.breadcrumbFolderNode.name = site.entry.title;
+                this.documentList.folderNode.path.elements = null;
+            }
         } else {
             this.breadcrumbFolderTitle = null;
         }

--- a/lib/content-services/src/lib/document-list/components/document-list.component.ts
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.ts
@@ -843,14 +843,13 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
         if (err.message) {
             try {
                 if (JSON.parse(err.message).error.statusCode === 403) {
-                    this.setLoadingState(false);
                     this.noPermission = true;
                 }
             } catch (error) {
             }
         }
+        this.setLoadingState(false);
         this.error.emit(err);
-
     }
 
 }

--- a/lib/core/datatable/components/datatable/datatable.component.scss
+++ b/lib/core/datatable/components/datatable/datatable.component.scss
@@ -267,8 +267,8 @@
         .adf-datatable-row {
             display: flex;
             align-items: center;
-            padding-left: 20px;
-            padding-right: 20px;
+            padding-left: 15px;
+            padding-right: 15px;
 
             .adf-datatable-checkbox {
                 max-width: $data-table-thumbnail-width;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x ] Bugfix
> - [ ] Feature
> - [x ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

When changing to a custom site in node-selector (custom site list) the breadcrumb would not update for the corresponding site title. Also there was an issue with the breadcrumb path to the root and it was not displaying correctly the path.
When changing to a not existing site the spinner for the document list would not finish and even though there was an error in console the UI never throw it.
The document list was not alligned with the breadcrumb.

**What is the new behaviour?**

Fixed the issues above and now the current breadcrumb folder is displaying correct and also the path to the root if navigating inside.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
