### PR TITLE
[ACA-3884]Attach cloud file - Ability to use the -appname- as placeholder in the destinationFolder 

### DIFF
--- a/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.spec.ts
@@ -27,7 +27,8 @@ import {
     FormFieldTypes,
     FormFieldMetadata,
     FormService,
-    DownloadService
+    DownloadService,
+    AppConfigService
 } from '@alfresco/adf-core';
 import { ProcessServiceCloudTestingModule } from '../../../../testing/process-service-cloud.testing.module';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
@@ -43,6 +44,7 @@ describe('AttachFileCloudWidgetComponent', () => {
     let fixture: ComponentFixture<AttachFileCloudWidgetComponent>;
     let element: HTMLInputElement;
     let contentCloudNodeSelectorService: ContentCloudNodeSelectorService;
+    let appConfigService: AppConfigService;
     let processCloudContentService: ProcessCloudContentService;
     let formService: FormService;
     let downloadService: DownloadService;
@@ -172,6 +174,9 @@ describe('AttachFileCloudWidgetComponent', () => {
         processCloudContentService = TestBed.inject(ProcessCloudContentService);
         contentCloudNodeSelectorService = TestBed.inject(
             ContentCloudNodeSelectorService
+        );
+        appConfigService = TestBed.inject(
+            AppConfigService
         );
         formService = TestBed.inject(FormService);
     }));
@@ -387,6 +392,21 @@ describe('AttachFileCloudWidgetComponent', () => {
 
             expect(widget.rootNodeId).toEqual('-root-');
             expect(openUploadFileDialogSpy).toHaveBeenCalledWith('-root-', 'multiple', true);
+        });
+
+        it('should return the application name in case -appname- placeholder is present', async() => {
+            appConfigService.config = Object.assign(appConfigService.config, {
+                'alfresco-deployed-apps': [
+                    {
+                      'name': 'fakeapp'
+                    }
+                  ]
+            });
+            expect(widget.replaceAppNameAliasWithValue('/myfiles/-appname-/folder')).toBe('/myfiles/fakeapp/folder');
+        });
+
+        it('should return the same value in case -appname- placeholder is NOT present', async() => {
+            expect(widget.replaceAppNameAliasWithValue('/myfiles/fakepath/folder')).toBe('/myfiles/fakepath/folder');
         });
 
         describe('FilesSource', () => {


### PR DESCRIPTION
It allows you to define a more dynamic path as destination folder such as
-root-/-appname-/folder
and at runtime it would be replaced with 
-root-/myapp/folder

**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
