### PR TITLE
[ACA-4202] - caching with version number for the url

### DIFF
--- a/lib/core/viewer/components/viewer.component.spec.ts
+++ b/lib/core/viewer/components/viewer.component.spec.ts
@@ -376,6 +376,26 @@ describe('ViewerComponent', () => {
         expect(component.fileTitle).toBe('file2');
     }));
 
+    it('should append version of the file to the file content URL', fakeAsync(() => {
+        spyOn(alfrescoApiService.nodesApi, 'getNode').and.returnValue(
+            Promise.resolve(new NodeEntry({ entry: { name: 'file1', content: {}, properties: { 'cm:versionLabel' : '10'} } }))
+        );
+        spyOn(alfrescoApiService.versionsApi, 'getVersion').and.returnValue(Promise.resolve(undefined));
+
+        component.nodeId = 'id1';
+        component.urlFile = null;
+        component.displayName = null;
+        component.blobFile = null;
+        component.showViewer = true;
+
+        component.versionId = null;
+        component.ngOnChanges();
+        tick();
+
+        expect(component.fileTitle).toBe('file1');
+        expect(component.urlFileContent).toContain('/public/alfresco/versions/1/nodes/id1/content?attachment=false&10');
+    }));
+
     it('should change display name every time node\`s version changes', fakeAsync(() => {
         spyOn(alfrescoApiService.nodesApi, 'getNode').and.returnValue(
             Promise.resolve(new NodeEntry({ entry: { name: 'node1', content: {} } }))

--- a/lib/core/viewer/components/viewer.component.ts
+++ b/lib/core/viewer/components/viewer.component.ts
@@ -391,9 +391,13 @@ export class ViewerComponent implements OnChanges, OnInit, OnDestroy {
 
         this.fileTitle = this.getDisplayName(versionData ? versionData.name : nodeData.name);
 
+        const currentFileVersion = this.nodeEntry.entry.properties['cm:versionLabel'] ?
+            encodeURI(this.nodeEntry.entry.properties['cm:versionLabel']) : encodeURI('1.0');
+
         this.urlFileContent = versionData ? this.apiService.contentApi.getVersionContentUrl(this.nodeId, versionData.id) :
             this.apiService.contentApi.getContentUrl(this.nodeId);
-        this.urlFileContent = this.cacheBusterNumber ? this.urlFileContent + '&' + this.cacheBusterNumber : this.urlFileContent;
+        this.urlFileContent = this.cacheBusterNumber ? this.urlFileContent + '&' + currentFileVersion + '&' + this.cacheBusterNumber :
+            this.urlFileContent + '&' + currentFileVersion;
 
         this.extension = this.getFileExtension(versionData ? versionData.name : nodeData.name);
 

--- a/lib/core/viewer/components/viewer.component.ts
+++ b/lib/core/viewer/components/viewer.component.ts
@@ -391,8 +391,8 @@ export class ViewerComponent implements OnChanges, OnInit, OnDestroy {
 
         this.fileTitle = this.getDisplayName(versionData ? versionData.name : nodeData.name);
 
-        const currentFileVersion = this.nodeEntry.entry.properties['cm:versionLabel'] ?
-            encodeURI(this.nodeEntry.entry.properties['cm:versionLabel']) : encodeURI('1.0');
+        const currentFileVersion = this.nodeEntry?.entry?.properties && this.nodeEntry.entry.properties['cm:versionLabel'] ?
+            encodeURI(this.nodeEntry?.entry?.properties['cm:versionLabel']) : encodeURI('1.0');
 
         this.urlFileContent = versionData ? this.apiService.contentApi.getVersionContentUrl(this.nodeId, versionData.id) :
             this.apiService.contentApi.getContentUrl(this.nodeId);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Uploading as new version a file with the same name, the browser cache prevents the user to see the versioned file


**What is the new behaviour?**
File are now cached wih url and version this should show the new file whenever a new version has been uploaded.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://alfresco.atlassian.net/browse/ACA-4202