### PR TITLE
[ADF-5102] Added indeterminate state for 'select all' in datatable

### DIFF
--- a/lib/core/datatable/components/datatable/datatable.component.html
+++ b/lib/core/datatable/components/datatable/datatable.component.html
@@ -18,7 +18,7 @@
             </div>
             <!-- Columns -->
             <div *ngIf="multiselect" class="adf-datatable-cell-header adf-datatable-checkbox">
-                <mat-checkbox [checked]="isSelectAllChecked" (change)="onSelectAllClick($event)" class="adf-checkbox-sr-only">{{ 'ADF-DATATABLE.ACCESSIBILITY.SELECT_ALL' | translate }}</mat-checkbox>
+                <mat-checkbox [indeterminate]="isSelectAllIndeterminate" [checked]="isSelectAllChecked" (change)="onSelectAllClick($event)" class="adf-checkbox-sr-only">{{ 'ADF-DATATABLE.ACCESSIBILITY.SELECT_ALL' | translate }}</mat-checkbox>
             </div>
             <div class="adf-datatable-cell--{{col.type || 'text'}} {{col.cssClass}} adf-datatable-cell-header"
                  *ngFor="let col of data.getColumns()"

--- a/lib/core/datatable/components/datatable/datatable.component.spec.ts
+++ b/lib/core/datatable/components/datatable/datatable.component.spec.ts
@@ -918,6 +918,31 @@ describe('DataTable', () => {
         expect(dataTable.isSelectAllChecked).toBe(true);
     });
 
+    it('should have indeterminate state for "select all" when at least 1 row is selected or not all rows', () => {
+        dataTable.data = new ObjectDataTableAdapter(
+            [{ name: '1' }, { name: '2' }],
+            [
+                new ObjectDataColumn({ key: 'name', sortable: false }),
+                new ObjectDataColumn({ key: 'other', sortable: false })
+            ]
+        );
+        const rows = dataTable.data.getRows();
+
+        dataTable.multiselect = true;
+        dataTable.onCheckboxChange(rows[0], <MatCheckboxChange> { checked: true });
+        expect(dataTable.isSelectAllIndeterminate).toBe(true);
+        expect(dataTable.isSelectAllChecked).toBe(false);
+
+        dataTable.onCheckboxChange(rows[1], <MatCheckboxChange> { checked: true });
+        expect(dataTable.isSelectAllIndeterminate).toBe(false);
+        expect(dataTable.isSelectAllChecked).toBe(true);
+
+        dataTable.onCheckboxChange(rows[0], <MatCheckboxChange> { checked: false });
+        dataTable.onCheckboxChange(rows[1], <MatCheckboxChange> { checked: false });
+        expect(dataTable.isSelectAllIndeterminate).toBe(false);
+        expect(dataTable.isSelectAllChecked).toBe(false);
+    });
+
     it('should allow select row when multi-select enabled', () => {
         const data = new ObjectDataTableAdapter([{}, {}], []);
         const rows = data.getRows();

--- a/lib/core/datatable/components/datatable/datatable.component.ts
+++ b/lib/core/datatable/components/datatable/datatable.component.ts
@@ -178,6 +178,7 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck,
     noPermissionTemplate: TemplateRef<any>;
     loadingTemplate: TemplateRef<any>;
 
+    isSelectAllIndeterminate: boolean = false;
     isSelectAllChecked: boolean = false;
     selection = new Array<DataRow>();
 
@@ -529,6 +530,7 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck,
 
     onSelectAllClick(matCheckboxChange: MatCheckboxChange) {
         this.isSelectAllChecked = matCheckboxChange.checked;
+        this.isSelectAllIndeterminate = false;
 
         if (this.multiselect) {
             const rows = this.data.getRows();
@@ -552,6 +554,29 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck,
 
         const domEventName = newValue ? 'row-select' : 'row-unselect';
         this.emitRowSelectionEvent(domEventName, row);
+        this.checkSelectAllCheckboxState();
+    }
+
+    checkSelectAllCheckboxState() {
+        if (this.multiselect) {
+            let numberOfSelectedRows: number = 0;
+            const rows = this.data.getRows();
+            rows.forEach((row) => {
+                if (row.isSelected) {
+                    numberOfSelectedRows++;
+                }
+            });
+            if (numberOfSelectedRows === rows.length) {
+                this.isSelectAllChecked = true;
+                this.isSelectAllIndeterminate = false;
+            } else if (numberOfSelectedRows > 0 && numberOfSelectedRows < rows.length) {
+                this.isSelectAllChecked = false;
+                this.isSelectAllIndeterminate = true;
+            } else {
+                this.isSelectAllChecked = false;
+                this.isSelectAllIndeterminate = false;
+            }
+        }
     }
 
     onImageLoadingError(event: Event, row: DataRow) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://github.com/Alfresco/alfresco-ng2-components/issues/4422
https://issues.alfresco.com/jira/browse/ADF-5102
In the current state there is no indeterminate state for the checkbox. It is either checked when we enable the checkbox or either unchecked if we unselect all.

**What is the new behaviour?**

Created an indeterminate state that is enabled when there is at least 1 row selected or the number of rows selected is less with 1 than the number of all rows.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
