### PR TITLE
[ADF-5106] allow to redefine form widgets (APS 1.x and cloud)

### DIFF
--- a/lib/core/form/components/form-base.component.ts
+++ b/lib/core/form/components/form-base.component.ts
@@ -201,15 +201,11 @@ export abstract class FormBaseComponent {
         this.error.emit(err);
     }
 
-    abstract onRefreshClicked();
+    abstract onRefreshClicked(): void;
+    abstract saveTaskForm(): void;
+    abstract completeTaskForm(outcome?: string): void;
 
-    abstract saveTaskForm();
-
-    abstract completeTaskForm(outcome?: string);
-
-    protected abstract onTaskSaved(form: FormModel);
-
-    protected abstract storeFormAsMetadata();
-
-    protected abstract onExecuteOutcome(outcome: FormOutcomeModel);
+    protected abstract onTaskSaved(form: FormModel): void;
+    protected abstract storeFormAsMetadata(): void;
+    protected abstract onExecuteOutcome(outcome: FormOutcomeModel): boolean;
 }

--- a/lib/process-services-cloud/src/lib/form/components/cloud-form-rendering.service.ts
+++ b/lib/process-services-cloud/src/lib/form/components/cloud-form-rendering.service.ts
@@ -1,0 +1,38 @@
+/*!
+ * @license
+ * Copyright 2019 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Injectable } from '@angular/core';
+import { FormRenderingService } from '@alfresco/adf-core';
+import { AttachFileCloudWidgetComponent } from './widgets/attach-file/attach-file-cloud-widget.component';
+import { DropdownCloudWidgetComponent } from './widgets/dropdown/dropdown-cloud.widget';
+import { DateCloudWidgetComponent } from './widgets/date/date-cloud.widget';
+import { PeopleCloudWidgetComponent } from './widgets/people/people-cloud.widget';
+import { GroupCloudWidgetComponent } from './widgets/group/group-cloud.widget';
+
+@Injectable({
+    providedIn: 'root'
+})
+export class CloudFormRenderingService extends FormRenderingService {
+    constructor() {
+        super();
+        this.setComponentTypeResolver('upload', () => AttachFileCloudWidgetComponent, true);
+        this.setComponentTypeResolver('dropdown', () => DropdownCloudWidgetComponent, true);
+        this.setComponentTypeResolver('date', () => DateCloudWidgetComponent, true);
+        this.setComponentTypeResolver('people', () => PeopleCloudWidgetComponent, true);
+        this.setComponentTypeResolver('functional-group', () => GroupCloudWidgetComponent, true);
+    }
+}

--- a/lib/process-services-cloud/src/lib/form/components/form-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/form/components/form-cloud.component.ts
@@ -39,16 +39,15 @@ import {
 } from '@alfresco/adf-core';
 import { FormCloudService } from '../services/form-cloud.service';
 import { TaskVariableCloud } from '../models/task-variable-cloud.model';
-import { DropdownCloudWidgetComponent } from './widgets/dropdown/dropdown-cloud.widget';
-import { AttachFileCloudWidgetComponent } from './widgets/attach-file/attach-file-cloud-widget.component';
-import { DateCloudWidgetComponent } from './widgets/date/date-cloud.widget';
-import { PeopleCloudWidgetComponent } from './widgets/people/people-cloud.widget';
-import { GroupCloudWidgetComponent } from './widgets/group/group-cloud.widget';
 import { TaskDetailsCloudModel } from '../../task/start-task/models/task-details-cloud.model';
+import { CloudFormRenderingService } from './cloud-form-rendering.service';
 
 @Component({
     selector: 'adf-cloud-form',
-    templateUrl: './form-cloud.component.html'
+    templateUrl: './form-cloud.component.html',
+    providers: [
+        { provide: FormRenderingService, useClass: CloudFormRenderingService }
+    ]
 })
 export class FormCloudComponent extends FormBaseComponent implements OnChanges, OnDestroy {
 
@@ -113,21 +112,15 @@ export class FormCloudComponent extends FormBaseComponent implements OnChanges, 
     constructor(protected formCloudService: FormCloudService,
                 protected formService: FormService,
                 private notificationService: NotificationService,
-                private formRenderingService: FormRenderingService,
                 protected visibilityService: WidgetVisibilityService,
                 private appConfigService: AppConfigService) {
         super();
 
         this.formService.formContentClicked
-        .pipe(takeUntil(this.onDestroy$))
-        .subscribe((content) => {
-            this.formContentClicked.emit(content);
-        });
-        this.formRenderingService.setComponentTypeResolver('upload', () => AttachFileCloudWidgetComponent, true);
-        this.formRenderingService.setComponentTypeResolver('dropdown', () => DropdownCloudWidgetComponent, true);
-        this.formRenderingService.setComponentTypeResolver('date', () => DateCloudWidgetComponent, true);
-        this.formRenderingService.setComponentTypeResolver('people', () => PeopleCloudWidgetComponent, true);
-        this.formRenderingService.setComponentTypeResolver('functional-group', () => GroupCloudWidgetComponent, true);
+            .pipe(takeUntil(this.onDestroy$))
+            .subscribe((content) => {
+                this.formContentClicked.emit(content);
+            });
     }
 
     ngOnChanges(changes: SimpleChanges) {

--- a/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.ts
@@ -42,6 +42,8 @@ export class AttachFileCloudWidgetComponent extends UploadCloudWidgetComponent
     implements OnInit {
     static ACS_SERVICE = 'alfresco-content';
 
+    typeId = 'AttachFileCloudWidgetComponent';
+
     constructor(
         formService: FormService,
         logger: LogService,

--- a/lib/process-services-cloud/src/lib/form/components/widgets/date/date-cloud.widget.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/date/date-cloud.widget.ts
@@ -38,6 +38,7 @@ import { MOMENT_DATE_FORMATS, MomentDateAdapter, baseHost, WidgetComponent,
 })
 export class DateCloudWidgetComponent extends WidgetComponent implements OnInit, OnDestroy {
 
+    typeId = 'DateCloudWidgetComponent';
     DATE_FORMAT_CLOUD = 'YYYY-MM-DD';
 
     minDate: Moment;

--- a/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.ts
@@ -32,6 +32,7 @@ import { takeUntil } from 'rxjs/operators';
 })
 export class DropdownCloudWidgetComponent extends WidgetComponent implements OnInit, OnDestroy {
 
+    typeId = 'DropdownCloudWidgetComponent';
     protected onDestroy$ = new Subject<boolean>();
 
     constructor(public formService: FormService,

--- a/lib/process-services-cloud/src/lib/form/components/widgets/group/group-cloud.widget.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/group/group-cloud.widget.ts
@@ -33,6 +33,7 @@ export class GroupCloudWidgetComponent extends WidgetComponent implements OnInit
 
     private onDestroy$ = new Subject<boolean>();
 
+    typeId = 'GroupCloudWidgetComponent';
     roles: string[];
     mode: string;
     title: string;

--- a/lib/process-services-cloud/src/lib/form/components/widgets/people/people-cloud.widget.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/people/people-cloud.widget.ts
@@ -33,6 +33,7 @@ export class PeopleCloudWidgetComponent extends WidgetComponent implements OnIni
 
     private onDestroy$ = new Subject<boolean>();
 
+    typeId = 'PeopleCloudWidgetComponent';
     appName: string;
     roles: string[];
     mode: string;

--- a/lib/process-services-cloud/src/lib/form/public-api.ts
+++ b/lib/process-services-cloud/src/lib/form/public-api.ts
@@ -19,6 +19,7 @@ export * from './models/task-variable-cloud.model';
 
 export * from './components/form-cloud.component';
 export * from './components/form-definition-selector-cloud.component';
+export * from './components/cloud-form-rendering.service';
 
 export * from './services/form-cloud.service';
 export * from './services/form-definition-selector-cloud.service';

--- a/lib/process-services/src/lib/content-widget/attach-file-widget.component.ts
+++ b/lib/process-services/src/lib/content-widget/attach-file-widget.component.ts
@@ -55,6 +55,7 @@ import { AttachFileWidgetDialogService } from './attach-file-widget-dialog.servi
 })
 export class AttachFileWidgetComponent extends UploadWidgetComponent implements OnInit, OnDestroy {
 
+    typeId = 'AttachFileWidgetComponent';
     repositoryList = [];
     private tempFilesList = [];
     private onDestroy$ = new Subject<boolean>();

--- a/lib/process-services/src/lib/content-widget/attach-folder-widget.component.ts
+++ b/lib/process-services/src/lib/content-widget/attach-folder-widget.component.ts
@@ -45,6 +45,7 @@ import { Node } from '@alfresco/js-api';
 })
 export class AttachFolderWidgetComponent extends WidgetComponent implements OnInit {
 
+    typeId = 'AttachFolderWidgetComponent';
     hasFolder: boolean = false;
     selectedFolderName: string = '';
 

--- a/lib/process-services/src/lib/form/form.component.spec.ts
+++ b/lib/process-services/src/lib/form/form.component.spec.ts
@@ -16,7 +16,7 @@
  */
 
 import { SimpleChange, ComponentFactoryResolver, Injector, NgModule, Component } from '@angular/core';
