### PR TITLE
[ACA-2983] Changed the labels from the inputs name and type to always floating

### DIFF
--- a/lib/process-services/src/lib/process-list/components/start-process.component.html
+++ b/lib/process-services/src/lib/process-list/components/start-process.component.html
@@ -1,24 +1,13 @@
 <div class="adf-start-process">
-    <div class="title" *ngIf="title">{{ title | translate}}</div>
+    <div class="adf-title" *ngIf="title">{{ title | translate}}</div>
     <div class="content" *ngIf="isProcessDefinitionEmpty()">
         <div class="subtitle" id="error-message" *ngIf="errorMessageId">
             {{errorMessageId|translate}}
         </div>
-        <mat-form-field class="adf-process-input-container">
-            <input
-                matInput
-                placeholder="{{'ADF_PROCESS_LIST.START_PROCESS.FORM.LABEL.NAME' | translate}}"
-                [formControl]="processNameInput"
-                id="processName"
-                required/>
-                <mat-error *ngIf="nameController.hasError('maxlength')">
-                    {{ 'ADF_PROCESS_LIST.START_PROCESS.ERROR.MAXIMUM_LENGTH' | translate : { characters : maxProcessNameLength } }}
-                </mat-error>
-        </mat-form-field>
-        <mat-form-field class="adf-process-input-container">
+        <mat-form-field class="adf-process-input-container" [floatLabel]="'always'">
+            <mat-label>{{'ADF_PROCESS_LIST.START_PROCESS.FORM.LABEL.TYPE' | translate}}</mat-label>
             <input
                 type="text"
-                placeholder="{{'ADF_PROCESS_LIST.START_PROCESS.FORM.LABEL.TYPE'|translate}}"
                 matInput
                 [formControl]="processDefinitionInput"
                 [matAutocomplete]="auto"
@@ -42,6 +31,18 @@
                     <mat-icon>arrow_drop_down</mat-icon>
                 </button>
             </div>
+        </mat-form-field>
+
+        <mat-form-field class="adf-process-input-container" [floatLabel]="'always'">
+            <mat-label>{{'ADF_PROCESS_LIST.START_PROCESS.FORM.LABEL.NAME' | translate}}</mat-label>
+            <input
+                matInput
+                [formControl]="processNameInput"
+                id="processName"
+                required/>
+            <mat-error *ngIf="nameController.hasError('maxlength')">
+                {{ 'ADF_PROCESS_LIST.START_PROCESS.ERROR.MAXIMUM_LENGTH' | translate : { characters : maxProcessNameLength } }}
+            </mat-error>
         </mat-form-field>
 
         <adf-start-form

