### PR TITLE
[ACA-3368] Update datatable columns when presetColumn schema changes

### DIFF
--- a/lib/core/datatable/components/datatable/datatable.component.spec.ts
+++ b/lib/core/datatable/components/datatable/datatable.component.spec.ts
@@ -1230,15 +1230,18 @@ describe('DataTable', () => {
     });
 
     it('should update data columns when columns input changes', () => {
+        const existingDataColumnsSchema = [new ObjectDataColumn({ key: 'id' })];
+        const existingData = [{ id: 'fake-data' }];
         dataTable.data = new ObjectDataTableAdapter(
-            [{ id: 'fake-data' }],
-            [new ObjectDataColumn({ key: 'id' })]
+            existingData,
+            existingDataColumnsSchema
         );
 
-        const columnsChange = new SimpleChange(null, [{ key: 'fake-key' }], false);
+        const newDataColumnsSchema = { key: 'new-column'};
+        const columnsChange = new SimpleChange(null, [newDataColumnsSchema], false);
         dataTable.ngOnChanges({ 'columns': columnsChange });
-        const expectedDataColumns = [new ObjectDataColumn({ key: 'fake-key' })];
-        expect(dataTable.data.getColumns()).toEqual(expectedDataColumns);
+        const expectedNewDataColumns = [new ObjectDataColumn(newDataColumnsSchema)];
+        expect(dataTable.data.getColumns()).toEqual(expectedNewDataColumns);
     });
 });
 

--- a/lib/core/datatable/components/datatable/datatable.component.spec.ts
+++ b/lib/core/datatable/components/datatable/datatable.component.spec.ts
@@ -1228,6 +1228,18 @@ describe('DataTable', () => {
         expect(dataTable.data.getRows().length).toEqual(2);
         expect(dataTable.resolverFn).toHaveBeenCalledTimes(4);
     });
