### PR TITLE
[ACA-3731] E2E test to validate Save, Save as and Delete buttons availability on custom filters

### DIFF
--- a/e2e/process-services-cloud/edit-task-filters-component.e2e.ts
+++ b/e2e/process-services-cloud/edit-task-filters-component.e2e.ts
@@ -291,7 +291,7 @@ describe('Edit task filters cloud', () => {
         await tasksCloudDemoPage.editTaskFilterCloudComponent().editTaskFilterDialog().clickOnCancelButton();
     });
 
-    async function createNewCustomFilter(name: string) {
+    async function createNewCustomFilter(name: string): Promise<void> {
         await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter('my-tasks');
 
         const editTaskFilterCloudComponent = tasksCloudDemoPage.editTaskFilterCloudComponent();

--- a/e2e/process-services-cloud/edit-task-filters-component.e2e.ts
+++ b/e2e/process-services-cloud/edit-task-filters-component.e2e.ts
@@ -114,21 +114,27 @@ describe('Edit task filters cloud', () => {
         await tasksCloudDemoPage.editTaskFilterCloudComponent().openFilter();
     });
 
-    it('[C291795] New filter is added when clicking Save As button', async () => {
-        await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter('my-tasks');
+    it('[C586756] Delete, Save and Save as actions should be displayed and enabled when clicking on custom filter header', async () => {
+        await createNewCustomFilter('New');
 
+        await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter('custom-new');
+        await tasksCloudDemoPage.editTaskFilterCloudComponent().openFilter();
+        await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter('custom-new');
+        await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('New');
         const editTaskFilterCloudComponent = tasksCloudDemoPage.editTaskFilterCloudComponent();
-        await editTaskFilterCloudComponent.openFilter();
-        await editTaskFilterCloudComponent.setSortFilterDropDown('Id');
+        await editTaskFilterCloudComponent.setSortFilterDropDown('Priority');
 
-        await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter('my-tasks');
+        await editTaskFilterCloudComponent.checkSaveButtonIsDisplayed();
+        await editTaskFilterCloudComponent.checkSaveAsButtonIsDisplayed();
+        await editTaskFilterCloudComponent.checkDeleteButtonIsDisplayed();
 
-        await tasksCloudDemoPage.editTaskFilterCloudComponent().clickSaveAsButton();
+        await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().checkSaveButtonIsEnabled()).toEqual(true);
+        await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().checkSaveAsButtonIsEnabled()).toEqual(true);
+        await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().checkDeleteButtonIsEnabled()).toEqual(true);
+    });
 
-        const editTaskFilterDialog = tasksCloudDemoPage.editTaskFilterCloudComponent().editTaskFilterDialog();
-        await editTaskFilterDialog.setFilterName('New');
-        await editTaskFilterDialog.clickOnSaveButton();
-
+    it('[C291795] New filter is added when clicking Save As button', async () => {
+        await createNewCustomFilter('New');
         await expect(await tasksCloudDemoPage.taskFilterCloudComponent.getActiveFilterName()).toBe('New');
         await tasksCloudDemoPage.editTaskFilterCloudComponent().openFilter();
         await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().checkSaveButtonIsEnabled()).toEqual(false);
@@ -284,4 +290,20 @@ describe('Edit task filters cloud', () => {
         await expect(await tasksCloudDemoPage.editTaskFilterCloudComponent().editTaskFilterDialog().getFilterName()).toEqual('My Tasks');
         await tasksCloudDemoPage.editTaskFilterCloudComponent().editTaskFilterDialog().clickOnCancelButton();
     });
+
+    async function createNewCustomFilter(name: string) {
+        await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter('my-tasks');
+
+        const editTaskFilterCloudComponent = tasksCloudDemoPage.editTaskFilterCloudComponent();
+        await editTaskFilterCloudComponent.openFilter();
+        await editTaskFilterCloudComponent.setSortFilterDropDown('Id');
+
+        await tasksCloudDemoPage.taskFilterCloudComponent.clickTaskFilter('my-tasks');
+
+        await tasksCloudDemoPage.editTaskFilterCloudComponent().clickSaveAsButton();
+
+        const editTaskFilterDialog = tasksCloudDemoPage.editTaskFilterCloudComponent().editTaskFilterDialog();
+        await editTaskFilterDialog.setFilterName(name);
+        await editTaskFilterDialog.clickOnSaveButton();
+    }
 });


### PR DESCRIPTION
* Add createNewCustomFilter() method in edit-task-filters-component.e2e.ts

**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe: E2E test for Delete, Save and Save as actions that should be displayed and enabled when clicking on custom filter header


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
