### PR TITLE
[ADF-5297] Success Snackbar messages showning as errors

### DIFF
--- a/demo-shell/src/app/components/files/files.component.html
+++ b/demo-shell/src/app/components/files/files.component.html
@@ -83,7 +83,7 @@
                         mat-icon-button
                         [disabled]="!canCreateContent(documentList.folderNode)"
                         title="{{ 'DOCUMENT_LIST.TOOLBAR.NEW_FOLDER' | translate }}"
-                        (error)="openSnackMessage($event)"
+                        (error)="openSnackMessageError($event)"
                         (success)="documentList.reload()"
                         [adf-create-folder]="currentFolderId"
                         matTooltip="{{ 'DOCUMENT_LIST.TOOLBAR.NEW_FOLDER' | translate }}">
@@ -101,7 +101,7 @@
                         mat-icon-button
                             [disabled]="!canEditFolder(documentList.selection)"
                             title="{{ 'DOCUMENT_LIST.TOOLBAR.EDIT_FOLDER' | translate }}"
-                            (error)="openSnackMessage($event)"
+                            (error)="openSnackMessageError($event)"
                             [adf-edit-folder]="documentList.selection[0]?.entry"
                             (success)="documentList.reload()"
                             matTooltip="{{ 'DOCUMENT_LIST.TOOLBAR.EDIT_FOLDER' | translate }}">
@@ -184,7 +184,7 @@
                         <span>{{ 'DOCUMENT_LIST.TOOLBAR.CARDVIEW' | translate }}</span>
                     </button>
                     <button mat-menu-item
-                            (error)="openSnackMessage($event)"
+                            (error)="openSnackMessageError($event)"
                             [adf-create-folder]="currentFolderId">
                         <mat-icon>create_new_folder</mat-icon>
                         <span>{{ 'DOCUMENT_LIST.TOOLBAR.NEW_FOLDER' | translate }}</span>
@@ -196,7 +196,7 @@
                     </button>
                     <button mat-menu-item
                             [disabled]="!canEditFolder(documentList.selection)"
-                            (error)="openSnackMessage($event)"
+                            (error)="openSnackMessageError($event)"
                             [adf-edit-folder]="documentList.selection[0]?.entry">
                         <mat-icon>create</mat-icon>
                         <span>{{ 'DOCUMENT_LIST.TOOLBAR.EDIT_FOLDER' | translate }}</span>
@@ -673,7 +673,7 @@
                 [multipleFiles]="multipleFileUpload"
                 [uploadFolders]="folderUpload"
                 [maxFilesSize]="maxSizeShow ? maxFilesSize : null"
-                (error)="openSnackMessage($event)"
+                (error)="openSnackMessageError($event)"
                 [versioning]="versioning"
                 [adf-check-allowable-operation]="'create'"
                 [adf-nodes]="enableUpload ? getCurrentDocumentListNode() : []"
@@ -691,7 +691,7 @@
                 [multipleFiles]="multipleFileUpload"
                 [uploadFolders]="folderUpload"
                 [versioning]="versioning"
-                (error)="openSnackMessage($event)"
+                (error)="openSnackMessageError($event)"
                 [adf-check-allowable-operation]="'create'"
                 [adf-nodes]="enableUpload ? getCurrentDocumentListNode() : []"
                 (permissionEvent)="handlePermissionError($event)">
@@ -718,4 +718,4 @@
     </div>
 </div>
 
-<adf-file-uploading-dialog #fileDialog (error)="openSnackMessage($event)"></adf-file-uploading-dialog>
+<adf-file-uploading-dialog #fileDialog (error)="openSnackMessageError($event)"></adf-file-uploading-dialog>

--- a/demo-shell/src/app/components/files/files.component.ts
+++ b/demo-shell/src/app/components/files/files.component.ts
@@ -407,12 +407,16 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
             action: event.action,
             type: event.type
         }).subscribe((message) => {
-            this.openSnackMessage(message);
+            this.openSnackMessageError(message);
         });
     }
 
-    openSnackMessage(message: string) {
+    openSnackMessageError(message: string) {
         this.notificationService.showError(message);
+    }
+
+    openSnackMessageInfo(message: string) {
+        this.notificationService.showInfo(message);
     }
 
     emitReadyEvent(event: NodePaging) {
@@ -438,12 +442,12 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
                 translatedErrorMessage = this.translateService.instant('OPERATION.ERROR.UNKNOWN');
         }
 
-        this.openSnackMessage(translatedErrorMessage);
+        this.openSnackMessageError(translatedErrorMessage);
     }
 
     onContentActionSuccess(message: string) {
         const translatedMessage: any = this.translateService.instant(message);
-        this.openSnackMessage(translatedMessage);
+        this.openSnackMessageInfo(translatedMessage);
         this.documentList.reload();
     }
 
@@ -451,7 +455,7 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
         this.uploadService.fileDeleted.next(message);
         this.deleteElementSuccess.emit();
         this.documentList.reload();
-        this.openSnackMessage(message);
+        this.openSnackMessageInfo(message);
     }
 
     onPermissionRequested(node: any) {
@@ -471,7 +475,7 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
             });
         } else {
             const translatedErrorMessage: any = this.translateService.instant('OPERATION.ERROR.PERMISSION');
-            this.openSnackMessage(translatedErrorMessage);
+            this.openSnackMessageError(translatedErrorMessage);
         }
     }
 
@@ -489,7 +493,7 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
             });
         } else {
             const translatedErrorMessage: any = this.translateService.instant('OPERATION.ERROR.PERMISSION');
-            this.openSnackMessage(translatedErrorMessage);
+            this.openSnackMessageError(translatedErrorMessage);
         }
     }
 
@@ -653,7 +657,7 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
             });
         } else {
             const translatedErrorMessage: any = this.translateService.instant('OPERATION.ERROR.PERMISSION');
-            this.openSnackMessage(translatedErrorMessage);
+            this.openSnackMessageError(translatedErrorMessage);
         }
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ADF-5297


**What is the new behaviour?**
Success snackbar messages are showing in red as if they were errors. They are supposed to be orange, the principal accent color of the app.
<img width="1680" alt="Screen Shot 2020-12-01 at 16 29 16" src="https://user-images.githubusercontent.com/18293044/100769635-3938e980-33f4-11eb-99a8-f1ed3ea46efa.png">


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
