### PR TITLE
[ADF-5158] ECM Version Directive

### DIFF
--- a/docs/core/directives/version-compatibility.directive.md
+++ b/docs/core/directives/version-compatibility.directive.md
@@ -1,0 +1,56 @@
+# [Version Compatibility Directive](../../../lib/core/directives/version-compatibility.directive.ts "Defined in version-compatibility.directive.ts")
+
+Enables/disables components based on ACS version in use.
+
+## Basic usage
+
+```html
+<button *adf-ecm-version="'6.0.0'">
+    My Action
+</button>
+```
+
+## Class members
+
+### Properties
+
+| Name | Type | Default value | Description |
+| ---- | ---- | ------------- | ----------- |
+| adf-ecm-version | `string` | | The minimum version required for a given component to work propertly. |
+
+## Details
+
+Add the directive to a component or HTML element to enable or disable it based on the version of ACS running in the app.
+
+The directive takes the version specified in the html and compares it to the version of Alfresco Content Services running in the app. 
+
+This will allow certain features to be only present under specific versions. 
+
+#### Major version
+```html
+<button *adf-ecm-version="'7'">
+    My Action
+</button>
+```
+
+#### Major and minor version 
+```html
+<button *adf-ecm-version="'6.2'">
+    My Action
+</button>
+```
+
+#### Major, minor and patch version 
+```html
+<button *adf-ecm-version="'6.0.1'">
+    My Action
+</button>
+```
+
+It can be set to match major, minor and patches of ACS versions. Fox example, if the version `6` is specifed it will enable the component from `6.0.0` onwards. 
+
+If the minimum version required is not matched the component will not be initialized and will disappear from the DOM tree.
+
+```
+Note, if you don’t place the * in front, the app won’t be able to inject the TemplateRef and ViewContainerRef required for this directive to work. 
+```

--- a/docs/core/directives/version-compatibility.directive.md
+++ b/docs/core/directives/version-compatibility.directive.md
@@ -5,7 +5,7 @@ Enables/disables components based on ACS version in use.
 ## Basic usage
 
 ```html
-<button *adf-ecm-version="'6.0.0'">
+<button *adf-acs-version="'6.0.0'">
     My Action
 </button>
 ```
@@ -28,21 +28,21 @@ This will allow certain features to be only present under specific versions.
 
 #### Major version
 ```html
-<button *adf-ecm-version="'7'">
+<button *adf-acs-version="'7'">
     My Action
 </button>
 ```
 
 #### Major and minor version 
 ```html
-<button *adf-ecm-version="'6.2'">
+<button *adf-acs-version="'6.2'">
     My Action
 </button>
 ```
 
 #### Major, minor and patch version 
 ```html
-<button *adf-ecm-version="'6.0.1'">
+<button *adf-acs-version="'6.0.1'">
     My Action
 </button>
 ```

--- a/docs/core/directives/version-compatibility.directive.md
+++ b/docs/core/directives/version-compatibility.directive.md
@@ -16,7 +16,7 @@ Enables/disables components based on ACS version in use.
 
 | Name | Type | Default value | Description |
 | ---- | ---- | ------------- | ----------- |
-| adf-ecm-version | `string` | | The minimum version required for a given component to work propertly. |
+| adf-acs-version | `string` | | The minimum version required for a given component to work propertly. |
 
 ## Details
 

--- a/lib/core/core.module.ts
+++ b/lib/core/core.module.ts
@@ -57,6 +57,8 @@ import { ExtensionsModule } from '@alfresco/adf-extensions';
 import { directionalityConfigFactory } from './services/directionality-config-factory';
 import { DirectionalityConfigService } from './services/directionality-config.service';
 import { SearchTextModule } from './search-text/search-text-input.module';
