### PR TITLE
Improve search filter component: hide a facet if there is no filter category

### DIFF
--- a/lib/content-services/src/lib/search/components/search-filter/search-filter.component.ts
+++ b/lib/content-services/src/lib/search/components/search-filter/search-filter.component.ts
@@ -212,20 +212,23 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
                 this.updateExistingBuckets(responseField, responseBuckets, alreadyExistingField, alreadyExistingBuckets);
             } else if (responseField) {
 
-                const bucketList = new SearchFilterList<FacetFieldBucket>(responseBuckets, field.pageSize);
-                bucketList.filter = this.getBucketFilterFunction(bucketList);
+                // New feature: Hide facet if the field doesn't have filter category
+                if(responseBuckets.length > 0) {
+                    const bucketList = new SearchFilterList<FacetFieldBucket>(responseBuckets, field.pageSize);
+                    bucketList.filter = this.getBucketFilterFunction(bucketList);
 
-                if (!this.responseFacets) {
-                    this.responseFacets = [];
+                    if (!this.responseFacets) {
+                        this.responseFacets = [];
+                    }
+                    this.responseFacets.push(<FacetField> {
+                        ...field,
+                        type: responseField.type || itemType,
+                        label: field.label,
+                        pageSize: field.pageSize | this.DEFAULT_PAGE_SIZE,
+                        currentPageSize: field.pageSize | this.DEFAULT_PAGE_SIZE,
+                        buckets: bucketList
+                    });
                 }
-                this.responseFacets.push(<FacetField> {
-                    ...field,
-                    type: responseField.type || itemType,
-                    label: field.label,
-                    pageSize: field.pageSize | this.DEFAULT_PAGE_SIZE,
-                    currentPageSize: field.pageSize | this.DEFAULT_PAGE_SIZE,
-                    buckets: bucketList
-                });
             }
         });
     }
@@ -267,20 +270,23 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
                 this.updateExistingBuckets(responseField, responseBuckets, alreadyExistingField, alreadyExistingBuckets);
             } else if (responseField) {
 
-                const bucketList = new SearchFilterList<FacetFieldBucket>(responseBuckets, this.facetQueriesPageSize);
-                bucketList.filter = this.getBucketFilterFunction(bucketList);
+                // New feature: Hide facet if the field doesn't have filter category
+                if(responseBuckets.length > 0) {
+                    const bucketList = new SearchFilterList<FacetFieldBucket>(responseBuckets, this.facetQueriesPageSize);
+                    bucketList.filter = this.getBucketFilterFunction(bucketList);
 
-                if (!this.responseFacets) {
-                    this.responseFacets = [];
+                    if (!this.responseFacets) {
+                        this.responseFacets = [];
+                    }
+                    this.responseFacets.push(<FacetField> {
+                        field: group,
+                        type: responseField.type || 'query',
+                        label: group,
+                        pageSize: this.DEFAULT_PAGE_SIZE,
+                        currentPageSize: this.DEFAULT_PAGE_SIZE,
+                        buckets: bucketList
+                    });
                 }
-                this.responseFacets.push(<FacetField> {
-                    field: group,
-                    type: responseField.type || 'query',
-                    label: group,
-                    pageSize: this.DEFAULT_PAGE_SIZE,
-                    currentPageSize: this.DEFAULT_PAGE_SIZE,
-                    buckets: bucketList
-                });
             }
         });
 


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe: This PR improve the search filter component by hiding facets without filter category.


**What is the current behaviour?** (You can also link to an open issue here)
All configured facets are shown in the result page.


**What is the new behaviour?**
Only configured facets with filter categories are shown.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
