### PR TITLE
remove unused ID and fix the duplicate warning

### DIFF
--- a/lib/process-services-cloud/src/lib/group/components/group-cloud.component.html
+++ b/lib/process-services-cloud/src/lib/group/components/group-cloud.component.html
@@ -23,7 +23,6 @@
                    (focus)="setFocus(true)"
                    (blur)="setFocus(false)"
                    class="adf-group-input"
-                   id="group-name"
                    data-automation-id="adf-cloud-group-search-input" #groupInput>
         </mat-chip-list>
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

if the component is used multiple times, the non-unique "ID" clashes at runtime

<img width="1404" alt="Screenshot 2020-07-30 at 12 33 24" src="https://user-images.githubusercontent.com/503991/88918230-0ec9fa80-d261-11ea-948e-1f1a7908c658.png">

**What is the new behaviour?**

- remove the ID (not used anywhere)
- fix the Chrome/Edge warnings on the duplicate ID



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
