### PR TITLE
ACA-4176 & ACA-4177 Show number of groups, sites and files during environment scan

### DIFF
--- a/lib/cli/scripts/scan-env.ts
+++ b/lib/cli/scripts/scan-env.ts
@@ -1,4 +1,4 @@
-const { AlfrescoApiCompatibility, PeopleApi, NodesApi } = require('@alfresco/js-api');
+const { AlfrescoApiCompatibility, PeopleApi, NodesApi, GroupsApi, SitesApi, SearchApi } = require('@alfresco/js-api');
 const program = require('commander');
 
 const MAX_ATTEMPTS = 10;
@@ -26,6 +26,15 @@ export default async function main(_args: string[]) {
 
     const homeFoldersCount = await getHomeFoldersCount();
     console.log("User's Home Folders :", homeFoldersCount);
+
+    const groupsCount = await getGroupsCount();
+    console.log('Groups              :', groupsCount);
+
+    const sitesCount = await getSitesCount();
+    console.log('Sites               :', sitesCount);
+
+    const filesCount = await getFilesCount();
+    console.log('Files               :', filesCount);
 
 }
 
@@ -77,8 +86,49 @@ async function getPeopleCount(skipCount: number = 0): Promise<PeopleTally> {
 async function getHomeFoldersCount(): Promise<number> {
     try {
         const nodesApi = new NodesApi(jsApiConnection);
-        const homesFolderApiResult = await nodesApi.listNodeChildren('-root-', { relativePath: USERS_HOME_RELATIVE_PATH });
+        const homesFolderApiResult = await nodesApi.listNodeChildren('-root-', {
+            maxItems: 1,
+            relativePath: USERS_HOME_RELATIVE_PATH
+        });
         return homesFolderApiResult.list.pagination.totalItems;
+    } catch (error) {
+        console.log(error);
+    }
+}
+
+async function getGroupsCount(): Promise<number> {
+    try {
+        const groupsApi = new GroupsApi(jsApiConnection);
+        const groupsApiResult = await groupsApi.listGroups({ maxItems: 1 });
+        return groupsApiResult.list.pagination.totalItems;
+    } catch (error) {
+        console.log(error);
+    }
+}
+
+async function getSitesCount(): Promise<number> {
+    try {
+        const sitesApi = new SitesApi(jsApiConnection);
+        const sitesApiResult = await sitesApi.listSites({ maxItems: 1 });
+        return sitesApiResult.list.pagination.totalItems;
+    } catch (error) {
+        console.log(error);
+    }
+}
+
+async function getFilesCount(): Promise<number> {
+    try {
+        const searchApi = new SearchApi(jsApiConnection);
+        const searchApiResult = await searchApi.search({
+            query: {
+                query: "select * from cmis:document",
+                language: 'cmis'
+            },
+            paging: {
+                maxItems: 1
+            }
+        });
+        return searchApiResult.list.pagination.totalItems;
     } catch (error) {
         console.log(error);
     }
@@ -89,3 +139,5 @@ async function wait(ms: number) {
         setTimeout(resolve, ms);
     });
 }
+
+main([]);

--- a/lib/cli/scripts/scan-env.ts
+++ b/lib/cli/scripts/scan-env.ts
@@ -139,5 +139,3 @@ async function wait(ms: number) {
         setTimeout(resolve, ms);
     });
 }
-
-main([]);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Environment scan will only show the number of active, deactivated users and home folders.

**What is the new behaviour?**

Environment scan also shows the number of groups, sites and files.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
