### PR TITLE
[ACA-3499] Card View Textitem update on change

### DIFF
--- a/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.html
+++ b/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.html
@@ -14,8 +14,7 @@
                    class="adf-property-value"
                    [placeholder]="property.default"
                    [(ngModel)]="editedValue"
-                   (blur)="update()"
-                   (keydown.enter)="update()"
+                   (ngModelChange)="update()"
                    [disabled]="!isEditable"
                    (dblclick)="copyToClipboard(property.displayValue)"
                    matTooltipShowDelay="1000"
@@ -30,8 +29,7 @@
                       class="adf-property-value"
                       [placeholder]="property.default"
                       [(ngModel)]="editedValue"
-                      (blur)="update()"
-                      (keydown.enter)="update()"
+                      (ngModelChange)="update()"
                       [disabled]="!isEditable"
                       [attr.data-automation-id]="'card-textitem-value-' + property.key"></textarea>
             <button mat-button
@@ -104,8 +102,7 @@
                    [ngClass]="{ 'adf-textitem-clickable-value': !isEditable }"
                    [placeholder]="property.default"
                    [(ngModel)]="editedValue"
-                   (blur)="update()"
-                   (keydown.enter)="update()"
+                   (ngModelChange)="update()"
                    [disabled]="!isEditable"
                    [attr.data-automation-id]="'card-textitem-value-' + property.key">
             <button mat-icon-button

--- a/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
+++ b/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
@@ -736,7 +736,6 @@ describe('CardViewTextItemComponent', () => {
         const editInput = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-value-${key}"]`));
         editInput.nativeElement.value = value;
         editInput.nativeElement.dispatchEvent(new Event('input'));
-        editInput.nativeElement.dispatchEvent(new Event('blur'));
         fixture.detectChanges();
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
The Card View Textitem sends an update event only on blur or when enter is pressed.


**What is the new behaviour?**
The Card View Textitem sends an update event every time the value is changed.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ACA-3499
https://github.com/Alfresco/alfresco-content-app/issues/1460