### PR TITLE
Fix broken e2e tests because of the lack of thrown error

### DIFF
--- a/lib/testing/src/lib/core/pages/data-table-component.page.ts
+++ b/lib/testing/src/lib/core/pages/data-table-component.page.ts
@@ -267,6 +267,8 @@ export class DataTableComponentPage {
             if (retry < 3) {
                 retry++;
                 await this.checkContentIsDisplayed(columnName, columnValue, retry);
+            } else {
+                throw error;
             }
         }
     }
@@ -281,6 +283,8 @@ export class DataTableComponentPage {
             if (retry < 3) {
                 retry++;
                 await this.checkContentIsNotDisplayed(columnName, columnValue, retry);
+            } else {
+                throw error;
             }
         }
     }


### PR DESCRIPTION
The e2es in the ADF apps are broken.