### PR TITLE
[ACA-3314] Add cancelButton and noFormTemplate form elements

### DIFF
--- a/lib/testing/src/lib/core/pages/form/form-fields.ts
+++ b/lib/testing/src/lib/core/pages/form/form-fields.ts
@@ -27,9 +27,11 @@ export class FormFields {
     valueLocator: Locator = by.css('input');
     labelLocator: Locator = by.css('label');
     noFormMessage: ElementFinder = element(by.css('.adf-empty-content__title'));
+    noFormTemplate: ElementFinder = element(by.css('adf-empty-content'));
     completedTaskNoFormMessage: ElementFinder = element(by.css('div[id*="completed-form-message"] p'));
     attachFormButton: ElementFinder = element(by.id('adf-attach-form-attach-button'));
     completeButton: ElementFinder = element(by.id('adf-form-complete'));
+    cancelButton: ElementFinder = element(by.css('#adf-no-form-cancel-button'));
     errorMessage: Locator = by.css('.adf-error-text-container .adf-error-text');
 
     selectFormDropdown = new DropdownPage(element.all(by.css('adf-attach-form div[class*="mat-select-arrow"]')).first());
@@ -104,6 +106,17 @@ export class FormFields {
         await BrowserActions.click(this.saveButton);
     }
 
+    async isNoFormTemplateDisplayed(): Promise<boolean> {
+        try {
+            await BrowserVisibility.waitUntilElementIsVisible(
+                this.noFormTemplate
+            );
+            return true;
+        } catch (error) {
+            return false;
+        }
+    }
+
     async noFormIsDisplayed(): Promise<void> {
         await BrowserVisibility.waitUntilElementIsNotVisible(this.formContent);
     }
@@ -152,5 +165,29 @@ export class FormFields {
     async isCompleteFormButtonDisabled(): Promise<string> {
         await BrowserVisibility.waitUntilElementIsVisible(this.completeButton);
         return this.completeButton.getAttribute('disabled');
+    }
+
+    async isCancelButtonDisplayed(): Promise<boolean> {
+        try {
+            await BrowserVisibility.waitUntilElementIsVisible(
+                this.cancelButton
+            );
+            return true;
+        } catch (error) {
+            return false;
+        }
+    }
+
+    async isCancelButtonEnabled(): Promise<boolean> {
+        try {
+            await this.cancelButton.isEnabled();
+            return true;
+        } catch (error) {
+            return false;
+        }
+    }
+
+    async clickCancelButton(): Promise<void> {
+        await BrowserActions.click(this.cancelButton);
     }
 }

--- a/lib/testing/src/lib/process-services/pages/task-list.page.ts
+++ b/lib/testing/src/lib/process-services/pages/task-list.page.ts
@@ -21,10 +21,19 @@ import { BrowserActions } from '../../core/utils/browser-actions';
 import { element, by, ElementFinder } from 'protractor';
 
 export class TaskListPage {
+    rootElement: ElementFinder;
+    dataTable: DataTableComponentPage;
+    noTasksFound: ElementFinder;
 
-    noTasksFound: ElementFinder = element(by.css('div[class="adf-empty-content__title"]'));
-    taskList: ElementFinder = element(by.css('adf-tasklist'));
-    dataTable: DataTableComponentPage = new DataTableComponentPage(this.taskList);
+    constructor(
+        rootElement: ElementFinder = element.all(by.css("adf-tasklist")).first()
+    ) {
+        this.rootElement = rootElement;
+        this.dataTable = new DataTableComponentPage(this.rootElement);
+        this.noTasksFound = this.rootElement.element(
+            by.css('div[class="adf-empty-content__title"]')
+        );
+    }
 
     getDataTable() {
         return this.dataTable;
@@ -43,7 +52,7 @@ export class TaskListPage {
     }
 
     async checkTaskListIsLoaded(): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.taskList);
+        await BrowserVisibility.waitUntilElementIsVisible(this.rootElement);
     }
 
     getNoTasksFoundMessage(): Promise<string> {
@@ -60,11 +69,5 @@ export class TaskListPage {
 
     getAllRowsNameColumn(): Promise<any> {
         return this.dataTable.getAllRowsColumnValues('Name');
-    }
-
-    async clickOnTask(taskName: string): Promise<void> {
-        await BrowserActions.clickExecuteScript(
-            `span[aria-label="${taskName}"]`
-        );
     }
 }

--- a/lib/testing/src/lib/process-services/pages/task-list.page.ts
+++ b/lib/testing/src/lib/process-services/pages/task-list.page.ts
@@ -26,7 +26,7 @@ export class TaskListPage {
     noTasksFound: ElementFinder;
 
     constructor(
-        rootElement: ElementFinder = element.all(by.css("adf-tasklist")).first()
+        rootElement: ElementFinder = element.all(by.css('adf-tasklist')).first()
     ) {
         this.rootElement = rootElement;
         this.dataTable = new DataTableComponentPage(this.rootElement);

--- a/lib/testing/src/lib/process-services/pages/task-list.page.ts
+++ b/lib/testing/src/lib/process-services/pages/task-list.page.ts
@@ -61,4 +61,10 @@ export class TaskListPage {
     getAllRowsNameColumn(): Promise<any> {
         return this.dataTable.getAllRowsColumnValues('Name');
     }
+
+    async clickOnTask(taskName: string): Promise<void> {
+        await BrowserActions.clickExecuteScript(
+            `span[aria-label="${taskName}"]`
+        );
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
1. FormFields page:
- Add missing `noFormTemplate` and `cancelButton` elements in FormFields;
- Add `isNoFormTemplateDisplayed()` method that is checking if the template (not the message) of a task without a form is displayed;
- Add `isCancelButtonDisplayed()` method to check if `Cancel` button is displayed;
- Add `isCancelButtonEnabled()` method to check if `Cancel` button is enabled;
- Add `clickCancelButton()` method - this action is possible on a task without form;

2. TaskListPage:
- Add a rootElement for task list;