### PR TITLE
[ADF-5153] Transclusion exposed from the DataTable to the DocumentList

### DIFF
--- a/lib/content-services/src/lib/document-list/components/document-list.component.html
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.html
@@ -24,7 +24,7 @@
     (row-unselect)="onNodeUnselect($event.detail)"
     [class.adf-datatable-gallery-thumbnails]="data.thumbnails">
 
-    <ng-template *ngIf="allowFiltering" let-col>
+    <ng-template let-col>
         <!-- [ACA-3206] TODO : Implement search/filter widget HERE -->
     </ng-template>
 

--- a/lib/content-services/src/lib/document-list/components/document-list.component.html
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.html
@@ -14,6 +14,7 @@
     [showHeader]="!isEmpty() && showHeader"
     [rowMenuCacheEnabled]="false"
     [stickyHeader]="stickyHeader"
+    [allowFiltering]="allowFiltering"
     (showRowContextMenu)="onShowRowContextMenu($event)"
     (showRowActionsMenu)="onShowRowActionsMenu($event)"
     (executeRowAction)="onExecuteRowAction($event)"
@@ -23,7 +24,7 @@
     (row-unselect)="onNodeUnselect($event.detail)"
     [class.adf-datatable-gallery-thumbnails]="data.thumbnails">
 
-    <ng-template let-col>
+    <ng-template *ngIf="allowFiltering" let-col>
         <!-- [ACA-3206] TODO : Implement search/filter widget HERE -->
     </ng-template>
 

--- a/lib/content-services/src/lib/document-list/components/document-list.component.html
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.html
@@ -23,6 +23,10 @@
     (row-unselect)="onNodeUnselect($event.detail)"
     [class.adf-datatable-gallery-thumbnails]="data.thumbnails">
 
+    <ng-template let-col>
+        <!-- [ACA-3206] TODO : Implement search/filter widget HERE -->
+    </ng-template>
+
     <adf-no-content-template>
         <ng-template>
             <adf-empty-list *ngIf="!customNoContentTemplate">

--- a/lib/content-services/src/lib/document-list/components/document-list.component.ts
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.ts
@@ -308,6 +308,7 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
     noPermission: boolean = false;
     selection = new Array<NodeEntry>();
     $folderNode: Subject<Node> = new Subject<Node>();
+    allowFiltering: boolean = true;
 
     // @deprecated 3.0.0
     folderNode: Node;

--- a/lib/core/datatable/components/datatable/datatable.component.html
+++ b/lib/core/datatable/components/datatable/datatable.component.html
@@ -34,7 +34,7 @@
                  adf-drop-zone dropTarget="header" [dropColumn]="col">
                 <span *ngIf="col.title" class="adf-datatable-cell-value">{{ col.title | translate}}</span>
                 <span *ngIf="col.title && col.sortable" class="adf-sr-only" aria-live="polite">{{ getSortLiveAnnouncement(col) | translate: { string: col.title | translate } }}</span>
-                <ng-template [ngTemplateOutlet]="filterTemplateRef" [ngTemplateOutletContext]="{$implicit: col}"></ng-template>
+                <ng-template *ngIf="allowFiltering" [ngTemplateOutlet]="filterTemplateRef" [ngTemplateOutletContext]="{$implicit: col}"></ng-template>
             </div>
             <!-- Actions (right) -->
             <div *ngIf="actions && actionsPosition === 'right'" class="adf-actions-column adf-datatable-cell-header adf-datatable__actions-cell">

--- a/lib/core/datatable/components/datatable/datatable.component.html
+++ b/lib/core/datatable/components/datatable/datatable.component.html
@@ -34,6 +34,7 @@
                  adf-drop-zone dropTarget="header" [dropColumn]="col">
                 <span *ngIf="col.title" class="adf-datatable-cell-value">{{ col.title | translate}}</span>
                 <span *ngIf="col.title && col.sortable" class="adf-sr-only" aria-live="polite">{{ getSortLiveAnnouncement(col) | translate: { string: col.title | translate } }}</span>
+                <ng-template [ngTemplateOutlet]="filterTemplateRef" [ngTemplateOutletContext]="{$implicit: col}"></ng-template>
             </div>
             <!-- Actions (right) -->
             <div *ngIf="actions && actionsPosition === 'right'" class="adf-actions-column adf-datatable-cell-header adf-datatable__actions-cell">

--- a/lib/core/datatable/components/datatable/datatable.component.ts
+++ b/lib/core/datatable/components/datatable/datatable.component.ts
@@ -169,12 +169,18 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck,
     @Input()
     resolverFn: (row: DataRow, col: DataColumn) => any = null;
 
-    noContentTemplate: TemplateRef<any>;
-    noPermissionTemplate: TemplateRef<any>;
-    loadingTemplate: TemplateRef<any>;
+    /**
+     * Flag that indicate if the datatable allow the use facet widget search for filtering.
+     */
+    @Input()
+    allowFiltering: boolean = false;
 
     @ContentChild(TemplateRef)
     filterTemplateRef: TemplateRef<any>;
+
+    noContentTemplate: TemplateRef<any>;
+    noPermissionTemplate: TemplateRef<any>;
+    loadingTemplate: TemplateRef<any>;
 
     isSelectAllIndeterminate: boolean = false;
     isSelectAllChecked: boolean = false;

--- a/lib/core/datatable/components/datatable/datatable.component.ts
+++ b/lib/core/datatable/components/datatable/datatable.component.ts
@@ -173,6 +173,9 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck,
     noPermissionTemplate: TemplateRef<any>;
     loadingTemplate: TemplateRef<any>;
 
+    @ContentChild(TemplateRef)
+    filterTemplateRef: TemplateRef<any>;
+
     isSelectAllIndeterminate: boolean = false;
     isSelectAllChecked: boolean = false;
     selection = new Array<DataRow>();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
No content exposed from the DataTable to the DocumentList.


**What is the new behaviour?**
In order to implement the facet widget to filter the DataTable we need some exposed content of the DataTable inside the DocumentList. 
This is done using the ng-template element through those two components.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-5153