### PR TITLE
Fix clickUntilIsNotVisible by removing one return

### DIFF
--- a/lib/testing/src/lib/core/utils/browser-actions.ts
+++ b/lib/testing/src/lib/core/utils/browser-actions.ts
@@ -36,7 +36,7 @@ export class BrowserActions {
             await this.click(elementToClick);
 
             try {
-                return BrowserVisibility.waitUntilElementIsVisible(elementToFind);
+                BrowserVisibility.waitUntilElementIsVisible(elementToFind);
                 return true;
             } catch (error) {
                 return false;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
