### PR TITLE
Ability to check if loggedIn based on provider

### DIFF
--- a/lib/core/services/authentication.service.spec.ts
+++ b/lib/core/services/authentication.service.spec.ts
@@ -76,7 +76,7 @@ describe('AuthenticationService', () => {
             expect(apiService.getInstance).toHaveBeenCalled();
         });
 
-        it('should check if loggedin on ECM in case the priveder is ECM', () => {
+        it('should check if loggedin on ECM in case the provider is ECM', () => {
             spyOn(authService, 'isEcmLoggedIn').and.returnValue(true);
             expect(authService.isLoggedInWith('ECM')).toBe(true);
         });
@@ -203,7 +203,7 @@ describe('AuthenticationService', () => {
             expect(apiService.getInstance).not.toHaveBeenCalled();
         });
 
-        it('should check if loggedin on BPM in case the priveder is BPM', () => {
+        it('should check if loggedin on BPM in case the provider is BPM', () => {
             spyOn(authService, 'isBpmLoggedIn').and.returnValue(true);
             expect(authService.isLoggedInWith('BPM')).toBe(true);
         });

--- a/lib/core/services/authentication.service.spec.ts
+++ b/lib/core/services/authentication.service.spec.ts
@@ -76,6 +76,11 @@ describe('AuthenticationService', () => {
             expect(apiService.getInstance).toHaveBeenCalled();
         });
 
+        it('should check if loggedin on ECM in case the priveder is ECM', () => {
+            spyOn(authService, 'isEcmLoggedIn').and.returnValue(true);
+            expect(authService.isLoggedInWith('ECM')).toBe(true);
+        });
+
         it('should require remember me set for ECM check', () => {
             spyOn(cookie, 'isEnabled').and.returnValue(true);
             spyOn(authService, 'isRememberMeSet').and.returnValue(false);
@@ -196,6 +201,11 @@ describe('AuthenticationService', () => {
 
             expect(authService.isBpmLoggedIn()).toBeFalsy();
             expect(apiService.getInstance).not.toHaveBeenCalled();
+        });
+
+        it('should check if loggedin on BPM in case the priveder is BPM', () => {
+            spyOn(authService, 'isBpmLoggedIn').and.returnValue(true);
+            expect(authService.isLoggedInWith('BPM')).toBe(true);
         });
 
         it('should not require cookie service enabled for BPM check', () => {

--- a/lib/core/services/authentication.service.ts
+++ b/lib/core/services/authentication.service.ts
@@ -61,6 +61,16 @@ export class AuthenticationService {
         return this.alfrescoApi.getInstance().isLoggedIn();
     }
 
+    isLoggedInWith(provider: string) {
+        if (provider === 'BPM') {
+            return this.isBpmLoggedIn();
+        } else if (provider === 'ECM') {
+            return this.isEcmLoggedIn();
+        } else {
+            return this.isLoggedIn();
+        }
+    }
+
     /**
      * Does the provider support OAuth?
      * @returns True if supported, false otherwise

--- a/lib/core/services/authentication.service.ts
+++ b/lib/core/services/authentication.service.ts
@@ -61,7 +61,7 @@ export class AuthenticationService {
         return this.alfrescoApi.getInstance().isLoggedIn();
     }
 
-    isLoggedInWith(provider: string) {
+    isLoggedInWith(provider: string): boolean {
         if (provider === 'BPM') {
             return this.isBpmLoggedIn();
         } else if (provider === 'ECM') {

--- a/lib/extensions/src/lib/config/navbar.extensions.ts
+++ b/lib/extensions/src/lib/config/navbar.extensions.ts
@@ -25,6 +25,7 @@ export interface NavBarLinkRef extends ExtensionElement {
     icon: string;
     title: string;
     route: string;
+    provider?: string;
 
     url?: string; // evaluated at runtime based on route ref
     description?: string;

--- a/lib/extensions/src/lib/config/schema/plugin-extension.schema.json
+++ b/lib/extensions/src/lib/config/schema/plugin-extension.schema.json
@@ -178,6 +178,11 @@
           "description": "Unique identifier",
           "type": "string"
         },
+        "provider": {
+          "description": "Define on which system the user should be authenticate",
+          "type": "string",
+          "enum": ["BPM", "ECM", "ALL"]
+        },
         "icon": {
           "description": "Element icon",
           "type": "string"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
There is no way to know if user is loggedin base on external provider


**What is the new behaviour?**
Provide a way to check if user is loggedin base on external provider



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
