### PR TITLE
[AAE-3410] NodeSelector - Use user alias (-my-) name as default for upload of type Alfresco Content only

### DIFF
--- a/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.spec.ts
@@ -461,7 +461,7 @@ describe('AttachFileCloudWidgetComponent', () => {
         });
 
         describe('FilesSource', () => {
-            it('Should set default root alias (-root-) as rootNodeId if fileSource set only to Alfresco Content', async () => {
+            it('Should set default user alias (-my-) as rootNodeId if fileSource set only to Alfresco Content', async () => {
                 widget.field = new FormFieldModel(new FormModel(), {
                     type: FormFieldTypes.UPLOAD,
                     value: []
@@ -478,8 +478,8 @@ describe('AttachFileCloudWidgetComponent', () => {
                 await fixture.whenStable();
                 fixture.detectChanges();
 
-                expect(widget.rootNodeId).toEqual('-root-');
-                expect(openUploadFileDialogSpy).toHaveBeenCalledWith('-root-', 'single', false);
+                expect(widget.rootNodeId).toEqual('-my-');
+                expect(openUploadFileDialogSpy).toHaveBeenCalledWith('-my-', 'single', false);
             });
 
             it('should display tooltip when tooltip is set', async(() => {

--- a/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.spec.ts
@@ -379,7 +379,29 @@ describe('AttachFileCloudWidgetComponent', () => {
             expect(openUploadFileDialogSpy).toHaveBeenCalledWith('-root-', 'single', true);
         });
 
-        it('Should be able to set default alias as rootNodeId if destinationFolderPath contains wrong alias', async () => {
+        it('Should set default user alias (-my-) as rootNodeId if destinationFolderPath contains wrong alias and single upload for Alfresco Content + Locale', async () => {
+            widget.field = new FormFieldModel(new FormModel(), {
+                type: FormFieldTypes.UPLOAD,
+                value: []
+            });
+            widget.field.id = 'attach-file-alfresco';
+            widget.field.params = <FormFieldMetadata> allSourceWithWrongAliasParams;
+            widget.field.params.multiple = false;
+            fixture.detectChanges();
+            await fixture.whenStable();
+            const attachButton: HTMLButtonElement = element.querySelector('#attach-file-alfresco');
+
+            expect(attachButton).not.toBeNull();
+
+            attachButton.click();
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            expect(widget.rootNodeId).toEqual('-my-');
+            expect(openUploadFileDialogSpy).toHaveBeenCalledWith('-my-', 'single', true);
+        });
+
+        it('Should set default user alias (-my-) as rootNodeId if destinationFolderPath contains wrong alias and multiple upload for Alfresco Content + Locale', async () => {
             widget.field = new FormFieldModel(new FormModel(), {
                 type: FormFieldTypes.UPLOAD,
                 value: []
@@ -401,7 +423,7 @@ describe('AttachFileCloudWidgetComponent', () => {
             expect(openUploadFileDialogSpy).toHaveBeenCalledWith('-my-', 'multiple', true);
         });
 
-        it('Should be able to set default alias as rootNodeId if destinationFolderPath does not have alias', async () => {
+        it('Should set default user alias (-my-) as rootNodeId if destinationFolderPath does not have alias for Alfresco Content + Locale', async () => {
             widget.field = new FormFieldModel(new FormModel(), {
                 type: FormFieldTypes.UPLOAD,
                 value: []
@@ -439,8 +461,7 @@ describe('AttachFileCloudWidgetComponent', () => {
         });
 
         describe('FilesSource', () => {
-
-            it('should be able to set myFiles folderId as rootNodeId if fileSource set only to content', async () => {
+            it('Should set default root alias (-root-) as rootNodeId if fileSource set only to Alfresco Content', async () => {
                 widget.field = new FormFieldModel(new FormModel(), {
                     type: FormFieldTypes.UPLOAD,
                     value: []
@@ -457,30 +478,8 @@ describe('AttachFileCloudWidgetComponent', () => {
                 await fixture.whenStable();
                 fixture.detectChanges();
 
-                expect(widget.rootNodeId).toEqual('-my-');
-                expect(openUploadFileDialogSpy).toHaveBeenCalledWith('-my-', 'single', false);
-            });
-
-            it('should be able to set root folderId as rootNodeId if fileSource set to content and local', async () => {
-                widget.field = new FormFieldModel(new FormModel(), {
-                    type: FormFieldTypes.UPLOAD,
-                    value: []
-                });
-                widget.field.id = 'attach-file-alfresco';
-                widget.field.params = <FormFieldMetadata> allSourceWithWrongAliasParams;
-                widget.field.params.multiple = false;
-                fixture.detectChanges();
-                await fixture.whenStable();
-                const attachButton: HTMLButtonElement = element.querySelector('#attach-file-alfresco');
-
-                expect(attachButton).not.toBeNull();
-
-                attachButton.click();
-                await fixture.whenStable();
-                fixture.detectChanges();
-
-                expect(widget.rootNodeId).toEqual('-my-');
-                expect(openUploadFileDialogSpy).toHaveBeenCalledWith('-my-', 'single', true);
+                expect(widget.rootNodeId).toEqual('-root-');
+                expect(openUploadFileDialogSpy).toHaveBeenCalledWith('-root-', 'single', false);
             });
 
             it('should display tooltip when tooltip is set', async(() => {

--- a/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.ts
@@ -64,7 +64,7 @@ export class AttachFileCloudWidgetComponent extends UploadCloudWidgetComponent i
     static RETRIEVE_METADATA_OPTION = 'retrieveMetadata';
 
     typeId = 'AttachFileCloudWidgetComponent';
-    rootNodeId = AttachFileCloudWidgetComponent.ALIAS_ROOT_FOLDER;
+    rootNodeId = AttachFileCloudWidgetComponent.ALIAS_USER_FOLDER;
     selectedNode: Node;
 
     constructor(

--- a/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.ts
@@ -54,13 +54,17 @@ import { DestinationFolderPathModel } from '../../../models/form-cloud-represent
 })
 export class AttachFileCloudWidgetComponent extends UploadCloudWidgetComponent implements OnInit {
 
+    static ALIAS_ROOT_FOLDER = '-root-';
     static ALIAS_USER_FOLDER = '-my-';
     static APP_NAME = '-appname-';
-    static VALID_ALIAS = ['-root-', AttachFileCloudWidgetComponent.ALIAS_USER_FOLDER, '-shared-'];
+    static VALID_ALIAS = [
+        AttachFileCloudWidgetComponent.ALIAS_ROOT_FOLDER,
+        AttachFileCloudWidgetComponent.ALIAS_USER_FOLDER, '-shared-'
+    ];
     static RETRIEVE_METADATA_OPTION = 'retrieveMetadata';
 
     typeId = 'AttachFileCloudWidgetComponent';
-    rootNodeId = AttachFileCloudWidgetComponent.ALIAS_USER_FOLDER;
+    rootNodeId = AttachFileCloudWidgetComponent.ALIAS_ROOT_FOLDER;
     selectedNode: Node;
 
     constructor(


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
