### PR TITLE
[ACA-3795] E2E test to validate Delete Save and Save as actions should be displayed and enabled when clicking on custom filter header

### DIFF
--- a/e2e/process-services-cloud/edit-process-filters-component.e2e.ts
+++ b/e2e/process-services-cloud/edit-process-filters-component.e2e.ts
@@ -73,7 +73,7 @@ describe('Edit process filters cloud', () => {
         await processCloudDemoPage.processFilterCloudComponent.clickAllProcessesFilter();
     });
 
-    it('[C291804] Delete Save and Save as actions should be displayed when clicking on custom filter header', async () => {
+    it('[C291804] Delete Save and Save as actions should be displayed when clicking on default filter header', async () => {
         await processCloudDemoPage.processFilterCloudComponent.clickAllProcessesFilter();
         await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('All');
         await processCloudDemoPage.editProcessFilterCloudComponent().checkSaveButtonIsDisplayed();
@@ -85,14 +85,25 @@ describe('Edit process filters cloud', () => {
         await processCloudDemoPage.editProcessFilterCloudComponent().openFilter();
     });
 
+    it('[C586757] Delete Save and Save as actions should be displayed and enabled when clicking on custom filter header', async () => {
+        await createNewProcessCustomFilter('New');
+        await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('New');
+        await processCloudDemoPage.processFilterCloudComponent.clickProcessFilter('custom-new');
+        await processCloudDemoPage.editProcessFilterCloudComponent().openFilter();
+        await processCloudDemoPage.editProcessFilterCloudComponent().setSortFilterDropDown('StartDate');
+        await expect(await processCloudDemoPage.editProcessFilterCloudComponent().getSortFilterDropDownValue()).toEqual('StartDate');
+
+        await processCloudDemoPage.editProcessFilterCloudComponent().checkSaveButtonIsDisplayed();
+        await processCloudDemoPage.editProcessFilterCloudComponent().checkSaveAsButtonIsDisplayed();
+        await processCloudDemoPage.editProcessFilterCloudComponent().checkDeleteButtonIsDisplayed();
+
+        await expect(await processCloudDemoPage.editProcessFilterCloudComponent().checkSaveButtonIsEnabled()).toEqual(true);
+        await expect(await processCloudDemoPage.editProcessFilterCloudComponent().checkSaveAsButtonIsEnabled()).toEqual(true);
+        await expect(await processCloudDemoPage.editProcessFilterCloudComponent().checkDeleteButtonIsEnabled()).toEqual(true);
+    });
+
     it('[C291805] New process filter is added when clicking Save As button', async () => {
-        await processCloudDemoPage.editProcessFilterCloudComponent().setSortFilterDropDown('Id');
-        await processCloudDemoPage.processFilterCloudComponent.clickAllProcessesFilter();
-
-        await processCloudDemoPage.editProcessFilterCloudComponent().clickSaveAsButton();
-        await processCloudDemoPage.editProcessFilterCloudComponent().editProcessFilterDialog().setFilterName('New');
-        await processCloudDemoPage.editProcessFilterCloudComponent().editProcessFilterDialog().clickOnSaveButton();
-
+        await createNewProcessCustomFilter('New');
         await browser.driver.sleep(1000);
 
         await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('New');
@@ -236,4 +247,13 @@ describe('Edit process filters cloud', () => {
         await expect(await processCloudDemoPage.editProcessFilterCloudComponent().editProcessFilterDialog().getFilterName()).toEqual(PROCESSES.ALL);
         await processCloudDemoPage.editProcessFilterCloudComponent().editProcessFilterDialog().clickOnCancelButton();
     });
+
+    async function createNewProcessCustomFilter(name: string): Promise<void> {
+        await processCloudDemoPage.editProcessFilterCloudComponent().setSortFilterDropDown('Id');
+        await processCloudDemoPage.processFilterCloudComponent.clickAllProcessesFilter();
+
+        await processCloudDemoPage.editProcessFilterCloudComponent().clickSaveAsButton();
+        await processCloudDemoPage.editProcessFilterCloudComponent().editProcessFilterDialog().setFilterName(name);
+        await processCloudDemoPage.editProcessFilterCloudComponent().editProcessFilterDialog().clickOnSaveButton();
+    }
 });


### PR DESCRIPTION
* Add createNewProcessCustomFilter() method in edit-process-filters-component.e2e.ts

**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe: Delete Save and Save as actions should be displayed and enabled when clicking on custom filter header


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
