### PR TITLE
[ACA-2962] Fix attach file widget shows Local source when only link is enabled

### DIFF
--- a/lib/process-services/src/lib/content-widget/attach-file-widget.component.ts
+++ b/lib/process-services/src/lib/content-widget/attach-file-widget.component.ts
@@ -105,7 +105,8 @@ export class AttachFileWidgetComponent extends UploadWidgetComponent implements 
     isAllFileSourceSelected(): boolean {
         return this.field.params &&
             this.field.params.fileSource &&
-            this.field.params.fileSource.serviceId === 'all-file-sources';
+            this.field.params.fileSource.serviceId === 'all-file-sources' &&
+            !this.field.params.link;
     }
 
     isOnlyLocalSourceSelected(): boolean {

--- a/lib/process-services/src/lib/content-widget/attach-file-widget.components.spec.ts
+++ b/lib/process-services/src/lib/content-widget/attach-file-widget.components.spec.ts
@@ -63,6 +63,13 @@ const allSourceParams = {
     }
 };
 
+const allSourceParamsWithLinkEnabled = {
+    fileSource: {
+        serviceId: 'all-file-sources'
+    },
+    link: true
+};
+
 const definedSourceParams = {
     fileSource: {
         serviceId: 'goku-sources',
@@ -163,7 +170,7 @@ describe('AttachFileWidgetComponent', () => {
         });
     }));
 
-    it('should show up all the repository option on menu list', async(() => {
+    it('should show up all the repository option on menu list', async() => {
         widget.field = new FormFieldModel(new FormModel(), {
             type: FormFieldTypes.UPLOAD,
             value: []
@@ -178,15 +185,51 @@ describe('AttachFileWidgetComponent', () => {
             attachButton.click();
             fixture.detectChanges();
             fixture.whenStable().then(() => {
-                expect(fixture.debugElement.queryAll(By.css('#attach-local-file'))).not.toBeNull();
-                expect(fixture.debugElement.queryAll(By.css('#attach-local-file'))).not.toBeUndefined();
-                expect(fixture.debugElement.queryAll(By.css('#attach-SHAREME'))).not.toBeNull();
-                expect(fixture.debugElement.queryAll(By.css('#attach-SHAREME'))).not.toBeUndefined();
-                expect(fixture.debugElement.queryAll(By.css('#attach-GOKUSHARE'))).not.toBeNull();
-                expect(fixture.debugElement.queryAll(By.css('#attach-GOKUSHARE'))).not.toBeUndefined();
+                const localFileOption = fixture.debugElement.queryAll(By.css('#attach-local-file'));
+                const fakeRepoOption1 = fixture.debugElement.queryAll(By.css('#attach-SHAREME'));
+                const fakeRepoOption2 = fixture.debugElement.queryAll(By.css('#attach-GOKUSHARE'));
+
+                expect(localFileOption.length).toEqual(1);
+                expect(localFileOption[0]).not.toBeNull();
+
+                expect(fakeRepoOption1.length).toEqual(1);
+                expect(fakeRepoOption1[0]).not.toBeNull();
+
+                expect(fakeRepoOption2.length).toEqual(1);
+                expect(fakeRepoOption2[0]).not.toBeNull();
             });
         });
-    }));
+    });
+
+    it ('should show only remote repos when just link to files is true', async () => {
+        widget.field = new FormFieldModel(new FormModel(), {
+            type: FormFieldTypes.UPLOAD,
+            value: []
+        });
+        widget.field.id = 'attach-file-attach';
+        widget.field.params = <FormFieldMetadata> allSourceParamsWithLinkEnabled;
+        spyOn(activitiContentService, 'getAlfrescoRepositories').and.returnValue(of(fakeRepositoryListAnswer));
+        fixture.detectChanges();
+        fixture.whenRenderingDone().then(() => {
+            const attachButton: HTMLButtonElement = element.querySelector('#attach-file-attach');
+            expect(attachButton).not.toBeNull();
+            attachButton.click();
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+                const localFileOption = fixture.debugElement.queryAll(By.css('#attach-local-file'));
+                const fakeRepoOption1 = fixture.debugElement.queryAll(By.css('#attach-SHAREME'));
+                const fakeRepoOption2 = fixture.debugElement.queryAll(By.css('#attach-GOKUSHARE'));
+
+                expect(localFileOption.length).toEqual(0);
+
+                expect(fakeRepoOption1.length).toEqual(1);
+                expect(fakeRepoOption1[0]).not.toBeNull();
+
+                expect(fakeRepoOption2.length).toEqual(1);
+                expect(fakeRepoOption2[0]).not.toBeNull();
+            });
+        });
+    });
 
     it('should be able to upload files coming from content node selector', async(() => {
         spyOn(activitiContentService, 'getAlfrescoRepositories').and.returnValue(of(fakeRepositoryListAnswer));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ACA-2962


**What is the new behaviour?**
When the just link to files option is enabled the Local source option is not displayed for the attach file widget


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
