### PR TITLE
[ACA-3506] - Filter are kept when reloaded

### DIFF
--- a/demo-shell/src/app.config.json
+++ b/demo-shell/src/app.config.json
@@ -460,7 +460,8 @@
             "pattern": "cm:name:'(.*?)'",
             "field": "cm:name",
             "placeholder": "SEARCH.SEARCH_HEADER.FILTERS.NAME.PLACEHOLDER",
-            "searchSuffix" : "*"
+            "searchSuffix" : "*",
+            "allowUpdateOnChange" : false
           }
         }
       },
@@ -473,6 +474,7 @@
           "selector": "check-list",
           "settings": {
             "pageSize": 5,
+            "allowUpdateOnChange" : false,
             "operator": "OR",
             "options": [
               {
@@ -495,6 +497,7 @@
         "component": {
           "selector": "check-list",
           "settings": {
+            "allowUpdateOnChange" : false,
             "options": [
               {
                 "name": "SEARCH.SEARCH_HEADER.FILTERS.SIZE.SMALL",
@@ -524,6 +527,7 @@
         "component": {
           "selector": "date-range",
           "settings": {
+            "allowUpdateOnChange" : false,
             "field": "cm:created",
             "dateFormat": "DD-MMM-YY",
             "maxDate": "today"

--- a/demo-shell/src/app/components/files/files.component.html
+++ b/demo-shell/src/app/components/files/files.component.html
@@ -240,11 +240,13 @@
                 <adf-custom-header-filter-template *ngIf="enableCustomHeaderFilter">
                     <ng-template let-col>
                         <adf-search-header [col]="col"
+                                           [value]="paramValues? paramValues[col.key] : 'SANDRO'"
                                            [currentFolderNodeId]="currentFolderId"
                                            [maxItems]="pagination?.maxItems"
                                            [skipCount]="pagination?.skipCount"
                                            (update)="onFilterUpdate($event)"
-                                           (clear)="onAllFilterCleared()">
+                                           (clear)="onAllFilterCleared()"
+                                           (selection)="onFilterSelected($event)">
                         </adf-search-header>
                     </ng-template>
                 </adf-custom-header-filter-template>

--- a/demo-shell/src/app/components/files/files.component.html
+++ b/demo-shell/src/app/components/files/files.component.html
@@ -240,7 +240,7 @@
                 <adf-custom-header-filter-template *ngIf="enableCustomHeaderFilter">
                     <ng-template let-col>
                         <adf-search-header [col]="col"
-                                           [value]="paramValues? paramValues[col.key] : 'SANDRO'"
+                                           [value]="paramValues? paramValues[col.key] : null"
                                            [currentFolderNodeId]="currentFolderId"
                                            [maxItems]="pagination?.maxItems"
                                            [skipCount]="pagination?.skipCount"

--- a/demo-shell/src/app/components/files/files.component.ts
+++ b/demo-shell/src/app/components/files/files.component.ts
@@ -163,6 +163,9 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
     @Input()
     enableCustomHeaderFilter = false;
 
+    @Input()
+    paramValues: Map <any, any> = null;
+
     @Output()
     documentListReady: EventEmitter<any> = new EventEmitter();
 
@@ -656,6 +659,16 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
     onAllFilterCleared() {
         this.documentList.node = null;
         this.documentList.reload();
+    }
+
+    onFilterSelected(currentActiveFilters: Map<string, string>) {
+        const objectFromMap = {};
+        currentActiveFilters.forEach((value, key) => {
+            objectFromMap[key] = value;
+        });
+
+        this.router.navigate([this.navigationRoute, this.currentFolderId
+            , 'display', this.displayMode], { queryParams: objectFromMap});
     }
 
 }

--- a/demo-shell/src/app/components/files/files.component.ts
+++ b/demo-shell/src/app/components/files/files.component.ts
@@ -658,17 +658,27 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
 
     onAllFilterCleared() {
         this.documentList.node = null;
+        if (this.currentFolderId === '-my-') {
+            this.router.navigate([this.navigationRoute, '']);
+        } else {
+            this.router.navigate([this.navigationRoute, this.currentFolderId, 'display', this.displayMode]);
+        }
         this.documentList.reload();
     }
 
     onFilterSelected(currentActiveFilters: Map<string, string>) {
         const objectFromMap = {};
-        currentActiveFilters.forEach((value, key) => {
-            objectFromMap[key] = value;
+        currentActiveFilters.forEach((value: any, key) => {
+            let paramValue = null;
+            if (value && value.from && value.to) {
+                paramValue = `${value.from}||${value.to}`;
+            } else {
+                paramValue = value;
+            }
+            objectFromMap[key] = paramValue;
         });
 
-        this.router.navigate([this.navigationRoute, this.currentFolderId
-            , 'display', this.displayMode], { queryParams: objectFromMap});
+        this.router.navigate([], { relativeTo: this.route, queryParams: objectFromMap });
     }
 
 }

--- a/demo-shell/src/app/components/files/filtered-search.component.html
+++ b/demo-shell/src/app/components/files/filtered-search.component.html
@@ -4,5 +4,6 @@
                      [showSettingsPanel]="false"
                      [navigationRoute]="navigationRoute"
                      [currentFolderId]="currentFolderId"
-                     [enableCustomHeaderFilter]="true">
+                     [enableCustomHeaderFilter]="true"
+                     [paramValues]="queryParams">
 </app-files-component>

--- a/demo-shell/src/app/components/files/filtered-search.component.ts
+++ b/demo-shell/src/app/components/files/filtered-search.component.ts
@@ -32,6 +32,7 @@ export class FilteredSearchComponent {
     queryParams = null;
 
     constructor(@Optional() private route: ActivatedRoute) {
+
         if (this.route) {
             this.route.params.forEach((params: Params) => {
                 if (params['id'] && this.currentFolderId !== params['id']) {

--- a/demo-shell/src/app/components/files/filtered-search.component.ts
+++ b/demo-shell/src/app/components/files/filtered-search.component.ts
@@ -29,12 +29,18 @@ export class FilteredSearchComponent {
     navigationRoute = '/filtered-search';
     currentFolderId = '-my-';
 
+    queryParams = null;
+
     constructor(@Optional() private route: ActivatedRoute) {
         if (this.route) {
             this.route.params.forEach((params: Params) => {
                 if (params['id'] && this.currentFolderId !== params['id']) {
                     this.currentFolderId = params['id'];
                 }
+            });
+
+            this.route.queryParamMap.subscribe((queryMap: Params) => {
+                this.queryParams = queryMap.params;
             });
         }
     }

--- a/docs/content-services/components/search-check-list.component.md
+++ b/docs/content-services/components/search-check-list.component.md
@@ -26,6 +26,7 @@ Implements a checklist [widget](../../../lib/testing/src/lib/core/pages/form/wid
                     "pageSize": 5,
                     "settings": {
                         "operator": "OR",
+                        "allowUpdateOnChange": true,
                         "options": [
                             { "name": "Folder", "value": "TYPE:'cm:folder'" },
                             { "name": "Document", "value": "TYPE:'cm:content'" }
@@ -44,6 +45,7 @@ Implements a checklist [widget](../../../lib/testing/src/lib/core/pages/form/wid
 | ---- | ---- | ----------- |
 | operator | `string` | Logical operator to combine query fragments. Can be 'AND' or 'OR'. |
 | options | `array` | Array of objects with `name` and `value` properties. Each object defines a checkbox, labelled with `name`, that adds the query fragment in `value` to the query when enabled. |
+| allowUpdateOnChange | `boolean` | Enable/Disable the update fire event when text has been changed
 
 ## Details
 

--- a/docs/content-services/components/search-check-list.component.md
+++ b/docs/content-services/components/search-check-list.component.md
@@ -45,7 +45,7 @@ Implements a checklist [widget](../../../lib/testing/src/lib/core/pages/form/wid
 | ---- | ---- | ----------- |
 | operator | `string` | Logical operator to combine query fragments. Can be 'AND' or 'OR'. |
 | options | `array` | Array of objects with `name` and `value` properties. Each object defines a checkbox, labelled with `name`, that adds the query fragment in `value` to the query when enabled. |
-| allowUpdateOnChange | `boolean` | Enable/Disable the update fire event when text has been changed
+| allowUpdateOnChange | `boolean` | Enable/Disable the update fire event when text has been changed. By default is true.
 
 ## Details
 

--- a/docs/content-services/components/search-text.component.md
+++ b/docs/content-services/components/search-text.component.md
@@ -29,7 +29,8 @@ Implements a text input [widget](../../../lib/testing/src/lib/core/pages/form/wi
                         "searchSuffix": "",
                         "pattern": "cm:name:'(.*?)'",
                         "field": "cm:name",
-                        "placeholder": "Enter the name"
+                        "placeholder": "Enter the name",
+                        "allowUpdateOnChange": true
                     }
                 }
             }
@@ -47,6 +48,7 @@ Implements a text input [widget](../../../lib/testing/src/lib/core/pages/form/wi
 | placeholder | string | Text displayed in the [widget](../../../lib/testing/src/lib/core/pages/form/widgets/widget.ts) when the input string is empty |
 | searchSuffix | string | Text to append always in the search of a string|
 | searchPrefix | string | Text to prepend always in the search of a string|
+| allowUpdateOnChange | `boolean` | Enable/Disable the update fire event when text has been changed
 
 ## Details
 

--- a/docs/content-services/components/search-text.component.md
+++ b/docs/content-services/components/search-text.component.md
@@ -48,7 +48,7 @@ Implements a text input [widget](../../../lib/testing/src/lib/core/pages/form/wi
 | placeholder | string | Text displayed in the [widget](../../../lib/testing/src/lib/core/pages/form/widgets/widget.ts) when the input string is empty |
 | searchSuffix | string | Text to append always in the search of a string|
 | searchPrefix | string | Text to prepend always in the search of a string|
-| allowUpdateOnChange | `boolean` | Enable/Disable the update fire event when text has been changed
+| allowUpdateOnChange | `boolean` | Enable/Disable the update fire event when text has been changed. By default is true.
 
 ## Details
 

--- a/lib/content-services/src/lib/search/components/search-check-list/search-check-list.component.html
+++ b/lib/content-services/src/lib/search/components/search-check-list/search-check-list.component.html
@@ -15,7 +15,7 @@
 
     </mat-checkbox>
 </div>
-
+ 
 <div class="adf-facet-buttons" *ngIf="options.fitsPage">
     <button mat-button color="primary" (click)="reset()">
         {{ 'SEARCH.FILTER.ACTIONS.CLEAR-ALL' | translate }}

--- a/lib/content-services/src/lib/search/components/search-check-list/search-check-list.component.ts
+++ b/lib/content-services/src/lib/search/components/search-check-list/search-check-list.component.ts
@@ -82,6 +82,15 @@ export class SearchCheckListComponent implements SearchWidget, OnInit {
         return !!checkedValues.length;
     }
 
+    getCurrentValue() {
+        return this.getCheckedValues();
+    }
+
+    setValue(value: any) {
+        this.options.items.filter((item) => item.value === value)
+            .map((item) => item.checked = true);
+    }
+
     private getCheckedValues() {
         return this.options.items
             .filter((option) => option.checked)

--- a/lib/content-services/src/lib/search/components/search-check-list/search-check-list.component.ts
+++ b/lib/content-services/src/lib/search/components/search-check-list/search-check-list.component.ts
@@ -84,7 +84,7 @@ export class SearchCheckListComponent implements SearchWidget, OnInit {
         option.checked = event.checked;
         const checkedValues = this.getCheckedValues();
         this.isActive = !!checkedValues.length;
-        if(this.enableChangeUpdate) {
+        if (this.enableChangeUpdate) {
             this.submitValues();
         }
     }

--- a/lib/content-services/src/lib/search/components/search-check-list/search-check-list.component.ts
+++ b/lib/content-services/src/lib/search/components/search-check-list/search-check-list.component.ts
@@ -42,8 +42,10 @@ export class SearchCheckListComponent implements SearchWidget, OnInit {
     context?: SearchQueryBuilderService;
     options: SearchFilterList<SearchListOption>;
     operator: string = 'OR';
+    startValue: SearchListOption = null;
     pageSize = 5;
     isActive = false;
+    enableChangeUpdate = true;
 
     constructor() {
         this.options = new SearchFilterList<SearchListOption>();
@@ -56,6 +58,12 @@ export class SearchCheckListComponent implements SearchWidget, OnInit {
 
             if (this.settings.options && this.settings.options.length > 0) {
                 this.options = new SearchFilterList(this.settings.options, this.pageSize);
+            }
+
+            this.enableChangeUpdate = this.settings.allowUpdateOnChange;
+
+            if (this.startValue) {
+                this.setValue(this.startValue);
             }
         }
     }
@@ -74,7 +82,11 @@ export class SearchCheckListComponent implements SearchWidget, OnInit {
 
     changeHandler(event: MatCheckboxChange, option: any) {
         option.checked = event.checked;
-        this.submitValues();
+        const checkedValues = this.getCheckedValues();
+        this.isActive = !!checkedValues.length;
+        if(this.enableChangeUpdate) {
+            this.submitValues();
+        }
     }
 
     hasValidValue() {
@@ -87,8 +99,9 @@ export class SearchCheckListComponent implements SearchWidget, OnInit {
     }
 
     setValue(value: any) {
-        this.options.items.filter((item) => item.value === value)
+        this.options.items.filter((item) => value.includes(item.value))
             .map((item) => item.checked = true);
+        this.submitValues();
     }
 
     private getCheckedValues() {
@@ -99,11 +112,7 @@ export class SearchCheckListComponent implements SearchWidget, OnInit {
 
     submitValues() {
         const checkedValues = this.getCheckedValues();
-
-        this.isActive = !!checkedValues.length;
-
         const query = checkedValues.join(` ${this.operator} `);
-
         if (this.id && this.context) {
             this.context.queryFragments[this.id] = query;
             this.context.update();

--- a/lib/content-services/src/lib/search/components/search-check-list/search-check-list.component.ts
+++ b/lib/content-services/src/lib/search/components/search-check-list/search-check-list.component.ts
@@ -60,11 +60,14 @@ export class SearchCheckListComponent implements SearchWidget, OnInit {
                 this.options = new SearchFilterList(this.settings.options, this.pageSize);
             }
 
-            this.enableChangeUpdate = this.settings.allowUpdateOnChange;
-
-            if (this.startValue) {
-                this.setValue(this.startValue);
+            if (this.settings.allowUpdateOnChange !== undefined &&
+                this.settings.allowUpdateOnChange !== null) {
+                this.enableChangeUpdate = this.settings.allowUpdateOnChange;
             }
+        }
+
+        if (this.startValue) {
+            this.setValue(this.startValue);
         }
     }
 

--- a/lib/content-services/src/lib/search/components/search-date-range/search-date-range.component.ts
+++ b/lib/content-services/src/lib/search/components/search-date-range/search-date-range.component.ts
@@ -58,7 +58,6 @@ export class SearchDateRangeComponent implements SearchWidget, OnInit, OnDestroy
     maxDate: any;
     isActive = false;
     startValue: any = null;
-    
 
     private onDestroy$ = new Subject<boolean>();
 
@@ -140,7 +139,7 @@ export class SearchDateRangeComponent implements SearchWidget, OnInit, OnDestroy
     }
 
     getCurrentValue() {
-        return { from : this.dateAdapter.format(this.form.value.from, this.datePickerDateFormat), 
+        return { from : this.dateAdapter.format(this.form.value.from, this.datePickerDateFormat),
                 to: this.dateAdapter.format(this.form.value.from, this.datePickerDateFormat) };
     }
 

--- a/lib/content-services/src/lib/search/components/search-date-range/search-date-range.component.ts
+++ b/lib/content-services/src/lib/search/components/search-date-range/search-date-range.component.ts
@@ -137,6 +137,15 @@ export class SearchDateRangeComponent implements SearchWidget, OnInit, OnDestroy
         return this.form.valid;
     }
 
+    getCurrentValue() {
+        return this.form.value;
+    }
+
+    setValue(value: any) {
+        this.form['from'].setValue(value);
+        this.form['to'].setValue(value);
+    }
+
     reset() {
         this.isActive = false;
         this.form.reset({

--- a/lib/content-services/src/lib/search/components/search-date-range/search-date-range.component.ts
+++ b/lib/content-services/src/lib/search/components/search-date-range/search-date-range.component.ts
@@ -57,6 +57,8 @@ export class SearchDateRangeComponent implements SearchWidget, OnInit, OnDestroy
     datePickerDateFormat = DEFAULT_FORMAT_DATE;
     maxDate: any;
     isActive = false;
+    startValue: any = null;
+    
 
     private onDestroy$ = new Subject<boolean>();
 
@@ -95,14 +97,6 @@ export class SearchDateRangeComponent implements SearchWidget, OnInit, OnDestroy
             Validators.required
         ]);
 
-        this.from = new FormControl('', validators);
-        this.to = new FormControl('', validators);
-
-        this.form = new FormGroup({
-            from: this.from,
-            to: this.to
-        });
-
         if (this.settings && this.settings.maxDate) {
             if (this.settings.maxDate === 'today') {
                 this.maxDate = this.dateAdapter.today().endOf('day');
@@ -110,6 +104,14 @@ export class SearchDateRangeComponent implements SearchWidget, OnInit, OnDestroy
                 this.maxDate = moment(this.settings.maxDate).endOf('day');
             }
         }
+
+        this.from = new FormControl('', validators);
+        this.to = new FormControl('', validators);
+
+        this.form = new FormGroup({
+            from: this.from,
+            to: this.to
+        });
     }
 
     ngOnDestroy() {
@@ -138,12 +140,21 @@ export class SearchDateRangeComponent implements SearchWidget, OnInit, OnDestroy
     }
 
     getCurrentValue() {
-        return this.form.value;
+        return { from : this.dateAdapter.format(this.form.value.from, this.datePickerDateFormat), 
+                to: this.dateAdapter.format(this.form.value.from, this.datePickerDateFormat) };
     }
 
-    setValue(value: any) {
-        this.form['from'].setValue(value);
-        this.form['to'].setValue(value);
+    setValue(parsedDate: string) {
+        const splittedValue = parsedDate.split('||');
+        const fromValue = this.dateAdapter.parse(splittedValue[0], this.datePickerDateFormat);
+        const toValue = this.dateAdapter.parse(splittedValue[1], this.datePickerDateFormat);
+        this.from.setValue(fromValue);
+        this.from.markAsDirty();
+        this.from.markAsTouched();
+        this.to.setValue(toValue);
+        this.to.markAsDirty();
+        this.to.markAsTouched();
+        this.submitValues();
     }
 
     reset() {
@@ -159,6 +170,7 @@ export class SearchDateRangeComponent implements SearchWidget, OnInit, OnDestroy
     }
 
     onChangedHandler(event: any, formControl: FormControl) {
+
         const inputValue = event.srcElement.value;
 
         const formatDate = this.dateAdapter.parse(inputValue, this.datePickerDateFormat);

--- a/lib/content-services/src/lib/search/components/search-date-range/search-date-range.component.ts
+++ b/lib/content-services/src/lib/search/components/search-date-range/search-date-range.component.ts
@@ -105,9 +105,9 @@ export class SearchDateRangeComponent implements SearchWidget, OnInit, OnDestroy
         }
 
         if (this.startValue) {
-            const splittedValue = this.startValue.split('||');
-            const fromValue = this.dateAdapter.parse(splittedValue[0], this.datePickerDateFormat);
-            const toValue = this.dateAdapter.parse(splittedValue[1], this.datePickerDateFormat);
+            const splitValue = this.startValue.split('||');
+            const fromValue = this.dateAdapter.parse(splitValue[0], this.datePickerDateFormat);
+            const toValue = this.dateAdapter.parse(splitValue[1], this.datePickerDateFormat);
             this.from = new FormControl(fromValue, validators);
             this.to = new FormControl(toValue, validators);
         } else {
@@ -152,9 +152,9 @@ export class SearchDateRangeComponent implements SearchWidget, OnInit, OnDestroy
     }
 
     setValue(parsedDate: string) {
-        const splittedValue = parsedDate.split('||');
-        const fromValue = this.dateAdapter.parse(splittedValue[0], this.datePickerDateFormat);
-        const toValue = this.dateAdapter.parse(splittedValue[1], this.datePickerDateFormat);
+        const splitValue = parsedDate.split('||');
+        const fromValue = this.dateAdapter.parse(splitValue[0], this.datePickerDateFormat);
+        const toValue = this.dateAdapter.parse(splitValue[1], this.datePickerDateFormat);
         this.from.setValue(fromValue);
         this.from.markAsDirty();
         this.from.markAsTouched();

--- a/lib/content-services/src/lib/search/components/search-date-range/search-date-range.component.ts
+++ b/lib/content-services/src/lib/search/components/search-date-range/search-date-range.component.ts
@@ -57,7 +57,7 @@ export class SearchDateRangeComponent implements SearchWidget, OnInit, OnDestroy
     datePickerDateFormat = DEFAULT_FORMAT_DATE;
     maxDate: any;
     isActive = false;
-    startValue: any = null;
+    startValue: any;
 
     private onDestroy$ = new Subject<boolean>();
 
@@ -104,8 +104,16 @@ export class SearchDateRangeComponent implements SearchWidget, OnInit, OnDestroy
             }
         }
 
-        this.from = new FormControl('', validators);
-        this.to = new FormControl('', validators);
+        if (this.startValue) {
+            const splittedValue = this.startValue.split('||');
+            const fromValue = this.dateAdapter.parse(splittedValue[0], this.datePickerDateFormat);
+            const toValue = this.dateAdapter.parse(splittedValue[1], this.datePickerDateFormat);
+            this.from = new FormControl(fromValue, validators);
+            this.to = new FormControl(toValue, validators);
+        } else {
+            this.from = new FormControl('', validators);
+            this.to = new FormControl('', validators);
+        }
 
         this.form = new FormGroup({
             from: this.from,

--- a/lib/content-services/src/lib/search/components/search-header/search-header.component.html
+++ b/lib/content-services/src/lib/search/components/search-header/search-header.component.html
@@ -8,7 +8,7 @@
             (keyup.enter)="$event.stopPropagation()"
             class="adf-filter-button"
             [matTooltip]="getTooltipTranslation(col?.title)">
-            <adf-icon value="adf:filter"
+            <adf-icon value="adf:filter" 
                 [ngClass]="{ 'adf-icon-active': isActive() || menuTrigger.menuOpen }"
                 matBadge="filter"
                 matBadgeColor="warn"

--- a/lib/content-services/src/lib/search/components/search-header/search-header.component.html
+++ b/lib/content-services/src/lib/search/components/search-header/search-header.component.html
@@ -24,7 +24,7 @@
                         [id]="category?.id"
                         [selector]="category?.component?.selector"
                         [settings]="category?.component?.settings"
-                        [value]="value">
+                        [value]="initialValue">
                     </adf-search-widget-container>
                 </div>
                 <mat-dialog-actions class="adf-filter-actions">

--- a/lib/content-services/src/lib/search/components/search-header/search-header.component.html
+++ b/lib/content-services/src/lib/search/components/search-header/search-header.component.html
@@ -23,7 +23,8 @@
                         (keypress)="onKeyPressed($event, menuTrigger)"
                         [id]="category?.id"
                         [selector]="category?.component?.selector"
-                        [settings]="category?.component?.settings">
+                        [settings]="category?.component?.settings"
+                        [value]="value">
                     </adf-search-widget-container>
                 </div>
                 <mat-dialog-actions class="adf-filter-actions">

--- a/lib/content-services/src/lib/search/components/search-header/search-header.component.spec.ts
+++ b/lib/content-services/src/lib/search/components/search-header/search-header.component.spec.ts
@@ -173,7 +173,8 @@ describe('SearchHeaderComponent', () => {
         spyOn(queryBuilder, 'isNoFilterActive').and.returnValue(false);
         spyOn(alfrescoApiService.searchApi, 'search').and.returnValue(Promise.resolve(fakeNodePaging));
         spyOn(queryBuilder, 'buildQuery').and.returnValue({});
-        spyOn(component.widgetContainer, 'resetInnerWidget').and.stub();
+        queryBuilder.queryFragments['fake'] = 'test';
+        spyOn(component.widgetContainer, 'resetInnerWidget').and.callThrough();
         const fakeEvent = jasmine.createSpyObj('event', ['stopPropagation']);
         const menuButton: HTMLButtonElement = fixture.nativeElement.querySelector('#filter-menu-button');
         component.update.subscribe((newNodePaging) => {

--- a/lib/content-services/src/lib/search/components/search-header/search-header.component.ts
+++ b/lib/content-services/src/lib/search/components/search-header/search-header.component.ts
@@ -191,7 +191,7 @@ export class SearchHeaderComponent implements OnInit, OnChanges, OnDestroy {
         this.searchHeaderQueryBuilder.setCurrentRootFolderId(currentFolderId);
         if (this.value) {
             this.searchHeaderQueryBuilder.setActiveFilter(this.category.columnKey, this.initialValue);
-            this.widgetContainer.setValue(this.value);
+            this.initialValue = this.value;
         }
     }
 

--- a/lib/content-services/src/lib/search/components/search-header/search-header.component.ts
+++ b/lib/content-services/src/lib/search/components/search-header/search-header.component.ts
@@ -52,6 +52,9 @@ export class SearchHeaderComponent implements OnInit, OnChanges, OnDestroy {
     @Input()
     col: DataColumn;
 
+    @Input()
+    value: any;
+
     /** The id of the current folder of the document list. */
     @Input()
     currentFolderNodeId: string;
@@ -71,6 +74,10 @@ export class SearchHeaderComponent implements OnInit, OnChanges, OnDestroy {
     /** Emitted when the last of all the filters is cleared. */
     @Output()
     clear: EventEmitter<any> = new EventEmitter();
+
+    /** Emitted when a filter value is selected */
+    @Output()
+    selection: EventEmitter<Map<string, string>> = new EventEmitter();
 
     @ViewChild(SearchWidgetContainerComponent)
     widgetContainer: SearchWidgetContainerComponent;
@@ -138,7 +145,8 @@ export class SearchHeaderComponent implements OnInit, OnChanges, OnDestroy {
     onApply() {
         if (this.widgetContainer.hasValueSelected()) {
             this.widgetContainer.applyInnerWidget();
-            this.searchHeaderQueryBuilder.setActiveFilter(this.category.columnKey);
+            this.searchHeaderQueryBuilder.setActiveFilter(this.category.columnKey, this.widgetContainer.getCurrentValue());
+            this.selection.emit(this.searchHeaderQueryBuilder.getActiveFilters());
             this.searchHeaderQueryBuilder.execute();
         } else {
             this.clearHeader();

--- a/lib/content-services/src/lib/search/components/search-number-range/search-number-range.component.ts
+++ b/lib/content-services/src/lib/search/components/search-number-range/search-number-range.component.ts
@@ -45,6 +45,7 @@ export class SearchNumberRangeComponent implements SearchWidget, OnInit {
     format = '[{FROM} TO {TO}]';
 
     isActive = false;
+    startValue: any;
 
     validators: Validators;
 
@@ -68,6 +69,10 @@ export class SearchNumberRangeComponent implements SearchWidget, OnInit {
             from: this.from,
             to: this.to
         }, this.formValidator);
+
+        if (this.startValue) {
+            this.setValue(this.startValue);
+        }
     }
 
     formValidator(formGroup: FormGroup) {

--- a/lib/content-services/src/lib/search/components/search-number-range/search-number-range.component.ts
+++ b/lib/content-services/src/lib/search/components/search-number-range/search-number-range.component.ts
@@ -108,6 +108,15 @@ export class SearchNumberRangeComponent implements SearchWidget, OnInit {
         return this.form.valid;
     }
 
+    getCurrentValue() {
+        return this.form.value;
+    }
+
+    setValue(value: any) {
+        this.form['from'].setValue(value);
+        this.form['to'].setValue(value);
+    }
+
     reset() {
         this.isActive = false;
 

--- a/lib/content-services/src/lib/search/components/search-number-range/search-number-range.component.ts
+++ b/lib/content-services/src/lib/search/components/search-number-range/search-number-range.component.ts
@@ -62,17 +62,18 @@ export class SearchNumberRangeComponent implements SearchWidget, OnInit {
             Validators.min(0)
         ]);
 
-        this.from = new FormControl('', this.validators);
-        this.to = new FormControl('', this.validators);
+        if (this.startValue) {
+            this.from = new FormControl(this.startValue['from'], this.validators);
+            this.to = new FormControl(this.startValue['to'], this.validators);
+        } else {
+            this.from = new FormControl('', this.validators);
+            this.to = new FormControl('', this.validators);
+        }
 
         this.form = new FormGroup({
             from: this.from,
             to: this.to
         }, this.formValidator);
-
-        if (this.startValue) {
-            this.setValue(this.startValue);
-        }
     }
 
     formValidator(formGroup: FormGroup) {

--- a/lib/content-services/src/lib/search/components/search-radio/search-radio.component.spec.ts
+++ b/lib/content-services/src/lib/search/components/search-radio/search-radio.component.spec.ts
@@ -41,10 +41,10 @@ describe('SearchRadioComponent', () => {
 
    describe('Pagination', () => {
         it('should show 5 items when pageSize not defined', () => {
-            component.id = 'checklist';
+            component.id = 'radio';
             component.context = <any> {
                 queryFragments: {
-                    'checklist': 'query'
+                    'radio': 'query'
                 },
                 update() {}
             };
@@ -60,10 +60,10 @@ describe('SearchRadioComponent', () => {
         });
 
         it('should show all items when pageSize is high', () => {
-            component.id = 'checklist';
+            component.id = 'radio';
             component.context = <any> {
                 queryFragments: {
-                    'checklist': 'query'
+                    'radio': 'query'
                 },
                 update() {}
             };
@@ -78,21 +78,22 @@ describe('SearchRadioComponent', () => {
         });
     });
 
-   it('should able to check the radio button', () => {
-        component.id = 'checklist';
+   it('should able to check the radio button', async () => {
+        component.id = 'radio';
         component.context = <any> {
             queryFragments: {
-                'checklist': 'query'
+                'radio': 'query'
             },
             update: () => {}
         };
         component.settings = <any> { options: sizeOptions };
         spyOn(component.context, 'update').and.stub();
-        component.ngOnInit();
         fixture.detectChanges();
+        await fixture.whenStable();
 
         const optionElements = fixture.debugElement.query(By.css('mat-radio-button'));
         optionElements.triggerEventHandler('change', { checked: true });
+        fixture.detectChanges();
 
         expect(component.context.update).toHaveBeenCalled();
         expect(component.context.queryFragments[component.id]).toBe(sizeOptions[0].value);

--- a/lib/content-services/src/lib/search/components/search-radio/search-radio.component.ts
+++ b/lib/content-services/src/lib/search/components/search-radio/search-radio.component.ts
@@ -47,6 +47,7 @@ export class SearchRadioComponent implements SearchWidget, OnInit {
     options: SearchFilterList<SearchRadioOption>;
     pageSize = 5;
     isActive = false;
+    startValue: SearchRadioOption[];
 
     constructor() {
         this.options = new SearchFilterList<SearchRadioOption>();
@@ -61,11 +62,6 @@ export class SearchRadioComponent implements SearchWidget, OnInit {
                     this.settings.options, this.pageSize
                 );
             }
-        }
-
-        const initialValue = this.getSelectedValue();
-        if (initialValue !== null) {
-            this.setValue(initialValue);
         }
     }
 

--- a/lib/content-services/src/lib/search/components/search-radio/search-radio.component.ts
+++ b/lib/content-services/src/lib/search/components/search-radio/search-radio.component.ts
@@ -85,7 +85,7 @@ export class SearchRadioComponent implements SearchWidget, OnInit {
 
     submitValues() {
         const currentValue = this.getSelectedValue();
-        this.setValue(currentValue);
+        this.applyValue(currentValue);
     }
 
     hasValidValue() {
@@ -93,14 +93,22 @@ export class SearchRadioComponent implements SearchWidget, OnInit {
         return !!currentValue;
     }
 
-    private setValue(newValue: string) {
+    getCurrentValue() {
+        return this.getSelectedValue();
+    }
+
+    setValue(value: any) {
+        this.applyValue(value);
+    }
+
+    private applyValue(newValue: string) {
         this.value = newValue;
         this.context.queryFragments[this.id] = newValue;
         this.context.update();
     }
 
     changeHandler(event: MatRadioChange) {
-        this.setValue(event.value);
+        this.applyValue(event.value);
     }
 
     reset() {
@@ -108,7 +116,7 @@ export class SearchRadioComponent implements SearchWidget, OnInit {
 
         const initialValue = this.getSelectedValue();
         if (initialValue !== null) {
-            this.setValue(initialValue);
+            this.applyValue(initialValue);
         }
     }
 }

--- a/lib/content-services/src/lib/search/components/search-radio/search-radio.component.ts
+++ b/lib/content-services/src/lib/search/components/search-radio/search-radio.component.ts
@@ -47,7 +47,7 @@ export class SearchRadioComponent implements SearchWidget, OnInit {
     options: SearchFilterList<SearchRadioOption>;
     pageSize = 5;
     isActive = false;
-    startValue: SearchRadioOption[];
+    startValue: any;
 
     constructor() {
         this.options = new SearchFilterList<SearchRadioOption>();
@@ -62,6 +62,14 @@ export class SearchRadioComponent implements SearchWidget, OnInit {
                     this.settings.options, this.pageSize
                 );
             }
+        }
+
+        const initialValue = this.getSelectedValue();
+
+        if (initialValue !== null) {
+            this.setValue(initialValue);
+        } else if (this.startValue !== null) {
+            this.setValue(initialValue);
         }
     }
 
@@ -81,7 +89,7 @@ export class SearchRadioComponent implements SearchWidget, OnInit {
 
     submitValues() {
         const currentValue = this.getSelectedValue();
-        this.applyValue(currentValue);
+        this.setValue(currentValue);
     }
 
     hasValidValue() {
@@ -89,22 +97,18 @@ export class SearchRadioComponent implements SearchWidget, OnInit {
         return !!currentValue;
     }
 
-    getCurrentValue() {
-        return this.getSelectedValue();
-    }
-
-    setValue(value: any) {
-        this.applyValue(value);
-    }
-
-    private applyValue(newValue: string) {
+    setValue(newValue: string) {
         this.value = newValue;
         this.context.queryFragments[this.id] = newValue;
         this.context.update();
     }
 
+    getCurrentValue() {
+        return this.getSelectedValue();
+    }
+
     changeHandler(event: MatRadioChange) {
-        this.applyValue(event.value);
+        this.setValue(event.value);
     }
 
     reset() {
@@ -112,7 +116,7 @@ export class SearchRadioComponent implements SearchWidget, OnInit {
 
         const initialValue = this.getSelectedValue();
         if (initialValue !== null) {
-            this.applyValue(initialValue);
+            this.setValue(initialValue);
         }
     }
 }

--- a/lib/content-services/src/lib/search/components/search-slider/search-slider.component.ts
+++ b/lib/content-services/src/lib/search/components/search-slider/search-slider.component.ts
@@ -37,6 +37,7 @@ export class SearchSliderComponent implements SearchWidget, OnInit {
     min: number;
     max: number;
     thumbLabel = false;
+    startValue: any;
 
     /** The numeric value represented by the slider. */
     @Input()
@@ -57,6 +58,10 @@ export class SearchSliderComponent implements SearchWidget, OnInit {
             }
 
             this.thumbLabel = this.settings['thumbLabel'] ? true : false;
+
+            if (this.startValue) {
+                this.setValue(this.startValue);
+            }
         }
     }
 

--- a/lib/content-services/src/lib/search/components/search-slider/search-slider.component.ts
+++ b/lib/content-services/src/lib/search/components/search-slider/search-slider.component.ts
@@ -78,6 +78,15 @@ export class SearchSliderComponent implements SearchWidget, OnInit {
         return !!this.value;
     }
 
+    getCurrentValue() {
+        return this.value;
+    }
+
+    setValue(value: any) {
+        this.value = value;
+        this.submitValues();
+    }
+
     private updateQuery(value: number | null) {
         if (this.id && this.context && this.settings && this.settings.field) {
             if (value === null) {

--- a/lib/content-services/src/lib/search/components/search-slider/search-slider.component.ts
+++ b/lib/content-services/src/lib/search/components/search-slider/search-slider.component.ts
@@ -29,6 +29,8 @@ import { MatSliderChange } from '@angular/material/slider';
     host: { class: 'adf-search-slider' }
 })
 export class SearchSliderComponent implements SearchWidget, OnInit {
+    isActive?: boolean;
+    startValue: any;
 
     id: string;
     settings: SearchWidgetSettings;
@@ -37,7 +39,6 @@ export class SearchSliderComponent implements SearchWidget, OnInit {
     min: number;
     max: number;
     thumbLabel = false;
-    startValue: any;
 
     /** The numeric value represented by the slider. */
     @Input()
@@ -58,10 +59,10 @@ export class SearchSliderComponent implements SearchWidget, OnInit {
             }
 
             this.thumbLabel = this.settings['thumbLabel'] ? true : false;
+        }
 
-            if (this.startValue) {
-                this.setValue(this.startValue);
-            }
+        if (this.startValue) {
+            this.setValue(this.startValue);
         }
     }
 

--- a/lib/content-services/src/lib/search/components/search-text/search-text.component.ts
+++ b/lib/content-services/src/lib/search/components/search-text/search-text.component.ts
@@ -36,15 +36,22 @@ export class SearchTextComponent implements SearchWidget, OnInit {
     id: string;
     settings: SearchWidgetSettings;
     context: SearchQueryBuilderService;
+    startValue: string;
     isActive = false;
+    enableChangeUpdate = true;
 
     ngOnInit() {
         if (this.context && this.settings && this.settings.pattern) {
             const pattern = new RegExp(this.settings.pattern, 'g');
             const match = pattern.exec(this.context.queryFragments[this.id] || '');
+            this.enableChangeUpdate = this.settings.allowUpdateOnChange;
 
             if (match && match.length > 1) {
                 this.value = match[1];
+            }
+
+            if (this.startValue) {
+                this.setValue(this.startValue);
             }
         }
     }
@@ -58,12 +65,13 @@ export class SearchTextComponent implements SearchWidget, OnInit {
 
     onChangedHandler(event) {
         this.value = event.target.value;
-        this.updateQuery(this.value);
+        this.isActive = !!this.value;
+        if (this.enableChangeUpdate) {
+            this.updateQuery(this.value);
+        }
     }
 
     private updateQuery(value: string) {
-        this.isActive = !!value;
-
         if (this.context && this.settings && this.settings.field) {
             this.context.queryFragments[this.id] = value ? `${this.settings.field}:'${this.getSearchPrefix()}${value}${this.getSearchSuffix()}'` : '';
             this.context.update();

--- a/lib/content-services/src/lib/search/components/search-text/search-text.component.ts
+++ b/lib/content-services/src/lib/search/components/search-text/search-text.component.ts
@@ -79,6 +79,15 @@ export class SearchTextComponent implements SearchWidget, OnInit {
         return !!this.value;
     }
 
+    getCurrentValue() {
+        return this.value;
+    }
+
+    setValue(value: string) {
+        this.value = value;
+        this.submitValues();
+    }
+
     private getSearchPrefix(): string {
         return this.settings.searchPrefix ? this.settings.searchPrefix : '';
     }

--- a/lib/content-services/src/lib/search/components/search-text/search-text.component.ts
+++ b/lib/content-services/src/lib/search/components/search-text/search-text.component.ts
@@ -44,7 +44,10 @@ export class SearchTextComponent implements SearchWidget, OnInit {
         if (this.context && this.settings && this.settings.pattern) {
             const pattern = new RegExp(this.settings.pattern, 'g');
             const match = pattern.exec(this.context.queryFragments[this.id] || '');
-            this.enableChangeUpdate = this.settings.allowUpdateOnChange;
+            if (this.settings.allowUpdateOnChange !== undefined &&
+                this.settings.allowUpdateOnChange !== null) {
+                this.enableChangeUpdate = this.settings.allowUpdateOnChange;
+            }
 
             if (match && match.length > 1) {
                 this.value = match[1];

--- a/lib/content-services/src/lib/search/components/search-widget-container/search-widget-container.component.ts
+++ b/lib/content-services/src/lib/search/components/search-widget-container/search-widget-container.component.ts
@@ -69,7 +69,7 @@ export class SearchWidgetContainerComponent implements OnInit, OnDestroy {
             ref.instance.id = this.id;
             ref.instance.settings = { ...this.settings };
             ref.instance.context = this.queryBuilder;
-            if(this.value) {
+            if (this.value) {
                 ref.instance.isActive = true;
                 ref.instance.startValue = this.value;
             }

--- a/lib/content-services/src/lib/search/components/search-widget-container/search-widget-container.component.ts
+++ b/lib/content-services/src/lib/search/components/search-widget-container/search-widget-container.component.ts
@@ -69,8 +69,9 @@ export class SearchWidgetContainerComponent implements OnInit, OnDestroy {
             ref.instance.id = this.id;
             ref.instance.settings = { ...this.settings };
             ref.instance.context = this.queryBuilder;
-            if (this.value) {
-                this.setValue(this.value);
+            if(this.value) {
+                ref.instance.isActive = true;
+                ref.instance.startValue = this.value;
             }
         }
     }
@@ -87,8 +88,8 @@ export class SearchWidgetContainerComponent implements OnInit, OnDestroy {
     }
 
     setValue(currentValue: string | Object) {
-        this.componentRef.instance.setValue(currentValue);
         this.componentRef.instance.isActive = true;
+        this.componentRef.instance.setValue(currentValue);
     }
 
     hasValueSelected() {

--- a/lib/content-services/src/lib/search/components/search-widget-container/search-widget-container.component.ts
+++ b/lib/content-services/src/lib/search/components/search-widget-container/search-widget-container.component.ts
@@ -41,6 +41,9 @@ export class SearchWidgetContainerComponent implements OnInit, OnDestroy {
     @Input()
     config: any;
 
+    @Input()
+    value: any;
+
     componentRef: ComponentRef<any>;
 
     constructor(
@@ -66,6 +69,9 @@ export class SearchWidgetContainerComponent implements OnInit, OnDestroy {
             ref.instance.id = this.id;
             ref.instance.settings = { ...this.settings };
             ref.instance.context = this.queryBuilder;
+            if (this.value) {
+                this.setValue(this.value);
+            }
         }
     }
 
@@ -80,8 +86,17 @@ export class SearchWidgetContainerComponent implements OnInit, OnDestroy {
         this.componentRef.instance.submitValues();
     }
 
+    setValue(currentValue: string | Object) {
+        this.componentRef.instance.setValue(currentValue);
+        this.componentRef.instance.isActive = true;
+    }
+
     hasValueSelected() {
         return this.componentRef.instance.hasValidValue();
+    }
+
+    getCurrentValue() {
+        return this.componentRef.instance.getCurrentValue();
     }
 
     resetInnerWidget() {

--- a/lib/content-services/src/lib/search/search-header-query-builder.service.spec.ts
+++ b/lib/content-services/src/lib/search/search-header-query-builder.service.spec.ts
@@ -136,39 +136,6 @@ describe('SearchHeaderQueryBuilder', () => {
         );
     });
 
-    it('should replace the new query filter for the old parent node with the new one', () => {
-        const expectedResult = [
-            { query: 'PARENT:"workspace://SpacesStore/fake-next-node-id"' }
-        ];
-
-        const config: SearchConfiguration = {
-            categories: [
-                <any> { id: 'cat1', enabled: true },
-                <any> { id: 'cat2', enabled: true }
-            ],
-            filterQueries: [
-                { query: 'PARENT:"workspace://SpacesStore/fake-node-id' }
-            ]
-        };
-
-        const searchHeaderService = new SearchHeaderQueryBuilderService(
-            buildConfig(config),
-            null,
-            null
-        );
-
-        searchHeaderService.currentParentFolderId = 'fake-node-id';
-
-        searchHeaderService.setCurrentRootFolderId(
-            'fake-next-node-id'
-        );
-
-        expect(searchHeaderService.filterQueries).toEqual(
-            expectedResult,
-            'Filters are not as expected'
-        );
-    });
-
     it('should not add duplicate column names in activeFilters', () => {
         const activeFilter = 'FakeColumn';
 
@@ -187,11 +154,11 @@ describe('SearchHeaderQueryBuilder', () => {
             null
         );
 
-        expect(searchHeaderService.activeFilters.length).toBe(0);
+        expect(searchHeaderService.activeFilters.size).toBe(0);
 
-        searchHeaderService.setActiveFilter(activeFilter);
-        searchHeaderService.setActiveFilter(activeFilter);
+        searchHeaderService.setActiveFilter(activeFilter, 'fake-value');
+        searchHeaderService.setActiveFilter(activeFilter, 'fake-value');
 
-        expect(searchHeaderService.activeFilters.length).toBe(1);
+        expect(searchHeaderService.activeFilters.size).toBe(1);
     });
 });

--- a/lib/content-services/src/lib/search/search-header-query-builder.service.ts
+++ b/lib/content-services/src/lib/search/search-header-query-builder.service.ts
@@ -36,7 +36,8 @@ export class SearchHeaderQueryBuilderService extends BaseQueryBuilderService {
     constructor(appConfig: AppConfigService, alfrescoApiService: AlfrescoApiService, private nodeApiService: NodesApiService) {
         super(appConfig, alfrescoApiService);
 
-        this.updated.pipe(filter((query: QueryBody) => !!query)).subscribe(() => {
+        this.updated.pipe(
+            filter((query: QueryBody) => !!query)).subscribe(() => {
             this.execute();
         });
     }

--- a/lib/content-services/src/lib/search/search-header-query-builder.service.ts
+++ b/lib/content-services/src/lib/search/search-header-query-builder.service.ts
@@ -29,7 +29,7 @@ export class SearchHeaderQueryBuilderService extends BaseQueryBuilderService {
 
     private customSources = ['-trashcan-', '-sharedlinks-', '-sites-', '-mysites-', '-favorites-', '-recent-', '-my-'];
 
-    activeFilters: string[] = [];
+    activeFilters: Map<string, string> = new Map();
     currentParentFolderId: string;
 
     constructor(appConfig: AppConfigService, alfrescoApiService: AlfrescoApiService, private nodeApiService: NodesApiService) {
@@ -53,18 +53,22 @@ export class SearchHeaderQueryBuilderService extends BaseQueryBuilderService {
         }
     }
 
-    setActiveFilter(columnActivated: string) {
-        if (!this.activeFilters.includes(columnActivated)) {
-            this.activeFilters.push(columnActivated);
-        }
+    setActiveFilter(columnActivated: string, filterValue: string) {
+        this.activeFilters.set(columnActivated, filterValue);
+    }
+
+    getActiveFilters(): Map<string, string> {
+        return this.activeFilters;
     }
 
     isNoFilterActive(): boolean {
-        return this.activeFilters.length === 0;
+        return this.activeFilters.size === 0;
     }
 
     removeActiveFilter(columnRemoved: string) {
-        this.activeFilters = this.activeFilters.filter((column) => column !== columnRemoved);
+        if (this.activeFilters.get(columnRemoved) !== null) {
+            this.activeFilters.delete(columnRemoved);
+        }
     }
 
     getCategoryForColumn(columnKey: string): SearchCategory {

--- a/lib/content-services/src/lib/search/search-widget.interface.ts
+++ b/lib/content-services/src/lib/search/search-widget.interface.ts
@@ -23,6 +23,7 @@ export interface SearchWidget {
     settings?: SearchWidgetSettings;
     context?: SearchQueryBuilderService;
     isActive?: boolean;
+    startValue: any;
     reset();
     submitValues();
     hasValidValue();

--- a/lib/content-services/src/lib/search/search-widget.interface.ts
+++ b/lib/content-services/src/lib/search/search-widget.interface.ts
@@ -26,4 +26,6 @@ export interface SearchWidget {
     reset();
     submitValues();
     hasValidValue();
+    getCurrentValue();
+    setValue(value: any);
 }

--- a/scripts/travis/build/build.sh
+++ b/scripts/travis/build/build.sh
@@ -8,7 +8,7 @@ rm -rf tmp && mkdir tmp;
 
 npx @alfresco/adf-cli@alpha update-commit-sha --pointer "HEAD" --pathPackage "$(pwd)"
 
-if [[ $TRAVIS_PULL_REQUEST == "false" ]];
+if [[ "${TRAVIS_EVENT_TYPE}" == "push" ]];
 then
     if [[ $TRAVIS_BRANCH == "develop" ]];
     then

--- a/scripts/travis/e2e/content-services-e2e.sh
+++ b/scripts/travis/e2e/content-services-e2e.sh
@@ -10,7 +10,7 @@ export CONTEXT_ENV="content-services"
 export PROVIDER='ECM'
 export AUTH_TYPE='BASIC'
 
-if [[ $TRAVIS_PULL_REQUEST == "true"  ]]; then
+if [ "${TRAVIS_EVENT_TYPE}" == "pull_request" ]; then
     echo "Calculate affected e2e $BASE_HASH $HEAD_HASH"
     ./scripts/git-util/check-branch-updated.sh -b $TRAVIS_BRANCH || exit 1;
     AFFECTED_LIBS="$(nx affected:libs --base=$BASE_HASH --head=$HEAD_HASH --plain)"
@@ -23,7 +23,7 @@ fi;
 
 #-b is needed to run the Folder upload test that are not workin in Headless chrome
 RUN_E2E=$(echo ./scripts/test-e2e-lib.sh -host http://localhost:4200 -proxy "$E2E_HOST" -u "$E2E_USERNAME" -p "$E2E_PASSWORD" -e "$E2E_EMAIL" --use-dist -b -save -m 4 || exit 1)
-if [[  $AFFECTED_LIBS =~ "testing" || $AFFECTED_LIBS =~ "$CONTEXT_ENV" || $TRAVIS_PULL_REQUEST == "false"  ]]; then
+if [[  $AFFECTED_LIBS =~ "testing" || $AFFECTED_LIBS =~ "$CONTEXT_ENV" ||  "${TRAVIS_EVENT_TYPE}" == "push" ]]; then
     $RUN_CHECK
     $RUN_E2E --folder $CONTEXT_ENV
 else if [[ $AFFECTED_E2E = "e2e/$CONTEXT_ENV" ]];

--- a/scripts/travis/e2e/content-services-e2e.sh
+++ b/scripts/travis/e2e/content-services-e2e.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+echo "Start Content service e2e"
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 cd $DIR/../../../

--- a/scripts/travis/e2e/content-services-e2e.sh
+++ b/scripts/travis/e2e/content-services-e2e.sh
@@ -8,11 +8,13 @@ export CONTEXT_ENV="content-services"
 export PROVIDER='ECM'
 export AUTH_TYPE='BASIC'
 
-
 if [[ $TRAVIS_PULL_REQUEST == "true"  ]]; then
+    echo "Calculate affected e2e $BASE_HASH $HEAD_HASH"
     ./scripts/git-util/check-branch-updated.sh -b $TRAVIS_BRANCH || exit 1;
     AFFECTED_LIBS="$(nx affected:libs --base=$BASE_HASH --head=$HEAD_HASH --plain)"
+    echo "Affected libs ${AFFECTED_LIBS}"
     AFFECTED_E2E="$(./scripts/git-util/affected-folder.sh -b $TRAVIS_BRANCH -f "e2e/$CONTEXT_ENV")";
+    echo "Affected e2e ${AFFECTED_E2E}"
 fi;
 
 ./node_modules/@alfresco/adf-cli/bin/adf-cli check-cs-env --host "$E2E_HOST" -u "$E2E_USERNAME" -p "$E2E_PASSWORD" || exit 1

--- a/scripts/travis/e2e/core-e2e.sh
+++ b/scripts/travis/e2e/core-e2e.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 echo "Start Core e2e"
+echo "Start Core e2e $TRAVIS_PULL_REQUEST"
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -10,7 +11,7 @@ export CONTEXT_ENV="core"
 export PROVIDER='ALL'
 export AUTH_TYPE='BASIC'
 
-if [[ $TRAVIS_PULL_REQUEST == "true"  ]]; then
+if [ "${TRAVIS_EVENT_TYPE}" == "pull_request" ]; then
     echo "Calculate affected e2e $BASE_HASH $HEAD_HASH"
     ./scripts/git-util/check-branch-updated.sh -b $TRAVIS_BRANCH || exit 1;
     AFFECTED_LIBS="$(nx affected:libs --base=$BASE_HASH --head=$HEAD_HASH --plain)"
@@ -23,7 +24,7 @@ fi;
 ./node_modules/@alfresco/adf-cli/bin/adf-cli check-cs-env --host "$E2E_HOST" -u "$E2E_USERNAME" -p "$E2E_PASSWORD" || exit 1
 RUN_E2E=$(echo ./scripts/test-e2e-lib.sh -host http://localhost:4200 -proxy "$E2E_HOST" -u "$E2E_USERNAME" -p "$E2E_PASSWORD" -e "$E2E_EMAIL" --use-dist -m 2 || exit 1)
 
-if [[  $AFFECTED_LIBS =~ "testing" || $AFFECTED_LIBS =~ "$CONTEXT_ENV" || $TRAVIS_PULL_REQUEST == "false"  ]];
+if [[  $AFFECTED_LIBS =~ "testing" || $AFFECTED_LIBS =~ "$CONTEXT_ENV" || "${TRAVIS_EVENT_TYPE}" == "push"  ]];
 then
     $RUN_E2E --folder $CONTEXT_ENV || exit 1
 else if [[ $AFFECTED_E2E = "e2e/$CONTEXT_ENV" ]];

--- a/scripts/travis/e2e/core-e2e.sh
+++ b/scripts/travis/e2e/core-e2e.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+echo "Start Core e2e"
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 cd $DIR/../../../

--- a/scripts/travis/e2e/core-e2e.sh
+++ b/scripts/travis/e2e/core-e2e.sh
@@ -9,9 +9,12 @@ export PROVIDER='ALL'
 export AUTH_TYPE='BASIC'
 
 if [[ $TRAVIS_PULL_REQUEST == "true"  ]]; then
+    echo "Calculate affected e2e $BASE_HASH $HEAD_HASH"
     ./scripts/git-util/check-branch-updated.sh -b $TRAVIS_BRANCH || exit 1;
     AFFECTED_LIBS="$(nx affected:libs --base=$BASE_HASH --head=$HEAD_HASH --plain)"
+    echo "Affected libs ${AFFECTED_LIBS}"
     AFFECTED_E2E="$(./scripts/git-util/affected-folder.sh -b $TRAVIS_BRANCH -f "e2e/$CONTEXT_ENV")";
+    echo "Affected e2e ${AFFECTED_E2E}"
 fi;
 
 ./node_modules/@alfresco/adf-cli/bin/adf-cli check-ps-env --host "$E2E_HOST" -u "$E2E_USERNAME" -p "$E2E_PASSWORD" || exit 1

--- a/scripts/travis/e2e/insights-e2e.sh
+++ b/scripts/travis/e2e/insights-e2e.sh
@@ -9,7 +9,7 @@ export AUTH_TYPE='BASIC'
 
 cd $DIR/../../../
 
-if [[ $TRAVIS_PULL_REQUEST == "true"  ]]; then
+if [ "${TRAVIS_EVENT_TYPE}" == "pull_request" ]; then
     echo "Calculate affected e2e $BASE_HASH $HEAD_HASH"
     ./scripts/git-util/check-branch-updated.sh -b $TRAVIS_BRANCH || exit 1;
     echo "Affected libs ${AFFECTED_LIBS}"
@@ -17,7 +17,7 @@ if [[ $TRAVIS_PULL_REQUEST == "true"  ]]; then
     echo "Affected e2e ${AFFECTED_E2E}"
 fi;
 
-if [[  $AFFECTED_LIBS =~ "testing" || $AFFECTED_LIBS =~ "insight" || $TRAVIS_PULL_REQUEST == "false"  ]];
+if [[  $AFFECTED_LIBS =~ "testing" || $AFFECTED_LIBS =~ "insight" || "${TRAVIS_EVENT_TYPE}" == "push"  ]];
 then
   ./node_modules/@alfresco/adf-cli/bin/adf-cli check-ps-env --host "$E2E_HOST" -u "$E2E_USERNAME" -p "$E2E_PASSWORD" || exit 1;
   ./scripts/test-e2e-lib.sh -host http://localhost:4200 -proxy "$E2E_HOST" -u "$E2E_USERNAME" -p "$E2E_PASSWORD" -e "$E2E_EMAIL" --folder insights --use-dist   || exit 1;

--- a/scripts/travis/e2e/insights-e2e.sh
+++ b/scripts/travis/e2e/insights-e2e.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+echo "Start insight e2e"
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export PROVIDER='BPM'

--- a/scripts/travis/e2e/insights-e2e.sh
+++ b/scripts/travis/e2e/insights-e2e.sh
@@ -8,8 +8,11 @@ export AUTH_TYPE='BASIC'
 cd $DIR/../../../
 
 if [[ $TRAVIS_PULL_REQUEST == "true"  ]]; then
+    echo "Calculate affected e2e $BASE_HASH $HEAD_HASH"
     ./scripts/git-util/check-branch-updated.sh -b $TRAVIS_BRANCH || exit 1;
+    echo "Affected libs ${AFFECTED_LIBS}"
     AFFECTED_LIBS="$(nx affected:libs --base=$BASE_HASH --head=$HEAD_HASH --plain)"
+    echo "Affected e2e ${AFFECTED_E2E}"
 fi;
 
 if [[  $AFFECTED_LIBS =~ "testing" || $AFFECTED_LIBS =~ "insight" || $TRAVIS_PULL_REQUEST == "false"  ]];

--- a/scripts/travis/e2e/process-services-cloud-e2e.sh
+++ b/scripts/travis/e2e/process-services-cloud-e2e.sh
@@ -9,9 +9,12 @@ export PROVIDER="ALL"
 export AUTH_TYPE="OAUTH"
 
 if [[ $TRAVIS_PULL_REQUEST == "true"  ]]; then
+    echo "Calculate affected e2e $BASE_HASH $HEAD_HASH"
     ./scripts/git-util/check-branch-updated.sh -b $TRAVIS_BRANCH || exit 1;
     AFFECTED_LIBS="$(nx affected:libs --base=$BASE_HASH --head=$HEAD_HASH --plain)"
+    echo "Affected libs ${AFFECTED_LIBS}"
     AFFECTED_E2E="$(./scripts/git-util/affected-folder.sh -b $TRAVIS_BRANCH -f "e2e/$CONTEXT_ENV")";
+    echo "Affected e2e ${AFFECTED_E2E}"
 fi;
 
 RUN_E2E=$(echo ./scripts/test-e2e-lib.sh -host http://localhost:4200 -proxy "$E2E_HOST_BPM" -u "$E2E_USERNAME" -p "$E2E_PASSWORD" -e "$E2E_EMAIL" -host_sso "$E2E_HOST_SSO" -identity_admin_email "$E2E_ADMIN_EMAIL_IDENTITY" -identity_admin_password "$E2E_ADMIN_PASSWORD_IDENTITY" -prefix $TRAVIS_BUILD_NUMBER --use-dist -m 2 -save -b )

--- a/scripts/travis/e2e/process-services-cloud-e2e.sh
+++ b/scripts/travis/e2e/process-services-cloud-e2e.sh
@@ -10,7 +10,7 @@ export CONTEXT_ENV="process-services-cloud"
 export PROVIDER="ALL"
 export AUTH_TYPE="OAUTH"
 
-if [[ $TRAVIS_PULL_REQUEST == "true"  ]]; then
+if [ "${TRAVIS_EVENT_TYPE}" == "pull_request" ]; then
     echo "Calculate affected e2e $BASE_HASH $HEAD_HASH"
     ./scripts/git-util/check-branch-updated.sh -b $TRAVIS_BRANCH || exit 1;
     AFFECTED_LIBS="$(nx affected:libs --base=$BASE_HASH --head=$HEAD_HASH --plain)"
@@ -27,7 +27,7 @@ check_env(){
    ./node_modules/@alfresco/adf-cli/bin/adf-cli check-cs-env --host "$E2E_HOST_BPM" -u "$E2E_ADMIN_EMAIL_IDENTITY" -p "$E2E_ADMIN_PASSWORD_IDENTITY" || exit 1
 }
 
-if [[  $AFFECTED_LIBS =~ "testing" || $AFFECTED_LIBS =~ "$CONTEXT_ENV" || $TRAVIS_PULL_REQUEST == "false"  ]];
+if [[  $AFFECTED_LIBS =~ "testing" || $AFFECTED_LIBS =~ "$CONTEXT_ENV" || "${TRAVIS_EVENT_TYPE}" == "push"  ]];
 then
     echo "Case 1 - adf-testing has been changed";
     check_env;

--- a/scripts/travis/e2e/process-services-cloud-e2e.sh
+++ b/scripts/travis/e2e/process-services-cloud-e2e.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+echo "Start process services cloud e2e"
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 cd $DIR/../../../

--- a/scripts/travis/e2e/process-services-e2e.sh
+++ b/scripts/travis/e2e/process-services-e2e.sh
@@ -8,6 +8,8 @@ export CONTEXT_ENV="process-services"
 export PROVIDER='BPM'
 export AUTH_TYPE='BASIC'
 
+echo "Start process services e2e"
+
 if [[ $TRAVIS_PULL_REQUEST == "true"  ]]; then
     echo "Calculate affected e2e $BASE_HASH $HEAD_HASH"
     ./scripts/git-util/check-branch-updated.sh -b $TRAVIS_BRANCH || exit 1;

--- a/scripts/travis/e2e/process-services-e2e.sh
+++ b/scripts/travis/e2e/process-services-e2e.sh
@@ -10,7 +10,7 @@ export AUTH_TYPE='BASIC'
 
 echo "Start process services e2e"
 
-if [[ $TRAVIS_PULL_REQUEST == "true"  ]]; then
+if [ "${TRAVIS_EVENT_TYPE}" == "pull_request" ]; then
     echo "Calculate affected e2e $BASE_HASH $HEAD_HASH"
     ./scripts/git-util/check-branch-updated.sh -b $TRAVIS_BRANCH || exit 1;
     AFFECTED_LIBS="$(nx affected:libs --base=$BASE_HASH --head=$HEAD_HASH --plain)"
@@ -22,7 +22,7 @@ fi;
 ./node_modules/@alfresco/adf-cli/bin/adf-cli check-ps-env --host "$E2E_HOST" -u "$E2E_USERNAME" -p "$E2E_PASSWORD" || exit 1
 RUN_E2E=$(echo ./scripts/test-e2e-lib.sh -host http://localhost:4200 -proxy "$E2E_HOST" -u "$E2E_USERNAME" -p "$E2E_PASSWORD" -e "$E2E_EMAIL" --use-dist -m 2 || exit 1)
 
-if [[  $AFFECTED_LIBS =~ "testing" || $AFFECTED_LIBS =~ "$CONTEXT_ENV" || $TRAVIS_PULL_REQUEST == "false"  ]];
+if [[  $AFFECTED_LIBS =~ "testing" || $AFFECTED_LIBS =~ "$CONTEXT_ENV" || "${TRAVIS_EVENT_TYPE}" == "push"  ]];
 then
     $RUN_E2E --folder $CONTEXT_ENV
 else if [[ $AFFECTED_E2E = "e2e/$CONTEXT_ENV" ]];

--- a/scripts/travis/e2e/process-services-e2e.sh
+++ b/scripts/travis/e2e/process-services-e2e.sh
@@ -9,9 +9,12 @@ export PROVIDER='BPM'
 export AUTH_TYPE='BASIC'
 
 if [[ $TRAVIS_PULL_REQUEST == "true"  ]]; then
+    echo "Calculate affected e2e $BASE_HASH $HEAD_HASH"
     ./scripts/git-util/check-branch-updated.sh -b $TRAVIS_BRANCH || exit 1;
     AFFECTED_LIBS="$(nx affected:libs --base=$BASE_HASH --head=$HEAD_HASH --plain)"
+    echo "Affected libs ${AFFECTED_LIBS}"
     AFFECTED_E2E="$(./scripts/git-util/affected-folder.sh -b $TRAVIS_BRANCH -f "e2e/$CONTEXT_ENV")";
+    echo "Affected e2e ${AFFECTED_E2E}"
 fi;
 
 ./node_modules/@alfresco/adf-cli/bin/adf-cli check-ps-env --host "$E2E_HOST" -u "$E2E_USERNAME" -p "$E2E_PASSWORD" || exit 1

--- a/scripts/travis/e2e/search-e2e.sh
+++ b/scripts/travis/e2e/search-e2e.sh
@@ -2,6 +2,8 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+echo "Start search e2e"
+
 cd $DIR/../../../
 
 export CONTEXT_ENV="search"

--- a/scripts/travis/e2e/search-e2e.sh
+++ b/scripts/travis/e2e/search-e2e.sh
@@ -9,9 +9,12 @@ export PROVIDER='ECM'
 export AUTH_TYPE='BASIC'
 
 if [[ $TRAVIS_PULL_REQUEST == "true"  ]]; then
+    echo "Calculate affected e2e $BASE_HASH $HEAD_HASH"
     ./scripts/git-util/check-branch-updated.sh -b $TRAVIS_BRANCH || exit 1;
     AFFECTED_LIBS="$(nx affected:libs --base=$BASE_HASH --head=$HEAD_HASH --plain)"
+    echo "Affected libs ${AFFECTED_LIBS}"
     AFFECTED_E2E="$(./scripts/git-util/affected-folder.sh -b $TRAVIS_BRANCH -f "e2e/$CONTEXT_ENV")";
+    echo "Affected e2e ${AFFECTED_E2E}"
 fi;
 
 ./node_modules/@alfresco/adf-cli/bin/adf-cli check-cs-env --host "$E2E_HOST" -u "$E2E_USERNAME" -p "$E2E_PASSWORD" || exit 1

--- a/scripts/travis/e2e/search-e2e.sh
+++ b/scripts/travis/e2e/search-e2e.sh
@@ -10,7 +10,7 @@ export CONTEXT_ENV="search"
 export PROVIDER='ECM'
 export AUTH_TYPE='BASIC'
 
-if [[ $TRAVIS_PULL_REQUEST == "true"  ]]; then
+if [ "${TRAVIS_EVENT_TYPE}" == "pull_request" ];then
     echo "Calculate affected e2e $BASE_HASH $HEAD_HASH"
     ./scripts/git-util/check-branch-updated.sh -b $TRAVIS_BRANCH || exit 1;
     AFFECTED_LIBS="$(nx affected:libs --base=$BASE_HASH --head=$HEAD_HASH --plain)"
@@ -22,7 +22,7 @@ fi;
 ./node_modules/@alfresco/adf-cli/bin/adf-cli check-cs-env --host "$E2E_HOST" -u "$E2E_USERNAME" -p "$E2E_PASSWORD" || exit 1
 RUN_E2E=$(echo ./scripts/test-e2e-lib.sh -host http://localhost:4200 -proxy "$E2E_HOST" -u "$E2E_USERNAME" -p "$E2E_PASSWORD" -e "$E2E_EMAIL" --use-dist -m 2 || exit 1)
 
-if [[  $AFFECTED_LIBS =~ "testing" || $AFFECTED_LIBS =~ "content-services" || $TRAVIS_PULL_REQUEST == "false"  ]];
+if [[  $AFFECTED_LIBS =~ "testing" || $AFFECTED_LIBS =~ "content-services" || "${TRAVIS_EVENT_TYPE}" == "push"  ]];
 then
     $RUN_E2E --folder $CONTEXT_ENV
 else if [[ $AFFECTED_E2E = "e2e/$CONTEXT_ENV" ]];

--- a/scripts/travis/release/release-npm.sh
+++ b/scripts/travis/release/release-npm.sh
@@ -4,7 +4,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 cd $DIR/../../../
 
-if [[ $TRAVIS_PULL_REQUEST == "false" ]];
+if [[ "${TRAVIS_EVENT_TYPE}" == "push" ]];
 then
     TAG_NPM=latest
     if [[ $TRAVIS_BRANCH == "develop" ]];

--- a/scripts/travis/unit-test/content.sh
+++ b/scripts/travis/unit-test/content.sh
@@ -9,7 +9,7 @@ ng test content-services --watch=false || exit 1;
 # echo "================== content-services unit ==================="
 
 AFFECTED_LIBS="$(nx affected:libs --base=$BASE_HASH --head=$HEAD_HASH --plain)"
-if [[ $AFFECTED_LIBS =~ "content-services" || $TRAVIS_PULL_REQUEST == "false"  ]];
+if [[ $AFFECTED_LIBS =~ "content-services" ||  "${TRAVIS_EVENT_TYPE}" == "push"  ]];
 then
     ng test content-services --watch=false || exit 1;
 fi;

--- a/scripts/travis/unit-test/core-extension.sh
+++ b/scripts/travis/unit-test/core-extension.sh
@@ -9,14 +9,14 @@ AFFECTED_LIBS="$(nx affected:libs --base=$BASE_HASH --head=$HEAD_HASH --plain)"
 
 echo "================== core unit ==================="
 
-if [[ $AFFECTED_LIBS =~ "core" || $TRAVIS_PULL_REQUEST == "false" ]];
+if [[ $AFFECTED_LIBS =~ "core" || "${TRAVIS_EVENT_TYPE}" == "push" ]];
 then
     ng test core --watch=false || exit 1;
 fi;
 
 echo "================== extensions unit ==================="
 
-if [[ $AFFECTED_LIBS =~ "extensions" || $TRAVIS_PULL_REQUEST == "false"  ]];
+if [[ $AFFECTED_LIBS =~ "extensions" || "${TRAVIS_EVENT_TYPE}" == "push"  ]];
 then
     ng test extensions --watch=false || exit 1;
 fi;

--- a/scripts/travis/unit-test/process.sh
+++ b/scripts/travis/unit-test/process.sh
@@ -10,19 +10,19 @@ cd $DIR/../../../
 AFFECTED_LIBS="$(nx affected:libs --base=$BASE_HASH --head=$HEAD_HASH --plain)"
 
 echo "================== process-services unit ==================="
-if [[ $AFFECTED_LIBS =~ "process-services" || $TRAVIS_PULL_REQUEST == "false"  ]];
+if [[ $AFFECTED_LIBS =~ "process-services" || "${TRAVIS_EVENT_TYPE}" == "push"  ]];
 then
     ng test process-services --watch=false || exit 1;
 fi;
 
 echo "================== insights unit ==================="
-if [[ $AFFECTED_LIBS =~ "insights" || $TRAVIS_PULL_REQUEST == "false"  ]];
+if [[ $AFFECTED_LIBS =~ "insights" || "${TRAVIS_EVENT_TYPE}" == "push"  ]];
 then
     ng test insights --watch=false || exit 1;
 fi;
 
 echo "================== process-services-cloud unit ==================="
-if [[ $AFFECTED_LIBS =~ "process-services-cloud" || $TRAVIS_PULL_REQUEST == "false"  ]];
+if [[ $AFFECTED_LIBS =~ "process-services-cloud" || "${TRAVIS_EVENT_TYPE}" == "push"  ]];
 then
     ng test process-services-cloud --watch=false || exit 1;
 fi;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [X] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
When refreshing filters selection are lost


**What is the new behaviour?**
When selecting/reloading the page filters are saving their values


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://issues.alfresco.com/jira/browse/ACA-3506