### PR TITLE
[ACA-2520] Opacity of tab label of info drawer set to 1

### DIFF
--- a/lib/core/info-drawer/info-drawer-layout.component.scss
+++ b/lib/core/info-drawer/info-drawer-layout.component.scss
@@ -27,6 +27,7 @@
                 text-align: left;
                 color: mat-color($accent);
                 text-transform: uppercase;
+                opacity: 1;
 
                 &-active {
                     color: mat-color($primary);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe: Styling


**What is the current behaviour?** (You can also link to an open issue here)
Labels of tabs in info drawer have a default opacity of 0.6 which create ussies for AA accessibility requirements.


**What is the new behaviour?**
Now the opacity of those labels is set to 1.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ACA-2520