### PR TITLE
[MNT-21920] Fix Card View Integers initialization when they are set to 0

### DIFF
--- a/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.ts
+++ b/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.ts
@@ -201,7 +201,7 @@ export class ContentMetadataComponent implements OnChanges, OnInit, OnDestroy {
 
     showGroup(group: CardViewGroup): boolean {
         const properties = group.properties.filter((property) => {
-            return !!property.displayValue;
+            return !this.isEmpty(property.displayValue);
         });
 
         return properties.length > 0;
@@ -224,5 +224,9 @@ export class ContentMetadataComponent implements OnChanges, OnInit, OnDestroy {
         if (event.keyCode === 37 || event.keyCode === 39) { // ArrowLeft && ArrowRight
             event.stopPropagation();
         }
+    }
+
+    private isEmpty(value: any): boolean {
+        return value === undefined || value === null || value === '';
     }
 }

--- a/lib/content-services/src/lib/content-metadata/services/property-groups-translator.service.spec.ts
+++ b/lib/content-services/src/lib/content-metadata/services/property-groups-translator.service.spec.ts
@@ -86,14 +86,14 @@ describe('PropertyGroupTranslatorService', () => {
                 mandatory: false,
                 multiValued: false
             },
-                {
-                    name: 'FAS:ALOY',
-                    title: 'title',
-                    dataType: 'd:text',
-                    defaultValue: 'defaultValue',
-                    mandatory: false,
-                    multiValued: false
-                }];
+            {
+                name: 'FAS:ALOY',
+                title: 'title',
+                dataType: 'd:text',
+                defaultValue: 'defaultValue',
+                mandatory: false,
+                multiValued: false
+            }];
             propertyGroups.push(propertyGroup);
 
             propertyValues = { 'FAS:PLAGUE': 'The Chariot Line' };
@@ -253,6 +253,17 @@ describe('PropertyGroupTranslatorService', () => {
             expect(cardViewProperty.value).toBe(1024);
         });
 
+        it('should translate properly the value attribute for d:int and value is 0', () => {
+            property.dataType = 'd:int';
+
+            propertyValues = { 'FAS:PLAGUE': 0 };
+            const cardViewGroup = service.translateToCardViewGroups(propertyGroups, propertyValues, null);
+
+            const cardViewProperty: CardViewIntItemModel = <CardViewIntItemModel> cardViewGroup[0].properties[0];
+            expect(cardViewProperty instanceof CardViewIntItemModel).toBeTruthy('Property should be instance of CardViewIntItemModel');
+            expect(cardViewProperty.value).toBe(0);
+        });
+
         it('should translate properly the value attribute for d:long', () => {
             property.dataType = 'd:long';
 
@@ -273,6 +284,17 @@ describe('PropertyGroupTranslatorService', () => {
             const cardViewProperty: CardViewFloatItemModel = <CardViewFloatItemModel> cardViewGroup[0].properties[0];
             expect(cardViewProperty instanceof CardViewFloatItemModel).toBeTruthy('Property should be instance of CardViewFloatItemModel');
             expect(cardViewProperty.value).toBe(1024.24);
+        });
+
+        it('should translate properly the value attribute for d:float and value is 0', () => {
+            property.dataType = 'd:float';
+
+            propertyValues = { 'FAS:PLAGUE': 0 };
+            const cardViewGroup = service.translateToCardViewGroups(propertyGroups, propertyValues, null);
+
+            const cardViewProperty: CardViewFloatItemModel = <CardViewFloatItemModel> cardViewGroup[0].properties[0];
+            expect(cardViewProperty instanceof CardViewFloatItemModel).toBeTruthy('Property should be instance of CardViewFloatItemModel');
+            expect(cardViewProperty.value).toBe(0);
         });
 
         it('should translate properly the value attribute for d:double', () => {
@@ -309,7 +331,7 @@ describe('PropertyGroupTranslatorService', () => {
                             }
                         }
                     ]
-                } as Constraint ]
+                } as Constraint]
             };
             property.dataType = 'd:text';
             propertyValues = { 'FAS:PLAGUE': 'two' };

--- a/lib/content-services/src/lib/content-metadata/services/property-groups-translator.service.ts
+++ b/lib/content-services/src/lib/content-metadata/services/property-groups-translator.service.ts
@@ -77,7 +77,7 @@ export class PropertyGroupTranslatorService {
 
     private translate(property: Property, propertyValues: any, constraints: Constraint[]): CardViewItem {
         let propertyValue: any;
-        if (propertyValues && propertyValues[property.name]) {
+        if (propertyValues && !this.isEmpty(propertyValues[property.name])) {
             propertyValue = propertyValues[property.name];
         }
 
@@ -158,5 +158,9 @@ export class PropertyGroupTranslatorService {
         if (PropertyGroupTranslatorService.RECOGNISED_ECM_TYPES.indexOf(ecmPropertyType) === -1) {
             this.logService.error(`Unknown type for mapping: ${ecmPropertyType}`);
         }
+    }
+
+    private isEmpty(value: any): boolean {
+        return value === undefined || value === null || value === '';
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/MNT-21920


**What is the new behaviour?**
When an integer text edit card view was set to 0 the component would understand it as an empty field. This issue has been addresses by improving the way we tell if it's empty or not.

<img width="319" alt="Screen Shot 2020-11-05 at 13 34 35" src="https://user-images.githubusercontent.com/18293044/98247544-a8452e80-1f6b-11eb-894d-81e03d9361fb.png">


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
