### PR TITLE
Readded column key as key parameter

### DIFF
--- a/demo-shell/src/app/components/files/filtered-search.component.ts
+++ b/demo-shell/src/app/components/files/filtered-search.component.ts
@@ -48,7 +48,7 @@ export class FilteredSearchComponent {
     }
 
     onSortingChanged(event) {
-        this.filterSorting = event.detail.column + '-' + event.detail.direction;
+        this.filterSorting = event.detail.key + '-' + event.detail.direction;
     }
 
 }

--- a/lib/content-services/src/lib/document-list/components/document-list.component.ts
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.ts
@@ -702,7 +702,7 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
     }
 
     onSortingChanged(event: CustomEvent) {
-        this.orderBy = this.buildOrderByArray(event.detail.key, event.detail.direction);
+        this.orderBy = this.buildOrderByArray(event.detail.sortingKey, event.detail.direction);
         this.reload();
     }
 

--- a/lib/core/datatable/components/datatable/datatable.component.spec.ts
+++ b/lib/core/datatable/components/datatable/datatable.component.spec.ts
@@ -290,7 +290,8 @@ describe('DataTable', () => {
         dataTable.data.setSorting(new DataSorting('name', 'desc'));
 
         fixture.nativeElement.addEventListener('sorting-changed', (event: CustomEvent) => {
-            expect(event.detail.key).toBe('displayName');
+            expect(event.detail.key).toBe('name');
+            expect(event.detail.sortingKey).toBe('displayName');
             expect(event.detail.direction).toBe('asc');
             done();
         });

--- a/lib/core/datatable/components/datatable/datatable.component.ts
+++ b/lib/core/datatable/components/datatable/datatable.component.ts
@@ -771,11 +771,11 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck,
         this.elementRef.nativeElement.dispatchEvent(domEvent);
     }
 
-    private emitSortingChangedEvent(column: string, key: string, direction: string) {
+    private emitSortingChangedEvent(key: string, sortingKey: string, direction: string) {
         const domEvent = new CustomEvent('sorting-changed', {
             detail: {
-                column,
                 key,
+                sortingKey,
                 direction
             },
             bubbles: true


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Column key is used on sorting for process and now that the value has been changed into the sorting key is creating problems on the sorting side.


**What is the new behaviour?**
We have readded the key as the column name key and added the extra parameter sortingKey


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
