### PR TITLE
[ADF-5177] Search-header execute when enter is pressed

### DIFF
--- a/lib/content-services/src/lib/search/components/search-header/search-header.component.html
+++ b/lib/content-services/src/lib/search/components/search-header/search-header.component.html
@@ -17,6 +17,7 @@
             <div (click)="onMenuClick($event)" class="adf-filter-container">
                 <div class="adf-filter-title">{{ 'SEARCH.SEARCH_HEADER.TITLE' | translate }}</div>
                 <adf-search-widget-container
+                    (keydown.enter)="onApply()"
                     [id]="category?.id"
                     [selector]="category?.component?.selector"
                     [settings]="category?.component?.settings">
@@ -28,7 +29,7 @@
                 </button>
                 <button mat-button color="primary"
                         id="apply-filter-button"
-                        class="adf-filter-apply-button" (click)="onApplyButtonClick()">
+                        class="adf-filter-apply-button" (click)="onApply()">
                         {{ 'SEARCH.SEARCH_HEADER.APPLY' | translate | uppercase }}
                 </button>
             </mat-dialog-actions>

--- a/lib/content-services/src/lib/search/components/search-header/search-header.component.spec.ts
+++ b/lib/content-services/src/lib/search/components/search-header/search-header.component.spec.ts
@@ -84,7 +84,7 @@ describe('SearchHeaderComponent', () => {
         expect(element).not.toBeUndefined();
     });
 
-    it('should emit the node paging received from the queryBuilder after the filter gets applied', async (done) => {
+    it('should emit the node paging received from the queryBuilder after the Apply button is clicked', async (done) => {
         spyOn(alfrescoApiService.searchApi, 'search').and.returnValue(Promise.resolve(fakeNodePaging));
         spyOn(queryBuilder, 'buildQuery').and.returnValue({});
         component.update.subscribe((newNodePaging) => {
@@ -98,6 +98,24 @@ describe('SearchHeaderComponent', () => {
         component.widgetContainer.componentRef.instance.value = 'searchText';
         const applyButton = fixture.debugElement.query(By.css('#apply-filter-button'));
         applyButton.triggerEventHandler('click', {});
+        fixture.detectChanges();
+        await fixture.whenStable();
+    });
+
+    it('should emit the node paging received from the queryBuilder after the Enter key is pressed', async (done) => {
+        spyOn(alfrescoApiService.searchApi, 'search').and.returnValue(Promise.resolve(fakeNodePaging));
+        spyOn(queryBuilder, 'buildQuery').and.returnValue({});
+        component.update.subscribe((newNodePaging) => {
+            expect(newNodePaging).toBe(fakeNodePaging);
+            done();
+        });
+        const menuButton: HTMLButtonElement = fixture.nativeElement.querySelector('#filter-menu-button');
+        menuButton.click();
+        fixture.detectChanges();
+        await fixture.whenStable();
+        component.widgetContainer.componentRef.instance.value = 'searchText';
+        const widgetContainer = fixture.debugElement.query(By.css('adf-search-widget-container'));
+        widgetContainer.triggerEventHandler('keydown.enter', {});
         fixture.detectChanges();
         await fixture.whenStable();
     });

--- a/lib/content-services/src/lib/search/components/search-header/search-header.component.ts
+++ b/lib/content-services/src/lib/search/components/search-header/search-header.component.ts
@@ -128,7 +128,7 @@ export class SearchHeaderComponent implements OnInit, OnChanges, OnDestroy {
         event.stopPropagation();
     }
 
-    onApplyButtonClick() {
+    onApply() {
         // TODO Move this piece of code in the search text widget
         if (this.widgetContainer.selector === 'text' && this.widgetContainer.componentRef.instance.value === '') {
             this.clearHeader();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
The search-header executes the search only when the "Apply" button is clicked.


**What is the new behaviour?**
The search-header executes the search also when the user press Enter while having the focus on the widget.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-5177