### PR TITLE
Improve search filter component: hide a facet if there is no filter category

### DIFF
--- a/demo-shell/src/app.config.json
+++ b/demo-shell/src/app.config.json
@@ -215,7 +215,7 @@
       "mincount": 1,
       "queries": [
         {
-          "query": "created:2020",
+          "query": "created:2019",
           "label": "SEARCH.FACET_QUERIES.CREATED_THIS_YEAR"
         },
         {

--- a/demo-shell/src/app.config.json
+++ b/demo-shell/src/app.config.json
@@ -215,7 +215,7 @@
       "mincount": 1,
       "queries": [
         {
-          "query": "created:2019",
+          "query": "created:2020",
           "label": "SEARCH.FACET_QUERIES.CREATED_THIS_YEAR"
         },
         {

--- a/e2e/search/search-filters.e2e.ts
+++ b/e2e/search/search-filters.e2e.ts
@@ -34,6 +34,7 @@ import {
 } from '@alfresco/adf-testing';
 import { browser } from 'protractor';
 import { SearchConfiguration } from './search.config';
+import moment from 'moment-es6';
 
 describe('Search Filters', () => {
 
@@ -177,6 +178,14 @@ describe('Search Filters', () => {
     });
 
     it('[C291980] Should group search facets under specified labels', async () => {
+        const currentYear = moment().year();
+
+        jsonFile.facetQueries.queries[0] = {'query': `created:${currentYear}`, 'label': 'SEARCH.FACET_QUERIES.CREATED_THIS_YEAR'};
+        jsonFile.facetQueries.queries[1] = {'query': `content.mimetype:text/html`, 'label': 'SEARCH.FACET_QUERIES.MIMETYPE', 'group': 'Type facet queries'};
+        jsonFile.facetQueries.queries[2] = {'query': `content.size:[0 TO 10240]`, 'label': 'SEARCH.FACET_QUERIES.XTRASMALL', 'group': 'Size facet queries'};
+
+        await LocalStorageUtil.setConfigField('search', JSON.stringify(jsonFile));
+
         await searchBarPage.clickOnSearchIcon();
         await searchBarPage.enterTextAndPressEnter('*');
         await searchResults.dataTable.waitTillContentLoaded();

--- a/lib/content-services/src/lib/mock/search-filter-mock.ts
+++ b/lib/content-services/src/lib/mock/search-filter-mock.ts
@@ -609,3 +609,21 @@ export const filteredResult = [
     'my4 (665)',
     'my5 (1866)'
 ];
+
+export const mockContentSizeResponseBucket = {
+        'label': '5875',
+        'filterQuery': 'content.size:5875',
+        'metrics': [
+            {
+                'type': 'count',
+                'value': {
+                    'count': 364
+                }
+            }
+        ]
+    };
+
+export function getMockSearchResultWithResponseBucket() {
+    mockSearchResult.list.context.facets[3].buckets.push(mockContentSizeResponseBucket);
+    return mockSearchResult;
+}

--- a/lib/content-services/src/lib/search/components/search-filter/search-filter.component.spec.ts
+++ b/lib/content-services/src/lib/search/components/search-filter/search-filter.component.spec.ts
@@ -30,6 +30,7 @@ import {
     expandableCategories,
     expandedCategories,
     filteredResult,
+    getMockSearchResultWithResponseBucket,
     mockSearchResult,
     searchFilter,
     simpleCategories,
@@ -340,7 +341,7 @@ describe('SearchFilterComponent', () => {
             };
 
             component.onDataLoaded(data);
-            expect(component.responseFacets.length).toEqual(2);
+            expect(component.responseFacets.length).toEqual(1);
             expect(component.responseFacets[0].buckets.items[0].count).toEqual(10);
             expect(component.responseFacets[0].buckets.items[1].count).toEqual(1);
         });
@@ -706,9 +707,8 @@ describe('SearchFilterComponent', () => {
 
             component.onDataLoaded(data);
 
-            expect(component.responseFacets.length).toBe(2);
+            expect(component.responseFacets.length).toBe(1);
             expect(component.responseFacets[0].buckets.length).toEqual(1);
-            expect(component.responseFacets[1].buckets.length).toEqual(0);
         });
     });
 
@@ -799,8 +799,26 @@ describe('SearchFilterComponent', () => {
             fixture.detectChanges();
 
             panels = fixture.debugElement.queryAll(By.css('.mat-expansion-panel'));
-            expect(panels.length).toBe(16);
+            expect(panels.length).toBe(8);
         }));
+
+        it('should add a panel only for the response buckets that are present in the response', async () => {
+            appConfigService.config.search = searchFilter;
+            queryBuilder.resetToDefaults();
+
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            const inputElement = fixture.debugElement.query(By.css('[data-automation-id="expansion-panel-Name"] input'));
+            inputElement.triggerEventHandler('change', { target: { value: '*' } });
+
+            queryBuilder.executed.next(<any> getMockSearchResultWithResponseBucket());
+            fixture.detectChanges();
+
+            const panels = fixture.debugElement.queryAll(By.css('.mat-expansion-panel'));
+
+            expect(panels.length).toBe(9);
+        });
 
         it('should show the long facet options list with pagination', () => {
             const panel = '[data-automation-id="expansion-panel-Size facet queries"]';

--- a/lib/content-services/src/lib/search/components/search-filter/search-filter.component.ts
+++ b/lib/content-services/src/lib/search/components/search-filter/search-filter.component.ts
@@ -214,8 +214,6 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
 
                 this.updateExistingBuckets(responseField, responseBuckets, alreadyExistingField, alreadyExistingBuckets);
             } else if (responseField && this.showContextFacets) {
-
-                // New feature: Hide facet if the field doesn't have filter category
                 if(responseBuckets.length > 0) {
                     const bucketList = new SearchFilterList<FacetFieldBucket>(responseBuckets, field.pageSize);
                     bucketList.filter = this.getBucketFilterFunction(bucketList);
@@ -272,8 +270,6 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
 
                 this.updateExistingBuckets(responseField, responseBuckets, alreadyExistingField, alreadyExistingBuckets);
             } else if (responseField && this.showContextFacets) {
-
-                // New feature: Hide facet if the field doesn't have filter category
                 if(responseBuckets.length > 0) {
                     const bucketList = new SearchFilterList<FacetFieldBucket>(responseBuckets, this.facetQueriesPageSize);
                     bucketList.filter = this.getBucketFilterFunction(bucketList);

--- a/lib/content-services/src/lib/search/components/search-filter/search-filter.component.ts
+++ b/lib/content-services/src/lib/search/components/search-filter/search-filter.component.ts
@@ -215,20 +215,23 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
                 this.updateExistingBuckets(responseField, responseBuckets, alreadyExistingField, alreadyExistingBuckets);
             } else if (responseField && this.showContextFacets) {
 
-                const bucketList = new SearchFilterList<FacetFieldBucket>(responseBuckets, field.pageSize);
-                bucketList.filter = this.getBucketFilterFunction(bucketList);
+                // New feature: Hide facet if the field doesn't have filter category
+                if(responseBuckets.length > 0) {
+                    const bucketList = new SearchFilterList<FacetFieldBucket>(responseBuckets, field.pageSize);
+                    bucketList.filter = this.getBucketFilterFunction(bucketList);
 
-                if (!this.responseFacets) {
-                    this.responseFacets = [];
+                    if (!this.responseFacets) {
+                        this.responseFacets = [];
+                    }
+                    this.responseFacets.push(<FacetField> {
+                        ...field,
+                        type: responseField.type || itemType,
+                        label: field.label,
+                        pageSize: field.pageSize | this.DEFAULT_PAGE_SIZE,
+                        currentPageSize: field.pageSize | this.DEFAULT_PAGE_SIZE,
+                        buckets: bucketList
+                    });
                 }
-                this.responseFacets.push(<FacetField> {
-                    ...field,
-                    type: responseField.type || itemType,
-                    label: field.label,
-                    pageSize: field.pageSize | this.DEFAULT_PAGE_SIZE,
-                    currentPageSize: field.pageSize | this.DEFAULT_PAGE_SIZE,
-                    buckets: bucketList
-                });
             }
         });
     }
@@ -270,20 +273,23 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
                 this.updateExistingBuckets(responseField, responseBuckets, alreadyExistingField, alreadyExistingBuckets);
             } else if (responseField && this.showContextFacets) {
 
-                const bucketList = new SearchFilterList<FacetFieldBucket>(responseBuckets, this.facetQueriesPageSize);
-                bucketList.filter = this.getBucketFilterFunction(bucketList);
+                // New feature: Hide facet if the field doesn't have filter category
+                if(responseBuckets.length > 0) {
+                    const bucketList = new SearchFilterList<FacetFieldBucket>(responseBuckets, this.facetQueriesPageSize);
+                    bucketList.filter = this.getBucketFilterFunction(bucketList);
 
-                if (!this.responseFacets) {
-                    this.responseFacets = [];
+                    if (!this.responseFacets) {
+                        this.responseFacets = [];
+                    }
+                    this.responseFacets.push(<FacetField> {
+                        field: group,
+                        type: responseField.type || 'query',
+                        label: group,
+                        pageSize: this.DEFAULT_PAGE_SIZE,
+                        currentPageSize: this.DEFAULT_PAGE_SIZE,
+                        buckets: bucketList
+                    });
                 }
-                this.responseFacets.push(<FacetField> {
-                    field: group,
-                    type: responseField.type || 'query',
-                    label: group,
-                    pageSize: this.DEFAULT_PAGE_SIZE,
-                    currentPageSize: this.DEFAULT_PAGE_SIZE,
-                    buckets: bucketList
-                });
             }
         });
 

--- a/lib/content-services/src/lib/search/components/search-filter/search-filter.component.ts
+++ b/lib/content-services/src/lib/search/components/search-filter/search-filter.component.ts
@@ -214,7 +214,7 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
 
                 this.updateExistingBuckets(responseField, responseBuckets, alreadyExistingField, alreadyExistingBuckets);
             } else if (responseField && this.showContextFacets) {
-                if(responseBuckets.length > 0) {
+                if (responseBuckets.length > 0) {
                     const bucketList = new SearchFilterList<FacetFieldBucket>(responseBuckets, field.pageSize);
                     bucketList.filter = this.getBucketFilterFunction(bucketList);
 
@@ -270,7 +270,7 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
 
                 this.updateExistingBuckets(responseField, responseBuckets, alreadyExistingField, alreadyExistingBuckets);
             } else if (responseField && this.showContextFacets) {
-                if(responseBuckets.length > 0) {
+                if (responseBuckets.length > 0) {
                     const bucketList = new SearchFilterList<FacetFieldBucket>(responseBuckets, this.facetQueriesPageSize);
                     bucketList.filter = this.getBucketFilterFunction(bucketList);
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [X] Other... Please describe:
This PR improve the search filter component by hiding facets without filter category.

**What is the current behaviour?** (You can also link to an open issue here)
All configured facets are shown in the result page.


**What is the new behaviour?**
Only configured facets with filter categories are shown.



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
