### PR TITLE
[AAE-2487] Fix Checkbox Widget bug

### DIFF
--- a/lib/core/form/components/widgets/checkbox/checkbox.widget.html
+++ b/lib/core/form/components/widgets/checkbox/checkbox.widget.html
@@ -5,8 +5,8 @@
         color="primary"
         [required]="field.required"
         [disabled]="field.readOnly || readOnly"
-        [(ngModel)]="field.value"
-        (ngModelChange)="onFieldChanged(field)">
+        [(ngModel)]="checkboxValue"
+        (ngModelChange)="onCheckboxToggled()">
         {{field.name | translate }}
         <span *ngIf="field.required">*</span>
     </mat-checkbox>

--- a/lib/core/form/components/widgets/checkbox/checkbox.widget.spec.ts
+++ b/lib/core/form/components/widgets/checkbox/checkbox.widget.spec.ts
@@ -25,6 +25,7 @@ import { FormBaseModule } from 'core/form/form-base.module';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TranslateService, TranslateStore, TranslateLoader } from '@ngx-translate/core';
 import { TranslateLoaderService } from 'core/services';
+import { MatCheckboxModule } from '@angular/material';
 
 describe('CheckboxWidgetComponent', () => {
 
@@ -35,7 +36,8 @@ describe('CheckboxWidgetComponent', () => {
     setupTestBed({
         imports: [
             NoopAnimationsModule,
-            FormBaseModule
+            FormBaseModule,
+            MatCheckboxModule
         ],
         providers: [
             TranslateStore,
@@ -62,12 +64,67 @@ describe('CheckboxWidgetComponent', () => {
                 readOnly: false,
                 required: true
             });
-            fixture.detectChanges();
         });
 
         it('should be marked as invalid when required', async(() => {
+            fixture.detectChanges();
             fixture.whenStable().then(() => {
                 expect(element.querySelector('.adf-invalid')).not.toBeNull();
+            });
+        }));
+
+        it('should be checked if boolean true is passed', async(() => {
+            widget.field.value = true;
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+                fixture.detectChanges();
+                const checkbox = fixture.debugElement.nativeElement.querySelector('mat-checkbox input');
+                expect(checkbox.getAttribute('aria-checked')).toBe('true');
+                expect(widget.checkboxValue).toBe(true);
+            });
+        }));
+
+        it('should be checked if string "true" is passed', async(() => {
+            widget.field.value = 'true';
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+                fixture.detectChanges();
+                const checkbox = fixture.debugElement.nativeElement.querySelector('mat-checkbox input');
+                expect(checkbox.getAttribute('aria-checked')).toBe('true');
+                expect(widget.checkboxValue).toBe(true);
+            });
+        }));
+
+        it('should not be checked if boolean false is passed', async(() => {
+            widget.field.value = false;
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+                fixture.detectChanges();
+                const checkbox = fixture.debugElement.nativeElement.querySelector('mat-checkbox input');
+                expect(checkbox.getAttribute('aria-checked')).toBe('false');
+                expect(widget.checkboxValue).toBe(false);
+            });
+        }));
+
+        it('should not be checked if string "false" is passed', async(() => {
+            widget.field.value = 'false';
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+                fixture.detectChanges();
+                const checkbox = fixture.debugElement.nativeElement.querySelector('mat-checkbox input');
+                expect(checkbox.getAttribute('aria-checked')).toBe('false');
+                expect(widget.checkboxValue).toBe(false);
+            });
+        }));
+
+        it('should not be checked if null is passed', async(() => {
+            widget.field.value = null;
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+                fixture.detectChanges();
+                const checkbox = fixture.debugElement.nativeElement.querySelector('mat-checkbox input');
+                expect(checkbox.getAttribute('aria-checked')).toBe('false');
+                expect(widget.checkboxValue).toBe(false);
             });
         }));
    });

--- a/lib/core/form/components/widgets/checkbox/checkbox.widget.ts
+++ b/lib/core/form/components/widgets/checkbox/checkbox.widget.ts
@@ -17,9 +17,9 @@
 
 /* tslint:disable:component-selector no-input-rename */
 
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component, ViewEncapsulation, OnInit } from '@angular/core';
 import { FormService } from './../../../services/form.service';
-import { baseHost , WidgetComponent } from './../widget.component';
+import { baseHost, WidgetComponent } from './../widget.component';
 
 @Component({
     selector: 'checkbox-widget',
@@ -27,10 +27,23 @@ import { baseHost , WidgetComponent } from './../widget.component';
     host: baseHost,
     encapsulation: ViewEncapsulation.None
 })
-export class CheckboxWidgetComponent extends WidgetComponent {
+export class CheckboxWidgetComponent extends WidgetComponent implements OnInit {
+    checkboxValue: boolean;
 
     constructor(public formService: FormService) {
         super(formService);
     }
 
+    ngOnInit() {
+        this.checkboxValue = this.parseValue(this.field.value);
+    }
+
+    parseValue(value: any) {
+        return value === true || value === 'true';
+    }
+
+    onCheckboxToggled() {
+        this.field.value = this.checkboxValue;
+        this.onFieldChanged(this.field);
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/AAE-2487
The checkbox widget was always showing as checked because the field value is a string and returned tru always when parsing.

**What is the new behaviour?**
Before that value is applied the widget parses the value so it knows when it's checked and when its not.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
