### PR TITLE
[ADF-5174] Add Permisssions Dialog to adf-testing Lib

### DIFF
--- a/e2e/content-services/permissions/permissions-component.e2e.ts
+++ b/e2e/content-services/permissions/permissions-component.e2e.ts
@@ -183,7 +183,7 @@ describe('Permissions Component', () => {
             await contentServicesPage.checkSelectedSiteIsDisplayed('My files');
             await contentList.rightClickOnRow(fileModel.name);
             await contentServicesPage.pressContextMenuActionNamed('Permission');
-            await permissionsPage.checkPermissionContainerIsDisplayed();
+            await permissionsPage.addPermissionsDialog.checkPermissionContainerIsDisplayed();
         });
 
         afterEach(async () => {
@@ -195,47 +195,47 @@ describe('Permissions Component', () => {
     });
 
         it('[C268974] Inherit Permission', async () => {
-            await permissionsPage.checkPermissionInheritedButtonIsDisplayed();
-            await expect(await permissionsPage.getPermissionInheritedButtonText()).toBe('Permission Inherited');
-            await permissionsPage.checkPermissionsDatatableIsDisplayed();
-            await permissionsPage.clickPermissionInheritedButton();
-            await expect(await permissionsPage.getPermissionInheritedButtonText()).toBe('Inherit Permission');
-            await permissionsPage.checkNoPermissionsIsDisplayed();
-            await permissionsPage.clickPermissionInheritedButton();
-            await expect(await permissionsPage.getPermissionInheritedButtonText()).toBe('Permission Inherited');
-            await permissionsPage.checkPermissionsDatatableIsDisplayed();
+            await permissionsPage.addPermissionsDialog.checkPermissionInheritedButtonIsDisplayed();
+            await expect(await permissionsPage.addPermissionsDialog.getPermissionInheritedButtonText()).toBe('Permission Inherited');
+            await permissionsPage.addPermissionsDialog.checkPermissionsDatatableIsDisplayed();
+            await permissionsPage.addPermissionsDialog.clickPermissionInheritedButton();
+            await expect(await permissionsPage.addPermissionsDialog.getPermissionInheritedButtonText()).toBe('Inherit Permission');
+            await permissionsPage.addPermissionsDialog.checkNoPermissionsIsDisplayed();
+            await permissionsPage.addPermissionsDialog.clickPermissionInheritedButton();
+            await expect(await permissionsPage.addPermissionsDialog.getPermissionInheritedButtonText()).toBe('Permission Inherited');
+            await permissionsPage.addPermissionsDialog.checkPermissionsDatatableIsDisplayed();
         });
 
         it('[C286272] Should be able to see results when searching for a user', async () => {
             await permissionsPage.checkAddPermissionButtonIsDisplayed();
-            await permissionsPage.clickAddPermissionButton();
-            await permissionsPage.checkAddPermissionDialogIsDisplayed();
-            await permissionsPage.checkSearchUserInputIsDisplayed();
-            await permissionsPage.searchUserOrGroup('a');
-            await permissionsPage.checkResultListIsDisplayed();
+            await permissionsPage.addPermissionsDialog.clickAddPermissionButton();
+            await permissionsPage.addPermissionsDialog.checkAddPermissionDialogIsDisplayed();
+            await permissionsPage.addPermissionsDialog.checkSearchUserInputIsDisplayed();
+            await permissionsPage.addPermissionsDialog.searchUserOrGroup('a');
+            await permissionsPage.addPermissionsDialog.checkResultListIsDisplayed();
         });
 
         it('[C276979] Should be able to give permissions to a group of people', async () => {
             await permissionsPage.checkAddPermissionButtonIsDisplayed();
-            await permissionsPage.clickAddPermissionButton();
-            await permissionsPage.checkAddPermissionDialogIsDisplayed();
-            await permissionsPage.checkSearchUserInputIsDisplayed();
-            await permissionsPage.searchUserOrGroup('GROUP_' + groupBody.id);
-            await permissionsPage.clickUserOrGroup('GROUP_' + groupBody.id);
-            await permissionsPage.checkUserOrGroupIsAdded('GROUP_' + groupBody.id);
+            await permissionsPage.addPermissionsDialog.clickAddPermissionButton();
+            await permissionsPage.addPermissionsDialog.checkAddPermissionDialogIsDisplayed();
+            await permissionsPage.addPermissionsDialog.checkSearchUserInputIsDisplayed();
+            await permissionsPage.addPermissionsDialog.searchUserOrGroup('GROUP_' + groupBody.id);
+            await permissionsPage.addPermissionsDialog.clickUserOrGroup('GROUP_' + groupBody.id);
+            await permissionsPage.addPermissionsDialog.checkUserOrGroupIsAdded('GROUP_' + groupBody.id);
         });
 
         it('[C277100] Should display EVERYONE group in the search result set', async () => {
             await permissionsPage.checkAddPermissionButtonIsDisplayed();
-            await permissionsPage.clickAddPermissionButton();
-            await permissionsPage.checkAddPermissionDialogIsDisplayed();
-            await permissionsPage.checkSearchUserInputIsDisplayed();
-            await permissionsPage.searchUserOrGroup(filePermissionUser.email);
-            await permissionsPage.checkResultListIsDisplayed();
-            await permissionsPage.checkUserOrGroupIsDisplayed('EVERYONE');
-            await permissionsPage.searchUserOrGroup('somerandomtext');
-            await permissionsPage.checkResultListIsDisplayed();
-            await permissionsPage.checkUserOrGroupIsDisplayed('EVERYONE');
+            await permissionsPage.addPermissionsDialog.clickAddPermissionButton();
+            await permissionsPage.addPermissionsDialog.checkAddPermissionDialogIsDisplayed();
+            await permissionsPage.addPermissionsDialog.checkSearchUserInputIsDisplayed();
+            await permissionsPage.addPermissionsDialog.searchUserOrGroup(filePermissionUser.email);
+            await permissionsPage.addPermissionsDialog.checkResultListIsDisplayed();
+            await permissionsPage.addPermissionsDialog.checkUserOrGroupIsDisplayed('EVERYONE');
+            await permissionsPage.addPermissionsDialog.searchUserOrGroup('somerandomtext');
+            await permissionsPage.addPermissionsDialog.checkResultListIsDisplayed();
+            await permissionsPage.addPermissionsDialog.checkUserOrGroupIsDisplayed('EVERYONE');
         });
    });
 
