### PR TITLE
[ACA-3426] Move filter-menu inside search and renamed as search-header

### DIFF
--- a/demo-shell/src/app/components/files/files.component.html
+++ b/demo-shell/src/app/components/files/files.component.html
@@ -244,9 +244,11 @@
                 (folderChange)="onFolderChange($event)"
                 (permissionError)="handlePermissionError($event)"
                 (name-click)="documentList.onNodeDblClick($event.detail?.node)">
-                <ng-template let-col>
-                    <adf-search-header [col]="col"></adf-search-header>
-                </ng-template>
+                <adf-custom-header-filter-template *ngIf="enableCustomHeaderFilter">
+                    <ng-template let-col>
+                        <div>My custom filter for {{col.title}}</div>
+                    </ng-template>
+                </adf-custom-header-filter-template>
                 <adf-custom-no-permission-template *ngIf="enableCustomPermissionMessage">
                     <h1>You don't have permissions</h1>
                 </adf-custom-no-permission-template>

--- a/demo-shell/src/app/components/files/files.component.html
+++ b/demo-shell/src/app/components/files/files.component.html
@@ -246,7 +246,7 @@
                 (name-click)="documentList.onNodeDblClick($event.detail?.node)">
                 <adf-custom-header-filter-template *ngIf="enableCustomHeaderFilter">
                     <ng-template let-col>
-                        <div>My custom filter for {{col.title}}</div>
+                        <adf-search-header [col]="col"></adf-search-header>
                     </ng-template>
                 </adf-custom-header-filter-template>
                 <adf-custom-no-permission-template *ngIf="enableCustomPermissionMessage">

--- a/demo-shell/src/app/components/files/files.component.html
+++ b/demo-shell/src/app/components/files/files.component.html
@@ -244,6 +244,9 @@
                 (folderChange)="onFolderChange($event)"
                 (permissionError)="handlePermissionError($event)"
                 (name-click)="documentList.onNodeDblClick($event.detail?.node)">
+                <ng-template let-col>
+                    <adf-search-header [col]="col"></adf-search-header>
+                </ng-template>
                 <adf-custom-no-permission-template *ngIf="enableCustomPermissionMessage">
                     <h1>You don't have permissions</h1>
                 </adf-custom-no-permission-template>

--- a/demo-shell/src/app/components/files/files.component.ts
+++ b/demo-shell/src/app/components/files/files.component.ts
@@ -195,6 +195,7 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
     stickyHeader: boolean;
     warnOnMultipleUploads = false;
     thumbnails = false;
+    enableCustomHeaderFilter = false;
     enableCustomPermissionMessage = false;
     enableMediumTimeFormat = false;
     displayEmptyMetadata = false;

--- a/demo-shell/src/app/components/files/files.component.ts
+++ b/demo-shell/src/app/components/files/files.component.ts
@@ -195,7 +195,7 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
     stickyHeader: boolean;
     warnOnMultipleUploads = false;
     thumbnails = false;
-    enableCustomHeaderFilter = false;
+    enableCustomHeaderFilter = true;
     enableCustomPermissionMessage = false;
     enableMediumTimeFormat = false;
     displayEmptyMetadata = false;

--- a/lib/content-services/src/lib/document-list/components/document-list.component.html
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.html
@@ -25,7 +25,10 @@
     [class.adf-datatable-gallery-thumbnails]="data.thumbnails">
 
     <ng-template let-col>
-        <adf-search-header [col]="col"></adf-search-header>
+        <ng-template
+            [ngTemplateOutlet]="filterTemplateRef"
+            [ngTemplateOutletContext]="{$implicit: col}">
+        </ng-template>
     </ng-template>
 
     <adf-no-content-template>

--- a/lib/content-services/src/lib/document-list/components/document-list.component.html
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.html
@@ -26,7 +26,6 @@
 
     <adf-header-filter-template>
         <ng-template let-col>
