### PR TITLE
[AAE-2200] Upload dialog title should match selected site.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,4 +66,3 @@ All components are supported in the following browsers:
 * Due to a [known issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1188880) in Firefox, the Alfresco Upload Component does not currently support folder upload functionality on Firefox.    
 
 See the [Browser Support](BROWSER-SUPPORT.md) article for more details. 
-

--- a/README.md
+++ b/README.md
@@ -65,4 +65,5 @@ All components are supported in the following browsers:
 
 * Due to a [known issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1188880) in Firefox, the Alfresco Upload Component does not currently support folder upload functionality on Firefox.    
 
-See the [Browser Support](BROWSER-SUPPORT.md) article for more details. 
+See the [Browser Support](BROWSER-SUPPORT.md) article for more details.
+

--- a/docs/content-services/components/content-node-selector-panel.component.md
+++ b/docs/content-services/components/content-node-selector-panel.component.md
@@ -49,6 +49,7 @@ Opens a [Content Node Selector](content-node-selector.component.md)  in its own 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | select | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`Node`](https://github.com/Alfresco/alfresco-js-api/blob/development/src/api/content-rest-api/docs/Node.md)`[]>` | Emitted when the user has chosen an item. |
+| siteChange | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<string>` | Emitted when the select site changes. |
 
 ## Details
 

--- a/docs/process-services/components/process-list.component.md
+++ b/docs/process-services/components/process-list.component.md
@@ -193,7 +193,7 @@ The Process Instance List also supports pagination:
 
 Emitted before the context menu is displayed for a row.
 
-Note that the [ProcessInstanceListComponent](../../../lib/process-services/src/lib/process-list/components/process-list.component.ts) itself does not populate the context menu with items. You can provide all necessary content via the handler.
+Note that the [`ProcessInstanceListComponent`](../../../lib/process-services/src/lib/process-list/components/process-list.component.ts) itself does not populate the context menu with items. You can provide all necessary content via the handler.
 
 ```html
 <adf-process-instance-list

--- a/docs/process-services/components/task-list.component.md
+++ b/docs/process-services/components/task-list.component.md
@@ -235,7 +235,7 @@ You can customize the styling of a column and also add features like tooltips an
 
 Emitted before the context menu is displayed for a row.
 
-Note that the [TaskListComponent](../../process-services/components/task-list.component.md) itself does not populate the context menu with items.
+Note that the [`TaskListComponent`](../../process-services/components/task-list.component.md) itself does not populate the context menu with items.
 You can provide all necessary content via the handler.
 
 ```html
@@ -270,7 +270,7 @@ onShowRowContextMenu(event: DataCellEvent) {
 
 This event is cancellable. You can use `event.preventDefault()` to prevent the default behavior.
 
-The [TaskListComponent](../../process-services/components/task-list.component.md) will automatically render the supplied menu items.
+The [`TaskListComponent`](../../process-services/components/task-list.component.md) will automatically render the supplied menu items.
 
 See the [ContextMenu](https://www.npmjs.com/package/ng2-alfresco-core)
 documentation for more details on the format and behavior of context actions.

--- a/lib/content-services/src/lib/content-node-selector/content-node-dialog.service.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-dialog.service.ts
@@ -179,7 +179,7 @@ export class ContentNodeDialogService {
         });
 
         const data: ContentNodeSelectorComponentData = {
-            title: this.getTitleTranslation(action, contentEntry.name),
+            title: this.getTitleTranslation(action, this.translation.instant('DROPDOWN.MY_FILES_OPTION')),
             actionName: action,
             currentFolderId: contentEntry.id,
             imageResolver: this.imageResolver.bind(this),
@@ -206,7 +206,7 @@ export class ContentNodeDialogService {
         });
 
         const data: ContentNodeSelectorComponentData = {
-            title: this.getTitleTranslation(action, contentEntry.name),
+            title: this.getTitleTranslation(action, this.translation.instant('DROPDOWN.MY_FILES_OPTION')),
             actionName: action,
             currentFolderId: contentEntry.id,
             imageResolver: this.imageResolver.bind(this),

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.html
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.html
@@ -29,6 +29,7 @@
         [placeholder]="'NODE_SELECTOR.SELECT_LOCATION'"
         [hideMyFiles]="dropdownHideMyFiles"
         [siteList]="dropdownSiteList"
+        [value]="startSiteGuid"
         data-automation-id="content-node-selector-sites-combo">
     </adf-sites-dropdown>
 

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.spec.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.spec.ts
@@ -27,6 +27,7 @@ import { ContentNodeSelectorService } from './content-node-selector.service';
 import { ContentTestingModule } from '../testing/content.testing.module';
 import { DocumentListService } from '../document-list/services/document-list.service';
 import { DocumentListComponent } from '../document-list/components/document-list.component';
+import { DropdownSitesComponent } from '../site-dropdown/sites-dropdown.component';
 import { CustomResourcesService } from '../document-list/services/custom-resources.service';
 import { ShareDataRow } from '../document-list';
 
@@ -54,6 +55,7 @@ describe('ContentNodeSelectorComponent', () => {
     let contentNodeSelectorService: ContentNodeSelectorService;
     let searchService: SearchService;
     let nodeService: NodesApiService;
+    let sitesService: SitesService;
     let searchSpy: jasmine.Spy;
     let cnSearchSpy: jasmine.Spy;
 
@@ -85,15 +87,17 @@ describe('ContentNodeSelectorComponent', () => {
             searchService = TestBed.get(SearchService);
             nodeService = TestBed.get(NodesApiService);
             contentNodeSelectorService = TestBed.get(ContentNodeSelectorService);
-            spyOn(nodeService, 'getNode').and.returnValue(of({ id: 'fake-node', path: {
-                elements: [{ type: 'node'}]
-            },  allowableOperations: ['updatePermissions']}));
+            sitesService = TestBed.get(SitesService);
+
+            spyOn(nodeService,  'getNode').and.returnValue(of({ id: 'fake-node', path: { elements: [{ nodeType: 'st:site', name: 'fake-site'}] } }));
             cnSearchSpy = spyOn(contentNodeSelectorService, 'search').and.callThrough();
             searchSpy = spyOn(searchService, 'searchByQueryBody').and.callFake(() => {
                 return new Observable((observer: Observer<NodePaging>) => {
                     _observer = observer;
                 });
             });
+            const fakeSite = new SiteEntry({ entry: { id: 'fake-site', guid: 'fake-site', title: 'fake-site', visibility: 'visible' } });
+            spyOn(sitesService, 'getSite').and.returnValue(of(fakeSite));
         });
 
         afterEach(() => {
@@ -103,11 +107,9 @@ describe('ContentNodeSelectorComponent', () => {
         describe('Parameters', () => {
 
             let documentListService: DocumentListService;
-            let sitesService: SitesService;
 
             beforeEach(() => {
                 documentListService = TestBed.get(DocumentListService);
-                sitesService = TestBed.get(SitesService);
 
                 spyOn(documentListService, 'getFolderNode').and.returnValue(of(<NodeEntry> { entry: { path: { elements: [] } } }));
                 spyOn(documentListService, 'getFolder').and.returnValue(throwError('No results for test'));
@@ -210,11 +212,9 @@ describe('ContentNodeSelectorComponent', () => {
         describe('Breadcrumbs', () => {
 
             let documentListService: DocumentListService;
-            let sitesService: SitesService;
 
             beforeEach(() => {
                 documentListService = TestBed.get(DocumentListService);
-                sitesService = TestBed.get(SitesService);
 
                 spyOn(documentListService, 'getFolderNode').and.returnValue(of(<NodeEntry> { entry: { path: { elements: [] } } }));
                 spyOn(documentListService, 'getFolder').and.returnValue(throwError('No results for test'));
@@ -356,25 +356,37 @@ describe('ContentNodeSelectorComponent', () => {
         });
 
         describe('Site selection', () => {
-            let sitesService: SitesService;
 
             beforeEach(() => {
-                sitesService = TestBed.get(SitesService);
                 spyOn(sitesService, 'getSites').and.returnValue(of({ list: { entries: [] } }));
-                spyOn(sitesService, 'getSite').and.returnValue(of({ entry: { title: 'nuku-nuku' } }));
-
-                component.currentFolderId = 'cat-girl-nuku-nuku';
+                component.currentFolderId = 'fake-starting-folder';
             });
 
-            it('should trigger site change when site is selected', async ((done) => {
+            it('should trigger siteChange event on init with parent site Title of start folder', (done) => {
                 component.siteChange.subscribe((siteTitle: string) => {
-                    expect(siteTitle).toBe('nuku-nuku');
+                    expect(siteTitle).toBe('fake-site');
                     done();
                 });
 
                 component.ngOnInit();
                 fixture.detectChanges();
-            }));
+                expect(component.startSiteGuid).toBe('fake-site');
+            });
+
+            it('should trigger siteChange event when a site is selected in sites-dropdown', (done) => {
+                const fakeSiteEntry = new SiteEntry({ entry: { title: 'fake-new-site', guid: 'fake-new-site' } });
+                fixture.detectChanges();
+
+                fixture.whenStable().then(() => {
+                    component.siteChange.subscribe((siteTitle: string) => {
+                        expect(siteTitle).toBe('fake-new-site');
+                        done();
+                    });
+
+                    const sitesDropdown = fixture.debugElement.query(By.directive(DropdownSitesComponent));
+                    sitesDropdown.componentInstance.selectedSite({value: fakeSiteEntry});
+                });
+            });
         });
 
         describe('Search functionality', () => {
@@ -419,7 +431,6 @@ describe('ContentNodeSelectorComponent', () => {
                     }
                 }));
 
-                const sitesService = TestBed.get(SitesService);
                 spyOn(sitesService, 'getSites').and.returnValue(of({ list: { entries: [] } }));
 
                 const customResourcesService = TestBed.get(CustomResourcesService);
@@ -910,7 +921,6 @@ describe('ContentNodeSelectorComponent', () => {
             }
 
             beforeEach(() => {
-                const sitesService = TestBed.get(SitesService);
                 spyOn(sitesService, 'getSites').and.returnValue(of({ list: { entries: [] } }));
             });
 

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.ts
@@ -22,7 +22,6 @@ import {
     PaginationModel,
     UserPreferenceValues,
     InfinitePaginationComponent, PaginatedComponent,
-    ActivitiContentService,
     NodesApiService,
     SitesService
 } from '@alfresco/adf-core';
@@ -216,7 +215,6 @@ export class ContentNodeSelectorPanelComponent implements OnInit, OnDestroy {
     constructor(private contentNodeSelectorService: ContentNodeSelectorService,
                 private customResourcesService: CustomResourcesService,
                 private userPreferencesService: UserPreferencesService,
-                private activitiContentService: ActivitiContentService,
                 private nodesApiService: NodesApiService,
                 private sitesService: SitesService) {
     }
@@ -264,7 +262,7 @@ export class ContentNodeSelectorPanelComponent implements OnInit, OnDestroy {
 
     private getStartSite() {
         this.nodesApiService.getNode(this.currentFolderId).subscribe((startNodeEntry) => {
-            this.startSiteGuid = this.activitiContentService.getSiteNameFromNodePath(startNodeEntry);
+            this.startSiteGuid = this.sitesService.getSiteNameFromNodePath(startNodeEntry);
             if (this.startSiteGuid) {
                 this.sitesService.getSite(this.startSiteGuid).subscribe((startSiteEntry) => {
                     if (startSiteEntry instanceof SiteEntry) {

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.ts
@@ -21,7 +21,10 @@ import {
     UserPreferencesService,
     PaginationModel,
     UserPreferenceValues,
-    InfinitePaginationComponent, PaginatedComponent
+    InfinitePaginationComponent, PaginatedComponent,
+    ActivitiContentService,
+    NodesApiService,
+    SitesService
 } from '@alfresco/adf-core';
 import { FormControl } from '@angular/forms';
 import { Node, NodePaging, Pagination, SiteEntry, SitePaging } from '@alfresco/js-api';
@@ -176,6 +179,9 @@ export class ContentNodeSelectorPanelComponent implements OnInit, OnDestroy {
     @Output()
     select: EventEmitter<Node[]> = new EventEmitter<Node[]>();
 
+    @Output()
+    siteChange: EventEmitter<string> = new EventEmitter<string>();
+
     @ViewChild('documentList')
     documentList: DocumentListComponent;
 
@@ -191,6 +197,7 @@ export class ContentNodeSelectorPanelComponent implements OnInit, OnDestroy {
     _chosenNode: Node = null;
     folderIdToShow: string | null = null;
     breadcrumbFolderTitle: string | null = null;
+    startSiteGuid: string | null = null;
 
     pagination: PaginationModel = this.DEFAULT_PAGINATION;
 
@@ -207,7 +214,10 @@ export class ContentNodeSelectorPanelComponent implements OnInit, OnDestroy {
 
     constructor(private contentNodeSelectorService: ContentNodeSelectorService,
                 private customResourcesService: CustomResourcesService,
-                private userPreferencesService: UserPreferencesService) {
+                private userPreferencesService: UserPreferencesService,
+                private activitiContentService: ActivitiContentService,
+                private nodesApiService: NodesApiService,
+                private sitesService: SitesService) {
     }
 
     set chosenNode(value: Node) {
@@ -238,6 +248,9 @@ export class ContentNodeSelectorPanelComponent implements OnInit, OnDestroy {
 
         this.target = this.documentList;
         this.folderIdToShow = this.currentFolderId;
+        if (this.currentFolderId) {
+            this.getStartSite();
+        }
 
         this.breadcrumbTransform = this.breadcrumbTransform ? this.breadcrumbTransform : null;
         this.isSelectionValid = this.isSelectionValid ? this.isSelectionValid : defaultValidation;
@@ -246,6 +259,19 @@ export class ContentNodeSelectorPanelComponent implements OnInit, OnDestroy {
     ngOnDestroy() {
         this.onDestroy$.next(true);
         this.onDestroy$.complete();
+    }
+
+    private getStartSite() {
+        this.nodesApiService.getNode(this.currentFolderId).subscribe((startNodeEntry) => {
+            this.startSiteGuid = this.activitiContentService.getSiteNameFromNodePath(startNodeEntry);
+            if (this.startSiteGuid) {
+                this.sitesService.getSite(this.startSiteGuid).subscribe((startSiteEntry) => {
+                    if (startSiteEntry instanceof SiteEntry) {
+                        this.siteChange.emit(startSiteEntry.entry.title);
+                    }
+                });
+            }
+        });
     }
 
     private createRowFilter(filter?: RowFilter) {
@@ -280,8 +306,8 @@ export class ContentNodeSelectorPanelComponent implements OnInit, OnDestroy {
     siteChanged(chosenSite: SiteEntry): void {
         this.siteId = chosenSite.entry.guid;
         this.setTitleIfCustomSite(chosenSite);
+        this.siteChange.next(chosenSite.entry.title);
         this.updateResults();
-
     }
 
     /**

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.ts
@@ -179,6 +179,7 @@ export class ContentNodeSelectorPanelComponent implements OnInit, OnDestroy {
     @Output()
     select: EventEmitter<Node[]> = new EventEmitter<Node[]>();
 
+    /** Emitted when the select site changes. */
     @Output()
     siteChange: EventEmitter<string> = new EventEmitter<string>();
 

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.ts
@@ -307,7 +307,7 @@ export class ContentNodeSelectorPanelComponent implements OnInit, OnDestroy {
     siteChanged(chosenSite: SiteEntry): void {
         this.siteId = chosenSite.entry.guid;
         this.setTitleIfCustomSite(chosenSite);
-        this.siteChange.next(chosenSite.entry.title);
+        this.siteChange.emit(chosenSite.entry.title);
         this.updateResults();
     }
 

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector.component.html
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector.component.html
@@ -18,7 +18,8 @@
         [showSearch]="data?.showSearch"
         [showDropdownSiteList]="data?.showDropdownSiteList"
         [showFilesInResult]="data?.showFilesInResult"
-        (select)="onSelect($event)">
+        (select)="onSelect($event)"
+        (siteChange)="onSiteChange($event)">
     </adf-content-node-selector-panel>
 </mat-dialog-content>
 

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector.component.spec.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector.component.spec.ts
@@ -20,6 +20,7 @@ import { CUSTOM_ELEMENTS_SCHEMA, EventEmitter } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ContentNodeSelectorComponent } from './content-node-selector.component';
 import { Node } from '@alfresco/js-api';
+import { ContentNodeSelectorPanelComponent } from '@alfresco/adf-content-services';
 import { By } from '@angular/platform-browser';
 import { setupTestBed, SitesService } from '@alfresco/adf-core';
 import { of } from 'rxjs';
@@ -159,8 +160,10 @@ describe('ContentNodeSelectorDialogComponent', () => {
 
     describe('Title', () => {
 
-        it('should be updated when a node is chosen', () => {
-            component.onSelect([new Node({ id: 'fake', name: 'fake-node' })]);
+        it('should be updated when a site is chosen', () => {
+            const fakeSiteTitle = 'My fake site';
+            const contentNodePanel = fixture.debugElement.query(By.directive(ContentNodeSelectorPanelComponent));
+            contentNodePanel.componentInstance.siteChange.emit(fakeSiteTitle);
             fixture.detectChanges();
 
             const titleElement = fixture.debugElement.query(By.css('[data-automation-id="content-node-selector-title"]'));

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector.component.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector.component.ts
@@ -34,7 +34,7 @@ export class ContentNodeSelectorComponent {
     buttonActionName: string;
     chosenNode: Node[];
 
-    constructor(public translation: TranslationService,
+    constructor(private translation: TranslationService,
                 @Inject(MAT_DIALOG_DATA) public data: ContentNodeSelectorComponentData) {
         this.action = data.actionName ? data.actionName.toUpperCase() : 'CHOOSE';
         this.buttonActionName = `NODE_SELECTOR.${this.action}`;
@@ -47,7 +47,10 @@ export class ContentNodeSelectorComponent {
 
     onSelect(nodeList: Node[]) {
         this.chosenNode = nodeList;
-        this.updateTitle(nodeList);
+    }
+
+    onSiteChange(siteTitle: string) {
+        this.updateTitle(siteTitle);
     }
 
     onClick(): void {
@@ -55,13 +58,13 @@ export class ContentNodeSelectorComponent {
         this.data.select.complete();
     }
 
-    updateTitle(nodeList: Node[]): void {
-        if (this.action === 'CHOOSE' && nodeList) {
-            this.title = this.getTitleTranslation(this.action, nodeList[0].name);
+    updateTitle(siteTitle: string) {
+        if (this.action === 'CHOOSE' && siteTitle) {
+            this.title = this.getTitleTranslation(this.action, siteTitle);
         }
     }
 
     getTitleTranslation(action: string, name: string): string {
-        return this.translation.instant(`NODE_SELECTOR.${action}_ITEM`, { name });
+        return this.translation.instant(`NODE_SELECTOR.${action}_ITEM`, { name: this.translation.instant(name) });
     }
 }

--- a/lib/content-services/src/lib/mock/public-api.ts
+++ b/lib/content-services/src/lib/mock/public-api.ts
@@ -20,3 +20,4 @@ export * from './document-list.component.mock';
 export * from './search.component.mock';
 export * from './search.service.mock';
 export * from './search-filter-mock';
+export * from './sites-dropdown.component.mock';

--- a/lib/content-services/src/lib/mock/sites-dropdown.component.mock.ts
+++ b/lib/content-services/src/lib/mock/sites-dropdown.component.mock.ts
@@ -1,0 +1,217 @@
+/*!
+ * @license
+ * Copyright 2019 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { SitePaging } from '@alfresco/js-api';
+
+/* We are using functions instead of const here to pass a new instance of the object each time */
+export function getFakeSitePaging(): SitePaging {
+    return {
+        'list': {
+            'pagination': {
+                'count': 2,
+                'hasMoreItems': true,
+                'totalItems': 2,
+                'skipCount': 0,
+                'maxItems': 100
+            },
+            'entries': [
+                {
+                    'entry': {
+                        'role': 'SiteManager',
+                        'visibility': 'PUBLIC',
+                        'guid': 'fake-1',
+                        'description': 'fake-test-site',
+                        'id': 'fake-test-site',
+                        'preset': 'site-dashboard',
+                        'title': 'fake-test-site'
+                    }
+                },
+                {
+                    'entry': {
+                        'role': 'SiteManager',
+                        'visibility': 'PUBLIC',
+                        'guid': 'fake-2',
+                        'description': 'This is a Sample Alfresco Team site.',
+                        'id': 'swsdp',
+                        'preset': 'site-dashboard',
+                        'title': 'fake-test-2'
+                    }
+                }
+            ]
+        }
+    };
+}
+
+export function getFakeSitePagingNoMoreItems(): SitePaging {
+    return {
+        'list': {
+            'pagination': {
+                'count': 2,
+                'hasMoreItems': false,
+                'totalItems': 2,
+                'skipCount': 0,
+                'maxItems': 100
+            },
+            'entries': [
+                {
+                    'entry': {
+                        'role': 'SiteManager',
+                        'visibility': 'PUBLIC',
+                        'guid': 'fake-1',
+                        'description': 'fake-test-site',
+                        'id': 'fake-test-site',
+                        'preset': 'site-dashboard',
+                        'title': 'fake-test-site'
+                    }
+                },
+                {
+                    'entry': {
+                        'role': 'SiteManager',
+                        'visibility': 'PUBLIC',
+                        'guid': 'fake-2',
+                        'description': 'This is a Sample Alfresco Team site.',
+                        'id': 'swsdp',
+                        'preset': 'site-dashboard',
+                        'title': 'fake-test-2'
+                    }
+                }
+            ]
+        }
+    };
+}
+
+export function getFakeSitePagingWithMembers() {
+    return {
+        'list': {
+            'entries': [{
+                'entry': {
+                    'visibility': 'MODERATED',
+                    'guid': 'b4cff62a-664d-4d45-9302-98723eac1319',
+                    'description': 'This is a Sample Alfresco Team site.',
+                    'id': 'MODERATED-SITE',
+                    'preset': 'site-dashboard',
+                    'title': 'FAKE-MODERATED-SITE'
+                },
+                'relations': {
+                    'members': {
+                        'list': {
+                            'pagination': {
+                                'count': 3,
+                                'hasMoreItems': false,
+                                'skipCount': 0,
+                                'maxItems': 100
+                            },
+                            'entries': [
+                                {
+                                    'entry': {
+                                        'role': 'SiteManager',
+                                        'person': {
+                                            'firstName': 'Administrator',
+                                            'emailNotificationsEnabled': true,
+                                            'company': {},
+                                            'id': 'admin',
+                                            'enabled': true,
+                                            'email': 'admin@alfresco.com'
+                                        },
+                                        'id': 'admin'
+                                    }
+                                },
+                                {
+                                    'entry': {
+                                        'role': 'SiteCollaborator',
+                                        'person': {
+                                            'lastName': 'Beecher',
+                                            'userStatus': 'Helping to design the look and feel of the new web site',
+                                            'jobTitle': 'Graphic Designer',
+                                            'statusUpdatedAt': '2011-02-15T20:20:13.432+0000',
+                                            'mobile': '0112211001100',
+                                            'emailNotificationsEnabled': true,
+                                            'description': 'Alice is a demo user for the sample Alfresco Team site.',
+                                            'telephone': '0112211001100',
+                                            'enabled': false,
+                                            'firstName': 'Alice',
+                                            'skypeId': 'abeecher',
+                                            'avatarId': '198500fc-1e99-4f5f-8926-248cea433366',
+                                            'location': 'Tilbury, UK',
+                                            'company': {
+                                                'organization': 'Moresby, Garland and Wedge',
+                                                'address1': '200 Butterwick Street',
+                                                'address2': 'Tilbury',
+                                                'address3': 'UK',
+                                                'postcode': 'ALF1 SAM1'
+                                            },
+                                            'id': 'abeecher',
+                                            'email': 'abeecher@example.com'
+                                        },
+                                        'id': 'abeecher'
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }, {
+                'entry': {
+                    'visibility': 'PUBLIC',
+                    'guid': 'b4cff62a-664d-4d45-9302-98723eac1319',
+                    'description': 'This is a Sample Alfresco Team site.',
+                    'id': 'PUBLIC-SITE',
+                    'preset': 'site-dashboard',
+                    'title': 'FAKE-SITE-PUBLIC'
+                }
+            }, {
+                'entry': {
+                    'visibility': 'PRIVATE',
+                    'guid': 'b4cff62a-664d-4d45-9302-98723eac1319',
+                    'description': 'This is a Sample Alfresco Team site.',
+                    'id': 'MEMBER-SITE',
+                    'preset': 'site-dashboard',
+                    'title': 'FAKE-PRIVATE-SITE-MEMBER'
+                },
+                'relations': {
+                    'members': {
+                        'list': {
+                            'pagination': {
+                                'count': 3,
+                                'hasMoreItems': false,
+                                'skipCount': 0,
+                                'maxItems': 100
+                            },
+                            'entries': [
+                                {
+                                    'entry': {
+                                        'role': 'SiteManager',
+                                        'person': {
+                                            'firstName': 'Administrator',
+                                            'emailNotificationsEnabled': true,
+                                            'company': {},
+                                            'id': 'admin',
+                                            'enabled': true,
+                                            'email': 'admin@alfresco.com'
+                                        },
+                                        'id': 'test'
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+            ]
+        }
+    };
+}

--- a/lib/content-services/src/lib/mock/sites-dropdown.component.mock.ts
+++ b/lib/content-services/src/lib/mock/sites-dropdown.component.mock.ts
@@ -17,7 +17,7 @@
 
 import { SitePaging } from '@alfresco/js-api';
 
-/* We are using functions instead of const here to pass a new instance of the object each time */
+/* We are using functions instead of constants here to pass a new instance of the object each time */
 export function getFakeSitePaging(): SitePaging {
     return {
         'list': {
@@ -87,6 +87,82 @@ export function getFakeSitePagingNoMoreItems(): SitePaging {
                         'id': 'swsdp',
                         'preset': 'site-dashboard',
                         'title': 'fake-test-2'
+                    }
+                }
+            ]
+        }
+    };
+}
+
+export function getFakeSitePagingFirstPage(): SitePaging {
+    return {
+        'list': {
+            'pagination': {
+                'count': 2,
+                'hasMoreItems': true,
+                'totalItems': 2,
+                'skipCount': 0,
+                'maxItems': 4
+            },
+            'entries': [
+                {
+                    'entry': {
+                        'role': 'SiteManager',
+                        'visibility': 'PUBLIC',
+                        'guid': 'fake-1',
+                        'description': 'fake-test-site',
+                        'id': 'fake-test-site',
+                        'preset': 'site-dashboard',
+                        'title': 'fake-test-site'
+                    }
+                },
+                {
+                    'entry': {
+                        'role': 'SiteManager',
+                        'visibility': 'PUBLIC',
+                        'guid': 'fake-2',
+                        'description': 'This is a Sample Alfresco Team site.',
+                        'id': 'swsdp',
+                        'preset': 'site-dashboard',
+                        'title': 'fake-test-2'
+                    }
+                }
+            ]
+        }
+    };
+}
+
+export function getFakeSitePagingLastPage(): SitePaging {
+    return {
+        'list': {
+            'pagination': {
+                'count': 4,
+                'hasMoreItems': false,
+                'totalItems': 2,
+                'skipCount': 2,
+                'maxItems': 4
+            },
+            'entries': [
+                {
+                    'entry': {
+                        'role': 'SiteManager',
+                        'visibility': 'PUBLIC',
+                        'guid': 'fake-3',
+                        'description': 'fake-test-3',
+                        'id': 'fake-test-3',
+                        'preset': 'site-dashboard',
+                        'title': 'fake-test-3'
+                    }
+                },
+                {
+                    'entry': {
+                        'role': 'SiteManager',
+                        'visibility': 'PUBLIC',
+                        'guid': 'fake-test-4',
+                        'description': 'This is a Sample Alfresco Team site.',
+                        'id': 'fake-test-4',
+                        'preset': 'site-dashboard',
+                        'title': 'fake-test-4'
                     }
                 }
             ]

--- a/lib/content-services/src/lib/site-dropdown/sites-dropdown.component.spec.ts
+++ b/lib/content-services/src/lib/site-dropdown/sites-dropdown.component.spec.ts
@@ -22,6 +22,26 @@ import { DropdownSitesComponent, Relations } from './sites-dropdown.component';
 import { SitesService, setupTestBed, CoreModule, AlfrescoApiService, AlfrescoApiServiceMock } from '@alfresco/adf-core';
 import { of } from 'rxjs';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { getFakeSitePaging, getFakeSitePagingNoMoreItems, getFakeSitePagingWithMembers } from '../mock';
+
+const customSiteList = {
+    'list': {
+        'entries': [
+            {
+                'entry': {
+                    'guid': '-my-',
+                    'title': 'PERSONAL_FILES'
+                }
+            },
+            {
+                'entry': {
+                    'guid': '-mysites-',
+                    'title': 'FILE_LIBRARIES'
+                }
+            }
+        ]
+    }
+};
 
 describe('DropdownSitesComponent', () => {
 
@@ -54,45 +74,10 @@ describe('DropdownSitesComponent', () => {
                 debug = fixture.debugElement;
                 element = fixture.nativeElement;
                 component = fixture.componentInstance;
+                spyOn(siteService, 'getSites').and.returnValue(of(getFakeSitePaging()));
             }));
 
             it('Should show loading item if there are more itemes', async(() => {
-                spyOn(siteService, 'getSites').and.returnValue(of({
-                    'list': {
-                        'pagination': {
-                            'count': 2,
-                            'hasMoreItems': true,
-                            'totalItems': 2,
-                            'skipCount': 0,
-                            'maxItems': 100
-                        },
-                        'entries': [
-                            {
-                                'entry': {
-                                    'role': 'SiteManager',
-                                    'visibility': 'PUBLIC',
-                                    'guid': 'fake-1',
-                                    'description': 'fake-test-site',
-                                    'id': 'fake-test-site',
-                                    'preset': 'site-dashboard',
-                                    'title': 'fake-test-site'
-                                }
-                            },
-                            {
-                                'entry': {
-                                    'role': 'SiteManager',
-                                    'visibility': 'PUBLIC',
-                                    'guid': 'fake-2',
-                                    'description': 'This is a Sample Alfresco Team site.',
-                                    'id': 'swsdp',
-                                    'preset': 'site-dashboard',
-                                    'title': 'fake-test-2'
-                                }
-                            }
-                        ]
-                    }
-                }));
-
                 fixture.detectChanges();
                 fixture.whenStable().then(() => {
                     fixture.detectChanges();
@@ -101,42 +86,6 @@ describe('DropdownSitesComponent', () => {
             }));
 
             it('Should not show loading item if there are more itemes', async(() => {
-                spyOn(siteService, 'getSites').and.returnValue(of({
-                    'list': {
-                        'pagination': {
-                            'count': 2,
-                            'hasMoreItems': false,
-                            'totalItems': 2,
-                            'skipCount': 0,
-                            'maxItems': 100
-                        },
-                        'entries': [
-                            {
-                                'entry': {
-                                    'role': 'SiteManager',
-                                    'visibility': 'PUBLIC',
-                                    'guid': 'fake-1',
-                                    'description': 'fake-test-site',
-                                    'id': 'fake-test-site',
-                                    'preset': 'site-dashboard',
-                                    'title': 'fake-test-site'
-                                }
-                            },
-                            {
-                                'entry': {
-                                    'role': 'SiteManager',
-                                    'visibility': 'PUBLIC',
-                                    'guid': 'fake-2',
-                                    'description': 'This is a Sample Alfresco Team site.',
-                                    'id': 'swsdp',
-                                    'preset': 'site-dashboard',
-                                    'title': 'fake-test-2'
-                                }
-                            }
-                        ]
-                    }
-                }));
-
                 fixture.detectChanges();
                 fixture.whenStable().then(() => {
                     fixture.detectChanges();
@@ -150,41 +99,7 @@ describe('DropdownSitesComponent', () => {
 
             beforeEach(async(() => {
                 siteService = TestBed.get(SitesService);
-                spyOn(siteService, 'getSites').and.returnValue(of({
-                    'list': {
-                        'pagination': {
-                            'count': 2,
-                            'hasMoreItems': false,
-                            'totalItems': 2,
-                            'skipCount': 0,
-                            'maxItems': 100
-                        },
-                        'entries': [
-                            {
-                                'entry': {
-                                    'role': 'SiteManager',
-                                    'visibility': 'PUBLIC',
-                                    'guid': 'fake-1',
-                                    'description': 'fake-test-site',
-                                    'id': 'fake-test-site',
-                                    'preset': 'site-dashboard',
-                                    'title': 'fake-test-site'
-                                }
-                            },
-                            {
-                                'entry': {
-                                    'role': 'SiteManager',
-                                    'visibility': 'PUBLIC',
-                                    'guid': 'fake-2',
-                                    'description': 'This is a Sample Alfresco Team site.',
-                                    'id': 'swsdp',
-                                    'preset': 'site-dashboard',
-                                    'title': 'fake-test-2'
-                                }
-                            }
-                        ]
-                    }
-                }));
+                spyOn(siteService, 'getSites').and.returnValue(of(getFakeSitePagingNoMoreItems()));
 
                 fixture = TestBed.createComponent(DropdownSitesComponent);
                 debug = fixture.debugElement;
@@ -260,24 +175,7 @@ describe('DropdownSitesComponent', () => {
             }));
 
             it('should load custom sites when the \'siteList\' input property is given a value', async(() => {
-                component.siteList = {
-                    'list': {
-                        'entries': [
-                            {
-                                'entry': {
-                                    'guid': '-my-',
-                                    'title': 'PERSONAL_FILES'
-                                }
-                            },
-                            {
-                                'entry': {
-                                    'guid': '-mysites-',
-                                    'title': 'FILE_LIBRARIES'
-                                }
-                            }
-                        ]
-                    }
-                };
+                component.siteList = customSiteList;
 
                 fixture.detectChanges();
 
@@ -339,129 +237,11 @@ describe('DropdownSitesComponent', () => {
             });
         });
 
-        describe('Sites  with members', () => {
+        describe('Sites with members', () => {
 
             beforeEach(async(() => {
                 siteService = TestBed.get(SitesService);
-                spyOn(siteService, 'getSites').and.returnValue(of({
-                    'list': {
-                        'entries': [{
-                            'entry': {
-                                'visibility': 'MODERATED',
-                                'guid': 'b4cff62a-664d-4d45-9302-98723eac1319',
-                                'description': 'This is a Sample Alfresco Team site.',
-                                'id': 'MODERATED-SITE',
-                                'preset': 'site-dashboard',
-                                'title': 'FAKE-MODERATED-SITE'
-                            },
-                            'relations': {
-                                'members': {
-                                    'list': {
-                                        'pagination': {
-                                            'count': 3,
-                                            'hasMoreItems': false,
-                                            'skipCount': 0,
-                                            'maxItems': 100
-                                        },
-                                        'entries': [
-                                            {
-                                                'entry': {
-                                                    'role': 'SiteManager',
-                                                    'person': {
-                                                        'firstName': 'Administrator',
-                                                        'emailNotificationsEnabled': true,
-                                                        'company': {},
-                                                        'id': 'admin',
-                                                        'enabled': true,
-                                                        'email': 'admin@alfresco.com'
-                                                    },
-                                                    'id': 'admin'
-                                                }
-                                            },
-                                            {
-                                                'entry': {
-                                                    'role': 'SiteCollaborator',
-                                                    'person': {
-                                                        'lastName': 'Beecher',
-                                                        'userStatus': 'Helping to design the look and feel of the new web site',
-                                                        'jobTitle': 'Graphic Designer',
-                                                        'statusUpdatedAt': '2011-02-15T20:20:13.432+0000',
-                                                        'mobile': '0112211001100',
-                                                        'emailNotificationsEnabled': true,
-                                                        'description': 'Alice is a demo user for the sample Alfresco Team site.',
-                                                        'telephone': '0112211001100',
-                                                        'enabled': false,
-                                                        'firstName': 'Alice',
-                                                        'skypeId': 'abeecher',
-                                                        'avatarId': '198500fc-1e99-4f5f-8926-248cea433366',
-                                                        'location': 'Tilbury, UK',
-                                                        'company': {
-                                                            'organization': 'Moresby, Garland and Wedge',
-                                                            'address1': '200 Butterwick Street',
-                                                            'address2': 'Tilbury',
-                                                            'address3': 'UK',
-                                                            'postcode': 'ALF1 SAM1'
-                                                        },
-                                                        'id': 'abeecher',
-                                                        'email': 'abeecher@example.com'
-                                                    },
-                                                    'id': 'abeecher'
-                                                }
-                                            }
-                                        ]
-                                    }
-                                }
-                            }
-                        }, {
-                            'entry': {
-                                'visibility': 'PUBLIC',
-                                'guid': 'b4cff62a-664d-4d45-9302-98723eac1319',
-                                'description': 'This is a Sample Alfresco Team site.',
-                                'id': 'PUBLIC-SITE',
-                                'preset': 'site-dashboard',
-                                'title': 'FAKE-SITE-PUBLIC'
-                            }
-                        }, {
-                            'entry': {
-                                'visibility': 'PRIVATE',
-                                'guid': 'b4cff62a-664d-4d45-9302-98723eac1319',
-                                'description': 'This is a Sample Alfresco Team site.',
-                                'id': 'MEMBER-SITE',
-                                'preset': 'site-dashboard',
-                                'title': 'FAKE-PRIVATE-SITE-MEMBER'
-                            },
-                            'relations': {
-                                'members': {
-                                    'list': {
-                                        'pagination': {
-                                            'count': 3,
-                                            'hasMoreItems': false,
-                                            'skipCount': 0,
-                                            'maxItems': 100
-                                        },
-                                        'entries': [
-                                            {
-                                                'entry': {
-                                                    'role': 'SiteManager',
-                                                    'person': {
-                                                        'firstName': 'Administrator',
-                                                        'emailNotificationsEnabled': true,
-                                                        'company': {},
-                                                        'id': 'admin',
-                                                        'enabled': true,
-                                                        'email': 'admin@alfresco.com'
-                                                    },
-                                                    'id': 'test'
-                                                }
-                                            }
-                                        ]
-                                    }
-                                }
-                            }
-                        }
-                        ]
-                    }
-                }));
+                spyOn(siteService, 'getSites').and.returnValue(of(getFakeSitePagingWithMembers()));
 
                 fixture = TestBed.createComponent(DropdownSitesComponent);
                 debug = fixture.debugElement;

--- a/lib/content-services/src/lib/site-dropdown/sites-dropdown.component.spec.ts
+++ b/lib/content-services/src/lib/site-dropdown/sites-dropdown.component.spec.ts
@@ -22,7 +22,12 @@ import { DropdownSitesComponent, Relations } from './sites-dropdown.component';
 import { SitesService, setupTestBed, CoreModule, AlfrescoApiService, AlfrescoApiServiceMock } from '@alfresco/adf-core';
 import { of } from 'rxjs';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { getFakeSitePaging, getFakeSitePagingNoMoreItems, getFakeSitePagingWithMembers } from '../mock';
+import { getFakeSitePaging,
+    getFakeSitePagingNoMoreItems,
+    getFakeSitePagingFirstPage,
+    getFakeSitePagingLastPage,
+    getFakeSitePagingWithMembers
+} from '../mock';
 
 const customSiteList = {
     'list': {
@@ -232,6 +237,38 @@ describe('DropdownSitesComponent', () => {
 
                 fixture.whenStable().then(() => {
                     expect(component.selected.entry.title).toBe('fake-test-2');
+                    done();
+                });
+            });
+        });
+
+        describe('Default value', () => {
+
+            beforeEach(async(() => {
+                siteService = TestBed.get(SitesService);
+                spyOn(siteService, 'getSites').and.returnValues(of(getFakeSitePagingFirstPage()), of(getFakeSitePagingLastPage()));
+
+                fixture = TestBed.createComponent(DropdownSitesComponent);
+                component = fixture.componentInstance;
+            }));
+
+            it('should load new sites if default value is not in the first page', (done) => {
+                component.value = 'fake-test-4';
+                fixture.detectChanges();
+
+                fixture.whenStable().then(() => {
+                    expect(component.selected.entry.title).toBe('fake-test-4');
+                    done();
+                });
+            });
+
+            it('should NOT reload infinitely if default value is NOT found after all sites are loaded', (done) => {
+                component.value = 'nonexistent-site';
+                fixture.detectChanges();
+
+                fixture.whenStable().then(() => {
+                    expect(component.selected).toBeUndefined();
+                    expect(component.loading).toBeFalsy();
                     done();
                 });
             });

--- a/lib/content-services/src/lib/site-dropdown/sites-dropdown.component.ts
+++ b/lib/content-services/src/lib/site-dropdown/sites-dropdown.component.ts
@@ -164,7 +164,7 @@ export class DropdownSitesComponent implements OnInit, OnDestroy {
 
                 this.selected = this.siteList.list.entries.find((site: SiteEntry) => site.entry.id === this.value);
 
-                if (this.value && !this.selected && !this.allSitesLoaded()) {
+                if (this.value && !this.selected && this.siteList.list.pagination.hasMoreItems) {
                     this.loadSiteList();
                 }
 
@@ -194,9 +194,5 @@ export class DropdownSitesComponent implements OnInit, OnDestroy {
             !!site.relations.members.list.entries.find((member) => {
                 return member.entry.id.toLowerCase() === loggedUserName.toLowerCase();
             });
-    }
-
-    private allSitesLoaded(): boolean {
-        return this.skipCount > this.siteList.list.entries.length;
     }
 }

--- a/lib/content-services/src/lib/site-dropdown/sites-dropdown.component.ts
+++ b/lib/content-services/src/lib/site-dropdown/sites-dropdown.component.ts
@@ -142,8 +142,8 @@ export class DropdownSitesComponent implements OnInit, OnDestroy {
                     if (!this.hideMyFiles) {
                         const siteEntry = new SiteEntry({
                             entry: {
-                                id: '-my-',
-                                guid: '-my-',
+                                id: this.MY_FILES_VALUE,
+                                guid: this.MY_FILES_VALUE,
                                 title: 'DROPDOWN.MY_FILES_OPTION'
                             }
                         });
@@ -151,7 +151,7 @@ export class DropdownSitesComponent implements OnInit, OnDestroy {
                         this.siteList.list.entries.unshift(siteEntry);
 
                         if (!this.value) {
-                            this.value = '-my-';
+                            this.value = this.MY_FILES_VALUE;
                         }
                     }
 
@@ -163,6 +163,10 @@ export class DropdownSitesComponent implements OnInit, OnDestroy {
                 }
 
                 this.selected = this.siteList.list.entries.find((site: SiteEntry) => site.entry.id === this.value);
+
+                if (!this.selected) {
+                    this.loadSiteList();
+                }
 
                 this.loading = false;
             },

--- a/lib/content-services/src/lib/site-dropdown/sites-dropdown.component.ts
+++ b/lib/content-services/src/lib/site-dropdown/sites-dropdown.component.ts
@@ -164,7 +164,7 @@ export class DropdownSitesComponent implements OnInit, OnDestroy {
 
                 this.selected = this.siteList.list.entries.find((site: SiteEntry) => site.entry.id === this.value);
 
-                if (!this.selected) {
+                if (this.value && !this.selected && !this.allSitesLoaded()) {
                     this.loadSiteList();
                 }
 
@@ -196,4 +196,7 @@ export class DropdownSitesComponent implements OnInit, OnDestroy {
             });
     }
 
+    private allSitesLoaded(): boolean {
+        return this.skipCount > this.siteList.list.entries.length;
+    }
 }

--- a/lib/content-services/src/lib/site-dropdown/sites-dropdown.component.ts
+++ b/lib/content-services/src/lib/site-dropdown/sites-dropdown.component.ts
@@ -164,7 +164,7 @@ export class DropdownSitesComponent implements OnInit, OnDestroy {
 
                 this.selected = this.siteList.list.entries.find((site: SiteEntry) => site.entry.id === this.value);
 
-                if (this.value && !this.selected && this.siteList.list.pagination.hasMoreItems) {
+                if (this.value && !this.selected && this.siteListHasMoreItems()) {
                     this.loadSiteList();
                 }
 
@@ -176,11 +176,15 @@ export class DropdownSitesComponent implements OnInit, OnDestroy {
     }
 
     showLoading(): boolean {
-        return this.loading && (this.siteList && this.siteList.list.pagination && this.siteList.list.pagination.hasMoreItems);
+        return this.loading && this.siteListHasMoreItems();
     }
 
     isInfiniteScrollingEnabled(): boolean {
-        return !this.loading && (this.siteList && this.siteList.list.pagination && this.siteList.list.pagination.hasMoreItems);
+        return !this.loading && this.siteListHasMoreItems();
+    }
+
+    private siteListHasMoreItems(): boolean {
+        return this.siteList && this.siteList.list.pagination && this.siteList.list.pagination.hasMoreItems;
     }
 
     private filteredResultsByMember(sites: SitePaging): SitePaging {

--- a/lib/core/form/services/activiti-alfresco.service.ts
+++ b/lib/core/form/services/activiti-alfresco.service.ts
@@ -110,9 +110,9 @@ export class ActivitiContentService {
             );
     }
 
-    private getSiteNameFromNodePath(node: MinimalNode): string {
+    getSiteNameFromNodePath(node: MinimalNode): string {
         let siteName = '';
-        if (node.path) {
+        if (node.path && node.path.elements) {
             const foundNode = node.path
                 .elements.find((pathNode: MinimalNode) =>
                     pathNode.nodeType === 'st:site' &&

--- a/lib/core/form/services/activiti-alfresco.service.ts
+++ b/lib/core/form/services/activiti-alfresco.service.ts
@@ -17,6 +17,7 @@
 
 import { AlfrescoApiService } from '../../services/alfresco-api.service';
 import { LogService } from '../../services/log.service';
+import { SitesService } from '../../services/sites.service';
 import { Injectable } from '@angular/core';
 import { AlfrescoApiCompatibility, MinimalNode, RelatedContentRepresentation } from '@alfresco/js-api';
 import { Observable, from, throwError } from 'rxjs';
@@ -33,7 +34,8 @@ export class ActivitiContentService {
     static GENERIC_ERROR_MESSAGE: string = 'Server error';
 
     constructor(private apiService: AlfrescoApiService,
-                private logService: LogService) {
+                private logService: LogService,
+                private sitesService: SitesService) {
     }
 
     /**
@@ -95,7 +97,7 @@ export class ActivitiContentService {
 
     applyAlfrescoNode(node: MinimalNode, siteId: string, accountId: string) {
         const apiService: AlfrescoApiCompatibility = this.apiService.getInstance();
-        const currentSideId = siteId ? siteId : this.getSiteNameFromNodePath(node);
+        const currentSideId = siteId ? siteId : this.sitesService.getSiteNameFromNodePath(node);
         const params: RelatedContentRepresentation = {
             source: accountId,
             mimeType: node.content.mimeType,
@@ -108,18 +110,6 @@ export class ActivitiContentService {
                 map(this.toJson),
                 catchError((err) => this.handleError(err))
             );
-    }
-
-    getSiteNameFromNodePath(node: MinimalNode): string {
-        let siteName = '';
-        if (node.path && node.path.elements) {
-            const foundNode = node.path
-                .elements.find((pathNode: MinimalNode) =>
-                    pathNode.nodeType === 'st:site' &&
-                    pathNode.name !== 'Sites');
-            siteName = foundNode ? foundNode.name : '';
-        }
-        return siteName.toLocaleLowerCase();
     }
 
     toJson(res: any) {

--- a/lib/core/services/sites.service.ts
+++ b/lib/core/services/sites.service.ts
@@ -18,7 +18,7 @@
 import { Injectable } from '@angular/core';
 import { Observable, from, throwError } from 'rxjs';
 import { AlfrescoApiService } from './alfresco-api.service';
-import { SitePaging, SiteEntry, SitesApi, SiteMembershipRequestWithPersonPaging } from '@alfresco/js-api';
+import { SitePaging, SiteEntry, MinimalNode, SitesApi, SiteMembershipRequestWithPersonPaging } from '@alfresco/js-api';
 import { catchError } from 'rxjs/operators';
 
 @Injectable({
@@ -101,6 +101,24 @@ export class SitesService {
      */
     getEcmCurrentLoggedUserName(): string {
         return this.apiService.getInstance().getEcmUsername();
+    }
+
+    /**
+     * Looks for a site inside the path of a Node and returns its guid if it finds one.
+     * (return an empty string if no site is found)
+     * @param node Node to look for parent site
+     * @returns Site guid
+     */
+    getSiteNameFromNodePath(node: MinimalNode): string {
+        let siteName = '';
+        if (node.path && node.path.elements) {
+            const foundNode = node.path
+                .elements.find((pathNode: MinimalNode) =>
+                    pathNode.nodeType === 'st:site' &&
+                    pathNode.name !== 'Sites');
+            siteName = foundNode ? foundNode.name : '';
+        }
+        return siteName.toLocaleLowerCase();
     }
 
     /**

--- a/lib/process-services/src/lib/content-widget/attach-file-widget-dialog.component.html
+++ b/lib/process-services/src/lib/content-widget/attach-file-widget-dialog.component.html
@@ -1,6 +1,8 @@
 <header
     mat-dialog-title
-    data-automation-id="content-node-selector-title">{{title}}
+    data-automation-id="content-node-selector-title">
+    <span *ngIf="isLoggedIn(); else loginTitle">{{title}}</span>
+    <ng-template #loginTitle>{{data.title}}</ng-template>
 </header>
 
 <mat-dialog-content class="adf-login-dialog-content">
@@ -10,7 +12,8 @@
                                      id="attach-file-content-node"
                                      [isSelectionValid]="data?.isSelectionValid"
                                      [showFilesInResult]="data?.showFilesInResult"
-                                     (select)="onSelect($event)">
+                                     (select)="onSelect($event)"
+                                     (siteChange)="onSiteChange($event)">
     </adf-content-node-selector-panel>
 </mat-dialog-content>
 

--- a/lib/process-services/src/lib/content-widget/attach-file-widget-dialog.component.spec.ts
+++ b/lib/process-services/src/lib/content-widget/attach-file-widget-dialog.component.spec.ts
@@ -145,22 +145,14 @@ describe('AttachFileWidgetDialogComponent', () => {
             });
         });
 
-        it('should update the title when the selected node is a file', () => {
-            const fakeNode: Node = new Node({ id: 'fake', isFile: true});
-            contentNodePanel.componentInstance.select.emit([fakeNode]);
+        it('should update the title when a site is selected', () => {
+            const fakeSiteTitle = 'My fake site';
+            contentNodePanel.componentInstance.siteChange.emit(fakeSiteTitle);
             fixture.detectChanges();
+
             const titleElement = fixture.debugElement.query(By.css('[data-automation-id="content-node-selector-title"]'));
             expect(titleElement).not.toBeNull();
             expect(titleElement.nativeElement.innerText).toBe('ATTACH-FILE.ACTIONS.CHOOSE_ITEM');
-        });
-
-        it('should update the title when the selected node is a folder', () => {
-            const fakeNode: Node = new Node({ id: 'fake', isFolder: true});
-            contentNodePanel.componentInstance.select.emit([fakeNode]);
-            fixture.detectChanges();
-            const titleElement = fixture.debugElement.query(By.css('[data-automation-id="content-node-selector-title"]'));
-            expect(titleElement).not.toBeNull();
-            expect(titleElement.nativeElement.innerText).toBe('ATTACH-FILE.ACTIONS.CHOOSE_IN');
         });
    });
 });

--- a/lib/process-services/src/lib/content-widget/attach-file-widget-dialog.component.ts
+++ b/lib/process-services/src/lib/content-widget/attach-file-widget-dialog.component.ts
@@ -50,7 +50,7 @@ export class AttachFileWidgetDialogComponent {
         (<any> externalApiService).init(data.ecmHost, data.context);
         this.action = data.actionName ? data.actionName.toUpperCase() : 'CHOOSE';
         this.buttonActionName = `ATTACH-FILE.ACTIONS.${this.action}`;
-        this.title = data.title;
+        this.updateTitle('DROPDOWN.MY_FILES_OPTION');
     }
 
     isLoggedIn() {
@@ -66,12 +66,11 @@ export class AttachFileWidgetDialogComponent {
     }
 
     onSelect(nodeList: Node[]) {
-        if (nodeList && nodeList[0].isFile) {
-            this.chosenNode = nodeList;
-        } else {
-            this.chosenNode = null;
-        }
-        this.updateTitle(nodeList);
+        this.chosenNode = nodeList;
+    }
+
+    onSiteChange(siteTitle: string) {
+        this.updateTitle(siteTitle);
     }
 
     onClick() {
@@ -79,17 +78,14 @@ export class AttachFileWidgetDialogComponent {
         this.data.selected.complete();
     }
 
-    updateTitle(nodeList: Node[]): void {
-        if (this.action === 'CHOOSE' && nodeList) {
-            if (nodeList[0].isFile) {
-                this.title = this.getTitleTranslation(this.action + '_ITEM', nodeList[0].name);
-            } else if (nodeList[0].isFolder) {
-                this.title = this.getTitleTranslation(this.action + '_IN', nodeList[0].name);
-            }
+    updateTitle(siteTitle: string) {
+        if (this.action === 'CHOOSE' && siteTitle) {
+            this.title = this.getTitleTranslation(this.action, siteTitle);
         }
     }
 
-    getTitleTranslation(action: string, name: string): string {
-        return this.translation.instant(`ATTACH-FILE.ACTIONS.${action}`, { name });
+    getTitleTranslation(action: string, name?: string): string {
+        const translatedName = this.translation.instant(name);
+        return this.translation.instant(`ATTACH-FILE.ACTIONS.${action}_IN`, { name: translatedName });
     }
 }

--- a/lib/process-services/src/lib/content-widget/attach-file-widget-dialog.component.ts
+++ b/lib/process-services/src/lib/content-widget/attach-file-widget-dialog.component.ts
@@ -85,7 +85,6 @@ export class AttachFileWidgetDialogComponent {
     }
 
     getTitleTranslation(action: string, name?: string): string {
-        const translatedName = this.translation.instant(name);
-        return this.translation.instant(`ATTACH-FILE.ACTIONS.${action}_IN`, { name: translatedName });
+        return this.translation.instant(`ATTACH-FILE.ACTIONS.${action}_ITEM`, { name: this.translation.instant(name) });
     }
 }

--- a/lib/process-services/src/lib/content-widget/attach-file-widget-dialog.service.ts
+++ b/lib/process-services/src/lib/content-widget/attach-file-widget-dialog.service.ts
@@ -54,7 +54,7 @@ export class AttachFileWidgetDialogService {
             selected,
             ecmHost,
             context,
-            isSelectionValid: this.isNodeValid.bind(this),
+            isSelectionValid: this.isNodeFile.bind(this),
             showFilesInResult: true
         };
 
@@ -71,8 +71,8 @@ export class AttachFileWidgetDialogService {
         this.dialog.closeAll();
     }
 
-    private isNodeValid(entry: Node): boolean {
-        return entry.isFile || entry.isFolder;
+    private isNodeFile(entry: Node): boolean {
+        return entry.isFile;
     }
 
     private getLoginTitleTranslation(ecmHost: string): string {

--- a/lib/process-services/src/lib/i18n/en.json
+++ b/lib/process-services/src/lib/i18n/en.json
@@ -332,13 +332,8 @@
     "ACTIONS": {
       "LOGIN": "Login",
       "CANCEL": "Cancel",
-<<<<<<< HEAD
       "CHOOSE": "Select",
       "CHOOSE_ITEM": "Select content to attach from '{{ name }}'"
-=======
-      "CHOOSE": "Choose",
-      "CHOOSE_IN": "Choose file in '{{ name }}'..."
->>>>>>> [AAE-2200] Minor fixes on attach-file-widget-dialog
     }
   },
   "ADF_TASK_FORM": {

--- a/lib/process-services/src/lib/i18n/en.json
+++ b/lib/process-services/src/lib/i18n/en.json
@@ -332,8 +332,13 @@
     "ACTIONS": {
       "LOGIN": "Login",
       "CANCEL": "Cancel",
+<<<<<<< HEAD
       "CHOOSE": "Select",
       "CHOOSE_ITEM": "Select content to attach from '{{ name }}'"
+=======
+      "CHOOSE": "Choose",
+      "CHOOSE_IN": "Choose file in '{{ name }}'..."
+>>>>>>> [AAE-2200] Minor fixes on attach-file-widget-dialog
     }
   },
   "ADF_TASK_FORM": {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
The update of the title doesn't match the selected site but the selected node and not every time depending on the context of the upload. Also when the site-dropdown receives a site guid as init value and the site isn't int the first loaded site list it doesn't select that site.


**What is the new behaviour?**
The title of an upload dialog is now matching its selected site inside the dropdown-site. Also at the initialisation is a start folder is selected the site-dropdown select the parent site of that folder (My files by default) which leads to the update of the title of the dialog.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/AAE-2200
*Open dialog with starting folder inside "My site 1"*
![open-dialog-with-starting-folder-inside-my-site-1](https://user-images.githubusercontent.com/41227846/80492440-4eccc900-8964-11ea-8701-f41e0af66f61.png)
*Open dialog without starting folder*
![open-dialog-without-starting-folder](https://user-images.githubusercontent.com/41227846/80492457-53917d00-8964-11ea-86e9-13f87e97c206.png)
*Updated dialog after changing site using site-dropdown*
![updated-dialog-after-changing-site](https://user-images.githubusercontent.com/41227846/80492466-57bd9a80-8964-11ea-9fa8-9828fe548038.png)
