### PR TITLE
[ADF-3499] Make Card View Text Item reactive to user input

### DIFF
--- a/lib/core/card-view/card-view.module.ts
+++ b/lib/core/card-view/card-view.module.ts
@@ -17,7 +17,7 @@
 
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatCheckboxModule } from '@angular/material/checkbox';
@@ -51,6 +51,7 @@ import { SelectFilterInputComponent } from './components/card-view-selectitem/se
     imports: [
         CommonModule,
         FormsModule,
+        ReactiveFormsModule,
         FlexLayoutModule,
         TranslateModule,
         MatDatepickerModule,

--- a/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.html
+++ b/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.html
@@ -13,9 +13,8 @@
                    *ngIf="!property.multiline"
                    class="adf-property-value"
                    [placeholder]="property.default"
-                   [(ngModel)]="editedValue"
-                   (blur)="update()"
-                   (keydown.enter)="update()"
+                   [value]="editedValue"
+                   [formControl]="textInput"
                    [disabled]="!isEditable"
                    (dblclick)="copyToClipboard(property.displayValue)"
                    matTooltipShowDelay="1000"
@@ -29,9 +28,7 @@
                       matAutosizeMaxRows="5"
                       class="adf-property-value"
                       [placeholder]="property.default"
-                      [(ngModel)]="editedValue"
-                      (blur)="update()"
-                      (keydown.enter)="update()"
+                      [formControl]="textInput"
                       [disabled]="!isEditable"
                       [attr.data-automation-id]="'card-textitem-value-' + property.key"></textarea>
             <button mat-button

--- a/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.html
+++ b/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.html
@@ -15,7 +15,6 @@
                    [placeholder]="property.default"
                    [value]="editedValue"
                    [formControl]="textInput"
-                   [disabled]="!isEditable"
                    (dblclick)="copyToClipboard(property.displayValue)"
                    matTooltipShowDelay="1000"
                    [matTooltip]="'CORE.METADATA.ACTIONS.COPY_TO_CLIPBOARD' | translate"
@@ -29,7 +28,6 @@
                       class="adf-property-value"
                       [placeholder]="property.default"
                       [formControl]="textInput"
-                      [disabled]="!isEditable"
                       [attr.data-automation-id]="'card-textitem-value-' + property.key"></textarea>
             <button mat-button
                     matSuffix

--- a/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
+++ b/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, tick, fakeAsync, async } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { CardViewTextItemModel } from '../../models/card-view-textitem.model';
 import { CardViewUpdateService } from '../../services/card-view-update.service';
@@ -25,7 +25,7 @@ import { CoreTestingModule } from '../../../testing/core.testing.module';
 import { CardViewItemFloatValidator, CardViewItemIntValidator, CardViewIntItemModel, CardViewFloatItemModel } from '@alfresco/adf-core';
 import { MatChipsModule } from '@angular/material/chips';
 import { ClipboardService } from '../../../clipboard/clipboard.service';
-import { DebugElement } from '@angular/core';
+import { DebugElement, SimpleChange } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { CardViewItemValidator } from '../../interfaces/card-view-item-validator.interface';
 
@@ -63,34 +63,35 @@ describe('CardViewTextItemComponent', () => {
             });
         });
 