@@ -250,12 +250,12 @@ describe('Permissions Component', () => {
             await contentList.rightClickOnRow(fileModel.name);
             await contentServicesPage.pressContextMenuActionNamed('Permission');
             await permissionsPage.checkAddPermissionButtonIsDisplayed();
-            await permissionsPage.clickAddPermissionButton();
-            await permissionsPage.checkAddPermissionDialogIsDisplayed();
-            await permissionsPage.checkSearchUserInputIsDisplayed();
-            await permissionsPage.searchUserOrGroup(filePermissionUser.email);
-            await permissionsPage.clickUserOrGroup(filePermissionUser.firstName);
-            await permissionsPage.checkUserOrGroupIsAdded(filePermissionUser.email);
+            await permissionsPage.addPermissionsDialog.clickAddPermissionButton();
+            await permissionsPage.addPermissionsDialog.checkAddPermissionDialogIsDisplayed();
+            await permissionsPage.addPermissionsDialog.checkSearchUserInputIsDisplayed();
+            await permissionsPage.addPermissionsDialog.searchUserOrGroup(filePermissionUser.email);
+            await permissionsPage.addPermissionsDialog.clickUserOrGroup(filePermissionUser.firstName);
+            await permissionsPage.addPermissionsDialog.checkUserOrGroupIsAdded(filePermissionUser.email);
         });
 
         afterEach(async () => {
@@ -263,43 +263,43 @@ describe('Permissions Component', () => {
         });
 
         it('[C274691] Should be able to add a new User with permission to the file and also change locally set permissions', async () => {
-            await expect(await permissionsPage.getRoleCellValue(filePermissionUser.email)).toEqual('Contributor');
-            await permissionsPage.clickRoleDropdownByUserOrGroupName(filePermissionUser.email);
-            const roleDropdownOptions = permissionsPage.getRoleDropdownOptions();
+            await expect(await permissionsPage.addPermissionsDialog.getRoleCellValue(filePermissionUser.email)).toEqual('Contributor');
+            await permissionsPage.addPermissionsDialog.clickRoleDropdownByUserOrGroupName(filePermissionUser.email);
+            const roleDropdownOptions = permissionsPage.addPermissionsDialog.getRoleDropdownOptions();
             await expect(await roleDropdownOptions.count()).toBe(5);
             await expect(await BrowserActions.getText(roleDropdownOptions.get(0))).toBe('Contributor');
             await expect(await BrowserActions.getText(roleDropdownOptions.get(1))).toBe('Collaborator');
             await expect(await BrowserActions.getText(roleDropdownOptions.get(2))).toBe('Coordinator');
             await expect(await BrowserActions.getText(roleDropdownOptions.get(3))).toBe('Editor');
             await expect(await BrowserActions.getText(roleDropdownOptions.get(4))).toBe('Consumer');
-            await permissionsPage.selectOption('Collaborator');
-            await expect(await permissionsPage.getRoleCellValue(filePermissionUser.email)).toEqual('Collaborator');
-            await permissionsPage.clickRoleDropdownByUserOrGroupName(filePermissionUser.email);
-            await permissionsPage.selectOption('Coordinator');
-            await expect(await permissionsPage.getRoleCellValue(filePermissionUser.email)).toEqual('Coordinator');
-            await permissionsPage.clickRoleDropdownByUserOrGroupName(filePermissionUser.email);
-            await permissionsPage.selectOption('Editor');
-            await expect(await permissionsPage.getRoleCellValue(filePermissionUser.email)).toEqual('Editor');
-            await permissionsPage.clickRoleDropdownByUserOrGroupName(filePermissionUser.email);
-            await permissionsPage.selectOption('Consumer');
-            await expect(await permissionsPage.getRoleCellValue(filePermissionUser.email)).toEqual('Consumer');
+            await permissionsPage.addPermissionsDialog.selectOption('Collaborator');
+            await expect(await permissionsPage.addPermissionsDialog.getRoleCellValue(filePermissionUser.email)).toEqual('Collaborator');
+            await permissionsPage.addPermissionsDialog.clickRoleDropdownByUserOrGroupName(filePermissionUser.email);
+            await permissionsPage.addPermissionsDialog.selectOption('Coordinator');
+            await expect(await permissionsPage.addPermissionsDialog.getRoleCellValue(filePermissionUser.email)).toEqual('Coordinator');
+            await permissionsPage.addPermissionsDialog.clickRoleDropdownByUserOrGroupName(filePermissionUser.email);
+            await permissionsPage.addPermissionsDialog.selectOption('Editor');
+            await expect(await permissionsPage.addPermissionsDialog.getRoleCellValue(filePermissionUser.email)).toEqual('Editor');
+            await permissionsPage.addPermissionsDialog.clickRoleDropdownByUserOrGroupName(filePermissionUser.email);
+            await permissionsPage.addPermissionsDialog.selectOption('Consumer');
+            await expect(await permissionsPage.addPermissionsDialog.getRoleCellValue(filePermissionUser.email)).toEqual('Consumer');
         });
 
         it('[C276980] Should not be able to duplicate User or Group to the locally set permissions', async () => {
-            await expect(await permissionsPage.getRoleCellValue(filePermissionUser.email)).toEqual('Contributor');
-            await permissionsPage.clickAddPermissionButton();
-            await permissionsPage.checkAddPermissionDialogIsDisplayed();
-            await permissionsPage.checkSearchUserInputIsDisplayed();
-            await permissionsPage.searchUserOrGroup(filePermissionUser.email);
-            await permissionsPage.clickUserOrGroup(filePermissionUser.firstName);
+            await expect(await permissionsPage.addPermissionsDialog.getRoleCellValue(filePermissionUser.email)).toEqual('Contributor');
+            await permissionsPage.addPermissionsDialog.clickAddPermissionButton();
+            await permissionsPage.addPermissionsDialog.checkAddPermissionDialogIsDisplayed();
+            await permissionsPage.addPermissionsDialog.checkSearchUserInputIsDisplayed();
+            await permissionsPage.addPermissionsDialog.searchUserOrGroup(filePermissionUser.email);
+            await permissionsPage.addPermissionsDialog.clickUserOrGroup(filePermissionUser.firstName);
 
             await notificationHistoryPage.checkNotifyContains(duplicateUserPermissionMessage);
         });
 
         it('[C276982] Should be able to remove User or Group from the locally set permissions', async () => {
-            await expect(await permissionsPage.getRoleCellValue(filePermissionUser.email)).toEqual('Contributor');
-            await permissionsPage.clickDeletePermissionButton();
-            await permissionsPage.checkUserOrGroupIsDeleted(filePermissionUser.email);
+            await expect(await permissionsPage.addPermissionsDialog.getRoleCellValue(filePermissionUser.email)).toEqual('Contributor');
+            await permissionsPage.addPermissionsDialog.clickDeletePermissionButton();
+            await permissionsPage.addPermissionsDialog.checkUserOrGroupIsDeleted(filePermissionUser.email);
         });
    });
 
