### PR TITLE
[ACA-3527] Add check to activeFilters update

### DIFF
--- a/lib/content-services/src/lib/search/search-header-query-builder.service.spec.ts
+++ b/lib/content-services/src/lib/search/search-header-query-builder.service.spec.ts
@@ -175,4 +175,30 @@ describe('SearchHeaderQueryBuilder', () => {
             'Filters are not as expected'
         );
     });
+
+    it('should not add duplicate column names in activeFilters', () => {
+        const activeFilter = 'FakeColumn';
+
+        const config: SearchConfiguration = {
+            categories: [
+                <any> { id: 'cat1', enabled: true }
+            ],
+            filterQueries: [
+                { query: 'PARENT:"workspace://SpacesStore/fake-node-id' }
+            ]
+        };
+
+        const searchHeaderService = new SearchHeaderQueryBuilderService(
+            buildConfig(config),
+            null,
+            null
+        );
+
+        expect(searchHeaderService.activeFilters.length).toBe(0);
+
+        searchHeaderService.setActiveFilter(activeFilter);
+        searchHeaderService.setActiveFilter(activeFilter);
+
+        expect(searchHeaderService.activeFilters.length).toBe(1);
+    });
 });

--- a/lib/content-services/src/lib/search/search-header-query-builder.service.ts
+++ b/lib/content-services/src/lib/search/search-header-query-builder.service.ts
@@ -54,7 +54,9 @@ export class SearchHeaderQueryBuilderService extends BaseQueryBuilderService {
     }
 
     setActiveFilter(columnActivated: string) {
-        this.activeFilters.push(columnActivated);
+        if (!this.activeFilters.includes(columnActivated)) {
+            this.activeFilters.push(columnActivated);
+        }
     }
 
     isNoFilterActive(): boolean {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
The search-header-service add duplicate column names inside the activeFilters array which disturb the clear behaviour of the search-header.


**What is the new behaviour?**
The search-header-service now check if a column name is present inside the activeFilters array to avoid duplicates and secure the clear behaviour.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ACA-3527