+import { versionCompatibilityFactory } from './services/version-compatibility-factory';
+import { VersionCompatibilityService } from './services/version-compatibility.service';
 
 @NgModule({
     imports: [
@@ -148,6 +150,12 @@ export class CoreModule {
                     provide: APP_INITIALIZER,
                     useFactory: directionalityConfigFactory,
                     deps: [ DirectionalityConfigService ],
+                    multi: true
+                },
+                {
+                    provide: APP_INITIALIZER,
+                    useFactory: versionCompatibilityFactory,
+                    deps: [ VersionCompatibilityService ],
                     multi: true
                 }
             ]

--- a/lib/core/directives/directive.module.ts
+++ b/lib/core/directives/directive.module.ts
@@ -27,6 +27,7 @@ import { CheckAllowableOperationDirective } from './check-allowable-operation.di
 import { NodeRestoreDirective } from './node-restore.directive';
 import { UploadDirective } from './upload.directive';
 import { NodeDownloadDirective } from './node-download.directive';
+import { VersionCompatibilityDirective } from './version-compatibility.directive';
 
 @NgModule({
     imports: [
@@ -41,7 +42,8 @@ import { NodeDownloadDirective } from './node-download.directive';
         CheckAllowableOperationDirective,
         NodeRestoreDirective,
         NodeDownloadDirective,
-        UploadDirective
+        UploadDirective,
+        VersionCompatibilityDirective
     ],
     exports: [
         HighlightDirective,
@@ -51,7 +53,8 @@ import { NodeDownloadDirective } from './node-download.directive';
         CheckAllowableOperationDirective,
         NodeRestoreDirective,
         NodeDownloadDirective,
-        UploadDirective
+        UploadDirective,
+        VersionCompatibilityDirective
     ]
 })
 export class DirectiveModule {}

--- a/lib/core/directives/version-compatibility.directive.spec.ts
+++ b/lib/core/directives/version-compatibility.directive.spec.ts
@@ -25,22 +25,22 @@ import { VersionCompatibilityService } from '@alfresco/adf-core';
 
 @Component({
     template: `
-        <div *adf-ecm-version="'8'" class="hidden-content-1">
+        <div *adf-acs-version="'8'" class="hidden-content-1">
             My hidden content 1
         </div>
-        <div *adf-ecm-version="'7.1'" class="hidden-content-2">
+        <div *adf-acs-version="'7.1'" class="hidden-content-2">
             My hidden content 2
         </div>
-        <div *adf-ecm-version="'7.0.2'" class="hidden-content-3">
+        <div *adf-acs-version="'7.0.2'" class="hidden-content-3">
             My hidden content 3
         </div>
-        <div *adf-ecm-version="'6.1.5'" class="visible-content-1">
+        <div *adf-acs-version="'6.1.5'" class="visible-content-1">
             My visible content 1
         </div>
-        <div *adf-ecm-version="'6.1'" class="visible-content-2">
+        <div *adf-acs-version="'6.1'" class="visible-content-2">
             My visible content 2
         </div>
-        <div *adf-ecm-version="'6'" class="visible-content-3">
+        <div *adf-acs-version="'6'" class="visible-content-3">
             My visible content 3
         </div>
         `
@@ -51,7 +51,7 @@ describe('VersionCompatibilityDirective', () => {
     let fixture: ComponentFixture<TestComponent>;
     let versionCompatibilityService: VersionCompatibilityService;
 
-    const ecmVersionMock = {
+    const acsResponceMock = {
         display: '7.0.1',
         major: '7',
         minor: '0',
@@ -70,7 +70,7 @@ describe('VersionCompatibilityDirective', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(TestComponent);
         versionCompatibilityService = TestBed.get(VersionCompatibilityService);
-        spyOn(versionCompatibilityService, 'getEcmVersion').and.returnValue(ecmVersionMock);
+        spyOn(versionCompatibilityService, 'getAcsVersion').and.returnValue(acsResponceMock);
     });
 
     it('should display component when the version is supported', () => {

--- a/lib/core/directives/version-compatibility.directive.spec.ts
+++ b/lib/core/directives/version-compatibility.directive.spec.ts
@@ -1,0 +1,95 @@
+/*!
+ * @license
+ * Copyright 2019 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component } from '@angular/core';
+import { By } from '@angular/platform-browser';
+import { TranslateModule } from '@ngx-translate/core';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { setupTestBed } from '../testing/setup-test-bed';
+import { CoreTestingModule } from '../testing/core.testing.module';
+import { VersionCompatibilityService } from '@alfresco/adf-core';
+
+@Component({
+    template: `
+        <div *adf-ecm-version="'8'" class="hidden-content-1">
+            My hidden content 1
+        </div>
+        <div *adf-ecm-version="'7.1'" class="hidden-content-2">
+            My hidden content 2
+        </div>
+        <div *adf-ecm-version="'7.0.2'" class="hidden-content-3">
+            My hidden content 3
+        </div>
+        <div *adf-ecm-version="'6.1.5'" class="visible-content-1">
+            My visible content 1
+        </div>
+        <div *adf-ecm-version="'6.1'" class="visible-content-2">
+            My visible content 2
+        </div>
+        <div *adf-ecm-version="'6'" class="visible-content-3">
+            My visible content 3
+        </div>
+        `
+})
+class TestComponent { }
+
+describe('VersionCompatibilityDirective', () => {
+    let fixture: ComponentFixture<TestComponent>;
+    let versionCompatibilityService: VersionCompatibilityService;
+
+    const ecmVersionMock = {
+        display: '7.0.1',
+        major: '7',
+        minor: '0',
+        patch: '1'
+    };
+
+    setupTestBed({
+        imports: [
+            TranslateModule.forRoot(),
+            CoreTestingModule
+        ],
+        declarations: [TestComponent
+        ]
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(TestComponent);
+        versionCompatibilityService = TestBed.get(VersionCompatibilityService);
+        spyOn(versionCompatibilityService, 'getEcmVersion').and.returnValue(ecmVersionMock);
+    });
+
+    it('should display component when the version is supported', () => {
+        fixture.detectChanges();
+        const element1 = fixture.debugElement.query(By.css('[class="visible-content-1"]'));
+        const element2 = fixture.debugElement.query(By.css('[class="visible-content-2"]'));
+        const element3 = fixture.debugElement.query(By.css('[class="visible-content-3"]'));
+        expect(element1).toBeDefined();
+        expect(element2).toBeDefined();
+        expect(element3).toBeDefined();
+    });
+
+    it('should hide component when the version is not supported', () => {
+        fixture.detectChanges();
+        const element1 = fixture.debugElement.query(By.css('[class="hidden-content-1"]'));
+        const element2 = fixture.debugElement.query(By.css('[class="hidden-content-2"]'));
+        const element3 = fixture.debugElement.query(By.css('[class="hidden-content-3"]'));
+        expect(element1).toBeNull();
+        expect(element2).toBeNull();
+        expect(element3).toBeNull();
+    });
+});

--- a/lib/core/directives/version-compatibility.directive.ts
+++ b/lib/core/directives/version-compatibility.directive.ts
@@ -20,12 +20,12 @@ import { VersionCompatibilityService } from '../services/version-compatibility.s
 import { VersionModel } from '../models/product-version.model';
 
 @Directive({
-    // tslint:disable-next-line: directive-selector
+    
     selector: '[adf-ecm-version]'
 })
 export class VersionCompatibilityDirective {
 
-    /** Enables/disables . */
+    /** Minimum version required for component to work correctly . */
     @Input('adf-ecm-version')
     set version(requiredVersion: string) {
         this.validateVersion(requiredVersion);

--- a/lib/core/directives/version-compatibility.directive.ts
+++ b/lib/core/directives/version-compatibility.directive.ts
@@ -20,7 +20,7 @@ import { VersionCompatibilityService } from '../services/version-compatibility.s
 import { VersionModel } from '../models/product-version.model';
 
 @Directive({
-    selector: '[adf-ecm-version]'
+    selector: '[adf-acs-version]'
 })
 export class VersionCompatibilityDirective {
 

--- a/lib/core/directives/version-compatibility.directive.ts
+++ b/lib/core/directives/version-compatibility.directive.ts
@@ -1,0 +1,87 @@
+/*!
+ * @license
+ * Copyright 2019 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Directive, Input, ViewContainerRef, TemplateRef } from '@angular/core';
+import { VersionCompatibilityService } from '../services/version-compatibility.service';
+import { VersionModel } from '../models/product-version.model';
+
+@Directive({
+    // tslint:disable-next-line: directive-selector
+    selector: '[adf-ecm-version]'
+})
+export class VersionCompatibilityDirective {
+
+    /** Enables/disables . */
+    @Input('adf-ecm-version')
+    set version(requiredVersion: string) {
+        this.validateVersion(requiredVersion);
+    }
+
+    constructor(
+        private templateRef: TemplateRef<any>,
+        private viewContainer: ViewContainerRef,
+        private versionCompatibilityService: VersionCompatibilityService
+    ) {
+    }
+
+    private validateVersion(requiredVersion: string) {
+        if (requiredVersion && this.isVersionSupported(requiredVersion)) {
+            this.viewContainer.createEmbeddedView(this.templateRef);
+        } else {
+            this.viewContainer.clear();
+        }
+    }
+
+    private parseVersion(version: string): VersionModel {
+        const major = version.split('.')[0];
+        const minor = version.split('.')[1] || '0';
+        const patch = version.split('.')[2] || '0';
+
+        return {
+            major: major,
+            minor: minor,
+            patch: patch
+        } as VersionModel;
+    }
+
+    private isVersionSupported(requiredVersion: string): boolean {
+        const parsedRequiredVersion = this.parseVersion(requiredVersion);
+        const currentVersion = this.versionCompatibilityService.getEcmVersion();
+
+        let versionSupported = false;
+
+        if (currentVersion) {
+            if (+currentVersion.major > +parsedRequiredVersion.major) {
+                versionSupported = true;
+            }
+
+            if (currentVersion.major === parsedRequiredVersion.major &&
+                +currentVersion.minor > +parsedRequiredVersion.minor) {
+                versionSupported = true;
+            }
+
+            if (currentVersion.major === parsedRequiredVersion.major &&
+                currentVersion.minor === parsedRequiredVersion.minor &&
+                +currentVersion.patch >= +parsedRequiredVersion.patch) {
+                versionSupported = true;
+            }
+        }
+
+        return versionSupported;
+    }
+
+}

--- a/lib/core/directives/version-compatibility.directive.ts
+++ b/lib/core/directives/version-compatibility.directive.ts
@@ -67,14 +67,10 @@ export class VersionCompatibilityDirective {
         if (currentVersion) {
             if (+currentVersion.major > +parsedRequiredVersion.major) {
                 versionSupported = true;
-            }
-
-            if (currentVersion.major === parsedRequiredVersion.major &&
+            } else if (currentVersion.major === parsedRequiredVersion.major &&
                 +currentVersion.minor > +parsedRequiredVersion.minor) {
                 versionSupported = true;
-            }
-
-            if (currentVersion.major === parsedRequiredVersion.major &&
+            } else if (currentVersion.major === parsedRequiredVersion.major &&
                 currentVersion.minor === parsedRequiredVersion.minor &&
                 +currentVersion.patch >= +parsedRequiredVersion.patch) {
                 versionSupported = true;

--- a/lib/core/directives/version-compatibility.directive.ts
+++ b/lib/core/directives/version-compatibility.directive.ts
@@ -20,15 +20,14 @@ import { VersionCompatibilityService } from '../services/version-compatibility.s
 import { VersionModel } from '../models/product-version.model';
 
 @Directive({
-    
     selector: '[adf-ecm-version]'
 })
 export class VersionCompatibilityDirective {
 
     /** Minimum version required for component to work correctly . */
-    @Input('adf-ecm-version')
+    @Input('adf-acs-version')
     set version(requiredVersion: string) {
-        this.validateVersion(requiredVersion);
+        this.validateAcsVersion(requiredVersion);
     }
 
     constructor(
@@ -38,7 +37,7 @@ export class VersionCompatibilityDirective {
     ) {
     }
 
-    private validateVersion(requiredVersion: string) {
+    private validateAcsVersion(requiredVersion: string) {
         if (requiredVersion && this.isVersionSupported(requiredVersion)) {
             this.viewContainer.createEmbeddedView(this.templateRef);
         } else {
@@ -60,7 +59,7 @@ export class VersionCompatibilityDirective {
 
     private isVersionSupported(requiredVersion: string): boolean {
         const parsedRequiredVersion = this.parseVersion(requiredVersion);
-        const currentVersion = this.versionCompatibilityService.getEcmVersion();
+        const currentVersion = this.versionCompatibilityService.getAcsVersion();
 
         let versionSupported = false;
 

--- a/lib/core/search-text/search-text-input.component.spec.ts
+++ b/lib/core/search-text/search-text-input.component.spec.ts
@@ -67,15 +67,17 @@ describe('SearchTextInputComponent', () => {
 
         beforeEach(() => {
             component.expandable = false;
-            fixture.detectChanges();
         });
 
         it('search button should be hide', () => {
+            fixture.detectChanges();
             const searchButton: any = element.querySelector('#adf-search-button');
             expect(searchButton).toBe(null);
         });
 
         it('should not have animation', () => {
+            userPreferencesService.setWithoutStore('textOrientation', 'rtl');
+            fixture.detectChanges();
             expect(component.subscriptAnimationState.value).toBe('no-animation');
         });
     });

--- a/lib/core/search-text/search-text-input.component.spec.ts
+++ b/lib/core/search-text/search-text-input.component.spec.ts
@@ -24,7 +24,6 @@ import { Subject } from 'rxjs';
 import { TranslateModule } from '@ngx-translate/core';
 import { UserPreferencesService } from '../services/user-preferences.service';
 import { setupTestBed } from '../testing/setup-test-bed';
-import { CoreModule } from '../core.module';
 
 describe('SearchTextInputComponent', () => {
 
@@ -37,7 +36,6 @@ describe('SearchTextInputComponent', () => {
     setupTestBed({
         imports: [
             TranslateModule.forRoot(),
-            CoreModule.forRoot(),
             CoreTestingModule
         ]
     });
@@ -58,6 +56,7 @@ describe('SearchTextInputComponent', () => {
     describe('component rendering', () => {
 
         it('should display a search input field when specified', async(() => {
+            fixture.detectChanges();
             component.inputType = 'search';
             fixture.detectChanges();
             expect(element.querySelectorAll('input[type="search"]').length).toBe(1);

--- a/lib/core/services/public-api.ts
+++ b/lib/core/services/public-api.ts
@@ -61,4 +61,5 @@ export * from './ecm-user.service';
 export * from './identity-user.service';
 export * from './identity-group.service';
 export * from './identity-role.service';
+export * from './version-compatibility.service';
 export * from './auth-bearer.interceptor';

--- a/lib/core/services/version-compatibility-factory.ts
+++ b/lib/core/services/version-compatibility-factory.ts
@@ -15,14 +15,8 @@
  * limitations under the License.
  */
 
-export * from './highlight.directive';
-export * from './logout.directive';
-export * from './node-delete.directive';
-export * from './node-favorite.directive';
-export * from './check-allowable-operation.directive';
-export * from './node-restore.directive';
-export * from './node-download.directive';
-export * from './upload.directive';
-export * from './version-compatibility.directive';
+import { VersionCompatibilityService } from './version-compatibility.service';
 
-export * from './directive.module';
+export function versionCompatibilityFactory(
+    versionCompatibilityService: VersionCompatibilityService
+): Function { return () => versionCompatibilityService; }

--- a/lib/core/services/version-compatibility.service.spec.ts
+++ b/lib/core/services/version-compatibility.service.spec.ts
@@ -30,7 +30,7 @@ describe('VersionCompatibilityService', () => {
     let alfrescoApiService: AlfrescoApiServiceMock;
     let discoveryApiService: DiscoveryApiService;
 
-    const ecmResponceMock = {
+    const acsResponceMock = {
         version: {
             display: '7.0.1',
             major: '7',
@@ -48,19 +48,19 @@ describe('VersionCompatibilityService', () => {
 
     beforeEach(() => {
         discoveryApiService = TestBed.get(DiscoveryApiService);
-        spyOn(discoveryApiService, 'getEcmProductInfo').and.returnValue(of(ecmResponceMock));
+        spyOn(discoveryApiService, 'getEcmProductInfo').and.returnValue(of(acsResponceMock));
         versionCompatibilityService = TestBed.get(VersionCompatibilityService);
         alfrescoApiService = new AlfrescoApiServiceMock(new AppConfigService(null), null);
 
     });
 
-    it('should get ECMs running version', (done) => {
+    it('should get ACS running version', (done) => {
         versionCompatibilityService = new VersionCompatibilityService(alfrescoApiService, discoveryApiService);
         alfrescoApiService.initialize();
         setTimeout(() => {
-            const ecmVersion = versionCompatibilityService.getEcmVersion();
-            expect(ecmVersion).toBeDefined();
-            expect(ecmVersion.display).toBe('7.0.1');
+            const acsVersion = versionCompatibilityService.getAcsVersion();
+            expect(acsVersion).toBeDefined();
+            expect(acsVersion.display).toBe('7.0.1');
             done();
         }, 100);
     });

--- a/lib/core/services/version-compatibility.service.spec.ts
+++ b/lib/core/services/version-compatibility.service.spec.ts
@@ -1,0 +1,67 @@
+/*!
+ * @license
+ * Copyright 2019 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { AppConfigService } from '../app-config/app-config.service';
+import { DiscoveryApiService } from './discovery-api.service';
+import { setupTestBed } from '../testing/setup-test-bed';
+import { CoreTestingModule } from '../testing/core.testing.module';
+import { AlfrescoApiServiceMock } from '../mock/alfresco-api.service.mock';
+import { VersionCompatibilityService } from './version-compatibility.service';
+import { of } from 'rxjs';
+import { TranslateModule } from '@ngx-translate/core';
+
+describe('VersionCompatibilityService', () => {
+    let versionCompatibilityService: VersionCompatibilityService;
+    let alfrescoApiService: AlfrescoApiServiceMock;
+    let discoveryApiService: DiscoveryApiService;
+
+    const ecmResponceMock = {
+        version: {
+            display: '7.0.1',
+            major: '7',
+            minor: '0',
+            patch: '1'
+        }
+    };
+
+    setupTestBed({
+        imports: [
+            TranslateModule.forRoot(),
+            CoreTestingModule
+        ]
+    });
+
+    beforeEach(() => {
+        discoveryApiService = TestBed.get(DiscoveryApiService);
+        spyOn(discoveryApiService, 'getEcmProductInfo').and.returnValue(of(ecmResponceMock));
+        versionCompatibilityService = TestBed.get(VersionCompatibilityService);
+        alfrescoApiService = new AlfrescoApiServiceMock(new AppConfigService(null), null);
+
+    });
+
+    it('should get ECMs running version', (done) => {
+        versionCompatibilityService = new VersionCompatibilityService(alfrescoApiService, discoveryApiService);
+        alfrescoApiService.initialize();
+        setTimeout(() => {
+            const ecmVersion = versionCompatibilityService.getEcmVersion();
+            expect(ecmVersion).toBeDefined();
+            expect(ecmVersion.display).toBe('7.0.1');
+            done();
+        }, 100);
+    });
+});

--- a/lib/core/services/version-compatibility.service.spec.ts
+++ b/lib/core/services/version-compatibility.service.spec.ts
@@ -24,11 +24,13 @@ import { AlfrescoApiServiceMock } from '../mock/alfresco-api.service.mock';
 import { VersionCompatibilityService } from './version-compatibility.service';
 import { of } from 'rxjs';
 import { TranslateModule } from '@ngx-translate/core';
+import { AuthenticationService } from './authentication.service';
 
 describe('VersionCompatibilityService', () => {
     let versionCompatibilityService: VersionCompatibilityService;
     let alfrescoApiService: AlfrescoApiServiceMock;
     let discoveryApiService: DiscoveryApiService;
+    let authenticationService: AuthenticationService;
 
     const acsResponceMock = {
         version: {
@@ -48,14 +50,20 @@ describe('VersionCompatibilityService', () => {
 
     beforeEach(() => {
         discoveryApiService = TestBed.get(DiscoveryApiService);
+        authenticationService = TestBed.get(AuthenticationService);
         spyOn(discoveryApiService, 'getEcmProductInfo').and.returnValue(of(acsResponceMock));
+        spyOn(authenticationService, 'isEcmLoggedIn').and.returnValue(true);
         versionCompatibilityService = TestBed.get(VersionCompatibilityService);
         alfrescoApiService = new AlfrescoApiServiceMock(new AppConfigService(null), null);
 
     });
 
     it('should get ACS running version', (done) => {
-        versionCompatibilityService = new VersionCompatibilityService(alfrescoApiService, discoveryApiService);
+        versionCompatibilityService = new VersionCompatibilityService(
+            alfrescoApiService,
+            authenticationService,
+            discoveryApiService
+        );
         alfrescoApiService.initialize();
         setTimeout(() => {
             const acsVersion = versionCompatibilityService.getAcsVersion();

--- a/lib/core/services/version-compatibility.service.ts
+++ b/lib/core/services/version-compatibility.service.ts
@@ -1,0 +1,49 @@
+/*!
+ * @license
+ * Copyright 2019 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Injectable } from '@angular/core';
+import { AlfrescoApiService } from './alfresco-api.service';
+import { filter } from 'rxjs/operators';
+import { DiscoveryApiService } from './discovery-api.service';
+import { EcmProductVersionModel, VersionModel } from '../models/product-version.model';
+
+@Injectable({
+    providedIn: 'root'
+})
+export class VersionCompatibilityService {
+    private ecmVersion: VersionModel;
+
+    constructor(
+        private alfrescoApiService: AlfrescoApiService,
+        private discoveryApiService: DiscoveryApiService
+    ) {
+        this.alfrescoApiService.alfrescoApiInitialized
+            .pipe(filter(status => status))
+            .subscribe(this.initCompatibilityVersion.bind(this));
+    }
+
+    private initCompatibilityVersion() {
+        this.discoveryApiService.getEcmProductInfo().toPromise().then(
+            (ecmInfo: EcmProductVersionModel) => {
+                this.ecmVersion = ecmInfo.version;
+            });
+    }
+
+    public getEcmVersion(): VersionModel {
+        return this.ecmVersion;
+    }
+}

--- a/lib/core/services/version-compatibility.service.ts
+++ b/lib/core/services/version-compatibility.service.ts
@@ -19,13 +19,13 @@ import { Injectable } from '@angular/core';
 import { AlfrescoApiService } from './alfresco-api.service';
 import { filter } from 'rxjs/operators';
 import { DiscoveryApiService } from './discovery-api.service';
-import { EcmProductVersionModel, VersionModel } from '../models/product-version.model';
+import { VersionModel, EcmProductVersionModel } from '../models/product-version.model';
 
 @Injectable({
     providedIn: 'root'
 })
 export class VersionCompatibilityService {
-    private ecmVersion: VersionModel;
+    private acsVersion: VersionModel;
 
     constructor(
         private alfrescoApiService: AlfrescoApiService,
@@ -38,12 +38,12 @@ export class VersionCompatibilityService {
 
     private initCompatibilityVersion() {
         this.discoveryApiService.getEcmProductInfo().toPromise().then(
-            (ecmInfo: EcmProductVersionModel) => {
-                this.ecmVersion = ecmInfo.version;
+            (acsInfo: EcmProductVersionModel) => {
+                this.acsVersion = acsInfo.version;
             });
     }
 
-    public getEcmVersion(): VersionModel {
-        return this.ecmVersion;
+    public getAcsVersion(): VersionModel {
+        return this.acsVersion;
     }
 }

--- a/lib/core/services/version-compatibility.service.ts
+++ b/lib/core/services/version-compatibility.service.ts
@@ -20,6 +20,7 @@ import { AlfrescoApiService } from './alfresco-api.service';
 import { filter } from 'rxjs/operators';
 import { DiscoveryApiService } from './discovery-api.service';
 import { VersionModel, EcmProductVersionModel } from '../models/product-version.model';
+import { AuthenticationService } from './authentication.service';
 
 @Injectable({
     providedIn: 'root'
@@ -29,6 +30,7 @@ export class VersionCompatibilityService {
 
     constructor(
         private alfrescoApiService: AlfrescoApiService,
+        private authService: AuthenticationService,
         private discoveryApiService: DiscoveryApiService
     ) {
         this.alfrescoApiService.alfrescoApiInitialized
@@ -37,10 +39,12 @@ export class VersionCompatibilityService {
     }
 
     private initCompatibilityVersion() {
-        this.discoveryApiService.getEcmProductInfo().toPromise().then(
-            (acsInfo: EcmProductVersionModel) => {
-                this.acsVersion = acsInfo.version;
-            });
+        if (this.authService.isEcmLoggedIn()) {
+            this.discoveryApiService.getEcmProductInfo().toPromise().then(
+                (acsInfo: EcmProductVersionModel) => {
+                    this.acsVersion = acsInfo.version;
+                });
+        }
     }
 
     public getAcsVersion(): VersionModel {

--- a/lib/core/testing/core.testing.module.ts
+++ b/lib/core/testing/core.testing.module.ts
@@ -32,6 +32,8 @@ import { CookieServiceMock } from '../mock/cookie.service.mock';
 import { HttpClientModule } from '@angular/common/http';
 import { directionalityConfigFactory } from '../services/directionality-config-factory';
 import { DirectionalityConfigService } from '../services/directionality-config.service';
+import { versionCompatibilityFactory } from '../services/version-compatibility-factory';
+import { VersionCompatibilityService } from '../services/version-compatibility.service';
 
 @NgModule({
     imports: [
@@ -51,6 +53,12 @@ import { DirectionalityConfigService } from '../services/directionality-config.s
             provide: APP_INITIALIZER,
             useFactory: directionalityConfigFactory,
             deps: [ DirectionalityConfigService ],
+            multi: true
+        },
+        {
+            provide: APP_INITIALIZER,
+            useFactory: versionCompatibilityFactory,
+            deps: [ VersionCompatibilityService ],
             multi: true
         }
     ],

--- a/lib/process-services-cloud/src/lib/app/services/apps-process-cloud.service.spec.ts
+++ b/lib/process-services-cloud/src/lib/app/services/apps-process-cloud.service.spec.ts
@@ -17,7 +17,7 @@
 
 import { TestBed } from '@angular/core/testing';
 import { throwError } from 'rxjs';
-import { setupTestBed, CoreModule, AppConfigService, AlfrescoApiService, CoreTestingModule } from '@alfresco/adf-core';
+import { setupTestBed, AppConfigService, AlfrescoApiService, CoreTestingModule } from '@alfresco/adf-core';
 import { HttpErrorResponse } from '@angular/common/http';
 import { AppsProcessCloudService } from './apps-process-cloud.service';
 import { fakeApplicationInstance } from '../mock/app-model.mock';

--- a/lib/process-services-cloud/src/lib/app/services/apps-process-cloud.service.spec.ts
+++ b/lib/process-services-cloud/src/lib/app/services/apps-process-cloud.service.spec.ts
@@ -17,7 +17,7 @@
 
 import { TestBed } from '@angular/core/testing';
 import { throwError } from 'rxjs';
-import { setupTestBed, CoreModule, AppConfigService, AlfrescoApiService } from '@alfresco/adf-core';
+import { setupTestBed, CoreModule, AppConfigService, AlfrescoApiService, CoreTestingModule } from '@alfresco/adf-core';
 import { HttpErrorResponse } from '@angular/common/http';
 import { AppsProcessCloudService } from './apps-process-cloud.service';
 import { fakeApplicationInstance } from '../mock/app-model.mock';
@@ -40,7 +40,7 @@ describe('AppsProcessCloudService', () => {
     setupTestBed({
         imports: [
             TranslateModule.forRoot(),
-            CoreModule.forRoot(),
+            CoreTestingModule,
             ProcessServiceCloudTestingModule
         ]
     });

--- a/lib/process-services-cloud/src/lib/form/components/form-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/form-cloud.component.spec.ts
@@ -29,7 +29,8 @@ import {
     FormOutcomeModel,
     setupTestBed,
     TRANSLATION_PROVIDER,
-    WidgetVisibilityService
+    WidgetVisibilityService,
+    VersionCompatibilityService
 } from '@alfresco/adf-core';
 import { ProcessServiceCloudTestingModule } from '../../testing/process-service-cloud.testing.module';
 import { FormCloudService } from '../services/form-cloud.service';
@@ -68,7 +69,7 @@ describe('FormCloudComponent', () => {
         exports: [CustomWidget],
         entryComponents: [CustomWidget]
     })
-    class CustomUploadModule {}
+    class CustomUploadModule { }
 
     function buildWidget(type: string, injector: Injector): any {
         const resolver = formRenderingService.getComponentTypeResolver(type);
@@ -97,6 +98,10 @@ describe('FormCloudComponent', () => {
                     name: 'app',
                     source: 'resources'
                 }
+            },
+            {
+                provide: VersionCompatibilityService,
+                useValue: {}
             }
         ]
     });
@@ -116,7 +121,7 @@ describe('FormCloudComponent', () => {
         fixture = TestBed.createComponent(FormCloudComponent);
         formComponent = fixture.componentInstance;
         fixture.detectChanges();
-   }));
+    }));
 
     it('should register custom [upload] widget', () => {
         const widget = buildWidget('upload', fixture.componentRef.injector);
@@ -190,7 +195,7 @@ describe('FormCloudComponent', () => {
 
         expect(formComponent.showTitle).toBeTruthy();
         expect(formComponent.isTitleEnabled()).toBeTruthy();
-   });
+    });
 
     it('should not allow title if showTitle is false', () => {
         const formModel = new FormModel();
@@ -212,14 +217,14 @@ describe('FormCloudComponent', () => {
     it('should enable custom outcome buttons', () => {
         const formModel = new FormModel();
         formComponent.form = formModel;
-        const outcome = new FormOutcomeModel(<any> formModel, { id: 'action1', name: 'Action 1' });
+        const outcome = new FormOutcomeModel(<any>formModel, { id: 'action1', name: 'Action 1' });
         expect(formComponent.isOutcomeButtonVisible(outcome, formComponent.form.readOnly)).toBeTruthy();
     });
 
     it('should allow controlling [complete] button visibility', () => {
         const formModel = new FormModel();
         formComponent.form = formModel;
-        const outcome = new FormOutcomeModel(<any> formModel, { id: '$save', name: FormOutcomeModel.SAVE_ACTION });
+        const outcome = new FormOutcomeModel(<any>formModel, { id: '$save', name: FormOutcomeModel.SAVE_ACTION });
 
         formComponent.showSaveButton = true;
         expect(formComponent.isOutcomeButtonVisible(outcome, formComponent.form.readOnly)).toBeTruthy();
@@ -232,7 +237,7 @@ describe('FormCloudComponent', () => {
         const formModel = new FormModel();
         formModel.readOnly = true;
         formComponent.form = formModel;
-        const outcome = new FormOutcomeModel(<any> formModel, { id: '$complete', name: FormOutcomeModel.COMPLETE_ACTION });
+        const outcome = new FormOutcomeModel(<any>formModel, { id: '$complete', name: FormOutcomeModel.COMPLETE_ACTION });
 
         formComponent.showCompleteButton = true;
         expect(formComponent.isOutcomeButtonVisible(outcome, formComponent.form.readOnly)).toBeTruthy();
@@ -242,7 +247,7 @@ describe('FormCloudComponent', () => {
         const formModel = new FormModel();
         formModel.readOnly = true;
         formComponent.form = formModel;
-        const outcome = new FormOutcomeModel(<any> formModel, { id: '$save', name: FormOutcomeModel.SAVE_ACTION });
+        const outcome = new FormOutcomeModel(<any>formModel, { id: '$save', name: FormOutcomeModel.SAVE_ACTION });
 
         formComponent.showSaveButton = true;
         expect(formComponent.isOutcomeButtonVisible(outcome, formComponent.form.readOnly)).toBeFalsy();
@@ -252,13 +257,13 @@ describe('FormCloudComponent', () => {
         const formModel = new FormModel({ selectedOutcome: 'custom-outcome' });
         formModel.readOnly = true;
         formComponent.form = formModel;
-        let outcome = new FormOutcomeModel(<any> formModel, { id: '$customoutome', name: 'custom-outcome' });
+        let outcome = new FormOutcomeModel(<any>formModel, { id: '$customoutome', name: 'custom-outcome' });
 
         formComponent.showCompleteButton = true;
         formComponent.showSaveButton = true;
         expect(formComponent.isOutcomeButtonVisible(outcome, formComponent.form.readOnly)).toBeTruthy();
 
-        outcome = new FormOutcomeModel(<any> formModel, { id: '$customoutome2', name: 'custom-outcome2' });
+        outcome = new FormOutcomeModel(<any>formModel, { id: '$customoutome2', name: 'custom-outcome2' });
         expect(formComponent.isOutcomeButtonVisible(outcome, formComponent.form.readOnly)).toBeFalsy();
     });
 
@@ -266,7 +271,7 @@ describe('FormCloudComponent', () => {
         const formModel = new FormModel();
         formModel.readOnly = false;
         formComponent.form = formModel;
-        const outcome = new FormOutcomeModel(<any> formModel, { id: '$save', name: FormOutcomeModel.COMPLETE_ACTION });
+        const outcome = new FormOutcomeModel(<any>formModel, { id: '$save', name: FormOutcomeModel.COMPLETE_ACTION });
 
         formComponent.showCompleteButton = true;
         expect(formComponent.isOutcomeButtonVisible(outcome, formComponent.form.readOnly)).toBeTruthy();
@@ -370,7 +375,7 @@ describe('FormCloudComponent', () => {
         spyOn(formCloudService, 'getTaskForm').and.returnValue(of(cloudFormMock));
         spyOn(formCloudService, 'getTaskVariables').and.returnValue(of([]));
         spyOn(formCloudService, 'getProcessStorageFolderTask')
-            .and.returnValue( of({nodeId : '123', path: '/a/path/type', type: 'fakeType'}));
+            .and.returnValue(of({ nodeId: '123', path: '/a/path/type', type: 'fakeType' }));
         const taskId = '<task id>';
         const appName = 'test-app';
         formComponent.appName = appName;
@@ -389,7 +394,7 @@ describe('FormCloudComponent', () => {
         spyOn(formCloudService, 'getTaskForm').and.returnValue(of(cloudFormMock));
         spyOn(formCloudService, 'getTaskVariables').and.returnValue(of([]));
         spyOn(formCloudService, 'getProcessStorageFolderTask')
-            .and.returnValue( of({nodeId : '123', path: '/a/path/type', type: 'fakeType'}));
+            .and.returnValue(of({ nodeId: '123', path: '/a/path/type', type: 'fakeType' }));
         const taskId = '<task id>';
         const processInstanceId = 'i-am-the-process-instance-id';
         const appName = 'test-app';
@@ -443,7 +448,7 @@ describe('FormCloudComponent', () => {
     it('should complete form on custom outcome click', () => {
         const formModel = new FormModel();
         const outcomeName = 'Custom Action';
-        const outcome = new FormOutcomeModel(<any> formModel, { id: 'custom1', name: outcomeName });
+        const outcome = new FormOutcomeModel(<any>formModel, { id: 'custom1', name: outcomeName });
 
         let saved = false;
         formComponent.form = formModel;
@@ -458,7 +463,7 @@ describe('FormCloudComponent', () => {
 
     it('should save form on [save] outcome click', () => {
         const formModel = new FormModel();
-        const outcome = new FormOutcomeModel(<any> formModel, {
+        const outcome = new FormOutcomeModel(<any>formModel, {
             id: FormCloudComponent.SAVE_OUTCOME_ID,
             name: 'Save',
             isSystem: true
@@ -474,7 +479,7 @@ describe('FormCloudComponent', () => {
 
     it('should complete form on [complete] outcome click', () => {
         const formModel = new FormModel();
-        const outcome = new FormOutcomeModel(<any> formModel, {
+        const outcome = new FormOutcomeModel(<any>formModel, {
             id: FormCloudComponent.COMPLETE_OUTCOME_ID,
             name: 'Complete',
             isSystem: true
@@ -490,7 +495,7 @@ describe('FormCloudComponent', () => {
 
     it('should emit form saved event on custom outcome click', () => {
         const formModel = new FormModel();
-        const outcome = new FormOutcomeModel(<any> formModel, {
+        const outcome = new FormOutcomeModel(<any>formModel, {
             id: FormCloudComponent.CUSTOM_OUTCOME_ID,
             name: 'Custom',
             isSystem: true
@@ -508,7 +513,7 @@ describe('FormCloudComponent', () => {
     it('should do nothing when clicking outcome for readonly form', () => {
         const formModel = new FormModel();
         const outcomeName = 'Custom Action';
-        const outcome = new FormOutcomeModel(<any> formModel, { id: 'custom1', name: outcomeName });
+        const outcome = new FormOutcomeModel(<any>formModel, { id: 'custom1', name: outcomeName });
 
         formComponent.form = formModel;
         spyOn(formComponent, 'completeTaskForm').and.stub();
@@ -527,7 +532,7 @@ describe('FormCloudComponent', () => {
     it('should require loaded form when clicking outcome', () => {
         const formModel = new FormModel();
         const outcomeName = 'Custom Action';
-        const outcome = new FormOutcomeModel(<any> formModel, { id: 'custom1', name: outcomeName });
+        const outcome = new FormOutcomeModel(<any>formModel, { id: 'custom1', name: outcomeName });
 
         formComponent.readOnly = false;
         formComponent.form = null;
@@ -536,7 +541,7 @@ describe('FormCloudComponent', () => {
 
     it('should not execute unknown system outcome', () => {
         const formModel = new FormModel();
-        const outcome = new FormOutcomeModel(<any> formModel, { id: 'unknown', name: 'Unknown', isSystem: true });
+        const outcome = new FormOutcomeModel(<any>formModel, { id: 'unknown', name: 'Unknown', isSystem: true });
 
         formComponent.form = formModel;
         expect(formComponent.onOutcomeClicked(outcome)).toBeFalsy();
@@ -544,12 +549,12 @@ describe('FormCloudComponent', () => {
 
     it('should require custom action name to complete form', () => {
         const formModel = new FormModel();
-        let outcome = new FormOutcomeModel(<any> formModel, { id: 'custom' });
+        let outcome = new FormOutcomeModel(<any>formModel, { id: 'custom' });
 
         formComponent.form = formModel;
         expect(formComponent.onOutcomeClicked(outcome)).toBeFalsy();
 
-        outcome = new FormOutcomeModel(<any> formModel, { id: 'custom', name: 'Custom' });
+        outcome = new FormOutcomeModel(<any>formModel, { id: 'custom', name: 'Custom' });
         spyOn(formComponent, 'completeTaskForm').and.stub();
         expect(formComponent.onOutcomeClicked(outcome)).toBeTruthy();
     });
@@ -787,7 +792,7 @@ describe('FormCloudComponent', () => {
 
     it('should prevent default outcome execution', () => {
 
-        const outcome = new FormOutcomeModel(<any> new FormModel(), {
+        const outcome = new FormOutcomeModel(<any>new FormModel(), {
             id: FormCloudComponent.CUSTOM_OUTCOME_ID,
             name: 'Custom'
         });
@@ -804,7 +809,7 @@ describe('FormCloudComponent', () => {
     });
 
     it('should not prevent default outcome execution', () => {
-        const outcome = new FormOutcomeModel(<any> new FormModel(), {
+        const outcome = new FormOutcomeModel(<any>new FormModel(), {
             id: FormCloudComponent.CUSTOM_OUTCOME_ID,
             name: 'Custom'
         });
@@ -832,7 +837,7 @@ describe('FormCloudComponent', () => {
         formComponent.checkVisibility(field);
         expect(visibilityService.refreshVisibility).not.toHaveBeenCalled();
 
-        field = new FormFieldModel(<any> new FormModel());
+        field = new FormFieldModel(<any>new FormModel());
         formComponent.checkVisibility(field);
         expect(visibilityService.refreshVisibility).toHaveBeenCalledWith(field.form);
     });
@@ -842,7 +847,7 @@ describe('FormCloudComponent', () => {
         formModel.readOnly = true;
         formComponent.form = formModel;
 
-        const outcome = new FormOutcomeModel(<any> new FormModel(), {
+        const outcome = new FormOutcomeModel(<any>new FormModel(), {
             id: FormCloudComponent.CUSTOM_OUTCOME_ID,
             name: 'Custom'
         });
@@ -912,7 +917,7 @@ describe('FormCloudComponent', () => {
             done();
         });
 
-        const outcome = new FormOutcomeModel(<any> new FormModel(), {
+        const outcome = new FormOutcomeModel(<any>new FormModel(), {
             id: FormCloudComponent.CUSTOM_OUTCOME_ID,
             name: 'Custom'
         });
@@ -947,7 +952,7 @@ describe('FormCloudComponent', () => {
         });
 
         formComponent.ngOnChanges({ 'data': change });
-   });
+    });
 
     it('should refresh radio buttons value when id is given to data', () => {
         formComponent.form = new FormModel(JSON.parse(JSON.stringify(cloudFormMock)));
@@ -990,7 +995,7 @@ describe('FormCloudComponent', () => {
     });
 
     describe('Multilingual Form', () => {
-        it('should  translate form labels  on language change',  async () => {
+        it('should  translate form labels  on language change', async () => {
             spyOn(formCloudService, 'getForm').and.returnValue(of(multilingualForm));
             const formId = '123';
             const appName = 'test-app';

--- a/lib/process-services-cloud/src/lib/form/components/form-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/form-cloud.component.spec.ts
@@ -217,14 +217,14 @@ describe('FormCloudComponent', () => {
     it('should enable custom outcome buttons', () => {
         const formModel = new FormModel();
         formComponent.form = formModel;
-        const outcome = new FormOutcomeModel(<any>formModel, { id: 'action1', name: 'Action 1' });
+        const outcome = new FormOutcomeModel(<any> formModel, { id: 'action1', name: 'Action 1' });
         expect(formComponent.isOutcomeButtonVisible(outcome, formComponent.form.readOnly)).toBeTruthy();
     });
 
     it('should allow controlling [complete] button visibility', () => {
         const formModel = new FormModel();
         formComponent.form = formModel;
-        const outcome = new FormOutcomeModel(<any>formModel, { id: '$save', name: FormOutcomeModel.SAVE_ACTION });
+        const outcome = new FormOutcomeModel(<any> formModel, { id: '$save', name: FormOutcomeModel.SAVE_ACTION });
 
         formComponent.showSaveButton = true;
         expect(formComponent.isOutcomeButtonVisible(outcome, formComponent.form.readOnly)).toBeTruthy();
@@ -237,7 +237,7 @@ describe('FormCloudComponent', () => {
         const formModel = new FormModel();
         formModel.readOnly = true;
         formComponent.form = formModel;
-        const outcome = new FormOutcomeModel(<any>formModel, { id: '$complete', name: FormOutcomeModel.COMPLETE_ACTION });
+        const outcome = new FormOutcomeModel(<any> formModel, { id: '$complete', name: FormOutcomeModel.COMPLETE_ACTION });
 
         formComponent.showCompleteButton = true;
         expect(formComponent.isOutcomeButtonVisible(outcome, formComponent.form.readOnly)).toBeTruthy();
@@ -247,7 +247,7 @@ describe('FormCloudComponent', () => {
         const formModel = new FormModel();
         formModel.readOnly = true;
         formComponent.form = formModel;
-        const outcome = new FormOutcomeModel(<any>formModel, { id: '$save', name: FormOutcomeModel.SAVE_ACTION });
+        const outcome = new FormOutcomeModel(<any> formModel, { id: '$save', name: FormOutcomeModel.SAVE_ACTION });
 
         formComponent.showSaveButton = true;
         expect(formComponent.isOutcomeButtonVisible(outcome, formComponent.form.readOnly)).toBeFalsy();
@@ -257,13 +257,13 @@ describe('FormCloudComponent', () => {
         const formModel = new FormModel({ selectedOutcome: 'custom-outcome' });
         formModel.readOnly = true;
         formComponent.form = formModel;
-        let outcome = new FormOutcomeModel(<any>formModel, { id: '$customoutome', name: 'custom-outcome' });
+        let outcome = new FormOutcomeModel(<any> formModel, { id: '$customoutome', name: 'custom-outcome' });
 
         formComponent.showCompleteButton = true;
         formComponent.showSaveButton = true;
         expect(formComponent.isOutcomeButtonVisible(outcome, formComponent.form.readOnly)).toBeTruthy();
 
-        outcome = new FormOutcomeModel(<any>formModel, { id: '$customoutome2', name: 'custom-outcome2' });
+        outcome = new FormOutcomeModel(<any> formModel, { id: '$customoutome2', name: 'custom-outcome2' });
         expect(formComponent.isOutcomeButtonVisible(outcome, formComponent.form.readOnly)).toBeFalsy();
     });
 
@@ -271,7 +271,7 @@ describe('FormCloudComponent', () => {
         const formModel = new FormModel();
         formModel.readOnly = false;
         formComponent.form = formModel;
-        const outcome = new FormOutcomeModel(<any>formModel, { id: '$save', name: FormOutcomeModel.COMPLETE_ACTION });
+        const outcome = new FormOutcomeModel(<any> formModel, { id: '$save', name: FormOutcomeModel.COMPLETE_ACTION });
 
         formComponent.showCompleteButton = true;
         expect(formComponent.isOutcomeButtonVisible(outcome, formComponent.form.readOnly)).toBeTruthy();
@@ -448,7 +448,7 @@ describe('FormCloudComponent', () => {
     it('should complete form on custom outcome click', () => {
         const formModel = new FormModel();
         const outcomeName = 'Custom Action';
-        const outcome = new FormOutcomeModel(<any>formModel, { id: 'custom1', name: outcomeName });
+        const outcome = new FormOutcomeModel(<any> formModel, { id: 'custom1', name: outcomeName });
 
         let saved = false;
         formComponent.form = formModel;
@@ -463,7 +463,7 @@ describe('FormCloudComponent', () => {
 
     it('should save form on [save] outcome click', () => {
         const formModel = new FormModel();
-        const outcome = new FormOutcomeModel(<any>formModel, {
+        const outcome = new FormOutcomeModel(<any> formModel, {
             id: FormCloudComponent.SAVE_OUTCOME_ID,
             name: 'Save',
             isSystem: true
@@ -479,7 +479,7 @@ describe('FormCloudComponent', () => {
 
     it('should complete form on [complete] outcome click', () => {
         const formModel = new FormModel();
-        const outcome = new FormOutcomeModel(<any>formModel, {
+        const outcome = new FormOutcomeModel(<any> formModel, {
             id: FormCloudComponent.COMPLETE_OUTCOME_ID,
             name: 'Complete',
             isSystem: true
@@ -495,7 +495,7 @@ describe('FormCloudComponent', () => {
 
     it('should emit form saved event on custom outcome click', () => {
         const formModel = new FormModel();
-        const outcome = new FormOutcomeModel(<any>formModel, {
+        const outcome = new FormOutcomeModel(<any> formModel, {
             id: FormCloudComponent.CUSTOM_OUTCOME_ID,
             name: 'Custom',
             isSystem: true
@@ -513,7 +513,7 @@ describe('FormCloudComponent', () => {
     it('should do nothing when clicking outcome for readonly form', () => {
         const formModel = new FormModel();
         const outcomeName = 'Custom Action';
-        const outcome = new FormOutcomeModel(<any>formModel, { id: 'custom1', name: outcomeName });
+        const outcome = new FormOutcomeModel(<any> formModel, { id: 'custom1', name: outcomeName });
 
         formComponent.form = formModel;
         spyOn(formComponent, 'completeTaskForm').and.stub();
@@ -532,7 +532,7 @@ describe('FormCloudComponent', () => {
     it('should require loaded form when clicking outcome', () => {
         const formModel = new FormModel();
         const outcomeName = 'Custom Action';
-        const outcome = new FormOutcomeModel(<any>formModel, { id: 'custom1', name: outcomeName });
+        const outcome = new FormOutcomeModel(<any> formModel, { id: 'custom1', name: outcomeName });
 
         formComponent.readOnly = false;
         formComponent.form = null;
@@ -541,7 +541,7 @@ describe('FormCloudComponent', () => {
 
     it('should not execute unknown system outcome', () => {
         const formModel = new FormModel();
-        const outcome = new FormOutcomeModel(<any>formModel, { id: 'unknown', name: 'Unknown', isSystem: true });
+        const outcome = new FormOutcomeModel(<any> formModel, { id: 'unknown', name: 'Unknown', isSystem: true });
 
         formComponent.form = formModel;
         expect(formComponent.onOutcomeClicked(outcome)).toBeFalsy();
@@ -549,12 +549,12 @@ describe('FormCloudComponent', () => {
 
     it('should require custom action name to complete form', () => {
         const formModel = new FormModel();
-        let outcome = new FormOutcomeModel(<any>formModel, { id: 'custom' });
+        let outcome = new FormOutcomeModel(<any> formModel, { id: 'custom' });
 
         formComponent.form = formModel;
         expect(formComponent.onOutcomeClicked(outcome)).toBeFalsy();
 
-        outcome = new FormOutcomeModel(<any>formModel, { id: 'custom', name: 'Custom' });
+        outcome = new FormOutcomeModel(<any> formModel, { id: 'custom', name: 'Custom' });
         spyOn(formComponent, 'completeTaskForm').and.stub();
         expect(formComponent.onOutcomeClicked(outcome)).toBeTruthy();
     });
@@ -792,7 +792,7 @@ describe('FormCloudComponent', () => {
 
     it('should prevent default outcome execution', () => {
 
-        const outcome = new FormOutcomeModel(<any>new FormModel(), {
+        const outcome = new FormOutcomeModel(<any> new FormModel(), {
             id: FormCloudComponent.CUSTOM_OUTCOME_ID,
             name: 'Custom'
         });
@@ -809,7 +809,7 @@ describe('FormCloudComponent', () => {
     });
 
     it('should not prevent default outcome execution', () => {
-        const outcome = new FormOutcomeModel(<any>new FormModel(), {
+        const outcome = new FormOutcomeModel(<any> new FormModel(), {
             id: FormCloudComponent.CUSTOM_OUTCOME_ID,
             name: 'Custom'
         });
@@ -837,7 +837,7 @@ describe('FormCloudComponent', () => {
         formComponent.checkVisibility(field);
         expect(visibilityService.refreshVisibility).not.toHaveBeenCalled();
 
-        field = new FormFieldModel(<any>new FormModel());
+        field = new FormFieldModel(<any> new FormModel());
         formComponent.checkVisibility(field);
         expect(visibilityService.refreshVisibility).toHaveBeenCalledWith(field.form);
     });
@@ -847,7 +847,7 @@ describe('FormCloudComponent', () => {
         formModel.readOnly = true;
         formComponent.form = formModel;
 
-        const outcome = new FormOutcomeModel(<any>new FormModel(), {
+        const outcome = new FormOutcomeModel(<any> new FormModel(), {
             id: FormCloudComponent.CUSTOM_OUTCOME_ID,
             name: 'Custom'
         });
@@ -917,7 +917,7 @@ describe('FormCloudComponent', () => {
             done();
         });
 
-        const outcome = new FormOutcomeModel(<any>new FormModel(), {
+        const outcome = new FormOutcomeModel(<any> new FormModel(), {
             id: FormCloudComponent.CUSTOM_OUTCOME_ID,
             name: 'Custom'
         });

--- a/lib/process-services-cloud/src/lib/group/components/group-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/group/components/group-cloud.component.spec.ts
@@ -27,7 +27,7 @@ import {
     IdentityGroupService,
     mockIdentityGroups,
     AlfrescoApiService,
-    CoreModule
+    CoreTestingModule
 } from '@alfresco/adf-core';
 import { SimpleChange } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
@@ -53,7 +53,7 @@ describe('GroupCloudComponent', () => {
     setupTestBed({
         imports: [
             TranslateModule.forRoot(),
-            CoreModule.forRoot(),
+            CoreTestingModule,
             ProcessServiceCloudTestingModule,
             GroupCloudModule
         ]

--- a/lib/process-services-cloud/src/lib/people/components/people-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/people/components/people-cloud.component.spec.ts
@@ -20,9 +20,9 @@ import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import {
     IdentityUserService,
     AlfrescoApiService,
-    CoreModule,
     setupTestBed,
-    IdentityUserModel
+    IdentityUserModel,
+    CoreTestingModule
 } from '@alfresco/adf-core';
 import { ProcessServiceCloudTestingModule } from '../../testing/process-service-cloud.testing.module';
 import { of } from 'rxjs';
@@ -58,7 +58,7 @@ describe('PeopleCloudComponent', () => {
     setupTestBed({
         imports: [
             TranslateModule.forRoot(),
-            CoreModule.forRoot(),
+            CoreTestingModule,
             ProcessServiceCloudTestingModule,
             PeopleCloudModule
         ]

--- a/lib/process-services/src/lib/content-widget/attach-file-widget-dialog.component.spec.ts
+++ b/lib/process-services/src/lib/content-widget/attach-file-widget-dialog.component.spec.ts
@@ -21,7 +21,7 @@ import { ContentModule, ContentNodeSelectorPanelComponent } from '@alfresco/adf-
 import { EventEmitter } from '@angular/core';
 import { ProcessTestingModule } from '../testing/process.testing.module';
 import { AttachFileWidgetDialogComponent } from './attach-file-widget-dialog.component';
-import { setupTestBed, AuthenticationService, SitesService, CoreModule } from '@alfresco/adf-core';
+import { setupTestBed, AuthenticationService, SitesService } from '@alfresco/adf-core';
 import { AttachFileWidgetDialogComponentData } from './attach-file-widget-dialog-component.interface';
 import { of } from 'rxjs';
 import { By } from '@angular/platform-browser';
@@ -47,7 +47,6 @@ describe('AttachFileWidgetDialogComponent', () => {
     setupTestBed({
         imports: [
             TranslateModule.forRoot(),
-            CoreModule.forRoot(),
             ProcessTestingModule,
             ContentModule.forRoot()
         ],
@@ -73,6 +72,7 @@ describe('AttachFileWidgetDialogComponent', () => {
     });
 
     it('should be able to create the widget', () => {
+        fixture.detectChanges();
         expect(widget).not.toBeNull();
     });
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-5158


**What is the new behaviour?**
This new directive allows component to hide when the app is not running the ACS version required for them to work properly. 

```html
<button *adf-ecm-version="'6.0.0'">
    My Action
</button>
```
This means this button will be present in the DOM tree from 6.0.0 onwards. Otherwise it will be removed to avoid the component breaking the app.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
