### PR TITLE
[ACA-2596] - fix: heading markup for bread crumbs

### DIFF
--- a/lib/content-services/src/lib/breadcrumb/breadcrumb.component.html
+++ b/lib/content-services/src/lib/breadcrumb/breadcrumb.component.html
@@ -54,7 +54,7 @@
             {{ item.name | translate }}
         </a>
 
-        <div *ngSwitchCase="true" class="adf-breadcrumb-item-current"
+        <div *ngSwitchCase="true" class="adf-breadcrumb-item-current" role="heading" aria-level="2"
             aria-current="location">
             {{ item.name | translate }}
         </div>
@@ -72,7 +72,7 @@
     [attr.aria-label]="'BREADCRUMB.ARIA-LABEL.BREADCRUMB' | translate"
 >
     <div class="adf-breadcrumb-item adf-active" role="listitem">
-        <div class="adf-breadcrumb-item-current">
+        <div class="adf-breadcrumb-item-current" role="heading" aria-level="2">
             {{ root | translate }}
         </div>
     </div>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Breadcrumbs text are not announcing as headings


**What is the new behaviour?**
Breadcrumbs will now announce as headings


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
