### PR TITLE
[ACA-2523] Fix text color of comment user icon

### DIFF
--- a/lib/core/comments/comment-list.component.scss
+++ b/lib/core/comments/comment-list.component.scss
@@ -48,7 +48,7 @@
             padding: 10px 5px;
             width: 30px;
             background-color: mat-color($primary);
-            color: mat-contrast($primary, default);
+            color: mat-color($primary, default-contrast);
             border-radius: 50%;
             font-size: 16px;
             text-align: center;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
The previous update of comment colors isn't working the way I implemented it (using the mat-contrast function) and the color inside the user icon in a comment didn't change depending on the constrast of the primary color of the theme.


**What is the new behaviour?**
I used the safer mat-color function to import the default contrast of the selected theme for the text inside the user icon in a comment.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ACA-2523