-            <adf-search-header *ngIf="!customHeaderFilterTemplate" [col]="col"></adf-search-header>
             <ng-template [ngTemplateOutlet]="customHeaderFilterTemplate?.template"
                 [ngTemplateOutletContext]="{$implicit: col}">
             </ng-template>

--- a/lib/content-services/src/lib/document-list/components/document-list.component.html
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.html
@@ -24,12 +24,14 @@
     (row-unselect)="onNodeUnselect($event.detail)"
     [class.adf-datatable-gallery-thumbnails]="data.thumbnails">
 
-    <ng-template let-col>
-        <ng-template
-            [ngTemplateOutlet]="filterTemplateRef"
-            [ngTemplateOutletContext]="{$implicit: col}">
+    <adf-header-filter-template>
+        <ng-template let-col>
+            <adf-search-header *ngIf="!customHeaderFilterTemplate" [col]="col"></adf-search-header>
+            <ng-template [ngTemplateOutlet]="customHeaderFilterTemplate?.template"
+                [ngTemplateOutletContext]="{$implicit: col}">
+            </ng-template>
         </ng-template>
-    </ng-template>
+    </adf-header-filter-template>
 
     <adf-no-content-template>
         <ng-template>

--- a/lib/content-services/src/lib/document-list/components/document-list.component.html
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.html
@@ -25,7 +25,7 @@
     [class.adf-datatable-gallery-thumbnails]="data.thumbnails">
 
     <ng-template let-col>
-        <adf-filter-menu class="adf-filter-menu" [col]="col"></adf-filter-menu>
+        <adf-search-header [col]="col"></adf-search-header>
     </ng-template>
 
     <adf-no-content-template>

--- a/lib/content-services/src/lib/document-list/components/document-list.component.ts
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.ts
@@ -40,6 +40,7 @@ import {
     CustomLoadingContentTemplateDirective,
     CustomNoPermissionTemplateDirective,
     CustomEmptyContentTemplateDirective,
+    CustomHeaderFilterTemplateDirective,
     RequestPaginationModel,
     AlfrescoApiService,
     UserPreferenceValues,
@@ -90,6 +91,9 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
 
     @ContentChild(CustomEmptyContentTemplateDirective)
     customNoContentTemplate: CustomEmptyContentTemplateDirective;
+
+    @ContentChild(CustomHeaderFilterTemplateDirective)
+    customHeaderFilterTemplate: CustomHeaderFilterTemplateDirective;
 
     /** Include additional information about the node in the server request. For example: association, isLink, isLocked and others. */
     @Input()

--- a/lib/content-services/src/lib/document-list/components/document-list.component.ts
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.ts
@@ -19,7 +19,7 @@
 
 import {
     AfterContentInit, Component, ContentChild, ElementRef, EventEmitter, HostListener, Input, NgZone,
-    OnChanges, OnDestroy, OnInit, Output, SimpleChanges, ViewChild, ViewEncapsulation
+    OnChanges, OnDestroy, OnInit, Output, SimpleChanges, ViewChild, ViewEncapsulation, TemplateRef
 } from '@angular/core';
 
 import {
@@ -301,6 +301,9 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
 
     @ViewChild('dataTable')
     dataTable: DataTableComponent;
+
+    @ContentChild(TemplateRef)
+    filterTemplateRef: TemplateRef<any>;
 
     actions: ContentActionModel[] = [];
     contextActionHandler: Subject<any> = new Subject();
@@ -855,4 +858,8 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
         this.error.emit(err);
     }
 
+    onFilterUpdate(newNodePaging: NodePaging) {
+        this.node = newNodePaging;
+        this.reload();
+    }
 }

--- a/lib/content-services/src/lib/document-list/document-list.module.ts
+++ b/lib/content-services/src/lib/document-list/document-list.module.ts
@@ -19,6 +19,7 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { CoreModule, EditJsonDialogModule } from '@alfresco/adf-core';
+import { SearchModule } from '../search';
 
 import { MaterialModule } from '../material.module';
 import { UploadModule } from '../upload/upload.module';
