### PR TITLE
[AAE-3200] Attach button of content node selector becomes enabled when selecting a folder

### DIFF
--- a/e2e/protractor.excludes.json
+++ b/e2e/protractor.excludes.json
@@ -5,10 +5,6 @@
   "C362241": "Include once ADF starts using ACS 7, https://issues.alfresco.com/jira/browse/ADF-5182",
   "C362242": "Include once ADF starts using ACS 7, https://issues.alfresco.com/jira/browse/ADF-5182",
   "C362265": "Include once ADF starts using ACS 7, https://issues.alfresco.com/jira/browse/ADF-5182",
-  "C311287": "https://issues.alfresco.com/jira/browse/AAE-3200",
-  "C260140": "https://issues.alfresco.com/jira/browse/AAE-3200",
-  "C261160": "https://issues.alfresco.com/jira/browse/AAE-3200",
-  "C246534": "https://issues.alfresco.com/jira/browse/AAE-3200",
   "C310358": "Include once process storage services removed, https://issues.alfresco.com/jira/browse/AAE-3177",
   "C311290": "Include once process storage services removed, https://issues.alfresco.com/jira/browse/AAE-3177"
 }

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector.component.html
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector.component.html
@@ -44,7 +44,7 @@
         </button>
 
         <button mat-button
-                [disabled]="!chosenNode"
+                [disabled]="!hasNodeSelected()"
                 class="adf-choose-action"
                 (click)="onClick()"
                 data-automation-id="content-node-selector-actions-choose">{{ buttonActionName | translate }}

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector.component.spec.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector.component.spec.ts
@@ -161,6 +161,22 @@ describe('ContentNodeSelectorDialogComponent', () => {
             const actionButton = fixture.debugElement.query(By.css('[data-automation-id="content-node-selector-actions-choose"]'));
             expect(actionButton.nativeElement.disabled).toBeFalsy();
         });
+
+        it('should be disabled when no node chosen', () => {
+            component.onSelect([new Node({ id: 'fake' })]);
+            fixture.detectChanges();
+
+            const actionButtonWithNodeSelected = fixture.debugElement.query(By.css('[data-automation-id="content-node-selector-actions-choose"]'));
+
+            expect(actionButtonWithNodeSelected.nativeElement.disabled).toBe(false);
+
+            component.onSelect([]);
+            fixture.detectChanges();
+
+            const actionButtonWithoutNodeSelected = fixture.debugElement.query(By.css('[data-automation-id="content-node-selector-actions-choose"]'));
+
+            expect(actionButtonWithoutNodeSelected.nativeElement.disabled).toBe(true);
+        });
     });
 
     describe('Title', () => {

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector.component.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector.component.ts
@@ -82,4 +82,8 @@ export class ContentNodeSelectorComponent {
     onError(error) {
         this.notificationService.showError(error);
     }
+
+    hasNodeSelected(): boolean {
+        return this.chosenNode?.length > 0;
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://issues.alfresco.com/jira/browse/AAE-3200

**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
