### PR TITLE
[AAE-2321] Should not be able to start a process with space(s) in the beginning/end of process name (Process Services Cloud)

### DIFF
--- a/lib/process-services-cloud/src/lib/i18n/en.json
+++ b/lib/process-services-cloud/src/lib/i18n/en.json
@@ -41,7 +41,8 @@
         "START": "Couldn't start new process instance, check you have access.",
         "PROCESS_NAME_REQUIRED": "Process Name is required",
         "PROCESS_DEFINITION_REQUIRED": "Process Definition is required",
-        "MAXIMUM_LENGTH": "Length exceeded, {{characters}} characters max."
+        "MAXIMUM_LENGTH": "Length exceeded, {{characters}} characters max.",
+        "SPACE_VALIDATOR": "Space is not allowed in the beginning or the end of the text."
       }
     }
   },

--- a/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.html
+++ b/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.html
@@ -45,6 +45,9 @@
                 <mat-error id="adf-start-process-maxlength-error" *ngIf="processInstanceName.hasError('maxlength')">
                     {{ 'ADF_CLOUD_PROCESS_LIST.ADF_CLOUD_START_PROCESS.ERROR.MAXIMUM_LENGTH' | translate : { characters : maxNameLength } }}
                 </mat-error>
+                <mat-error *ngIf="processInstanceName.hasError('pattern')">
+                    {{ 'ADF_PROCESS_LIST.START_PROCESS.ERROR.SPACE_VALIDATOR' | translate }}
+                </mat-error>
             </mat-form-field>
         </form>
 

--- a/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.spec.ts
@@ -555,6 +555,18 @@ describe('StartProcessCloudComponent', () => {
             expect(processInstanceName.valid).toBeTruthy();
         });
 
+        it('should have start button disabled process name has a space as the first or last character.', async(() => {
+            component.appName = 'myApp';
+            component.processDefinitionName = ' Space in the beginning';
+            component.ngOnChanges({});
+            fixture.detectChanges();
+            const startBtn = fixture.nativeElement.querySelector('#button-start');
+            expect(startBtn.disabled).toBe(true);
+            component.processDefinitionName = 'Space in the end ';
+            fixture.detectChanges();
+            expect(startBtn.disabled).toBe(true);
+        }));
+
         it('should emit processDefinitionSelection event when a process definition is selected', (done) => {
             component.processDefinitionSelection.subscribe((processDefinition) => {
                 expect(processDefinition).toEqual(fakeProcessDefinitions[0]);

--- a/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.ts
@@ -108,7 +108,7 @@ export class StartProcessCloudComponent implements OnChanges, OnInit, OnDestroy 
 
     ngOnInit() {
         this.processForm = this.formBuilder.group({
-            processInstanceName: new FormControl(this.name, [Validators.required, Validators.maxLength(this.getMaxNameLength()), this.whitespaceValidator]),
+            processInstanceName: new FormControl(this.name, [Validators.required, Validators.maxLength(this.getMaxNameLength()), Validators.pattern('^[^\\s]+(\\s+[^\\s]+)*$')]),
             processDefinition: new FormControl(this.processDefinitionName, [Validators.required, this.processDefinitionNameValidator()])
         });
 
@@ -295,12 +295,6 @@ export class StartProcessCloudComponent implements OnChanges, OnInit, OnDestroy 
 
     getProcessDefinitionValue(process: ProcessDefinitionCloud): string {
         return !!process.name ? process.name : process.key;
-    }
-
-    public whitespaceValidator(control: FormControl) {
-        const isWhitespace = (control.value || '').trim().length === 0;
-        const isValid = !isWhitespace;
-        return isValid ? null : { 'whitespace': true };
     }
 
     get processInstanceName(): AbstractControl {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://issues.alfresco.com/jira/browse/AAE-2423
In process process-services-cloud we can have spaces at the end of the process name and start the process. also there is no error thrown if the process name contains only a space character but the start button is disabled.

**What is the new behaviour?**

Can't start a process having space(s) in the beginning/end of the process definition name and added error for that.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
