### PR TITLE
[ACA-3942] Enable assignee edit button only when userTask shared among the candidates

### DIFF
--- a/lib/process-services-cloud/src/lib/task/services/task-cloud.service.spec.ts
+++ b/lib/process-services-cloud/src/lib/task/services/task-cloud.service.spec.ts
@@ -139,6 +139,11 @@ describe('Task Cloud Service', () => {
         expect(isTaskEditable).toEqual(true);
     });
 
+    it('should verify if the task assignee property is clickable', () => {
+        const isAssigneePropertyClickable = service.isAssigneePropertyClickable(assignedTaskDetailsCloudMock, [ { icon: '', value: 'user' } ], [ { icon: '', value: 'group' } ]);
+        expect(isAssigneePropertyClickable).toEqual(true);
+    });
+
     it('should complete task with owner as null', async(() => {
         const appName = 'simple-app';
         const taskId = '68d54a8f';

--- a/lib/process-services-cloud/src/lib/task/services/task-cloud.service.ts
+++ b/lib/process-services-cloud/src/lib/task/services/task-cloud.service.ts
@@ -16,7 +16,7 @@
  */
 
 import { Injectable } from '@angular/core';
-import { AlfrescoApiService, LogService, AppConfigService, IdentityUserService } from '@alfresco/adf-core';
+import { AlfrescoApiService, LogService, AppConfigService, IdentityUserService, CardViewArrayItem } from '@alfresco/adf-core';
 import { throwError, Observable, of, Subject } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { TaskDetailsCloudModel, StartTaskCloudResponseModel } from '../start-task/models/task-details-cloud.model';
@@ -28,6 +28,7 @@ import { StartTaskCloudRequestModel } from '../start-task/models/start-task-clou
 })
 export class TaskCloudService extends BaseCloudService {
 
+    static TASK_ASSIGNED_STATE = 'ASSIGNED';
     dataChangesDetected$ = new Subject();
 
     constructor(
@@ -63,7 +64,7 @@ export class TaskCloudService extends BaseCloudService {
      * @returns Boolean value if the task can be completed
      */
     canCompleteTask(taskDetails: TaskDetailsCloudModel): boolean {
-        return taskDetails && taskDetails.status === 'ASSIGNED' && this.isAssignedToMe(taskDetails.assignee);
+        return taskDetails && taskDetails.status === TaskCloudService.TASK_ASSIGNED_STATE && this.isAssignedToMe(taskDetails.assignee);
     }
 
     /**
@@ -72,7 +73,16 @@ export class TaskCloudService extends BaseCloudService {
      * @returns Boolean value if the task is editable
      */
     isTaskEditable(taskDetails: TaskDetailsCloudModel): boolean {
-        return taskDetails && taskDetails.status === 'ASSIGNED' && this.isAssignedToMe(taskDetails.assignee);
+        return taskDetails && taskDetails.status === TaskCloudService.TASK_ASSIGNED_STATE && this.isAssignedToMe(taskDetails.assignee);
+    }
+
+    isAssigneePropertyClickable(taskDetails: TaskDetailsCloudModel, candidateUsers: CardViewArrayItem[], candidateGroups: CardViewArrayItem[]): boolean {
+        let isClickable = false;
+        const states = [TaskCloudService.TASK_ASSIGNED_STATE];
+        if (candidateUsers?.length || candidateGroups?.length) {
+            isClickable = states.includes(taskDetails.status);
+        }
+        return isClickable;
     }
 
     /**
@@ -91,7 +101,7 @@ export class TaskCloudService extends BaseCloudService {
      */
     canUnclaimTask(taskDetails: TaskDetailsCloudModel): boolean {
         const currentUser = this.identityUserService.getCurrentUserInfo().username;
-        return taskDetails && taskDetails.status === 'ASSIGNED' && taskDetails.assignee === currentUser;
+        return taskDetails && taskDetails.status === TaskCloudService.TASK_ASSIGNED_STATE && taskDetails.assignee === currentUser;
     }
 
     /**

--- a/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.spec.ts
@@ -19,7 +19,7 @@ import { TaskHeaderCloudComponent } from './task-header-cloud.component';
 import { of, throwError } from 'rxjs';
 import { By } from '@angular/platform-browser';
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
-import { setupTestBed, AppConfigService, JwtHelperService } from '@alfresco/adf-core';
+import { setupTestBed, AppConfigService } from '@alfresco/adf-core';
 import { ProcessServiceCloudTestingModule } from '../../../testing/process-service-cloud.testing.module';
 import { TaskCloudService } from '../../services/task-cloud.service';
 import { TaskHeaderCloudModule } from '../task-header-cloud.module';
@@ -43,8 +43,6 @@ describe('TaskHeaderCloudComponent', () => {
     let getCandidateGroupsSpy: jasmine.Spy;
     let getCandidateUsersSpy: jasmine.Spy;
     let isTaskEditableSpy: jasmine.Spy;
-    let jwtHelperService: JwtHelperService;
-    let hasRealmRoleSpy: jasmine.Spy;
 
     const mockCandidateUsers = ['mockuser1', 'mockuser2', 'mockuser3'];
     const mockCandidateGroups = ['mockgroup1', 'mockgroup2', 'mockgroup3'];
@@ -62,14 +60,12 @@ describe('TaskHeaderCloudComponent', () => {
         component = fixture.componentInstance;
         appConfigService = TestBed.inject(AppConfigService);
         taskCloudService = TestBed.inject(TaskCloudService);
-        jwtHelperService = TestBed.inject(JwtHelperService);
         component.appName = 'mock-app-name';
         component.taskId = 'mock-task-id';
         getTaskByIdSpy = spyOn(taskCloudService, 'getTaskById').and.returnValue(of(assignedTaskDetailsCloudMock));
         isTaskEditableSpy = spyOn(taskCloudService, 'isTaskEditable').and.returnValue(true);
         getCandidateUsersSpy = spyOn(taskCloudService, 'getCandidateUsers').and.returnValue(of(mockCandidateUsers));
         getCandidateGroupsSpy = spyOn(taskCloudService, 'getCandidateGroups').and.returnValue(of(mockCandidateGroups));
-        hasRealmRoleSpy = spyOn(jwtHelperService, 'hasRealmRole').and.returnValue(false);
     });
 
     describe('Task Details', () => {
@@ -268,74 +264,23 @@ describe('TaskHeaderCloudComponent', () => {
             });
         }));
 
-        it('should render assignee edit icon for a assigned task if the task shared among condidates', () => {
-            fixture.detectChanges();
-
-            const editIcon = fixture.debugElement.query(By.css(`[data-automation-id="header-assignee"] [data-automation-id="card-textitem-clickable-icon-assignee"]`));
-            expect(editIcon).not.toBeNull();
-            expect(editIcon.nativeElement.innerText).toBe('create');
-        });
-
-        it('should not render assignee edit icon for a created task if the task shared among condidates', async () => {
-            getTaskByIdSpy.and.returnValue(of(createdTaskDetailsCloudMock));
-
-            component.ngOnChanges();
-            fixture.detectChanges();
-            await fixture.whenStable();
-
-            const editIcon = fixture.debugElement.query(By.css(`[data-automation-id="header-assignee"] [data-automation-id="card-textitem-clickable-icon-assignee"]`));
-            expect(editIcon).toBeNull();
-        });
-
-        it('should not render assignee edit icon for a assigned task if current logged user has just user role', async() => {
-            getCandidateUsersSpy.and.returnValue(of([]));
-            getCandidateGroupsSpy.and.returnValue(of([]));
-            component.ngOnChanges();
-
-            fixture.detectChanges();
-            await fixture.whenStable();
-
-            const editIcon = fixture.debugElement.query(By.css(`[data-automation-id="header-assignee"] [data-automation-id="card-textitem-clickable-icon-assignee"]`));
-            expect(editIcon).toBeNull();
-        });
-
-        it('should not render edit assignee icon for a created task if current logged user has just user role', async () => {
-            getCandidateUsersSpy.and.returnValue(of([]));
-            getCandidateGroupsSpy.and.returnValue(of([]));
-            component.ngOnChanges();
-
-            fixture.detectChanges();
-            await fixture.whenStable();
-
-            const editIcon = fixture.debugElement.query(By.css(`[data-automation-id="header-assignee"] [data-automation-id="card-textitem-clickable-icon-assignee"]`));
-            expect(editIcon).toBeNull();
-        });
-
-        it('should render edit icon for a assigned task if current logged user has admin role', () => {
-            hasRealmRoleSpy.and.returnValue(true);
-            fixture.detectChanges();
-
-            const editIcon = fixture.debugElement.query(By.css(`[data-automation-id="header-assignee"] [data-automation-id="card-textitem-clickable-icon-assignee"]`));
-            expect(editIcon).not.toBeNull();
-            expect(editIcon.nativeElement.innerText).toBe('create');
-        });
-
-        it('should render edit icon for a created task if current logged user has admin role', () => {
-            hasRealmRoleSpy.and.returnValue(true);
-            getTaskByIdSpy.and.returnValue(of(createdTaskDetailsCloudMock));
-            fixture.detectChanges();
-
-            const editIcon = fixture.debugElement.query(By.css(`[data-automation-id="header-assignee"] [data-automation-id="card-textitem-clickable-icon-assignee"]`));
-            expect(editIcon).not.toBeNull();
-            expect(editIcon.nativeElement.innerText).toBe('create');
-        });
-
-        it('should render defined edit icon for assignee property if the task in created state and assingee should have admin role', () => {
+        it('should render defined edit icon for assignee property if the task in assigned state and shared among candidates', () => {
             fixture.detectChanges();
 
             const value = fixture.debugElement.query(By.css(`[data-automation-id="header-assignee"] [data-automation-id="card-textitem-clickable-icon-assignee"]`));
             expect(value).not.toBeNull();
             expect(value.nativeElement.innerText).toBe('create');
+        });
+
+        it('should not render defined edit icon for assignee property if the task in created state and shared among condidates', async () => {
+            getTaskByIdSpy.and.returnValue(of(createdTaskDetailsCloudMock));
+
+            component.ngOnChanges();
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            const editIcon = fixture.debugElement.query(By.css(`[data-automation-id="header-assignee"] [data-automation-id="card-textitem-clickable-icon-assignee"]`));
+            expect(editIcon).toBeNull();
         });
 
         it('should render edit icon if the task in assigned state and assingee should be current user', () => {

--- a/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.spec.ts
@@ -19,7 +19,7 @@ import { TaskHeaderCloudComponent } from './task-header-cloud.component';
 import { of, throwError } from 'rxjs';
 import { By } from '@angular/platform-browser';
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
-import { setupTestBed, AppConfigService } from '@alfresco/adf-core';
+import { setupTestBed, AppConfigService, JwtHelperService } from '@alfresco/adf-core';
 import { ProcessServiceCloudTestingModule } from '../../../testing/process-service-cloud.testing.module';
 import { TaskCloudService } from '../../services/task-cloud.service';
 import { TaskHeaderCloudModule } from '../task-header-cloud.module';
@@ -28,7 +28,8 @@ import {
     completedTaskDetailsCloudMock,
     createdStateTaskDetailsCloudMock,
     suspendedTaskDetailsCloudMock,
-    taskDetailsWithParentTaskIdMock
+    taskDetailsWithParentTaskIdMock,
+    createdTaskDetailsCloudMock
 } from '../mocks/task-details-cloud.mock';
 import moment from 'moment-es6';
 import { TranslateModule } from '@ngx-translate/core';
@@ -42,6 +43,8 @@ describe('TaskHeaderCloudComponent', () => {
     let getCandidateGroupsSpy: jasmine.Spy;
     let getCandidateUsersSpy: jasmine.Spy;
     let isTaskEditableSpy: jasmine.Spy;
+    let jwtHelperService: JwtHelperService;
+    let hasRealmRoleSpy: jasmine.Spy;
 
     const mockCandidateUsers = ['mockuser1', 'mockuser2', 'mockuser3'];
     const mockCandidateGroups = ['mockgroup1', 'mockgroup2', 'mockgroup3'];
@@ -59,12 +62,14 @@ describe('TaskHeaderCloudComponent', () => {
         component = fixture.componentInstance;
         appConfigService = TestBed.inject(AppConfigService);
         taskCloudService = TestBed.inject(TaskCloudService);
+        jwtHelperService = TestBed.inject(JwtHelperService);
         component.appName = 'mock-app-name';
         component.taskId = 'mock-task-id';
         getTaskByIdSpy = spyOn(taskCloudService, 'getTaskById').and.returnValue(of(assignedTaskDetailsCloudMock));
         isTaskEditableSpy = spyOn(taskCloudService, 'isTaskEditable').and.returnValue(true);
         getCandidateUsersSpy = spyOn(taskCloudService, 'getCandidateUsers').and.returnValue(of(mockCandidateUsers));
         getCandidateGroupsSpy = spyOn(taskCloudService, 'getCandidateGroups').and.returnValue(of(mockCandidateGroups));
+        hasRealmRoleSpy = spyOn(jwtHelperService, 'hasRealmRole').and.returnValue(false);
     });
 
     describe('Task Details', () => {
@@ -263,7 +268,69 @@ describe('TaskHeaderCloudComponent', () => {
             });
         }));
 
-        it('should render defined edit icon for assignee property if the task in assigned state and assingee should be current user', () => {
+        it('should render assignee edit icon for a assigned task if the task shared among condidates', () => {
+            fixture.detectChanges();
+
+            const editIcon = fixture.debugElement.query(By.css(`[data-automation-id="header-assignee"] [data-automation-id="card-textitem-clickable-icon-assignee"]`));
+            expect(editIcon).not.toBeNull();
+            expect(editIcon.nativeElement.innerText).toBe('create');
+        });
+
+        it('should not render assignee edit icon for a created task if the task shared among condidates', async () => {
+            getTaskByIdSpy.and.returnValue(of(createdTaskDetailsCloudMock));
+
+            component.ngOnChanges();
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            const editIcon = fixture.debugElement.query(By.css(`[data-automation-id="header-assignee"] [data-automation-id="card-textitem-clickable-icon-assignee"]`));
+            expect(editIcon).toBeNull();
+        });
+
+        it('should not render assignee edit icon for a assigned task if current logged user has just user role', async() => {
+            getCandidateUsersSpy.and.returnValue(of([]));
+            getCandidateGroupsSpy.and.returnValue(of([]));
+            component.ngOnChanges();
+
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            const editIcon = fixture.debugElement.query(By.css(`[data-automation-id="header-assignee"] [data-automation-id="card-textitem-clickable-icon-assignee"]`));
+            expect(editIcon).toBeNull();
+        });
+
+        it('should not render edit assignee icon for a created task if current logged user has just user role', async () => {
+            getCandidateUsersSpy.and.returnValue(of([]));
+            getCandidateGroupsSpy.and.returnValue(of([]));
+            component.ngOnChanges();
+
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            const editIcon = fixture.debugElement.query(By.css(`[data-automation-id="header-assignee"] [data-automation-id="card-textitem-clickable-icon-assignee"]`));
+            expect(editIcon).toBeNull();
+        });
+
+        it('should render edit icon for a assigned task if current logged user has admin role', () => {
+            hasRealmRoleSpy.and.returnValue(true);
+            fixture.detectChanges();
+
+            const editIcon = fixture.debugElement.query(By.css(`[data-automation-id="header-assignee"] [data-automation-id="card-textitem-clickable-icon-assignee"]`));
+            expect(editIcon).not.toBeNull();
+            expect(editIcon.nativeElement.innerText).toBe('create');
+        });
+
+        it('should render edit icon for a created task if current logged user has admin role', () => {
+            hasRealmRoleSpy.and.returnValue(true);
+            getTaskByIdSpy.and.returnValue(of(createdTaskDetailsCloudMock));
+            fixture.detectChanges();
+
+            const editIcon = fixture.debugElement.query(By.css(`[data-automation-id="header-assignee"] [data-automation-id="card-textitem-clickable-icon-assignee"]`));
+            expect(editIcon).not.toBeNull();
+            expect(editIcon.nativeElement.innerText).toBe('create');
+        });
+
+        it('should render defined edit icon for assignee property if the task in created state and assingee should have admin role', () => {
             fixture.detectChanges();
 
             const value = fixture.debugElement.query(By.css(`[data-automation-id="header-assignee"] [data-automation-id="card-textitem-clickable-icon-assignee"]`));

--- a/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.ts
@@ -29,7 +29,8 @@ import {
     UpdateNotification,
     CardViewUpdateService,
     CardViewDatetimeItemModel,
-    CardViewArrayItem
+    CardViewArrayItem,
+    JwtHelperService
 } from '@alfresco/adf-core';
 import { TaskDetailsCloudModel, TaskStatus } from '../../start-task/models/task-details-cloud.model';
 import { TaskCloudService } from '../../services/task-cloud.service';
@@ -83,6 +84,7 @@ export class TaskHeaderCloudComponent implements OnInit, OnDestroy, OnChanges {
         private taskCloudService: TaskCloudService,
         private translationService: TranslationService,
         private appConfig: AppConfigService,
+        private jwtHelperService: JwtHelperService,
         private cardViewUpdateService: CardViewUpdateService
     ) {
         this.dateFormat = this.appConfig.get('dateValues.defaultDateFormat');
@@ -141,7 +143,7 @@ export class TaskHeaderCloudComponent implements OnInit, OnDestroy, OnChanges {
                     label: 'ADF_CLOUD_TASK_HEADER.PROPERTIES.ASSIGNEE',
                     value: this.taskDetails.assignee,
                     key: 'assignee',
-                    clickable: this.isClickable(),
+                    clickable: this.isAssigneePropertyClickable(),
                     default: this.translationService.instant('ADF_CLOUD_TASK_HEADER.PROPERTIES.ASSIGNEE_DEFAULT'),
                     icon: 'create'
                 }
@@ -318,9 +320,21 @@ export class TaskHeaderCloudComponent implements OnInit, OnDestroy, OnChanges {
         return this.taskCloudService.isTaskEditable(this.taskDetails);
     }
 
-    isClickable(): boolean {
-        const states: TaskStatus[] = ['ASSIGNED', 'CREATED'];
-        return states.includes(this.taskDetails.status);
+    isAssigneePropertyClickable(): boolean {
+        let isClickable = false;
+        let states: TaskStatus[] = [];
+        if (this.jwtHelperService.hasRealmRole('ACTIVITI_ADMIN')) {
+            states = ['ASSIGNED', 'CREATED'];
+            isClickable = states.includes(this.taskDetails.status);
+        } else if (this.hasCandidates()) {
+            states = ['ASSIGNED'];
+            isClickable = states.includes(this.taskDetails.status);
+        }
+        return isClickable;
+    }
+
+    hasCandidates() {
+        return (this.candidateGroups && this.candidateGroups.length) || (this.candidateUsers && this.candidateUsers.length);
     }
 
     private isValidSelection(filteredProperties: string[], cardItem: CardViewBaseItemModel): boolean {

--- a/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.ts
@@ -29,10 +29,9 @@ import {
     UpdateNotification,
     CardViewUpdateService,
     CardViewDatetimeItemModel,
-    CardViewArrayItem,
-    JwtHelperService
+    CardViewArrayItem
 } from '@alfresco/adf-core';
-import { TaskDetailsCloudModel, TaskStatus } from '../../start-task/models/task-details-cloud.model';
+import { TaskDetailsCloudModel } from '../../start-task/models/task-details-cloud.model';
 import { TaskCloudService } from '../../services/task-cloud.service';
 import { NumericFieldValidator } from '../../../validators/numeric-field.validator';
 
@@ -84,7 +83,6 @@ export class TaskHeaderCloudComponent implements OnInit, OnDestroy, OnChanges {
         private taskCloudService: TaskCloudService,
         private translationService: TranslationService,
         private appConfig: AppConfigService,
-        private jwtHelperService: JwtHelperService,
         private cardViewUpdateService: CardViewUpdateService
     ) {
         this.dateFormat = this.appConfig.get('dateValues.defaultDateFormat');
@@ -321,20 +319,7 @@ export class TaskHeaderCloudComponent implements OnInit, OnDestroy, OnChanges {
     }
 
     isAssigneePropertyClickable(): boolean {
-        let isClickable = false;
-        let states: TaskStatus[] = [];
-        if (this.jwtHelperService.hasRealmRole('ACTIVITI_ADMIN')) {
-            states = ['ASSIGNED', 'CREATED'];
-            isClickable = states.includes(this.taskDetails.status);
-        } else if (this.hasCandidates()) {
-            states = ['ASSIGNED'];
-            isClickable = states.includes(this.taskDetails.status);
-        }
-        return isClickable;
-    }
-
-    hasCandidates() {
-        return (this.candidateGroups && this.candidateGroups.length) || (this.candidateUsers && this.candidateUsers.length);
+        return this.taskCloudService.isAssigneePropertyClickable(this.taskDetails, this.candidateUsers, this.candidateGroups);
     }
 
     private isValidSelection(filteredProperties: string[], cardItem: CardViewBaseItemModel): boolean {


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://issues.alfresco.com/jira/browse/ACA-3942

**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
