### PR TITLE
[ACA-4124] Change name displayed for groups in Add Permission Panel Component

### DIFF
--- a/demo-shell/src/app/components/error/demo-error.component.html
+++ b/demo-shell/src/app/components/error/demo-error.component.html
@@ -1,15 +1,22 @@
-<div fxLayout="column" fxLayoutAlign="center center">
+<div fxLayout="column"
+     fxLayoutAlign="center center">
     <adf-error-content [errorCode]="errorCode">
-        <div adf-error-content-actions class="app-error-content-buttons">
-            <a a id="adf-secondary-button" mat-raised-button color="primary"
-                 (click)="onReportIssue()"
-                class="app-error-content-description-link">
+        <div adf-error-content-actions
+             class="app-error-content-buttons">
+            <a *ngIf="'ERROR_CONTENT.' + errorCode + '.SECONDARY_BUTTON.TEXT' | translate"
+                id="adf-secondary-button"
+               mat-raised-button
+               color="primary"
+               (click)="onReportIssue()"
+               class="app-error-content-description-link">
                 {{ 'ERROR_CONTENT.' + errorCode + '.SECONDARY_BUTTON.TEXT' | translate | uppercase }}
             </a>
-            <a id="adf-return-button" mat-raised-button color="primary" (click)="onReturnButton()">
+            <a id="adf-return-button"
+               mat-raised-button
+               color="primary"
+               (click)="onReturnButton()">
                 {{ 'ERROR_CONTENT.' + errorCode + '.RETURN_BUTTON.TEXT' | translate | uppercase }}
             </a>
         </div>
     </adf-error-content>
 </div>
-

--- a/e2e/content-services/permissions/permissions-component.e2e.ts
+++ b/e2e/content-services/permissions/permissions-component.e2e.ts
@@ -228,7 +228,7 @@ describe('Permissions Component', () => {
             await permissionsPage.addPermissionsDialog.checkAddPermissionDialogIsDisplayed();
             await permissionsPage.addPermissionsDialog.checkSearchUserInputIsDisplayed();
             await permissionsPage.addPermissionsDialog.searchUserOrGroup(groupBody.id);
-            await permissionsPage.addPermissionsDialog.clickUserOrGroup(groupBody.id);
+            await permissionsPage.addPermissionsDialog.clickUserOrGroup(groupBody.displayName);
             await permissionsPage.addPermissionsDialog.checkUserOrGroupIsAdded(groupBody.id);
         });
 

--- a/e2e/content-services/permissions/permissions-component.e2e.ts
+++ b/e2e/content-services/permissions/permissions-component.e2e.ts
@@ -227,9 +227,9 @@ describe('Permissions Component', () => {
             await permissionsPage.addPermissionsDialog.clickAddPermissionButton();
             await permissionsPage.addPermissionsDialog.checkAddPermissionDialogIsDisplayed();
             await permissionsPage.addPermissionsDialog.checkSearchUserInputIsDisplayed();
-            await permissionsPage.addPermissionsDialog.searchUserOrGroup('GROUP_' + groupBody.id);
-            await permissionsPage.addPermissionsDialog.clickUserOrGroup('GROUP_' + groupBody.id);
-            await permissionsPage.addPermissionsDialog.checkUserOrGroupIsAdded('GROUP_' + groupBody.id);
+            await permissionsPage.addPermissionsDialog.searchUserOrGroup(groupBody.id);
+            await permissionsPage.addPermissionsDialog.clickUserOrGroup(groupBody.id);
+            await permissionsPage.addPermissionsDialog.checkUserOrGroupIsAdded(groupBody.id);
         });
 
         it('[C277100] Should display EVERYONE group in the search result set', async () => {

--- a/lib/content-services/src/lib/permission-manager/components/add-permission/add-permission-panel.component.html
+++ b/lib/content-services/src/lib/permission-manager/components/add-permission/add-permission-panel.component.html
@@ -54,8 +54,8 @@
                 <mat-icon id="add-person-icon" mat-list-icon>person_add</mat-icon>
             </ng-template>
             <p>
-             {{item.entry?.properties['cm:authorityName']?
-                                    item.entry?.properties['cm:authorityName'] :
+             {{item.entry?.properties['cm:authorityDisplayName']?
+                                    item.entry?.properties['cm:authorityDisplayName'] :
                                     item.entry?.properties['cm:owner']?.displayName}}</p>
         </mat-list-option>
     </mat-selection-list>

--- a/lib/core/i18n/en.json
+++ b/lib/core/i18n/en.json
@@ -429,6 +429,16 @@
         "TEXT": "Back to home"
       }
     },
+    "503": {
+      "TITLE": "An error occurred.",
+      "DESCRIPTION": "Service Temporarily Unavailable [503].",
+      "SECONDARY_BUTTON": {
+        "TEXT": ""
+      },
+      "RETURN_BUTTON": {
+        "TEXT": "Back to home"
+      }
+    },
     "504": {
       "TITLE": "An error occurred.",
       "DESCRIPTION": "The server timed out, try again or contact IT support [504].",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ACA-4124


**What is the new behaviour?**
ADF's Add Permission Panel Component currently displays the `authorityName` instead of `authorityDisplayName`. 
`authorityDisplayName` is much more understandable for users.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
