### PR TITLE
[ADF-5134] REGRESSION - Fix People and Group Components firing twice

### DIFF
--- a/lib/process-services-cloud/src/lib/group/components/group-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/group/components/group-cloud.component.ts
@@ -157,7 +157,6 @@ export class GroupCloudComponent implements OnInit, OnChanges, OnDestroy {
 
         if (changes.appName && this.isAppNameChanged(changes.appName)) {
             this.loadClientId();
-            this.initSearch();
         }
     }
 

--- a/lib/process-services-cloud/src/lib/people/components/people-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/people/components/people-cloud.component.ts
@@ -170,7 +170,6 @@ export class PeopleCloudComponent implements OnInit, OnChanges, OnDestroy {
 
         if (changes.appName && this.isAppNameChanged(changes.appName)) {
             this.loadClientId();
-            this.initSearch();
         }
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-5134
Both components, People and group cloud components where calling the init and loader methos twice causing these components to have multiple threads of the observables in the form inside.

It was causing to display the same people/group twice.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