--- a/lib/process-services/src/lib/process-list/components/start-process.component.scss
+++ b/lib/process-services/src/lib/process-list/components/start-process.component.scss
@@ -1,60 +1,61 @@
-.adf {
-    &-start-process {
-        width: 96%;
-        margin-left: auto;
-        margin-right: auto;
-        margin-top: 10px;
-        .mat-select-trigger {
-            font-size: 14px !important;
+@mixin adf-process-services-create-theme($theme) {
+    .adf {
+        &-start-process {
+            width: 96%;
+            margin-left: auto;
+            margin-right: auto;
+            margin-top: 10px;
+            .mat-select-trigger {
+                font-size: 14px !important;
+            }
+            mat-form-field {
+                width: 100%;
+            }
+            mat-select {
+                width: 100%;
+                padding: 16px 0 0;
+            }
+            .mat-form-field-label {
+                color: map_get($mat-grey,A400);
+            }
+            .mat-content-actions {
+                text-align: right;
+            }
+            .mat-button {
+                text-transform: uppercase !important;
+            }
         }
-        mat-form-field {
-            width: 100%;
+        &-title {
+            padding-bottom: 1.25em;
         }
-        mat-select {
-            width: 100%;
-            padding: 16px 0 0;
+        &-process-input-container {
+            mat-form-field {
+                width: 100%;
+            }
         }
-        .mat-form-field-label {
-            color: #bababa;
+        &-process-input-autocomplete {
+            display: flex;
+            button {
+                position: absolute;
+                right: -14px;
+                top: 0;
+            }
         }
-        .mat-content-actions {
-            text-align: right;
+        &-start-form-container {
+            .mat-card {
+                box-shadow: none !important;
+                padding: 0 !important;
+            }
         }
-        .mat-button {
-            text-transform: uppercase !important;
+        &-start-form-actions {
+            text-align: right !important;
         }
     }
-    &-title {
-        padding-bottom: 1.25em;
-    }
-    &-process-input-container {
-        mat-form-field {
-            width: 100%;
+    @media (max-width: 600px) {
+        .adf-start-process {
+            width: 90%;
+            margin-left: auto;
+            margin-right: auto;
         }
-    }
-    &-process-input-autocomplete {
-        display: flex;
-        button {
-            position: absolute;
-            right: -14px;
-            top: 0;
-        }
-    }
-    &-start-form-container {
-        .mat-card {
-            box-shadow: none !important;
-            padding: 0 !important;
-        }
-    }
-    &-start-form-actions {
-        text-align: right !important;
-    }
-}
-
-@media (max-width: 600px) {
-    .adf-start-process {
-        width: 90%;
-        margin-left: auto;
-        margin-right: auto;
     }
 }

--- a/lib/process-services/src/lib/process-list/components/start-process.component.scss
+++ b/lib/process-services/src/lib/process-list/components/start-process.component.scss
@@ -16,7 +16,7 @@
                 padding: 16px 0 0;
             }
             .mat-form-field-label {
-                color: mat-color($mat-grey,A400);
+                color: mat-color($mat-grey, A400);
             }
             .mat-content-actions {
                 text-align: right;

--- a/lib/process-services/src/lib/process-list/components/start-process.component.scss
+++ b/lib/process-services/src/lib/process-list/components/start-process.component.scss
@@ -24,7 +24,7 @@
             text-transform: uppercase !important;
         }
     }
-    &-title  {
+    &-title {
         padding-bottom: 1.25em;
     }
     &-process-input-container {

--- a/lib/process-services/src/lib/process-list/components/start-process.component.scss
+++ b/lib/process-services/src/lib/process-list/components/start-process.component.scss
@@ -14,12 +14,18 @@
             width: 100%;
             padding: 16px 0 0;
         }
+        .mat-form-field-label {
+            color: #bababa;
+        }
         .mat-content-actions {
             text-align: right;
         }
         .mat-button {
             text-transform: uppercase !important;
         }
+    }
+    &-title  {
+        padding-bottom: 1.25em;
     }
     &-process-input-container {
         mat-form-field {

--- a/lib/process-services/src/lib/process-list/components/start-process.component.scss
+++ b/lib/process-services/src/lib/process-list/components/start-process.component.scss
@@ -16,7 +16,7 @@
                 padding: 16px 0 0;
             }
             .mat-form-field-label {
-                color: map_get($mat-grey,A400);
+                color: mat-color($mat-grey,A400);
             }
             .mat-content-actions {
                 text-align: right;

--- a/lib/process-services/src/lib/process-list/components/start-process.component.spec.ts
+++ b/lib/process-services/src/lib/process-list/components/start-process.component.spec.ts
@@ -148,6 +148,22 @@ describe('StartFormComponent', () => {
                 });
             }));
 
+            it('should have labels for process name and type', async(() => {
+                component.processDefinitionInput.setValue('My Default Name');
+                component.processNameInput.setValue('claim');
+                const inputLabelsNodes = document.querySelectorAll('.adf-start-process .adf-process-input-container mat-label');
+                expect(inputLabelsNodes.length).toBe(2);
+            }));
+
+            it('should have floating labels for process name and type', async(() => {
+                component.processDefinitionInput.setValue('My Default Name');
+                component.processNameInput.setValue('claim');
+                const inputLabelsNodes = document.querySelectorAll('.adf-start-process .adf-process-input-container');
+                inputLabelsNodes.forEach(labelNode => {
+                    expect(labelNode.getAttribute('ng-reflect-float-label')).toBe('always');
+                });
+            }));
+
             it('should load start form from service', async(() => {
                 fixture.detectChanges();
                 fixture.whenStable().then(() => {

--- a/lib/process-services/src/lib/process-list/components/start-process.component.ts
+++ b/lib/process-services/src/lib/process-list/components/start-process.component.ts
@@ -37,7 +37,6 @@ import { MinimalNode, RelatedContentRepresentation } from '@alfresco/js-api';
 @Component({
     selector: 'adf-start-process',
     templateUrl: './start-process.component.html',
-    styleUrls: ['./start-process.component.scss'],
     encapsulation: ViewEncapsulation.None
 })
 export class StartProcessInstanceComponent implements OnChanges, OnInit, OnDestroy {

--- a/lib/process-services/src/lib/styles/_index.scss
+++ b/lib/process-services/src/lib/styles/_index.scss
@@ -10,6 +10,7 @@
 @import '../app-list/apps-list.component';
 @import '../content-widget/attach-file-widget-dialog.component';
 @import '../form/start-form.component';
+@import '../process-list/components/start-process.component';
 
 @mixin adf-process-services-theme($theme) {
     @include adf-process-filters-theme($theme);
@@ -24,4 +25,5 @@
     @include adf-task-standalone-component-theme($theme);
     @include adf-attach-file-widget-dialog-component-theme($theme);
     @include adf-start-form-component-theme($theme);
+    @include adf-process-services-create-theme($theme);
  }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [x] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://issues.alfresco.com/jira/browse/ACA-2983
The labels from creating a new process (process name and type) are in the same position as the place holder.

**What is the new behaviour?**

Added floating labels from the 2 inputs and switched the positions of the 2 inputs.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