-        it('should render the label and value', async () => {
-            component.ngOnChanges();
+        it('should render the label and value', () => {
             fixture.detectChanges();
-            await fixture.whenStable();
+            fixture.whenStable().then(() => {
 
-            const labelValue = fixture.debugElement.query(By.css('.adf-property-label'));
-            expect(labelValue).not.toBeNull();
-            expect(labelValue.nativeElement.innerText).toBe('Text label');
+                const labelValue = fixture.debugElement.query(By.css('.adf-property-label'));
+                expect(labelValue).not.toBeNull();
+                expect(labelValue.nativeElement.innerText).toBe('Text label');
 
-            const value = getTextFieldValue(component.property.key);
-            expect(value).toBe('Lorem ipsum');
+                const value = getTextFieldValue(component.property.key);
+                expect(value).toBe('Lorem ipsum');
+            });
         });
 
-        it('should render the displayName as value when available', async () => {
+        it('should render the displayName as value when available', () => {
             component.property = new CardViewTextItemModel({
                 label: 'Name label',
                 value: { id: 123, displayName: 'User Name' },
                 key: 'namekey'
             });
-            component.ngOnChanges();
             fixture.detectChanges();
-            await fixture.whenStable();
+            fixture.whenStable().then(() => {
 
-            const value = getTextFieldValue(component.property.key);
-            expect(value).toBe('User Name');
+                const value = getTextFieldValue(component.property.key);
+                expect(value).toBe('User Name');
+
+            });
         });
 
-        it('should render the default as value if the value is empty, editable is false and displayEmpty is true', async () => {
+        it('should render the default as value if the value is empty, editable is false and displayEmpty is true', () => {
             component.property = new CardViewTextItemModel({
                 label: 'Text label',
                 value: '',
@@ -99,15 +100,15 @@ describe('CardViewTextItemComponent', () => {
                 editable: false
             });
             component.displayEmpty = true;
-            component.ngOnChanges();
             fixture.detectChanges();
-            await fixture.whenStable();
+            fixture.whenStable().then(() => {
 
-            const value = getTextFieldValue(component.property.key);
-            expect(value).toBe('FAKE-DEFAULT-KEY');
+                const value = getTextFieldValue(component.property.key);
+                expect(value).toBe('FAKE-DEFAULT-KEY');
+            });
         });
 
-        it('should render the default as value if the value is empty and editable true', async () => {
+        it('should render the default as value if the value is empty and editable true', () => {
             component.property = new CardViewTextItemModel({
                 label: 'Text label',
                 value: '',
@@ -116,57 +117,57 @@ describe('CardViewTextItemComponent', () => {
                 editable: true
             });
             component.editable = true;
-            component.ngOnChanges();
             fixture.detectChanges();
-            await fixture.whenStable();
+            fixture.whenStable().then(() => {
 
-            const value = getTextFieldValue(component.property.key);
-            expect(value).toBe('FAKE-DEFAULT-KEY');
+                const value = getTextFieldValue(component.property.key);
+                expect(value).toBe('FAKE-DEFAULT-KEY');
+            });
         });
 
-        it('should render value when editable:true', async () => {
+        it('should render value when editable:true', () => {
             component.editable = true;
             component.property.editable = true;
-            component.ngOnChanges();
             fixture.detectChanges();
-            await fixture.whenStable();
+            fixture.whenStable().then(() => {
 
-            const value = getTextFieldValue(component.property.key);
-            expect(value).toBe('Lorem ipsum');
+                const value = getTextFieldValue(component.property.key);
+                expect(value).toBe('Lorem ipsum');
+            });
         });
 
         it('should render the edit icon in case of editable:true', () => {
             component.editable = true;
             component.property.editable = true;
-            component.ngOnChanges();
+
             fixture.detectChanges();
 
             const editIcon = fixture.debugElement.query(By.css('.adf-textitem-edit-icon'));
             expect(editIcon).not.toBeNull('Edit icon should be shown');
         });
 
-        it('should NOT render the edit icon in case of editable:false', async () => {
+        it('should NOT render the edit icon in case of editable:false', () => {
             component.editable = false;
-            component.ngOnChanges();
             fixture.detectChanges();
-            await fixture.whenStable();
-
-            const editIcon = fixture.debugElement.query(By.css('.adf-textitem-edit-icon'));
-            expect(editIcon).toBeNull('Edit icon should NOT be shown');
+            fixture.whenStable().then(() => {
+                const editIcon = fixture.debugElement.query(By.css('.adf-textitem-edit-icon'));
+                expect(editIcon).toBeNull('Edit icon should NOT be shown');
+            });
         });
 
-        it('should NOT render the picker and toggle in case of editable:true but (general) editable:false', async () => {
+        it('should NOT render the picker and toggle in case of editable:true but (general) editable:false', () => {
             component.editable = false;
             component.property.editable = true;
-            component.ngOnChanges();
-            fixture.detectChanges();
-            await fixture.whenStable();
 
-            const editIcon = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-edit-icon-${component.property.key}"]`));
-            expect(editIcon).toBeNull('Edit icon should NOT be shown');
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+
+                const editIcon = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-edit-icon-${component.property.key}"]`));
+                expect(editIcon).toBeNull('Edit icon should NOT be shown');
+            });
         });
 
-        it('should render chips for multivalue properties when chips are enabled', async () => {
+        it('should render chips for multivalue properties when chips are enabled', () => {
             component.property = new CardViewTextItemModel({
                 label: 'Text label',
                 value: ['item1', 'item2', 'item3'],
@@ -176,19 +177,20 @@ describe('CardViewTextItemComponent', () => {
                 multivalued: true
             });
             component.useChipsForMultiValueProperty = true;
-            component.ngOnChanges();
-            fixture.detectChanges();
-            await fixture.whenStable();
 
-            const valueChips = fixture.debugElement.queryAll(By.css(`mat-chip`));
-            expect(valueChips).not.toBeNull();
-            expect(valueChips.length).toBe(3);
-            expect(valueChips[0].nativeElement.innerText.trim()).toBe('item1');
-            expect(valueChips[1].nativeElement.innerText.trim()).toBe('item2');
-            expect(valueChips[2].nativeElement.innerText.trim()).toBe('item3');
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+
+                const valueChips = fixture.debugElement.queryAll(By.css(`mat-chip`));
+                expect(valueChips).not.toBeNull();
+                expect(valueChips.length).toBe(3);
+                expect(valueChips[0].nativeElement.innerText.trim()).toBe('item1');
+                expect(valueChips[1].nativeElement.innerText.trim()).toBe('item2');
+                expect(valueChips[2].nativeElement.innerText.trim()).toBe('item3');
+            });
         });
 
-        it('should render string for multivalue properties when chips are disabled', async () => {
+        it('should render string for multivalue properties when chips are disabled', () => {
             component.property = new CardViewTextItemModel({
                 label: 'Text label',
                 value: ['item1', 'item2', 'item3'],
@@ -199,14 +201,15 @@ describe('CardViewTextItemComponent', () => {
             });
 
             component.useChipsForMultiValueProperty = false;
-            component.ngOnChanges();
-            fixture.detectChanges();
-            await fixture.whenStable();
 
-            const valueChips = fixture.debugElement.query(By.css(`mat-chip-list`));
-            const value = getTextFieldValue(component.property.key);
-            expect(value).toBe('item1,item2,item3');
-            expect(valueChips).toBeNull();
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+
+                const valueChips = fixture.debugElement.query(By.css(`mat-chip-list`));
+                const value = getTextFieldValue(component.property.key);
+                expect(value).toBe('item1,item2,item3');
+                expect(valueChips).toBeNull();
+            });
         });
     });
 
@@ -221,126 +224,135 @@ describe('CardViewTextItemComponent', () => {
             });
         });
 
-        it('should render the default as value if the value is empty, clickable is false and displayEmpty is true', async () => {
+        it('should render the default as value if the value is empty, clickable is false and displayEmpty is true', () => {
             component.property.clickable = false;
             component.displayEmpty = true;
-            component.ngOnChanges();
-            fixture.detectChanges();
-            await fixture.whenStable();
-            fixture.detectChanges();
 
-            const value = getTextFieldValue(component.property.key);
-            expect(value).toBe('FAKE-DEFAULT-KEY');
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+                fixture.detectChanges();
+
+                const value = getTextFieldValue(component.property.key);
+                expect(value).toBe('FAKE-DEFAULT-KEY');
+            });
         });
 
-        it('should render the default as value if the value is empty and clickable true', async () => {
+        it('should render the default as value if the value is empty and clickable true', () => {
             component.property.clickable = true;
-            component.ngOnChanges();
-            fixture.detectChanges();
-            await fixture.whenStable();
-            fixture.detectChanges();
 
-            const value = getTextFieldValue(component.property.key);
-            expect(value).toBe('FAKE-DEFAULT-KEY');
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+                fixture.detectChanges();
+
+                const value = getTextFieldValue(component.property.key);
+                expect(value).toBe('FAKE-DEFAULT-KEY');
+            });
         });
 
-        it('should not render the edit icon in case of clickable true but edit false', async () => {
+        it('should not render the edit icon in case of clickable true but edit false', () => {
             component.property.clickable = true;
-            component.ngOnChanges();
-            fixture.detectChanges();
-            await fixture.whenStable();
-            fixture.detectChanges();
 
-            const value = fixture.debugElement.query(By.css('.adf-textitem-edit-icon'));
-            expect(value).toBeNull();
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+                fixture.detectChanges();
+
+                const value = fixture.debugElement.query(By.css('.adf-textitem-edit-icon'));
+                expect(value).toBeNull();
+            });
         });
 
-        it('should not render the clickable icon in case editable set to false', async () => {
+        it('should not render the clickable icon in case editable set to false', () => {
             component.property.clickable = true;
             component.property.icon = 'create';
             component.editable = false;
-            component.ngOnChanges();
-            fixture.detectChanges();
-            await fixture.whenStable();
-            fixture.detectChanges();
 
-            const value = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-clickable-icon-${component.property.key}"]`));
-            expect(value).toBeNull('icon should NOT be shown');
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+                fixture.detectChanges();
+
+                const value = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-clickable-icon-${component.property.key}"]`));
+                expect(value).toBeNull('icon should NOT be shown');
+            });
         });
 
-        it('should render the defined clickable icon in case of clickable true and editable input set to true', async () => {
+        it('should render the defined clickable icon in case of clickable true and editable input set to true', () => {
             component.property.clickable = true;
             component.property.icon = 'FAKE_ICON';
             component.editable = true;
-            component.ngOnChanges();
-            fixture.detectChanges();
-            await fixture.whenStable();
-            fixture.detectChanges();
 
-            const value = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-clickable-icon-${component.property.key}"]`));
-            expect(value).not.toBeNull();
-            expect(value.nativeElement.innerText).toBe('FAKE_ICON');
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+                fixture.detectChanges();
+
+                const value = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-clickable-icon-${component.property.key}"]`));
+                expect(value).not.toBeNull();
+                expect(value.nativeElement.innerText).toBe('FAKE_ICON');
+            });
         });
 
-        it('should not render clickable icon in case of clickable true and icon undefined', async () => {
+        it('should not render clickable icon in case of clickable true and icon undefined', () => {
             component.property.clickable = true;
             component.editable = true;
-            component.ngOnChanges();
-            fixture.detectChanges();
-            await fixture.whenStable();
-            fixture.detectChanges();
 
-            const value = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-clickable-icon-${component.property.key}"]`));
-            expect(value).toBeNull('icon should NOT be shown');
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+                fixture.detectChanges();
+
+                const value = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-clickable-icon-${component.property.key}"]`));
+                expect(value).toBeNull('icon should NOT be shown');
+            });
         });
 
-        it('should not render the edit icon in case of clickable false and icon defined', async () => {
+        it('should not render the edit icon in case of clickable false and icon defined', () => {
             component.property.clickable = false;
             component.property.icon = 'FAKE_ICON';
-            component.ngOnChanges();
-            fixture.detectChanges();
-            await fixture.whenStable();
-            fixture.detectChanges();
 
-            const value = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-edit-icon-${component.property.icon}"]`));
-            expect(value).toBeNull('Edit icon should NOT be shown');
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+                fixture.detectChanges();
+
+                const value = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-edit-icon-${component.property.icon}"]`));
+                expect(value).toBeNull('Edit icon should NOT be shown');
+            });
         });
 
-        it('should call back function when clickable property enabled', async () => {
+        it('should call back function when clickable property enabled', () => {
             const callBackSpy = jasmine.createSpy('callBack');
             component.property.clickable = true;
             component.property.icon = 'FAKE_ICON';
             component.property.clickCallBack = callBackSpy;
             component.editable = true;
-            component.ngOnChanges();
-            fixture.detectChanges();
-            await fixture.whenStable();
-            fixture.detectChanges();
 
-            const value = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-clickable-icon-${component.property.key}"]`));
-            expect(value.nativeElement.innerText).toBe('FAKE_ICON');
-            value.nativeElement.click();
-            expect(callBackSpy).toHaveBeenCalled();
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+                fixture.detectChanges();
+
+                const value = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-clickable-icon-${component.property.key}"]`));
+                expect(value.nativeElement.innerText).toBe('FAKE_ICON');
+                value.nativeElement.click();
+                expect(callBackSpy).toHaveBeenCalled();
+            });
         });
 
-        it('should click event to the event stream when clickable property enabled', async () => {
+        it('should click event to the event stream when clickable property enabled', () => {
             const cardViewUpdateService = TestBed.inject(CardViewUpdateService);
             spyOn(cardViewUpdateService, 'clicked').and.stub();
 
             component.property.clickable = true;
             component.property.icon = 'FAKE_ICON';
             component.editable = false;
-            component.ngOnChanges();
-            fixture.detectChanges();
-            await fixture.whenStable();
-            fixture.detectChanges();
 
-            const value = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-toggle-${component.property.key}"]`));
-            value.nativeElement.click();
-            expect(cardViewUpdateService.clicked).toHaveBeenCalled();
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+                fixture.detectChanges();
+
+                const value = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-toggle-${component.property.key}"]`));
+                value.nativeElement.click();
+                expect(cardViewUpdateService.clicked).toHaveBeenCalled();
+            });
         });
 
-        it('should update input the value on input updated', async (done) => {
+        it('should update input the value on input updated', fakeAsync((done) => {
             const cardViewUpdateService = TestBed.inject(CardViewUpdateService);
 
             component.property.clickable = true;
@@ -348,26 +360,27 @@ describe('CardViewTextItemComponent', () => {
             component.editable = true;
             component.property.isValid = () => true;
             const expectedText = 'changed text';
-            component.ngOnChanges();
-            fixture.detectChanges();
-            await fixture.whenStable();
-            fixture.detectChanges();
 
-            const disposableUpdate = cardViewUpdateService.itemUpdated$.subscribe((updateNotification) => {
-                expect(updateNotification.target).toEqual({ ...component.property });
-                expect(updateNotification.changed).toEqual({ textkey: expectedText });
-                disposableUpdate.unsubscribe();
-                done();
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+                fixture.detectChanges();
+
+                const disposableUpdate = cardViewUpdateService.itemUpdated$.subscribe((updateNotification) => {
+                    expect(updateNotification.target).toEqual({ ...component.property });
+                    expect(updateNotification.changed).toEqual({ textkey: expectedText });
+
+                    expect(getTextFieldValue(component.property.key)).toEqual(expectedText);
+                    expect(component.property.value).toBe(expectedText);
+                    disposableUpdate.unsubscribe();
+                    done();
+                });
+
+                updateTextField(component.property.key, expectedText);
+                tick(600);
+
+                fixture.detectChanges();
             });
-
-            updateTextField(component.property.key, expectedText);
-
-            component.ngOnChanges();
-            fixture.detectChanges();
-
-            expect(getTextFieldValue(component.property.key)).toEqual(expectedText);
-            expect(component.property.value).toBe(expectedText);
-        });
+        }));
 
         it('should copy value to clipboard on double click', async () => {
             const clipboardService = TestBed.inject(ClipboardService);
@@ -377,7 +390,6 @@ describe('CardViewTextItemComponent', () => {
             component.property.icon = 'FAKE_ICON';
             component.editable = false;
             component.copyToClipboardAction = true;
-            component.ngOnChanges();
             fixture.detectChanges();
             await fixture.whenStable();
             fixture.detectChanges();
@@ -388,7 +400,6 @@ describe('CardViewTextItemComponent', () => {
             fixture.detectChanges();
             expect(clipboardService.copyContentToClipboard).toHaveBeenCalledWith('myValueToCopy', 'CORE.METADATA.ACCESSIBILITY.COPY_TO_CLIPBOARD_MESSAGE');
         });
-
     });
 
     describe('Update', () => {
@@ -403,101 +414,131 @@ describe('CardViewTextItemComponent', () => {
             });
         });
 
-        it('should call the isValid method with the edited value', async () => {
-            component.ngOnChanges();
-            fixture.detectChanges();
-            await fixture.whenStable();
-            fixture.detectChanges();
+        it('should call the isValid method with the edited value', fakeAsync(() => {
 
-            spyOn(component.property, 'isValid');
-            updateTextField(component.property.key, 'updated-value');
-            expect(component.property.isValid).toHaveBeenCalledWith('updated-value');
-        });
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+                fixture.detectChanges();
 
-        it('should trigger the update event if the editedValue is valid', async () => {
+                spyOn(component.property, 'isValid');
+                updateTextField(component.property.key, 'updated-value');
+                tick(600);
+                fixture.detectChanges();
+                fixture.whenStable().then(() => {
+                    expect(component.property.isValid).toHaveBeenCalledWith('updated-value');
+                });
+            });
+        }));
+
+        it('should trigger the update event if the editedValue is valid', fakeAsync(() => {
             component.property.isValid = () => true;
-            component.ngOnChanges();
-            fixture.detectChanges();
-            await fixture.whenStable();
-            fixture.detectChanges();
-            const cardViewUpdateService = TestBed.inject(CardViewUpdateService);
-            const property = { ...component.property };
 
-            spyOn(cardViewUpdateService, 'update');
-            updateTextField(component.property.key, 'updated-value');
-            expect(cardViewUpdateService.update).toHaveBeenCalledWith(property, 'updated-value');
-        });
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+                fixture.detectChanges();
+                const cardViewUpdateService = TestBed.inject(CardViewUpdateService);
+                const property = { ...component.property };
 
-        it('should NOT trigger the update event if the editedValue is invalid', async () => {
+                spyOn(cardViewUpdateService, 'update');
+                updateTextField(component.property.key, 'updated-value');
+                tick(600);
+                fixture.detectChanges();
+                fixture.whenStable().then(() => {
+                    expect(cardViewUpdateService.update).toHaveBeenCalledWith(property, 'updated-value');
+                });
+            });
+        }));
+
+        it('should NOT trigger the update event if the editedValue is invalid', fakeAsync(() => {
             component.property.isValid = () => false;
-            component.ngOnChanges();
-            fixture.detectChanges();
-            await fixture.whenStable();
-            fixture.detectChanges();
-            const cardViewUpdateService = TestBed.inject(CardViewUpdateService);
 
-            spyOn(cardViewUpdateService, 'update');
-            updateTextField(component.property.key, 'updated-value');
-            expect(cardViewUpdateService.update).not.toHaveBeenCalled();
-        });
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+                fixture.detectChanges();
+                const cardViewUpdateService = TestBed.inject(CardViewUpdateService);
 
-        it('should set the errorMessages properly if the editedValue is invalid', async () => {
+                spyOn(cardViewUpdateService, 'update');
+                updateTextField(component.property.key, 'updated-value');
+                tick(600);
+                fixture.detectChanges();
+                fixture.whenStable().then(() => {
+                    expect(cardViewUpdateService.update).not.toHaveBeenCalled();
+                });
+            });
+        }));
+
+        it('should set the errorMessages properly if the editedValue is invalid', fakeAsync(() => {
             const expectedErrorMessages = [{ message: 'Something went wrong' } as CardViewItemValidator];
             component.property.isValid = () => false;
             component.property.getValidationErrors = () => expectedErrorMessages;
 
-            component.ngOnChanges();
             fixture.detectChanges();
-            await fixture.whenStable();
+            fixture.whenStable().then(() => {
 
-            updateTextField(component.property.key, 'updated-value');
-            expect(component.errors).toBe(expectedErrorMessages);
-        });
+                updateTextField(component.property.key, 'updated-value');
+                tick(600);
+                fixture.detectChanges();
+                fixture.whenStable().then(() => {
+                    expect(component.errors).toBe(expectedErrorMessages);
+                });
+            });
+        }));
 
-        it('should render the error when the editedValue is invalid', async () => {
+        it('should render the error when the editedValue is invalid', fakeAsync(() => {
             const expectedErrorMessages = [{ message: 'Something went wrong' } as CardViewItemValidator];
             component.property.isValid = () => false;
             component.property.getValidationErrors = () => expectedErrorMessages;
             component.editable = true;
-            component.ngOnChanges();
+
             fixture.detectChanges();
-            await fixture.whenStable();
+            fixture.whenStable().then(() => {
 
-            updateTextField(component.property.key, 'updated-value');
-            const errorMessage = fixture.debugElement.nativeElement.querySelector('.adf-textitem-editable-error').textContent;
-            expect(errorMessage).toBe('Something went wrong');
-        });
+                updateTextField(component.property.key, 'updated-value');
+                tick(600);
+                fixture.detectChanges();
+                fixture.whenStable().then(() => {
+                    const errorMessage = fixture.debugElement.nativeElement.querySelector('.adf-textitem-editable-error').textContent;
+                    expect(errorMessage).toBe('Something went wrong');
+                });
+            });
+        }));
 
-        it('should reset erros when exiting editable mode', async () => {
+        it('should reset erros when exiting editable mode', fakeAsync(() => {
             let errorMessage: string;
             const expectedErrorMessages = [{ message: 'Something went wrong' } as CardViewItemValidator];
             component.property.isValid = () => false;
             component.property.getValidationErrors = () => expectedErrorMessages;
             component.editable = true;
-            component.ngOnChanges();
+
             fixture.detectChanges();
-            await fixture.whenStable();
+            fixture.whenStable().then(() => {
 
-            updateTextField(component.property.key, 'updated-value');
+                updateTextField(component.property.key, 'updated-value');
+                tick(600);
+                fixture.detectChanges();
+                fixture.whenStable().then(() => {
 
-            component.editable = false;
-            component.ngOnChanges();
-            fixture.detectChanges();
-            errorMessage = fixture.debugElement.nativeElement.querySelector('.adf-textitem-editable-error');
-            expect(errorMessage).toBe(null);
-            expect(component.errors).toEqual([]);
-        });
+                    component.editable = false;
 
-        it('should update the property value after a successful update attempt', async () => {
+                    fixture.detectChanges();
+                    errorMessage = fixture.debugElement.nativeElement.querySelector('.adf-textitem-editable-error');
+                    expect(errorMessage).toBe(null);
+                    expect(component.errors).toEqual([]);
+                });
+            });
+        }));
+
+        it('should update the property value after a successful update attempt', () => {
             component.property.isValid = () => true;
             component.update();
-            component.ngOnChanges();
+
             fixture.detectChanges();
-            await fixture.whenStable();
-            expect(component.property.value).toBe(component.editedValue);
+            fixture.whenStable().then(() => {
+                expect(component.property.value).toBe(component.editedValue);
+            });
         });
 
-        it('should render the default as value if the value is empty, clickable is false and displayEmpty is true', async(async (done) => {
+        it('should render the default as value if the value is empty, clickable is true and displayEmpty is true', async ((done) => {
             const functionTestClick = () => done();
 
             component.property = new CardViewTextItemModel({
@@ -511,81 +552,90 @@ describe('CardViewTextItemComponent', () => {
                 }
             });
             component.displayEmpty = true;
-            component.ngOnChanges();
-            fixture.detectChanges();
-            await fixture.whenStable();
 
-            const inputField = getTextField(component.property.key);
-            inputField.nativeElement.click();
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+
+                const inputField = getTextField(component.property.key);
+                inputField.nativeElement.click();
+            });
         }));
 
-        it('should trigger an update event on the CardViewUpdateService [integration]', async (done) => {
+        it('should trigger an update event on the CardViewUpdateService [integration]', fakeAsync((done) => {
             component.property.isValid = () => true;
             const cardViewUpdateService = TestBed.inject(CardViewUpdateService);
             const expectedText = 'changed text';
-            component.ngOnChanges();
+
             fixture.detectChanges();
-            await fixture.whenStable();
+            fixture.whenStable().then(() => {
 
-            const disposableUpdate = cardViewUpdateService.itemUpdated$.subscribe(
-                (updateNotification) => {
-                    expect(updateNotification.target).toEqual({ ...component.property });
-                    expect(updateNotification.changed).toEqual({ textkey: expectedText });
-                    disposableUpdate.unsubscribe();
-                    done();
-                }
-            );
+                const disposableUpdate = cardViewUpdateService.itemUpdated$.subscribe(
+                    (updateNotification) => {
+                        expect(updateNotification.target).toEqual({ ...component.property });
+                        expect(updateNotification.changed).toEqual({ textkey: expectedText });
+                        disposableUpdate.unsubscribe();
+                        done();
+                    }
+                );
 
-            updateTextField(component.property.key, expectedText);
-        });
+                updateTextField(component.property.key, expectedText);
+            });
+        }));
 
-        it('should update the value using the updateItem$ subject', async(async () => {
+        it('should update the value using the updateItem$ subject', (() => {
             component.property.isValid = () => true;
             const cardViewUpdateService = TestBed.inject(CardViewUpdateService);
             const expectedText = 'changed text';
-            component.ngOnChanges();
+
             fixture.detectChanges();
-            await fixture.whenStable();
+            fixture.whenStable().then(() => {
 
-            let value = getTextFieldValue(component.property.key);
-            expect(value).toEqual('Lorem ipsum');
-            expect(component.property.value).toBe('Lorem ipsum');
+                let value = getTextFieldValue(component.property.key);
+                expect(value).toEqual('Lorem ipsum');
+                expect(component.property.value).toBe('Lorem ipsum');
 
-            cardViewUpdateService.updateElement({ key: component.property.key, value: expectedText } as any);
-            component.ngOnChanges();
-            fixture.detectChanges();
-            await fixture.whenStable();
+                cardViewUpdateService.updateElement({ key: component.property.key, value: expectedText } as any);
+                component.ngOnChanges({ property: new SimpleChange(value, expectedText, false) });
+                fixture.detectChanges();
+                fixture.whenStable().then(() => {
 
-            value = getTextFieldValue(component.property.key);
-            expect(value).toEqual(expectedText);
-            expect(component.property.value).toBe(expectedText);
+                    value = getTextFieldValue(component.property.key);
+                    expect(value).toEqual(expectedText);
+                    expect(component.property.value).toBe(expectedText);
+                });
+            });
         }));
 
-        it('should update multiline input the value on input updated', async (done) => {
+        it('should update multiline input the value on input updated', fakeAsync((done) => {
             component.property.isValid = () => true;
             component.property.multiline = true;
             const expectedText = 'changed text';
             spyOn(component, 'update').and.callThrough();
             const cardViewUpdateService = TestBed.inject(CardViewUpdateService);
-            component.ngOnChanges();
-            fixture.detectChanges();
-            await fixture.whenStable();
 
-            const disposableUpdate = cardViewUpdateService.itemUpdated$.subscribe((updateNotification) => {
-                expect(updateNotification.target).toEqual({ ...component.property });
-                expect(updateNotification.changed).toEqual({ textkey: expectedText });
-                disposableUpdate.unsubscribe();
-                done();
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+
+                const disposableUpdate = cardViewUpdateService.itemUpdated$.subscribe((updateNotification) => {
+                    expect(updateNotification.target).toEqual({ ...component.property });
+                    expect(updateNotification.changed).toEqual({ textkey: expectedText });
+                    disposableUpdate.unsubscribe();
+                    done();
+                });
+
+                updateTextField(component.property.key, expectedText);
+                tick(600);
+                fixture.detectChanges();
+                fixture.whenStable().then(() => {
+
+                    expect(component.update).toHaveBeenCalled();
+                    fixture.detectChanges();
+
+                    expect(getTextFieldValue(component.property.key)).toEqual(expectedText);
+                    expect(component.property.value).toBe(expectedText);
+                });
             });
-
-            updateTextField(component.property.key, expectedText);
-
-            expect(component.update).toHaveBeenCalled();
-            fixture.detectChanges();
-
-            expect(getTextFieldValue(component.property.key)).toEqual(expectedText);
-            expect(component.property.value).toBe(expectedText);
-        });
+        }));
     });
 
     describe('number', () => {
@@ -605,98 +655,106 @@ describe('CardViewTextItemComponent', () => {
 
         });
 
-        it('should show validation error when string passed', async () => {
-            component.ngOnChanges();
+        it('should show validation error when string passed', fakeAsync(() => {
             fixture.detectChanges();
-            await fixture.whenStable();
+            fixture.whenStable().then(() => {
 
-            updateTextField(component.property.key, 'update number');
+                updateTextField(component.property.key, 'update number');
+                tick(600);
+                fixture.detectChanges();
+                fixture.whenStable().then(() => {
+                    const error = getTextFieldError(component.property.key);
+                    expect(error).toEqual('CORE.CARDVIEW.VALIDATORS.INT_VALIDATION_ERROR');
+                    expect(component.property.value).toBe(10);
+                });
+            });
+        }));
 
+        it('should show validation error for empty string', fakeAsync(() => {
             fixture.detectChanges();
-            const error = getTextFieldError(component.property.key);
-            expect(error).toEqual('CORE.CARDVIEW.VALIDATORS.INT_VALIDATION_ERROR');
-            expect(component.property.value).toBe(10);
-        });
+            fixture.whenStable().then(() => {
 
-        it('should show validation error for empty string', async () => {
-            component.ngOnChanges();
+                updateTextField(component.property.key, ' ');
+                tick(600);
+                fixture.detectChanges();
+                fixture.whenStable().then(() => {
+                    const error = getTextFieldError(component.property.key);
+                    expect(error).toEqual('CORE.CARDVIEW.VALIDATORS.INT_VALIDATION_ERROR');
+                    expect(component.property.value).toBe(10);
+                });
+            });
+        }));
+
+        it('should show validation error for float number', fakeAsync(() => {
             fixture.detectChanges();
-            await fixture.whenStable();
+            fixture.whenStable().then(() => {
 
-            updateTextField(component.property.key, ' ');
+                updateTextField(component.property.key, 123.456);
+                tick(600);
+                fixture.detectChanges();
+                fixture.whenStable().then(() => {
 
+                    const error = getTextFieldError(component.property.key);
+                    expect(error).toEqual('CORE.CARDVIEW.VALIDATORS.INT_VALIDATION_ERROR');
+                    expect(component.property.value).toBe(10);
+                });
+            });
+        }));
+
+        it('should show validation error for exceed the number limit (2147483648)', fakeAsync(() => {
             fixture.detectChanges();
-            const error = getTextFieldError(component.property.key);
-            expect(error).toEqual('CORE.CARDVIEW.VALIDATORS.INT_VALIDATION_ERROR');
-            expect(component.property.value).toBe(10);
-            expect(component.property.value).toBe(10);
-        });
+            fixture.whenStable().then(() => {
 
-        it('should show validation error for float number', async () => {
-            component.ngOnChanges();
+                updateTextField(component.property.key, 2147483648);
+                fixture.detectChanges();
+                fixture.whenStable().then(() => {
+                    const error = getTextFieldError(component.property.key);
+                    expect(error).toEqual('CORE.CARDVIEW.VALIDATORS.INT_VALIDATION_ERROR');
+                    expect(component.property.value).toBe(10);
+                });
+            });
+        }));
+
+        it('should not show validation error for below the number limit (2147483647)', fakeAsync(() => {
             fixture.detectChanges();
-            await fixture.whenStable();
+            fixture.whenStable().then(() => {
 
-            updateTextField(component.property.key, 123.456);
+                updateTextField(component.property.key, 2147483647);
+                fixture.detectChanges();
+                fixture.whenStable().then(() => {
+                    const error = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-error-${component.property.key}"] li`));
+                    expect(error).toBeFalsy();
 
-            fixture.detectChanges();
-            const error = getTextFieldError(component.property.key);
-            expect(error).toEqual('CORE.CARDVIEW.VALIDATORS.INT_VALIDATION_ERROR');
-            expect(component.property.value).toBe(10);
-            expect(component.property.value).toBe(10);
-        });
+                    expect(component.property.value).toBe('2147483647');
+                });
+            });
+        }));
 
-        it('should show validation error for exceed the number limit (2147483648)', async () => {
-            component.ngOnChanges();
-            fixture.detectChanges();
-            await fixture.whenStable();
-
-            updateTextField(component.property.key, 2147483648);
-
-            fixture.detectChanges();
-            const error = getTextFieldError(component.property.key);
-            expect(error).toEqual('CORE.CARDVIEW.VALIDATORS.INT_VALIDATION_ERROR');
-            expect(component.property.value).toBe(10);
-            expect(component.property.value).toBe(10);
-        });
-
-        it('should not show validation error for below the number limit (2147483647)', async () => {
-            component.ngOnChanges();
-            fixture.detectChanges();
-            await fixture.whenStable();
-
-            updateTextField(component.property.key, 2147483647);
-
-            fixture.detectChanges();
-            const error = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-error-${component.property.key}"] li`));
-            expect(error).toBeFalsy();
-
-            expect(component.property.value).toBe('2147483647');
-        });
-
-        it('should update input the value on input updated', async (done) => {
+        it('should update input the value on input updated', fakeAsync((done) => {
             const expectedNumber = 2020;
             spyOn(component, 'update').and.callThrough();
-            component.ngOnChanges();
             fixture.detectChanges();
-            await fixture.whenStable();
+            fixture.whenStable().then(() => {
 
-            const disposableUpdate = cardViewUpdateService.itemUpdated$.subscribe((updateNotification) => {
-                expect(updateNotification.target).toEqual({ ...component.property });
-                expect(updateNotification.changed).toEqual({ textkey: expectedNumber.toString() });
-                disposableUpdate.unsubscribe();
-                done();
+                const disposableUpdate = cardViewUpdateService.itemUpdated$.subscribe((updateNotification) => {
+                    expect(updateNotification.target).toEqual({ ...component.property });
+                    expect(updateNotification.changed).toEqual({ textkey: expectedNumber.toString() });
+                    disposableUpdate.unsubscribe();
+                    done();
+                });
+
+                updateTextField(component.property.key, expectedNumber);
+                tick(600);
+                fixture.detectChanges();
+                fixture.whenStable().then(() => {
+                    const error = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-error-${component.property.key}"] li`));
+                    expect(error).toBeFalsy();
+
+                    expect(getTextFieldValue(component.property.key)).toEqual(expectedNumber.toString());
+                    expect(component.property.value).toBe(expectedNumber.toString());
+                });
             });
-
-            updateTextField(component.property.key, expectedNumber);
-
-            fixture.detectChanges();
-            const error = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-error-${component.property.key}"] li`));
-            expect(error).toBeFalsy();
-
-            expect(getTextFieldValue(component.property.key)).toEqual(expectedNumber.toString());
-            expect(component.property.value).toBe(expectedNumber.toString());
-        });
+        }));
     });
 
     describe('float', () => {
@@ -716,62 +774,67 @@ describe('CardViewTextItemComponent', () => {
             component.property.validators.push(new CardViewItemFloatValidator());
         });
 
-        it('should show validation error when string passed', async () => {
-            component.ngOnChanges();
+        it('should show validation error when string passed', fakeAsync(() => {
             fixture.detectChanges();
-            await fixture.whenStable();
+            fixture.whenStable().then(() => {
 
-            updateTextField(component.property.key, 'hello there');
+                updateTextField(component.property.key, 'hello there');
+                tick(600);
+                fixture.detectChanges();
+                fixture.whenStable().then(() => {
+                    const error = getTextFieldError(component.property.key);
+                    expect(error).toEqual('CORE.CARDVIEW.VALIDATORS.FLOAT_VALIDATION_ERROR');
+                    expect(component.property.value).toBe(floatValue);
+                });
+            });
+        }));
 
+        it('should show validation error for empty string', fakeAsync(() => {
             fixture.detectChanges();
-            const error = getTextFieldError(component.property.key);
-            expect(error).toEqual('CORE.CARDVIEW.VALIDATORS.FLOAT_VALIDATION_ERROR');
-            expect(component.property.value).toBe(floatValue);
-        });
+            fixture.whenStable().then(() => {
 
-        it('should show validation error for empty string', async () => {
-            component.ngOnChanges();
-            fixture.detectChanges();
-            await fixture.whenStable();
+                updateTextField(component.property.key, ' ');
+                tick(600);
+                fixture.detectChanges();
+                fixture.whenStable().then(() => {
+                    const error = getTextFieldError(component.property.key);
+                    expect(error).toEqual('CORE.CARDVIEW.VALIDATORS.FLOAT_VALIDATION_ERROR');
+                    expect(component.property.value).toBe(floatValue);
+                });
+            });
+        }));
 
-            updateTextField(component.property.key, ' ');
-
-            fixture.detectChanges();
-            const error = getTextFieldError(component.property.key);
-            expect(error).toEqual('CORE.CARDVIEW.VALIDATORS.FLOAT_VALIDATION_ERROR');
-            expect(component.property.value).toBe(floatValue);
-        });
-
-        it('should update input the value on input updated', async (done) => {
+        it('should update input the value on input updated', fakeAsync((done) => {
             const expectedNumber = 88.44;
             spyOn(component, 'update').and.callThrough();
-            component.ngOnChanges();
             fixture.detectChanges();
-            await fixture.whenStable();
+            fixture.whenStable().then(() => {
 
-            const disposableUpdate = cardViewUpdateService.itemUpdated$.subscribe((updateNotification) => {
-                expect(updateNotification.target).toEqual({ ...component.property });
-                expect(updateNotification.changed).toEqual({ textkey: expectedNumber.toString() });
-                disposableUpdate.unsubscribe();
-                done();
+                const disposableUpdate = cardViewUpdateService.itemUpdated$.subscribe((updateNotification) => {
+                    expect(updateNotification.target).toEqual({ ...component.property });
+                    expect(updateNotification.changed).toEqual({ textkey: expectedNumber.toString() });
+                    disposableUpdate.unsubscribe();
+                    done();
+                });
+
+                updateTextField(component.property.key, expectedNumber);
+                tick(600);
+                fixture.detectChanges();
+                fixture.whenStable().then(() => {
+                    const error = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-error-${component.property.key}"] li`));
+                    expect(error).toBeFalsy();
+
+                    expect(getTextFieldValue(component.property.key)).toEqual(expectedNumber.toString());
+                    expect(component.property.value).toBe(expectedNumber.toString());
+                });
             });
-
-            updateTextField(component.property.key, expectedNumber);
-
-            fixture.detectChanges();
-            const error = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-error-${component.property.key}"] li`));
-            expect(error).toBeFalsy();
-
-            expect(getTextFieldValue(component.property.key)).toEqual(expectedNumber.toString());
-            expect(component.property.value).toBe(expectedNumber.toString());
-        });
+        }));
     });
 
     function updateTextField(key, value) {
         const editInput = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-value-${key}"]`));
         editInput.nativeElement.value = value;
         editInput.nativeElement.dispatchEvent(new Event('input'));
-        editInput.nativeElement.dispatchEvent(new Event('blur'));
         fixture.detectChanges();
     }
 

--- a/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
+++ b/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { ComponentFixture, TestBed, tick, fakeAsync, async } from '@angular/core/testing';
+import { ComponentFixture, TestBed, tick, fakeAsync, async, discardPeriodicTasks } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { CardViewTextItemModel } from '../../models/card-view-textitem.model';
 import { CardViewUpdateService } from '../../services/card-view-update.service';
@@ -61,6 +61,7 @@ describe('CardViewTextItemComponent', () => {
                 default: 'FAKE-DEFAULT-KEY',
                 editable: false
             });
+            component.ngOnChanges({ property: new SimpleChange(null, null, true) });
         });
 
         it('should render the label and value', () => {
@@ -82,6 +83,7 @@ describe('CardViewTextItemComponent', () => {
                 value: { id: 123, displayName: 'User Name' },
                 key: 'namekey'
             });
+            component.ngOnChanges({ property: new SimpleChange(null, null, true) });
             fixture.detectChanges();
             fixture.whenStable().then(() => {
 
@@ -100,6 +102,7 @@ describe('CardViewTextItemComponent', () => {
                 editable: false
             });
             component.displayEmpty = true;
+            component.ngOnChanges({ property: new SimpleChange(null, null, true) });
             fixture.detectChanges();
             fixture.whenStable().then(() => {
 
@@ -117,6 +120,7 @@ describe('CardViewTextItemComponent', () => {
                 editable: true
             });
             component.editable = true;
+            component.ngOnChanges({ property: new SimpleChange(null, null, true) });
             fixture.detectChanges();
             fixture.whenStable().then(() => {
 
@@ -177,6 +181,7 @@ describe('CardViewTextItemComponent', () => {
                 multivalued: true
             });
             component.useChipsForMultiValueProperty = true;
+            component.ngOnChanges({ property: new SimpleChange(null, null, true) });
 
             fixture.detectChanges();
             fixture.whenStable().then(() => {
@@ -201,6 +206,7 @@ describe('CardViewTextItemComponent', () => {
             });
 
             component.useChipsForMultiValueProperty = false;
+            component.ngOnChanges({ property: new SimpleChange(null, null, true) });
 
             fixture.detectChanges();
             fixture.whenStable().then(() => {
@@ -222,6 +228,7 @@ describe('CardViewTextItemComponent', () => {
                 default: 'FAKE-DEFAULT-KEY',
                 editable: false
             });
+            component.ngOnChanges({ property: new SimpleChange(null, null, true) });
         });
 
         it('should render the default as value if the value is empty, clickable is false and displayEmpty is true', () => {
@@ -279,6 +286,7 @@ describe('CardViewTextItemComponent', () => {
             component.property.clickable = true;
             component.property.icon = 'FAKE_ICON';
             component.editable = true;
+            component.ngOnChanges({ property: new SimpleChange(null, null, true) });
 
             fixture.detectChanges();
             fixture.whenStable().then(() => {
@@ -360,7 +368,7 @@ describe('CardViewTextItemComponent', () => {
             component.editable = true;
             component.property.isValid = () => true;
             const expectedText = 'changed text';
-
+            component.ngOnChanges({});
             fixture.detectChanges();
             fixture.whenStable().then(() => {
                 fixture.detectChanges();
@@ -370,15 +378,15 @@ describe('CardViewTextItemComponent', () => {
                     expect(updateNotification.changed).toEqual({ textkey: expectedText });
 
                     expect(getTextFieldValue(component.property.key)).toEqual(expectedText);
-                    expect(component.property.value).toBe(expectedText);
                     disposableUpdate.unsubscribe();
                     done();
                 });
 
                 updateTextField(component.property.key, expectedText);
-                tick(600);
+                tick(1000);
 
                 fixture.detectChanges();
+                discardPeriodicTasks();
             });
         }));
 
@@ -412,10 +420,10 @@ describe('CardViewTextItemComponent', () => {
                 default: 'FAKE-DEFAULT-KEY',
                 editable: true
             });
+            component.ngOnChanges({ property: new SimpleChange(null, null, true) });
         });
 
         it('should call the isValid method with the edited value', fakeAsync(() => {
-
             fixture.detectChanges();
             fixture.whenStable().then(() => {
                 fixture.detectChanges();
@@ -538,7 +546,7 @@ describe('CardViewTextItemComponent', () => {
             });
         });
 
-        it('should render the default as value if the value is empty, clickable is true and displayEmpty is true', async ((done) => {
+        it('should render the default as value if the value is empty, clickable is true and displayEmpty is true', async((done) => {
             const functionTestClick = () => done();
 
             component.property = new CardViewTextItemModel({
@@ -652,7 +660,7 @@ describe('CardViewTextItemComponent', () => {
             });
             component.editable = true;
             component.property.validators.push(new CardViewItemIntValidator());
-
+            component.ngOnChanges({ property: new SimpleChange(null, null, true) });
         });
 
         it('should show validation error when string passed', fakeAsync(() => {
@@ -772,6 +780,7 @@ describe('CardViewTextItemComponent', () => {
             });
             component.editable = true;
             component.property.validators.push(new CardViewItemFloatValidator());
+            component.ngOnChanges({ property: new SimpleChange(null, null, true) });
         });
 
         it('should show validation error when string passed', fakeAsync(() => {

--- a/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
+++ b/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
@@ -64,20 +64,19 @@ describe('CardViewTextItemComponent', () => {
             component.ngOnChanges({ property: new SimpleChange(null, null, true) });
         });
 
-        it('should render the label and value', () => {
+        it('should render the label and value', async () => {
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
+            await fixture.whenStable();
 
-                const labelValue = fixture.debugElement.query(By.css('.adf-property-label'));
-                expect(labelValue).not.toBeNull();
-                expect(labelValue.nativeElement.innerText).toBe('Text label');
+            const labelValue = fixture.debugElement.query(By.css('.adf-property-label'));
+            expect(labelValue).not.toBeNull();
+            expect(labelValue.nativeElement.innerText).toBe('Text label');
 
-                const value = getTextFieldValue(component.property.key);
-                expect(value).toBe('Lorem ipsum');
-            });
+            const value = getTextFieldValue(component.property.key);
+            expect(value).toBe('Lorem ipsum');
         });
 
-        it('should render the displayName as value when available', () => {
+        it('should render the displayName as value when available', async () => {
             component.property = new CardViewTextItemModel({
                 label: 'Name label',
                 value: { id: 123, displayName: 'User Name' },
@@ -85,15 +84,12 @@ describe('CardViewTextItemComponent', () => {
             });
             component.ngOnChanges({ property: new SimpleChange(null, null, true) });
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
-
-                const value = getTextFieldValue(component.property.key);
-                expect(value).toBe('User Name');
-
-            });
+            await fixture.whenStable();
+            const value = getTextFieldValue(component.property.key);
+            expect(value).toBe('User Name');
         });
 
-        it('should render the default as value if the value is empty, editable is false and displayEmpty is true', () => {
+        it('should render the default as value if the value is empty, editable is false and displayEmpty is true', async () => {
             component.property = new CardViewTextItemModel({
                 label: 'Text label',
                 value: '',
@@ -104,14 +100,12 @@ describe('CardViewTextItemComponent', () => {
             component.displayEmpty = true;
             component.ngOnChanges({ property: new SimpleChange(null, null, true) });
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
-
-                const value = getTextFieldValue(component.property.key);
-                expect(value).toBe('FAKE-DEFAULT-KEY');
-            });
+            await fixture.whenStable();
+            const value = getTextFieldValue(component.property.key);
+            expect(value).toBe('FAKE-DEFAULT-KEY');
         });
 
-        it('should render the default as value if the value is empty and editable true', () => {
+        it('should render the default as value if the value is empty and editable true', async () => {
             component.property = new CardViewTextItemModel({
                 label: 'Text label',
                 value: '',
@@ -122,22 +116,19 @@ describe('CardViewTextItemComponent', () => {
             component.editable = true;
             component.ngOnChanges({ property: new SimpleChange(null, null, true) });
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
-
-                const value = getTextFieldValue(component.property.key);
-                expect(value).toBe('FAKE-DEFAULT-KEY');
-            });
+            await fixture.whenStable();
+            const value = getTextFieldValue(component.property.key);
+            expect(value).toBe('FAKE-DEFAULT-KEY');
         });
 
-        it('should render value when editable:true', () => {
+        it('should render value when editable:true', async () => {
             component.editable = true;
             component.property.editable = true;
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
+            await fixture.whenStable();
+            const value = getTextFieldValue(component.property.key);
+            expect(value).toBe('Lorem ipsum');
 
-                const value = getTextFieldValue(component.property.key);
-                expect(value).toBe('Lorem ipsum');
-            });
         });
 
         it('should render the edit icon in case of editable:true', () => {
@@ -150,28 +141,26 @@ describe('CardViewTextItemComponent', () => {
             expect(editIcon).not.toBeNull('Edit icon should be shown');
         });
 
-        it('should NOT render the edit icon in case of editable:false', () => {
+        it('should NOT render the edit icon in case of editable:false', async () => {
             component.editable = false;
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
-                const editIcon = fixture.debugElement.query(By.css('.adf-textitem-edit-icon'));
-                expect(editIcon).toBeNull('Edit icon should NOT be shown');
-            });
+            await fixture.whenStable();
+            const editIcon = fixture.debugElement.query(By.css('.adf-textitem-edit-icon'));
+            expect(editIcon).toBeNull('Edit icon should NOT be shown');
         });
 
-        it('should NOT render the picker and toggle in case of editable:true but (general) editable:false', () => {
+        it('should NOT render the picker and toggle in case of editable:true but (general) editable:false', async () => {
             component.editable = false;
             component.property.editable = true;
 
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
+            await fixture.whenStable();
+            const editIcon = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-edit-icon-${component.property.key}"]`));
+            expect(editIcon).toBeNull('Edit icon should NOT be shown');
 
-                const editIcon = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-edit-icon-${component.property.key}"]`));
-                expect(editIcon).toBeNull('Edit icon should NOT be shown');
-            });
         });
 
-        it('should render chips for multivalue properties when chips are enabled', () => {
+        it('should render chips for multivalue properties when chips are enabled', async () => {
             component.property = new CardViewTextItemModel({
                 label: 'Text label',
                 value: ['item1', 'item2', 'item3'],
@@ -184,18 +173,17 @@ describe('CardViewTextItemComponent', () => {
             component.ngOnChanges({ property: new SimpleChange(null, null, true) });
 
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
+            await fixture.whenStable();
+            const valueChips = fixture.debugElement.queryAll(By.css(`mat-chip`));
+            expect(valueChips).not.toBeNull();
+            expect(valueChips.length).toBe(3);
+            expect(valueChips[0].nativeElement.innerText.trim()).toBe('item1');
+            expect(valueChips[1].nativeElement.innerText.trim()).toBe('item2');
+            expect(valueChips[2].nativeElement.innerText.trim()).toBe('item3');
 
-                const valueChips = fixture.debugElement.queryAll(By.css(`mat-chip`));
-                expect(valueChips).not.toBeNull();
-                expect(valueChips.length).toBe(3);
-                expect(valueChips[0].nativeElement.innerText.trim()).toBe('item1');
-                expect(valueChips[1].nativeElement.innerText.trim()).toBe('item2');
-                expect(valueChips[2].nativeElement.innerText.trim()).toBe('item3');
-            });
         });
 
-        it('should render string for multivalue properties when chips are disabled', () => {
+        it('should render string for multivalue properties when chips are disabled', async () => {
             component.property = new CardViewTextItemModel({
                 label: 'Text label',
                 value: ['item1', 'item2', 'item3'],
@@ -209,13 +197,11 @@ describe('CardViewTextItemComponent', () => {
             component.ngOnChanges({ property: new SimpleChange(null, null, true) });
 
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
-
-                const valueChips = fixture.debugElement.query(By.css(`mat-chip-list`));
-                const value = getTextFieldValue(component.property.key);
-                expect(value).toBe('item1,item2,item3');
-                expect(valueChips).toBeNull();
-            });
+            await fixture.whenStable();
+            const valueChips = fixture.debugElement.query(By.css(`mat-chip-list`));
+            const value = getTextFieldValue(component.property.key);
+            expect(value).toBe('item1,item2,item3');
+            expect(valueChips).toBeNull();
         });
     });
 
@@ -231,7 +217,7 @@ describe('CardViewTextItemComponent', () => {
             component.ngOnChanges({ property: new SimpleChange(null, null, true) });
         });
 
-        it('should render the default as value if the value is empty, clickable is false and displayEmpty is true', () => {
+        it('should render the default as value if the value is empty, clickable is false and displayEmpty is true', (done) => {
             component.property.clickable = false;
             component.displayEmpty = true;
 
@@ -241,123 +227,122 @@ describe('CardViewTextItemComponent', () => {
 
                 const value = getTextFieldValue(component.property.key);
                 expect(value).toBe('FAKE-DEFAULT-KEY');
+                done();
             });
         });
 
-        it('should render the default as value if the value is empty and clickable true', () => {
+        it('should render the default as value if the value is empty and clickable true', async () => {
             component.property.clickable = true;
 
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
-                fixture.detectChanges();
-
-                const value = getTextFieldValue(component.property.key);
-                expect(value).toBe('FAKE-DEFAULT-KEY');
-            });
+            await fixture.whenStable();
+            fixture.detectChanges();
+            const value = getTextFieldValue(component.property.key);
+            expect(value).toBe('FAKE-DEFAULT-KEY');
         });
 
-        it('should not render the edit icon in case of clickable true but edit false', () => {
+        it('should not render the edit icon in case of clickable true but edit false', async () => {
             component.property.clickable = true;
 
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
-                fixture.detectChanges();
+            await fixture.whenStable();
+            fixture.detectChanges();
+            const value = fixture.debugElement.query(By.css('.adf-textitem-edit-icon'));
+            expect(value).toBeNull();
 
-                const value = fixture.debugElement.query(By.css('.adf-textitem-edit-icon'));
-                expect(value).toBeNull();
-            });
         });
 
-        it('should not render the clickable icon in case editable set to false', () => {
+        it('should not render the clickable icon in case editable set to false', async () => {
             component.property.clickable = true;
             component.property.icon = 'create';
             component.editable = false;
 
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
-                fixture.detectChanges();
+            await fixture.whenStable();
+            fixture.detectChanges();
 
-                const value = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-clickable-icon-${component.property.key}"]`));
-                expect(value).toBeNull('icon should NOT be shown');
-            });
+            const value = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-clickable-icon-${component.property.key}"]`));
+            expect(value).toBeNull('icon should NOT be shown');
+
         });
 
-        it('should render the defined clickable icon in case of clickable true and editable input set to true', () => {
+        it('should render the defined clickable icon in case of clickable true and editable input set to true', async () => {
             component.property.clickable = true;
             component.property.icon = 'FAKE_ICON';
             component.editable = true;
             component.ngOnChanges({ property: new SimpleChange(null, null, true) });
 
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
-                fixture.detectChanges();
+            await fixture.whenStable();
+            fixture.detectChanges();
 
-                const value = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-clickable-icon-${component.property.key}"]`));
-                expect(value).not.toBeNull();
-                expect(value.nativeElement.innerText).toBe('FAKE_ICON');
-            });
+            const value = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-clickable-icon-${component.property.key}"]`));
+            expect(value).not.toBeNull();
+            expect(value.nativeElement.innerText).toBe('FAKE_ICON');
+
         });
 
-        it('should not render clickable icon in case of clickable true and icon undefined', () => {
+        it('should not render clickable icon in case of clickable true and icon undefined', async () => {
             component.property.clickable = true;
             component.editable = true;
 
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
-                fixture.detectChanges();
+            await fixture.whenStable();
+            fixture.detectChanges();
 
-                const value = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-clickable-icon-${component.property.key}"]`));
-                expect(value).toBeNull('icon should NOT be shown');
-            });
+            const value = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-clickable-icon-${component.property.key}"]`));
+            expect(value).toBeNull('icon should NOT be shown');
         });
 
-        it('should not render the edit icon in case of clickable false and icon defined', () => {
+        it('should not render the edit icon in case of clickable false and icon defined', async () => {
             component.property.clickable = false;
             component.property.icon = 'FAKE_ICON';
 
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
-                fixture.detectChanges();
+            await fixture.whenStable();
+            fixture.detectChanges();
 
-                const value = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-edit-icon-${component.property.icon}"]`));
-                expect(value).toBeNull('Edit icon should NOT be shown');
-            });
+            const value = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-edit-icon-${component.property.icon}"]`));
+            expect(value).toBeNull('Edit icon should NOT be shown');
+
         });
 
-        it('should call back function when clickable property enabled', () => {
+        it('should call back function when clickable property enabled', async () => {
             const callBackSpy = jasmine.createSpy('callBack');
             component.property.clickable = true;
             component.property.icon = 'FAKE_ICON';
             component.property.clickCallBack = callBackSpy;
             component.editable = true;
+            component.ngOnChanges({});
 
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
-                fixture.detectChanges();
+            await fixture.whenStable();
+            fixture.detectChanges();
 
-                const value = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-clickable-icon-${component.property.key}"]`));
-                expect(value.nativeElement.innerText).toBe('FAKE_ICON');
-                value.nativeElement.click();
-                expect(callBackSpy).toHaveBeenCalled();
-            });
+            const value = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-clickable-icon-${component.property.key}"]`));
+            expect(value.nativeElement.innerText).toBe('FAKE_ICON');
+            value.nativeElement.click();
+            fixture.detectChanges();
+            expect(callBackSpy).toHaveBeenCalled();
         });
 
-        it('should click event to the event stream when clickable property enabled', () => {
+        it('should click event to the event stream when clickable property enabled', async () => {
             const cardViewUpdateService = TestBed.inject(CardViewUpdateService);
             spyOn(cardViewUpdateService, 'clicked').and.stub();
 
             component.property.clickable = true;
             component.property.icon = 'FAKE_ICON';
             component.editable = false;
+            component.ngOnChanges({});
 
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
-                fixture.detectChanges();
+            await fixture.whenStable();
+            fixture.detectChanges();
 
-                const value = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-toggle-${component.property.key}"]`));
-                value.nativeElement.click();
-                expect(cardViewUpdateService.clicked).toHaveBeenCalled();
-            });
+            const value = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-toggle-${component.property.key}"]`));
+            value.nativeElement.click();
+            fixture.detectChanges();
+            expect(cardViewUpdateService.clicked).toHaveBeenCalled();
         });
 
         it('should update input the value on input updated', fakeAsync((done) => {
@@ -423,7 +408,7 @@ describe('CardViewTextItemComponent', () => {
             component.ngOnChanges({ property: new SimpleChange(null, null, true) });
         });
 
-        it('should call the isValid method with the edited value', fakeAsync(() => {
+        it('should call the isValid method with the edited value', fakeAsync((done) => {
             fixture.detectChanges();
             fixture.whenStable().then(() => {
                 fixture.detectChanges();
@@ -434,11 +419,12 @@ describe('CardViewTextItemComponent', () => {
                 fixture.detectChanges();
                 fixture.whenStable().then(() => {
                     expect(component.property.isValid).toHaveBeenCalledWith('updated-value');
+                    done();
                 });
             });
         }));
 
-        it('should trigger the update event if the editedValue is valid', fakeAsync(() => {
+        it('should trigger the update event if the editedValue is valid', fakeAsync((done) => {
             component.property.isValid = () => true;
 
             fixture.detectChanges();
@@ -453,11 +439,12 @@ describe('CardViewTextItemComponent', () => {
                 fixture.detectChanges();
                 fixture.whenStable().then(() => {
                     expect(cardViewUpdateService.update).toHaveBeenCalledWith(property, 'updated-value');
+                    done();
                 });
             });
         }));
 
-        it('should NOT trigger the update event if the editedValue is invalid', fakeAsync(() => {
+        it('should NOT trigger the update event if the editedValue is invalid', fakeAsync((done) => {
             component.property.isValid = () => false;
 
             fixture.detectChanges();
@@ -471,11 +458,12 @@ describe('CardViewTextItemComponent', () => {
                 fixture.detectChanges();
                 fixture.whenStable().then(() => {
                     expect(cardViewUpdateService.update).not.toHaveBeenCalled();
+                    done();
                 });
             });
         }));
 
-        it('should set the errorMessages properly if the editedValue is invalid', fakeAsync(() => {
+        it('should set the errorMessages properly if the editedValue is invalid', fakeAsync((done) => {
             const expectedErrorMessages = [{ message: 'Something went wrong' } as CardViewItemValidator];
             component.property.isValid = () => false;
             component.property.getValidationErrors = () => expectedErrorMessages;
@@ -488,11 +476,12 @@ describe('CardViewTextItemComponent', () => {
                 fixture.detectChanges();
                 fixture.whenStable().then(() => {
                     expect(component.errors).toBe(expectedErrorMessages);
+                    done();
                 });
             });
         }));
 
-        it('should render the error when the editedValue is invalid', fakeAsync(() => {
+        it('should render the error when the editedValue is invalid', fakeAsync((done) => {
             const expectedErrorMessages = [{ message: 'Something went wrong' } as CardViewItemValidator];
             component.property.isValid = () => false;
             component.property.getValidationErrors = () => expectedErrorMessages;
@@ -507,11 +496,12 @@ describe('CardViewTextItemComponent', () => {
                 fixture.whenStable().then(() => {
                     const errorMessage = fixture.debugElement.nativeElement.querySelector('.adf-textitem-editable-error').textContent;
                     expect(errorMessage).toBe('Something went wrong');
+                    done();
                 });
             });
         }));
 
-        it('should reset erros when exiting editable mode', fakeAsync(() => {
+        it('should reset erros when exiting editable mode', fakeAsync((done) => {
             let errorMessage: string;
             const expectedErrorMessages = [{ message: 'Something went wrong' } as CardViewItemValidator];
             component.property.isValid = () => false;
@@ -532,21 +522,21 @@ describe('CardViewTextItemComponent', () => {
                     errorMessage = fixture.debugElement.nativeElement.querySelector('.adf-textitem-editable-error');
                     expect(errorMessage).toBe(null);
                     expect(component.errors).toEqual([]);
+                    done();
                 });
             });
         }));
 
-        it('should update the property value after a successful update attempt', () => {
+        it('should update the property value after a successful update attempt', async () => {
             component.property.isValid = () => true;
             component.update();
 
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
-                expect(component.property.value).toBe(component.editedValue);
-            });
+            await fixture.whenStable();
+            expect(component.property.value).toBe(component.editedValue);
         });
 
-        it('should render the default as value if the value is empty, clickable is true and displayEmpty is true', async((done) => {
+        it('should render the default as value if the value is empty, clickable is true and displayEmpty is true', async(async (done) => {
             const functionTestClick = () => done();
 
             component.property = new CardViewTextItemModel({
@@ -562,11 +552,10 @@ describe('CardViewTextItemComponent', () => {
             component.displayEmpty = true;
 
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
+            await fixture.whenStable();
 
-                const inputField = getTextField(component.property.key);
-                inputField.nativeElement.click();
-            });
+            const inputField = getTextField(component.property.key);
+            inputField.nativeElement.click();
         }));
 
         it('should trigger an update event on the CardViewUpdateService [integration]', fakeAsync((done) => {
@@ -590,28 +579,27 @@ describe('CardViewTextItemComponent', () => {
             });
         }));
 
-        it('should update the value using the updateItem$ subject', (() => {
+        it('should update the value using the updateItem$ subject', (async () => {
             component.property.isValid = () => true;
             const cardViewUpdateService = TestBed.inject(CardViewUpdateService);
             const expectedText = 'changed text';
 
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
+            await fixture.whenStable();
 
-                let value = getTextFieldValue(component.property.key);
-                expect(value).toEqual('Lorem ipsum');
-                expect(component.property.value).toBe('Lorem ipsum');
+            let value = getTextFieldValue(component.property.key);
+            expect(value).toEqual('Lorem ipsum');
+            expect(component.property.value).toBe('Lorem ipsum');
 
-                cardViewUpdateService.updateElement({ key: component.property.key, value: expectedText } as any);
-                component.ngOnChanges({ property: new SimpleChange(value, expectedText, false) });
-                fixture.detectChanges();
-                fixture.whenStable().then(() => {
+            cardViewUpdateService.updateElement({ key: component.property.key, value: expectedText } as any);
+            component.ngOnChanges({ property: new SimpleChange(value, expectedText, false) });
+            fixture.detectChanges();
+            await fixture.whenStable();
 
-                    value = getTextFieldValue(component.property.key);
-                    expect(value).toEqual(expectedText);
-                    expect(component.property.value).toBe(expectedText);
-                });
-            });
+            value = getTextFieldValue(component.property.key);
+            expect(value).toEqual(expectedText);
+            expect(component.property.value).toBe(expectedText);
+
         }));
 
         it('should update multiline input the value on input updated', fakeAsync((done) => {
@@ -663,7 +651,7 @@ describe('CardViewTextItemComponent', () => {
             component.ngOnChanges({ property: new SimpleChange(null, null, true) });
         });
 
-        it('should show validation error when string passed', fakeAsync(() => {
+        it('should show validation error when string passed', fakeAsync((done) => {
             fixture.detectChanges();
             fixture.whenStable().then(() => {
 
@@ -674,11 +662,12 @@ describe('CardViewTextItemComponent', () => {
                     const error = getTextFieldError(component.property.key);
                     expect(error).toEqual('CORE.CARDVIEW.VALIDATORS.INT_VALIDATION_ERROR');
                     expect(component.property.value).toBe(10);
+                    done();
                 });
             });
         }));
 
-        it('should show validation error for empty string', fakeAsync(() => {
+        it('should show validation error for empty string', fakeAsync((done) => {
             fixture.detectChanges();
             fixture.whenStable().then(() => {
 
@@ -689,11 +678,12 @@ describe('CardViewTextItemComponent', () => {
                     const error = getTextFieldError(component.property.key);
                     expect(error).toEqual('CORE.CARDVIEW.VALIDATORS.INT_VALIDATION_ERROR');
                     expect(component.property.value).toBe(10);
+                    done();
                 });
             });
         }));
 
-        it('should show validation error for float number', fakeAsync(() => {
+        it('should show validation error for float number', fakeAsync((done) => {
             fixture.detectChanges();
             fixture.whenStable().then(() => {
 
@@ -705,11 +695,12 @@ describe('CardViewTextItemComponent', () => {
                     const error = getTextFieldError(component.property.key);
                     expect(error).toEqual('CORE.CARDVIEW.VALIDATORS.INT_VALIDATION_ERROR');
                     expect(component.property.value).toBe(10);
+                    done();
                 });
             });
         }));
 
-        it('should show validation error for exceed the number limit (2147483648)', fakeAsync(() => {
+        it('should show validation error for exceed the number limit (2147483648)', fakeAsync((done) => {
             fixture.detectChanges();
             fixture.whenStable().then(() => {
 
@@ -719,11 +710,12 @@ describe('CardViewTextItemComponent', () => {
                     const error = getTextFieldError(component.property.key);
                     expect(error).toEqual('CORE.CARDVIEW.VALIDATORS.INT_VALIDATION_ERROR');
                     expect(component.property.value).toBe(10);
+                    done();
                 });
             });
         }));
 
-        it('should not show validation error for below the number limit (2147483647)', fakeAsync(() => {
+        it('should not show validation error for below the number limit (2147483647)', fakeAsync((done) => {
             fixture.detectChanges();
             fixture.whenStable().then(() => {
 
@@ -734,6 +726,7 @@ describe('CardViewTextItemComponent', () => {
                     expect(error).toBeFalsy();
 
                     expect(component.property.value).toBe('2147483647');
+                    done();
                 });
             });
         }));
@@ -783,7 +776,7 @@ describe('CardViewTextItemComponent', () => {
             component.ngOnChanges({ property: new SimpleChange(null, null, true) });
         });
 
-        it('should show validation error when string passed', fakeAsync(() => {
+        it('should show validation error when string passed', fakeAsync((done) => {
             fixture.detectChanges();
             fixture.whenStable().then(() => {
 
@@ -794,11 +787,12 @@ describe('CardViewTextItemComponent', () => {
                     const error = getTextFieldError(component.property.key);
                     expect(error).toEqual('CORE.CARDVIEW.VALIDATORS.FLOAT_VALIDATION_ERROR');
                     expect(component.property.value).toBe(floatValue);
+                    done();
                 });
             });
         }));
 
-        it('should show validation error for empty string', fakeAsync(() => {
+        it('should show validation error for empty string', fakeAsync((done) => {
             fixture.detectChanges();
             fixture.whenStable().then(() => {
 
@@ -809,6 +803,7 @@ describe('CardViewTextItemComponent', () => {
                     const error = getTextFieldError(component.property.key);
                     expect(error).toEqual('CORE.CARDVIEW.VALIDATORS.FLOAT_VALIDATION_ERROR');
                     expect(component.property.value).toBe(floatValue);
+                    done();
                 });
             });
         }));

--- a/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.ts
+++ b/lib/core/card-view/components/card-view-textitem/card-view-textitem.component.ts
@@ -113,6 +113,7 @@ export class CardViewTextItemComponent extends BaseCardView<CardViewTextItemMode
         } else {
             this.editedValue = this.property.displayValue;
             this.textInput.setValue(this.editedValue);
+            this.isEditable ? this.textInput.enable() : this.textInput.disable();
         }
 
         this.resetErrorMessages();

--- a/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.spec.ts
@@ -268,7 +268,7 @@ describe('TaskHeaderCloudComponent', () => {
             expect(statusEl.nativeElement.value).toBe('ASSIGNED');
         });
 
-        it('should render defined edit icon for assignee property if the task in assigned state and shared among candidates', () => {
+        it('should render defined edit icon for assignee property if the task in assigned state and shared among candidates', async () => {
             fixture.detectChanges();
             await fixture.whenStable();
             const value = fixture.debugElement.query(By.css(`[data-automation-id="header-assignee"] [data-automation-id="card-textitem-clickable-icon-assignee"]`));

--- a/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.spec.ts
@@ -99,126 +99,115 @@ describe('TaskHeaderCloudComponent', () => {
             expect(taskTitle).toBeTruthy();
         });
 
-        it('should fectch task details when appName and taskId defined', () => {
+        it('should fectch task details when appName and taskId defined', async () => {
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
-                expect(getTaskByIdSpy).toHaveBeenCalled();
-                expect(component.taskDetails).toBe(assignedTaskDetailsCloudMock);
-            });
+            await fixture.whenStable();
+            expect(getTaskByIdSpy).toHaveBeenCalled();
+            expect(component.taskDetails).toBe(assignedTaskDetailsCloudMock);
+
         });
 
-        it('should display assignee', () => {
+        it('should display assignee', async () => {
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
-                const assigneeEl = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-assignee"]'));
-                expect(assigneeEl.nativeElement.value).toBe('AssignedTaskUser');
-            });
+            await fixture.whenStable();
+            const assigneeEl = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-assignee"]'));
+            expect(assigneeEl.nativeElement.value).toBe('AssignedTaskUser');
         });
 
-        it('should display status', () => {
+        it('should display status', async () => {
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
-                fixture.detectChanges();
-                const statusEl = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-status"]'));
-                expect(statusEl.nativeElement.value).toBe('ASSIGNED');
-            });
+            await fixture.whenStable();
+            fixture.detectChanges();
+            const statusEl = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-status"]'));
+            expect(statusEl.nativeElement.value).toBe('ASSIGNED');
         });
 
-        it('should display priority', () => {
+        it('should display priority', async () => {
             fixture.detectChanges();
 
-            fixture.whenStable().then(() => {
-                fixture.detectChanges();
-                const priorityEl = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-priority"]'));
-                expect(priorityEl.nativeElement.value).toBe('5');
-            });
-        });
-
-        it('should display error if priority is not a number', (done) => {
+            await fixture.whenStable();
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
-                fixture.detectChanges();
-
-                const formPriorityEl = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-priority"]'));
-                formPriorityEl.nativeElement.value = 'stringValue';
-                formPriorityEl.nativeElement.dispatchEvent(new Event('input'));
-
-                fixture.detectChanges();
-                fixture.whenStable().then(() => {
-                    fixture.detectChanges();
-
-                    const errorMessageEl = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-error-priority"]'));
-                    expect(errorMessageEl).not.toBeNull();
-                    done();
-                });
-            });
+            const priorityEl = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-priority"]'));
+            expect(priorityEl.nativeElement.value).toBe('5');
         });
 
-        it('should display due date', () => {
+        it('should display error if priority is not a number', async (done) => {
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
-                fixture.detectChanges();
+            await fixture.whenStable();
+            fixture.detectChanges();
 
-                const valueEl = fixture.debugElement.query(By.css('[data-automation-id="header-dueDate"] .adf-property-value'));
-                expect(valueEl.nativeElement.innerText.trim()).toBe(moment(assignedTaskDetailsCloudMock.dueDate, 'x').format('MMM D, Y, H:mm'));
-            });
+            const formPriorityEl = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-priority"]'));
+            formPriorityEl.nativeElement.value = 'stringValue';
+            formPriorityEl.nativeElement.dispatchEvent(new Event('input'));
+
+            fixture.detectChanges();
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            const errorMessageEl = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-error-priority"]'));
+            expect(errorMessageEl).not.toBeNull();
+            done();
+
         });
 
-        it('should display placeholder if no due date', () => {
+        it('should display due date', async () => {
+            fixture.detectChanges();
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            const valueEl = fixture.debugElement.query(By.css('[data-automation-id="header-dueDate"] .adf-property-value'));
+            expect(valueEl.nativeElement.innerText.trim()).toBe(moment(assignedTaskDetailsCloudMock.dueDate, 'x').format('MMM D, Y, H:mm'));
+        });
+
+        it('should display placeholder if no due date', async () => {
             component.taskDetails.dueDate = null;
             component.refreshData();
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
-                const valueEl = fixture.debugElement.query(By.css('[data-automation-id="header-dueDate"] .adf-property-value'));
-                expect(valueEl.nativeElement.innerText.trim()).toBe('ADF_CLOUD_TASK_HEADER.PROPERTIES.DUE_DATE_DEFAULT');
-            });
+            await fixture.whenStable();
+            const valueEl = fixture.debugElement.query(By.css('[data-automation-id="header-dueDate"] .adf-property-value'));
+            expect(valueEl.nativeElement.innerText.trim()).toBe('ADF_CLOUD_TASK_HEADER.PROPERTIES.DUE_DATE_DEFAULT');
         });
 
-        it('should display the default parent value if is undefined', () => {
+        it('should display the default parent value if is undefined', async () => {
             component.taskDetails.processInstanceId = null;
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
-                const valueEl = fixture.debugElement.query(By.css('[data-automation-id="header-parentName"] input'));
-                expect(valueEl.nativeElement.value).toEqual('ADF_CLOUD_TASK_HEADER.PROPERTIES.PARENT_NAME_DEFAULT');
-            });
+            await fixture.whenStable();
+            const valueEl = fixture.debugElement.query(By.css('[data-automation-id="header-parentName"] input'));
+            expect(valueEl.nativeElement.value).toEqual('ADF_CLOUD_TASK_HEADER.PROPERTIES.PARENT_NAME_DEFAULT');
         });
 
-        it('should be able to call update service on updating task description', (done) => {
+        it('should be able to call update service on updating task description', async (done) => {
             spyOn(taskCloudService, 'updateTask').and.returnValue(of(assignedTaskDetailsCloudMock));
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
-                fixture.detectChanges();
-                const inputEl = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-description"]'));
-                inputEl.nativeElement.value = 'updated description';
-                inputEl.nativeElement.dispatchEvent(new Event('input'));
-                fixture.detectChanges();
-                fixture.whenStable().then(() => {
-                    fixture.detectChanges();
-                    expect(taskCloudService.updateTask).toHaveBeenCalled();
-                    done();
-                });
-            });
+            await fixture.whenStable();
+            fixture.detectChanges();
+            const inputEl = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-description"]'));
+            inputEl.nativeElement.value = 'updated description';
+            inputEl.nativeElement.dispatchEvent(new Event('input'));
+            fixture.detectChanges();
+            await fixture.whenStable();
+            fixture.detectChanges();
+            expect(taskCloudService.updateTask).toHaveBeenCalled();
+            done();
         });
 
-        it('should roll back task description on error', async(() => {
+        it('should roll back task description on error', async(async () => {
             spyOn(taskCloudService, 'updateTask').and.returnValue(throwError('fake'));
             fixture.detectChanges();
 
-            fixture.whenStable().then(() => {
-                fixture.detectChanges();
-                let description = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-description"]'));
-                expect(description.nativeElement.value.trim()).toEqual('This is the description');
-                const inputEl = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-description"]'));
-                inputEl.nativeElement.value = 'updated description';
-                inputEl.nativeElement.dispatchEvent(new Event('input'));
-                fixture.detectChanges();
-                fixture.whenStable().then(() => {
-                    fixture.detectChanges();
-                    description = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-description"]'));
-                    expect(description.nativeElement.value.trim()).toEqual('This is the description');
-                    expect(taskCloudService.updateTask).toHaveBeenCalled();
-                });
-            });
+            await fixture.whenStable();
+            fixture.detectChanges();
+            let description = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-description"]'));
+            expect(description.nativeElement.value.trim()).toEqual('This is the description');
+            const inputEl = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-description"]'));
+            inputEl.nativeElement.value = 'updated description';
+            inputEl.nativeElement.dispatchEvent(new Event('input'));
+            fixture.detectChanges();
+            await fixture.whenStable();
+            fixture.detectChanges();
+            description = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-description"]'));
+            expect(description.nativeElement.value.trim()).toEqual('This is the description');
+            expect(taskCloudService.updateTask).toHaveBeenCalled();
         }));
 
         it('should show loading spinner when properties are not loaded', () => {
@@ -236,27 +225,24 @@ describe('TaskHeaderCloudComponent', () => {
             component.ngOnChanges();
         });
 
-        it('should fectch parent task details if the task has parent id', () => {
+        it('should fectch parent task details if the task has parent id', async () => {
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
-                expect(getTaskByIdSpy).toHaveBeenCalledTimes(2);
-            });
+            await fixture.whenStable();
+            expect(getTaskByIdSpy).toHaveBeenCalledTimes(2);
         });
 
-        it('should display parent task id', () => {
+        it('should display parent task id', async () => {
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
-                const assigneeEl = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-parentTaskId"'));
-                expect(assigneeEl.nativeElement.value).toBe('mock-parent-task-id');
-            });
+            await fixture.whenStable();
+            const assigneeEl = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-parentTaskId"'));
+            expect(assigneeEl.nativeElement.value).toBe('mock-parent-task-id');
         });
 
-        it('should display parent task name', () => {
+        it('should display parent task name', async () => {
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
-                const statusEl = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-parentName"]'));
-                expect(statusEl.nativeElement.value.trim()).toBe('This is a parent task name');
-            });
+            await fixture.whenStable();
+            const statusEl = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-parentName"]'));
+            expect(statusEl.nativeElement.value.trim()).toBe('This is a parent task name');
         });
     });
 
@@ -267,30 +253,27 @@ describe('TaskHeaderCloudComponent', () => {
             component.ngOnChanges();
         });
 
-        it('should display assignee', () => {
+        it('should display assignee', async () => {
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
-                fixture.detectChanges();
-                const assigneeEl = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-assignee"]'));
-                expect(assigneeEl.nativeElement.value).toBe('AssignedTaskUser');
-            });
+            await fixture.whenStable();
+            fixture.detectChanges();
+            const assigneeEl = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-assignee"]'));
+            expect(assigneeEl.nativeElement.value).toBe('AssignedTaskUser');
         });
 
-        it('should display status', () => {
+        it('should display status', async () => {
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
-                const statusEl = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-status"]'));
-                expect(statusEl.nativeElement.value).toBe('ASSIGNED');
-            });
+            await fixture.whenStable();
+            const statusEl = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-status"]'));
+            expect(statusEl.nativeElement.value).toBe('ASSIGNED');
         });
 
         it('should render defined edit icon for assignee property if the task in assigned state and shared among candidates', () => {
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
-                const value = fixture.debugElement.query(By.css(`[data-automation-id="header-assignee"] [data-automation-id="card-textitem-clickable-icon-assignee"]`));
-                expect(value).not.toBeNull();
-                expect(value.nativeElement.innerText).toBe('create');
-            });
+            await fixture.whenStable();
+            const value = fixture.debugElement.query(By.css(`[data-automation-id="header-assignee"] [data-automation-id="card-textitem-clickable-icon-assignee"]`));
+            expect(value).not.toBeNull();
+            expect(value.nativeElement.innerText).toBe('create');
         });
 
         it('should not render defined edit icon for assignee property if the task in created state and shared among condidates', async () => {
@@ -342,22 +325,20 @@ describe('TaskHeaderCloudComponent', () => {
             component.ngOnChanges();
         });
 
-        it('should display status', () => {
+        it('should display status', async () => {
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
-                fixture.detectChanges();
-                const statusEl = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-status"]'));
-                expect(statusEl.nativeElement.value).toBe('CREATED');
-            });
+            await fixture.whenStable();
+            fixture.detectChanges();
+            const statusEl = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-status"]'));
+            expect(statusEl.nativeElement.value).toBe('CREATED');
         });
 
-        it('should display placeholder if no assignee', () => {
+        it('should display placeholder if no assignee', async () => {
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
-                fixture.detectChanges();
-                const assigneeEl = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-assignee"]'));
-                expect(assigneeEl.nativeElement.value).toBe('ADF_CLOUD_TASK_HEADER.PROPERTIES.ASSIGNEE_DEFAULT');
-            });
+            await fixture.whenStable();
+            fixture.detectChanges();
+            const assigneeEl = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-assignee"]'));
+            expect(assigneeEl.nativeElement.value).toBe('ADF_CLOUD_TASK_HEADER.PROPERTIES.ASSIGNEE_DEFAULT');
         });
 
         it('should not render defined clickable edit icon for assignee property if the task in created state and not assigned', () => {
@@ -385,12 +366,11 @@ describe('TaskHeaderCloudComponent', () => {
             component.ngOnChanges();
         });
 
-        it('should display status', () => {
+        it('should display status', async () => {
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
-                const statusEl = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-status"]'));
-                expect(statusEl.nativeElement.value).toBe('COMPLETED');
-            });
+            await fixture.whenStable();
+            const statusEl = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-status"]'));
+            expect(statusEl.nativeElement.value).toBe('COMPLETED');
         });
 
         it('should not render defined clickable edit icon for assignee property if the task in completed state', () => {
@@ -405,7 +385,7 @@ describe('TaskHeaderCloudComponent', () => {
             const descriptionEditIcon = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-edit-icon-description"]`));
             const dueDateEditIcon = fixture.debugElement.query(By.css(`[data-automation-id="datepickertoggle-dueDate"]`));
             expect(priorityEditIcon).toBeNull('Edit icon should NOT be shown');
-            expect(descriptionEditIcon).toBeNull('Edit icon should NOT be shown');
+            expect(descriptionEditIcon).toBeNull('Edit icon shouaaa`zld NOT be shown');
             expect(dueDateEditIcon).toBeNull('Edit icon should NOT be shown');
         });
     });
@@ -418,12 +398,11 @@ describe('TaskHeaderCloudComponent', () => {
             component.ngOnChanges();
         });
 
-        it('should display status', () => {
+        it('should display status', async () => {
             fixture.detectChanges();
-            fixture.whenStable().then(() => {
-                const statusEl = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-status"]'));
-                expect(statusEl.nativeElement.value).toBe('SUSPENDED');
-            });
+            await fixture.whenStable();
+            const statusEl = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-status"]'));
+            expect(statusEl.nativeElement.value).toBe('SUSPENDED');
         });
 
         it('should not render defined clickable edit icon for assignee property if the task in suspended state', () => {
@@ -445,92 +424,85 @@ describe('TaskHeaderCloudComponent', () => {
 
     describe('Task with candidates', () => {
 
-        it('should display candidate groups', () => {
+        it('should display candidate groups', async () => {
             component.ngOnChanges();
             fixture.detectChanges();
 
-            fixture.whenStable().then(() => {
-                const candidateGroup1 = fixture.nativeElement.querySelector('[data-automation-id="card-arrayitem-chip-mockgroup1"] span');
-                const candidateGroup2 = fixture.nativeElement.querySelector('[data-automation-id="card-arrayitem-chip-mockgroup2"] span');
-                expect(getCandidateGroupsSpy).toHaveBeenCalled();
-                expect(candidateGroup1.innerText).toBe('mockgroup1');
-                expect(candidateGroup2.innerText).toBe('mockgroup2');
-            });
+            await fixture.whenStable();
+            const candidateGroup1 = fixture.nativeElement.querySelector('[data-automation-id="card-arrayitem-chip-mockgroup1"] span');
+            const candidateGroup2 = fixture.nativeElement.querySelector('[data-automation-id="card-arrayitem-chip-mockgroup2"] span');
+            expect(getCandidateGroupsSpy).toHaveBeenCalled();
+            expect(candidateGroup1.innerText).toBe('mockgroup1');
+            expect(candidateGroup2.innerText).toBe('mockgroup2');
         });
 
-        it('should display candidate user', () => {
+        it('should display candidate user', async () => {
             component.ngOnChanges();
             fixture.detectChanges();
 
-            fixture.whenStable().then(() => {
-                const candidateUser1 = fixture.nativeElement.querySelector('[data-automation-id="card-arrayitem-chip-mockuser1"] span');
-                const candidateUser2 = fixture.nativeElement.querySelector('[data-automation-id="card-arrayitem-chip-mockuser2"] span');
-                expect(getCandidateUsersSpy).toHaveBeenCalled();
-                expect(candidateUser1.innerText).toBe('mockuser1');
-                expect(candidateUser2.innerText).toBe('mockuser2');
-            });
+            await fixture.whenStable();
+            const candidateUser1 = fixture.nativeElement.querySelector('[data-automation-id="card-arrayitem-chip-mockuser1"] span');
+            const candidateUser2 = fixture.nativeElement.querySelector('[data-automation-id="card-arrayitem-chip-mockuser2"] span');
+            expect(getCandidateUsersSpy).toHaveBeenCalled();
+            expect(candidateUser1.innerText).toBe('mockuser1');
+            expect(candidateUser2.innerText).toBe('mockuser2');
         });
 
-        it('should display placeholder if no candidate groups', () => {
+        it('should display placeholder if no candidate groups', async () => {
             getCandidateGroupsSpy.and.returnValue(of([]));
             fixture.detectChanges();
             component.ngOnChanges();
             fixture.detectChanges();
 
-            fixture.whenStable().then(() => {
-                const labelValue = fixture.debugElement.query(By.css('[data-automation-id="card-array-label-candidateGroups"]'));
-                const defaultElement = fixture.debugElement.query(By.css('[data-automation-id="card-arrayitem-default"]'));
-                expect(labelValue.nativeElement.innerText).toBe('ADF_CLOUD_TASK_HEADER.PROPERTIES.CANDIDATE_GROUPS');
-                expect(defaultElement.nativeElement.innerText).toBe('ADF_CLOUD_TASK_HEADER.PROPERTIES.CANDIDATE_GROUPS_DEFAULT');
-            });
-
+            await fixture.whenStable();
+            const labelValue = fixture.debugElement.query(By.css('[data-automation-id="card-array-label-candidateGroups"]'));
+            const defaultElement = fixture.debugElement.query(By.css('[data-automation-id="card-arrayitem-default"]'));
+            expect(labelValue.nativeElement.innerText).toBe('ADF_CLOUD_TASK_HEADER.PROPERTIES.CANDIDATE_GROUPS');
+            expect(defaultElement.nativeElement.innerText).toBe('ADF_CLOUD_TASK_HEADER.PROPERTIES.CANDIDATE_GROUPS_DEFAULT');
         });
 
-        it('should display placeholder if no candidate users', () => {
+        it('should display placeholder if no candidate users', async () => {
             getCandidateUsersSpy.and.returnValue(of([]));
             fixture.detectChanges();
             component.ngOnChanges();
             fixture.detectChanges();
 
-            fixture.whenStable().then(() => {
-                const labelValue = fixture.debugElement.query(By.css('[data-automation-id="card-array-label-candidateUsers"]'));
-                const defaultElement = fixture.debugElement.query(By.css('[data-automation-id="card-arrayitem-default"]'));
-                expect(labelValue.nativeElement.innerText).toBe('ADF_CLOUD_TASK_HEADER.PROPERTIES.CANDIDATE_USERS');
-                expect(defaultElement.nativeElement.innerText).toBe('ADF_CLOUD_TASK_HEADER.PROPERTIES.CANDIDATE_USERS_DEFAULT');
-            });
+            await fixture.whenStable();
+            const labelValue = fixture.debugElement.query(By.css('[data-automation-id="card-array-label-candidateUsers"]'));
+            const defaultElement = fixture.debugElement.query(By.css('[data-automation-id="card-arrayitem-default"]'));
+            expect(labelValue.nativeElement.innerText).toBe('ADF_CLOUD_TASK_HEADER.PROPERTIES.CANDIDATE_USERS');
+            expect(defaultElement.nativeElement.innerText).toBe('ADF_CLOUD_TASK_HEADER.PROPERTIES.CANDIDATE_USERS_DEFAULT');
         });
     });
 
     describe('Config properties', () => {
 
-        it('should show only the properties from the configuration file', () => {
+        it('should show only the properties from the configuration file', async () => {
             spyOn(appConfigService, 'get').and.returnValue(['assignee', 'status']);
             component.ngOnChanges();
             fixture.detectChanges();
             const propertyList = fixture.debugElement.queryAll(By.css('.adf-property-list .adf-property'));
 
-            fixture.whenStable().then(() => {
-                expect(propertyList).toBeDefined();
-                expect(propertyList).not.toBeNull();
-                expect(propertyList.length).toBe(2);
-                expect(propertyList[0].nativeElement.textContent).toContain('ADF_CLOUD_TASK_HEADER.PROPERTIES.ASSIGNEE');
-                expect(propertyList[1].nativeElement.textContent).toContain('ADF_CLOUD_TASK_HEADER.PROPERTIES.STATUS');
-            });
+            await fixture.whenStable();
+            expect(propertyList).toBeDefined();
+            expect(propertyList).not.toBeNull();
+            expect(propertyList.length).toBe(2);
+            expect(propertyList[0].nativeElement.textContent).toContain('ADF_CLOUD_TASK_HEADER.PROPERTIES.ASSIGNEE');
+            expect(propertyList[1].nativeElement.textContent).toContain('ADF_CLOUD_TASK_HEADER.PROPERTIES.STATUS');
         });
 
-        it('should show all the default properties if there is no configuration', () => {
+        it('should show all the default properties if there is no configuration', async () => {
             spyOn(appConfigService, 'get').and.returnValue(null);
             component.ngOnChanges();
             fixture.detectChanges();
 
-            fixture.whenStable().then(() => {
-                const propertyList = fixture.debugElement.queryAll(By.css('.adf-property-list .adf-property'));
-                expect(propertyList).toBeDefined();
-                expect(propertyList).not.toBeNull();
-                expect(propertyList.length).toBe(component.properties.length);
-                expect(propertyList[0].nativeElement.textContent).toContain('ADF_CLOUD_TASK_HEADER.PROPERTIES.ASSIGNEE');
-                expect(propertyList[1].nativeElement.textContent).toContain('ADF_CLOUD_TASK_HEADER.PROPERTIES.STATUS');
-            });
+            await fixture.whenStable();
+            const propertyList = fixture.debugElement.queryAll(By.css('.adf-property-list .adf-property'));
+            expect(propertyList).toBeDefined();
+            expect(propertyList).not.toBeNull();
+            expect(propertyList.length).toBe(component.properties.length);
+            expect(propertyList[0].nativeElement.textContent).toContain('ADF_CLOUD_TASK_HEADER.PROPERTIES.ASSIGNEE');
+            expect(propertyList[1].nativeElement.textContent).toContain('ADF_CLOUD_TASK_HEADER.PROPERTIES.STATUS');
         });
     });
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ACA-3499
The Card View Text Item input required to click outside to trigger the change event.

**What is the new behaviour?**
The Card View Text Item input now makes use of a much ore modern form control instead of the ngModel it was using. This allows it to fire in a control manner.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
