### PR TITLE
[AAE-2321] Should not be able to start a process with space as name (Process Services)

### DIFF
--- a/lib/process-services/src/lib/i18n/en.json
+++ b/lib/process-services/src/lib/i18n/en.json
@@ -288,7 +288,9 @@
       "ERROR": {
         "LOAD_PROCESS_DEFS": "Couldn't load process definitions, check you have access.",
         "START": "Couldn't start new process instance, check you have access.",
-        "MAXIMUM_LENGTH": "Length exceeded, {{characters}} characters max."
+        "MAXIMUM_LENGTH": "Length exceeded, {{characters}} characters max.",
+        "SPACE_VALIDATOR": "Space is not allowed in the beginning or the end of the text.",
+        "PROCESS_NAME_REQUIRED": "Process name is required."
       }
     },
     "PROCESS-ATTACHMENT": {

--- a/lib/process-services/src/lib/process-list/components/start-process.component.html
+++ b/lib/process-services/src/lib/process-list/components/start-process.component.html
@@ -43,13 +43,19 @@
             <mat-error *ngIf="nameController.hasError('maxlength')">
                 {{ 'ADF_PROCESS_LIST.START_PROCESS.ERROR.MAXIMUM_LENGTH' | translate : { characters : maxProcessNameLength } }}
             </mat-error>
+            <mat-error *ngIf="nameController.hasError('required')">
+                {{ 'ADF_PROCESS_LIST.START_PROCESS.ERROR.PROCESS_NAME_REQUIRED' | translate }}
+            </mat-error>
+            <mat-error *ngIf="nameController.hasError('pattern')">
+                {{ 'ADF_PROCESS_LIST.START_PROCESS.ERROR.SPACE_VALIDATOR' | translate }}
+            </mat-error>
         </mat-form-field>
 
         <adf-start-form
             #startForm
             *ngIf="hasStartForm()"
             [data]="values"
-            [disableStartProcessButton]="!hasProcessName()"
+            [disableStartProcessButton]="!validateForm()"
             [processDefinitionId]="selectedProcessDef.id"
             (outcomeClick)="onOutcomeClick($event)"
             [showRefreshButton]="false">

--- a/lib/process-services/src/lib/process-list/components/start-process.component.spec.ts
+++ b/lib/process-services/src/lib/process-list/components/start-process.component.spec.ts
@@ -129,6 +129,17 @@ describe('StartFormComponent', () => {
                     expect(startBtn.disabled).toBe(true);
                 });
             }));
+
+            it('should have start button disabled process name has a space as the first or last character.', async(() => {
+                component.processNameInput.setValue(' Space in the beginning');
+                component.processDefinitionInput.setValue(testProcessDef.name);
+                fixture.detectChanges();
+                const startBtn = fixture.nativeElement.querySelector('#button-start');
+                expect(startBtn.disabled).toBe(true);
+                component.processNameInput.setValue('Space in the end ');
+                fixture.detectChanges();
+                expect(startBtn.disabled).toBe(true);
+            }));
         });
 
         describe('with start form', () => {

--- a/lib/process-services/src/lib/process-list/components/start-process.component.ts
+++ b/lib/process-services/src/lib/process-list/components/start-process.component.ts
@@ -117,7 +117,7 @@ export class StartProcessInstanceComponent implements OnChanges, OnInit, OnDestr
         }
 
     ngOnInit() {
-        this.processNameInput = new FormControl(this.name, [Validators.required, Validators.maxLength(this.maxProcessNameLength)]);
+        this.processNameInput = new FormControl(this.name, [Validators.required, Validators.maxLength(this.maxProcessNameLength), Validators.pattern('^[^\\s]+(\\s+[^\\s]+)*$')]);
         this.processDefinitionInput = new FormControl();
 
         this.loadStartProcess();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/AAE-2321
The start button for new process is enabled even though there name of the process is only a space character.

**What is the new behaviour?**

Disabled the button even for having space characters at the beginning of the name or at the end. Also added 2 new errors for the process name input.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
