### PR TITLE
[ADF-5165] [Regression] Fix Checkbok widget in completed tasks

### DIFF
--- a/lib/core/form/components/widgets/core/form-field.model.spec.ts
+++ b/lib/core/form/components/widgets/core/form-field.model.spec.ts
@@ -249,6 +249,150 @@ describe('FormFieldModel', () => {
         expect(field.value).toBe('28-04-2017');
     });
 
+    it('should parse the checkbox set to "true" when it is readonly', () => {
+        const form = new FormModel();
+        const field = new FormFieldModel(form, {
+            fieldType: 'FormFieldRepresentation',
+            id: 'checkbox',
+            name: 'Checkbox',
+            type: 'readonly',
+            value: 'true',
+            required: false,
+            readOnly: true,
+            params: {
+                field: {
+                    id: 'checkbox',
+                    name: 'Checkbox',
+                    type: 'boolean',
+                    value: null,
+                    required: false,
+                    readOnly: false
+                }
+            }
+        });
+        expect(field.value).toBeTruthy();
+    });
+
+    it('should parse the checkbox set to null when it is readonly', () => {
+        const form = new FormModel();
+        const field = new FormFieldModel(form, {
+            fieldType: 'FormFieldRepresentation',
+            id: 'checkbox',
+            name: 'Checkbox',
+            type: 'readonly',
+            value: null,
+            required: false,
+            readOnly: true,
+            params: {
+                field: {
+                    id: 'checkbox',
+                    name: 'Checkbox',
+                    type: 'boolean',
+                    value: null,
+                    required: false,
+                    readOnly: false
+                }
+            }
+        });
+        expect(field.value).toBeFalsy();
+    });
+
+    it('should parse the checkbox set to "false" when it is readonly', () => {
+        const form = new FormModel();
+        const field = new FormFieldModel(form, {
+            fieldType: 'FormFieldRepresentation',
+            id: 'checkbox',
+            name: 'Checkbox',
+            type: 'readonly',
+            value: 'false',
+            required: false,
+            readOnly: true,
+            params: {
+                field: {
+                    id: 'checkbox',
+                    name: 'Checkbox',
+                    type: 'boolean',
+                    value: null,
+                    required: false,
+                    readOnly: false
+                }
+            }
+        });
+        expect(field.value).toBeFalsy();
+    });
+
+    it('should parse the checkbox set to "true" when it is editable', () => {
+        const form = new FormModel();
+        const field = new FormFieldModel(form, {
+            fieldType: 'FormFieldRepresentation',
+            id: 'checkbox',
+            name: 'Checkbox',
+            type: 'boolean',
+            value: 'true',
+            required: false,
+            readOnly: true,
+            params: {
+                field: {
+                    id: 'checkbox',
+                    name: 'Checkbox',
+                    type: 'boolean',
+                    value: null,
+                    required: false,
+                    readOnly: false
+                }
+            }
+        });
+        expect(field.value).toBeTruthy();
+    });
+
+    it('should parse the checkbox set to null when it is editable', () => {
+        const form = new FormModel();
+        const field = new FormFieldModel(form, {
+            fieldType: 'FormFieldRepresentation',
+            id: 'checkbox',
+            name: 'Checkbox',
+            type: 'boolean',
+            value: null,
+            required: false,
+            readOnly: true,
+            params: {
+                field: {
+                    id: 'checkbox',
+                    name: 'Checkbox',
+                    type: 'boolean',
+                    value: null,
+                    required: false,
+                    readOnly: false
+                }
+            }
+        });
+        expect(field.value).toBeFalsy();
+    });
+
+    it('should parse the checkbox set to "false" when it is editable', () => {
+        const form = new FormModel();
+        const field = new FormFieldModel(form, {
+            fieldType: 'FormFieldRepresentation',
+            id: 'checkbox',
+            name: 'Checkbox',
+            type: 'boolean',
+            value: 'false',
+            required: false,
+            readOnly: true,
+            params: {
+                field: {
+                    id: 'checkbox',
+                    name: 'Checkbox',
+                    type: 'boolean',
+                    value: null,
+                    required: false,
+                    readOnly: false
+                }
+            }
+        });
+        expect(field.value).toBeFalsy();
+    });
+
     it('should return the label of selected dropdown value ', () => {
         const field = new FormFieldModel(new FormModel(), {
             type: FormFieldTypes.DROPDOWN,

--- a/lib/core/form/components/widgets/core/form-field.model.ts
+++ b/lib/core/form/components/widgets/core/form-field.model.ts
@@ -320,7 +320,7 @@ export class FormFieldModel extends FormWidgetModel {
             }
         }
 
-        if (json.type === FormFieldTypes.BOOLEAN) {
+        if (this.isCheckboxField(json)) {
             value = json.value === 'true' || json.value === true ? true : false;
         }
 
@@ -445,6 +445,13 @@ export class FormFieldModel extends FormWidgetModel {
             json.params.field &&
             json.params.field.type === FormFieldTypes.DATETIME) ||
             json.type === FormFieldTypes.DATETIME;
+    }
+
+    private isCheckboxField(json: any): boolean {
+        return (json.params &&
+            json.params.field &&
+            json.params.field.type === FormFieldTypes.BOOLEAN) ||
+            json.type === FormFieldTypes.BOOLEAN;
     }
 
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-5165
Checkbox widgets were all checked when the task was completed.

**What is the new behaviour?**
It happened because the widget type changes from boolean to readonly. It's been fixed to represent the real value.
<img width="757" alt="Screen Shot 2020-08-12 at 12 47 10" src="https://user-images.githubusercontent.com/18293044/90011813-29a56180-dc9a-11ea-9cae-f2127cd3905f.png">

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