@@ -40,7 +41,8 @@ import { NameColumnComponent } from './components/name-column/name-column.compon
         FlexLayoutModule,
         MaterialModule,
         UploadModule,
-        EditJsonDialogModule
+        EditJsonDialogModule,
+        SearchModule
     ],
     declarations: [
         DocumentListComponent,

--- a/lib/content-services/src/lib/document-list/document-list.module.ts
+++ b/lib/content-services/src/lib/document-list/document-list.module.ts
@@ -19,7 +19,6 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { CoreModule, EditJsonDialogModule } from '@alfresco/adf-core';
-import { SearchModule } from '../search';
 
 import { MaterialModule } from '../material.module';
 import { UploadModule } from '../upload/upload.module';
@@ -41,8 +40,7 @@ import { NameColumnComponent } from './components/name-column/name-column.compon
         FlexLayoutModule,
         MaterialModule,
         UploadModule,
-        EditJsonDialogModule,
-        SearchModule
+        EditJsonDialogModule
     ],
     declarations: [
         DocumentListComponent,

--- a/lib/content-services/src/lib/document-list/document-list.module.ts
+++ b/lib/content-services/src/lib/document-list/document-list.module.ts
@@ -22,7 +22,6 @@ import { CoreModule, EditJsonDialogModule } from '@alfresco/adf-core';
 
 import { MaterialModule } from '../material.module';
 import { UploadModule } from '../upload/upload.module';
-import { SearchModule } from '../search/search.module';
 
 import { ContentActionListComponent } from './components/content-action/content-action-list.component';
 import { ContentActionComponent } from './components/content-action/content-action.component';
@@ -41,8 +40,7 @@ import { NameColumnComponent } from './components/name-column/name-column.compon
         FlexLayoutModule,
         MaterialModule,
         UploadModule,
-        EditJsonDialogModule,
-        SearchModule
+        EditJsonDialogModule
     ],
     declarations: [
         DocumentListComponent,

--- a/lib/content-services/src/lib/document-list/document-list.module.ts
+++ b/lib/content-services/src/lib/document-list/document-list.module.ts
@@ -22,6 +22,7 @@ import { CoreModule, EditJsonDialogModule } from '@alfresco/adf-core';
 
 import { MaterialModule } from '../material.module';
 import { UploadModule } from '../upload/upload.module';
+import { SearchModule } from '../search/search.module';
 
 import { ContentActionListComponent } from './components/content-action/content-action-list.component';
 import { ContentActionComponent } from './components/content-action/content-action.component';
@@ -32,7 +33,6 @@ import { LibraryStatusColumnComponent } from './components/library-status-column
 import { LibraryRoleColumnComponent } from './components/library-role-column/library-role-column.component';
 import { LibraryNameColumnComponent } from './components/library-name-column/library-name-column.component';
 import { NameColumnComponent } from './components/name-column/name-column.component';
-import { FilterMenuComponent } from './components/filter-menu/filter-menu.component';
 
 @NgModule({
     imports: [
@@ -41,7 +41,8 @@ import { FilterMenuComponent } from './components/filter-menu/filter-menu.compon
         FlexLayoutModule,
         MaterialModule,
         UploadModule,
-        EditJsonDialogModule
+        EditJsonDialogModule,
+        SearchModule
     ],
     declarations: [
         DocumentListComponent,
@@ -51,8 +52,7 @@ import { FilterMenuComponent } from './components/filter-menu/filter-menu.compon
         LibraryNameColumnComponent,
         NameColumnComponent,
         ContentActionComponent,
-        ContentActionListComponent,
-        FilterMenuComponent
+        ContentActionListComponent
     ],
     exports: [
         DocumentListComponent,

--- a/lib/content-services/src/lib/i18n/en.json
+++ b/lib/content-services/src/lib/i18n/en.json
@@ -62,11 +62,6 @@
       "VIEW": "View",
       "REMOVE": "Remove",
       "DOWNLOAD": "Download"
-    },
-    "FILTER_MENU" : {
-      "FILTER_BY": "Filter by {{ category }}",
-      "CLEAR": "Clear",
-      "APPLY": "Apply"
     }
   },
   "ALFRESCO_DOCUMENT_LIST": {
@@ -289,6 +284,11 @@
           "PROCESS_ACTION": "Start Process"
         }
       }
+    },
+    "SEARCH_HEADER" : {
+      "FILTER_BY": "Filter by {{ category }}",
+      "CLEAR": "Clear",
+      "APPLY": "Apply"
     }
   },
   "PERMISSION": {

--- a/lib/content-services/src/lib/search/components/search-header/search-header.component.html
+++ b/lib/content-services/src/lib/search/components/search-header/search-header.component.html
@@ -1,16 +1,16 @@
 <button mat-icon-button [matMenuTriggerFor]="filter"
     (click)="onMenuButtonClick($event)"
     class="adf-filter-button"
-    matTooltip="{{ 'ADF-DOCUMENT-LIST.FILTER_MENU.FILTER_BY' | translate:{category: col.title} }}">
+    matTooltip="{{ 'SEARCH.SEARCH_HEADER.FILTER_BY' | translate:{category: col.title} }}">
     <adf-icon value="adf:filter" color="primary"></adf-icon>
 </button>
 
 <mat-menu #filter="matMenu">
     <div>{{col.title}}</div>
     <mat-dialog-actions>
-        <button mat-button>{{ 'ADF-DOCUMENT-LIST.FILTER_MENU.CLEAR' | translate | uppercase }}
+        <button mat-button>{{ 'SEARCH.SEARCH_HEADER.CLEAR' | translate | uppercase }}
         </button>
-        <button mat-button>{{ 'ADF-DOCUMENT-LIST.FILTER_MENU.APPLY' | translate | uppercase }}
+        <button mat-button>{{ 'SEARCH.SEARCH_HEADER.APPLY' | translate | uppercase }}
         </button>
     </mat-dialog-actions>
 </mat-menu>

--- a/lib/content-services/src/lib/search/components/search-header/search-header.component.ts
+++ b/lib/content-services/src/lib/search/components/search-header/search-header.component.ts
@@ -19,10 +19,10 @@ import { Component, Input } from '@angular/core';
 import { DataColumn } from '@alfresco/adf-core';
 
 @Component({
-    selector: 'adf-filter-menu',
-    templateUrl: './filter-menu.component.html'
+    selector: 'adf-search-header',
+    templateUrl: './search-header.component.html'
 })
-export class FilterMenuComponent {
+export class SearchHeaderComponent {
 
     @Input()
     col: DataColumn;

--- a/lib/content-services/src/lib/search/search.module.ts
+++ b/lib/content-services/src/lib/search/search.module.ts
@@ -35,6 +35,7 @@ import { SearchNumberRangeComponent } from './components/search-number-range/sea
 import { SearchCheckListComponent } from './components/search-check-list/search-check-list.component';
 import { SearchDateRangeComponent } from './components/search-date-range/search-date-range.component';
 import { SearchSortingPickerComponent } from './components/search-sorting-picker/search-sorting-picker.component';
+import { SearchHeaderComponent } from './components/search-header/search-header.component';
 
 @NgModule({
     imports: [
@@ -57,7 +58,8 @@ import { SearchSortingPickerComponent } from './components/search-sorting-picker
         SearchNumberRangeComponent,
         SearchCheckListComponent,
         SearchDateRangeComponent,
-        SearchSortingPickerComponent
+        SearchSortingPickerComponent,
+        SearchHeaderComponent
     ],
     exports: [
         SearchComponent,
@@ -72,7 +74,8 @@ import { SearchSortingPickerComponent } from './components/search-sorting-picker
         SearchNumberRangeComponent,
         SearchCheckListComponent,
         SearchDateRangeComponent,
-        SearchSortingPickerComponent
+        SearchSortingPickerComponent,
+        SearchHeaderComponent
     ],
     entryComponents: [
         SearchWidgetContainerComponent,

--- a/lib/core/datatable/components/datatable/datatable.component.html
+++ b/lib/core/datatable/components/datatable/datatable.component.html
@@ -34,7 +34,7 @@
                  adf-drop-zone dropTarget="header" [dropColumn]="col">
                 <span *ngIf="col.title" class="adf-datatable-cell-value">{{ col.title | translate}}</span>
                 <span *ngIf="col.title && col.sortable" class="adf-sr-only" aria-live="polite">{{ getSortLiveAnnouncement(col) | translate: { string: col.title | translate } }}</span>
-                <ng-template *ngIf="allowFiltering" [ngTemplateOutlet]="filterTemplateRef" [ngTemplateOutletContext]="{$implicit: col}"></ng-template>
+                <ng-template *ngIf="allowFiltering" [ngTemplateOutlet]="headerFilterTemplate" [ngTemplateOutletContext]="{$implicit: col}"></ng-template>
             </div>
             <!-- Actions (right) -->
             <div *ngIf="actions && actionsPosition === 'right'" class="adf-actions-column adf-datatable-cell-header adf-datatable__actions-cell">

--- a/lib/core/datatable/components/datatable/datatable.component.ts
+++ b/lib/core/datatable/components/datatable/datatable.component.ts
@@ -175,9 +175,7 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck,
     @Input()
     allowFiltering: boolean = false;
 
-    @ContentChild(TemplateRef)
-    filterTemplateRef: TemplateRef<any>;
-
+    headerFilterTemplate: TemplateRef<any>;
     noContentTemplate: TemplateRef<any>;
     noPermissionTemplate: TemplateRef<any>;
     loadingTemplate: TemplateRef<any>;

--- a/lib/core/datatable/datatable.module.ts
+++ b/lib/core/datatable/datatable.module.ts
@@ -38,9 +38,11 @@ import { LocationCellComponent } from './components/location-cell/location-cell.
 import { LoadingContentTemplateDirective } from './directives/loading-template.directive';
 import { NoContentTemplateDirective } from './directives/no-content-template.directive';
 import { NoPermissionTemplateDirective } from './directives/no-permission-template.directive';
+import { HeaderFilterTemplateDirective } from './directives/header-filter-template.directive';
 import { CustomEmptyContentTemplateDirective } from './directives/custom-empty-content-template.directive';
 import { CustomLoadingContentTemplateDirective } from './directives/custom-loading-template.directive';
 import { CustomNoPermissionTemplateDirective } from './directives/custom-no-permission-template.directive';
+import { CustomHeaderFilterTemplateDirective } from './directives/custom-header-filter-template.directive';
 import { JsonCellComponent } from './components/json-cell/json-cell.component';
 import { ClipboardModule } from '../clipboard/clipboard.module';
 import { DropZoneDirective } from './directives/drop-zone.directive';
@@ -73,9 +75,11 @@ import { DataColumnModule } from '../data-column/data-column.module';
         NoContentTemplateDirective,
         NoPermissionTemplateDirective,
         LoadingContentTemplateDirective,
+        HeaderFilterTemplateDirective,
         CustomEmptyContentTemplateDirective,
         CustomLoadingContentTemplateDirective,
         CustomNoPermissionTemplateDirective,
+        CustomHeaderFilterTemplateDirective,
         DropZoneDirective
     ],
     exports: [
@@ -93,9 +97,11 @@ import { DataColumnModule } from '../data-column/data-column.module';
         NoContentTemplateDirective,
         NoPermissionTemplateDirective,
         LoadingContentTemplateDirective,
+        HeaderFilterTemplateDirective,
         CustomEmptyContentTemplateDirective,
         CustomLoadingContentTemplateDirective,
         CustomNoPermissionTemplateDirective,
+        CustomHeaderFilterTemplateDirective,
         DropZoneDirective
     ]
 

--- a/lib/core/datatable/directives/custom-header-filter-template.directive.ts
+++ b/lib/core/datatable/directives/custom-header-filter-template.directive.ts
@@ -1,0 +1,28 @@
+/*!
+ * @license
+ * Copyright 2019 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Directive, ContentChild, TemplateRef } from '@angular/core';
+
+@Directive({
+    selector: 'adf-custom-header-filter-template'
+})
+export class CustomHeaderFilterTemplateDirective {
+
+    @ContentChild(TemplateRef)
+    template: any;
+
+}

--- a/lib/core/datatable/directives/header-filter-template.directive.spec.ts
+++ b/lib/core/datatable/directives/header-filter-template.directive.spec.ts
@@ -1,0 +1,54 @@
+/*!
+ * @license
+ * Copyright 2019 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { DataTableComponent } from '../components/datatable/datatable.component';
+import { HeaderFilterTemplateDirective } from './header-filter-template.directive';
+import { setupTestBed } from '../../testing/setup-test-bed';
+import { CoreTestingModule } from '../../testing/core.testing.module';
+import { TranslateModule } from '@ngx-translate/core';
+
+describe('HeaderFilterTemplateDirective', () => {
+
+    let fixture: ComponentFixture<DataTableComponent>;
+    let dataTable: DataTableComponent;
+    let directive: HeaderFilterTemplateDirective;
+
+    setupTestBed({
+        imports: [
+            TranslateModule.forRoot(),
+            CoreTestingModule
+        ]
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(DataTableComponent);
+        dataTable = fixture.componentInstance;
+        directive = new HeaderFilterTemplateDirective(dataTable);
+    });
+
+    afterEach(() => {
+        fixture.destroy();
+    });
+
+    it('applies template to the datatable', () => {
+        const template: any = 'test template';
+        directive.template = template;
+        directive.ngAfterContentInit();
+        expect(dataTable.headerFilterTemplate).toBe(template);
+    });
+});

--- a/lib/core/datatable/directives/header-filter-template.directive.ts
+++ b/lib/core/datatable/directives/header-filter-template.directive.ts
@@ -1,0 +1,37 @@
+/*!
+ * @license
+ * Copyright 2019 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AfterContentInit, ContentChild, Directive, TemplateRef } from '@angular/core';
+import { DataTableComponent } from '../components/datatable/datatable.component';
+
+@Directive({
+    selector: 'adf-header-filter-template'
+})
+export class HeaderFilterTemplateDirective implements AfterContentInit {
+
+    @ContentChild(TemplateRef)
+    template: any;
+
+    constructor(private dataTable: DataTableComponent) {
+    }
+
+    ngAfterContentInit() {
+        if (this.dataTable) {
+            this.dataTable.headerFilterTemplate = this.template;
+        }
+    }
+}

--- a/lib/core/datatable/public-api.ts
+++ b/lib/core/datatable/public-api.ts
@@ -41,8 +41,10 @@ export * from './data/data-table.schema';
 export * from './directives/loading-template.directive';
 export * from './directives/no-content-template.directive';
 export * from './directives/no-permission-template.directive';
+export * from './directives/header-filter-template.directive';
 export * from './directives/custom-empty-content-template.directive';
 export * from './directives/custom-loading-template.directive';
 export * from './directives/custom-no-permission-template.directive';
+export * from './directives/custom-header-filter-template.directive';
 
 export * from './datatable.module';


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
The new component: adf-filter-menu was defined inside the document-list folder.


**What is the new behaviour?**
This new component is renamed adf-search-header and is now defined inside the search folder.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ACA-3426