### PR TITLE
[ACA-4205] reload on sorting only for server mode

### DIFF
--- a/demo-shell/src/app/components/files/files.component.ts
+++ b/demo-shell/src/app/components/files/files.component.ts
@@ -15,19 +15,15 @@
  * limitations under the License.
  */
 
-import {
-    Component, Input, OnInit, OnChanges, OnDestroy, Optional,
-    EventEmitter, ViewChild, SimpleChanges, Output
-} from '@angular/core';
+import { Component, Input, OnInit, OnChanges, OnDestroy, Optional, EventEmitter, ViewChild, SimpleChanges, Output } from '@angular/core';
 import { Location } from '@angular/common';
-
 import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import { MinimalNodeEntity, NodePaging, Pagination, MinimalNodeEntryEntity, SiteEntry, SearchEntry, NodeEntry } from '@alfresco/js-api';
 import {
-    AlfrescoApiService, AuthenticationService, AppConfigService, AppConfigValues, ContentService, TranslationService, FolderCreatedEvent, LogService, NotificationService,
+    AlfrescoApiService, AuthenticationService, AppConfigService, AppConfigValues, ContentService, FolderCreatedEvent, LogService, NotificationService,
     UploadService, DataRow, UserPreferencesService,
-    PaginationComponent, FormValues, DisplayMode, ShowHeaderMode, InfinitePaginationComponent, HighlightDirective,
+    PaginationComponent, FormValues, DisplayMode, ShowHeaderMode, InfinitePaginationComponent,
     SharedLinksApiService,
     FormRenderingService,
     FileUploadEvent
@@ -204,9 +200,6 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
     @ViewChild(InfinitePaginationComponent, { static: true })
     infinitePaginationComponent: InfinitePaginationComponent;
 
-    @ViewChild(HighlightDirective)
-    highlighter: HighlightDirective;
-
     permissionsStyle: PermissionStyleModel[] = [];
     infiniteScrolling: boolean;
     stickyHeader: boolean;
@@ -226,7 +219,6 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
                 private contentService: ContentService,
                 private dialog: MatDialog,
                 private location: Location,
-                private translateService: TranslationService,
                 private router: Router,
                 private logService: LogService,
                 private appConfig: AppConfigService,
@@ -402,12 +394,10 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
     }
 
     handlePermissionError(event: any) {
-        this.translateService.get('PERMISSION.LACKOF', {
+        this.notificationService.showError('PERMISSION.LACKOF', null, {
             permission: event.permission,
             action: event.action,
             type: event.type
-        }).subscribe((message) => {
-            this.openSnackMessageError(message);
         });
     }
 
@@ -429,25 +419,24 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
 
     onContentActionError(errors: any) {
         const errorStatusCode = JSON.parse(errors.message).error.statusCode;
-        let translatedErrorMessage: any;
+        let message: string;
 
         switch (errorStatusCode) {
             case 403:
-                translatedErrorMessage = this.translateService.instant('OPERATION.ERROR.PERMISSION');
+                message = 'OPERATION.ERROR.PERMISSION';
                 break;
             case 409:
-                translatedErrorMessage = this.translateService.instant('OPERATION.ERROR.CONFLICT');
+                message = 'OPERATION.ERROR.CONFLICT';
                 break;
             default:
-                translatedErrorMessage = this.translateService.instant('OPERATION.ERROR.UNKNOWN');
+                message = 'OPERATION.ERROR.UNKNOWN';
         }
 
-        this.openSnackMessageError(translatedErrorMessage);
+        this.openSnackMessageError(message);
     }
 
     onContentActionSuccess(message: string) {
-        const translatedMessage: any = this.translateService.instant(message);
-        this.openSnackMessageInfo(translatedMessage);
+        this.openSnackMessageInfo(message);
         this.documentList.reload();
     }
 
@@ -469,31 +458,30 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
 
         if (this.contentService.hasAllowableOperations(contentEntry, 'update')) {
             this.dialog.open(VersionManagerDialogAdapterComponent, {
-                data: { contentEntry: contentEntry, showComments: showComments, allowDownload: allowDownload },
+                data: { contentEntry, showComments, allowDownload },
                 panelClass: 'adf-version-manager-dialog',
                 width: '630px'
             });
         } else {
-            const translatedErrorMessage: any = this.translateService.instant('OPERATION.ERROR.PERMISSION');
-            this.openSnackMessageError(translatedErrorMessage);
+            this.openSnackMessageError('OPERATION.ERROR.PERMISSION');
         }
     }
 
     onManageMetadata(event: any) {
         const contentEntry = event.value.entry;
+        const displayEmptyMetadata = this.displayEmptyMetadata;
 
         if (this.contentService.hasAllowableOperations(contentEntry, 'update')) {
             this.dialog.open(MetadataDialogAdapterComponent, {
                 data: {
-                    contentEntry: contentEntry,
-                    displayEmptyMetadata: this.displayEmptyMetadata
+                    contentEntry,
+                    displayEmptyMetadata
                 },
                 panelClass: 'adf-metadata-manager-dialog',
                 width: '630px'
             });
         } else {
-            const translatedErrorMessage: any = this.translateService.instant('OPERATION.ERROR.PERMISSION');
-            this.openSnackMessageError(translatedErrorMessage);
+            this.openSnackMessageError('OPERATION.ERROR.PERMISSION');
         }
     }
 
@@ -501,17 +489,17 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
         this.currentFolderId = site.entry.guid;
     }
 
-    hasSelection(selection: Array<MinimalNodeEntity>): boolean {
+    hasSelection(selection: Array<any>): boolean {
         return selection && selection.length > 0;
     }
 
     hasOneFileSelected(): boolean {
-        const selection: Array<MinimalNodeEntity> = this.documentList.selection;
+        const selection = this.documentList.selection;
         return selection && selection.length === 1 && selection[0].entry.isFile;
     }
 
     userHasPermissionToManageVersions(): boolean {
-        const selection: Array<MinimalNodeEntity> = this.documentList.selection;
+        const selection = this.documentList.selection;
         return this.contentService.hasAllowableOperations(selection[0].entry, 'update');
     }
 
@@ -606,7 +594,6 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
 
     canDownloadNode(node: MinimalNodeEntity): boolean {
         return node && node.entry && node.entry.name === 'custom';
-
     }
 
     onBeginUpload(event: UploadFilesEvent) {
@@ -656,8 +643,7 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
                 width: '630px'
             });
         } else {
-            const translatedErrorMessage: any = this.translateService.instant('OPERATION.ERROR.PERMISSION');
-            this.openSnackMessageError(translatedErrorMessage);
+            this.openSnackMessageError('OPERATION.ERROR.PERMISSION');
         }
     }
 

--- a/lib/content-services/src/lib/document-list/components/document-list.component.ts
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.ts
@@ -201,7 +201,7 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
      * before delivering it.
      */
     @Input()
-    sortingMode = 'server';
+    sortingMode: 'server' | 'client' = 'server';
 
     /** The inline style to apply to every row. See
      * the Angular NgStyle
@@ -707,8 +707,11 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
 
     onSortingChanged(event: CustomEvent) {
         this.orderBy = this.buildOrderByArray(event.detail.sortingKey, event.detail.direction);
-        this.reload();
         this.sortingSubject.next([this.additionalSorting, event.detail]);
+
+        if (this.sortingMode === 'server') {
+            this.reload();
+        }
     }
 
     private buildOrderByArray(currentKey: string, currentDirection: string): string[] {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

- do not force data reload on sorting change, when the mode is "client"
- add the typing restrictions for the `sortingMode` property in document list

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://alfresco.atlassian.net/browse/ACA-4205