### PR TITLE
[AAE-3273] Manage empty option in retrieve content metadata dropdowns

### DIFF
--- a/lib/core/form/components/widgets/core/form.model.spec.ts
+++ b/lib/core/form/components/widgets/core/form.model.spec.ts
@@ -24,6 +24,7 @@ import { FormFieldModel } from './form-field.model';
 import { FormOutcomeModel } from './form-outcome.model';
 import { FormModel } from './form.model';
 import { TabModel } from './tab.model';
+import { fakeMetadataForm } from 'process-services-cloud/src/lib/form/mocks/cloud-form.mock';
 
 describe('FormModel', () => {
     let formService: FormService;
@@ -556,6 +557,36 @@ describe('FormModel', () => {
         it('should not find a process variable', () => {
             const missing = form.getProcessVariableValue('missing');
             expect(missing).toBeUndefined();
+        });
+    });
+
+    describe('add values not present', () => {
+        let form: FormModel;
+
+        beforeEach(() => {
+            form = new FormModel(fakeMetadataForm);
+            form.values['pfx_property_three'] = {};
+            form.values['pfx_property_four'] = 'empty';
+            form.values['pfx_property_five'] = 'green';
+        });
+
+        it('should not find a process variable', () => {
+            const values = {
+                pfx_property_one: 'testValue',
+                pfx_property_two: true,
+                pfx_property_three: 'opt_1',
+                pfx_property_four: 'option_2',
+                pfx_property_five: 'orange',
+                pfx_property_none: 'no_form_field'
+            };
+
+            const data = form.addValuesNotPresent(values);
+
+            expect(data).toContain({ name: 'pfx_property_one', value: 'testValue' });
+            expect(data).toContain({ name: 'pfx_property_two', value: true });
+            expect(data).toContain({ name: 'pfx_property_three', value: 'opt_1' });
+            expect(data).toContain({ name: 'pfx_property_four', value: 'option_2' });
+            expect(data).toContain({ name: 'pfx_property_five', value: 'green' });
         });
     });
 });

--- a/lib/core/form/components/widgets/core/form.model.ts
+++ b/lib/core/form/components/widgets/core/form.model.ts
@@ -375,4 +375,24 @@ export class FormModel {
             );
         }
     }
+
+    addValuesNotPresent(valuesToSetIfNotPresent: FormValues): { name: string; value: any }[] {
+        const keys = Object.keys(valuesToSetIfNotPresent);
+        keys.forEach(key => {
+            if (!this.values[key] || this.isEmptyDropdownOption(key)) {
+                this.values[key] = valuesToSetIfNotPresent[key];
+            }
+        });
+        const data = [];
+        const fields = Object.keys(this.values);
+        fields.forEach(field => data.push({ name: field, value: this.values[field] }));
+        return data;
+    }
+
+    private isEmptyDropdownOption(key: string): boolean {
+        if (this.getFieldById(key) && (this.getFieldById(key).type === FormFieldTypes.DROPDOWN)) {
+            return typeof this.values[key] === 'string' ? this.values[key] === 'empty' : Object.keys(this.values[key]).length === 0;
+        }
+        return false;
+    }
 }

