### PR TITLE
[ADF-5175] - perform the search when at least one filter is active

### DIFF
--- a/lib/content-services/src/lib/search/components/search-header/search-header.component.spec.ts
+++ b/lib/content-services/src/lib/search/components/search-header/search-header.component.spec.ts
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Subject, Subscription } from 'rxjs';
+import { Subject } from 'rxjs';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TranslateModule } from '@ngx-translate/core';
 import { SearchService, setupTestBed, AlfrescoApiService } from '@alfresco/adf-core';

--- a/lib/content-services/src/lib/search/components/search-header/search-header.component.spec.ts
+++ b/lib/content-services/src/lib/search/components/search-header/search-header.component.spec.ts
@@ -47,7 +47,6 @@ describe('SearchHeaderComponent', () => {
     let component: SearchHeaderComponent;
     let queryBuilder: SearchHeaderQueryBuilderService;
     let alfrescoApiService: AlfrescoApiService;
-    let eventSub: Subscription;
 
     const searchMock: any = {
         dataLoaded: new Subject()
@@ -75,7 +74,6 @@ describe('SearchHeaderComponent', () => {
     });
 
     afterEach(() => {
-        eventSub.unsubscribe();
         fixture.destroy();
     });
 
@@ -89,7 +87,7 @@ describe('SearchHeaderComponent', () => {
     it('should emit the node paging received from the queryBuilder after the filter gets applied', async (done) => {
         spyOn(alfrescoApiService.searchApi, 'search').and.returnValue(Promise.resolve(fakeNodePaging));
         spyOn(queryBuilder, 'buildQuery').and.returnValue({});
-        eventSub = component.update.subscribe((newNodePaging) => {
+        component.update.subscribe((newNodePaging) => {
             expect(newNodePaging).toBe(fakeNodePaging);
             done();
         });
@@ -107,7 +105,7 @@ describe('SearchHeaderComponent', () => {
     it('should execute a new query when the page size is changed', async (done) => {
         spyOn(alfrescoApiService.searchApi, 'search').and.returnValue(Promise.resolve(fakeNodePaging));
         spyOn(queryBuilder, 'buildQuery').and.returnValue({});
-        eventSub = component.update.subscribe((newNodePaging) => {
+        component.update.subscribe((newNodePaging) => {
             expect(newNodePaging).toBe(fakeNodePaging);
             done();
         });
@@ -121,7 +119,7 @@ describe('SearchHeaderComponent', () => {
     it('should execute a new query when a new page is requested', async (done) => {
         spyOn(alfrescoApiService.searchApi, 'search').and.returnValue(Promise.resolve(fakeNodePaging));
         spyOn(queryBuilder, 'buildQuery').and.returnValue({});
-        eventSub = component.update.subscribe((newNodePaging) => {
+        component.update.subscribe((newNodePaging) => {
             expect(newNodePaging).toBe(fakeNodePaging);
             done();
         });
@@ -138,7 +136,7 @@ describe('SearchHeaderComponent', () => {
         spyOn(queryBuilder, 'buildQuery').and.returnValue({});
         spyOn(component.widgetContainer, 'resetInnerWidget').and.stub();
         const fakeEvent = jasmine.createSpyObj('event', ['stopPropagation']);
-        eventSub = component.clear.subscribe(() => {
+        component.clear.subscribe(() => {
             done();
         });
 
@@ -159,7 +157,7 @@ describe('SearchHeaderComponent', () => {
         spyOn(component.widgetContainer, 'resetInnerWidget').and.stub();
         const fakeEvent = jasmine.createSpyObj('event', ['stopPropagation']);
         const menuButton: HTMLButtonElement = fixture.nativeElement.querySelector('#filter-menu-button');
-        eventSub = component.update.subscribe((newNodePaging) => {
+        component.update.subscribe((newNodePaging) => {
             expect(newNodePaging).toBe(fakeNodePaging);
             done();
         });

--- a/lib/content-services/src/lib/search/components/search-header/search-header.component.ts
+++ b/lib/content-services/src/lib/search/components/search-header/search-header.component.ts
@@ -149,7 +149,11 @@ export class SearchHeaderComponent implements OnInit, OnChanges, OnDestroy {
         if (this.widgetContainer) {
             this.widgetContainer.resetInnerWidget();
             this.searchHeaderQueryBuilder.removeActiveFilter(this.category.columnKey);
-            this.clear.emit();
+            if (this.searchHeaderQueryBuilder.isNoFilterActive()) {
+                this.clear.emit();
+            } else {
+                this.searchHeaderQueryBuilder.execute();
+            }
         }
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
When clear is clicked all the filters are gone


**What is the new behaviour?**
When clear is clicked for a filter if there are any other filters active then a search is performed again.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-5175