### PR TITLE
[ACA-3329] Refactor isCompleteFormButtonDisabled method

### DIFF
--- a/e2e/pages/adf/process-services/process-list.page.ts
+++ b/e2e/pages/adf/process-services/process-list.page.ts
@@ -31,8 +31,13 @@ export class ProcessListPage {
         return BrowserVisibility.waitUntilElementIsNotPresent(this.processListTitle);
     }
 
-    async checkProcessListIsDisplayed(): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.processInstanceList);
+    async isProcessListDisplayed(): Promise<boolean> {
+        try {
+            await BrowserVisibility.waitUntilElementIsVisible(this.processInstanceList);
+            return true;
+        } catch (error) {
+            return false;
+        }
     }
 
 }

--- a/e2e/process-services-cloud/form-field/task-visibility-condition.e2e.ts
+++ b/e2e/process-services-cloud/form-field/task-visibility-condition.e2e.ts
@@ -87,14 +87,14 @@ describe('Task cloud visibility', async () => {
 
         await taskFormCloudComponent.formFields().checkWidgetIsVisible('Number1');
         await taskFormCloudComponent.formFields().checkWidgetIsHidden('Number2');
-        await expect(await taskFormCloudComponent.formFields().isCompleteFormButtonDisabled()).toBeTruthy();
+        await expect(await taskFormCloudComponent.formFields().isCompleteFormButtonEnabled()).toEqual(false);
 
         await taskFormCloudComponent.formFields().setFieldValue(by.id, 'Number1', '5');
         await taskFormCloudComponent.formFields().checkWidgetIsVisible('Number2');
-        await expect(await taskFormCloudComponent.formFields().isCompleteFormButtonDisabled()).toBeFalsy();
+        await expect(await taskFormCloudComponent.formFields().isCompleteFormButtonEnabled()).toEqual(true);
 
         await taskFormCloudComponent.formFields().setFieldValue(by.id, 'Number1', '123');
-        await expect(await taskFormCloudComponent.formFields().isCompleteFormButtonDisabled()).toBeTruthy();
+        await expect(await taskFormCloudComponent.formFields().isCompleteFormButtonEnabled()).toEqual(false);
         await taskFormCloudComponent.formFields().checkWidgetIsHidden('Number2');
     });
 
@@ -116,18 +116,18 @@ describe('Task cloud visibility', async () => {
 
         await taskFormCloudComponent.formFields().checkWidgetIsVisible('Number1');
         await taskFormCloudComponent.formFields().checkWidgetIsHidden('Number2');
-        await expect(await taskFormCloudComponent.formFields().isCompleteFormButtonDisabled()).toBeTruthy();
+        await expect(await taskFormCloudComponent.formFields().isCompleteFormButtonEnabled()).toEqual(false);
 
         await taskFormCloudComponent.formFields().setFieldValue(by.id, 'Number1', '5');
         await taskFormCloudComponent.formFields().checkWidgetIsVisible('Number2');
-        await expect(await taskFormCloudComponent.formFields().isCompleteFormButtonDisabled()).toBeFalsy();
+        await expect(await taskFormCloudComponent.formFields().isCompleteFormButtonEnabled()).toEqual(true);
 
         await taskFormCloudComponent.formFields().setFieldValue(by.id, 'Number1', '123');
-        await expect(await taskFormCloudComponent.formFields().isCompleteFormButtonDisabled()).toBeTruthy();
+        await expect(await taskFormCloudComponent.formFields().isCompleteFormButtonEnabled()).toEqual(false);
         await taskFormCloudComponent.formFields().checkWidgetIsHidden('Number2');
 
         await taskFormCloudComponent.formFields().setFieldValue(by.id, 'Number1', '4');
-        await expect(await taskFormCloudComponent.formFields().isCompleteFormButtonDisabled()).toBeFalsy();
+        await expect(await taskFormCloudComponent.formFields().isCompleteFormButtonEnabled()).toEqual(true);
         await taskFormCloudComponent.clickCompleteButton();
     });
 
@@ -148,12 +148,12 @@ describe('Task cloud visibility', async () => {
 
         await taskFormCloudComponent.formFields().checkWidgetIsVisible('Checkbox2');
         await taskFormCloudComponent.formFields().checkWidgetIsHidden('Checkbox3');
-        await expect(await taskFormCloudComponent.formFields().isCompleteFormButtonDisabled()).toBeTruthy();
+        await expect(await taskFormCloudComponent.formFields().isCompleteFormButtonEnabled()).toEqual(false);
 
         await taskFormCloudComponent.formFields().clickField(by.id, 'Checkbox1');
         await taskFormCloudComponent.formFields().clickField(by.id, 'Checkbox2');
         await taskFormCloudComponent.formFields().checkWidgetIsVisible('Checkbox3');
-        await expect(await taskFormCloudComponent.formFields().isCompleteFormButtonDisabled()).toBeFalsy();
+        await expect(await taskFormCloudComponent.formFields().isCompleteFormButtonEnabled()).toEqual(true);
 
         await taskFormCloudComponent.clickCompleteButton();
     });
