### PR TITLE
[AAE-2972] Add password visibility to login sso page

### DIFF
--- a/lib/testing/src/lib/core/pages/login-sso.page.ts
+++ b/lib/testing/src/lib/core/pages/login-sso.page.ts
@@ -30,7 +30,6 @@ export class LoginSSOPage {
     header = element(by.tagName('adf-layout-header'));
     loginError = element(by.css(`div[data-automation-id="login-error"]`));
     visibilityLabel = element(by.id('v'));
-    visibilityLabelImg = element(by.id('vi'));
 
     txtUsernameBasicAuth = element(by.css('input[id="username"]'));
     txtPasswordBasicAuth = element(by.css('input[id="password"]'));
@@ -136,7 +135,7 @@ export class LoginSSOPage {
 
     async displayPassword(): Promise<void> {
         await BrowserActions.click(this.visibilityLabel);
-        const passwordInputTypeText = element(by.css(`"input[name='password'][type='text']"`));
+        const passwordInputTypeText = element(by.css(`input[name="password"][type="text"]`));
         await BrowserVisibility.waitUntilElementIsVisible(passwordInputTypeText);
     }
 

--- a/lib/testing/src/lib/core/pages/login-sso.page.ts
+++ b/lib/testing/src/lib/core/pages/login-sso.page.ts
@@ -135,19 +135,9 @@ export class LoginSSOPage {
     }
 
     async displayPassword(): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.visibilityLabelImg);
-        await BrowserVisibility.waitUntilElementIsVisible(this.passwordField);
-        let imageSource = await this.visibilityLabelImg.getAttribute('src');
-        await expect(imageSource.split('/').pop()).toBe('eye-off.png',
-            'Password visibility image should be disabled');
-        await expect(await this.passwordField.getAttribute('type')).toBe('password',
-            'Password input should be password type');
         await BrowserActions.click(this.visibilityLabel);
-        imageSource = imageSource.replace('eye-off.png', 'eye.png');
-        const visibilityLabelImgEnabled = element(by.css(`img[src="${imageSource}"]`));
-        await BrowserVisibility.waitUntilElementIsVisible(visibilityLabelImgEnabled);
-        await expect(await this.passwordField.getAttribute('type')).toBe('text',
-            'Password input should be text type');
+        const passwordInputTypeText = element(by.css(`"input[name='password'][type='text']"`));
+        await BrowserVisibility.waitUntilElementIsVisible(passwordInputTypeText);
     }
 
 }

--- a/lib/testing/src/lib/core/pages/login-sso.page.ts
+++ b/lib/testing/src/lib/core/pages/login-sso.page.ts
@@ -29,6 +29,8 @@ export class LoginSSOPage {
     loginButton = element(by.css('input[type="submit"]'));
     header = element(by.tagName('adf-layout-header'));
     loginError = element(by.css(`div[data-automation-id="login-error"]`));
+    visibilityLabel = element(by.id('v'));
+    visibilityLabelImg = element(by.id('vi'));
 
     txtUsernameBasicAuth = element(by.css('input[id="username"]'));
     txtPasswordBasicAuth = element(by.css('input[id="password"]'));
@@ -77,6 +79,7 @@ export class LoginSSOPage {
         }
 
         await BrowserVisibility.waitUntilElementIsVisible(this.usernameField);
+        await this.displayPassword();
         await this.enterUsername(username);
         await this.enterPassword(password);
         await this.clickLoginButton();
@@ -129,6 +132,22 @@ export class LoginSSOPage {
 
     async getLoginErrorMessage() {
         return BrowserActions.getText(this.loginError);
+    }
+
+    async displayPassword(): Promise<void> {
+        await BrowserVisibility.waitUntilElementIsVisible(this.visibilityLabelImg);
+        await BrowserVisibility.waitUntilElementIsVisible(this.passwordField);
+        let imageSource = await this.visibilityLabelImg.getAttribute('src');
+        await expect(imageSource.split('/').pop()).toBe('eye-off.png',
+            'Password visibility image should be disabled');
+        await expect(await this.passwordField.getAttribute('type')).toBe('password',
+            'Password input should be password type');
+        await BrowserActions.click(this.visibilityLabel);
+        imageSource = imageSource.replace('eye-off.png', 'eye.png');
+        const visibilityLabelImgEnabled = element(by.css(`img[src="${imageSource}"]`));
+        await BrowserVisibility.waitUntilElementIsVisible(visibilityLabelImgEnabled);
+        await expect(await this.passwordField.getAttribute('type')).toBe('text',
+            'Password input should be text type');
     }
 
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [X] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
The login page for e2e tests fails randomly


**What is the new behaviour?**
Add password visibility to let the screenshots detect any possible bug when filling


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
