### PR TITLE
[ADF-5105] Force color of header button of upload dialog

### DIFF
--- a/lib/content-services/src/lib/upload/components/file-uploading-dialog.component.scss
+++ b/lib/content-services/src/lib/upload/components/file-uploading-dialog.component.scss
@@ -36,6 +36,7 @@
                 min-width: 0;
                 padding: 0;
                 line-height: 0;
+                color: mat-color($foreground, text, 0.54) !important;
             }
         }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe: Styling


**What is the current behaviour?** (You can also link to an open issue here)
When an upload has canceled the color of the button in the header is being disabled. That change its color to rgba(0,0,0,0.26) which have a too low contrast ratio for AA accessibility.


**What is the new behaviour?**
Now the color of this button is always rgba(0,0,0,54).


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-5105