### PR TITLE
[ADF-5209] When viewing a previous version, the title is not displayed correctly.

### DIFF
--- a/lib/core/viewer/components/viewer.component.spec.ts
+++ b/lib/core/viewer/components/viewer.component.spec.ts
@@ -27,7 +27,7 @@ import { RenderingQueueServices } from '../services/rendering-queue.services';
 import { ViewerComponent } from './viewer.component';
 import { setupTestBed } from '../../testing/setup-test-bed';
 import { AlfrescoApiServiceMock } from '../../mock/alfresco-api.service.mock';
-import { NodeEntry } from '@alfresco/js-api';
+import { NodeEntry, VersionEntry } from '@alfresco/js-api';
 import { CoreTestingModule } from '../../testing/core.testing.module';
 import { TranslateModule } from '@ngx-translate/core';
 
@@ -370,6 +370,35 @@ describe('ViewerComponent', () => {
         expect(component.fileTitle).toBe('file1');
 
         component.nodeId = 'id2';
+        component.ngOnChanges();
+        tick();
+
+        expect(component.fileTitle).toBe('file2');
+    }));
+
+    it('should change display name every time node\`s version changes', fakeAsync(() => {
+        spyOn(alfrescoApiService.nodesApi, 'getNode').and.returnValue(
+            Promise.resolve(new NodeEntry({ entry: { name: 'node1', content: {} } }))
+        );
+
+        spyOn(alfrescoApiService.versionsApi, 'getVersion').and.returnValues(
+            Promise.resolve(new VersionEntry({ entry: { name: 'file1', content: {} } })),
+            Promise.resolve(new VersionEntry({ entry: { name: 'file2', content: {} } }))
+        );
+
+        component.nodeId = 'id1';
+        component.urlFile = null;
+        component.displayName = null;
+        component.blobFile = null;
+        component.showViewer = true;
+
+        component.versionId = '1.0';
+        component.ngOnChanges();
+        tick();
+
+        expect(component.fileTitle).toBe('file1');
+
+        component.versionId = '1.1';
         component.ngOnChanges();
         tick();
 

--- a/lib/core/viewer/components/viewer.component.ts
+++ b/lib/core/viewer/components/viewer.component.ts
@@ -389,7 +389,8 @@ export class ViewerComponent implements OnChanges, OnInit, OnDestroy {
             this.mimeType = nodeData.content.mimeType;
         }
 
-        this.fileTitle = this.getDisplayName(nodeData.name);
+        this.fileTitle = this.getDisplayName(versionData ? versionData.name : nodeData.name);
+
         this.urlFileContent = versionData ? this.apiService.contentApi.getVersionContentUrl(this.nodeId, versionData.id) :
             this.apiService.contentApi.getContentUrl(this.nodeId);
         this.urlFileContent = this.cacheBusterNumber ? this.urlFileContent + '&' + this.cacheBusterNumber : this.urlFileContent;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Currently in ADF & ACA, when viewing a previous version, in the viewer on top the title of the node's version is always the title of the node (meaning the latest version)
https://issues.alfresco.com/jira/browse/ADF-5209

**What is the new behaviour?**

 I can see the correct version title.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
