### PR TITLE
[AAE-3204] Fix destinationFolder breadcrumb restriction not working

### DIFF
--- a/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.spec.ts
@@ -102,22 +102,6 @@ describe('AttachFileCloudWidgetComponent', () => {
         }
     };
 
-    const allSourceWithMyFilesParams = {
-        fileSource: {
-            name: 'all file sources',
-            serviceId: 'all-file-sources',
-            destinationFolderPath: '-my-'
-        }
-    };
-
-    const allSourceWithShareParams = {
-        fileSource: {
-            name: 'all file sources',
-            serviceId: 'all-file-sources',
-            destinationFolderPath: '-shared-'
-        }
-    };
-
     const allSourceWithWrongAliasParams = {
         fileSource: {
             name: 'all file sources',
@@ -309,16 +293,14 @@ describe('AttachFileCloudWidgetComponent', () => {
     });
 
     describe('destinationFolderPath', () => {
-
-        let fetchNodeIdFromRelativePathSpy: jasmine.Spy;
         let openUploadFileDialogSpy: jasmine.Spy;
 
         beforeEach(async(() => {
-            fetchNodeIdFromRelativePathSpy = spyOn(contentCloudNodeSelectorService, 'fetchNodeIdFromRelativePath').and.returnValue(mockNodeId);
             openUploadFileDialogSpy = spyOn(contentCloudNodeSelectorService, 'openUploadFileDialog').and.returnValue(of([fakeMinimalNode]));
         }));
 
-        it('should be able to fetch nodeId if destinationFolderPtah defined ', async() => {
+        it('should be able to fetch nodeId if destinationFolderPath is defined', async() => {
+            const fetchNodeIdFromRelativePathSpy = spyOn(contentCloudNodeSelectorService, 'fetchNodeIdFromRelativePath').and.returnValue(mockNodeId);
             widget.field = new FormFieldModel(new FormModel(), {
                 type: FormFieldTypes.UPLOAD,
                 value: []
@@ -342,7 +324,7 @@ describe('AttachFileCloudWidgetComponent', () => {
             expect(widget.rootNodeId).toEqual('mock-node-id');
         });
 
-        it('Should be able to set given alias as rootNodeId if destinationFolderPath contains only alias i.e -root-', async() => {
+        it('Should be able to set given alias as rootNodeId if the nodeId of the alias is not fetched from the api', async() => {
             widget.field = new FormFieldModel(new FormModel(), {
                 type: FormFieldTypes.UPLOAD,
                 value: []
@@ -361,48 +343,6 @@ describe('AttachFileCloudWidgetComponent', () => {
 
             expect(widget.rootNodeId).toEqual('-root-');
             expect(openUploadFileDialogSpy).toHaveBeenCalledWith('-root-', 'single', true);
-        });
-
-        it('Should be able to set given alias as rootNodeId if destinationFolderPath contains only alias i.e -my-', async() => {
-            widget.field = new FormFieldModel(new FormModel(), {
-                type: FormFieldTypes.UPLOAD,
-                value: []
-            });
-            widget.field.id = 'attach-file-alfresco';
-            widget.field.params = <FormFieldMetadata> allSourceWithMyFilesParams;
-            fixture.detectChanges();
-            await fixture.whenStable();
-            const attachButton: HTMLButtonElement = element.querySelector('#attach-file-alfresco');
-
-            expect(attachButton).not.toBeNull();
-
-            attachButton.click();
-            await fixture.whenStable();
-            fixture.detectChanges();
-
-            expect(widget.rootNodeId).toEqual('-my-');
-            expect(openUploadFileDialogSpy).toHaveBeenCalledWith('-my-', 'single', true);
-        });
-
-        it('Should be able to set given alias as rootNodeId if destinationFolderPath contains only alias i.e -shared-', async() => {
-            widget.field = new FormFieldModel(new FormModel(), {
-                type: FormFieldTypes.UPLOAD,
-                value: []
-            });
-            widget.field.id = 'attach-file-alfresco';
-            widget.field.params = <FormFieldMetadata> allSourceWithShareParams;
-            fixture.detectChanges();
-            await fixture.whenStable();
-            const attachButton: HTMLButtonElement = element.querySelector('#attach-file-alfresco');
-
-            expect(attachButton).not.toBeNull();
-
-            attachButton.click();
-            await fixture.whenStable();
-            fixture.detectChanges();
-
-            expect(widget.rootNodeId).toEqual('-shared-');
-            expect(openUploadFileDialogSpy).toHaveBeenCalledWith('-shared-', 'single', true);
         });
 
         it('Should be able to set default alias as rootNodeId if destinationFolderPath contains wrong alias', async() => {

--- a/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.ts
@@ -91,13 +91,11 @@ export class AttachFileCloudWidgetComponent extends UploadCloudWidgetComponent i
         if (this.isAlfrescoAndLocal()) {
             const destinationFolderPath = this.getAliasAndRelativePathFromDestinationFolderPath(this.field.params.fileSource.destinationFolderPath);
 
-            if (destinationFolderPath.path) {
+            if (destinationFolderPath.path || destinationFolderPath.alias) {
                 const opts = { relativePath: destinationFolderPath.path };
                 await this.contentNodeSelectorService.fetchNodeIdFromRelativePath(destinationFolderPath.alias, opts).then((nodeId: string) => {
                     this.rootNodeId = nodeId ? nodeId : destinationFolderPath.alias;
                 });
-            } else {
-                this.rootNodeId = destinationFolderPath.alias;
             }
         }
 

--- a/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.ts
@@ -90,13 +90,11 @@ export class AttachFileCloudWidgetComponent extends UploadCloudWidgetComponent i
 
         if (this.isAlfrescoAndLocal()) {
             const destinationFolderPath = this.getAliasAndRelativePathFromDestinationFolderPath(this.field.params.fileSource.destinationFolderPath);
+            const opts = { relativePath: destinationFolderPath.path };
 
-            if (destinationFolderPath.path || destinationFolderPath.alias) {
-                const opts = { relativePath: destinationFolderPath.path };
-                await this.contentNodeSelectorService.fetchNodeIdFromRelativePath(destinationFolderPath.alias, opts).then((nodeId: string) => {
-                    this.rootNodeId = nodeId ? nodeId : destinationFolderPath.alias;
-                });
-            }
+            await this.contentNodeSelectorService.fetchNodeIdFromRelativePath(destinationFolderPath.alias, opts).then((nodeId: string) => {
+                this.rootNodeId = nodeId ? nodeId : destinationFolderPath.alias;
+            });
         }
 
         this.contentNodeSelectorService

--- a/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.ts
@@ -92,9 +92,8 @@ export class AttachFileCloudWidgetComponent extends UploadCloudWidgetComponent i
             const destinationFolderPath = this.getAliasAndRelativePathFromDestinationFolderPath(this.field.params.fileSource.destinationFolderPath);
             const opts = { relativePath: destinationFolderPath.path };
 
-            await this.contentNodeSelectorService.fetchNodeIdFromRelativePath(destinationFolderPath.alias, opts).then((nodeId: string) => {
-                this.rootNodeId = nodeId ? nodeId : destinationFolderPath.alias;
-            });
+            const nodeId = await this.contentNodeSelectorService.fetchNodeIdFromRelativePath(destinationFolderPath.alias, opts);
+            this.rootNodeId = nodeId ? nodeId : destinationFolderPath.alias;
         }
 
         this.contentNodeSelectorService

--- a/lib/process-services-cloud/src/lib/form/services/content-cloud-node-selector.service.ts
+++ b/lib/process-services-cloud/src/lib/form/services/content-cloud-node-selector.service.ts
@@ -54,13 +54,11 @@ export class ContentCloudNodeSelectorService {
   }
 
     async fetchNodeIdFromRelativePath(alias: string, opts: { relativePath: string }): Promise<string> {
-        let nodeId = '';
-        await this.apiService.getInstance().node.getNode(alias, opts).then(node => {
-            nodeId = node.entry.id;
-        }).catch((err) => {
-            this.handleError(err);
-        });
-        return nodeId;
+        const nodeEntry = await this.apiService.getInstance().node
+            .getNode(alias, opts)
+            .catch((err) => this.handleError(err));
+
+        return nodeEntry?.entry?.id;
     }
 
   private openContentNodeDialog(data: ContentNodeSelectorComponentData, currentPanelClass: string, chosenWidth: string) {

--- a/lib/process-services-cloud/src/lib/form/services/content-cloud-node-selector.service.ts
+++ b/lib/process-services-cloud/src/lib/form/services/content-cloud-node-selector.service.ts
@@ -54,7 +54,7 @@ export class ContentCloudNodeSelectorService {
   }
 
     async fetchNodeIdFromRelativePath(alias: string, opts: { relativePath: string }): Promise<string> {
-        const nodeEntry = await this.apiService.getInstance().node
+        const nodeEntry: any = await this.apiService.getInstance().node
             .getNode(alias, opts)
             .catch((err) => this.handleError(err));
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/AAE-3204


**What is the new behaviour?**
The id needs to be fetched also when only an alias is present as destinationFolderPath


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