+
+    it('should update data columns when columns input changes', () => {
+        dataTable.data = new ObjectDataTableAdapter(
+            [{ id: 'fake-data' }],
+            [new ObjectDataColumn({ key: 'id' })]
+        );
+
+        const columnsChange = new SimpleChange(null, [{ key: 'fake-key' }], false);
+        dataTable.ngOnChanges({ 'columns': columnsChange });
+        const expectedDataColumns = [new ObjectDataColumn({ key: 'fake-key' })];
+        expect(dataTable.data.getColumns()).toEqual(expectedDataColumns);
+    });
 });
 
 describe('Accesibility', () => {

--- a/lib/core/datatable/components/datatable/datatable.component.ts
+++ b/lib/core/datatable/components/datatable/datatable.component.ts
@@ -32,6 +32,7 @@ import { DataTableAdapter } from '../../data/datatable-adapter';
 import { DataTableRowComponent } from './datatable-row.component';
 
 import { ObjectDataRow } from '../../data/object-datarow.model';
+import { ObjectDataColumn } from '../../data/object-datacolumn.model';
 import { ObjectDataTableAdapter } from '../../data/object-datatable-adapter';
 import { DataCellEvent } from './data-cell.event';
 import { DataRowActionEvent } from './data-row-action.event';
@@ -244,6 +245,15 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck,
             return;
         }
 
+        if (this.isPropertyChanged(changes['columns'])) {
+            if (this.isTableEmpty()) {
+                this.initTable();
+            } else {
+                this.setTableColumns(changes['columns'].currentValue);
+            }
+            return;
+        }
+
         if (changes.selectionMode && !changes.selectionMode.isFirstChange()) {
             this.resetSelection();
             this.emitRowSelectionEvent('row-unselect', null);
@@ -278,6 +288,10 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck,
 
     convertToRowsData(rows: any []): ObjectDataRow[] {
         return rows.map((row) => new ObjectDataRow(row, row.isSelected));
+    }
+
+    convertToColumnsData(columns: any []): ObjectDataColumn[] {
+        return columns.map((column) => new ObjectDataColumn(column));
     }
 
     convertToDataSorting(sorting: any[]): DataSorting | null {
@@ -366,7 +380,16 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck,
     private setTableRows(rows: any[]) {
         if (this.data) {
             this.resetSelection();
-            this.data.setRows(this.convertToRowsData(rows));
+            const rowsData = this.convertToRowsData(rows);
+            this.data.setRows(rowsData);
+        }
+    }
+
+    private setTableColumns(columns: any[]) {
+        if (this.data) {
+            this.resetSelection();
+            const columnsData = this.convertToColumnsData(columns);
+            this.data.setColumns(columnsData);
         }
     }
 

--- a/lib/core/datatable/components/datatable/datatable.component.ts
+++ b/lib/core/datatable/components/datatable/datatable.component.ts
@@ -226,30 +226,23 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck,
 
     ngOnChanges(changes: SimpleChanges) {
         this.initAndSubscribeClickStream();
-        if (this.isPropertyChanged(changes['data'])) {
-            if (this.isTableEmpty()) {
-                this.initTable();
-            } else {
-                this.data = changes['data'].currentValue;
-                this.resetSelection();
-            }
-            return;
-        }
 
-        if (this.isPropertyChanged(changes['rows'])) {
-            if (this.isTableEmpty()) {
-                this.initTable();
-            } else {
-                this.setTableRows(changes['rows'].currentValue);
-            }
-            return;
-        }
+        const dataChanges = changes['data'];
+        const rowChanges = changes['rows'];
+        const columnChanges = changes['columns'];
 
-        if (this.isPropertyChanged(changes['columns'])) {
+        if (this.isPropertyChanged(dataChanges) || this.isPropertyChanged(rowChanges) || this.isPropertyChanged(columnChanges)) {
             if (this.isTableEmpty()) {
                 this.initTable();
             } else {
-                this.setTableColumns(changes['columns'].currentValue);
+                if (dataChanges) {
+                    this.data = changes['data'].currentValue;
+                    this.resetSelection();
+                } else if (rowChanges) {
+                    this.setTableRows(changes['rows'].currentValue);
+                } else {
+                    this.setTableColumns(changes['columns'].currentValue);
+                }
             }
             return;
         }

--- a/lib/process-services/src/lib/mock/process/process-instances-list.mock.ts
+++ b/lib/process-services/src/lib/mock/process/process-instances-list.mock.ts
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-import { ObjectDataColumn } from '@alfresco/adf-core';
-
 export let fakeProcessInstance = {
     size: 2,
     total: 2,
@@ -133,26 +131,40 @@ export let fakeProcessInstancesEmpty = {
 };
 
 export let fakeProcessCustomSchema = [
-    new ObjectDataColumn({
+    {
         key: 'fakeName',
         type: 'text',
         title: 'ADF_PROCESS_LIST.PROPERTIES.FAKE',
         sortable: true
-    }),
-    new ObjectDataColumn({
+    },
+    {
         key: 'fakeProcessName',
         type: 'text',
         title: 'ADF_PROCESS_LIST.PROPERTIES.PROCESS_FAKE',
         sortable: true
-    })
+    }
 ];
 
 export let fakeProcessColumnSchema = {
     default: [
         {
-            key: 'name',
+            key: 'default-name',
             type: 'text',
             title: 'ADF_PROCESS_LIST.PROPERTIES.NAME',
+            sortable: true
+        }
+    ],
+    fakeRunningProcessSchema: [
+        {
+            key: 'process-id',
+            type: 'text',
+            title: 'ADF_PROCESS_LIST.PROPERTIES.FAKE',
+            sortable: true
+        },
+        {
+            key: 'process-name',
+            type: 'text',
+            title: 'ADF_PROCESS_LIST.PROPERTIES.PROCESS_FAKE',
             sortable: true
         }
     ],

--- a/lib/process-services/src/lib/mock/task/task-list.mock.ts
+++ b/lib/process-services/src/lib/mock/task/task-list.mock.ts
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-import { ObjectDataColumn } from '@alfresco/adf-core';
-
 export const fakeGlobalTask = {
     size: 2,
     start: 0,
@@ -79,26 +77,40 @@ export const fakeGlobalTask = {
 };
 
 export let fakeCustomSchema = [
-    new ObjectDataColumn({
+    {
         key: 'fakeName',
         type: 'text',
         title: 'ADF_TASK_LIST.PROPERTIES.FAKE',
         sortable: true
-    }),
-    new ObjectDataColumn({
+    },
+    {
         key: 'fakeTaskName',
         type: 'text',
         title: 'ADF_TASK_LIST.PROPERTIES.TASK_FAKE',
         sortable: true
-    })
+    }
 ];
 
 export let fakeColumnSchema = {
     default: [
         {
-            key: 'name',
+            key: 'fake-name',
             type: 'text',
             title: 'ADF_TASK_LIST.PROPERTIES.NAME',
+            sortable: true
+        }
+    ],
+    fakeMyTasksSchema: [
+        {
+            key: 'task-id',
+            type: 'text',
+            title: 'ADF_TASK_LIST.PROPERTIES.FAKE',
+            sortable: true
+        },
+        {
+            key: 'task-name',
+            type: 'text',
+            title: 'ADF_TASK_LIST.PROPERTIES.PROCESS_FAKE',
             sortable: true
         }
     ],

--- a/lib/process-services/src/lib/mock/task/task-list.mock.ts
+++ b/lib/process-services/src/lib/mock/task/task-list.mock.ts
@@ -94,7 +94,7 @@ export let fakeCustomSchema = [
 export let fakeColumnSchema = {
     default: [
         {
-            key: 'fake-name',
+            key: 'default-name',
             type: 'text',
             title: 'ADF_TASK_LIST.PROPERTIES.NAME',
             sortable: true

--- a/lib/process-services/src/lib/process-list/components/process-list.component.spec.ts
+++ b/lib/process-services/src/lib/process-list/components/process-list.component.spec.ts
@@ -442,11 +442,14 @@ describe('ProcessInstanceListComponent', () => {
             component.ngOnChanges({ 'presetColumn': presetColumnChange });
 
             const newColumnSchema = component.mergeJsonAndHtmlSchema();
+            const expectedColumn1 = new ObjectDataColumn(fakeProcessColumnSchema.fakeRunningProcessSchema[0]);
+            const expectedColumn2 = new ObjectDataColumn(fakeProcessColumnSchema.fakeRunningProcessSchema[1]);
+
             expect(component.columns).toEqual(newColumnSchema);
             expect(initialColumnSchema).not.toEqual(newColumnSchema);
             expect(component.columns.length).toEqual(2);
-            expect(component.columns[0]).toEqual(new ObjectDataColumn(fakeProcessColumnSchema.fakeRunningProcessSchema[0]));
-            expect(component.columns[1]).toEqual(new ObjectDataColumn(fakeProcessColumnSchema.fakeRunningProcessSchema[1]));
+            expect(component.columns[0]).toEqual(expectedColumn1);
+            expect(component.columns[1]).toEqual(expectedColumn2);
         });
     });
 });

--- a/lib/process-services/src/lib/process-list/components/process-list.component.spec.ts
+++ b/lib/process-services/src/lib/process-list/components/process-list.component.spec.ts
@@ -437,6 +437,14 @@ describe('ProcessInstanceListComponent', () => {
 
             component.ngOnChanges({'processInstanceId': change});
         });
+
+        it('should update columns when presetColumn schema changes', () => {
+            component.ngAfterContentInit();
+            component.columns = [];
+            const presetColumnChange = new SimpleChange(null, 'fakeProcessCustomSchema', false);
+            component.ngOnChanges({ 'presetColumn': presetColumnChange });
+            expect(component.columns).toEqual(component.mergeJsonAndHtmlSchema());
+        });
     });
 });
 

--- a/lib/process-services/src/lib/process-list/components/process-list.component.ts
+++ b/lib/process-services/src/lib/process-list/components/process-list.component.ts
@@ -181,6 +181,10 @@ export class ProcessInstanceListComponent extends DataTableSchema implements OnC
             }
             this.reload();
         }
+
+        if (changes['presetColumn']) {
+            this.columns = this.mergeJsonAndHtmlSchema();
+        }
     }
 
     private isSortChanged(changes: SimpleChanges): boolean {

--- a/lib/process-services/src/lib/process-list/components/process-list.component.ts
+++ b/lib/process-services/src/lib/process-list/components/process-list.component.ts
@@ -182,7 +182,8 @@ export class ProcessInstanceListComponent extends DataTableSchema implements OnC
             this.reload();
         }
 
-        if (changes['presetColumn']) {
+        const presetColumnChanges = changes['presetColumn'];
+        if (presetColumnChanges && !presetColumnChanges.firstChange) {
             this.columns = this.mergeJsonAndHtmlSchema();
         }
     }

--- a/lib/process-services/src/lib/task-list/components/task-list.component.spec.ts
+++ b/lib/process-services/src/lib/task-list/components/task-list.component.spec.ts
@@ -533,6 +533,14 @@ describe('TaskListComponent', () => {
                 responseText: JSON.stringify(fakeGlobalTask)
             });
         });
