### PR TITLE
[ADF-5223] Fix Amount widget styling

### DIFF
--- a/e2e/process-services/widgets/amount-widget.e2e.ts
+++ b/e2e/process-services/widgets/amount-widget.e2e.ts
@@ -74,7 +74,8 @@ describe('Amount Widget', () => {
         await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
         await expect(await widget.amountWidget().getAmountFieldLabel(app.FIELD.amount_input_id)).toContain('Amount');
         await expect(await widget.amountWidget().getPlaceholder(app.FIELD.amount_input_id)).toContain('Type amount');
-        await expect(await widget.amountWidget().getAmountFieldCurrency(app.FIELD.amount_input_id)).toBe('$');
+        const fieldCurrency = await widget.amountWidget().getAmountFieldCurrency(app.FIELD.amount_input_id);
+        await expect(fieldCurrency.trim()).toBe('$');
 
         await widget.amountWidget().setFieldValue(app.FIELD.amount_input_id, 4);
         await expect(await widget.amountWidget().getErrorMessage(app.FIELD.amount_input_id)).toBe('Can\'t be less than 5');

--- a/lib/core/form/components/widgets/amount/amount.widget.html
+++ b/lib/core/form/components/widgets/amount/amount.widget.html
@@ -1,21 +1,25 @@
-<div class="adf-amount-widget__container adf-amount-widget {{field.className}}" [class.adf-invalid]="!field.isValid" [class.adf-readonly]="field.readOnly">
-    <mat-form-field class="adf-amount-widget__input"  floatLabel="never">
-        <label class="adf-label" [attr.for]="field.id">{{field.name | translate }}<span *ngIf="isRequired()">*</span></label>
-        <span matPrefix class="adf-amount-widget__prefix-spacing">{{ currency }}</span>
+<div class="adf-amount-widget__container adf-amount-widget {{field.className}}"
+     [class.adf-invalid]="!field.isValid"
+     [class.adf-readonly]="field.readOnly">
+    <label class="adf-label"
+           [attr.for]="field.id">{{field.name | translate }}<span *ngIf="isRequired()">*</span></label>
+    <mat-form-field class="adf-amount-widget__input">
+        <span matPrefix class="adf-amount-widget__prefix-spacing">{{ currency }} &nbsp;</span>
         <input matInput
-                [matTooltip]="field.tooltip"
-                matTooltipPosition="above"
-                matTooltipShowDelay="1000"
-                class="adf-input"
-                type="text"
-                [id]="field.id"
-                [required]="isRequired()"
-                [placeholder]="placeholder"
-                [value]="field.value"
-                [(ngModel)]="field.value"
-                (ngModelChange)="onFieldChanged(field)"
-                [disabled]="field.readOnly">
+               [matTooltip]="field.tooltip"
+               matTooltipPosition="above"
+               matTooltipShowDelay="1000"
+               class="adf-input"
+               type="text"
+               [id]="field.id"
+               [required]="isRequired()"
+               [placeholder]="placeholder"
+               [value]="field.value"
+               [(ngModel)]="field.value"
+               (ngModelChange)="onFieldChanged(field)"
+               [disabled]="field.readOnly">
     </mat-form-field>
-    <error-widget [error]="field.validationSummary" ></error-widget>
-    <error-widget *ngIf="isInvalidFieldRequired()" required="{{ 'FORM.FIELD.REQUIRED' | translate }}"></error-widget>
+    <error-widget [error]="field.validationSummary"></error-widget>
+    <error-widget *ngIf="isInvalidFieldRequired()"
+                  required="{{ 'FORM.FIELD.REQUIRED' | translate }}"></error-widget>
 </div>

--- a/lib/core/form/components/widgets/amount/amount.widget.scss
+++ b/lib/core/form/components/widgets/amount/amount.widget.scss
@@ -6,20 +6,11 @@
     .adf {
         &-amount-widget {
             width: 100%;
-
-            .mat-input-element {
-                margin-left: 13px;
-                margin-right: 13px;
-            }
-        }
-
-        &-amount-widget__container .mat-form-field-label-wrapper {
-            top: 17px;
-            left: 12px;
-            right: 12px;
+            margin-top: 15px;
         }
 
         &-amount-widget__input {
+            margin-top: -15px;
 
             .mat-focused {
                 transition: none;
@@ -30,11 +21,6 @@
                     color: mat-color($foreground, secondary-text);
                 }
             }
-        }
-
-        &-amount-widget__prefix-spacing {
-            position: absolute;
-            top: 12px;
         }
     }
 }

--- a/lib/core/form/components/widgets/amount/amount.widget.spec.ts
+++ b/lib/core/form/components/widgets/amount/amount.widget.spec.ts
@@ -126,7 +126,7 @@ describe('AmountWidgetComponent - rendering', () => {
         const widgetLabel = fixture.nativeElement.querySelector('label.adf-label');
         expect(widgetLabel.textContent).toBe('Test Amount*');
         const widgetPrefix = fixture.nativeElement.querySelector('div.mat-form-field-prefix');
-        expect(widgetPrefix.textContent).toBe('$');
+        expect(widgetPrefix.textContent.trim()).toBe('$');
         expect(widget.field.isValid).toBe(false);
         const widgetById: HTMLInputElement = fixture.nativeElement.querySelector('#TestAmount1');
         expect(widgetById).toBeDefined();

--- a/lib/testing/src/lib/core/pages/form/widgets/amount-widget.page.ts
+++ b/lib/testing/src/lib/core/pages/form/widgets/amount-widget.page.ts
@@ -31,7 +31,7 @@ export class AmountWidgetPage {
 
     async getAmountFieldCurrency(fieldId: string): Promise<string> {
         const widget = await this.formFields.getWidget(fieldId);
-        return BrowserActions.getText(widget.element(this.currency).trim());
+        return BrowserActions.getText(widget.element(this.currency));
     }
 
     async setFieldValue(fieldId: string, value: any): Promise<void> {

--- a/lib/testing/src/lib/core/pages/form/widgets/amount-widget.page.ts
+++ b/lib/testing/src/lib/core/pages/form/widgets/amount-widget.page.ts
@@ -31,7 +31,7 @@ export class AmountWidgetPage {
 
     async getAmountFieldCurrency(fieldId: string): Promise<string> {
         const widget = await this.formFields.getWidget(fieldId);
-        return BrowserActions.getText(widget.element(this.currency));
+        return BrowserActions.getText(widget.element(this.currency).trim());
     }
 
     async setFieldValue(fieldId: string, value: any): Promise<void> {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ADF-5223


**What is the new behaviour?**
This widget wasn't representing the prefix correctly as it was hacked and hardcoded. Now it adapts to whatever currency is in use keeping the spacing in between.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
