### PR TITLE
[ACA-3447] Cancel upload of new version removes existing version

### DIFF
--- a/lib/core/services/upload.service.spec.ts
+++ b/lib/core/services/upload.service.spec.ts
@@ -216,7 +216,7 @@ describe('UploadService', () => {
         });
     });
 
-    it('should let file\'s version complete and then delete node version if it\'s not safe to abort', (done) => {
+    it('should delete node\'s version when cancelling the upload of the new file version', (done) => {
         const emitter = new EventEmitter();
 
         const emitterDisposable = emitter.subscribe((event) => {

--- a/lib/core/services/upload.service.ts
+++ b/lib/core/services/upload.service.ts
@@ -52,25 +52,25 @@ export class UploadService {
     fileUpload: Subject<FileUploadEvent> = new Subject<FileUploadEvent>();
     fileUploadStarting: Subject<FileUploadEvent> = new Subject<
         FileUploadEvent
-        >();
+    >();
     fileUploadCancelled: Subject<FileUploadEvent> = new Subject<
         FileUploadEvent
-        >();
+    >();
     fileUploadProgress: Subject<FileUploadEvent> = new Subject<
         FileUploadEvent
-        >();
+    >();
     fileUploadAborted: Subject<FileUploadEvent> = new Subject<
         FileUploadEvent
-        >();
+    >();
     fileUploadError: Subject<FileUploadErrorEvent> = new Subject<
         FileUploadErrorEvent
-        >();
+    >();
     fileUploadComplete: Subject<FileUploadCompleteEvent> = new Subject<
         FileUploadCompleteEvent
-        >();
+    >();
     fileUploadDeleted: Subject<FileUploadDeleteEvent> = new Subject<
         FileUploadDeleteEvent
-        >();
+    >();
     fileDeleted: Subject<string> = new Subject<string>();
 
     constructor(protected apiService: AlfrescoApiService, private appConfigService: AppConfigService) {
@@ -286,7 +286,7 @@ export class UploadService {
                 } else {
                     this.onUploadComplete(file, data);
                     if (emitter) {
-                        emitter.emit({value: data});
+                        emitter.emit( {value: data} );
                     }
                 }
             })

--- a/lib/core/services/upload.service.ts
+++ b/lib/core/services/upload.service.ts
@@ -286,7 +286,7 @@ export class UploadService {
                 } else {
                     this.onUploadComplete(file, data);
                     if (emitter) {
-                        emitter.emit( {value: data} );
+                        emitter.emit({ value: data });
                     }
                 }
             })
@@ -405,7 +405,7 @@ export class UploadService {
     private deleteAbortedNode(nodeId: string) {
         this.apiService
             .getInstance()
-            .core.nodesApi.deleteNode(nodeId, {permanent: true})
+            .core.nodesApi.deleteNode(nodeId, { permanent: true })
             .then(() => (this.abortedFile = undefined));
     }
 

--- a/lib/core/services/upload.service.ts
+++ b/lib/core/services/upload.service.ts
@@ -50,13 +50,27 @@ export class UploadService {
 
     queueChanged: Subject<FileModel[]> = new Subject<FileModel[]>();
     fileUpload: Subject<FileUploadEvent> = new Subject<FileUploadEvent>();
-    fileUploadStarting: Subject<FileUploadEvent> = new Subject<FileUploadEvent>();
-    fileUploadCancelled: Subject<FileUploadEvent> = new Subject<FileUploadEvent>();
-    fileUploadProgress: Subject<FileUploadEvent> = new Subject<FileUploadEvent>();
-    fileUploadAborted: Subject<FileUploadEvent> = new Subject<FileUploadEvent>();
-    fileUploadError: Subject<FileUploadErrorEvent> = new Subject<FileUploadErrorEvent>();
-    fileUploadComplete: Subject<FileUploadCompleteEvent> = new Subject<FileUploadCompleteEvent>();
-    fileUploadDeleted: Subject<FileUploadDeleteEvent> = new Subject<FileUploadDeleteEvent>();
+    fileUploadStarting: Subject<FileUploadEvent> = new Subject<
+        FileUploadEvent
+        >();
+    fileUploadCancelled: Subject<FileUploadEvent> = new Subject<
+        FileUploadEvent
+        >();
+    fileUploadProgress: Subject<FileUploadEvent> = new Subject<
+        FileUploadEvent
+        >();
+    fileUploadAborted: Subject<FileUploadEvent> = new Subject<
+        FileUploadEvent
+        >();
+    fileUploadError: Subject<FileUploadErrorEvent> = new Subject<
+        FileUploadErrorEvent
+        >();
+    fileUploadComplete: Subject<FileUploadCompleteEvent> = new Subject<
+        FileUploadCompleteEvent
+        >();
+    fileUploadDeleted: Subject<FileUploadDeleteEvent> = new Subject<
+        FileUploadDeleteEvent
+        >();
     fileDeleted: Subject<string> = new Subject<string>();
 
     constructor(protected apiService: AlfrescoApiService, private appConfigService: AppConfigService) {
@@ -249,13 +263,13 @@ export class UploadService {
             .on('abort', () => {
                 this.onUploadAborted(file);
                 if (emitter) {
-                    emitter.emit({value: 'File aborted'});
+                    emitter.emit({ value: 'File aborted' });
                 }
             })
             .on('error', (err) => {
                 this.onUploadError(file, err);
                 if (emitter) {
-                    emitter.emit({value: 'Error file uploaded'});
+                    emitter.emit({ value: 'Error file uploaded' });
                 }
             })
             .on('success', (data) => {
@@ -267,7 +281,7 @@ export class UploadService {
                         this.deleteAbortedNodeVersion(data.entry.id, data.entry.properties['cm:versionLabel']);
                     }
                     if (emitter) {
-                        emitter.emit({value: 'File deleted'});
+                        emitter.emit({ value: 'File deleted' });
                     }
                 } else {
                     this.onUploadComplete(file, data);
@@ -276,8 +290,7 @@ export class UploadService {
                     }
                 }
             })
-            .catch(() => {
-            });
+            .catch(() => {});
 
         return promise;
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://issues.alfresco.com/jira/browse/ACA-3447

When uploading a new version, if the upload is cancelled the existing document is being deleted. That is because we don't handle the case if the file si a node's version so we delete the whole node instead of the node's version in case.

**What is the new behaviour?**

Fixed the bug.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
