### PR TITLE
[ACA-3240] Information inside custom aspects when properties have default value is wrong displayed

### DIFF
--- a/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.html
+++ b/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.html
@@ -7,7 +7,8 @@
 
     <div *ngSwitchDefault>
         <mat-form-field class="adf-property-field adf-card-textitem-field"
-                        [ngClass]="{ 'adf-property-read-only': !isEditable }">
+                        [ngClass]="{ 'adf-property-read-only': !isEditable }"
+                        [floatLabel]="'never'">
             <input matInput
                    *ngIf="!property.multiline"
                    class="adf-property-value"
@@ -73,7 +74,8 @@
 
         <mat-form-field *ngIf="isEditable"
                         class="adf-property-field adf-textitem-chip-list-input"
-                        [ngClass]="{ 'adf-property-read-only': !isEditable }">
+                        [ngClass]="{ 'adf-property-read-only': !isEditable }"
+                        [floatLabel]="'never'">
             <input matInput
                    class="adf-property-value"
                    [placeholder]="property.default | translate"
@@ -94,7 +96,8 @@
          (click)="clicked()"
          fxLayout="row"
          fxLayoutAlign="space-between center">
-        <mat-form-field class="adf-property-field adf-card-textitem-field">
+        <mat-form-field class="adf-property-field adf-card-textitem-field"
+                        [floatLabel]="'never'">
             <input matInput
                    [type]=property.inputType
                    class="adf-property-value"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
[ACA-3240](https://issues.alfresco.com/jira/browse/ACA-3240)


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
