### PR TITLE
[AAE-3410] Restrict breadcrumb if upload widget type set to Alfresco Content

### DIFF
--- a/docs/content-services/components/content-node-selector-panel.component.md
+++ b/docs/content-services/components/content-node-selector-panel.component.md
@@ -52,6 +52,7 @@ Opens a [Content Node Selector](content-node-selector.component.md)  in its own 
 | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
 | navigationChange | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`NodeEntryEvent`](../../../lib/content-services/src/lib/document-list/components/node.event.ts)`>`           | Emitted when the navigation changes.      |
 | select           | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`Node`](https://github.com/Alfresco/alfresco-js-api/blob/develop/src/api/content-rest-api/docs/Node.md)`[]>` | Emitted when the user has chosen an item. |
+| showingSearch | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<boolean>` | Emitted when search is running. |
 | siteChange       | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<string>`                                                                                                       | Emitted when the select site changes.     |
 
 ## Details

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.ts
@@ -212,7 +212,7 @@ export class ContentNodeSelectorPanelComponent implements OnInit, OnDestroy {
     @Output()
     siteChange: EventEmitter<string> = new EventEmitter<string>();
 
-    /** Emitted on search input. */
+    /** Emitted when search is running. */
     @Output()
     showingSearch: EventEmitter<boolean> = new EventEmitter<boolean>();
 

--- a/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.spec.ts
@@ -376,7 +376,7 @@ describe('AttachFileCloudWidgetComponent', () => {
             fixture.detectChanges();
 
             expect(widget.rootNodeId).toEqual('-root-');
-            expect(openUploadFileDialogSpy).toHaveBeenCalledWith('-root-', 'single', true);
+            expect(openUploadFileDialogSpy).toHaveBeenCalledWith('-root-', 'single', true, true);
         });
 
         it('Should set default user alias (-my-) as rootNodeId if destinationFolderPath contains wrong alias and single upload for Alfresco Content + Locale', async () => {
@@ -398,7 +398,7 @@ describe('AttachFileCloudWidgetComponent', () => {
             fixture.detectChanges();
 
             expect(widget.rootNodeId).toEqual('-my-');
-            expect(openUploadFileDialogSpy).toHaveBeenCalledWith('-my-', 'single', true);
+            expect(openUploadFileDialogSpy).toHaveBeenCalledWith('-my-', 'single', true, true);
         });
 
         it('Should set default user alias (-my-) as rootNodeId if destinationFolderPath contains wrong alias and multiple upload for Alfresco Content + Locale', async () => {
@@ -420,7 +420,7 @@ describe('AttachFileCloudWidgetComponent', () => {
             fixture.detectChanges();
 
             expect(widget.rootNodeId).toEqual('-my-');
-            expect(openUploadFileDialogSpy).toHaveBeenCalledWith('-my-', 'multiple', true);
+            expect(openUploadFileDialogSpy).toHaveBeenCalledWith('-my-', 'multiple', true, true);
         });
 
         it('Should set default user alias (-my-) as rootNodeId if destinationFolderPath does not have alias for Alfresco Content + Locale', async () => {
@@ -442,7 +442,7 @@ describe('AttachFileCloudWidgetComponent', () => {
             fixture.detectChanges();
 
             expect(widget.rootNodeId).toEqual('-my-');
-            expect(openUploadFileDialogSpy).toHaveBeenCalledWith('-my-', 'multiple', true);
+            expect(openUploadFileDialogSpy).toHaveBeenCalledWith('-my-', 'multiple', true, true);
         });
 
         it('should return the application name in case -appname- placeholder is present', async() => {
@@ -461,7 +461,8 @@ describe('AttachFileCloudWidgetComponent', () => {
         });
 
         describe('FilesSource', () => {
-            it('Should set default user alias (-my-) as rootNodeId if fileSource set only to Alfresco Content', async () => {
+            it('Should be able to fetch nodeId of default user alias (-my-) if fileSource set only to Alfresco Content', async () => {
+                const fetchNodeIdFromRelativePathSpy = spyOn(contentCloudNodeSelectorService, 'fetchNodeIdFromRelativePath').and.returnValue(mockNodeId);
                 widget.field = new FormFieldModel(new FormModel(), {
                     type: FormFieldTypes.UPLOAD,
                     value: []
@@ -478,8 +479,61 @@ describe('AttachFileCloudWidgetComponent', () => {
                 await fixture.whenStable();
                 fixture.detectChanges();
 
+                const alias = '-my-';
+                const opt = { relativePath: '' };
+
+                expect(fetchNodeIdFromRelativePathSpy).toHaveBeenCalledWith(alias, opt);
+                expect(widget.rootNodeId).toEqual('mock-node-id');
+                expect(openUploadFileDialogSpy).toHaveBeenCalledWith('mock-node-id', 'single', false, true);
+            });
+
+            it('Should be able to fetch nodeId of default user alias (-my-) if fileSource set to multiple upload for Alfresco Content', async () => {
+                const fetchNodeIdFromRelativePathSpy = spyOn(contentCloudNodeSelectorService, 'fetchNodeIdFromRelativePath').and.returnValue(mockNodeId);
+                widget.field = new FormFieldModel(new FormModel(), {
+                    type: FormFieldTypes.UPLOAD,
+                    value: []
+                });
+                widget.field.id = 'attach-file-alfresco';
+                widget.field.params = <FormFieldMetadata> contentSourceParam;
+                widget.field.params.multiple = true;
+                fixture.detectChanges();
+                await fixture.whenStable();
+                const attachButton: HTMLButtonElement = element.querySelector('#attach-file-alfresco');
+
+                expect(attachButton).not.toBeNull();
+
+                attachButton.click();
+                await fixture.whenStable();
+                fixture.detectChanges();
+
+                const alias = '-my-';
+                const opt = { relativePath: '' };
+
+                expect(fetchNodeIdFromRelativePathSpy).toHaveBeenCalledWith(alias, opt);
+                expect(widget.rootNodeId).toEqual('mock-node-id');
+                expect(openUploadFileDialogSpy).toHaveBeenCalledWith('mock-node-id', 'multiple', false, true);
+            });
+
+            it('Should be able to set default user alias (-my-) as rootNodeId if the nodeId of the alias is not fetched from the api', async () => {
+                widget.field = new FormFieldModel(new FormModel(), {
+                    type: FormFieldTypes.UPLOAD,
+                    value: []
+                });
+                widget.field.id = 'attach-file-alfresco';
+                widget.field.params = <FormFieldMetadata> contentSourceParam;
+                widget.field.params.multiple = false;
+                fixture.detectChanges();
+                await fixture.whenStable();
+                const attachButton: HTMLButtonElement = element.querySelector('#attach-file-alfresco');
+
+                expect(attachButton).not.toBeNull();
+
+                attachButton.click();
+                await fixture.whenStable();
+                fixture.detectChanges();
+
                 expect(widget.rootNodeId).toEqual('-my-');
-                expect(openUploadFileDialogSpy).toHaveBeenCalledWith('-my-', 'single', false);
+                expect(openUploadFileDialogSpy).toHaveBeenCalledWith('-my-', 'single', false, true);
             });
 
             it('should display tooltip when tooltip is set', async(() => {

--- a/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.spec.ts
@@ -606,6 +606,7 @@ describe('AttachFileCloudWidgetComponent', () => {
     describe('when a file is uploaded', () => {
         beforeEach(async () => {
             apiServiceSpy = spyOn(alfrescoApiService.getInstance().node, 'getNode').and.returnValue(new Promise(resolve => resolve({entry: fakeNodeWithProperties})));
+            spyOn(contentCloudNodeSelectorService, 'fetchNodeIdFromRelativePath').and.returnValue(new Promise(resolve => resolve('fake-properties')));
             spyOn(
                 contentCloudNodeSelectorService,
                 'openUploadFileDialog'
@@ -703,6 +704,8 @@ describe('AttachFileCloudWidgetComponent', () => {
 
         it('should request form to be updated with metadata when retrieve is clicked', (done) => {
             updateFormSpy = spyOn(formService.updateFormValuesRequested, 'next');
+            widget.field.value = [fakeNodeWithProperties];
+            fixture.detectChanges();
 
             const menuButton: HTMLButtonElement = <HTMLButtonElement> (
                 fixture.debugElement.query(By.css('#file-fake-properties-option-menu'))

--- a/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.ts
@@ -124,17 +124,18 @@ export class AttachFileCloudWidgetComponent extends UploadCloudWidgetComponent i
 
     async openSelectDialog() {
         const selectedMode = this.field.params.multiple ? 'multiple' : 'single';
+        let destinationFolderPath = <DestinationFolderPathModel> { alias: AttachFileCloudWidgetComponent.ALIAS_USER_FOLDER, path: '' };
         if (this.isAlfrescoAndLocal()) {
-            const destinationFolderPath = this.getAliasAndRelativePathFromDestinationFolderPath(this.field.params.fileSource.destinationFolderPath);
+            destinationFolderPath = this.getAliasAndRelativePathFromDestinationFolderPath(this.field.params.fileSource.destinationFolderPath);
             destinationFolderPath.path = this.replaceAppNameAliasWithValue(destinationFolderPath.path);
-            const nodeId = await this.contentNodeSelectorService.fetchNodeIdFromRelativePath(destinationFolderPath.alias, { relativePath: destinationFolderPath.path });
-            this.rootNodeId = nodeId ? nodeId : destinationFolderPath.alias;
         }
+        const nodeId = await this.contentNodeSelectorService.fetchNodeIdFromRelativePath(destinationFolderPath.alias, { relativePath: destinationFolderPath.path });
+        this.rootNodeId = nodeId ? nodeId : destinationFolderPath.alias;
 
         this.contentNodeSelectorPanelService.customModels = this.field.params.customModels;
 
         this.contentNodeSelectorService
-            .openUploadFileDialog(this.rootNodeId, selectedMode, this.isAlfrescoAndLocal())
+            .openUploadFileDialog(this.rootNodeId, selectedMode, this.isAlfrescoAndLocal(), true)
             .subscribe((selections: Node[]) => {
                 selections.forEach(node => (node['isExternal'] = true));
                 const selectionWithoutDuplication = this.removeExistingSelection(selections);

--- a/lib/process-services-cloud/src/lib/form/services/content-cloud-node-selector.service.ts
+++ b/lib/process-services-cloud/src/lib/form/services/content-cloud-node-selector.service.ts
@@ -32,7 +32,7 @@ export class ContentCloudNodeSelectorService {
     private dialog: MatDialog) {
   }
 
-  openUploadFileDialog(currentFolderId?: string, selectionMode?: string, isAllFileSources?: boolean): Observable<Node[]> {
+  openUploadFileDialog(currentFolderId?: string, selectionMode?: string, isAllFileSources?: boolean, restrictRootToCurrentFolderId?: boolean): Observable<Node[]> {
     const select = new Subject<Node[]>();
     select.subscribe({
       complete: this.close.bind(this)
@@ -41,7 +41,7 @@ export class ContentCloudNodeSelectorService {
       title: 'Select a file',
       actionName: 'Attach',
       currentFolderId,
-      restrictRootToCurrentFolderId: isAllFileSources,
+      restrictRootToCurrentFolderId,
       select,
       selectionMode,
       isSelectionValid: (entry: Node) => entry.isFile,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://issues.alfresco.com/jira/browse/AAE-3410

**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
