### PR TITLE
[ACA-2577] Change color of dropdown-breadcrumb current folder

### DIFF
--- a/lib/content-services/src/lib/breadcrumb/dropdown-breadcrumb.component.scss
+++ b/lib/content-services/src/lib/breadcrumb/dropdown-breadcrumb.component.scss
@@ -63,6 +63,7 @@
             text-overflow: ellipsis;
             display: inline-block;
             width: 75%;
+            color: mat-color($foreground, text, 0.72);
         }
 
         &-dropdown-breadcrumb-path-option.mat-option {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe: Styling


**What is the current behaviour?** (You can also link to an open issue here)
The color of the current folder name in the breadcrumb-dropdown component has a low contrast with its background.

**What is the new behaviour?**
We now use a darker color for that text to avoid contrast issues.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ACA-2577