### PR TITLE
[ACA-3191] Remove adding Alfresco suffix by default in the repo name

### DIFF
--- a/lib/process-services/src/lib/process-list/components/start-process.component.spec.ts
+++ b/lib/process-services/src/lib/process-list/components/start-process.component.spec.ts
@@ -210,7 +210,7 @@ describe('StartFormComponent', () => {
                     'alfrescoRepositoryName': null
                 });
 
-                expect(component.getAlfrescoRepositoryName()).toBe('alfresco-1Alfresco');
+                expect(component.getAlfrescoRepositoryName()).toBe('alfresco-1');
             });
 
             it('alfrescoRepositoryName configuration property should be fetched', () => {

--- a/lib/process-services/src/lib/process-list/components/start-process.component.ts
+++ b/lib/process-services/src/lib/process-list/components/start-process.component.ts
@@ -213,7 +213,7 @@ export class StartProcessInstanceComponent implements OnChanges, OnInit, OnDestr
         if (!alfrescoRepositoryName) {
             alfrescoRepositoryName = 'alfresco-1';
         }
-        return alfrescoRepositoryName + 'Alfresco';
+        return alfrescoRepositoryName;
     }
 
     moveNodeFromCStoPS(): void {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ACA-3191


**What is the new behaviour?**
Removed adding the Alfresco suffix to the repo name by default


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
