### PR TITLE
[ACA-3218] Fix attach file widget - wrong payload when link is true

### DIFF
--- a/lib/core/form/services/activiti-alfresco.service.ts
+++ b/lib/core/form/services/activiti-alfresco.service.ts
@@ -102,7 +102,7 @@ export class ActivitiContentService {
             mimeType: node.content.mimeType,
             sourceId: node.id + ';' + node.properties['cm:versionLabel'] + '@' + currentSideId,
             name: node.name,
-            link: false
+            link: node.isLink
         };
         return from(apiService.activiti.contentApi.createTemporaryRelatedContent(params))
             .pipe(

--- a/lib/process-services/src/lib/content-widget/attach-file-widget.component.ts
+++ b/lib/process-services/src/lib/content-widget/attach-file-widget.component.ts
@@ -225,6 +225,11 @@ export class AttachFileWidgetComponent extends UploadWidgetComponent implements 
 
     private uploadFileFromCS(fileNodeList: any[], accountId: string, siteId?: string) {
         const filesSaved = [];
+
+        fileNodeList.forEach(node => {
+            node.isLink = this.field.params.link;
+        });
+
         from(fileNodeList).pipe(
             mergeMap((node) =>
                 zip(

--- a/lib/process-services/src/lib/content-widget/attach-file-widget.components.spec.ts
+++ b/lib/process-services/src/lib/content-widget/attach-file-widget.components.spec.ts
@@ -41,7 +41,8 @@ const fakeRepositoryListAnswer = [
         'serviceId': 'alfresco-9999-SHAREME',
         'metaDataAllowed': true,
         'name': 'SHAREME',
-        'repositoryUrl': 'http://localhost:0000/SHAREME'
+        'repositoryUrl': 'http://localhost:0000/SHAREME',
+        'id': 1000
     },
     {
         'authorized': true,
@@ -60,7 +61,8 @@ const onlyLocalParams = {
 const allSourceParams = {
     fileSource: {
         serviceId: 'all-file-sources'
-    }
+    },
+    link: false
 };
 
 const allSourceParamsWithLinkEnabled = {
@@ -229,6 +231,58 @@ describe('AttachFileWidgetComponent', () => {
                 expect(fakeRepoOption2[0]).not.toBeNull();
             });
         });
+    });
+
+    it('should isLink property of the selected node become true when the widget has link enabled', async (done) => {
+        spyOn(activitiContentService, 'getAlfrescoRepositories').and.returnValue(of(fakeRepositoryListAnswer));
+        const applyAlfrescoNodeSpy = spyOn(activitiContentService, 'applyAlfrescoNode');
+        spyOn(contentNodeDialogService, 'openFileBrowseDialogBySite').and.returnValue(of([fakeMinimalNode]));
+        widget.field = new FormFieldModel(new FormModel(), {
+            type: FormFieldTypes.UPLOAD,
+            value: []
+        });
+        widget.field.id = 'attach-file-attach';
+        widget.field.params = <FormFieldMetadata> allSourceParamsWithLinkEnabled;
+
+        fixture.detectChanges();
+        await fixture.whenRenderingDone();
+
+        const attachButton: HTMLButtonElement = element.querySelector('#attach-file-attach');
+        expect(attachButton).not.toBeNull();
+        attachButton.click();
+
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        fixture.debugElement.query(By.css('#attach-SHAREME')).nativeElement.click();
+        expect(applyAlfrescoNodeSpy).toHaveBeenCalledWith({ ...fakeMinimalNode, isLink: true }, undefined, 'alfresco-1000-SHAREME');
+        done();
+    });
+
+    it('should isLink property of the selected node become false when the widget has link disabled', async (done) => {
+        spyOn(activitiContentService, 'getAlfrescoRepositories').and.returnValue(of(fakeRepositoryListAnswer));
+        const applyAlfrescoNodeSpy = spyOn(activitiContentService, 'applyAlfrescoNode');
+        spyOn(contentNodeDialogService, 'openFileBrowseDialogBySite').and.returnValue(of([fakeMinimalNode]));
+        widget.field = new FormFieldModel(new FormModel(), {
+            type: FormFieldTypes.UPLOAD,
+            value: []
+        });
+        widget.field.id = 'attach-file-attach';
+        widget.field.params = <FormFieldMetadata> allSourceParams;
+
+        fixture.detectChanges();
+        await fixture.whenRenderingDone();
+
+        const attachButton: HTMLButtonElement = element.querySelector('#attach-file-attach');
+        expect(attachButton).not.toBeNull();
+        attachButton.click();
+
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        fixture.debugElement.query(By.css('#attach-SHAREME')).nativeElement.click();
+        expect(applyAlfrescoNodeSpy).toHaveBeenCalledWith({ ...fakeMinimalNode, isLink: false }, undefined, 'alfresco-1000-SHAREME');
+        done();
     });
 
     it('should be able to upload files coming from content node selector', async(() => {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ACA-3218


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
