### PR TITLE
[ACA-2493] Fix disabled create folder button color

### DIFF
--- a/lib/content-services/src/lib/dialogs/folder.dialog.scss
+++ b/lib/content-services/src/lib/dialogs/folder.dialog.scss
@@ -24,12 +24,17 @@
 @mixin adf-dialog-theme($theme) {
 
     $primary: map-get($theme, primary);
+    $foreground: map-get($theme, foreground);
 
     .adf-dialog-buttons button {
         text-transform: uppercase;
     }
+
     .adf-dialog-action-button:enabled {
         color: mat-color($primary);
     }
 
+    .adf-dialog-action-button:disabled > span {
+        color: mat-color($foreground, text, 0.54);
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe: Styling


**What is the current behaviour?** (You can also link to an open issue here)
The color of the disabled button is rgba(0,0,0,0.26) which is too light for AA Accessibility requirements.


**What is the new behaviour?**
Changes colors to rgba(0,0,0,0.54) (only when disabled).


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ACA-2493