### PR TITLE
[ACA-4168] - changed to public reset pagination

### DIFF
--- a/lib/content-services/src/lib/document-list/components/document-list.component.ts
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.ts
@@ -901,7 +901,7 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
         this.filterSelection.emit(activeFilters);
     }
 
-    private resetNewFolderPagination() {
+    resetNewFolderPagination() {
         this._pagination.skipCount = 0;
         this._pagination.maxItems = this.maxItems;
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
It's not possible reset the pagination of DL from outside and sometimes this is needed (navigation through Breadcrumb)


**What is the new behaviour?**
This method will allow the apps to reset the pagination whenever a navigation through breadcrum has been triggered.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
