### PR TITLE
[ADF-5129][ADF-5130] Fix Lock in Gallery view and Lock Dialog

### DIFF
--- a/demo-shell/src/app/components/files/files.component.scss
+++ b/demo-shell/src/app/components/files/files.component.scss
@@ -29,8 +29,9 @@
         }
     }
 
-    .app-datatable-card .app-lock-button {
+    .adf-datatable-card .app-lock-button {
         top: -10px;
+        position: absolute;
     }
 
     .app-site-container-style {

--- a/lib/content-services/src/lib/dialogs/node-lock.dialog.html
+++ b/lib/content-services/src/lib/dialogs/node-lock.dialog.html
@@ -5,7 +5,7 @@
 <mat-dialog-content>
     <br />
     <form [formGroup]="form" (submit)="submit()">
-        <mat-checkbox  data-automation-id="adf-lock-node-checkbox" class="adf-lock-file-name" [formControl]="form.controls['isLocked']" ngDefaultControl>
+        <mat-checkbox  data-automation-id="adf-lock-node-checkbox" class="adf-lock-file-name" matTooltip="{{ nodeName }}" [formControl]="form.controls['isLocked']" ngDefaultControl>
             {{ 'CORE.FILE_DIALOG.FILE_LOCK_CHECKBOX' | translate }} <strong>"{{ nodeName }}"</strong>
         </mat-checkbox>
 

--- a/lib/content-services/src/lib/document-list/components/document-list.component.scss
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.scss
@@ -25,10 +25,22 @@
         overflow-y: auto;
     }
 
-    .adf-datatable-selected > svg {
-        fill: $document-list-selection-color;
-        width: 32px;
-        height: 32px;
+    .adf-datatable-card {
+        .adf-datatable-selected > svg {
+            fill: $document-list-selection-color;
+            width: 30px;
+            height: 30px;
+            position: absolute;
+            top: 10px;
+        }
+    }
+
+    .adf-datatable-list {
+        .adf-datatable-selected > svg {
+            fill: $document-list-selection-color;
+            width: 30px;
+            height: 30px;
+        }
     }
 
     .adf-document-list_empty_template {
@@ -175,21 +187,23 @@
             height: 300px !important;
 
             img {
-                height: 100px;
+                height: 130px;
             }
 
-            :first-child .adf-cell-container .adf-cell-value {
-                display: flex;
-                width: 265px;
-                flex: 0 0 auto;
-                justify-content: center;
+            .adf-datatable-cell {
+                overflow: visible;
             }
 
-            .adf-datatable-cell.adf-datatable-table-cell.adf-datatable-cell--image {
+            .adf-datatable-cell.adf-datatable-cell--image {
                 flex: 0 0 auto;
                 display: flex;
                 flex-direction: column-reverse;
                 justify-content: space-between;
+
+                .adf-cell-value {
+                    display: flex;
+                    justify-content: center;
+                }
             }
         }
     }

--- a/lib/core/datatable/components/datatable/datatable.component.scss
+++ b/lib/core/datatable/components/datatable/datatable.component.scss
@@ -111,6 +111,10 @@
                 }
             }
 
+            .adf-datatable-cell--image {
+                margin-left: 8px;
+            }
+
             .adf-datatable-cell {
                 text-align: left;
                 flex: 0 1 24%;
@@ -144,6 +148,7 @@
                 height: 42px !important;
                 width: 42px !important;
                 right: 0;
+                top: 4px;
             }
 
             .adf-image-table-cell {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-5129
https://issues.alfresco.com/jira/browse/ADF-5130


**What is the new behaviour?**
The gallery view for the datatable component has been fixed. There were a few elements misaligned.

The lock file dialog now displays a tooltip to read the complete name of the file so it's readable when the name is truncated. 
![Screen Shot 2020-04-27 at 17 54 01](https://user-images.githubusercontent.com/18293044/80398817-24213880-88b0-11ea-9ece-346512957909.png)
![Screen Shot 2020-04-27 at 17 53 41](https://user-images.githubusercontent.com/18293044/80398819-25526580-88b0-11ea-8945-2d648e301242.png)
![Screen Shot 2020-04-27 at 17 54 14](https://user-images.githubusercontent.com/18293044/80398820-25eafc00-88b0-11ea-9be4-1744488d4122.png)


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
