### PR TITLE
[ADF-5177] Pressing enter close filter menu

### DIFF
--- a/lib/content-services/src/lib/search/components/search-header/search-header.component.html
+++ b/lib/content-services/src/lib/search/components/search-header/search-header.component.html
@@ -20,7 +20,7 @@
                 <div (click)="$event.stopPropagation()" class="adf-filter-container">
                     <div class="adf-filter-title">{{ category?.name | translate }}</div>
                     <adf-search-widget-container
-                        (keydown.enter)="onEnterPressed()"
+                        (keypress)="onKeyPressed($event, menuTrigger)"
                         [id]="category?.id"
                         [selector]="category?.component?.selector"
                         [settings]="category?.component?.settings">

--- a/lib/content-services/src/lib/search/components/search-header/search-header.component.spec.ts
+++ b/lib/content-services/src/lib/search/components/search-header/search-header.component.spec.ts
@@ -116,7 +116,7 @@ describe('SearchHeaderComponent', () => {
         await fixture.whenStable();
         component.widgetContainer.componentRef.instance.value = 'searchText';
         const widgetContainer = fixture.debugElement.query(By.css('adf-search-widget-container'));
-        widgetContainer.triggerEventHandler('keydown.enter', {});
+        widgetContainer.triggerEventHandler('keypress', {key: 'Enter'});
         fixture.detectChanges();
         await fixture.whenStable();
     });

--- a/lib/content-services/src/lib/search/components/search-header/search-header.component.ts
+++ b/lib/content-services/src/lib/search/components/search-header/search-header.component.ts
@@ -38,6 +38,7 @@ import { SearchCategory } from '../../search-category.interface';
 import { SEARCH_QUERY_SERVICE_TOKEN } from '../../search-query-service.token';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
+import { MatMenuTrigger } from '@angular/material/menu';
 
 @Component({
     selector: 'adf-search-header',
@@ -127,9 +128,10 @@ export class SearchHeaderComponent implements OnInit, OnChanges, OnDestroy {
         this.onDestroy$.complete();
     }
 
-    onEnterPressed() {
-        if (this.widgetContainer.selector !== 'check-list') {
+    onKeyPressed(event: KeyboardEvent, menuTrigger: MatMenuTrigger) {
+        if (event.key === 'Enter' && this.widgetContainer.selector !== 'check-list') {
             this.onApply();
+            menuTrigger.closeMenu();
         }
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Pressing enter in the text input of a filter applies the filter but doesn't close the menu.


**What is the new behaviour?**
Pressing enter in the text input of a filter applies the filter and closes the menu.
NOTE: I used the "keypress" event and not "keyup.enter" or "keydown.enter" event because each one would mess with the accessibility of the filter. (keyup close directly the menu when you open it using enter on the menu trigger button and keydown simply doesn't work for closing a mat-menu)


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-5177