### PR TITLE
[ADF-5295] Fix Session not reloaded after User logs in in other tab

### DIFF
--- a/lib/core/services/auth-guard.service.ts
+++ b/lib/core/services/auth-guard.service.ts
@@ -65,8 +65,6 @@ export class AuthGuard extends AuthGuardBase {
         } else {
             window.location.reload();
         }
-
-        window.removeEventListener('storage', this.ticketChangeBind);
     }
 
     async checkLogin(_: ActivatedRouteSnapshot, redirectUrl: string): Promise<boolean> {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ADF-5295


**What is the new behaviour?**
Supposing you have two tabs with the same user in both. You log in with a different user in the second tab. The first tab should reload with the same new session for the second tab.
Because it was removing the event listener for the window storage change, the user in the first tab was not getting the storage change and therefore, not reloading.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
