### PR TITLE
[ACA-3316] Fix process filters selection should reset if input changes to non ex…

### DIFF
--- a/lib/process-services/src/lib/process-list/components/process-filters.component.spec.ts
+++ b/lib/process-services/src/lib/process-list/components/process-filters.component.spec.ts
@@ -128,7 +128,6 @@ describe('ProcessFiltersComponent', () => {
         });
 
         fixture.detectChanges();
-        filterList.selectRunningFilter();
     });
 
     it('should return the filter task list, filtered By Name', (done) => {

--- a/lib/process-services/src/lib/process-list/components/process-filters.component.spec.ts
+++ b/lib/process-services/src/lib/process-list/components/process-filters.component.spec.ts
@@ -24,6 +24,7 @@ import { ProcessFiltersComponent } from './process-filters.component';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { fakeProcessFilters } from '../../mock';
 
 describe('ProcessFiltersComponent', () => {
 
@@ -51,13 +52,13 @@ describe('ProcessFiltersComponent', () => {
         fakeGlobalFilterPromise = Promise.resolve([
             new FilterProcessRepresentationModel({
                 id: 10,
-                name: 'FakeInvolvedTasks',
+                name: 'FakeCompleted',
                 icon: 'glyphicon-th',
                 filter: { state: 'open', assignment: 'fake-involved' }
             }),
             new FilterProcessRepresentationModel({
                 id: 20,
-                name: 'FakeMyTasks',
+                name: 'FakeAll',
                 icon: 'glyphicon-random',
                 filter: { state: 'open', assignment: 'fake-assignee' }
             }),
@@ -87,8 +88,8 @@ describe('ProcessFiltersComponent', () => {
             expect(res).toBeDefined();
             expect(filterList.filters).toBeDefined();
             expect(filterList.filters.length).toEqual(3);
-            expect(filterList.filters[0].name).toEqual('FakeInvolvedTasks');
-            expect(filterList.filters[1].name).toEqual('FakeMyTasks');
+            expect(filterList.filters[0].name).toEqual('FakeCompleted');
+            expect(filterList.filters[1].name).toEqual('FakeAll');
             expect(filterList.filters[2].name).toEqual('Running');
             done();
         });
@@ -123,11 +124,23 @@ describe('ProcessFiltersComponent', () => {
         expect(filterList.currentFilter).toBeUndefined();
 
         filterList.filterSelected.subscribe((filter) => {
-            expect(filter.name).toEqual('FakeInvolvedTasks');
+            expect(filter.name).toEqual('FakeCompleted');
             done();
         });
 
         fixture.detectChanges();
+    });
+
+    it('should reset selection when filterParam is a filter that does not exist', async () => {
+        spyOn(processFilterService, 'getProcessFilters').and.returnValue(from(fakeGlobalFilterPromise));
+        filterList.currentFilter = fakeProcessFilters.data[0];
+        filterList.filterParam = new FilterProcessRepresentationModel({ name: 'non-existing-filter' });
+        const appId = '1';
+        const change = new SimpleChange(null, appId, true);
+        filterList.ngOnChanges({ 'appId': change });
+        fixture.detectChanges();
+        await fixture.whenStable();
+        expect(filterList.currentFilter).toBe(undefined);
     });
 
     it('should return the filter task list, filtered By Name', (done) => {
@@ -183,7 +196,7 @@ describe('ProcessFiltersComponent', () => {
     it('should emit an event when a filter is selected', (done) => {
         const currentFilter = new FilterProcessRepresentationModel({
             id: 10,
-            name: 'FakeInvolvedTasks',
+            name: 'FakeCompleted',
             filter: { state: 'open', assignment: 'fake-involved' }
         });
 
@@ -229,7 +242,7 @@ describe('ProcessFiltersComponent', () => {
 
     it('should return the current filter after one is selected', () => {
         const filter = new FilterProcessRepresentationModel({
-            name: 'FakeMyTasks',
+            name: 'FakeAll',
             filter: { state: 'open', assignment: 'fake-assignee' }
         });
         expect(filterList.currentFilter).toBeUndefined();
@@ -252,7 +265,7 @@ describe('ProcessFiltersComponent', () => {
             expect(filterList.filters).toBeDefined();
             expect(filterList.filters.length).toEqual(3);
             expect(filterList.currentFilter).toBeDefined();
-            expect(filterList.currentFilter.name).toEqual('FakeMyTasks');
+            expect(filterList.currentFilter.name).toEqual('FakeAll');
             done();
         });
     });
@@ -260,7 +273,7 @@ describe('ProcessFiltersComponent', () => {
     it('should select the filter passed as input by name', (done) => {
         spyOn(processFilterService, 'getProcessFilters').and.returnValue(from(fakeGlobalFilterPromise));
 
-        filterList.filterParam = new FilterProcessRepresentationModel({ name: 'FakeMyTasks' });
+        filterList.filterParam = new FilterProcessRepresentationModel({ name: 'FakeAll' });
 
         const appId = 1;
         const change = new SimpleChange(null, appId, true);
@@ -272,7 +285,7 @@ describe('ProcessFiltersComponent', () => {
             expect(filterList.filters).toBeDefined();
             expect(filterList.filters.length).toEqual(3);
             expect(filterList.currentFilter).toBeDefined();
-            expect(filterList.currentFilter.name).toEqual('FakeMyTasks');
+            expect(filterList.currentFilter.name).toEqual('FakeAll');
             done();
         });
     });

--- a/lib/process-services/src/lib/process-list/components/process-filters.component.ts
+++ b/lib/process-services/src/lib/process-list/components/process-filters.component.ts
@@ -157,14 +157,17 @@ export class ProcessFiltersComponent implements OnInit, OnChanges {
      */
     selectProcessFilter(filterParam: FilterProcessRepresentationModel) {
         if (filterParam) {
-            this.filters.filter((processFilter: UserProcessInstanceFilterRepresentation, index) => {
-                if (filterParam.name && filterParam.name.toLowerCase() === processFilter.name.toLowerCase() ||
-                    filterParam.id === processFilter.id ||
-                    filterParam.index === index) {
-                    this.currentFilter = processFilter;
-                    this.filterSelected.emit(processFilter);
-                }
-            });
+            const newFilter = this.filters.find((processFilter, index) =>
+                filterParam.index === index ||
+                filterParam.id === processFilter.id ||
+                (filterParam.name &&
+                    (filterParam.name.toLocaleLowerCase() === processFilter.name.toLocaleLowerCase())
+                ));
+            this.currentFilter = newFilter;
+
+            if (newFilter) {
+                this.filterSelected.emit(newFilter);
+            }
         }
     }
 

--- a/lib/process-services/src/lib/task-list/components/task-filters.component.spec.ts
+++ b/lib/process-services/src/lib/task-list/components/task-filters.component.spec.ts
@@ -343,4 +343,16 @@ describe('TaskFiltersComponent', () => {
             done();
         });
     });
+
+    it('should reset selection when filterParam is a filter that does not exist', async () => {
+        spyOn(taskFilterService, 'getTaskListFilters').and.returnValue(from(fakeGlobalFilterPromise));
+        component.currentFilter = fakeGlobalFilter[0];
+        component.filterParam = new FilterRepresentationModel( {name: 'non-existing-filter'});
+        const appId = '1';
+        const change = new SimpleChange(null, appId, true);
+        component.ngOnChanges({ 'appId': change });
+        fixture.detectChanges();
+        await fixture.whenStable();
+        expect(component.currentFilter).toBe(undefined);
+    });
 });

--- a/lib/process-services/src/lib/task-list/components/task-filters.component.ts
+++ b/lib/process-services/src/lib/task-list/components/task-filters.component.ts
@@ -155,7 +155,7 @@ export class TaskFiltersComponent implements OnInit, OnChanges {
 
     /**
      * Pass the selected filter as next
-     * @param filter
+     * @param newFilter
      */
     public selectFilter(newFilter: FilterParamsModel) {
         if (newFilter) {


### PR DESCRIPTION
…isting filter

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ACA-3316


**What is the new behaviour?**
If there is any selected filter when the filterParam input changes to a non existing filter, the filter selection is cleared


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