--- a/lib/process-services-cloud/src/lib/form/components/form-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/form-cloud.component.spec.ts
@@ -131,11 +131,27 @@ describe('FormCloudComponent', () => {
         const fakeForm = new FormModel(JSON.parse(JSON.stringify(fakeMetadataForm)));
         formComponent.form = fakeForm;
         formComponent.formCloudRepresentationJSON = new FormCloudRepresentation(fakeForm);
+        formComponent.form.values['pfx_property_three'] = {};
+        formComponent.form.values['pfx_property_four'] = 'empty';
+        formComponent.form.values['pfx_property_five'] = 'green';
 
         const refreshFormSpy = spyOn<any>(formComponent, 'refreshFormData');
-        formService.updateFormValuesRequested.next({ pfx_property_one: 'testValue', pfx_property_two: true });
+        formService.updateFormValuesRequested.next(
+            {
+                pfx_property_one: 'testValue',
+                pfx_property_two: true,
+                pfx_property_three: 'opt_1',
+                pfx_property_four: 'option_2',
+                pfx_property_five: 'orange',
+                pfx_property_none: 'no_form_field'
+            }
+        );
         expect(refreshFormSpy).toHaveBeenCalled();
-        expect(formComponent.data).toContain({ name: 'pfx_property_one', value: 'testValue' }, { name: 'pfx_property_two', value: true });
+        expect(formComponent.data).toContain({ name: 'pfx_property_one', value: 'testValue' });
+        expect(formComponent.data).toContain({ name: 'pfx_property_two', value: true });
+        expect(formComponent.data).toContain({ name: 'pfx_property_three', value: 'opt_1' });
+        expect(formComponent.data).toContain({ name: 'pfx_property_four', value: 'option_2' });
+        expect(formComponent.data).toContain({ name: 'pfx_property_five', value: 'green' });
     });
 
     it('should register custom [upload] widget', () => {

--- a/lib/process-services-cloud/src/lib/form/components/form-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/form/components/form-cloud.component.ts
@@ -37,7 +37,6 @@ import {
 import { FormCloudService } from '../services/form-cloud.service';
 import { TaskVariableCloud } from '../models/task-variable-cloud.model';
 import { TaskDetailsCloudModel } from '../../task/start-task/models/task-details-cloud.model';
-import { FormFieldType } from '../../services/public-api';
 
 @Component({
     selector: 'adf-cloud-form',
@@ -117,24 +116,9 @@ export class FormCloudComponent extends FormBaseComponent implements OnChanges, 
         this.formService.updateFormValuesRequested
             .pipe(takeUntil(this.onDestroy$))
             .subscribe((valuesToSetIfNotPresent) => {
-                const keys = Object.keys(valuesToSetIfNotPresent);
-                keys.forEach(key => {
-                    if (!this.form.values[key] || this.isEmptyDropdownOption(key)) {
-                        this.form.values[key] = valuesToSetIfNotPresent[key];
-                    }
-                });
-                this.data = [];
-                const fields = Object.keys(this.form.values);
-                fields.forEach(field => this.data.push({ name: field, value: this.form.values[field] }));
+                this.data = this.form.addValuesNotPresent(valuesToSetIfNotPresent);
                 this.refreshFormData();
             });
-    }
-
-    private isEmptyDropdownOption(key: string): boolean {
-        if (this.form.getFieldById(key).type === FormFieldType.dropdown) {
-            return typeof this.form.values[key] === 'string' ? this.form.values[key] === 'empty' : Object.keys(this.form.values[key]).length === 0;
-        }
-        return false;
     }
 
     ngOnChanges(changes: SimpleChanges) {

--- a/lib/process-services-cloud/src/lib/form/components/form-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/form/components/form-cloud.component.ts
@@ -37,6 +37,7 @@ import {
 import { FormCloudService } from '../services/form-cloud.service';
 import { TaskVariableCloud } from '../models/task-variable-cloud.model';
 import { TaskDetailsCloudModel } from '../../task/start-task/models/task-details-cloud.model';
+import { FormFieldType } from '../../services/public-api';
 
 @Component({
     selector: 'adf-cloud-form',
@@ -118,7 +119,7 @@ export class FormCloudComponent extends FormBaseComponent implements OnChanges, 
             .subscribe((valuesToSetIfNotPresent) => {
                 const keys = Object.keys(valuesToSetIfNotPresent);
                 keys.forEach(key => {
-                    if (!this.form.values[key]) {
+                    if (!this.form.values[key] || this.isEmptyDropdownOption(key)) {
                         this.form.values[key] = valuesToSetIfNotPresent[key];
                     }
                 });
@@ -127,6 +128,13 @@ export class FormCloudComponent extends FormBaseComponent implements OnChanges, 
                 fields.forEach(field => this.data.push({ name: field, value: this.form.values[field] }));
                 this.refreshFormData();
             });
+    }
+
+    private isEmptyDropdownOption(key: string): boolean {
+        if (this.form.getFieldById(key).type === FormFieldType.dropdown) {
+            return typeof this.form.values[key] === 'string' ? this.form.values[key] === 'empty' : Object.keys(this.form.values[key]).length === 0;
+        }
+        return false;
     }
 
     ngOnChanges(changes: SimpleChanges) {

--- a/lib/process-services-cloud/src/lib/form/mocks/cloud-form.mock.ts
+++ b/lib/process-services-cloud/src/lib/form/mocks/cloud-form.mock.ts
@@ -1045,8 +1045,112 @@ export let fakeMetadataForm = {
                                 'link': false
                             }
                         }
+                    ],
+                    '4': [
+                        {
+                            'id': 'pfx_property_three',
+                            'name': 'pfx_property_three',
+                            'required': false,
+                            'readOnly': false,
+                            'colspan': 1,
+                            'params': {
+                                'existingColspan': 1,
+                                'maxColspan': 2
+                            },
+                            'visibilityCondition': null,
+                            'type': 'dropdown',
+                            'optionType': 'manual',
+                            'options': [
+                                {
+                                    'id': 'empty',
+                                    'name': 'Choose one...'
+                                },
+                                {
+                                    'id': 'opt_1',
+                                    'name': 'Option 1'
+                                },
+                                {
+                                    'id': 'opt_2',
+                                    'name': 'Option 2'
+                                }
+                            ],
+                            'value': 'empty',
+                            'restUrl': null,
+                            'restResponsePath': null,
+                            'restIdProperty': null,
+                            'restLabelProperty': null
+                        }
+                    ],
+                    '5': [
+                        {
+                            'id': 'pfx_property_four',
+                            'name': 'pfx_property_four',
+                            'required': false,
+                            'readOnly': false,
+                            'colspan': 1,
+                            'params': {
+                                'existingColspan': 1,
+                                'maxColspan': 2
+                            },
+                            'visibilityCondition': null,
+                            'type': 'dropdown',
+                            'optionType': 'manual',
+                            'options': [
+                                {
+                                    'id': 'empty',
+                                    'name': 'Choose one...'
+                                },
+                                {
+                                    'id': 'option_1',
+                                    'name': 'Option: 1'
+                                },
+                                {
+                                    'id': 'option_2',
+                                    'name': 'Option: 2'
+                                }
+                            ],
+                            'value': 'empty',
+                            'restUrl': null,
+                            'restResponsePath': null,
+                            'restIdProperty': null,
+                            'restLabelProperty': null
+                        }
+                    ],
+                    '6': [
+                        {
+                            'id': 'pfx_property_five',
+                            'name': 'pfx_property_five',
+                            'required': false,
+                            'readOnly': false,
+                            'colspan': 1,
+                            'params': {
+                                'existingColspan': 1,
+                                'maxColspan': 2
+                            },
+                            'visibilityCondition': null,
+                            'type': 'dropdown',
+                            'optionType': 'manual',
+                            'options': [
+                                {
+                                    'id': 'empty',
+                                    'name': 'Choose one...'
+                                },
+                                {
+                                    'id': 'green',
+                                    'name': 'Colour green'
+                                },
+                                {
+                                    'id': 'orange',
+                                    'name': 'Colour orange'
+                                }
+                            ],
+                            'value': 'empty',
+                            'restUrl': null,
+                            'restResponsePath': null,
+                            'restIdProperty': null,
+                            'restLabelProperty': null
+                        }
                     ]
-
                 },
                 'numberOfColumns': 2
             }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
When the empty value for a dropdown is selected, the retrieve metadata functionality does not populate the dropdown with the value of the property


**What is the new behaviour?**
Populate the dropdown with the property value when the empty value is present


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
