### PR TITLE
[ADF-5204] Metadata - Error message still appears after exiting Edit form

### DIFF
--- a/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.html
+++ b/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.html
@@ -53,7 +53,7 @@
 
     <mat-error [attr.data-automation-id]="'card-textitem-error-' + property.key"
                class="adf-textitem-editable-error"
-               *ngIf="hasErrors">
+               *ngIf="isEditable && hasErrors">
         <ul>
             <li *ngFor="let error of errors">{{ error.message | translate: error }}</li>
         </ul>

--- a/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
+++ b/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
@@ -454,6 +454,40 @@ describe('CardViewTextItemComponent', () => {
             expect(component.errors).toBe(expectedErrorMessages);
         });
 
+        it('should render the error when the editedValue is invalid', async () => {
+            const expectedErrorMessages = [{ message: 'Something went wrong' } as CardViewItemValidator];
+            component.property.isValid = () => false;
+            component.property.getValidationErrors = () => expectedErrorMessages;
+            component.editable = true;
+            component.ngOnChanges();
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            updateTextField(component.property.key, 'updated-value');
+            const errorMessage = fixture.debugElement.nativeElement.querySelector('.adf-textitem-editable-error').textContent;
+            expect(errorMessage).toBe('Something went wrong');
+        });
+
+        it('should reset erros when exiting editable mode', async () => {
+            let errorMessage: string;
+            const expectedErrorMessages = [{ message: 'Something went wrong' } as CardViewItemValidator];
+            component.property.isValid = () => false;
+            component.property.getValidationErrors = () => expectedErrorMessages;
+            component.editable = true;
+            component.ngOnChanges();
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            updateTextField(component.property.key, 'updated-value');
+
+            component.editable = false;
+            component.ngOnChanges();
+            fixture.detectChanges();
+            errorMessage = fixture.debugElement.nativeElement.querySelector('.adf-textitem-editable-error');
+            expect(errorMessage).toBe(null);
+            expect(component.errors).toEqual([]);
+        });
+
         it('should update the property value after a successful update attempt', async () => {
             component.property.isValid = () => true;
             component.update();

--- a/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.ts
+++ b/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.ts
@@ -90,6 +90,8 @@ export class CardViewTextItemComponent extends BaseCardView<CardViewTextItemMode
         } else {
             this.editedValue = this.property.displayValue;
         }
+
+        this.resetErrorMessages();
     }
 
     private resetErrorMessages() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
[ADF-5204](https://issues.alfresco.com/jira/browse/ADF-5204)


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