@@ -420,11 +420,11 @@ describe('Permissions Component', () => {
             await contentServicesPage.checkSelectedSiteIsDisplayed('My files');
             await contentList.rightClickOnRow('RoleConsumer' + fileModel.name);
             await contentServicesPage.pressContextMenuActionNamed('Permission');
-            await permissionsPage.checkPermissionInheritedButtonIsDisplayed();
+            await permissionsPage.addPermissionsDialog.checkPermissionInheritedButtonIsDisplayed();
             await permissionsPage.checkAddPermissionButtonIsDisplayed();
-            await permissionsPage.clickPermissionInheritedButton();
+            await permissionsPage.addPermissionsDialog.clickPermissionInheritedButton();
             await notificationHistoryPage.checkNotifyContains('You are not allowed to change permissions');
-            await permissionsPage.clickAddPermissionButton();
+            await permissionsPage.addPermissionsDialog.clickAddPermissionButton();
             await notificationHistoryPage.checkNotifyContains('You are not allowed to change permissions');
         });
    });

--- a/e2e/content-services/permissions/site-permissions.e2e.ts
+++ b/e2e/content-services/permissions/site-permissions.e2e.ts
@@ -172,25 +172,25 @@ describe('Permissions Component', () => {
 
             await contentServicesPage.pressContextMenuActionNamed('Permission');
 
-            await permissionsPage.checkPermissionInheritedButtonIsDisplayed();
+            await permissionsPage.addPermissionsDialog.checkPermissionInheritedButtonIsDisplayed();
             await permissionsPage.checkAddPermissionButtonIsDisplayed();
 
             await browser.sleep(5000);
 
-            await permissionsPage.clickAddPermissionButton();
-            await permissionsPage.checkAddPermissionDialogIsDisplayed();
-            await permissionsPage.checkSearchUserInputIsDisplayed();
+            await permissionsPage.addPermissionsDialog.clickAddPermissionButton();
+            await permissionsPage.addPermissionsDialog.checkAddPermissionDialogIsDisplayed();
+            await permissionsPage.addPermissionsDialog.checkSearchUserInputIsDisplayed();
 
-            await permissionsPage.searchUserOrGroup(consumerUser.email);
+            await permissionsPage.addPermissionsDialog.searchUserOrGroup(consumerUser.email);
 
-            await permissionsPage.clickUserOrGroup(consumerUser.firstName);
-            await permissionsPage.checkUserOrGroupIsAdded(consumerUser.email);
+            await permissionsPage.addPermissionsDialog.clickUserOrGroup(consumerUser.firstName);
+            await permissionsPage.addPermissionsDialog.checkUserOrGroupIsAdded(consumerUser.email);
 
-            await expect(await permissionsPage.getRoleCellValue(consumerUser.email)).toEqual('SiteCollaborator');
+            await expect(await permissionsPage.addPermissionsDialog.getRoleCellValue(consumerUser.email)).toEqual('SiteCollaborator');
 
-            await permissionsPage.clickRoleDropdownByUserOrGroupName(consumerUser.email);
+            await permissionsPage.addPermissionsDialog.clickRoleDropdownByUserOrGroupName(consumerUser.email);
 
-            const roleDropdownOptions = permissionsPage.getRoleDropdownOptions();
+            const roleDropdownOptions = permissionsPage.addPermissionsDialog.getRoleDropdownOptions();
 
             await expect(await roleDropdownOptions.count()).toBe(4);
             await expect(await BrowserActions.getText(roleDropdownOptions.get(0))).toBe(CONSTANTS.CS_USER_ROLES.COLLABORATOR);

--- a/e2e/pages/adf/permissions.page.ts
+++ b/e2e/pages/adf/permissions.page.ts
@@ -28,7 +28,7 @@ export class PermissionsPage {
     addPermissionsDialog: AddPermissionsDialogPage = new AddPermissionsDialogPage();
 
     addPermissionButton = element(by.css('button[data-automation-id="adf-add-permission-button"]'));
-    
+
     async checkAddPermissionButtonIsDisplayed(): Promise<void> {
         await BrowserVisibility.waitUntilElementIsVisible(this.addPermissionButton);
     }

--- a/e2e/pages/adf/permissions.page.ts
+++ b/e2e/pages/adf/permissions.page.ts
@@ -15,120 +15,21 @@
  * limitations under the License.
  */
 
-import { BrowserActions, BrowserVisibility, DataTableComponentPage, DropdownPage } from '@alfresco/adf-testing';
+import {
+    DataTableComponentPage,
+    AddPermissionsDialogPage,
+    BrowserVisibility
+} from '@alfresco/adf-testing';
 import { by, element } from 'protractor';
-
-const column = {
-    role: 'Role'
-};
 
 export class PermissionsPage {
 
     dataTableComponentPage: DataTableComponentPage = new DataTableComponentPage();
+    addPermissionsDialog: AddPermissionsDialogPage = new AddPermissionsDialogPage();
 
-    addPermissionButton = element(by.css("button[data-automation-id='adf-add-permission-button']"));
-    addPermissionDialog = element(by.css('adf-add-permission-dialog'));
-    searchUserInput = element(by.id('searchInput'));
-    searchResults = element(by.css('#adf-add-permission-authority-results #adf-search-results-content'));
-    addButton = element(by.id('add-permission-dialog-confirm-button'));
-    permissionInheritedButton = element.all(by.css("div[class='app-inherit_permission_button'] button")).first();
-    noPermissions = element(by.css('div[id="adf-no-permissions-template"]'));
-    deletePermissionButton = element(by.css(`button[data-automation-id='adf-delete-permission-button']`));
-    permissionDisplayContainer = element(by.css(`div[id='adf-permission-display-container']`));
-    closeButton = element(by.id('add-permission-dialog-close-button'));
-
-    async clickCloseButton(): Promise<void> {
-        await BrowserActions.click(this.closeButton);
-    }
-
+    addPermissionButton = element(by.css('button[data-automation-id="adf-add-permission-button"]'));
+    
     async checkAddPermissionButtonIsDisplayed(): Promise<void> {
         await BrowserVisibility.waitUntilElementIsVisible(this.addPermissionButton);
-    }
-
-    async clickAddPermissionButton(): Promise<void> {
-        await BrowserActions.clickExecuteScript('button[data-automation-id="adf-add-permission-button"]');
-    }
-
-    async checkAddPermissionDialogIsDisplayed() {
-        await BrowserVisibility.waitUntilElementIsVisible(this.addPermissionDialog);
-    }
-
-    async checkSearchUserInputIsDisplayed(): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.searchUserInput);
-    }
-
-    async searchUserOrGroup(name: string): Promise<void> {
-        await BrowserActions.clearSendKeys(this.searchUserInput, name);
-    }
-
-    async checkResultListIsDisplayed(): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.searchResults);
-    }
-
-    async clickUserOrGroup(name: string): Promise<void> {
-        const userOrGroupName = element(by.cssContainingText('mat-list-option .mat-list-text', name));
-        await BrowserActions.clickScript(userOrGroupName);
-        await BrowserActions.click(this.addButton);
-    }
-
-    async checkUserOrGroupIsAdded(name: string): Promise<void> {
-        const userOrGroupName = element(by.css('div[data-automation-id="text_' + name + '"]'));
-        await BrowserVisibility.waitUntilElementIsVisible(userOrGroupName);
-    }
-
-    async checkUserOrGroupIsDeleted(name: string): Promise<void> {
-        const userOrGroupName = element(by.css('div[data-automation-id="text_' + name + '"]'));
-        await BrowserVisibility.waitUntilElementIsNotVisible(userOrGroupName);
-    }
-
-    async checkPermissionInheritedButtonIsDisplayed() {
-        await BrowserVisibility.waitUntilElementIsVisible(this.permissionInheritedButton);
-    }
-
-    async clickPermissionInheritedButton(): Promise<void> {
-        await BrowserActions.click(this.permissionInheritedButton);
-    }
-
-    async clickDeletePermissionButton(): Promise<void> {
-        await BrowserActions.click(this.deletePermissionButton);
-    }
-
-    async checkNoPermissionsIsDisplayed(): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.noPermissions);
-    }
-
-    async getPermissionInheritedButtonText(): Promise<string> {
-        return BrowserActions.getText(this.permissionInheritedButton);
-    }
-
-    async checkPermissionsDatatableIsDisplayed(): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(element(by.css('[class*="adf-datatable-permission"]')));
-    }
-
-    async getRoleCellValue(rowName: string): Promise<string> {
-        const locator = this.dataTableComponentPage.getCellByRowContentAndColumn('Authority ID', rowName, column.role);
-        return BrowserActions.getText(locator);
-    }
-
-    async clickRoleDropdownByUserOrGroupName(name: string): Promise<void> {
-        const row = this.dataTableComponentPage.getRow('Authority ID', name);
-        await BrowserActions.click(row.element(by.id('adf-select-role-permission')));
-    }
-
-    getRoleDropdownOptions() {
-        return element.all(by.css('.mat-option-text'));
-    }
-
-    async selectOption(name: string): Promise<void> {
-        await new DropdownPage().selectOption(name);
-    }
-
-    async checkPermissionContainerIsDisplayed(): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.permissionDisplayContainer);
-    }
-
-    async checkUserOrGroupIsDisplayed(name: string): Promise<void> {
-        const userOrGroupName = element(by.cssContainingText('mat-list-option .mat-list-text', name));
-        await BrowserVisibility.waitUntilElementIsVisible(userOrGroupName);
     }
 }

