### PR TITLE
[ACA-3358] Show user friendly error templates when there are no applications/processDefinitions

### DIFF
--- a/demo-shell/src/app/components/process-service/process-service.component.html
+++ b/demo-shell/src/app/components/process-service/process-service.component.html
@@ -224,7 +224,8 @@
                         [name]="defaultProcessName"
                         (formContentClicked)="onContentClick($event)"
                         (start)="onStartProcessInstance($event)"
-                        (cancel)="onCancelProcessInstance()">
+                        (cancel)="onCancelProcessInstance()"
+                        (error)="onStartProcessError($event)">
                     </adf-start-process>
                 </div>
             </div>

--- a/demo-shell/src/app/components/process-service/process-service.component.ts
+++ b/demo-shell/src/app/components/process-service/process-service.component.ts
@@ -405,7 +405,7 @@ export class ProcessServiceComponent implements AfterViewInit, OnDestroy, OnInit
     }
 
     onStartProcessError(event: any) {
-        this.notificationService.openSnackMessage(event.response.body.message);
+        this.notificationService.showError(event.response.body.message);
     }
 
     isStartProcessMode(): boolean {

--- a/demo-shell/src/app/components/process-service/process-service.component.ts
+++ b/demo-shell/src/app/components/process-service/process-service.component.ts
@@ -36,7 +36,7 @@ import {
 import {
     FORM_FIELD_VALIDATORS, FormRenderingService, FormService,
     DynamicTableRow, ValidateDynamicTableRowEvent, AppConfigService, PaginationComponent, UserPreferenceValues,
-    AlfrescoApiService, UserPreferencesService, LogService, DataCellEvent
+    AlfrescoApiService, UserPreferencesService, LogService, DataCellEvent, NotificationService
 } from '@alfresco/adf-core';
 
 import { AnalyticsReportListComponent } from '@alfresco/adf-insights';
@@ -174,6 +174,7 @@ export class ProcessServiceComponent implements AfterViewInit, OnDestroy, OnInit
                 formRenderingService: FormRenderingService,
                 formService: FormService,
                 private location: Location,
+                private notificationService: NotificationService,
                 private preferenceService: UserPreferencesService) {
 
         this.defaultProcessName = this.appConfig.get<string>('adf-start-process.name');
@@ -401,6 +402,10 @@ export class ProcessServiceComponent implements AfterViewInit, OnDestroy, OnInit
     onCancelProcessInstance() {
         this.currentProcessInstanceId = null;
         this.reloadProcessFilters();
+    }
+
+    onStartProcessError(event: any) {
+        this.notificationService.openSnackMessage(event.response.body.message);
     }
 
     isStartProcessMode(): boolean {

--- a/demo-shell/src/app/components/process-service/process-service.component.ts
+++ b/demo-shell/src/app/components/process-service/process-service.component.ts
@@ -405,7 +405,7 @@ export class ProcessServiceComponent implements AfterViewInit, OnDestroy, OnInit
     }
 
     onStartProcessError(event: any) {
-        this.notificationService.showError(event.response.body.message);
+        this.notificationService.showError(event.message);
     }
 
     isStartProcessMode(): boolean {

--- a/docs/process-services/components/start-process.component.md
+++ b/docs/process-services/components/start-process.component.md
@@ -210,7 +210,7 @@ When an error occurs, the component will emit an error event that can be used to
 
 ```ts
     onError(error) {
-        this.notificationService.openSnackMessage(event.response.body.message);
+        this.notificationService.showError(event.response.body.message);
     }
 ```
 

--- a/docs/process-services/components/start-process.component.md
+++ b/docs/process-services/components/start-process.component.md
@@ -195,6 +195,25 @@ You can use the `showSelectApplicationDropdown` property to Hide or show applica
 ![Start process with selected application](../../docassets/images/start-process-with-selected-application.png)
 
 
+### Error handling
+
+When an error occurs, the component will emit an error event that can be used to handle errors. Example:
+
+```html
+ <adf-start-process 
+      [appId]="YOUR_APP_ID"
+      [title]="'ADF_PROCESS_LIST.START_PROCESS.FORM.TITLE'"
+      [name]="PROCESS_NAME"
+      (error)="onError($event)">
+ </adf-start-process>		 
+```
+
+```ts
+    onError(error) {
+        this.notificationService.openSnackMessage(event.response.body.message);
+    }
+```
+
 ## See also
 
 -   [Select Apps Dialog component](select-apps-dialog.component.md)

--- a/lib/core/templates/empty-content/empty-content.component.html
+++ b/lib/core/templates/empty-content/empty-content.component.html
@@ -1,5 +1,5 @@
 <div class="adf-empty-content">
-    <mat-icon class="adf-empty-content__icon">{{ icon }}</mat-icon>
+    <adf-icon class="adf-empty-content__icon" [value]="icon"></adf-icon>
     <div class="adf-empty-content__title">{{ title | translate }}</div>
     <div class="adf-empty-content__subtitle">{{ subtitle | translate }}</div>
     <ng-content></ng-content>

--- a/lib/core/templates/empty-content/empty-content.component.scss
+++ b/lib/core/templates/empty-content/empty-content.component.scss
@@ -12,9 +12,11 @@
         align-items: center;
 
         &__icon {
-            font-size: mat-font-size($config, display-3);
-            height: mat-font-size($config, display-3) !important;
-            width: mat-font-size($config, display-3) !important;
+            .mat-icon {
+                font-size: mat-font-size($config, display-3);
+                height: mat-font-size($config, display-3) !important;
+                width: mat-font-size($config, display-3) !important;
+            }
         }
 
         &__title {
@@ -34,5 +36,9 @@
             white-space: normal;
             text-align: center;
         }
+    }
+
+    .adf-icon {
+        opacity: 0.6;
     }
 }

--- a/lib/core/templates/empty-content/empty-content.component.scss
+++ b/lib/core/templates/empty-content/empty-content.component.scss
@@ -4,6 +4,7 @@
 
     $config: mat-typography-config();
     $foreground: map-get($theme, foreground);
+    $adf-empty-content-icon-opacity: 0.6;
 
     .adf-empty-content {
         color: mat-color($foreground, text, 0.54);
@@ -39,6 +40,6 @@
     }
 
     .adf-icon {
-        opacity: 0.6;
+        opacity: $adf-empty-content-icon-opacity;
     }
 }

