### PR TITLE
[ADF-155] Tags displayed only when they are referenced at least once

### DIFF
--- a/e2e/pages/adf/tag.page.ts
+++ b/e2e/pages/adf/tag.page.ts
@@ -135,7 +135,7 @@ export class TagPage {
 
     async checkListIsSorted(sortOrder, locator): Promise<boolean> {
         const tagList: ElementArrayFinder = element.all(locator);
-        await BrowserVisibility.waitUntilElementIsVisible(tagList.first());
+        await BrowserVisibility.waitUntilElementIsPresent(tagList.last());
         const initialList = [];
         await tagList.each(async (currentElement) => {
             const text = await BrowserActions.getText(currentElement);

--- a/lib/content-services/src/lib/tag/tag-list.component.html
+++ b/lib/content-services/src/lib/tag/tag-list.component.html
@@ -1,6 +1,6 @@
 <mat-chip-list class="adf-tag-chips-list">
     <div class="adf-list-tag" *ngFor="let currentEntry of tagsEntries; let idx = index">
-        <mat-chip class="adf-primary-background-color">
+        <mat-chip class="adf-primary-background-color" *ngIf="currentEntry.entry.count">
             <span id="tag_name_{{idx}}">{{currentEntry.entry.tag}}</span>
         </mat-chip>
     </div>

--- a/lib/content-services/src/lib/tag/tag-list.component.html
+++ b/lib/content-services/src/lib/tag/tag-list.component.html
@@ -1,6 +1,6 @@
 <mat-chip-list class="adf-tag-chips-list">
     <div class="adf-list-tag" *ngFor="let currentEntry of tagsEntries; let idx = index">
-        <mat-chip class="adf-primary-background-color" *ngIf="currentEntry.entry.count">
+        <mat-chip class="adf-primary-background-color" *ngIf="currentEntry.entry?.count">
             <span id="tag_name_{{idx}}">{{currentEntry.entry.tag}}</span>
         </mat-chip>
     </div>

--- a/lib/content-services/src/lib/tag/tag-list.component.spec.ts
+++ b/lib/content-services/src/lib/tag/tag-list.component.spec.ts
@@ -34,9 +34,13 @@ describe('TagList', () => {
                 'maxItems': 100
             },
             'entries': [{
-                'entry': {'tag': 'test1', 'id': '0ee933fa-57fc-4587-8a77-b787e814f1d2'}
-            }, {'entry': {'tag': 'test2', 'id': 'fcb92659-1f10-41b4-9b17-851b72a3b597'}}, {
-                'entry': {'tag': 'test3', 'id': 'fb4213c0-729d-466c-9a6c-ee2e937273bf'}
+                'entry': {'tag': 'test1', 'id': '0ee933fa-57fc-4587-8a77-b787e814f1d2', 'count': 1}
+            }, {
+                'entry': {'tag': 'test2', 'id': 'fcb92659-1f10-41b4-9b17-851b72a3b597', 'count': 2}
+            }, {
+                'entry': {'tag': 'test3', 'id': 'e9593eee-a291-44ce-8db8-f881a7048f89', 'count': 1}
+            }, {
+                'entry': {'tag': 'test4', 'id': 'fb4213c0-729d-466c-9a6c-ee2e937273bf'}
             }]
         }
     };
@@ -69,7 +73,7 @@ describe('TagList', () => {
     });
 
     describe('Rendering tests', () => {
-        it('Tag list relative a single node should be rendered', (done) => {
+        it('should render all tags with one reference or more', (done) => {
             component.result.subscribe(() => {
                 fixture.detectChanges();
 
@@ -81,6 +85,10 @@ describe('TagList', () => {
             });
 
             component.ngOnInit();
+        });
+
+        it('should not render tag without reference', () => {
+            expect(element.querySelector('tag_name_3')).toBeNull();
         });
     });
 });

--- a/lib/content-services/src/lib/tag/tag-list.component.ts
+++ b/lib/content-services/src/lib/tag/tag-list.component.ts
@@ -64,7 +64,8 @@ export class TagListComponent implements OnInit, OnDestroy {
         this.defaultPagination = {
             skipCount: 0,
             maxItems: this.size,
-            hasMoreItems: false
+            hasMoreItems: false,
+            include: ['count']
         };
 
         this.pagination = this.defaultPagination;
@@ -102,7 +103,8 @@ export class TagListComponent implements OnInit, OnDestroy {
 
             this.refreshTag({
                 skipCount: this.pagination.skipCount + this.pagination.count,
-                maxItems: this.size
+                maxItems: this.size,
+                include: ['count']
             });
         }
     }

--- a/lib/core/models/pagination.model.ts
+++ b/lib/core/models/pagination.model.ts
@@ -19,6 +19,7 @@ import { Pagination } from '@alfresco/js-api';
 
 export class PaginationModel extends Pagination {
     merge?: boolean;
+    include?: string[];
 
     constructor(input?: any) {
         super(input);
@@ -26,6 +27,7 @@ export class PaginationModel extends Pagination {
             this.count = input.count;
             this.hasMoreItems = input.hasMoreItems ? input.hasMoreItems : false;
             this.merge = input.merge ? input.merge : false;
+            this.include = input.include ? input.include : [];
             this.totalItems = input.totalItems;
             this.skipCount = input.skipCount;
             this.maxItems = input.maxItems;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
All existing tags are displayed in the tag-list even if it has 0 reference in any node.


**What is the new behaviour?**
When a tag has 0 reference its is still stored in the FrontEnd but not rendered in the template.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-155