### PR TITLE
[ACA-3960] FE - Users that are part of a candidate group should not be able to see 'Assignee' property as editable when on that user task candidate group was set as assignment

### DIFF
--- a/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.ts
@@ -318,6 +318,10 @@ export class TaskHeaderCloudComponent implements OnInit, OnDestroy, OnChanges {
         return this.taskCloudService.isTaskEditable(this.taskDetails);
     }
 
+    /**
+     * as per [ACA-3960] it required an empty array argument for now
+     * Empty array will be replaced with candidateGroups in feature
+     */
     isAssigneePropertyClickable(): boolean {
         return this.taskCloudService.isAssigneePropertyClickable(this.taskDetails, this.candidateUsers, []);
     }

--- a/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.ts
@@ -319,7 +319,7 @@ export class TaskHeaderCloudComponent implements OnInit, OnDestroy, OnChanges {
     }
 
     isAssigneePropertyClickable(): boolean {
-        return this.taskCloudService.isAssigneePropertyClickable(this.taskDetails, this.candidateUsers, this.candidateGroups);
+        return this.taskCloudService.isAssigneePropertyClickable(this.taskDetails, this.candidateUsers, []);
     }
 
     private isValidSelection(filteredProperties: string[], cardItem: CardViewBaseItemModel): boolean {


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://issues.alfresco.com/jira/browse/ACA-3960

**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