--- a/lib/core/templates/template.module.ts
+++ b/lib/core/templates/template.module.ts
@@ -21,12 +21,14 @@ import { TranslateModule } from '@ngx-translate/core';
 import { MaterialModule } from '../material.module';
 import { ErrorContentComponent } from './error-content/error-content.component';
 import { EmptyContentComponent } from './empty-content/empty-content.component';
+import { IconModule } from '../icon/icon.module';
 
 @NgModule({
     imports: [
         CommonModule,
         MaterialModule,
-        TranslateModule
+        TranslateModule,
+        IconModule
     ],
     declarations: [
         ErrorContentComponent,

--- a/lib/process-services/src/lib/i18n/en.json
+++ b/lib/process-services/src/lib/i18n/en.json
@@ -273,6 +273,8 @@
     "START_PROCESS": {
       "BUTTON": "Start Process",
       "NO_PROCESS_DEFINITIONS": "You can't start a process as there are no process definitions available",
+      "NO_START_FORM": "No Start Form",
+      "NO_PROCESS_DEF_SELECTED": "No Process definition selected",
       "FORM": {
         "TITLE": "Start Process",
         "LABEL": {

--- a/lib/process-services/src/lib/i18n/en.json
+++ b/lib/process-services/src/lib/i18n/en.json
@@ -273,8 +273,8 @@
     "START_PROCESS": {
       "BUTTON": "Start Process",
       "NO_PROCESS_DEFINITIONS": "You can't start a process as there are no process definitions available",
-      "NO_START_FORM": "No Start Form",
-      "NO_PROCESS_DEF_SELECTED": "No Process definition selected",
+      "NO_START_FORM": "No start form",
+      "NO_PROCESS_DEF_SELECTED": "No process definition selected",
       "FORM": {
         "TITLE": "Start Process",
         "LABEL": {

--- a/lib/process-services/src/lib/process-list/components/start-process.component.html
+++ b/lib/process-services/src/lib/process-list/components/start-process.component.html
@@ -1,116 +1,149 @@
-<div class="adf-start-process">
-    <div class="adf-title" *ngIf="title">{{ title | translate}}</div>
-    <div class="content" *ngIf="isProcessDefinitionEmpty()">
-        <div class="subtitle" id="error-message" *ngIf="errorMessageId">
-            {{errorMessageId|translate}}
-        </div>
-        <div class="adf-start-process-definition-container">
-            <mat-form-field *ngIf="showSelectApplicationDropdown" [floatLabel]="'always'" class="adf-start-process-app-list">
-                <mat-select
-                    placeholder="{{'ADF_PROCESS_LIST.START_PROCESS.FORM.LABEL.SELECT_APPLICATION' | translate}}"
-                    (selectionChange)="onAppSelectionChange($event)"
-                    [(ngModel)]="selectedApplication"
-                    data-automation-id="adf-start-process-apps-drop-down">
-                    <mat-option 
-                        *ngFor="let application of applications"
-                        [value]="application"
-                        [attr.data-automation-id]="'adf-start-process-apps-option-' + application.name">
-                        {{ application.name }}
-                    </mat-option>
-                </mat-select>
-            </mat-form-field>
-            <mat-form-field class="adf-process-input-container" [floatLabel]="'always'">
-                <mat-label>{{'ADF_PROCESS_LIST.START_PROCESS.FORM.LABEL.TYPE' | translate}}</mat-label>
-                <input
-                    type="text"
-                    matInput
-                    [formControl]="processDefinitionInput"
-                    [matAutocomplete]="auto"
-                    id="processDefinitionName"
-                    #inputAutocomplete>
-                <div class="adf-process-input-autocomplete">
-                    <mat-autocomplete
-                        #auto="matAutocomplete"
-                        id="processDefinitionOptions"
-                        [displayWith]="displayFn">
-                        <mat-option *ngFor="let processDef of filteredProcessesDefinitions$ | async" [value]="processDef.name"
-                        (click)="processDefinitionSelectionChanged(processDef)">
-                            {{ processDef.name }}
-                        </mat-option>
-                    </mat-autocomplete>
-                    <ng-container *ngIf="!isProcessDefinitionsLoading ; else showProcessDefLoadingTemplate">
-                        <button
-                            id="adf-select-process-dropdown"
-                            *ngIf="showSelectProcessDropdown"
-                            mat-icon-button
-                            (click)="displayDropdown($event)">
-                            <mat-icon>arrow_drop_down</mat-icon>
-                        </button>
-                    </ng-container>
-                    <ng-template #showProcessDefLoadingTemplate>
-                        <mat-spinner id="adf-select-process-spinner" [diameter]="20"></mat-spinner>
-                    </ng-template>
-                </div>
-            </mat-form-field>
-        </div>
-        <mat-form-field class="adf-process-input-container" [floatLabel]="'always'">
-            <mat-label>{{'ADF_PROCESS_LIST.START_PROCESS.FORM.LABEL.NAME' | translate}}</mat-label>
-            <input
-                matInput
-                [formControl]="processNameInput"
-                id="processName"
-                required/>
-            <mat-error *ngIf="nameController.hasError('maxlength')">
-                {{ 'ADF_PROCESS_LIST.START_PROCESS.ERROR.MAXIMUM_LENGTH' | translate : { characters : maxProcessNameLength } }}
-            </mat-error>
-            <mat-error *ngIf="nameController.hasError('required')">
-                {{ 'ADF_PROCESS_LIST.START_PROCESS.ERROR.PROCESS_NAME_REQUIRED' | translate }}
-            </mat-error>
-            <mat-error *ngIf="nameController.hasError('pattern')">
-                {{ 'ADF_PROCESS_LIST.START_PROCESS.ERROR.SPACE_VALIDATOR' | translate }}
-            </mat-error>
-        </mat-form-field>
 
-        <adf-start-form
-            #startForm
-            *ngIf="hasStartForm()"
-            [data]="values"
-            [disableStartProcessButton]="processNameInput.invalid"
-            [processDefinitionId]="selectedProcessDef.id"
-            (outcomeClick)="onOutcomeClick($event)"
-            [showRefreshButton]="false">
-            <button
-                adf-form-custom-button
-                mat-button
-                (click)="cancelStartProcess()"
-                id="cancel_process">
-                {{'ADF_PROCESS_LIST.START_PROCESS.FORM.ACTION.CANCEL'| translate | uppercase}}
-            </button>
-        </adf-start-form>
-    </div>
-    <div class="content" *ngIf="hasErrorMessage()">
-        <div class="subtitle" class="error-message" id="no-process-message">
-            {{'ADF_PROCESS_LIST.START_PROCESS.NO_PROCESS_DEFINITIONS' | translate | uppercase}}
+<ng-container *ngIf="isLoading(); then showLoadingTemplate; else showStartProcessTemplate"></ng-container>
+    <ng-template #showLoadingTemplate>
+        <mat-spinner class="adf-start-process-loading-margin"></mat-spinner>
+    </ng-template>
+<ng-template #showStartProcessTemplate>
+    <ng-container *ngIf="hasApplications() || hasProcessDefinitions() ; else showEmptyTemplate">
+        <div class="adf-start-process">
+            <div class="adf-title" *ngIf="title">{{ title | translate}}</div>
+            <div class="content">
+                <div class="subtitle" id="error-message" *ngIf="errorMessageId">
+                    {{errorMessageId|translate}}
+                </div>
+                <div class="adf-start-process-definition-container">
+                    <mat-form-field *ngIf="showSelectApplicationDropdown" [floatLabel]="'always'" class="adf-start-process-app-list">
+                        <mat-select
+                            placeholder="{{
+                                applicationDropdownPlaceholder ? 
+                                applicationDropdownPlaceholder : 
+                                'ADF_PROCESS_LIST.START_PROCESS.FORM.LABEL.SELECT_APPLICATION' | translate}}"
+                            (selectionChange)="onAppSelectionChange($event)"
+                            [(ngModel)]="selectedApplication"
+                            data-automation-id="adf-start-process-apps-drop-down">
+                            <mat-option 
+                                *ngFor="let application of applications"
+                                [value]="application"
+                                [attr.data-automation-id]="'adf-start-process-apps-option-' + application.name">
+                                {{ application.name }}
+                            </mat-option>
+                        </mat-select>
+                    </mat-form-field>
+                    <mat-form-field class="adf-process-input-container" [floatLabel]="'always'">
+                        <mat-label>{{'ADF_PROCESS_LIST.START_PROCESS.FORM.LABEL.TYPE' | translate}}</mat-label>
+                        <input
+                            type="text"
+                            matInput
+                            [formControl]="processDefinitionInput"
+                            [matAutocomplete]="auto"
+                            id="processDefinitionName"
+                            #inputAutocomplete>
+                        <div class="adf-process-input-autocomplete">
+                            <mat-autocomplete
+                                #auto="matAutocomplete"
+                                id="processDefinitionOptions"
+                                [displayWith]="displayFn">
+                                <mat-option *ngFor="let processDef of filteredProcessesDefinitions$ | async" [value]="processDef.name"
+                                (click)="processDefinitionSelectionChanged(processDef)">
+                                    {{ processDef.name }}
+                                </mat-option>
+                            </mat-autocomplete>
+                            <ng-container *ngIf="!isProcessDefinitionsLoading ; else showProcessDefLoadingTemplate">
+                                <button
+                                    id="adf-select-process-dropdown"
+                                    *ngIf="showSelectProcessDropdown"
+                                    mat-icon-button
+                                    (click)="displayDropdown($event)"
+                                    [disabled]="disableDropdownButton()">
+                                    <mat-icon>arrow_drop_down</mat-icon>
+                                </button>
+                            </ng-container>
+                            <ng-template #showProcessDefLoadingTemplate>
+                                <mat-spinner id="adf-select-process-spinner" [diameter]="20"></mat-spinner>
+                            </ng-template>
+                        </div>
+                    </mat-form-field>
+                </div>
+                <mat-form-field class="adf-process-input-container" [floatLabel]="'always'">
+                    <mat-label>{{'ADF_PROCESS_LIST.START_PROCESS.FORM.LABEL.NAME' | translate}}</mat-label>
+                    <input
+                        matInput
+                        [formControl]="processNameInput"
+                        id="processName"
+                        required/>
+                    <mat-error *ngIf="nameController.hasError('maxlength')">
+                        {{ 'ADF_PROCESS_LIST.START_PROCESS.ERROR.MAXIMUM_LENGTH' | translate : { characters : maxProcessNameLength } }}
+                    </mat-error>
+                    <mat-error *ngIf="nameController.hasError('required')">
+                        {{ 'ADF_PROCESS_LIST.START_PROCESS.ERROR.PROCESS_NAME_REQUIRED' | translate }}
+                    </mat-error>
+                    <mat-error *ngIf="nameController.hasError('pattern')">
+                        {{ 'ADF_PROCESS_LIST.START_PROCESS.ERROR.SPACE_VALIDATOR' | translate }}
+                    </mat-error>
+                </mat-form-field>
+        
+                <ng-container *ngIf="isProcessDefinitionSelected() ; else emptyProcessDefTemplate">
+                    <ng-container  *ngIf="hasStartForm(); else noStartFormTemplate">
+                        <adf-start-form
+                            #startForm
+                            [data]="values"
+                            [disableStartProcessButton]="processNameInput.invalid"
+                            [processDefinitionId]="selectedProcessDef.id"
+                            (outcomeClick)="onOutcomeClick($event)"
+                            [showRefreshButton]="false">
+                            <button
+                                adf-form-custom-button
+                                mat-button
+                                (click)="cancelStartProcess()"
+                                id="cancel_process">
+                                {{'ADF_PROCESS_LIST.START_PROCESS.FORM.ACTION.CANCEL'| translate | uppercase}}
+                            </button>
+                        </adf-start-form>
+                    </ng-container>
+                    <ng-template #noStartFormTemplate>
+                        <adf-empty-content 
+                            class="adf-start-process-empty-template"
+                            [icon]="emptyTemplateIcon ? emptyTemplateIcon : 'assessment'"
+                            [title]="'ADF_PROCESS_LIST.START_PROCESS.NO_START_FORM'  | translate">
+                        </adf-empty-content>
+                    </ng-template>
+                </ng-container>
+                <ng-template #emptyProcessDefTemplate>
+                    <adf-empty-content class="adf-start-process-empty-template"
+                        [icon]="emptyTemplateIcon ? emptyTemplateIcon : 'assessment'"
+                        [title]="'ADF_PROCESS_LIST.START_PROCESS.NO_PROCESS_DEF_SELECTED'  | translate">
+                    </adf-empty-content>
+                </ng-template>
+        
+            </div>
+            <div class="mat-content-actions" *ngIf="!hasStartForm()">
+                <button
+                    mat-button
+                    *ngIf="!hasStartForm()"
+                    (click)="cancelStartProcess()"
+                    id="cancel_process">
+                    {{'ADF_PROCESS_LIST.START_PROCESS.FORM.ACTION.CANCEL'| translate | uppercase}}
+                </button>
+                <button
+                    color="primary"
+                    mat-button
+                    *ngIf="!hasStartForm()"
+                    [disabled]="!validateForm()"
+                    (click)="startProcess()"
+                    data-automation-id="btn-start"
+                    id="button-start"
+                    class="btn-start">
+                    {{'ADF_PROCESS_LIST.START_PROCESS.FORM.ACTION.START' | translate | uppercase}}
+                </button>
+            </div>
         </div>
-    </div>
-    <div class="mat-content-actions" *ngIf="!hasStartForm()">
-        <button
-            mat-button
-            *ngIf="!hasStartForm()"
-            (click)="cancelStartProcess()"
-            id="cancel_process">
-            {{'ADF_PROCESS_LIST.START_PROCESS.FORM.ACTION.CANCEL'| translate | uppercase}}
-        </button>
-        <button
-            color="primary"
-            mat-button
-            *ngIf="!hasStartForm()"
-            [disabled]="!validateForm()"
-            (click)="startProcess()"
-            data-automation-id="btn-start"
-            id="button-start"
-            class="btn-start">
-            {{'ADF_PROCESS_LIST.START_PROCESS.FORM.ACTION.START' | translate | uppercase}}
-        </button>
-    </div>
-</div>
+    </ng-container>
+        <ng-template #showEmptyTemplate>
+            <adf-empty-content class="adf-start-process-empty-template"
+                [icon]="emptyTemplateIcon ? emptyTemplateIcon : 'assessment'"
+                [title]="
+                     emptyTemplateTitle ? emptyTemplateTitle : 
+                    'ADF_PROCESS_LIST.START_PROCESS.NO_PROCESS_DEFINITIONS' | translate">
+            </adf-empty-content>
+        </ng-template>    
+</ng-template>

--- a/lib/process-services/src/lib/process-list/components/start-process.component.html
+++ b/lib/process-services/src/lib/process-list/components/start-process.component.html
@@ -8,16 +8,10 @@
         <div class="adf-start-process">
             <div class="adf-title" *ngIf="title">{{ title | translate}}</div>
             <div class="content">
-                <div class="subtitle" id="error-message" *ngIf="errorMessageId">
-                    {{errorMessageId|translate}}
-                </div>
                 <div class="adf-start-process-definition-container">
                     <mat-form-field *ngIf="showSelectApplicationDropdown" [floatLabel]="'always'" class="adf-start-process-app-list">
                         <mat-select
-                            placeholder="{{
-                                applicationDropdownPlaceholder ? 
-                                applicationDropdownPlaceholder : 
-                                'ADF_PROCESS_LIST.START_PROCESS.FORM.LABEL.SELECT_APPLICATION' | translate}}"
+                            placeholder="{{ 'ADF_PROCESS_LIST.START_PROCESS.FORM.LABEL.SELECT_APPLICATION' | translate }}"
                             (selectionChange)="onAppSelectionChange($event)"
                             [(ngModel)]="selectedApplication"
                             data-automation-id="adf-start-process-apps-drop-down">
@@ -82,39 +76,43 @@
                     </mat-error>
                 </mat-form-field>
         
-                <ng-container *ngIf="isProcessDefinitionSelected() ; else emptyProcessDefTemplate">
-                    <ng-container  *ngIf="hasStartForm(); else noStartFormTemplate">
-                        <adf-start-form
-                            #startForm
-                            [data]="values"
-                            [disableStartProcessButton]="processNameInput.invalid"
-                            [processDefinitionId]="selectedProcessDef.id"
-                            (outcomeClick)="onOutcomeClick($event)"
-                            [showRefreshButton]="false">
-                            <button
-                                adf-form-custom-button
-                                mat-button
-                                (click)="cancelStartProcess()"
-                                id="cancel_process">
-                                {{'ADF_PROCESS_LIST.START_PROCESS.FORM.ACTION.CANCEL'| translate | uppercase}}
-                            </button>
-                        </adf-start-form>
+                <ng-container *ngIf="!isProcessDefinitionsLoading ; else showStartFormLoadingTemplate">
+                    <ng-container *ngIf="isProcessDefinitionSelected() ; else emptyProcessDefTemplate">
+                        <ng-container  *ngIf="hasStartForm(); else noStartFormTemplate">
+                            <adf-start-form
+                                #startForm
+                                [data]="values"
+                                [disableStartProcessButton]="processNameInput.invalid"
+                                [processDefinitionId]="selectedProcessDef.id"
+                                (outcomeClick)="onOutcomeClick($event)"
+                                [showRefreshButton]="false">
+                                <button
+                                    adf-form-custom-button
+                                    mat-button
+                                    (click)="cancelStartProcess()"
+                                    id="cancel_process">
+                                    {{'ADF_PROCESS_LIST.START_PROCESS.FORM.ACTION.CANCEL'| translate | uppercase}}
+                                </button>
+                            </adf-start-form>
+                        </ng-container>
+                        <ng-template #noStartFormTemplate>
+                            <adf-empty-content 
+                                class="adf-start-process-empty-template"
+                                [icon]="'assessment'"
+                                [title]="'ADF_PROCESS_LIST.START_PROCESS.NO_START_FORM'  | translate">
+                            </adf-empty-content>
+                        </ng-template>
                     </ng-container>
-                    <ng-template #noStartFormTemplate>
-                        <adf-empty-content 
-                            class="adf-start-process-empty-template"
-                            [icon]="emptyTemplateIcon ? emptyTemplateIcon : 'assessment'"
-                            [title]="'ADF_PROCESS_LIST.START_PROCESS.NO_START_FORM'  | translate">
+                    <ng-template #emptyProcessDefTemplate>
+                        <adf-empty-content class="adf-start-process-empty-template"
+                            [icon]="'assessment'"
+                            [title]="'ADF_PROCESS_LIST.START_PROCESS.NO_PROCESS_DEF_SELECTED'  | translate">
                         </adf-empty-content>
                     </ng-template>
                 </ng-container>
-                <ng-template #emptyProcessDefTemplate>
-                    <adf-empty-content class="adf-start-process-empty-template"
-                        [icon]="emptyTemplateIcon ? emptyTemplateIcon : 'assessment'"
-                        [title]="'ADF_PROCESS_LIST.START_PROCESS.NO_PROCESS_DEF_SELECTED'  | translate">
-                    </adf-empty-content>
+                <ng-template #showStartFormLoadingTemplate>
+                    <mat-spinner class="adf-start-process-loading-margin"></mat-spinner>
                 </ng-template>
-        
             </div>
             <div class="mat-content-actions" *ngIf="!hasStartForm()">
                 <button
@@ -140,10 +138,8 @@
     </ng-container>
         <ng-template #showEmptyTemplate>
             <adf-empty-content class="adf-start-process-empty-template"
-                [icon]="emptyTemplateIcon ? emptyTemplateIcon : 'assessment'"
-                [title]="
-                     emptyTemplateTitle ? emptyTemplateTitle : 
-                    'ADF_PROCESS_LIST.START_PROCESS.NO_PROCESS_DEFINITIONS' | translate">
+                [icon]="'assessment'"
+                [title]="'ADF_PROCESS_LIST.START_PROCESS.NO_PROCESS_DEFINITIONS' | translate">
             </adf-empty-content>
         </ng-template>    
 </ng-template>

--- a/lib/process-services/src/lib/process-list/components/start-process.component.html
+++ b/lib/process-services/src/lib/process-list/components/start-process.component.html
@@ -1,7 +1,7 @@
 
 <ng-container *ngIf="isLoading(); then showLoadingTemplate; else showStartProcessTemplate"></ng-container>
     <ng-template #showLoadingTemplate>
-        <mat-spinner class="adf-start-process-loading-margin"></mat-spinner>
+        <mat-spinner class="adf-start-process-loading"></mat-spinner>
     </ng-template>
 <ng-template #showStartProcessTemplate>
     <ng-container *ngIf="hasApplications() || hasProcessDefinitions() ; else showEmptyTemplate">
@@ -111,7 +111,7 @@
                     </ng-template>
                 </ng-container>
                 <ng-template #showStartFormLoadingTemplate>
-                    <mat-spinner class="adf-start-process-loading-margin"></mat-spinner>
+                    <mat-spinner class="adf-start-process-loading"></mat-spinner>
                 </ng-template>
             </div>
             <div class="mat-content-actions" *ngIf="!hasStartForm()">

--- a/lib/process-services/src/lib/process-list/components/start-process.component.scss
+++ b/lib/process-services/src/lib/process-list/components/start-process.component.scss
@@ -65,4 +65,9 @@
             margin-right: auto;
         }
     }
+
+    .adf-start-process-loading-margin {
+        margin-left: calc((100% - 100px) / 2);
+        margin-right: calc((100% - 100px) / 2);
+    }
 }

--- a/lib/process-services/src/lib/process-list/components/start-process.component.scss
+++ b/lib/process-services/src/lib/process-list/components/start-process.component.scss
@@ -66,7 +66,7 @@
         }
     }
 