--- a/lib/testing/src/lib/content-services/dialog/add-permissions-dialog.page.ts
+++ b/lib/testing/src/lib/content-services/dialog/add-permissions-dialog.page.ts
@@ -1,0 +1,132 @@
+/*!
+ * @license
+ * Copyright 2019 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { by, element } from 'protractor';
+import { BrowserActions } from '../../core/utils/browser-actions';
+import { DataTableComponentPage } from '../../core/pages/data-table-component.page';
+import { BrowserVisibility } from '../../core/utils/browser-visibility';
+import { DropdownPage } from '../../core/pages/material/dropdown.page';
+
+const column = {
+    role: 'Role'
+};
+
+export class AddPermissionsDialogPage {
+
+    dataTableComponentPage: DataTableComponentPage = new DataTableComponentPage();
+
+    addPermissionDialog = element(by.css('adf-add-permission-dialog'));
+    searchUserInput = element(by.id('searchInput'));
+    searchResults = element(by.css('#adf-add-permission-authority-results #adf-search-results-content'));
+    addButton = element(by.id('add-permission-dialog-confirm-button'));
+    permissionInheritedButton = element.all(by.css('div[class="app-inherit_permission_button"] button')).first();
+    noPermissions = element(by.id('adf-no-permissions-template'));
+    deletePermissionButton = element(by.css('button[data-automation-id="adf-delete-permission-button"]'));
+    permissionDisplayContainer = element(by.id('adf-permission-display-container'));
+    closeButton = element(by.id('add-permission-dialog-close-button'));
+
+    async clickCloseButton(): Promise<void> {
+        await BrowserActions.click(this.closeButton);
+    }
+
+    async clickAddPermissionButton(): Promise<void> {
+        await BrowserActions.clickExecuteScript('button[data-automation-id="adf-add-permission-button"]');
+    }
+
+    async checkAddPermissionDialogIsDisplayed() {
+        await BrowserVisibility.waitUntilElementIsVisible(this.addPermissionDialog);
+    }
+
+    async checkSearchUserInputIsDisplayed(): Promise<void> {
+        await BrowserVisibility.waitUntilElementIsVisible(this.searchUserInput);
+    }
+
+    async searchUserOrGroup(name: string): Promise<void> {
+        await BrowserActions.clearSendKeys(this.searchUserInput, name);
+    }
+
+    async checkResultListIsDisplayed(): Promise<void> {
+        await BrowserVisibility.waitUntilElementIsVisible(this.searchResults);
+    }
+
+    async clickUserOrGroup(name: string): Promise<void> {
+        const userOrGroupName = element(by.cssContainingText('mat-list-option .mat-list-text', name));
+        await BrowserActions.clickScript(userOrGroupName);
+        await BrowserActions.click(this.addButton);
+    }
+
+    async checkUserOrGroupIsAdded(name: string): Promise<void> {
+        const userOrGroupName = element(by.css('div[data-automation-id="text_' + name + '"]'));
+        await BrowserVisibility.waitUntilElementIsVisible(userOrGroupName);
+    }
+
+    async checkUserOrGroupIsDeleted(name: string): Promise<void> {
+        const userOrGroupName = element(by.css('div[data-automation-id="text_' + name + '"]'));
+        await BrowserVisibility.waitUntilElementIsNotVisible(userOrGroupName);
+    }
+
+    async checkPermissionInheritedButtonIsDisplayed() {
+        await BrowserVisibility.waitUntilElementIsVisible(this.permissionInheritedButton);
+    }
+
+    async clickPermissionInheritedButton(): Promise<void> {
+        await BrowserActions.click(this.permissionInheritedButton);
+    }
+
+    async clickDeletePermissionButton(): Promise<void> {
+        await BrowserActions.click(this.deletePermissionButton);
+    }
+
+    async checkNoPermissionsIsDisplayed(): Promise<void> {
+        await BrowserVisibility.waitUntilElementIsVisible(this.noPermissions);
+    }
+
+    async getPermissionInheritedButtonText(): Promise<string> {
+        return BrowserActions.getText(this.permissionInheritedButton);
+    }
+
+    async checkPermissionsDatatableIsDisplayed(): Promise<void> {
+        await BrowserVisibility.waitUntilElementIsVisible(element(by.css('[class*="adf-datatable-permission"]')));
+    }
+
+    async getRoleCellValue(rowName: string): Promise<string> {
+        const locator = this.dataTableComponentPage.getCellByRowContentAndColumn('Authority ID', rowName, column.role);
+        return BrowserActions.getText(locator);
+    }
+
+    async clickRoleDropdownByUserOrGroupName(name: string): Promise<void> {
+        const row = this.dataTableComponentPage.getRow('Authority ID', name);
+        await BrowserActions.click(row.element(by.id('adf-select-role-permission')));
+    }
+
+    getRoleDropdownOptions() {
+        return element.all(by.css('.mat-option-text'));
+    }
+
+    async selectOption(name: string): Promise<void> {
+        await new DropdownPage().selectOption(name);
+    }
+
+    async checkPermissionContainerIsDisplayed(): Promise<void> {
+        await BrowserVisibility.waitUntilElementIsVisible(this.permissionDisplayContainer);
+    }
+
+    async checkUserOrGroupIsDisplayed(name: string): Promise<void> {
+        const userOrGroupName = element(by.cssContainingText('mat-list-option .mat-list-text', name));
+        await BrowserVisibility.waitUntilElementIsVisible(userOrGroupName);
+    }
+}

--- a/lib/testing/src/lib/content-services/dialog/public-api.ts
+++ b/lib/testing/src/lib/content-services/dialog/public-api.ts
@@ -16,4 +16,5 @@
  */
 
 export * from './content-node-selector-dialog.page';
+export * from './add-permissions-dialog.page';
 export * from './download-dialog.page';


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-5174


**What is the new behaviour?**
We need to expose the Add Permissions Dialog Page in the adf-testing package so that we don't duplicate all this component's selectors on ADW when testing libraries and library member.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
