### PR TITLE
[ADF-5210] Order by folder on default

### DIFF
--- a/lib/content-services/src/lib/document-list/components/document-list.component.spec.ts
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.spec.ts
@@ -1451,7 +1451,7 @@ describe('DocumentList', () => {
             where: undefined,
             maxItems: 25,
             skipCount: 0,
-            orderBy: ['nodeType DESC', 'name asc' ],
+            orderBy: ['isFolder DESC', 'name asc' ],
             rootFolderId: 'fake-id'
         }, ['test-include']);
     });
@@ -1467,7 +1467,7 @@ describe('DocumentList', () => {
             where: '(isFolder=true)',
             maxItems: 25,
             skipCount: 0,
-            orderBy: ['nodeType DESC', 'name asc' ],
+            orderBy: ['isFolder DESC', 'name asc' ],
             rootFolderId: 'fake-id'
         }, ['test-include']);
     });
@@ -1484,7 +1484,7 @@ describe('DocumentList', () => {
             maxItems: 25,
             skipCount: 0,
             where: undefined,
-            orderBy: ['nodeType DESC', 'size DESC'],
+            orderBy: ['isFolder DESC', 'size DESC'],
             rootFolderId: 'fake-id'
         }, ['test-include']);
     });
@@ -1502,7 +1502,7 @@ describe('DocumentList', () => {
         expect(documentListService.getFolder).toHaveBeenCalledWith(null, {
             maxItems: 25,
             skipCount: 0,
-            orderBy: ['nodeType DESC', 'name asc' ],
+            orderBy: ['isFolder DESC', 'name asc' ],
             rootFolderId: 'folder-id',
             where: undefined
         }, undefined);

--- a/lib/content-services/src/lib/document-list/components/document-list.component.ts
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.ts
@@ -190,7 +190,7 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
      * rule to be added to the sorting apart from the one driven by the header.
      */
     @Input()
-    additionalSorting = ['nodeType DESC'];
+    additionalSorting = ['isFolder DESC'];
 
     /** Defines sorting mode. Can be either `client` (items in the list
      * are sorted client-side) or `server` (the ordering supplied by the


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Order by cm type makes Sites that is type cm:sites always on the top


**What is the new behaviour?**
Order by folder on default



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
