### PR TITLE
[ADF-5134] REGRESSION - Fix People and Group Components firing twice

### DIFF
--- a/lib/process-services-cloud/src/lib/group/components/group-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/group/components/group-cloud.component.spec.ts
@@ -221,11 +221,13 @@ describe('GroupCloudComponent', () => {
     describe('when application name defined', () => {
         let checkGroupHasAnyClientAppRoleSpy: jasmine.Spy;
         let checkGroupHasClientAppSpy: jasmine.Spy;
+        let getClientIdByApplicationNameSpy: jasmine.Spy;
 
         beforeEach(async(() => {
             findGroupsByNameSpy = spyOn(identityGroupService, 'findGroupsByName').and.returnValue(of(mockIdentityGroups));
             checkGroupHasAnyClientAppRoleSpy = spyOn(identityGroupService, 'checkGroupHasAnyClientAppRole').and.returnValue(of(true));
             checkGroupHasClientAppSpy = spyOn(identityGroupService, 'checkGroupHasClientApp').and.returnValue(of(true));
+            getClientIdByApplicationNameSpy = spyOn(identityGroupService, 'getClientIdByApplicationName').and.callThrough();
 
             component.preSelectGroups = [];
             component.appName = 'mock-app-name';
@@ -234,12 +236,6 @@ describe('GroupCloudComponent', () => {
         }));
 
         it('should fetch the client ID if appName specified', async (() => {
-            const getClientIdByApplicationNameSpy = spyOn(identityGroupService, 'getClientIdByApplicationName').and.callThrough();
-            component.appName = 'mock-app-name';
-
-            const change = new SimpleChange(null, 'mock-app-name', false);
-            component.ngOnChanges({ 'appName': change });
-
             fixture.detectChanges();
             fixture.whenStable().then(() => {
                 fixture.detectChanges();

--- a/lib/process-services-cloud/src/lib/group/components/group-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/group/components/group-cloud.component.ts
@@ -183,9 +183,6 @@ export class GroupCloudComponent implements OnChanges, OnDestroy {
                 }
             }),
             debounceTime(500),
-            distinctUntilChanged((a, b) => {
-                return JSON.stringify(a) === JSON.stringify(b);
-            }),
             distinctUntilChanged(),
             tap((value) => {
                 if (value.trim()) {

--- a/lib/process-services-cloud/src/lib/group/components/group-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/group/components/group-cloud.component.ts
@@ -18,7 +18,6 @@
 import {
     Component,
     ElementRef,
-    OnInit,
     Output,
     EventEmitter,
     ViewChild,

--- a/lib/process-services-cloud/src/lib/group/components/group-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/group/components/group-cloud.component.ts
@@ -54,7 +54,7 @@ import { ComponentSelectionMode } from '../../types';
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None
 })
-export class GroupCloudComponent implements OnInit, OnChanges, OnDestroy {
+export class GroupCloudComponent implements OnChanges, OnDestroy {
 
     /** Name of the application. If specified this shows the groups who have access to the app. */
     @Input()
@@ -136,11 +136,6 @@ export class GroupCloudComponent implements OnInit, OnChanges, OnDestroy {
         private identityGroupService: IdentityGroupService,
         private logService: LogService) {}
 
-    ngOnInit(): void {
-        this.loadClientId();
-        this.initSearch();
-    }
-
     ngOnChanges(changes: SimpleChanges): void {
         if (this.hasPreselectedGroupsChanged(changes) || this.hasModeChanged(changes) || this.isValidationChanged(changes)) {
             if (this.hasPreSelectGroups()) {
@@ -188,6 +183,9 @@ export class GroupCloudComponent implements OnInit, OnChanges, OnDestroy {
                 }
             }),
             debounceTime(500),
+            distinctUntilChanged((a, b) => {
+                return JSON.stringify(a) === JSON.stringify(b);
+            }),
             distinctUntilChanged(),
             tap((value) => {
                 if (value.trim()) {

--- a/lib/process-services-cloud/src/lib/group/components/group-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/group/components/group-cloud.component.ts
@@ -27,7 +27,7 @@ import {
     OnChanges,
     OnDestroy,
     ChangeDetectionStrategy,
-    SimpleChange
+    OnInit
 } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { trigger, state, style, transition, animate } from '@angular/animations';
@@ -53,7 +53,7 @@ import { ComponentSelectionMode } from '../../types';
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None
 })
-export class GroupCloudComponent implements OnChanges, OnDestroy {
+export class GroupCloudComponent implements OnInit, OnChanges, OnDestroy {
 
     /** Name of the application. If specified this shows the groups who have access to the app. */
     @Input()
@@ -135,6 +135,11 @@ export class GroupCloudComponent implements OnChanges, OnDestroy {
         private identityGroupService: IdentityGroupService,
         private logService: LogService) {}
 
+    ngOnInit(): void {
+        this.loadClientId();
+        this.initSearch();
+    }
+
     ngOnChanges(changes: SimpleChanges): void {
         if (this.hasPreselectedGroupsChanged(changes) || this.hasModeChanged(changes) || this.isValidationChanged(changes)) {
             if (this.hasPreSelectGroups()) {
@@ -148,18 +153,6 @@ export class GroupCloudComponent implements OnChanges, OnDestroy {
                 this.invalidGroups = [];
             }
         }
-
-        if (changes.appName && this.isAppNameChanged(changes.appName)) {
-            this.loadClientId();
-            this.initSearch();
-        }
-    }
-
-    private isAppNameChanged(change: SimpleChange): boolean {
-        return change
-            && change.previousValue !== change.currentValue
-            && this.appName
-            && this.appName.length > 0;
     }
 
     private async loadClientId(): Promise<void> {

--- a/lib/process-services-cloud/src/lib/people/components/people-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/people/components/people-cloud.component.spec.ts
@@ -276,11 +276,13 @@ describe('PeopleCloudComponent', () => {
     describe('when application name defined', () => {
         let checkUserHasAccessSpy: jasmine.Spy;
         let checkUserHasAnyClientAppRoleSpy: jasmine.Spy;
+        let getClientIdByApplicationNameSpy: jasmine.Spy;
 
         beforeEach(async(() => {
             findUsersByNameSpy = spyOn(identityService, 'findUsersByName').and.returnValue(of(mockUsers));
             checkUserHasAccessSpy = spyOn(identityService, 'checkUserHasClientApp').and.returnValue(of(true));
             checkUserHasAnyClientAppRoleSpy = spyOn(identityService, 'checkUserHasAnyClientAppRole').and.returnValue(of(true));
+            getClientIdByApplicationNameSpy = spyOn(identityService, 'getClientIdByApplicationName').and.callThrough();
 
             component.preSelectUsers = [];
             component.appName = 'mock-app-name';
@@ -289,7 +291,6 @@ describe('PeopleCloudComponent', () => {
         }));
 
         it('should fetch the client ID if appName specified', async (() => {
-            const getClientIdByApplicationNameSpy = spyOn(identityService, 'getClientIdByApplicationName').and.callThrough();
             component.appName = 'mock-app-name';
 
             const change = new SimpleChange(null, 'mock-app-name', false);

--- a/lib/process-services-cloud/src/lib/people/components/people-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/people/components/people-cloud.component.ts
@@ -18,7 +18,6 @@
 import { FormControl } from '@angular/forms';
 import {
     Component,
-    OnInit,
     Output,
     EventEmitter,
     ViewEncapsulation,

--- a/lib/process-services-cloud/src/lib/people/components/people-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/people/components/people-cloud.component.ts
@@ -26,7 +26,7 @@ import {
     OnChanges,
     OnDestroy,
     ChangeDetectionStrategy,
-    ViewChild, ElementRef, SimpleChange
+    ViewChild, ElementRef, SimpleChange, OnInit
 } from '@angular/core';
 import { Observable, of, BehaviorSubject, Subject } from 'rxjs';
 import { switchMap, debounceTime, distinctUntilChanged, mergeMap, tap, filter, map, takeUntil } from 'rxjs/operators';
@@ -57,7 +57,7 @@ import { ComponentSelectionMode } from '../../types';
     encapsulation: ViewEncapsulation.None
 })
 
-export class PeopleCloudComponent implements OnChanges, OnDestroy {
+export class PeopleCloudComponent implements OnInit, OnChanges, OnDestroy {
 
     /** Name of the application. If specified, this shows the users who have access to the app. */
     @Input()
@@ -144,6 +144,11 @@ export class PeopleCloudComponent implements OnChanges, OnDestroy {
         private identityUserService: IdentityUserService,
         private logService: LogService) {}
 
+    ngOnInit(): void {
+        this.loadClientId();
+        this.initSearch();
+    }
+
     ngOnChanges(changes: SimpleChanges): void {
 
         if (this.valueChanged(changes.preSelectUsers)
@@ -160,11 +165,6 @@ export class PeopleCloudComponent implements OnChanges, OnDestroy {
             if (!this.isValidationEnabled()) {
                 this.invalidUsers = [];
             }
-        }
-
-        if (changes.appName && this.isAppNameChanged(changes.appName)) {
-            this.loadClientId();
-            this.initSearch();
         }
     }
 
@@ -230,10 +230,6 @@ export class PeopleCloudComponent implements OnChanges, OnDestroy {
     ngOnDestroy(): void {
         this.onDestroy$.next(true);
         this.onDestroy$.complete();
-    }
-
-    private isAppNameChanged(change: SimpleChange): boolean {
-        return change && change.previousValue !== change.currentValue && this.appName && this.appName.length > 0;
     }
 
     isValidationEnabled(): boolean {

--- a/lib/process-services-cloud/src/lib/people/components/people-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/people/components/people-cloud.component.ts
@@ -58,7 +58,7 @@ import { ComponentSelectionMode } from '../../types';
     encapsulation: ViewEncapsulation.None
 })
 
-export class PeopleCloudComponent implements OnInit, OnChanges, OnDestroy {
+export class PeopleCloudComponent implements OnChanges, OnDestroy {
 
     /** Name of the application. If specified, this shows the users who have access to the app. */
     @Input()
@@ -144,11 +144,6 @@ export class PeopleCloudComponent implements OnInit, OnChanges, OnDestroy {
     constructor(
         private identityUserService: IdentityUserService,
         private logService: LogService) {}
-
-    ngOnInit(): void {
-        this.loadClientId();
-        this.initSearch();
-    }
 
     ngOnChanges(changes: SimpleChanges): void {
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-5134
Both components, People and group cloud components where calling the init and loader methos twice causing these components to have multiple threads of the observables in the form inside.

It was causing to display the same people/group twice.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
