### PR TITLE
[ACA-2523] Change comment colors

### DIFF
--- a/lib/core/comments/comment-list.component.scss
+++ b/lib/core/comments/comment-list.component.scss
@@ -2,6 +2,7 @@
 
 @mixin adf-task-list-comment-list-theme($theme) {
     $primary: map-get($theme, primary);
+    $foreground: map-get($theme, foreground);
     $primaryColor: mat-color($primary, 100);
     $rippleColor: mat-color($primary, 300);
 
@@ -47,6 +48,7 @@
             padding: 10px 5px;
             width: 30px;
             background-color: mat-color($primary);
+            color: mat-contrast($primary, default);
             border-radius: 50%;
             font-size: 16px;
             text-align: center;
@@ -73,7 +75,7 @@
             font-size: 14px;
             letter-spacing: -0.2px;
             line-height: 1.43;
-            opacity: 0.54;
+            color: mat-color($foreground, secondary-text);
         }
 
         &-comment-message-time {
@@ -81,7 +83,7 @@
             width: calc(100% - 10%);
             padding: 2px 10px;
             font-size: 12px !important;
-            opacity: 0.54;
+            color: mat-color($foreground, secondary-text);
         }
 
         &-comment-contents {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe: Styling


**What is the current behaviour?** (You can also link to an open issue here)
Texts in the comment component lack color contrast.


**What is the new behaviour?**
The color of the text inside the user icon is now depending on the contrast of the primary color. That will avoid having the default text color on dark background.
The comment message and message time are now using the secondary text color instead of opacity values.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ACA-2523