### PR TITLE
[ADF-5104] Change color of location text

### DIFF
--- a/lib/content-services/src/lib/content-node-selector/name-location-cell/name-location-cell.component.scss
+++ b/lib/content-services/src/lib/content-node-selector/name-location-cell/name-location-cell.component.scss
@@ -4,7 +4,7 @@
     .adf-name-location-cell {
         display: grid;
         &-location {
-            color: mat-color($foreground, base, 0.5);
+            color: mat-color($foreground, base, 0.54);
             font-size: 12px;
         }
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe: Styling


**What is the current behaviour?** (You can also link to an open issue here)
Color of location text is rgba(0,0,0,0.5) and have only 4:1 contrast ratio with the background.


**What is the new behaviour?**
Color of location text is rgba(0,0,0,0.54) that gives it 4.6:1 contrast ratio with the background.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-5104