@@ -170,12 +170,12 @@ describe('Task cloud visibility', async () => {
 
         await taskFormCloudComponent.formFields().checkWidgetIsVisible('Checkbox2');
         await taskFormCloudComponent.formFields().checkWidgetIsHidden('Checkbox3');
-        await expect(await taskFormCloudComponent.formFields().isCompleteFormButtonDisabled()).toBeTruthy();
+        await expect(await taskFormCloudComponent.formFields().isCompleteFormButtonEnabled()).toEqual(false);
 
         await taskFormCloudComponent.formFields().clickField(by.id, 'Checkbox1');
         await taskFormCloudComponent.formFields().clickField(by.id, 'Checkbox2');
         await taskFormCloudComponent.formFields().checkWidgetIsVisible('Checkbox3');
-        await expect(await taskFormCloudComponent.formFields().isCompleteFormButtonDisabled()).toBeFalsy();
+        await expect(await taskFormCloudComponent.formFields().isCompleteFormButtonEnabled()).toEqual(true);
 
         await taskFormCloudComponent.clickCompleteButton();
     });

--- a/e2e/process-services/process-filters-component.e2e.ts
+++ b/e2e/process-services/process-filters-component.e2e.ts
@@ -79,7 +79,7 @@ describe('Process Filters Test', () => {
     it('[C260387] Should the running process be displayed when clicking on Running filter', async () => {
         await processServicesPage.goToApp(app.title);
         await processServiceTabBarPage.clickProcessButton();
-        await processListPage.checkProcessListIsDisplayed();
+        await expect(await processListPage.isProcessListDisplayed()).toEqual(true);
 
         await processFiltersPage.clickCreateProcessButton();
         await processFiltersPage.clickNewProcessDropdown();
@@ -110,7 +110,7 @@ describe('Process Filters Test', () => {
     it('[C280063] Should both the new created process and a completed one to be displayed when clicking on All filter', async () => {
         await processServicesPage.goToApp(app.title);
         await processServiceTabBarPage.clickProcessButton();
-        await processListPage.checkProcessListIsDisplayed();
+        await expect(await processListPage.isProcessListDisplayed()).toEqual(true);
 
         await processFiltersPage.clickAllFilterButton();
         await processFiltersPage.checkFilterIsHighlighted(processFilter.all);
@@ -122,7 +122,7 @@ describe('Process Filters Test', () => {
     it('[C280064] Should the completed process be displayed when clicking on Completed filter', async () => {
         await processServicesPage.goToApp(app.title);
         await processServiceTabBarPage.clickProcessButton();
-        await processListPage.checkProcessListIsDisplayed();
+        await expect(await processListPage.isProcessListDisplayed()).toEqual(true);
 
         await processFiltersPage.clickCompletedFilterButton();
         await processFiltersPage.checkFilterIsHighlighted(processFilter.completed);
@@ -144,12 +144,12 @@ describe('Process Filters Test', () => {
 
         await processServicesPage.goToApp(app.title);
         await processServiceTabBarPage.clickProcessButton();
-        await processListPage.checkProcessListIsDisplayed();
+        await expect(await processListPage.isProcessListDisplayed()).toEqual(true);
 
         await expect(taskAppFilters.size).toBe(defaultFiltersNumber);
         for (const filter of taskAppFilters.data) {
             await BrowserActions.getUrl(processFilterUrl + filter.id);
-            await processListPage.checkProcessListIsDisplayed();
+            await expect(await processListPage.isProcessListDisplayed()).toEqual(true);
             await processFiltersPage.checkFilterIsHighlighted(filter.name);
         }
     });
@@ -157,7 +157,7 @@ describe('Process Filters Test', () => {
     it('[C260463] Should Cancel process be displayed in Completed process filters', async () => {
         await processServicesPage.goToApp(app.title);
         await processServiceTabBarPage.clickProcessButton();
-        await processListPage.checkProcessListIsDisplayed();
+        await expect(await processListPage.isProcessListDisplayed()).toEqual(true);
 
         await processFiltersPage.clickCreateProcessButton();
         await processFiltersPage.clickNewProcessDropdown();
@@ -178,13 +178,13 @@ describe('Process Filters Test', () => {
     it('[C213262] Default process filters', async () => {
         await processServicesPage.goToApp(app.title);
         await processServiceTabBarPage.clickProcessButton();
-        await processListPage.checkProcessListIsDisplayed();
+        await expect(await processListPage.isProcessListDisplayed()).toEqual(true);
 
         await processFiltersPage.clickCreateProcessButton();
         await processFiltersPage.clickNewProcessDropdown();
         await startProcessPage.enterProcessName(processTitle.one);
         await startProcessPage.clickFormStartProcessButton();
-        await processListPage.checkProcessListIsDisplayed();
+        await expect(await processListPage.isProcessListDisplayed()).toEqual(true);
 
         await processListDemoPage.checkProcessIsDisplayed(processTitle.one);
         await processFiltersPage.checkFilterIsHighlighted(processFilter.running);
@@ -195,7 +195,7 @@ describe('Process Filters Test', () => {
         await processFiltersPage.clickNewProcessDropdown();
         await startProcessPage.enterProcessName(processTitle.two);
         await startProcessPage.clickFormStartProcessButton();
-        await processListPage.checkProcessListIsDisplayed();
+        await expect(await processListPage.isProcessListDisplayed()).toEqual(true);
 
         await processListDemoPage.checkProcessIsDisplayed(processTitle.one);
         await processListDemoPage.checkProcessIsDisplayed(processTitle.two);

--- a/e2e/process-services/process-instance-details.e2e.ts
+++ b/e2e/process-services/process-instance-details.e2e.ts
@@ -59,7 +59,7 @@ describe('Process Instance Details', () => {
         await processServicesPage.checkApsContainer();
         await processServicesPage.goToApp(app.title);
         await processServiceTabBarPage.clickProcessButton();
-        await processListPage.checkProcessListIsDisplayed();
+        await expect(await processListPage.isProcessListDisplayed()).toEqual(true);
 
         process = await apiService.getInstance().activiti.processApi.getProcessInstance(processModel.id);
    });

--- a/e2e/process-services/stencil.e2e.ts
+++ b/e2e/process-services/stencil.e2e.ts
@@ -69,7 +69,7 @@ describe('Stencil', () => {
     it('[C245648] Can start an app with custom stencil included', async () => {
         const name = 'test stencil process';
         await processServiceTabBarPage.clickProcessButton();
-        await processListPage.checkProcessListIsDisplayed();
+        await expect(await processListPage.isProcessListDisplayed()).toEqual(true);
         await processFiltersPage.clickCreateProcessButton();
         await processFiltersPage.clickNewProcessDropdown();
 

--- a/e2e/process-services/task-assignee.e2e.ts
+++ b/e2e/process-services/task-assignee.e2e.ts
@@ -93,7 +93,7 @@ describe('Task Assignee', () => {
             const name = 'sample-process-one';
             await processServicesPage.goToApp(app.title);
             await processServiceTabBarPage.clickProcessButton();
-            await processListPage.checkProcessListIsDisplayed();
+            await expect(await processListPage.isProcessListDisplayed()).toEqual(true);
             await processFiltersPage.clickCreateProcessButton();
             await processFiltersPage.clickNewProcessDropdown();
             await startProcessPage.startProcess(name, app.processNames[0]);

--- a/e2e/process-services/widgets/amount-widget.e2e.ts
+++ b/e2e/process-services/widgets/amount-widget.e2e.ts
@@ -72,22 +72,22 @@ describe('Amount Widget', () => {
         await widget.checkboxWidget().clickCheckboxInput(app.FIELD.checkbox_id);
         await taskPage.formFields().checkWidgetIsVisible(app.FIELD.amount_input_id);
 
-        await expect(await taskPage.formFields().isCompleteFormButtonDisabled()).toBeTruthy();
+        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
         await expect(await widget.amountWidget().getAmountFieldLabel(app.FIELD.amount_input_id)).toContain('Amount');
         await expect(await widget.amountWidget().getPlaceholder(app.FIELD.amount_input_id)).toContain('Type amount');
         await expect(await widget.amountWidget().getAmountFieldCurrency(app.FIELD.amount_input_id)).toBe('$');
 
         await widget.amountWidget().setFieldValue(app.FIELD.amount_input_id, 4);
         await expect(await widget.amountWidget().getErrorMessage(app.FIELD.amount_input_id)).toBe('Can\'t be less than 5');
-        await expect(await taskPage.formFields().isCompleteFormButtonDisabled()).toBeTruthy();
+        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
         await widget.amountWidget().clearFieldValue(app.FIELD.amount_input_id);
 
         await widget.amountWidget().setFieldValue(app.FIELD.amount_input_id, 101);
         await expect(await widget.amountWidget().getErrorMessage(app.FIELD.amount_input_id)).toBe('Can\'t be greater than 100');
-        await expect(await taskPage.formFields().isCompleteFormButtonDisabled()).toBeTruthy();
+        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
         await widget.amountWidget().clearFieldValue(app.FIELD.amount_input_id);
 
         await widget.amountWidget().setFieldValue(app.FIELD.amount_input_id, 6);
-        await expect(await taskPage.formFields().isCompleteFormButtonDisabled()).toBeFalsy();
+        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
     });
 });

--- a/e2e/process-services/widgets/attach-folder-widget.e2e.ts
+++ b/e2e/process-services/widgets/attach-folder-widget.e2e.ts
@@ -72,6 +72,6 @@ describe('Attach Folder widget', () => {
         await widget.checkboxWidget().clickCheckboxInput(app.FIELD.checkbox_id);
         await taskPage.formFields().checkWidgetIsVisible(app.FIELD.upload_button_id);
 
-        await expect(await taskPage.formFields().isCompleteFormButtonDisabled()).toBeTruthy();
+        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
     });
 });

--- a/e2e/process-services/widgets/checkbox-widget.e2e.ts
+++ b/e2e/process-services/widgets/checkbox-widget.e2e.ts
@@ -69,9 +69,9 @@ describe('Checkbox Widget', () => {
     it('[C268554] Should be able to set general settings for Checkbox widget ', async () => {
         await taskPage.formFields().setValueInInputById(app.FIELD.number_input_id, '2');
         await expect(await widget.checkboxWidget().getCheckboxLabel()).toContain(app.FIELD.checkbox_label);
-        await expect(await taskPage.formFields().isCompleteFormButtonDisabled()).toBeTruthy();
+        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
         await widget.checkboxWidget().clickCheckboxInput(app.FIELD.checkbox_input_id);
-        await expect(await taskPage.formFields().isCompleteFormButtonDisabled()).toBeFalsy();
+        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
     });
 
     it('[C272812] Should be able to set visibility settings for Checkbox widget', async () => {

--- a/e2e/process-services/widgets/date-time-widget.e2e.ts
+++ b/e2e/process-services/widgets/date-time-widget.e2e.ts
@@ -68,13 +68,13 @@ describe('Date and time widget', () => {
 
     it('[C268818] Should be able to set general settings for Date Time widget', async () => {
         await expect(await widget.dateTimeWidget().getDateTimeLabel(app.FIELD.date_time_input)).toContain('Date');
-        await expect(await taskPage.formFields().isCompleteFormButtonDisabled()).toBeTruthy();
+        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
 
         await widget.dateTimeWidget().openDatepicker(app.FIELD.date_time_input);
         await widget.dateTimeWidget().selectDay('10');
         await widget.dateTimeWidget().selectHour('8');
         await widget.dateTimeWidget().selectMinute('30');
-        await expect(await taskPage.formFields().isCompleteFormButtonDisabled()).toBeFalsy();
+        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
 
         await expect(await widget.dateTimeWidget().getPlaceholder(app.FIELD.date_time_between_input)).toBe('Choose anything...');
     });

--- a/e2e/process-services/widgets/date-widget.e2e.ts
+++ b/e2e/process-services/widgets/date-widget.e2e.ts
@@ -80,10 +80,10 @@ describe('Date widget', () => {
 
         it('[C268814] Should be able to set general settings for Date widget', async () => {
             await expect(await dateWidget.getDateLabel(app.FIELD.date_input)).toContain('Date');
-            await expect(await taskPage.formFields().isCompleteFormButtonDisabled()).toBeTruthy();
+            await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
             await dateWidget.setDateInput(app.FIELD.date_input, '20-10-2018');
             await taskPage.formFields().saveForm();
-            await expect(await taskPage.formFields().isCompleteFormButtonDisabled()).toBeFalsy();
+            await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
         });
 
         it('[C277234] Should be able to set advanced settings for Date widget ', async () => {

--- a/e2e/process-services/widgets/dropdown-widget.e2e.ts
+++ b/e2e/process-services/widgets/dropdown-widget.e2e.ts
@@ -66,19 +66,19 @@ describe('Dropdown widget', () => {
     });
 
     it('[C269051] Should be possible to set general and options properties for Dropdown widget ', async () => {
-        await expect(await taskPage.formFields().isCompleteFormButtonDisabled()).toBeTruthy();
+        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
 
         await widget.dropdown().selectOption('Happy');
         await expect(await widget.dropdown().getSelectedOptionText(app.FIELD.general_dropdown)).toContain('Happy');
-        await expect(await taskPage.formFields().isCompleteFormButtonDisabled()).toBeFalsy();
+        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
 
         await widget.dropdown().selectOption('Choose one');
         await expect(await widget.dropdown().getSelectedOptionText(app.FIELD.general_dropdown)).toContain('Choose one');
-        await expect(await taskPage.formFields().isCompleteFormButtonDisabled()).toBeTruthy();
+        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
 
         await widget.dropdown().selectOption('Sad');
         await expect(await widget.dropdown().getSelectedOptionText(app.FIELD.general_dropdown)).toContain('Sad');
-        await expect(await taskPage.formFields().isCompleteFormButtonDisabled()).toBeFalsy();
+        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
     });
 
     it('[C269052] Should be possible to set visibility properties for Dropdown widget', async () => {

--- a/e2e/process-services/widgets/header-widget.e2e.ts
+++ b/e2e/process-services/widgets/header-widget.e2e.ts
@@ -72,6 +72,6 @@ describe('Header widget', async () => {
         await taskPage.formFields().checkWidgetIsVisible(app.FIELD.header_id);
 
         await expect(await widget.headerWidget().getFieldLabel(app.FIELD.header_id)).toBe('Header');
-        await expect(await taskPage.formFields().isCompleteFormButtonDisabled()).toBeFalsy();
+        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
     });
 });

--- a/e2e/process-services/widgets/multi-line-widget.e2e.ts
+++ b/e2e/process-services/widgets/multi-line-widget.e2e.ts
@@ -68,28 +68,28 @@ describe('Multi-line Widget', () => {
     it('[C268182] Should be able to set general properties for Multi-line Text Widget', async () => {
         const label = await widget.multilineTextWidget().getFieldLabel(app.FIELD.multiSimple);
         await expect(label).toBe('multiSimple*');
-        await expect(await taskPage.formFields().isCompleteFormButtonDisabled()).toBeTruthy();
+        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
         const placeHolder = await widget.multilineTextWidget().getFieldPlaceHolder(app.FIELD.multiSimple);
         await expect(placeHolder).toBe('Type something...');
         await widget.multilineTextWidget().setValue(app.FIELD.multiSimple, 'TEST');
-        await expect(await taskPage.formFields().isCompleteFormButtonDisabled()).toBeFalsy();
+        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
     });
 
     it('[C268184] Should be able to set advanced properties for Multi-line Text Widget', async () => {
         await widget.multilineTextWidget().setValue(app.FIELD.multiMinMax, 'A');
         await expect(await widget.multilineTextWidget().getErrorMessage(app.FIELD.multiMinMax)).toContain('Enter at least 4 characters');
-        await expect(await taskPage.formFields().isCompleteFormButtonDisabled()).toBeTruthy();
+        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
         await widget.multilineTextWidget().setValue(app.FIELD.multiMinMax, 'AAAAAAAAAAA');
         await expect(await widget.multilineTextWidget().getErrorMessage(app.FIELD.multiMinMax)).toContain('Enter no more than 10 characters');
-        await expect(await taskPage.formFields().isCompleteFormButtonDisabled()).toBeTruthy();
+        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
         await widget.multilineTextWidget().setValue(app.FIELD.multiMinMax, 'AAAA');
 
         await widget.multilineTextWidget().setValue(app.FIELD.multiSimple, 'TEST');
         await widget.multilineTextWidget().setValue(app.FIELD.multiRegexp, '3');
-        await expect(await taskPage.formFields().isCompleteFormButtonDisabled()).toBeTruthy();
+        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
         await expect(await widget.multilineTextWidget().getErrorMessage(app.FIELD.multiRegexp)).toContain('Enter a different value');
         await widget.multilineTextWidget().setValue(app.FIELD.multiRegexp, 'TE');
-        await expect(await taskPage.formFields().isCompleteFormButtonDisabled()).toBeFalsy();
+        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
     });
 
     it('[C268232] Should be able to set visibility properties for Multi-line Text Widget', async () => {

--- a/e2e/process-services/widgets/number-widget.e2e.ts
+++ b/e2e/process-services/widgets/number-widget.e2e.ts
@@ -67,12 +67,12 @@ describe('Number widget', () => {
    });
 
     it('[C269111] Should be able to set general properties for Number Widget', async () => {
-        await expect(await taskPage.formFields().isCompleteFormButtonDisabled()).toBeTruthy();
+        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
         await expect(await widget.numberWidget().getNumberFieldLabel(app.FIELD.number_general)).toContain('Number General');
         await expect(await widget.numberWidget().getPlaceholder(app.FIELD.number_general)).toContain('Type a number');
 
         await widget.numberWidget().setFieldValue(app.FIELD.number_general, 2);
-        await expect(await taskPage.formFields().isCompleteFormButtonDisabled()).toBeFalsy();
+        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
     });
 
     it('[C274702] Should be able to set advanced and visibility properties for Number Widget', async () => {
@@ -84,15 +84,15 @@ describe('Number widget', () => {
 
         await widget.numberWidget().setFieldValue(app.FIELD.number_visible, 2);
         await expect(await widget.numberWidget().getErrorMessage(app.FIELD.number_visible)).toBe('Can\'t be less than 3');
-        await expect(await taskPage.formFields().isCompleteFormButtonDisabled()).toBeTruthy();
+        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
         await widget.numberWidget().clearFieldValue(app.FIELD.number_visible);
 
         await widget.numberWidget().setFieldValue(app.FIELD.number_visible, 101);
         await expect(await widget.numberWidget().getErrorMessage(app.FIELD.number_visible)).toBe('Can\'t be greater than 100');
-        await expect(await taskPage.formFields().isCompleteFormButtonDisabled()).toBeTruthy();
+        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
         await widget.numberWidget().clearFieldValue(app.FIELD.number_visible);
 
         await widget.numberWidget().setFieldValue(app.FIELD.number_visible, 4);
-        await expect(await taskPage.formFields().isCompleteFormButtonDisabled()).toBeFalsy();
+        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
     });
 });

--- a/e2e/process-services/widgets/radio-buttons-widget.e2e.ts
+++ b/e2e/process-services/widgets/radio-buttons-widget.e2e.ts
@@ -74,11 +74,11 @@ describe('Radio Buttons Widget', () => {
 
     it('[C274704] Should be able to set visibility properties for Radio Button widget', async () => {
         await taskPage.formFields().checkWidgetIsHidden(app.FIELD.radio_buttons_id);
-        await expect(await taskPage.formFields().isCompleteFormButtonDisabled()).toBeTruthy();
+        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
 
         await widget.checkboxWidget().clickCheckboxInput(app.FIELD.checkbox_id);
         await expect(await widget.radioWidget().getRadioWidgetLabel(app.FIELD.radio_buttons_id)).toContain('Radio posts');
         await widget.radioWidget().selectOption(app.FIELD.radio_buttons_id, 1);
-        await expect(await taskPage.formFields().isCompleteFormButtonDisabled()).toBeFalsy();
+        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
     });
 });

--- a/e2e/process-services/widgets/text-widget.e2e.ts
+++ b/e2e/process-services/widgets/text-widget.e2e.ts
@@ -69,20 +69,20 @@ describe('Text widget', () => {
     it('[C268157] Should be able to set general properties for Text widget', async () => {
         const label = await widget.textWidget().getFieldLabel(app.FIELD.simpleText);
         await expect(label).toBe('textSimple*');
-        await expect(await taskPage.formFields().isCompleteFormButtonDisabled()).toBeTruthy();
+        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
         const placeHolder = await widget.textWidget().getFieldPlaceHolder(app.FIELD.simpleText);
         await expect(placeHolder).toBe('Type something...');
         await widget.textWidget().setValue(app.FIELD.simpleText, 'TEST');
-        await expect(await taskPage.formFields().isCompleteFormButtonDisabled()).toBeFalsy();
+        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
     });
 
     it('[C268170] Min-max length properties', async () => {
         await widget.textWidget().setValue(app.FIELD.textMinMax, 'A');
         await expect(await widget.textWidget().getErrorMessage(app.FIELD.textMinMax)).toContain('Enter at least 4 characters');
-        await expect(await taskPage.formFields().isCompleteFormButtonDisabled()).toBeTruthy();
+        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
         await widget.textWidget().setValue(app.FIELD.textMinMax, 'AAAAAAAAAAA');
         await expect(await widget.textWidget().getErrorMessage(app.FIELD.textMinMax)).toContain('Enter no more than 10 characters');
-        await expect(await taskPage.formFields().isCompleteFormButtonDisabled()).toBeTruthy();
+        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
     });
 
     it('[C268171] Input mask reversed checkbox properties', async () => {
@@ -98,10 +98,10 @@ describe('Text widget', () => {
     it('[C268177] Should be able to set Regex Pattern property for Text widget', async () => {
         await widget.textWidget().setValue(app.FIELD.simpleText, 'TEST');
         await widget.textWidget().setValue(app.FIELD.textRegexp, 'T');
-        await expect(await taskPage.formFields().isCompleteFormButtonDisabled()).toBeTruthy();
+        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
         await expect(await widget.textWidget().getErrorMessage(app.FIELD.textRegexp)).toContain('Enter a different value');
         await widget.textWidget().setValue(app.FIELD.textRegexp, 'TE');
-        await expect(await taskPage.formFields().isCompleteFormButtonDisabled()).toBeFalsy();
+        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
     });
 
     it('[C274712] Should be able to set visibility properties for Text widget ', async () => {

--- a/lib/testing/src/lib/core/pages/form/form-fields.ts
+++ b/lib/testing/src/lib/core/pages/form/form-fields.ts
@@ -162,9 +162,13 @@ export class FormFields {
         await BrowserActions.clearSendKeys(input, value);
     }
 
-    async isCompleteFormButtonDisabled(): Promise<string> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.completeButton);
-        return this.completeButton.getAttribute('disabled');
+    async isCompleteFormButtonEnabled(): Promise<boolean> {
+        try {
+            await this.completeButton.isEnabled();
+            return true;
+        } catch (error) {
+            return false;
+        }
     }
 
     async isCancelButtonDisplayed(): Promise<boolean> {

--- a/lib/testing/src/lib/core/pages/form/form-fields.ts
+++ b/lib/testing/src/lib/core/pages/form/form-fields.ts
@@ -165,8 +165,7 @@ export class FormFields {
     async isCompleteFormButtonEnabled(): Promise<boolean> {
         try {
             await BrowserVisibility.waitUntilElementIsVisible(this.completeButton);
-            await this.completeButton.isEnabled();
-            return true;
+            return await this.completeButton.isEnabled();
         } catch (error) {
             return false;
         }
@@ -174,9 +173,7 @@ export class FormFields {
 
     async isCancelButtonDisplayed(): Promise<boolean> {
         try {
-            await BrowserVisibility.waitUntilElementIsVisible(
-                this.cancelButton
-            );
+            await BrowserVisibility.waitUntilElementIsVisible(this.cancelButton);
             return true;
         } catch (error) {
             return false;
@@ -185,8 +182,8 @@ export class FormFields {
 
     async isCancelButtonEnabled(): Promise<boolean> {
         try {
-            await this.cancelButton.isEnabled();
-            return true;
+            await BrowserVisibility.waitUntilElementIsVisible(this.cancelButton);
+            return await this.cancelButton.isEnabled();
         } catch (error) {
             return false;
         }

--- a/lib/testing/src/lib/core/pages/form/form-fields.ts
+++ b/lib/testing/src/lib/core/pages/form/form-fields.ts
@@ -164,6 +164,7 @@ export class FormFields {
 
     async isCompleteFormButtonEnabled(): Promise<boolean> {
         try {
+            await BrowserVisibility.waitUntilElementIsVisible(this.completeButton);
             await this.completeButton.isEnabled();
             return true;
         } catch (error) {

--- a/lib/testing/src/lib/core/pages/form/form-fields.ts
+++ b/lib/testing/src/lib/core/pages/form/form-fields.ts
@@ -162,13 +162,17 @@ export class FormFields {
         await BrowserActions.clearSendKeys(input, value);
     }
 
-    async isCompleteFormButtonEnabled(): Promise<boolean> {
+    async isCompleteButtonDisplayed(): Promise<boolean> {
         try {
             await BrowserVisibility.waitUntilElementIsVisible(this.completeButton);
-            return await this.completeButton.isEnabled();
+            return true;
         } catch (error) {
             return false;
         }
+    }
+
+    async isCompleteFormButtonEnabled(): Promise<boolean> {
+        return this.completeButton.isEnabled();
     }
 
     async isCancelButtonDisplayed(): Promise<boolean> {
@@ -181,12 +185,7 @@ export class FormFields {
     }
 
     async isCancelButtonEnabled(): Promise<boolean> {
-        try {
-            await BrowserVisibility.waitUntilElementIsVisible(this.cancelButton);
-            return await this.cancelButton.isEnabled();
-        } catch (error) {
-            return false;
-        }
+            return this.cancelButton.isEnabled();
     }
 
     async clickCancelButton(): Promise<void> {

--- a/lib/testing/src/lib/core/pages/form/form-fields.ts
+++ b/lib/testing/src/lib/core/pages/form/form-fields.ts
@@ -185,7 +185,7 @@ export class FormFields {
     }
 
     async isCancelButtonEnabled(): Promise<boolean> {
-            return this.cancelButton.isEnabled();
+        return this.cancelButton.isEnabled();
     }
 
     async clickCancelButton(): Promise<void> {

--- a/lib/testing/src/lib/process-services/pages/form-fields.page.ts
+++ b/lib/testing/src/lib/process-services/pages/form-fields.page.ts
@@ -148,8 +148,12 @@ export class FormFieldsPage {
         await BrowserActions.clearSendKeys(input, value);
     }
 
-    async isCompleteFormButtonDisabled(): Promise<string> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.completeButton);
-        return this.completeButton.getAttribute('disabled');
+    async isCompleteFormButtonEnabled(): Promise<boolean> {
+        try {
+            await this.completeButton.isEnabled();
+            return true;
+        } catch (error) {
+            return false;
+        }
     }
 }

--- a/lib/testing/src/lib/process-services/pages/form-fields.page.ts
+++ b/lib/testing/src/lib/process-services/pages/form-fields.page.ts
@@ -148,12 +148,16 @@ export class FormFieldsPage {
         await BrowserActions.clearSendKeys(input, value);
     }
 
-    async isCompleteFormButtonEnabled(): Promise<boolean> {
+    async isCompleteButtonDisplayed(): Promise<boolean> {
         try {
             await BrowserVisibility.waitUntilElementIsVisible(this.completeButton);
-            return await this.completeButton.isEnabled();
+            return true;
         } catch (error) {
             return false;
         }
+    }
+
+    async isCompleteFormButtonEnabled(): Promise<boolean> {
+            return this.completeButton.isEnabled();
     }
 }

--- a/lib/testing/src/lib/process-services/pages/form-fields.page.ts
+++ b/lib/testing/src/lib/process-services/pages/form-fields.page.ts
@@ -150,8 +150,8 @@ export class FormFieldsPage {
 
     async isCompleteFormButtonEnabled(): Promise<boolean> {
         try {
-            await this.completeButton.isEnabled();
-            return true;
+            await BrowserVisibility.waitUntilElementIsVisible(this.completeButton);
+            return await this.completeButton.isEnabled();
         } catch (error) {
             return false;
         }

--- a/lib/testing/src/lib/process-services/pages/form-fields.page.ts
+++ b/lib/testing/src/lib/process-services/pages/form-fields.page.ts
@@ -158,6 +158,6 @@ export class FormFieldsPage {
     }
 
     async isCompleteFormButtonEnabled(): Promise<boolean> {
-            return this.completeButton.isEnabled();
+        return this.completeButton.isEnabled();
     }
 }

--- a/lib/testing/src/lib/process-services/pages/process-filters.page.ts
+++ b/lib/testing/src/lib/process-services/pages/process-filters.page.ts
@@ -19,6 +19,11 @@ import { by, element } from 'protractor';
 import { FiltersPage } from './filters.page';
 
 export class ProcessFiltersPage {
+    defaultProcessFilters = {
+        running: 'Running',
+        completed: 'Completed',
+        all: 'All'
+    };
 
     filtersPage = new FiltersPage();
 
@@ -40,26 +45,26 @@ export class ProcessFiltersPage {
     }
 
     async isRunningFilterHighlighted(): Promise<boolean> {
-        return this.filtersPage.isFilterHighlighted('Running');
+        return this.filtersPage.isFilterHighlighted(this.defaultProcessFilters.running);
     }
 
     async isCompletedFilterHighlighted(): Promise<boolean> {
-        return this.filtersPage.isFilterHighlighted('Completed');
+        return this.filtersPage.isFilterHighlighted(this.defaultProcessFilters.completed);
     }
 
     async isAllFilterHighlighted(): Promise<boolean> {
-        return this.filtersPage.isFilterHighlighted('All');
+        return this.filtersPage.isFilterHighlighted(this.defaultProcessFilters.all);
     }
 
     async isRunningFilterDisplayed(): Promise<boolean> {
-        return this.filtersPage.isFilterDisplayed('Running');
+        return this.filtersPage.isFilterDisplayed(this.defaultProcessFilters.running);
     }
 
     async isCompletedFilterDisplayed(): Promise<boolean> {
-        return this.filtersPage.isFilterDisplayed('Completed');
+        return this.filtersPage.isFilterDisplayed(this.defaultProcessFilters.completed);
     }
 
     async isAllFilterDisplayed(): Promise<boolean> {
-        return this.filtersPage.isFilterDisplayed('All');
+        return this.filtersPage.isFilterDisplayed(this.defaultProcessFilters.all);
     }
 }

--- a/lib/testing/src/lib/process-services/pages/process-list.page.ts
+++ b/lib/testing/src/lib/process-services/pages/process-list.page.ts
@@ -34,8 +34,13 @@ export class ProcessListPage {
         return BrowserVisibility.waitUntilElementIsNotPresent(this.processListEmptyTitle);
     }
 
-    async checkProcessListIsDisplayed(): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.processInstanceList);
+    async isProcessListDisplayed(): Promise<boolean> {
+        try {
+            await BrowserVisibility.waitUntilElementIsVisible(this.processInstanceList);
+            return true;
+        } catch (error) {
+            return false;
+        }
     }
 
     checkContentIsDisplayedByColumn(column: string, processName: string): Promise<void> {

--- a/lib/testing/src/lib/process-services/pages/task-filters.page.ts
+++ b/lib/testing/src/lib/process-services/pages/task-filters.page.ts
@@ -19,6 +19,12 @@ import { by, element } from 'protractor';
 import { FiltersPage } from './filters.page';
 
 export class TaskFiltersPage {
+    defaultTaskFilters = {
+        myTasks: 'My Tasks',
+        queuedTasks: 'Queued Tasks',
+        involvedTasks: 'Involved Tasks',
+        completedTasks: 'Completed Tasks'
+    };
 
     filtersPage = new FiltersPage();
 
@@ -45,34 +51,34 @@ export class TaskFiltersPage {
     }
 
     async isMyTasksFilterHighlighted(): Promise<boolean> {
-        return this.filtersPage.isFilterHighlighted('My Tasks');
+        return this.filtersPage.isFilterHighlighted(this.defaultTaskFilters.myTasks);
     }
 
     async isQueuedFilterHighlighted(): Promise<boolean> {
-        return this.filtersPage.isFilterHighlighted('Queued Tasks');
+        return this.filtersPage.isFilterHighlighted(this.defaultTaskFilters.queuedTasks);
     }
 
     async isCompletedFilterHighlighted(): Promise<boolean> {
-        return this.filtersPage.isFilterHighlighted('Completed Tasks');
+        return this.filtersPage.isFilterHighlighted(this.defaultTaskFilters.completedTasks);
     }
 
     async isInvolvedFilterHighlighted(): Promise<boolean> {
-        return this.filtersPage.isFilterHighlighted('Involved Tasks');
+        return this.filtersPage.isFilterHighlighted(this.defaultTaskFilters.involvedTasks);
     }
 
     async isMyTasksFilterDisplayed(): Promise<boolean> {
-        return this.filtersPage.isFilterDisplayed('My Tasks');
+        return this.filtersPage.isFilterDisplayed(this.defaultTaskFilters.myTasks);
     }
 
     async isQueuedFilterDisplayed(): Promise<boolean> {
-        return this.filtersPage.isFilterDisplayed('Queued Tasks');
+        return this.filtersPage.isFilterDisplayed(this.defaultTaskFilters.queuedTasks);
     }
 
     async isCompletedFilterDisplayed(): Promise<boolean> {
-        return this.filtersPage.isFilterDisplayed('Completed Tasks');
+        return this.filtersPage.isFilterDisplayed(this.defaultTaskFilters.completedTasks);
     }
 
     async isInvolvedFilterDisplayed(): Promise<boolean> {
-        return this.filtersPage.isFilterDisplayed('Involved Tasks');
+        return this.filtersPage.isFilterDisplayed(this.defaultTaskFilters.involvedTasks);
     }
 }


### PR DESCRIPTION
- Change the isCompleteFormButtonDisabled() method structure as per the [Code Style E2E 03-01](https://w3.alfresco.com/confluence/pages/viewpage.action?spaceKey=AP&title=Code+Style+E2E)
- Replace the isCompleteFormButtonDisabled() with isCompleteFormButtonEnabled() in the tests
- Add lists with the default tasks and process filters name in order to use a variable instead of a string (ADW eg. in the breadcrumb checks)

**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
