### PR TITLE
[ADF-5120] Fix initialization error of PS cloud Services

### DIFF
--- a/lib/process-services-cloud/src/lib/form/services/form-cloud.service.ts
+++ b/lib/process-services-cloud/src/lib/form/services/form-cloud.service.ts
@@ -41,8 +41,7 @@ export class FormCloudService extends BaseCloudService {
         apiService: AlfrescoApiService,
         appConfigService: AppConfigService
     ) {
-        super(apiService);
-        this.contextRoot = appConfigService.get('bpmHost', '');
+        super(apiService, appConfigService);
     }
 
     /**

--- a/lib/process-services-cloud/src/lib/form/services/form-definition-selector-cloud.service.ts
+++ b/lib/process-services-cloud/src/lib/form/services/form-definition-selector-cloud.service.ts
@@ -29,8 +29,7 @@ export class FormDefinitionSelectorCloudService extends BaseCloudService {
 
     constructor(apiService: AlfrescoApiService,
                 appConfigService: AppConfigService) {
-        super(apiService);
-        this.contextRoot = appConfigService.get('bpmHost', '');
+        super(apiService, appConfigService);
     }
 
     /**

--- a/lib/process-services-cloud/src/lib/process/process-list/services/process-list-cloud.service.ts
+++ b/lib/process-services-cloud/src/lib/process/process-list/services/process-list-cloud.service.ts
@@ -27,8 +27,7 @@ export class ProcessListCloudService extends BaseCloudService {
     constructor(apiService: AlfrescoApiService,
                 appConfigService: AppConfigService,
                 private logService: LogService) {
-        super(apiService);
-        this.contextRoot = appConfigService.get('bpmHost', '');
+        super(apiService, appConfigService);
     }
 
     /**

--- a/lib/process-services-cloud/src/lib/process/services/process-cloud.service.ts
+++ b/lib/process-services-cloud/src/lib/process/services/process-cloud.service.ts
@@ -32,8 +32,7 @@ export class ProcessCloudService extends BaseCloudService {
     constructor(apiService: AlfrescoApiService,
                 appConfigService: AppConfigService,
                 private logService: LogService) {
-        super(apiService);
-        this.contextRoot = appConfigService.get('bpmHost', '');
+        super(apiService, appConfigService);
     }
 
     /**

--- a/lib/process-services-cloud/src/lib/process/start-process/services/start-process-cloud.service.ts
+++ b/lib/process-services-cloud/src/lib/process/start-process/services/start-process-cloud.service.ts
@@ -32,8 +32,7 @@ export class StartProcessCloudService extends BaseCloudService {
     constructor(apiService: AlfrescoApiService,
                 private logService: LogService,
                 appConfigService: AppConfigService) {
-        super(apiService);
-        this.contextRoot = appConfigService.get('bpmHost', '');
+        super(apiService, appConfigService);
     }
 
     /**

--- a/lib/process-services-cloud/src/lib/services/base-cloud.service.ts
+++ b/lib/process-services-cloud/src/lib/services/base-cloud.service.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { AlfrescoApiService } from '@alfresco/adf-core';
+import { AlfrescoApiService, AppConfigService } from '@alfresco/adf-core';
 import { from, Observable } from 'rxjs';
 
 export interface CallApiParams {
@@ -35,8 +35,6 @@ export interface CallApiParams {
 
 export class BaseCloudService {
 
-    protected contextRoot: string;
-
     protected defaultParams: CallApiParams = {
         path: '',
         httpMethod: '',
@@ -45,7 +43,9 @@ export class BaseCloudService {
         returnType: Object
     };
 
-    constructor(protected apiService: AlfrescoApiService) {}
+    constructor(
+        protected apiService: AlfrescoApiService,
+        protected appConfigService: AppConfigService) {}
 
     getBasePath(appName: string): string {
         return appName
@@ -112,5 +112,9 @@ export class BaseCloudService {
                 params.contextRoot,
                 params.responseType
             );
+    }
+
+    protected get contextRoot() {
+        return this.appConfigService.get('bpmHost', '');
     }
 }

--- a/lib/process-services-cloud/src/lib/services/user-preference-cloud.service.ts
+++ b/lib/process-services-cloud/src/lib/services/user-preference-cloud.service.ts
@@ -28,8 +28,7 @@ export class UserPreferenceCloudService extends BaseCloudService implements Pref
     apiService: AlfrescoApiService,
     appConfigService: AppConfigService,
     private logService: LogService) {
-    super(apiService);
-    this.contextRoot = appConfigService.get('bpmHost', '');
+    super(apiService, appConfigService);
   }
 
   /**

--- a/lib/process-services-cloud/src/lib/task/services/start-task-cloud.service.ts
+++ b/lib/process-services-cloud/src/lib/task/services/start-task-cloud.service.ts
@@ -29,8 +29,7 @@ export class StartTaskCloudService extends BaseCloudService {
     constructor(
         apiService: AlfrescoApiService,
         appConfigService: AppConfigService) {
-        super(apiService);
-        this.contextRoot = appConfigService.get('bpmHost');
+        super(apiService, appConfigService);
     }
 
      /**

--- a/lib/process-services-cloud/src/lib/task/services/task-cloud.service.ts
+++ b/lib/process-services-cloud/src/lib/task/services/task-cloud.service.ts
@@ -36,8 +36,7 @@ export class TaskCloudService extends BaseCloudService {
         private logService: LogService,
         private identityUserService: IdentityUserService
     ) {
-        super(apiService);
-        this.contextRoot = appConfigService.get('bpmHost', '');
+        super(apiService, appConfigService);
     }
 
     /**

--- a/lib/process-services-cloud/src/lib/task/task-list/services/task-list-cloud.service.ts
+++ b/lib/process-services-cloud/src/lib/task/task-list/services/task-list-cloud.service.ts
@@ -28,8 +28,7 @@ export class TaskListCloudService extends BaseCloudService {
     constructor(apiService: AlfrescoApiService,
                 appConfigService: AppConfigService,
                 private logService: LogService) {
-        super(apiService);
-        this.contextRoot = appConfigService.get('bpmHost', '');
+        super(apiService, appConfigService);
     }
 
     /**


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-5120
Cloud services set their context root in their classes' constructor. the problem is that this property is set after a value found in the app.config.json. If the app config service has not been initialized yet it will fail to assign the correct value.

**What is the new behaviour?**
the context root is not set anymore in the constructor of these services, instead if that, it's set directly in the parent service from where these services extend and it happenst when the call is going to happen to ensure that everything has been initialized correctly along the way..


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