-    .adf-start-process-loading-margin {
+    .adf-start-process-loading {
         margin-left: calc((100% - 100px) / 2);
         margin-right: calc((100% - 100px) / 2);
     }

--- a/lib/process-services/src/lib/process-list/components/start-process.component.spec.ts
+++ b/lib/process-services/src/lib/process-list/components/start-process.component.spec.ts
@@ -712,50 +712,52 @@ describe('StartFormComponent', () => {
 
     describe('Empty Template', () => {
 
-        beforeEach(() => {
-            fixture.detectChanges();
-            getDefinitionsSpy.and.returnValue(of([]));
+        it('should show no process definition available template when application/process definitions are empty', async() => {
             getDeployedApplicationsSpy = spyOn(appsProcessService, 'getDeployedApplications').and.returnValue(of([]));
-        });
-
-        it('should show no process definition available template when application/process definitions are empty', () => {
+            getDefinitionsSpy.and.returnValue(of([]));
             component.showSelectApplicationDropdown = true;
-            const change = new SimpleChange(null, 3, true);
-            component.ngOnChanges({ 'appId': change });
-            component.applications = [];
-            component.processDefinitions = [];
+            component.appId = 3;
+            component.ngOnInit();
             fixture.detectChanges();
+            await fixture.whenStable();
             const noProcessElement = fixture.nativeElement.querySelector('.adf-empty-content__title');
             expect(noProcessElement).not.toBeNull('Expected no available process message to be present');
             expect(noProcessElement.innerText.trim()).toBe('ADF_PROCESS_LIST.START_PROCESS.NO_PROCESS_DEFINITIONS');
         });
 
-        it('should show no process definition available template if processDefinitions are empty', () => {
-            const change = new SimpleChange(null, 3, true);
-            component.ngOnChanges({ 'appId': change });
-            component.processDefinitions = [];
+        it('should show no process definition available template if processDefinitions are empty', async() => {
+            getDefinitionsSpy.and.returnValue(of([]));
+            component.appId = 3;
+            component.ngOnInit();
             fixture.detectChanges();
+            await fixture.whenStable();
             const noProcessElement = fixture.nativeElement.querySelector('.adf-empty-content__title');
             expect(noProcessElement).not.toBeNull('Expected no available process message to be present');
             expect(noProcessElement.innerText.trim()).toBe('ADF_PROCESS_LIST.START_PROCESS.NO_PROCESS_DEFINITIONS');
         });
 
-        it('should show no process definition selected template if there is no process definition selected', () => {
+        it('should show no process definition selected template if there is no process definition selected', async() => {
             component.showSelectApplicationDropdown = true;
-            const change = new SimpleChange(null, 3, true);
-            component.ngOnChanges({ 'appId': change });
+            getDefinitionsSpy.and.returnValue(of(testMultipleProcessDefs));
+            getDeployedApplicationsSpy = spyOn(appsProcessService, 'getDeployedApplications').and.returnValue(of(deployedApps));
+            component.appId = 1234;
+            component.ngOnInit();
             fixture.detectChanges();
+            await fixture.whenStable();
             const noProcessElement = fixture.nativeElement.querySelector('.adf-empty-content__title');
             expect(noProcessElement).not.toBeNull('Expected no available process message to be present');
             expect(noProcessElement.innerText.trim()).toBe('ADF_PROCESS_LIST.START_PROCESS.NO_PROCESS_DEF_SELECTED');
         });
 
-        it('should show no start form template if selected process definition does not have start form', () => {
+        it('should show no start form template if selected process definition does not have start form', async() => {
             component.showSelectApplicationDropdown = true;
-            const change = new SimpleChange(null, 3, true);
-            component.ngOnChanges({ 'appId': change });
-            component.selectedProcessDef = testMultipleProcessDefs[0];
+            getDefinitionsSpy.and.returnValue(of(testMultipleProcessDefs));
+            getDeployedApplicationsSpy = spyOn(appsProcessService, 'getDeployedApplications').and.returnValue(of(deployedApps));
+            component.processDefinitionName = 'My Process 1';
+            component.appId = 3;
+            component.ngOnInit();
             fixture.detectChanges();
+            await fixture.whenStable();
             const noProcessElement = fixture.nativeElement.querySelector('.adf-empty-content__title');
             expect(noProcessElement).not.toBeNull('Expected no available process message to be present');
             expect(noProcessElement.innerText.trim()).toBe('ADF_PROCESS_LIST.START_PROCESS.NO_START_FORM');
@@ -772,41 +774,42 @@ describe('StartFormComponent', () => {
             fixture.detectChanges();
         });
 
-        it('should emit error event in case loading process definitions failed', async(() => {
+        it('should emit error event in case loading process definitions failed', async() => {
+            const errorSpy = spyOn(component.error, 'emit');
             getDefinitionsSpy.and.returnValue(throwError(processDefError));
-            const errorSpy = spyOn(component.error, 'emit');
-            const change = new SimpleChange(null, 3, true);
-            component.ngOnChanges({ 'appId': change });
+            component.appId = 3;
+            component.ngOnInit();
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
-                expect(errorSpy).toHaveBeenCalledWith(processDefError);
-            });
-        }));
+            await fixture.whenStable();
+            expect(errorSpy).toHaveBeenCalledWith(processDefError);
+        });
 
-        it('should emit error event in case loading applications failed', async(() => {
+        it('should emit error event in case loading applications failed', async() => {
+            const errorSpy = spyOn(component.error, 'emit');
             getDeployedApplicationsSpy = spyOn(appsProcessService, 'getDeployedApplications').and.returnValue(throwError(applicationsError));
-            const errorSpy = spyOn(component.error, 'emit');
             component.showSelectApplicationDropdown = true;
-            const change = new SimpleChange(null, 3, true);
-            component.ngOnChanges({ 'appId': change });
+            component.appId = 3;
+            component.ngOnInit();
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
-                expect(errorSpy).toHaveBeenCalledWith(applicationsError);
-            });
-        }));
+            await fixture.whenStable();
+            expect(errorSpy).toHaveBeenCalledWith(applicationsError);
+        });
 
-        it('should emit error event in case start process failed', async(() => {
-            startProcessSpy.and.returnValue(throwError(startProcessError));
+        it('should emit error event in case start process failed', async() => {
             const errorSpy = spyOn(component.error, 'emit');
-            const change = new SimpleChange(null, 3, true);
-            component.ngOnChanges({ 'appId': change });
-            component.selectedProcessDef = testProcessDef;
+            getDefinitionsSpy.and.returnValue(of(testMultipleProcessDefs));
+            getDeployedApplicationsSpy = spyOn(appsProcessService, 'getDeployedApplications').and.returnValue(of(deployedApps));
+            startProcessSpy.and.returnValue(throwError(startProcessError));
+            component.showSelectApplicationDropdown = true;
+            component.processDefinitionName = 'My Process 1';
             component.name = 'mock name';
+            component.appId = 3;
+            component.ngOnInit();
+            fixture.detectChanges();
+            await fixture.whenStable();
             component.startProcess();
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
-                expect(errorSpy).toHaveBeenCalledWith(startProcessError);
-            });
-        }));
+            expect(errorSpy).toHaveBeenCalledWith(startProcessError);
+        });
     });
 });

--- a/lib/process-services/src/lib/process-list/components/start-process.component.spec.ts
+++ b/lib/process-services/src/lib/process-list/components/start-process.component.spec.ts
@@ -18,7 +18,7 @@
 import { DebugElement, SimpleChange } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivitiContentService, AppConfigService, FormService, setupTestBed, AppsProcessService } from '@alfresco/adf-core';
-import { of, throwError } from 'rxjs';
+import { of } from 'rxjs';
 
 import { ProcessInstanceVariable } from '../models/process-instance-variable.model';
 import { ProcessService } from '../services/process.service';
@@ -306,20 +306,6 @@ describe('StartFormComponent', () => {
             });
         });
 
-        it('should indicate an error to the user if process defs cannot be loaded', async(() => {
-            getDefinitionsSpy = getDefinitionsSpy.and.returnValue(throwError({}));
-            component.appId = 123;
-            const change = new SimpleChange(null, 123, true);
-            component.ngOnChanges({ 'appId': change });
-            fixture.detectChanges();
-
-            fixture.whenStable().then(() => {
-                const errorEl = fixture.nativeElement.querySelector('#error-message');
-                expect(errorEl).not.toBeNull('Expected error message to be present');
-                expect(errorEl.innerText.trim()).toBe('ADF_PROCESS_LIST.START_PROCESS.ERROR.LOAD_PROCESS_DEFS');
-            });
-        }));
-
         it('should show no process available message when no process definition is loaded', async(() => {
             getDefinitionsSpy = getDefinitionsSpy.and.returnValue(of([]));
             component.appId = 123;
@@ -328,7 +314,7 @@ describe('StartFormComponent', () => {
             fixture.detectChanges();
 
             fixture.whenStable().then(() => {
-                const noProcessElement = fixture.nativeElement.querySelector('#no-process-message');
+                const noProcessElement = fixture.nativeElement.querySelector('.adf-empty-content__title');
                 expect(noProcessElement).not.toBeNull('Expected no available process message to be present');
                 expect(noProcessElement.innerText.trim()).toBe('ADF_PROCESS_LIST.START_PROCESS.NO_PROCESS_DEFINITIONS');
             });
@@ -498,30 +484,6 @@ describe('StartFormComponent', () => {
             component.startProcess();
             fixture.whenStable().then(() => {
                 expect(emitSpy).toHaveBeenCalledWith(newProcess);
-            });
-        }));
-
-        it('should throw error event when process cannot be started', async(() => {
-            const errorSpy = spyOn(component.error, 'error');
-            const error = { message: 'My error' };
-            startProcessSpy = startProcessSpy.and.returnValue(throwError(error));
-            component.selectedProcessDef = testProcessDef;
-            component.startProcess();
-            fixture.whenStable().then(() => {
-                expect(errorSpy).toHaveBeenCalledWith(error);
-            });
-        }));
-
-        it('should indicate an error to the user if process cannot be started', async(() => {
-            fixture.detectChanges();
-            startProcessSpy = startProcessSpy.and.returnValue(throwError({}));
-            component.selectedProcessDef = testProcessDef;
-            component.startProcess();
-            fixture.detectChanges();
-            fixture.whenStable().then(() => {
-                const errorEl = fixture.nativeElement.querySelector('#error-message');
-                expect(errorEl).not.toBeNull();
-                expect(errorEl.innerText.trim()).toBe('ADF_PROCESS_LIST.START_PROCESS.ERROR.START');
             });
         }));
 

--- a/lib/process-services/src/lib/process-list/components/start-process.component.spec.ts
+++ b/lib/process-services/src/lib/process-list/components/start-process.component.spec.ts
@@ -715,50 +715,58 @@ describe('StartFormComponent', () => {
         it('should show no process definition available template when application/process definitions are empty', async() => {
             getDeployedApplicationsSpy = spyOn(appsProcessService, 'getDeployedApplications').and.returnValue(of([]));
             getDefinitionsSpy.and.returnValue(of([]));
+
             component.showSelectApplicationDropdown = true;
             component.appId = 3;
             component.ngOnInit();
             fixture.detectChanges();
             await fixture.whenStable();
             const noProcessElement = fixture.nativeElement.querySelector('.adf-empty-content__title');
+
             expect(noProcessElement).not.toBeNull('Expected no available process message to be present');
             expect(noProcessElement.innerText.trim()).toBe('ADF_PROCESS_LIST.START_PROCESS.NO_PROCESS_DEFINITIONS');
         });
 
         it('should show no process definition available template if processDefinitions are empty', async() => {
             getDefinitionsSpy.and.returnValue(of([]));
+
             component.appId = 3;
             component.ngOnInit();
             fixture.detectChanges();
             await fixture.whenStable();
             const noProcessElement = fixture.nativeElement.querySelector('.adf-empty-content__title');
+
             expect(noProcessElement).not.toBeNull('Expected no available process message to be present');
             expect(noProcessElement.innerText.trim()).toBe('ADF_PROCESS_LIST.START_PROCESS.NO_PROCESS_DEFINITIONS');
         });
 
         it('should show no process definition selected template if there is no process definition selected', async() => {
-            component.showSelectApplicationDropdown = true;
             getDefinitionsSpy.and.returnValue(of(testMultipleProcessDefs));
             getDeployedApplicationsSpy = spyOn(appsProcessService, 'getDeployedApplications').and.returnValue(of(deployedApps));
+
+            component.showSelectApplicationDropdown = true;
             component.appId = 1234;
             component.ngOnInit();
             fixture.detectChanges();
             await fixture.whenStable();
             const noProcessElement = fixture.nativeElement.querySelector('.adf-empty-content__title');
+
             expect(noProcessElement).not.toBeNull('Expected no available process message to be present');
             expect(noProcessElement.innerText.trim()).toBe('ADF_PROCESS_LIST.START_PROCESS.NO_PROCESS_DEF_SELECTED');
         });
 
         it('should show no start form template if selected process definition does not have start form', async() => {
-            component.showSelectApplicationDropdown = true;
             getDefinitionsSpy.and.returnValue(of(testMultipleProcessDefs));
             getDeployedApplicationsSpy = spyOn(appsProcessService, 'getDeployedApplications').and.returnValue(of(deployedApps));
+
+            component.showSelectApplicationDropdown = true;
             component.processDefinitionName = 'My Process 1';
             component.appId = 3;
             component.ngOnInit();
             fixture.detectChanges();
             await fixture.whenStable();
             const noProcessElement = fixture.nativeElement.querySelector('.adf-empty-content__title');
+
             expect(noProcessElement).not.toBeNull('Expected no available process message to be present');
             expect(noProcessElement.innerText.trim()).toBe('ADF_PROCESS_LIST.START_PROCESS.NO_START_FORM');
         });
@@ -777,21 +785,25 @@ describe('StartFormComponent', () => {
         it('should emit error event in case loading process definitions failed', async() => {
             const errorSpy = spyOn(component.error, 'emit');
             getDefinitionsSpy.and.returnValue(throwError(processDefError));
+
             component.appId = 3;
             component.ngOnInit();
             fixture.detectChanges();
             await fixture.whenStable();
+
             expect(errorSpy).toHaveBeenCalledWith(processDefError);
         });
 
         it('should emit error event in case loading applications failed', async() => {
             const errorSpy = spyOn(component.error, 'emit');
             getDeployedApplicationsSpy = spyOn(appsProcessService, 'getDeployedApplications').and.returnValue(throwError(applicationsError));
+
             component.showSelectApplicationDropdown = true;
             component.appId = 3;
             component.ngOnInit();
             fixture.detectChanges();
             await fixture.whenStable();
+
             expect(errorSpy).toHaveBeenCalledWith(applicationsError);
         });
 
@@ -800,6 +812,7 @@ describe('StartFormComponent', () => {
             getDefinitionsSpy.and.returnValue(of(testMultipleProcessDefs));
             getDeployedApplicationsSpy = spyOn(appsProcessService, 'getDeployedApplications').and.returnValue(of(deployedApps));
             startProcessSpy.and.returnValue(throwError(startProcessError));
+
             component.showSelectApplicationDropdown = true;
             component.processDefinitionName = 'My Process 1';
             component.name = 'mock name';
@@ -809,6 +822,7 @@ describe('StartFormComponent', () => {
             await fixture.whenStable();
             component.startProcess();
             fixture.detectChanges();
+
             expect(errorSpy).toHaveBeenCalledWith(startProcessError);
         });
     });

--- a/lib/process-services/src/lib/process-list/components/start-process.component.ts
+++ b/lib/process-services/src/lib/process-list/components/start-process.component.ts
@@ -311,11 +311,12 @@ export class StartProcessInstanceComponent implements OnChanges, OnInit, OnDestr
             this.loadProcessDefinitions(this.selectedApplication ? this.selectedApplication.id : null);
         } else {
             this.isProcessDefinitionsLoading = false;
-            this.resetSelectedProcessDefinition();
+            this.resetProcessDefinitions();
         }
     }
 
     onAppSelectionChange(selectedApplication: any) {
+        this.resetProcessDefinitions();
         this.selectedApplication = selectedApplication.value;
         this.applicationSelection.emit(this.selectedApplication);
         this.toggleProcessNameAndDefinitionsDropdown();
@@ -411,6 +412,11 @@ export class StartProcessInstanceComponent implements OnChanges, OnInit, OnDestr
         if (this.processDefinitionInput) {
             this.processDefinitionInput.setValue('');
         }
+    }
+
+    private resetProcessDefinitions() {
+        this.processDefinitions = [];
+        this.resetSelectedProcessDefinition();
     }
 
     public onOutcomeClick(outcome: string) {

--- a/lib/process-services/src/lib/process-list/components/start-process.component.ts
+++ b/lib/process-services/src/lib/process-list/components/start-process.component.ts
@@ -93,7 +93,7 @@ export class StartProcessInstanceComponent implements OnChanges, OnInit, OnDestr
 
     /** Emitted when the process is canceled. */
     @Output()
-    cancel: EventEmitter<any> = new EventEmitter<any>();
+    cancel: EventEmitter<void> = new EventEmitter<void>();
 
     /** Emitted when an error occurs. */
     @Output()

--- a/lib/testing/src/lib/process-services-cloud/pages/task-form-cloud-component.page.ts
+++ b/lib/testing/src/lib/process-services-cloud/pages/task-form-cloud-component.page.ts
@@ -29,7 +29,7 @@ export class TaskFormCloudComponent {
     claimButton: ElementFinder = element(by.css('button[adf-cloud-claim-task]'));
     form: ElementFinder = element(by.css('adf-cloud-form'));
     formTitle: ElementFinder = element(by.css(`span.adf-form-title`));
-    emptyContentIcon: ElementFinder = element(by.css(`div.adf-empty-content mat-icon.adf-empty-content__icon`));
+    emptyContentIcon: ElementFinder = element(by.css(`div.adf-empty-content adf-icon.adf-empty-content__icon`));
     emptyContentTitle: ElementFinder = element(by.css(`div.adf-empty-content div.adf-empty-content__title`));
     emptyContentSubtitle: ElementFinder = element(by.css(`div.adf-empty-content div.adf-empty-content__subtitle`));
     readOnlyForm = element(by.css('div[class="adf-readonly-form"]'));

--- a/lib/testing/src/lib/process-services/pages/start-process.page.ts
+++ b/lib/testing/src/lib/process-services/pages/start-process.page.ts
@@ -30,7 +30,7 @@ export class StartProcessPage {
     cancelProcessButton: ElementFinder = element(by.id('cancel_process'));
     formStartProcessButton: ElementFinder = element(by.css('button[data-automation-id="adf-form-start process"]'));
     startProcessButton: ElementFinder = element(by.css('button[data-automation-id="btn-start"]'));
-    noProcess: ElementFinder = element(by.id('no-process-message'));
+    noProcess: ElementFinder = element(by.css('.adf-empty-content__title'));
     processDefinition: ElementFinder = element(by.css('input[id="processDefinitionName"]'));
     processDefinitionOptionsPanel: ElementFinder = element(by.css('div[class*="mat-autocomplete-panel"]'));
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://issues.alfresco.com/jira/browse/ACA-3358

**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