-import { TestBed } from '@angular/core/testing';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { Observable, of, throwError } from 'rxjs';
 import { FormFieldModel, FormFieldTypes, FormModel, FormOutcomeEvent, FormOutcomeModel,
     FormService, WidgetVisibilityService, NodeService, ContainerModel, fakeForm,
@@ -29,32 +29,26 @@ import { ProcessFormRenderingService } from './process-form-rendering.service';
 
 describe('FormComponent', () => {
 
-    let formService: FormService;
+    let fixture: ComponentFixture<FormComponent>;
     let formComponent: FormComponent;
+
+    let formService: FormService;
     let visibilityService: WidgetVisibilityService;
     let nodeService: NodeService;
     let formRenderingService: ProcessFormRenderingService;
 
     @Component({
-        selector: 'adf-custom-upload-widget',
+        selector: 'adf-custom-widget',
         template: '<div></div>'
     })
-    class CustomUploadWidget {
-        typeId = 'CustomUploadWidget';
-    }
-
-    @Component({
-        selector: 'adf-custom-select-folder-widget',
-        template: '<div></div>'
-    })
-    class CustomSelectFolderWidget {
-        typeId = 'CustomSelectFolderWidget';
+    class CustomWidget {
+        typeId = 'CustomWidget';
     }
 
     @NgModule({
-        declarations: [CustomUploadWidget, CustomSelectFolderWidget],
-        exports: [CustomUploadWidget, CustomSelectFolderWidget],
-        entryComponents: [CustomUploadWidget, CustomSelectFolderWidget]
+        declarations: [CustomWidget],
+        exports: [CustomWidget],
+        entryComponents: [CustomWidget]
     })
     class CustomUploadModule {}
 
@@ -87,44 +81,32 @@ describe('FormComponent', () => {
         nodeService = TestBed.get(NodeService);
         formRenderingService = TestBed.get(ProcessFormRenderingService);
 
-        const fixture = TestBed.createComponent(FormComponent);
+        fixture = TestBed.createComponent(FormComponent);
         formComponent = fixture.componentInstance;
     });
 
-    it('should register own upload widget', () => {
-        const fixture = TestBed.createComponent(FormComponent);
-        expect(fixture.componentInstance).toBeDefined();
-
+    it('should register custom [upload] widget', () => {
         const widget = buildWidget('upload', fixture.componentRef.injector);
         expect(widget['typeId']).toBe('AttachFileWidgetComponent');
     });
 
-    it('should register own select-folder widget', () => {
-        const fixture = TestBed.createComponent(FormComponent);
-        expect(fixture.componentInstance).toBeDefined();
-
+    it('should register custom [select-folder] widget', () => {
         const widget = buildWidget('select-folder', fixture.componentRef.injector);
         expect(widget['typeId']).toBe('AttachFolderWidgetComponent');
     });
 
-    it('should allow to replace custom upload widget', () => {
-        formRenderingService.setComponentTypeResolver('upload', () => CustomUploadWidget, true);
-
-        const fixture = TestBed.createComponent(FormComponent);
-        expect(fixture.componentInstance).toBeDefined();
+    it('should allow to replace custom [upload] widget', () => {
+        formRenderingService.setComponentTypeResolver('upload', () => CustomWidget, true);
 
         const widget = buildWidget('upload', fixture.componentRef.injector);
-        expect(widget['typeId']).toBe('CustomUploadWidget');
+        expect(widget['typeId']).toBe('CustomWidget');
     });
 
-    it('should allow to replace custom select-folder widget', () => {
-        formRenderingService.setComponentTypeResolver('select-folder', () => CustomSelectFolderWidget, true);
-
-        const fixture = TestBed.createComponent(FormComponent);
-        expect(fixture.componentInstance).toBeDefined();
+    it('should allow to replace custom [select-folder] widget', () => {
+        formRenderingService.setComponentTypeResolver('select-folder', () => CustomWidget, true);
 
         const widget = buildWidget('select-folder', fixture.componentRef.injector);
-        expect(widget['typeId']).toBe('CustomSelectFolderWidget');
+        expect(widget['typeId']).toBe('CustomWidget');
     });
 
     it('should check form', () => {

--- a/lib/process-services/src/lib/form/form.component.ts
+++ b/lib/process-services/src/lib/form/form.component.ts
@@ -16,18 +16,21 @@
  */
 
 import { Component, EventEmitter, Input, Output, ViewEncapsulation, SimpleChanges, OnInit, OnDestroy, OnChanges } from '@angular/core';
-import { AttachFileWidgetComponent, AttachFolderWidgetComponent } from '../content-widget';
 import { EcmModelService, NodeService, WidgetVisibilityService,
     FormService, FormRenderingService, FormBaseComponent, FormOutcomeModel,
     FormEvent, FormErrorEvent, FormFieldModel,
     FormModel, FormOutcomeEvent, FormValues, ContentLinkModel } from '@alfresco/adf-core';
 import { Observable, of, Subject } from 'rxjs';
 import { switchMap, takeUntil } from 'rxjs/operators';
+import { ProcessFormRenderingService } from './process-form-rendering.service';
 
 @Component({
     selector: 'adf-form',
     templateUrl: './form.component.html',
-    encapsulation: ViewEncapsulation.None
+    encapsulation: ViewEncapsulation.None,
+    providers: [
+        { provide: FormRenderingService, useClass: ProcessFormRenderingService }
+    ]
 })
 export class FormComponent extends FormBaseComponent implements OnInit, OnDestroy, OnChanges {
 
@@ -86,11 +89,8 @@ export class FormComponent extends FormBaseComponent implements OnInit, OnDestro
     constructor(protected formService: FormService,
                 protected visibilityService: WidgetVisibilityService,
                 protected ecmModelService: EcmModelService,
-                protected nodeService: NodeService,
-                protected formRenderingService: FormRenderingService) {
+                protected nodeService: NodeService) {
         super();
-        this.formRenderingService.setComponentTypeResolver('upload', () => AttachFileWidgetComponent, true);
-        this.formRenderingService.setComponentTypeResolver('select-folder', () => AttachFolderWidgetComponent, true);
     }
 
     ngOnInit() {

--- a/lib/process-services/src/lib/form/process-form-rendering.service.ts
+++ b/lib/process-services/src/lib/form/process-form-rendering.service.ts
@@ -1,0 +1,32 @@
+/*!
+ * @license
+ * Copyright 2019 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Injectable } from '@angular/core';
+import { FormRenderingService } from '@alfresco/adf-core';
+import { AttachFileWidgetComponent } from '../content-widget/attach-file-widget.component';
+import { AttachFolderWidgetComponent } from '../content-widget/attach-folder-widget.component';
+
+@Injectable({
+    providedIn: 'root'
+})
+export class ProcessFormRenderingService extends FormRenderingService {
+    constructor() {
+        super();
+        this.setComponentTypeResolver('upload', () => AttachFileWidgetComponent, true);
+        this.setComponentTypeResolver('select-folder', () => AttachFolderWidgetComponent, true);
+    }
+}

--- a/lib/process-services/src/lib/form/public-api.ts
+++ b/lib/process-services/src/lib/form/public-api.ts
@@ -17,4 +17,5 @@
 
 export * from './form.component';
 export * from './start-form.component';
+export * from './process-form-rendering.service';
 export * from './form.module';

--- a/lib/process-services/src/lib/form/start-form.component.ts
+++ b/lib/process-services/src/lib/form/start-form.component.ts
@@ -30,12 +30,16 @@ import {
 } from '@angular/core';
 import { FormComponent } from './form.component';
 import { ContentLinkModel, FormService, WidgetVisibilityService, FormRenderingService, FormOutcomeModel } from '@alfresco/adf-core';
+import { ProcessFormRenderingService } from './process-form-rendering.service';
 
 @Component({
     selector: 'adf-start-form',
     templateUrl: './start-form.component.html',
     styleUrls: ['./start-form.component.scss'],
-    encapsulation: ViewEncapsulation.None
+    encapsulation: ViewEncapsulation.None,
+    providers: [
+        { provide: FormRenderingService, useClass: ProcessFormRenderingService }
+    ]
 })
 export class StartFormComponent extends FormComponent implements OnChanges, OnInit, OnDestroy {
 
@@ -70,10 +74,8 @@ export class StartFormComponent extends FormComponent implements OnChanges, OnIn
     @ViewChild('outcomesContainer', {})
     outcomesContainer: ElementRef = null;
 
-    constructor(formService: FormService,
-                visibilityService: WidgetVisibilityService,
-                formRenderingService: FormRenderingService) {
-        super(formService, visibilityService, null, null, formRenderingService);
+    constructor(formService: FormService, visibilityService: WidgetVisibilityService) {
+        super(formService, visibilityService, null, null);
         this.showTitle = false;
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Form and FormCloud register custom widgets in the constructor, so prevent any customisations of the service by developers.

**What is the new behaviour?**

- new `ProcessFormRenderingService` (alfresco/process-services)
- new `CloudFormRenderingService` (alfresco/process-services-cloud)

each service replaces the `FormRenderingService` at runtime and provides custom widgets that are relevant to the form

developers now can import one of those services and re-register the widgets 

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-5106