### PR TITLE
[ACA-2476] Fix color contrast in mat-calendar and mat-datetimepicker-calendar

### DIFF
--- a/lib/core/styles/_index.scss
+++ b/lib/core/styles/_index.scss
@@ -74,5 +74,7 @@
     @include adf-clipboard-theme($theme);
     @include adf-snackbar-theme($theme);
     @include mat-expansion-panel-theme--fix($theme);
+    @include mat-calendar-theme--fix($theme);
+    @include mat-datetimepicker-theme--fix($theme);
     @include adf-search-text-input-theme($theme);
 }

--- a/lib/core/styles/_mixins.scss
+++ b/lib/core/styles/_mixins.scss
@@ -80,3 +80,58 @@
         }
     }
 }
+
+@mixin mat-calendar-theme--fix($theme) {
+    $foreground: map-get($theme, foreground);
+
+    .mat-calendar {
+        .mat-calendar-header {
+            button {
+                color: mat-color($foreground, text, 0.87);
+
+                &:disabled {
+                    color: mat-color($foreground, text, 0.54);
+                }
+            }
+        }
+        .mat-calendar-content {
+            .mat-calendar-table-header th {
+                color: mat-color($foreground, text, 0.54);
+            }
+
+            .mat-calendar-body-disabled > div {
+                color: mat-color($foreground, text, 0.54) !important;
+            }
+        }
+    }
+}
+
+@mixin mat-datetimepicker-theme--fix($theme) {
+    $foreground: map-get($theme, foreground);
+
+    .mat-datetimepicker-calendar {
+        .mat-datetimepicker-calendar-header {
+            .mat-datetimepicker-calendar-header-year {
+                opacity: 1;
+            }
+
+            .mat-datetimepicker-calendar-header-date {
+                opacity: 1;
+            }
+
+            .mat-datetimepicker-calendar-header-time {
+                opacity: 1;
+            }
+        }
+
+        .mat-datetimepicker-calendar-content {
+            .mat-datetimepicker-calendar-table-header th {
+                color: mat-color($foreground, text, 0.54);
+            }
+
+            .mat-datetimepicker-calendar-body-disabled > div {
+                color: mat-color($foreground, text, 0.54);
+            }
+        }
+    }
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe: Styling


**What is the current behaviour?** (You can also link to an open issue here)
Some texts in the mat-calendar and mat-datetimepicker-calendar have a low contrast ratio with their background for AA Accessibility requirements.


**What is the new behaviour?**
Add 2 new mixins to fix mat-calendar and mat-datetimepicker themes. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ACA-2482
https://issues.alfresco.com/jira/browse/ACA-2476
