### PR TITLE
[ADF-4481] Fix Viewer peview for unsupported new versions

### DIFF
--- a/lib/core/viewer/components/img-viewer.component.html
+++ b/lib/core/viewer/components/img-viewer.component.html
@@ -1,5 +1,5 @@
 <div id="adf-image-container" (keydown)="onKeyDown($event)" class="adf-image-container" tabindex="0" role="img" [attr.aria-label]="nameFile" [style.transform]="transform" data-automation-id="adf-image-container">
-    <img id="viewer-image" [src]="urlFile" [alt]="nameFile" [ngStyle]="{ 'cursor' : isDragged ? 'move': 'default' } " />
+    <img id="viewer-image" [src]="urlFile" [alt]="nameFile" (error)="onImageError()" [ngStyle]="{ 'cursor' : isDragged ? 'move': 'default' } " />
 </div>
 
 <div class="adf-image-viewer__toolbar" *ngIf="showToolbar">

--- a/lib/core/viewer/components/img-viewer.component.ts
+++ b/lib/core/viewer/components/img-viewer.component.ts
@@ -62,7 +62,6 @@ export class ImgViewerComponent implements OnInit, OnChanges, OnDestroy {
     offsetY: number = 0;
     step: number = 4;
     isDragged: boolean = false;
-    isUnsupported: boolean = false;
 
     private drag = { x: 0, y: 0 };
     private delta = { x: 0, y: 0 };

--- a/lib/core/viewer/components/img-viewer.component.ts
+++ b/lib/core/viewer/components/img-viewer.component.ts
@@ -23,7 +23,9 @@ import {
     ViewEncapsulation,
     ElementRef,
     OnInit,
-    OnDestroy
+    OnDestroy,
+    Output,
+    EventEmitter
 } from '@angular/core';
 import { ContentService } from '../../services/content.service';
 import { AppConfigService } from './../../app-config/app-config.service';
@@ -50,6 +52,9 @@ export class ImgViewerComponent implements OnInit, OnChanges, OnDestroy {
     @Input()
     nameFile: string;
 
+    @Output()
+    error = new EventEmitter<any>();
+
     rotate: number = 0;
     scaleX: number = 1.0;
     scaleY: number = 1.0;
@@ -57,6 +62,7 @@ export class ImgViewerComponent implements OnInit, OnChanges, OnDestroy {
     offsetY: number = 0;
     step: number = 4;
     isDragged: boolean = false;
+    isUnsupported: boolean = false;
 
     private drag = { x: 0, y: 0 };
     private delta = { x: 0, y: 0 };
@@ -215,5 +221,9 @@ export class ImgViewerComponent implements OnInit, OnChanges, OnDestroy {
         this.scaleY = 1.0;
         this.offsetX = 0;
         this.offsetY = 0;
+    }
+
+    onImageError() {
+        this.error.emit();
     }
 }

--- a/lib/core/viewer/components/media-player.component.html
+++ b/lib/core/viewer/components/media-player.component.html
@@ -1,3 +1,3 @@
 <video controls>
-    <source [src]="urlFile" [type]="mimeType" />
+    <source [src]="urlFile" [type]="mimeType" (error)="onMediaPlayerError()"/>
 </video>

--- a/lib/core/viewer/components/media-player.component.ts
+++ b/lib/core/viewer/components/media-player.component.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Component, Input, OnChanges, SimpleChanges, ViewEncapsulation } from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges, ViewEncapsulation, Output, EventEmitter } from '@angular/core';
 import { ContentService } from '../../services/content.service';
 
 @Component({
@@ -39,6 +39,9 @@ export class MediaPlayerComponent implements OnChanges {
     @Input()
     nameFile: string;
 
+    @Output()
+    error = new EventEmitter<any>();
+
     constructor(private contentService: ContentService ) {}
 
     ngOnChanges(changes: SimpleChanges) {
@@ -51,5 +54,9 @@ export class MediaPlayerComponent implements OnChanges {
         if (!this.urlFile && !this.blobFile) {
             throw new Error('Attribute urlFile or blobFile is required');
         }
+    }
+
+    onMediaPlayerError() {
+        this.error.emit();
     }
 }

--- a/lib/core/viewer/components/viewer.component.html
+++ b/lib/core/viewer/components/viewer.component.html
@@ -3,22 +3,26 @@
      [class.adf-viewer-overlay-container]="overlayMode"
      [class.adf-viewer-inline-container]="!overlayMode">
 
-    <div class="adf-viewer-content" fxLayout="column" [cdkTrapFocus]="overlayMode" cdkTrapFocusAutoCapture>
+    <div class="adf-viewer-content"
+         fxLayout="column"
+         [cdkTrapFocus]="overlayMode"
+         cdkTrapFocusAutoCapture>
         <ng-content select="adf-viewer-toolbar"></ng-content>
         <ng-container *ngIf="showToolbar && !toolbar">
-            <adf-toolbar color="default" id="adf-viewer-toolbar" class="adf-viewer-toolbar">
+            <adf-toolbar color="default"
+                         id="adf-viewer-toolbar"
+                         class="adf-viewer-toolbar">
 
                 <adf-toolbar-title>
 
                     <ng-container *ngIf="allowLeftSidebar">
-                        <button
-                            mat-icon-button
-                            [attr.aria-expanded]="showLeftSidebar"
-                            [attr.aria-label]="'ADF_VIEWER.ACTIONS.INFO' | translate"
-                            title="{{ 'ADF_VIEWER.ACTIONS.INFO' | translate }}"
-                            data-automation-id="adf-toolbar-left-sidebar"
-                            [color]="showLeftSidebar ? 'accent' : 'default'"
-                            (click)="toggleLeftSidebar()">
+                        <button mat-icon-button
+                                [attr.aria-expanded]="showLeftSidebar"
+                                [attr.aria-label]="'ADF_VIEWER.ACTIONS.INFO' | translate"
+                                title="{{ 'ADF_VIEWER.ACTIONS.INFO' | translate }}"
+                                data-automation-id="adf-toolbar-left-sidebar"
+                                [color]="showLeftSidebar ? 'accent' : 'default'"
+                                (click)="toggleLeftSidebar()">
                             <mat-icon>info_outline</mat-icon>
                         </button>
                     </ng-container>
@@ -34,108 +38,108 @@
                     </button>
                 </adf-toolbar-title>
 
-                <div fxFlex="1 1 auto" class="adf-viewer__file-title">
-                    <button
-                        *ngIf="allowNavigate && canNavigateBefore"
-                        data-automation-id="adf-toolbar-pref-file"
-                        mat-icon-button
-                        [attr.aria-label]="'ADF_VIEWER.ACTIONS.PREV_FILE' | translate"
-                        title="{{ 'ADF_VIEWER.ACTIONS.PREV_FILE' | translate }}"
-                        (click)="onNavigateBeforeClick($event)">
+                <div fxFlex="1 1 auto"
+                     class="adf-viewer__file-title">
+                    <button *ngIf="allowNavigate && canNavigateBefore"
+                            data-automation-id="adf-toolbar-pref-file"
+                            mat-icon-button
+                            [attr.aria-label]="'ADF_VIEWER.ACTIONS.PREV_FILE' | translate"
+                            title="{{ 'ADF_VIEWER.ACTIONS.PREV_FILE' | translate }}"
+                            (click)="onNavigateBeforeClick($event)">
                         <mat-icon>navigate_before</mat-icon>
                     </button>
-                    <img class="adf-viewer__mimeicon" [alt]="mimeType" [src]="mimeType | adfMimeTypeIcon" data-automation-id="adf-file-thumbnail">
-                    <span class="adf-viewer__display-name" id="adf-viewer-display-name">{{ fileTitle }}</span>
-                    <button
-                        *ngIf="allowNavigate && canNavigateNext"
-                        data-automation-id="adf-toolbar-next-file"
-                        mat-icon-button
-                        [attr.aria-label]="'ADF_VIEWER.ACTIONS.NEXT_FILE' | translate"
-                        title="{{ 'ADF_VIEWER.ACTIONS.NEXT_FILE' | translate }}"
-                        (click)="onNavigateNextClick($event)">
+                    <img class="adf-viewer__mimeicon"
+                         [alt]="mimeType"
+                         [src]="mimeType | adfMimeTypeIcon"
+                         data-automation-id="adf-file-thumbnail">
+                    <span class="adf-viewer__display-name"
+                          id="adf-viewer-display-name">{{ fileTitle }}</span>
+                    <button *ngIf="allowNavigate && canNavigateNext"
+                            data-automation-id="adf-toolbar-next-file"
+                            mat-icon-button
+                            [attr.aria-label]="'ADF_VIEWER.ACTIONS.NEXT_FILE' | translate"
+                            title="{{ 'ADF_VIEWER.ACTIONS.NEXT_FILE' | translate }}"
+                            (click)="onNavigateNextClick($event)">
                         <mat-icon>navigate_next</mat-icon>
                     </button>
                 </div>
 
                 <ng-content select="adf-viewer-toolbar-actions"></ng-content>
 
-                <ng-container *ngIf="mnuOpenWith" data-automation-id='adf-toolbar-custom-btn'>
-                    <button
-                        id="adf-viewer-openwith"
-                        mat-button
-                        [matMenuTriggerFor]="mnuOpenWith"
-                        data-automation-id="adf-toolbar-open-with">
+                <ng-container *ngIf="mnuOpenWith"
+                              data-automation-id='adf-toolbar-custom-btn'>
+                    <button id="adf-viewer-openwith"
+                            mat-button
+                            [matMenuTriggerFor]="mnuOpenWith"
+                            data-automation-id="adf-toolbar-open-with">
                         <span>{{ 'ADF_VIEWER.ACTIONS.OPEN_WITH' | translate }}</span>
                         <mat-icon>arrow_drop_down</mat-icon>
                     </button>
-                    <mat-menu #mnuOpenWith="matMenu" [overlapTrigger]="false">
+                    <mat-menu #mnuOpenWith="matMenu"
+                              [overlapTrigger]="false">
                         <ng-content select="adf-viewer-open-with"></ng-content>
                     </mat-menu>
                 </ng-container>
 
                 <adf-toolbar-divider></adf-toolbar-divider>
 
-                <button
-                    id="adf-viewer-download"
-                    *ngIf="allowDownload"
-                    mat-icon-button
-                    [attr.aria-label]="'ADF_VIEWER.ACTIONS.DOWNLOAD' | translate"
-                    title="{{ 'ADF_VIEWER.ACTIONS.DOWNLOAD' | translate }}"
-                    data-automation-id="adf-toolbar-download"
-                    [adfNodeDownload]="nodeEntry"
-                    [version]="versionEntry">
+                <button id="adf-viewer-download"
+                        *ngIf="allowDownload"
+                        mat-icon-button
+                        [attr.aria-label]="'ADF_VIEWER.ACTIONS.DOWNLOAD' | translate"
+                        title="{{ 'ADF_VIEWER.ACTIONS.DOWNLOAD' | translate }}"
+                        data-automation-id="adf-toolbar-download"
+                        [adfNodeDownload]="nodeEntry"
+                        [version]="versionEntry">
                     <mat-icon>file_download</mat-icon>
                 </button>
 
-                <button
-                    id="adf-viewer-print"
-                    *ngIf="allowPrint"
-                    mat-icon-button
-                    [attr.aria-label]="'ADF_VIEWER.ACTIONS.PRINT' | translate"
-                    title="{{ 'ADF_VIEWER.ACTIONS.PRINT' | translate }}"
-                    data-automation-id="adf-toolbar-print"
-                    (click)="printContent()">
+                <button id="adf-viewer-print"
+                        *ngIf="allowPrint"
+                        mat-icon-button
+                        [attr.aria-label]="'ADF_VIEWER.ACTIONS.PRINT' | translate"
+                        title="{{ 'ADF_VIEWER.ACTIONS.PRINT' | translate }}"
+                        data-automation-id="adf-toolbar-print"
+                        (click)="printContent()">
                     <mat-icon>print</mat-icon>
                 </button>
 
-                <button
-                    id="adf-viewer-fullscreen"
-                    *ngIf="viewerType !== 'media' && allowFullScreen"
-                    mat-icon-button
-                    [attr.aria-label]="'ADF_VIEWER.ACTIONS.FULLSCREEN' | translate"
-                    title="{{ 'ADF_VIEWER.ACTIONS.FULLSCREEN' | translate }}"
-                    data-automation-id="adf-toolbar-fullscreen"
-                    (click)="enterFullScreen()">
+                <button id="adf-viewer-fullscreen"
+                        *ngIf="viewerType !== 'media' && allowFullScreen"
+                        mat-icon-button
+                        [attr.aria-label]="'ADF_VIEWER.ACTIONS.FULLSCREEN' | translate"
+                        title="{{ 'ADF_VIEWER.ACTIONS.FULLSCREEN' | translate }}"
+                        data-automation-id="adf-toolbar-fullscreen"
+                        (click)="enterFullScreen()">
                     <mat-icon>fullscreen</mat-icon>
                 </button>
 
                 <ng-container *ngIf="allowRightSidebar">
                     <adf-toolbar-divider></adf-toolbar-divider>
 
-                    <button
-                        mat-icon-button
-                        [attr.aria-expanded]="showRightSidebar"
-                        [attr.aria-label]="'ADF_VIEWER.ACTIONS.INFO' | translate"
-                        title="{{ 'ADF_VIEWER.ACTIONS.INFO' | translate }}"
-                        data-automation-id="adf-toolbar-sidebar"
-                        [color]="showRightSidebar ? 'accent' : 'default'"
-                        (click)="toggleSidebar()">
+                    <button mat-icon-button
+                            [attr.aria-expanded]="showRightSidebar"
+                            [attr.aria-label]="'ADF_VIEWER.ACTIONS.INFO' | translate"
+                            title="{{ 'ADF_VIEWER.ACTIONS.INFO' | translate }}"
+                            data-automation-id="adf-toolbar-sidebar"
+                            [color]="showRightSidebar ? 'accent' : 'default'"
+                            (click)="toggleSidebar()">
                         <mat-icon>info_outline</mat-icon>
                     </button>
 
                 </ng-container>
 
                 <ng-container *ngIf="mnuMoreActions">
-                    <button
-                        id="adf-viewer-moreactions"
-                        mat-icon-button
-                        [matMenuTriggerFor]="mnuMoreActions"
-                        [attr.aria-label]="'ADF_VIEWER.ACTIONS.MORE_ACTIONS' | translate"
-                        title="{{ 'ADF_VIEWER.ACTIONS.MORE_ACTIONS' | translate }}"
-                        data-automation-id="adf-toolbar-more-actions">
+                    <button id="adf-viewer-moreactions"
+                            mat-icon-button
+                            [matMenuTriggerFor]="mnuMoreActions"
+                            [attr.aria-label]="'ADF_VIEWER.ACTIONS.MORE_ACTIONS' | translate"
+                            title="{{ 'ADF_VIEWER.ACTIONS.MORE_ACTIONS' | translate }}"
+                            data-automation-id="adf-toolbar-more-actions">
                         <mat-icon>more_vert</mat-icon>
                     </button>
-                    <mat-menu #mnuMoreActions="matMenu" [overlapTrigger]="false">
+                    <mat-menu #mnuMoreActions="matMenu"
+                              [overlapTrigger]="false">
                         <ng-content select="adf-viewer-more-actions"></ng-content>
                     </mat-menu>
                 </ng-container>
@@ -143,30 +147,45 @@
             </adf-toolbar>
         </ng-container>
 
-        <div fxLayout="row" fxFlex="1 1 auto">
+        <div fxLayout="row"
+             fxFlex="1 1 auto">
             <ng-container *ngIf="allowRightSidebar && showRightSidebar">
-                <div class="adf-viewer__sidebar" [ngClass]="'adf-viewer__sidebar__right'" fxFlexOrder="4"  id="adf-right-sidebar" >
+                <div class="adf-viewer__sidebar"
+                     [ngClass]="'adf-viewer__sidebar__right'"
+                     fxFlexOrder="4"
+                     id="adf-right-sidebar">
                     <ng-container *ngIf="sidebarRightTemplate">
-                        <ng-container *ngTemplateOutlet="sidebarRightTemplate;context:sidebarRightTemplateContext"></ng-container>
+                        <ng-container *ngTemplateOutlet="sidebarRightTemplate;context:sidebarRightTemplateContext">
+                        </ng-container>
                     </ng-container>
-                    <ng-content *ngIf="!sidebarRightTemplate" select="adf-viewer-sidebar"></ng-content>
+                    <ng-content *ngIf="!sidebarRightTemplate"
+                                select="adf-viewer-sidebar"></ng-content>
                 </div>
             </ng-container>
 
             <ng-container *ngIf="allowLeftSidebar && showLeftSidebar">
-                <div class="adf-viewer__sidebar" [ngClass]="'adf-viewer__sidebar__left'" fxFlexOrder="1"  id="adf-left-sidebar" >
+                <div class="adf-viewer__sidebar"
+                     [ngClass]="'adf-viewer__sidebar__left'"
+                     fxFlexOrder="1"
+                     id="adf-left-sidebar">
                     <ng-container *ngIf="sidebarLeftTemplate">
-                        <ng-container *ngTemplateOutlet="sidebarLeftTemplate;context:sidebarLeftTemplateContext"></ng-container>
+                        <ng-container *ngTemplateOutlet="sidebarLeftTemplate;context:sidebarLeftTemplateContext">
+                        </ng-container>
                     </ng-container>
-                    <ng-content *ngIf="!sidebarLeftTemplate" select="adf-viewer-sidebar"></ng-content>
+                    <ng-content *ngIf="!sidebarLeftTemplate"
+                                select="adf-viewer-sidebar"></ng-content>
                 </div>
             </ng-container>
 
-            <div  *ngIf="isLoading"  class="adf-viewer-main" fxFlexOrder="1" fxFlex="1 1 auto">
+            <div *ngIf="isLoading"
+                 class="adf-viewer-main"
+                 fxFlexOrder="1"
+                 fxFlex="1 1 auto">
                 <div class="adf-viewer-layout-content adf-viewer__fullscreen-container">
                     <div class="adf-viewer-content-container">
                         <ng-container *ngIf="isLoading">
-                            <div class="adf-viewer__loading-screen" fxFlex="1 1 auto">
+                            <div class="adf-viewer__loading-screen"
+                                 fxFlex="1 1 auto">
                                 <h2>{{ 'ADF_VIEWER.LOADING' | translate }}</h2>
                                 <div>
                                     <mat-spinner></mat-spinner>
@@ -178,28 +197,48 @@
                 </div>
             </div>
 
-            <div  *ngIf="!isLoading"  class="adf-viewer-main" fxFlexOrder="1" fxFlex="1 1 auto">
+            <div *ngIf="!isLoading"
+                 class="adf-viewer-main"
+                 fxFlexOrder="1"
+                 fxFlex="1 1 auto">
                 <div class="adf-viewer-layout-content adf-viewer__fullscreen-container">
-                    <div class="adf-viewer-content-container" [ngSwitch]="viewerType">
+                    <div class="adf-viewer-content-container"
+                         [ngSwitch]="viewerType">
 
                         <ng-container *ngSwitchCase="'pdf'">
-                            <adf-pdf-viewer (close)="onBackButtonClick()" [thumbnailsTemplate]="thumbnailsTemplate" [allowThumbnails]="allowThumbnails" [blobFile]="blobFile" [urlFile]="urlFileContent" [nameFile]="displayName"></adf-pdf-viewer>
+                            <adf-pdf-viewer (close)="onBackButtonClick()"
+                                            [thumbnailsTemplate]="thumbnailsTemplate"
+                                            [allowThumbnails]="allowThumbnails"
+                                            [blobFile]="blobFile"
+                                            [urlFile]="urlFileContent"
+                                            [nameFile]="displayName"
+                                            (error)="onUnsupportedFile()"></adf-pdf-viewer>
                         </ng-container>
 
                         <ng-container *ngSwitchCase="'image'">
-                            <adf-img-viewer [urlFile]="urlFileContent" [nameFile]="displayName" [blobFile]="blobFile"></adf-img-viewer>
+                            <adf-img-viewer [urlFile]="urlFileContent"
+                                            [nameFile]="displayName"
+                                            [blobFile]="blobFile"
+                                            (error)="onUnsupportedFile()"></adf-img-viewer>
                         </ng-container>
 
                         <ng-container *ngSwitchCase="'media'">
-                            <adf-media-player id="adf-mdedia-player" [urlFile]="urlFileContent" [mimeType]="mimeType" [blobFile]="blobFile" [nameFile]="displayName"></adf-media-player>
+                            <adf-media-player id="adf-mdedia-player"
+                                              [urlFile]="urlFileContent"
+                                              [mimeType]="mimeType"
+                                              [blobFile]="blobFile"
+                                              [nameFile]="displayName"
+                                              (error)="onUnsupportedFile()"></adf-media-player>
                         </ng-container>
 
                         <ng-container *ngSwitchCase="'text'">
-                            <adf-txt-viewer [urlFile]="urlFileContent" [blobFile]="blobFile"></adf-txt-viewer>
+                            <adf-txt-viewer [urlFile]="urlFileContent"
+                                            [blobFile]="blobFile"></adf-txt-viewer>
                         </ng-container>
 
                         <ng-container *ngSwitchCase="'in_creation'">
-                            <div class="adf-viewer__loading-screen" fxFlex="1 1 auto">
+                            <div class="adf-viewer__loading-screen"
+                                 fxFlex="1 1 auto">
                                 <h2>{{ 'ADF_VIEWER.LOADING' | translate }}</h2>
                                 <div>
                                     <mat-spinner></mat-spinner>
@@ -209,21 +248,20 @@
 
                         <ng-container *ngSwitchCase="'custom'">
                             <ng-container *ngFor="let ext of viewerExtensions">
-                                <adf-preview-extension
-                                    *ngIf="checkExtensions(ext.fileExtension)"
-                                    [id]="ext.component"
-                                    [node]="nodeEntry.entry"
-                                    [url]="urlFileContent"
-                                    [extension]="extension"
-                                    [attr.data-automation-id]="ext.component">
+                                <adf-preview-extension *ngIf="checkExtensions(ext.fileExtension)"
+                                                       [id]="ext.component"
+                                                       [node]="nodeEntry.entry"
+                                                       [url]="urlFileContent"
+                                                       [extension]="extension"
+                                                       [attr.data-automation-id]="ext.component">
                                 </adf-preview-extension>
                             </ng-container>
 
-                            <span class="adf-viewer-custom-content" *ngFor="let extensionTemplate of extensionTemplates">
-                                <ng-template
-                                    *ngIf="extensionTemplate.isVisible"
-                                    [ngTemplateOutlet]="extensionTemplate.template"
-                                    [ngTemplateOutletContext]="{ urlFileContent: urlFileContent, extension:extension }">
+                            <span class="adf-viewer-custom-content"
+                                  *ngFor="let extensionTemplate of extensionTemplates">
+                                <ng-template *ngIf="extensionTemplate.isVisible"
+                                             [ngTemplateOutlet]="extensionTemplate.template"
+                                             [ngTemplateOutletContext]="{ urlFileContent: urlFileContent, extension:extension }">
                                 </ng-template>
                             </span>
                         </ng-container>

--- a/lib/core/viewer/components/viewer.component.spec.ts
+++ b/lib/core/viewer/components/viewer.component.spec.ts
@@ -878,6 +878,21 @@ describe('ViewerComponent', () => {
                 component.ngOnChanges();
             });
 
+            it('should swicth to the unkwown template if the type specific viewers throw an error', (done) => {
+                component.urlFile = 'fake-url-file.icns';
+                component.mimeType = 'image/png';
+                component.ngOnChanges();
+                fixture.detectChanges();
+
+                component.onUnsupportedFile();
+                fixture.detectChanges();
+                fixture.whenStable().then(() => {
+                    fixture.detectChanges();
+                    expect(element.querySelector('adf-viewer-unknown-format')).toBeDefined();
+                    done();
+                });
+            });
+
         });
 
         describe('Events', () => {

--- a/lib/core/viewer/components/viewer.component.ts
+++ b/lib/core/viewer/components/viewer.component.ts
@@ -669,6 +669,10 @@ export class ViewerComponent implements OnChanges, OnInit, OnDestroy {
 
     }
 
+    onUnsupportedFile() {
+        this.viewerType = 'unknown';
+    }
+
     private generateCacheBusterNumber() {
         this.cacheBusterNumber = Date.now();
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ADF-4481


**What is the new behaviour?**
If you were to upload a new version of a file of different type that is not supported it'd fail to load the viewer showing a null/undefined string. The viewer now is able to adapt in case an error happens in one of its type specific viewers.
<img width="444" alt="Screen Shot 2020-09-08 at 14 39 37" src="https://user-images.githubusercontent.com/18293044/92478365-5b024600-f1e2-11ea-8268-3e5f9c634c42.png">
<img width="444" alt="Screen Shot 2020-09-08 at 14 39 23" src="https://user-images.githubusercontent.com/18293044/92478373-5e95cd00-f1e2-11ea-8b2b-e3f333fa75bc.png">
<img width="394" alt="Screen Shot 2020-09-08 at 14 39 15" src="https://user-images.githubusercontent.com/18293044/92478388-62295400-f1e2-11ea-8b30-c8f2ace9b36b.png">



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
