### PR TITLE
[ADF-5063] Add translate pipe to attach file/folder widget titles

### DIFF
--- a/lib/process-services/src/lib/content-widget/attach-file-widget.component.html
+++ b/lib/process-services/src/lib/content-widget/attach-file-widget.component.html
@@ -1,7 +1,7 @@
 <div class="adf-attach-widget {{field.className}}"
     [class.adf-invalid]="!field.isValid"
     [class.adf-readonly]="field.readOnly">
-    <label class="adf-label" [attr.for]="field.id">{{field.name}}
+    <label class="adf-label" [attr.for]="field.id">{{field.name | translate}}
         <span *ngIf="isRequired()">*</span>
     </label>
     <div class="adf-attach-widget-container">

--- a/lib/process-services/src/lib/content-widget/attach-folder-widget.component.html
+++ b/lib/process-services/src/lib/content-widget/attach-folder-widget.component.html
@@ -1,7 +1,7 @@
 <div class="adf-attach-folder-widget {{field.className}}"
      [class.adf-invalid]="!field.isValid"
      [class.adf-readonly]="field.readOnly">
-    <label class="adf-label" [attr.for]="field.id">{{field.name}}<span *ngIf="isRequired()">*</span></label>
+    <label class="adf-label" [attr.for]="field.id">{{field.name | translate}}<span *ngIf="isRequired()">*</span></label>
     <div class="adf-attach-folder-widget-container">
         <div *ngIf="hasFolder" class="adf-attach-folder-result">
             <mat-icon>folder</mat-icon>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
No translate pipe on attach file/folder widget titles.


**What is the new behaviour?**
Translate si applied to those widgets titles.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ADF-5063