### PR TITLE
ACA-4175 Show number of user's home folders during environment scan

### DIFF
--- a/lib/cli/scripts/scan-env.ts
+++ b/lib/cli/scripts/scan-env.ts
@@ -76,9 +76,7 @@ async function getPeopleCount(skipCount: number = 0): Promise<PeopleTally> {
 async function getHomeFoldersCount(): Promise<number> {
     try {
         const nodesApi = new NodesApi(jsApiConnection);
-        const rootApiResult = await nodesApi.listNodeChildren('-root-');
-        const userHomesFolderId = rootApiResult.list.entries.find(associationEntry => associationEntry.entry.name === 'User Homes').entry.id;
-        const homesFolderApiResult = await nodesApi.listNodeChildren(userHomesFolderId);
+        const homesFolderApiResult = await nodesApi.listNodeChildren('-root-', { relativePath: 'User Homes' });
         return homesFolderApiResult.list.pagination.totalItems;
     } catch (error) {
         console.log(error);

--- a/lib/cli/scripts/scan-env.ts
+++ b/lib/cli/scripts/scan-env.ts
@@ -4,6 +4,7 @@ const program = require('commander');
 const MAX_ATTEMPTS = 10;
 const TIMEOUT = 60000;
 const MAX_PEOPLE_PER_PAGE = 100;
+const USERS_HOME_RELATIVE_PATH = 'User Homes';
 
 let jsApiConnection;
 let loginAttempts: number = 0;
@@ -76,7 +77,7 @@ async function getPeopleCount(skipCount: number = 0): Promise<PeopleTally> {
 async function getHomeFoldersCount(): Promise<number> {
     try {
         const nodesApi = new NodesApi(jsApiConnection);
-        const homesFolderApiResult = await nodesApi.listNodeChildren('-root-', { relativePath: 'User Homes' });
+        const homesFolderApiResult = await nodesApi.listNodeChildren('-root-', { relativePath: USERS_HOME_RELATIVE_PATH });
         return homesFolderApiResult.list.pagination.totalItems;
     } catch (error) {
         console.log(error);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

The environment scan shows only number of activated and deactivated users.

**What is the new behaviour?**

As well as the above information, the environment scan also show the number of user's home folders.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
