### PR TITLE
[ACA-3870] Fix Version Compatibility Initialization

### DIFF
--- a/lib/core/directives/version-compatibility.directive.ts
+++ b/lib/core/directives/version-compatibility.directive.ts
@@ -37,10 +37,12 @@ export class VersionCompatibilityDirective {
     }
 
     private validateAcsVersion(requiredVersion: string) {
-        if (requiredVersion && this.versionCompatibilityService.isVersionSupported(requiredVersion)) {
-            this.viewContainer.createEmbeddedView(this.templateRef);
-        } else {
-            this.viewContainer.clear();
-        }
+        this.versionCompatibilityService.acsVersionInitialized$.subscribe(() => {
+            if (requiredVersion && this.versionCompatibilityService.isVersionSupported(requiredVersion)) {
+                this.viewContainer.createEmbeddedView(this.templateRef);
+            } else {
+                this.viewContainer.clear();
+            }
+        });
     }
 }

--- a/lib/core/services/version-compatibility.service.spec.ts
+++ b/lib/core/services/version-compatibility.service.spec.ts
@@ -73,4 +73,11 @@ describe('VersionCompatibilityService', () => {
         expect(versionCompatibilityService.isVersionSupported('7.0.0')).toBe(true);
         expect(versionCompatibilityService.isVersionSupported('6.0.0')).toBe(true);
     });
+
+    it('should emit versionCompatibilityInitialized after retrieving acs version', (done) => {
+        versionCompatibilityService.acsVersionInitialized$.subscribe(() => {
+            expect(versionCompatibilityService.getAcsVersion()).toEqual({ display: '7.0.1', major: '7', minor: '0', patch: '1' } as any);
+            done();
+        });
+    });
 });

--- a/lib/core/services/version-compatibility.service.ts
+++ b/lib/core/services/version-compatibility.service.ts
@@ -19,6 +19,7 @@ import { Injectable } from '@angular/core';
 import { DiscoveryApiService } from './discovery-api.service';
 import { VersionModel, EcmProductVersionModel } from '../models/product-version.model';
 import { filter } from 'rxjs/operators';
+import { ReplaySubject } from 'rxjs';
 
 @Injectable({
     providedIn: 'root'
@@ -26,10 +27,17 @@ import { filter } from 'rxjs/operators';
 export class VersionCompatibilityService {
     private acsVersion: VersionModel;
 
+    acsVersionInitialized$ = new ReplaySubject();
+
     constructor(private discoveryApiService: DiscoveryApiService) {
         this.discoveryApiService.ecmProductInfo$
             .pipe(filter(acsInfo => !!acsInfo))
-            .subscribe((acsInfo: EcmProductVersionModel) => this.acsVersion = acsInfo.version);
+            .subscribe((acsInfo: EcmProductVersionModel) => this.initializeAcsVersion(acsInfo.version));
+    }
+
+    private initializeAcsVersion(acsVersion: VersionModel) {
+        this.acsVersion = acsVersion;
+        this.acsVersionInitialized$.next();
     }
 
     getAcsVersion(): VersionModel {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://issues.alfresco.com/jira/browse/ACA-3870


**What is the new behaviour?**
In slow internet connections the view was rendering before the discovery call to the API had returned the ACS version. Because of this, the directive was hiding whatever element it was applied to.

It now waits for the initialized observable to emit before assessing whether the element should be shown or hidden.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