+
+        it('should update columns when presetColumn schema changes', () => {
+            component.ngAfterContentInit();
+            component.columns = [];
+            const presetColumnChange = new SimpleChange(null, 'fakeCustomSchema', false);
+            component.ngOnChanges({ 'presetColumn': presetColumnChange });
+            expect(component.columns).toEqual(component.mergeJsonAndHtmlSchema());
+        });
     });
 
     it('should show the updated list when pagination changes', async(() => {

--- a/lib/process-services/src/lib/task-list/components/task-list.component.spec.ts
+++ b/lib/process-services/src/lib/task-list/components/task-list.component.spec.ts
@@ -545,13 +545,14 @@ describe('TaskListComponent', () => {
         component.ngOnChanges({ 'presetColumn': presetColumnChange });
 
         const newColumnSchema = component.mergeJsonAndHtmlSchema();
+        const expectedColumn1 = new ObjectDataColumn(fakeColumnSchema.fakeMyTasksSchema[0]);
+        const expectedColumn2 = new ObjectDataColumn(fakeColumnSchema.fakeMyTasksSchema[1]);
+
         expect(component.columns).toEqual(newColumnSchema);
         expect(initialColumnSchema).not.toEqual(newColumnSchema);
         expect(component.columns.length).toEqual(2);
-        const expCol1 = new ObjectDataColumn(fakeColumnSchema.fakeMyTasksSchema[0]);
-        const expCol2 = new ObjectDataColumn(fakeColumnSchema.fakeMyTasksSchema[1]);
-        expect(component.columns[0]).toEqual(expCol1);
-        expect(component.columns[1]).toEqual(expCol2);
+        expect(component.columns[0]).toEqual(expectedColumn1);
+        expect(component.columns[1]).toEqual(expectedColumn2);
     });
 
     it('should show the updated list when pagination changes', async(() => {

--- a/lib/process-services/src/lib/task-list/components/task-list.component.spec.ts
+++ b/lib/process-services/src/lib/task-list/components/task-list.component.spec.ts
@@ -18,11 +18,16 @@
 import { Component, SimpleChange, ViewChild, OnInit, Output, EventEmitter } from '@angular/core';
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { AppConfigService, setupTestBed, DataRowEvent, ObjectDataRow, DataCellEvent } from '@alfresco/adf-core';
+import { AppConfigService, setupTestBed, DataRowEvent, ObjectDataRow, DataCellEvent, ObjectDataColumn } from '@alfresco/adf-core';
 import { TaskListService } from '../services/tasklist.service';
 import { TaskListComponent } from './task-list.component';
 import { ProcessTestingModule } from '../../testing/process.testing.module';
-import { fakeGlobalTask, fakeCustomSchema, fakeEmptyTask, paginatedTask } from '../../mock';
+import {
+    fakeGlobalTask,
+    fakeEmptyTask,
+    paginatedTask,
+    fakeColumnSchema, fakeCustomSchema
+} from '../../mock';
 import { TranslateService, TranslateModule } from '@ngx-translate/core';
 import { of, Subject } from 'rxjs';
 
@@ -52,24 +57,10 @@ describe('TaskListComponent', () => {
         appConfig.config = Object.assign(appConfig.config, {
             'adf-task-list': {
                 'presets': {
-                    'fakeCustomSchema': [
-                        {
-                            'key': 'fakeName',
-                            'type': 'text',
-                            'title': 'ADF_TASK_LIST.PROPERTIES.FAKE',
-                            'sortable': true
-                        },
-                        {
-                            'key': 'fakeTaskName',
-                            'type': 'text',
-                            'title': 'ADF_TASK_LIST.PROPERTIES.TASK_FAKE',
-                            'sortable': true
-                        }
-                    ]
+                    fakeCustomSchema
                 }
             }
         });
-
     });
 
     beforeEach(() => {
@@ -114,7 +105,9 @@ describe('TaskListComponent', () => {
         component.presetColumn = 'fakeCustomSchema';
         component.ngAfterContentInit();
         fixture.detectChanges();
-        expect(component.columns).toEqual(fakeCustomSchema);
+        expect(component.columns.length).toEqual(2);
+        expect(component.columns[0]).toEqual(new ObjectDataColumn(fakeCustomSchema[0]));
+        expect(component.columns[1]).toEqual(new ObjectDataColumn(fakeCustomSchema[1]));
     });
 
     it('should fetch custom schemaColumn when the input presetColumn is defined', () => {
@@ -533,14 +526,32 @@ describe('TaskListComponent', () => {
                 responseText: JSON.stringify(fakeGlobalTask)
             });
         });
+    });
 
-        it('should update columns when presetColumn schema changes', () => {
-            component.ngAfterContentInit();
-            component.columns = [];
-            const presetColumnChange = new SimpleChange(null, 'fakeCustomSchema', false);
-            component.ngOnChanges({ 'presetColumn': presetColumnChange });
-            expect(component.columns).toEqual(component.mergeJsonAndHtmlSchema());
+    it('should update the columns when presetColumn schema changes', () => {
+        appConfig.config = Object.assign(appConfig.config, {
+            'adf-task-list': {
+                'presets': fakeColumnSchema
+            }
         });
+
+        component.presetColumn = 'fakeCustomSchema';
+        component.ngAfterContentInit();
+        const initialColumnSchema = component.mergeJsonAndHtmlSchema();
+        expect(component.columns).toEqual(initialColumnSchema);
+
+        component.presetColumn = 'fakeMyTasksSchema';
+        const presetColumnChange = new SimpleChange(null, 'fakeMyTasksSchema', false);
+        component.ngOnChanges({ 'presetColumn': presetColumnChange });
+
+        const newColumnSchema = component.mergeJsonAndHtmlSchema();
+        expect(component.columns).toEqual(newColumnSchema);
+        expect(initialColumnSchema).not.toEqual(newColumnSchema);
+        expect(component.columns.length).toEqual(2);
+        const expCol1 = new ObjectDataColumn(fakeColumnSchema.fakeMyTasksSchema[0]);
+        const expCol2 = new ObjectDataColumn(fakeColumnSchema.fakeMyTasksSchema[1]);
+        expect(component.columns[0]).toEqual(expCol1);
+        expect(component.columns[1]).toEqual(expCol2);
     });
 
     it('should show the updated list when pagination changes', async(() => {

--- a/lib/process-services/src/lib/task-list/components/task-list.component.ts
+++ b/lib/process-services/src/lib/task-list/components/task-list.component.ts
@@ -235,6 +235,11 @@ export class TaskListComponent extends DataTableSchema implements OnChanges, Aft
             }
             this.reload();
         }
+
+        const presetColumnChanges = changes['presetColumn'];
+        if (presetColumnChanges && !presetColumnChanges.firstChange) {
+            this.columns = this.mergeJsonAndHtmlSchema();
+        }
     }
 
     private isSortChanged(changes: SimpleChanges): boolean {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ACA-3368


**What is the new behaviour?**
The columns are updating when the schema changes


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
