### PR TITLE
TestElement prototype to greatly reduce e2e coding time

### DIFF
--- a/e2e/content-services/directives/create-library-directive.e2e.ts
+++ b/e2e/content-services/directives/create-library-directive.e2e.ts
@@ -68,38 +68,38 @@ describe('Create library directive', () => {
     });
 
     it('[C290158] Should display the Create Library defaults', async () => {
-        await expect(await createLibraryDialog.getTitle()).toMatch('Create Library');
-        await expect(await createLibraryDialog.isNameDisplayed()).toBe(true, 'Name input field is not displayed');
-        await expect(await createLibraryDialog.isLibraryIdDisplayed()).toBe(true, 'Library ID field is not displayed');
-        await expect(await createLibraryDialog.isDescriptionDisplayed()).toBe(true, 'Library description is not displayed');
-        await expect(await createLibraryDialog.isPublicDisplayed()).toBe(true, 'Public radio button is not displayed');
-        await expect(await createLibraryDialog.isPrivateDisplayed()).toBe(true, 'Private radio button is not displayed');
-        await expect(await createLibraryDialog.isModeratedDisplayed()).toBe(true, 'Moderated radio button is not displayed');
-        await expect(await createLibraryDialog.isCreateEnabled()).toBe(false, 'Create button is not disabled');
-        await expect(await createLibraryDialog.isCancelEnabled()).toBe(true, 'Cancel button is disabled');
+        await expect(await createLibraryDialog.libraryTitle.getText()).toMatch('Create Library');
+        await expect(await createLibraryDialog.libraryNameField.isDisplayed()).toBe(true, 'Name input field is not displayed');
+        await expect(await createLibraryDialog.libraryIdField.isDisplayed()).toBe(true, 'Library ID field is not displayed');
+        await expect(await createLibraryDialog.libraryDescriptionField.isDisplayed()).toBe(true, 'Library description is not displayed');
+        await expect(await createLibraryDialog.publicRadioButton.isDisplayed()).toBe(true, 'Public radio button is not displayed');
+        await expect(await createLibraryDialog.privateRadioButton.isDisplayed()).toBe(true, 'Private radio button is not displayed');
+        await expect(await createLibraryDialog.moderatedRadioButton.isDisplayed()).toBe(true, 'Moderated radio button is not displayed');
+        await expect(await createLibraryDialog.createButton.isEnabled()).toBe(false, 'Create button is not disabled');
+        await expect(await createLibraryDialog.cancelButton.isEnabled()).toBe(true, 'Cancel button is disabled');
         await expect(await createLibraryDialog.getSelectedRadio()).toMatch(visibility.public, 'The default visibility is not public');
     });
 
     it('[C290159] Should close the dialog when clicking Cancel button', async () => {
         const libraryName = 'cancelLibrary';
 
-        await createLibraryDialog.typeLibraryName(libraryName);
-        await createLibraryDialog.clickCancel();
-        await createLibraryDialog.waitForDialogToClose();
+        await createLibraryDialog.libraryNameField.typeText(libraryName);
+        await createLibraryDialog.cancelButton.click();
+        await createLibraryDialog.libraryDialog.waitNotPresent(60000);
     });
 
     it('[C290160] Should create a public library', async () => {
         const libraryName = StringUtil.generateRandomString();
         const libraryDescription = StringUtil.generateRandomString();
 
-        await createLibraryDialog.typeLibraryName(libraryName);
-        await createLibraryDialog.typeLibraryDescription(libraryDescription);
-        await createLibraryDialog.selectPublic();
+        await createLibraryDialog.libraryNameField.typeText(libraryName);
+        await createLibraryDialog.libraryDescriptionField.typeText(libraryDescription);
+        await createLibraryDialog.publicRadioButton.click();
 
         await expect(await createLibraryDialog.getSelectedRadio()).toMatch(visibility.public, 'The visibility is not public');
 
-        await createLibraryDialog.clickCreate();
-        await createLibraryDialog.waitForDialogToClose();
+        await createLibraryDialog.createButton.click();
+        await createLibraryDialog.libraryDialog.waitNotPresent(60000);
 
         await customSourcesPage.navigateToCustomSources();
         await customSourcesPage.selectMySitesSourceType();
@@ -112,14 +112,14 @@ describe('Create library directive', () => {
         const libraryName = StringUtil.generateRandomString();
         const libraryDescription = StringUtil.generateRandomString();
 
-        await createLibraryDialog.typeLibraryName(libraryName);
-        await createLibraryDialog.typeLibraryDescription(libraryDescription);
-        await createLibraryDialog.selectPrivate();
+        await createLibraryDialog.libraryNameField.typeText(libraryName);
+        await createLibraryDialog.libraryDescriptionField.typeText(libraryDescription);
+        await createLibraryDialog.privateRadioButton.click();
 
         await expect(await createLibraryDialog.getSelectedRadio()).toMatch(visibility.private, 'The visibility is not private');
 
-        await createLibraryDialog.clickCreate();
-        await createLibraryDialog.waitForDialogToClose();
+        await createLibraryDialog.createButton.click();
+        await createLibraryDialog.libraryDialog.waitNotPresent(60000);
 
         await customSourcesPage.navigateToCustomSources();
         await customSourcesPage.selectMySitesSourceType();
@@ -132,15 +132,15 @@ describe('Create library directive', () => {
         const libraryName = StringUtil.generateRandomString();
         const libraryId = StringUtil.generateRandomString();
         const libraryDescription = StringUtil.generateRandomString();
-        await createLibraryDialog.typeLibraryName(libraryName);
-        await createLibraryDialog.typeLibraryId(libraryId);
-        await createLibraryDialog.typeLibraryDescription(libraryDescription);
-        await createLibraryDialog.selectModerated();
+        await createLibraryDialog.libraryNameField.typeText(libraryName);
+        await createLibraryDialog.libraryIdField.typeText(libraryId);
+        await createLibraryDialog.libraryDescriptionField.typeText(libraryDescription);
+        await createLibraryDialog.moderatedRadioButton.click();
 
         await expect(await createLibraryDialog.getSelectedRadio()).toMatch(visibility.moderated, 'The visibility is not moderated');
 
-        await createLibraryDialog.clickCreate();
-        await createLibraryDialog.waitForDialogToClose();
+        await createLibraryDialog.createButton.click();
+        await createLibraryDialog.libraryDialog.waitNotPresent(60000);
 
         await customSourcesPage.navigateToCustomSources();
         await customSourcesPage.selectMySitesSourceType();
@@ -152,17 +152,17 @@ describe('Create library directive', () => {
     it('[C290163] Should disable Create button when a mandatory field is not filled in', async () => {
         const inputValue = StringUtil.generateRandomString();
 
-        await createLibraryDialog.typeLibraryName(inputValue);
-        await createLibraryDialog.clearLibraryId();
-        await expect(await createLibraryDialog.isCreateEnabled()).not.toBe(true, 'The Create button is enabled');
-        await createLibraryDialog.clearLibraryName();
+        await createLibraryDialog.libraryNameField.typeText(inputValue);
+        await createLibraryDialog.libraryIdField.clearInput();
+        await expect(await createLibraryDialog.createButton.isEnabled()).not.toBe(true, 'The Create button is enabled');
+        await createLibraryDialog.libraryNameField.clearInput();
 
-        await createLibraryDialog.typeLibraryId(inputValue);
-        await expect(await createLibraryDialog.isCreateEnabled()).not.toBe(true, 'The Create button is enabled');
-        await createLibraryDialog.clearLibraryId();
+        await createLibraryDialog.libraryIdField.typeText(inputValue);
+        await expect(await createLibraryDialog.createButton.isEnabled()).not.toBe(true, 'The Create button is enabled');
+        await createLibraryDialog.libraryIdField.clearInput();
 
-        await createLibraryDialog.typeLibraryDescription(inputValue);
-        await expect(await createLibraryDialog.isCreateEnabled()).not.toBe(true, 'The Create button is enabled');
+        await createLibraryDialog.libraryDescriptionField.typeText(inputValue);
+        await expect(await createLibraryDialog.createButton.isEnabled()).not.toBe(true, 'The Create button is enabled');
     });
 
     it('[C290164] Should auto-fill in the Library Id built from library name', async () => {
@@ -170,9 +170,9 @@ describe('Create library directive', () => {
         const libraryId: string[] = ['abcd1234', 'ab-cd-12-34', 'ab-cd1234link'];
 
         for (let i = 0; i < 3; i++) {
-            await createLibraryDialog.typeLibraryName(name[i]);
-            await createLibraryDialog.waitUntilLibraryIdTextHasValue(libraryId[i]);
-            await createLibraryDialog.clearLibraryName();
+            await createLibraryDialog.libraryNameField.typeText(name[i]);
+            await createLibraryDialog.libraryIdField.waitHasValue(libraryId[i]);
+            await createLibraryDialog.libraryNameField.clearInput();
         }
     });
 
@@ -180,12 +180,12 @@ describe('Create library directive', () => {
         const name = 'My Library';
         const libraryId: string[] = ['My New Library', 'My+New+Library123!', '<>'];
 
-        await createLibraryDialog.typeLibraryName(name);
+        await createLibraryDialog.libraryNameField.typeText(name);
 
         for (let i = 0; i < 3; i++) {
-            await createLibraryDialog.typeLibraryId(libraryId[i]);
-            await createLibraryDialog.waitErrorMessageIsDisplayed();
-            await expect(await createLibraryDialog.getErrorMessage()).toMatch('Use numbers and letters only');
+            await createLibraryDialog.libraryIdField.typeText(libraryId[i]);
+            await createLibraryDialog.errorMessage.waitVisible(60000);
+            await expect(await createLibraryDialog.errorMessage.getText()).toMatch('Use numbers and letters only');
         }
     });
 
@@ -193,52 +193,52 @@ describe('Create library directive', () => {
         const name = 'x';
         const libraryId = 'my-library-id';
 
-        await createLibraryDialog.typeLibraryName(name);
-        await createLibraryDialog.typeLibraryId(libraryId);
-        await createLibraryDialog.waitErrorMessageIsDisplayed();
-        await expect(await createLibraryDialog.getErrorMessage()).toMatch('Title must be at least 2 characters long');
+        await createLibraryDialog.libraryNameField.typeText(name);
+        await createLibraryDialog.libraryIdField.typeText(libraryId);
+        await createLibraryDialog.errorMessage.waitVisible(60000);
+        await expect(await createLibraryDialog.errorMessage.getText()).toMatch('Title must be at least 2 characters long');
     });
 
     it('[C291793] Should display error for Name field filled in with spaces only', async () => {
         const name = '    ';
         const libraryId = StringUtil.generateRandomString();
 
-        await createLibraryDialog.typeLibraryName(name);
-        await createLibraryDialog.typeLibraryId(libraryId);
+        await createLibraryDialog.libraryNameField.typeText(name);
+        await createLibraryDialog.libraryIdField.typeText(libraryId);
 
-        await createLibraryDialog.waitErrorMessageIsDisplayed();
-        await expect(await createLibraryDialog.getErrorMessage()).toMatch("Library name can't contain only spaces");
+        await createLibraryDialog.errorMessage.waitVisible(60000);
+        await expect(await createLibraryDialog.errorMessage.getText()).toMatch("Library name can't contain only spaces");
     });
 
     it('[C290177] Should not accept a duplicate Library Id', async () => {
         const name = 'My Library';
         const libraryId = StringUtil.generateRandomString();
 
-        await createLibraryDialog.typeLibraryName(name);
-        await createLibraryDialog.typeLibraryId(libraryId);
-        await createLibraryDialog.clickCreate();
-        await createLibraryDialog.waitForDialogToClose();
+        await createLibraryDialog.libraryNameField.typeText(name);
+        await createLibraryDialog.libraryIdField.typeText(libraryId);
+        await createLibraryDialog.createButton.click();
+        await createLibraryDialog.libraryDialog.waitNotPresent(60000);
 
         await contentServicesPage.openCreateLibraryDialog();
 
-        await createLibraryDialog.typeLibraryName(name);
-        await createLibraryDialog.typeLibraryId(libraryId);
-        await createLibraryDialog.waitErrorMessageIsDisplayed();
-        await expect(await createLibraryDialog.getErrorMessage()).toMatch("This Library ID isn't available. Try a different Library ID.");
+        await createLibraryDialog.libraryNameField.typeText(name);
+        await createLibraryDialog.libraryIdField.typeText(libraryId);
+        await createLibraryDialog.errorMessage.waitVisible(60000);
+        await expect(await createLibraryDialog.errorMessage.getText()).toMatch("This Library ID isn't available. Try a different Library ID.");
     });
 
     it('[C290178] Should accept the same library name but different Library Ids', async () => {
         const name = createSite.entry.title;
         const libraryId = StringUtil.generateRandomString();
 
-        await createLibraryDialog.typeLibraryName(name.toUpperCase());
-        await createLibraryDialog.typeLibraryId(libraryId);
+        await createLibraryDialog.libraryNameField.typeText(name.toUpperCase());
+        await createLibraryDialog.libraryIdField.typeText(libraryId);
 
-        await createLibraryDialog.waitForLibraryNameHint();
-        await expect(await createLibraryDialog.getLibraryNameHint()).toMatch('Library name already in use', 'The library name hint is wrong');
+        await createLibraryDialog.libraryNameHint.waitVisible();
+        await expect(await createLibraryDialog.libraryNameHint.getText()).toMatch('Library name already in use', 'The library name hint is wrong');
 
-        await createLibraryDialog.clickCreate();
-        await createLibraryDialog.waitForDialogToClose();
+        await createLibraryDialog.createButton.click();
+        await createLibraryDialog.libraryDialog.waitNotPresent(60000);
     });
 
     it('[C290179] Should not accept more than the expected characters for input fields', async () => {
@@ -246,11 +246,11 @@ describe('Create library directive', () => {
         const libraryId = StringUtil.generateRandomString(73);
         const libraryDescription = StringUtil.generateRandomString(513);
 
-        await createLibraryDialog.typeLibraryName(name);
-        await createLibraryDialog.typeLibraryId(libraryId);
-        await createLibraryDialog.typeLibraryDescription(libraryDescription);
+        await createLibraryDialog.libraryNameField.typeText(name);
+        await createLibraryDialog.libraryIdField.typeText(libraryId);
+        await createLibraryDialog.libraryDescriptionField.typeText(libraryDescription);
 
-        await createLibraryDialog.selectPublic();
+        await createLibraryDialog.publicRadioButton.click();
 
         await expect(await createLibraryDialog.getErrorMessages(0)).toMatch('Use 256 characters or less for title');
         await expect(await createLibraryDialog.getErrorMessages(1)).toMatch('Use 72 characters or less for the URL name');

--- a/e2e/content-services/lock-file.e2e.ts
+++ b/e2e/content-services/lock-file.e2e.ts
@@ -106,16 +106,16 @@ describe('Lock File', () => {
         it('[C286604] Should be able to open Lock file option by clicking the lock image', async () => {
             await contentServices.lockContent(pngFileModel.name);
 
-            await lockFilePage.checkLockFileCheckboxIsDisplayed();
-            await lockFilePage.checkCancelButtonIsDisplayed();
-            await lockFilePage.checkSaveButtonIsDisplayed();
+            await lockFilePage.lockFileCheckboxText.waitVisible();
+            await lockFilePage.cancelButton.waitVisible();
+            await lockFilePage.saveButton.waitVisible();
         });
 
         it('[C286625] Should be able to click Cancel to cancel lock file operation', async () => {
             await contentServices.lockContent(pngFileModel.name);
 
-            await lockFilePage.checkLockFileCheckboxIsDisplayed();
-            await lockFilePage.clickCancelButton();
+            await lockFilePage.lockFileCheckboxText.waitVisible();
+            await lockFilePage.cancelButton.click();
 
             await contentServices.checkUnlockedIcon(pngFileModel.name);
         });
@@ -123,9 +123,9 @@ describe('Lock File', () => {
         it('[C286603] Should be able to click on Lock file checkbox and lock a file', async () => {
             await contentServices.lockContent(pngFileToLock.name);
 
-            await lockFilePage.checkLockFileCheckboxIsDisplayed();
-            await lockFilePage.clickLockFileCheckbox();
-            await lockFilePage.clickSaveButton();
+            await lockFilePage.lockFileCheckboxText.waitVisible();
+            await lockFilePage.lockFileCheckbox.click();
+            await lockFilePage.saveButton.click();
 
             await contentServices.checkLockedIcon(pngFileToLock.name);
         });
@@ -133,15 +133,15 @@ describe('Lock File', () => {
         it('[C286618] Should be able to uncheck Lock file checkbox and unlock a file', async () => {
             await contentServices.lockContent(pngFileModel.name);
 
-            await lockFilePage.checkLockFileCheckboxIsDisplayed();
-            await lockFilePage.clickLockFileCheckbox();
-            await lockFilePage.clickSaveButton();
+            await lockFilePage.lockFileCheckboxText.waitVisible();
+            await lockFilePage.lockFileCheckbox.click();
+            await lockFilePage.saveButton.click();
 
             await contentServices.checkLockedIcon(pngFileModel.name);
             await contentServices.lockContent(pngFileModel.name);
 
-            await lockFilePage.clickLockFileCheckbox();
-            await lockFilePage.clickSaveButton();
+            await lockFilePage.lockFileCheckbox.click();
+            await lockFilePage.saveButton.click();
 
             await contentServices.checkUnlockedIcon(pngFileModel.name);
         });
@@ -174,9 +174,9 @@ describe('Lock File', () => {
         it('[C286610] Should not be able to delete a locked file', async () => {
             await contentServices.lockContent(pngFileModel.name);
 
-            await lockFilePage.checkLockFileCheckboxIsDisplayed();
-            await lockFilePage.clickLockFileCheckbox();
-            await lockFilePage.clickSaveButton();
+            await lockFilePage.lockFileCheckboxText.waitVisible();
+            await lockFilePage.lockFileCheckbox.click();
+            await lockFilePage.saveButton.click();
 
             try {
                 await apiService.getInstance().core.nodesApi.deleteNode(nodeId);
@@ -188,9 +188,9 @@ describe('Lock File', () => {
         it('[C286611] Should not be able to rename a locked file', async () => {
             await contentServices.lockContent(pngFileModel.name);
 
-            await lockFilePage.checkLockFileCheckboxIsDisplayed();
-            await lockFilePage.clickLockFileCheckbox();
-            await lockFilePage.clickSaveButton();
+            await lockFilePage.lockFileCheckboxText.waitVisible();
+            await lockFilePage.lockFileCheckbox.click();
+            await lockFilePage.saveButton.click();
 
             try {
                 await apiService.getInstance().core.nodesApi.updateNode(nodeId, { name: 'My new name' });
@@ -203,9 +203,9 @@ describe('Lock File', () => {
         it('[C286612] Should not be able to move a locked file', async () => {
             await contentServices.lockContent(pngFileModel.name);
 
-            await lockFilePage.checkLockFileCheckboxIsDisplayed();
-            await lockFilePage.clickLockFileCheckbox();
-            await lockFilePage.clickSaveButton();
+            await lockFilePage.lockFileCheckboxText.waitVisible();
+            await lockFilePage.lockFileCheckbox.click();
+            await lockFilePage.saveButton.click();
 
             try {
                 await apiService.getInstance().core.nodesApi.moveNode(nodeId, { targetParentId: '-my-' });
@@ -218,9 +218,9 @@ describe('Lock File', () => {
         it('[C286613] Should not be able to update a new version on a locked file', async () => {
             await contentServices.lockContent(pngFileModel.name);
 
-            await lockFilePage.checkLockFileCheckboxIsDisplayed();
-            await lockFilePage.clickLockFileCheckbox();
-            await lockFilePage.clickSaveButton();
+            await lockFilePage.lockFileCheckboxText.waitVisible();
+            await lockFilePage.lockFileCheckbox.click();
+            await lockFilePage.saveButton.click();
 
             try {
                 await apiService.getInstance().core.nodesApi.updateNodeContent(nodeId, 'NEW FILE CONTENT');
@@ -255,10 +255,10 @@ describe('Lock File', () => {
         it('[C286614] Owner of the locked file should be able to rename if Allow owner to modify is checked', async () => {
             await contentServices.lockContent(pngFileModel.name);
 
-            await lockFilePage.checkLockFileCheckboxIsDisplayed();
-            await lockFilePage.clickLockFileCheckbox();
-            await lockFilePage.clickAllowOwnerCheckbox();
-            await lockFilePage.clickSaveButton();
+            await lockFilePage.lockFileCheckboxText.waitVisible();
+            await lockFilePage.lockFileCheckbox.click();
+            await lockFilePage.allowOwnerCheckbox.click();
+            await lockFilePage.saveButton.click();
 
             try {
                 const response = await apiService.getInstance().core.nodesApi.updateNode(nodeId, { name: 'My new name' });
@@ -270,10 +270,10 @@ describe('Lock File', () => {
         it('[C286615] Owner of the locked file should be able to update a new version if Allow owner to modify is checked', async () => {
             await contentServices.lockContent(pngFileModel.name);
 
-            await lockFilePage.checkLockFileCheckboxIsDisplayed();
-            await lockFilePage.clickLockFileCheckbox();
-            await lockFilePage.clickAllowOwnerCheckbox();
-            await lockFilePage.clickSaveButton();
+            await lockFilePage.lockFileCheckboxText.waitVisible();
+            await lockFilePage.lockFileCheckbox.click();
+            await lockFilePage.allowOwnerCheckbox.click();
+            await lockFilePage.saveButton.click();
 
             try {
                 const response = await apiService.getInstance().core.nodesApi.updateNodeContent(nodeId, 'NEW FILE CONTENT');
@@ -285,10 +285,10 @@ describe('Lock File', () => {
         it('[C286616] Owner of the locked file should be able to move if Allow owner to modify is checked', async () => {
             await contentServices.lockContent(pngFileModel.name);
 
-            await lockFilePage.checkLockFileCheckboxIsDisplayed();
-            await lockFilePage.clickLockFileCheckbox();
-            await lockFilePage.clickAllowOwnerCheckbox();
-            await lockFilePage.clickSaveButton();
+            await lockFilePage.lockFileCheckboxText.waitVisible();
+            await lockFilePage.lockFileCheckbox.click();
+            await lockFilePage.allowOwnerCheckbox.click();
+            await lockFilePage.saveButton.click();
 
             try {
                 await apiService.getInstance().core.nodesApi.moveNode(nodeId, { targetParentId: '-my-' });
@@ -303,10 +303,10 @@ describe('Lock File', () => {
         it('[C286617] Owner of the locked file should be able to delete if Allow owner to modify is checked', async () => {
             await contentServices.lockContent(pngFileToLock.name);
 
-            await lockFilePage.checkLockFileCheckboxIsDisplayed();
-            await lockFilePage.clickLockFileCheckbox();
-            await lockFilePage.clickAllowOwnerCheckbox();
-            await lockFilePage.clickSaveButton();
+            await lockFilePage.lockFileCheckboxText.waitVisible();
+            await lockFilePage.lockFileCheckbox.click();
+            await lockFilePage.allowOwnerCheckbox.click();
+            await lockFilePage.saveButton.click();
 
             await contentServices.deleteContent(pngFileToBeLocked.entry.name);
             await contentServices.checkContentIsNotDisplayed(pngFileToBeLocked.entry.name);

--- a/e2e/content-services/pages/lock-file.page.ts
+++ b/e2e/content-services/pages/lock-file.page.ts
@@ -15,42 +15,13 @@
  * limitations under the License.
  */
 
-import { element, by } from 'protractor';
-import { BrowserVisibility, BrowserActions } from '@alfresco/adf-testing';
+import { TestElement } from '@alfresco/adf-testing';
 
 export class LockFilePage {
 
-    cancelButton = element(by.css('button[data-automation-id="lock-dialog-btn-cancel"]'));
-    saveButton = element(by.cssContainingText('button span', 'Save'));
-    lockFileCheckboxText = element(by.cssContainingText('mat-checkbox label span', ' Lock file '));
-    lockFileCheckbox = element(by.css('mat-checkbox[data-automation-id="adf-lock-node-checkbox"]'));
-    allowOwnerCheckbox = element(by.cssContainingText('mat-checkbox[class*="adf-lock-file-name"] span', ' Allow the owner to modify this file '));
-
-    async checkLockFileCheckboxIsDisplayed(): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.lockFileCheckboxText);
-    }
-
-    async checkCancelButtonIsDisplayed(): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.cancelButton);
-    }
-
-    async checkSaveButtonIsDisplayed(): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.saveButton);
-    }
-
-    async clickCancelButton(): Promise<void> {
-        await BrowserActions.click(this.cancelButton);
-    }
-
-    async clickLockFileCheckbox(): Promise<void> {
-        await BrowserActions.click(this.lockFileCheckbox);
-    }
-
-    async clickSaveButton(): Promise<void> {
-        await BrowserActions.click(this.saveButton);
-    }
-
-    async clickAllowOwnerCheckbox(): Promise<void> {
-        await BrowserActions.click(this.allowOwnerCheckbox);
-    }
+    cancelButton = TestElement.byCss('button[data-automation-id="lock-dialog-btn-cancel"]');
+    saveButton = TestElement.byText('button span', 'Save');
+    lockFileCheckboxText = TestElement.byText('mat-checkbox label span', ' Lock file ');
+    lockFileCheckbox = TestElement.byCss('mat-checkbox[data-automation-id="adf-lock-node-checkbox"]');
+    allowOwnerCheckbox = TestElement.byText('mat-checkbox[class*="adf-lock-file-name"] span', ' Allow the owner to modify this file ');
 }

--- a/e2e/content-services/pages/permissions.page.ts
+++ b/e2e/content-services/pages/permissions.page.ts
@@ -15,12 +15,7 @@
  * limitations under the License.
  */
 
-import {
-    DataTableComponentPage,
-    AddPermissionsDialogPage,
-    BrowserVisibility,
-    BrowserActions
-} from '@alfresco/adf-testing';
+import { DataTableComponentPage, AddPermissionsDialogPage, TestElement } from '@alfresco/adf-testing';
 import { browser, by, element } from 'protractor';
 
 export class PermissionsPage {
@@ -28,7 +23,7 @@ export class PermissionsPage {
     dataTableComponentPage = new DataTableComponentPage();
     addPermissionsDialog = new AddPermissionsDialogPage();
 
-    addPermissionButton = element(by.css("button[data-automation-id='adf-add-permission-button']"));
+    addPermissionButton = TestElement.byCss("button[data-automation-id='adf-add-permission-button']");
     addPermissionDialog = element(by.css('adf-add-permission-dialog'));
     searchUserInput = element(by.id('searchInput'));
     searchResults = element(by.css('#adf-add-permission-authority-results #adf-search-results-content'));
@@ -37,20 +32,12 @@ export class PermissionsPage {
     noPermissions = element(by.id('adf-no-permissions-template'));
     deletePermissionButton = element(by.css(`button[data-automation-id='adf-delete-permission-button']`));
     permissionDisplayContainer = element(by.id('adf-permission-display-container'));
-    closeButton = element(by.id('add-permission-dialog-close-button'));
-
-    async clickCloseButton(): Promise<void> {
-        await BrowserActions.click(this.closeButton);
-    }
+    closeButton = TestElement.byCss('#add-permission-dialog-close-button');
 
     async changePermission(name: string, role: string): Promise<void> {
         await this.addPermissionsDialog.clickRoleDropdownByUserOrGroupName(name);
         await this.addPermissionsDialog.selectOption(role);
         await browser.sleep(500);
         await this.dataTableComponentPage.checkRowIsNotSelected('Authority ID', name);
-    }
-
-    async checkAddPermissionButtonIsDisplayed(): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.addPermissionButton);
     }
 }

--- a/e2e/content-services/pages/tag.page.ts
+++ b/e2e/content-services/pages/tag.page.ts
@@ -15,29 +15,26 @@
  * limitations under the License.
  */
 
-import { Locator, element, by, protractor, browser } from 'protractor';
-import { BrowserVisibility, BrowserActions } from '@alfresco/adf-testing';
+import { element, by, protractor, browser } from 'protractor';
+import { BrowserActions, TestElement } from '@alfresco/adf-testing';
 
 export class TagPage {
 
-    addTagButton = element(by.id('add-tag'));
+    addTagButton = TestElement.byCss('#add-tag');
     insertNodeIdElement = element(by.css('input[id="nodeId"]'));
-    newTagInput = element(by.css('input[id="new-tag-text"]'));
-    tagListRow = element(by.css('adf-tag-node-actions-list mat-list-item'));
-    tagListByNodeIdRow = element(by.css('adf-tag-node-list mat-chip'));
-    errorMessage = element(by.css('mat-hint[data-automation-id="errorMessage"]'));
-    tagListRowLocator: Locator = by.css('adf-tag-node-actions-list mat-list-item div');
-    tagListByNodeIdRowLocator: Locator = by.css('adf-tag-node-list mat-chip span');
-    tagListContentServicesRowLocator: Locator = by.css('div[class*="adf-list-tag"]');
-    showDeleteButton = element(by.id('adf-remove-button-tag'));
-    showMoreButton = element(by.css('button[data-automation-id="show-more-tags"]'));
-    showLessButton = element(by.css('button[data-automation-id="show-fewer-tags"]'));
+    newTagInput = TestElement.byCss('input[id="new-tag-text"]');
+    tagListRow = TestElement.byCss('adf-tag-node-actions-list mat-list-item');
+    tagListByNodeIdRow = TestElement.byCss('adf-tag-node-list mat-chip');
+    errorMessage = TestElement.byCss('mat-hint[data-automation-id="errorMessage"]');
+    tagListContentServicesRowLocator = by.css('div[class*="adf-list-tag"]');
+    showDeleteButton = TestElement.byCss('#adf-remove-button-tag');
+    showMoreButton = TestElement.byCss('button[data-automation-id="show-more-tags"]');
+    showLessButton = TestElement.byCss('button[data-automation-id="show-fewer-tags"]');
     tagsOnPage = element.all(by.css('div[class*="adf-list-tag"]'));
-    confirmTag = element(by.id('adf-tag-node-send'));
+    confirmTag = TestElement.byCss('#adf-tag-node-send');
 
-    async getNodeId(): Promise<string> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.insertNodeIdElement);
-        return this.insertNodeIdElement.getAttribute('value');
+    getNodeId(): Promise<string> {
+        return new TestElement(this.insertNodeIdElement).getAttribute('value');
     }
 
     async insertNodeId(nodeId) {
@@ -47,163 +44,48 @@ export class TagPage {
         await this.insertNodeIdElement.sendKeys(' ');
         await browser.sleep(200);
         await this.insertNodeIdElement.sendKeys(protractor.Key.BACK_SPACE);
-        await this.clickConfirmTag();
-    }
-
-    async addNewTagInput(tag: string) {
-        await BrowserActions.clearSendKeys(this.newTagInput, tag);
+        await this.confirmTag.click();
     }
 
     async addTag(tag: string): Promise<void> {
-        await this.addNewTagInput(tag);
-        await BrowserActions.click(this.addTagButton);
+        await this.newTagInput.typeText(tag);
+        return this.addTagButton.click();
     }
 
-    async deleteTagFromTagListByNodeId(name: string): Promise<void> {
-        const deleteChip = element(by.id('tag_chips_delete_' + name));
-        await BrowserActions.click(deleteChip);
+    deleteTagFromTagListByNodeId(name: string): Promise<void> {
+        return TestElement.byId('tag_chips_delete_' + name).click();
     }
 
-    async deleteTagFromTagList(name: string): Promise<void> {
-        const deleteChip = element(by.id('tag_chips_delete_' + name));
-        await BrowserActions.click(deleteChip);
-    }
-
-    async getNewTagInput(): Promise<string> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.newTagInput);
-        return this.newTagInput.getAttribute('value');
-    }
-
-    async getNewTagPlaceholder(): Promise<string> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.newTagInput);
-        return this.newTagInput.getAttribute('data-placeholder');
+    deleteTagFromTagList(name: string): Promise<void> {
+        return TestElement.byId('tag_chips_delete_' + name).click();
     }
 
     async addTagButtonIsEnabled(): Promise<boolean> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.addTagButton);
+        await this.addTagButton.waitVisible();
         return this.addTagButton.isEnabled();
     }
 
-    async checkTagIsDisplayedInTagList(tagName: string): Promise<void> {
-        const tag = element(by.cssContainingText('div[id*="tag_name"]', tagName));
-        await BrowserVisibility.waitUntilElementIsVisible(tag);
+    checkTagIsDisplayedInTagList(tagName: string): Promise<void> {
+        return TestElement.byText('div[id*="tag_name"]', tagName).waitVisible();
     }
 
-    async checkTagIsNotDisplayedInTagList(tagName: string): Promise<void> {
-        const tag = element(by.cssContainingText('div[id*="tag_name"]', tagName));
-        await BrowserVisibility.waitUntilElementIsNotVisible(tag);
+    checkTagIsNotDisplayedInTagList(tagName: string): Promise<void> {
+        return TestElement.byText('div[id*="tag_name"]', tagName).waitNotVisible();
     }
 
-    async checkTagIsNotDisplayedInTagListByNodeId(tagName: string): Promise<void> {
-        const tag = element(by.cssContainingText('span[id*="tag_name"]', tagName));
-        await BrowserVisibility.waitUntilElementIsNotVisible(tag);
+    checkTagIsNotDisplayedInTagListByNodeId(tagName: string): Promise<void> {
+        return TestElement.byText('span[id*="tag_name"]', tagName).waitNotVisible();
     }
 
-    async checkTagIsDisplayedInTagListByNodeId(tagName: string): Promise<void> {
-        const tag = element(by.cssContainingText('span[id*="tag_name"]', tagName));
-        await BrowserVisibility.waitUntilElementIsVisible(tag);
+    checkTagIsDisplayedInTagListByNodeId(tagName: string): Promise<void> {
+        return TestElement.byText('span[id*="tag_name"]', tagName).waitVisible();
     }
 
-    async checkTagListIsEmpty(): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsNotVisible(this.tagListRow);
+    checkDeleteTagFromTagListByNodeIdIsDisplayed(name: string): Promise<void> {
+        return TestElement.byId('tag_chips_delete_' + name).waitVisible();
     }
 
-    async checkTagListByNodeIdIsEmpty(): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsNotVisible(this.tagListByNodeIdRow);
-    }
-
-    async checkTagIsDisplayedInTagListContentServices(tagName: string): Promise<void> {
-        const tag = element(by.cssContainingText('.adf-list-tag[id*="tag_name"]', tagName));
-        await BrowserVisibility.waitUntilElementIsVisible(tag);
-    }
-
-    async getErrorMessage(): Promise<string> {
-        return BrowserActions.getText(this.errorMessage);
-    }
-
-    async checkTagListIsOrderedAscending(): Promise<any> {
-        await this.checkListIsSorted(false, this.tagListRowLocator);
-    }
-
-    async checkTagListByNodeIdIsOrderedAscending(): Promise<any> {
-        await this.checkListIsSorted(false, this.tagListByNodeIdRowLocator);
-    }
-
-    async checkTagListContentServicesIsOrderedAscending(): Promise<any> {
-        await this.checkListIsSorted(false, this.tagListContentServicesRowLocator);
-    }
-
-    async checkListIsSorted(sortOrder, locator): Promise<boolean> {
-        const tagList = element.all(locator);
-        await BrowserVisibility.waitUntilElementIsVisible(tagList.first());
-        const initialList = [];
-        await tagList.each(async (currentElement) => {
-            const text = await BrowserActions.getText(currentElement);
-            initialList.push(text);
-        });
-        let sortedList = initialList;
-        sortedList = sortedList.sort();
-        if (sortOrder === false) {
-            sortedList = sortedList.reverse();
-        }
-        return initialList.toString() === sortedList.toString();
-    }
-
-    async checkDeleteTagFromTagListByNodeIdIsDisplayed(name: string): Promise<void> {
-        const deleteChip = element(by.id('tag_chips_delete_' + name));
-        await BrowserVisibility.waitUntilElementIsVisible(deleteChip);
-    }
-
-    async checkDeleteTagFromTagListByNodeIdIsNotDisplayed(name: string): Promise<void> {
-        const deleteChip = element(by.id('tag_chips_delete_' + name));
-        await BrowserVisibility.waitUntilElementIsNotVisible(deleteChip);
-    }
-
-    async clickShowDeleteButtonSwitch(): Promise<void> {
-        await BrowserActions.click(this.showDeleteButton);
-    }
-
-    async checkShowMoreButtonIsDisplayed(): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.showMoreButton);
-    }
-
-    async clickShowMoreButton(): Promise<void> {
-        await BrowserActions.click(this.showMoreButton);
-    }
-
-    async clickShowLessButton(): Promise<void> {
-        await BrowserActions.click(this.showLessButton);
-    }
-
-    async clickConfirmTag(): Promise<void> {
-        await BrowserActions.click(this.confirmTag);
-    }
-
-    async checkTagsOnList(): Promise<number> {
-        return this.tagsOnPage.count();
-    }
-
-    async checkShowLessButtonIsDisplayed(): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.showLessButton);
-    }
-
-    async checkShowLessButtonIsNotDisplayed(): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsNotVisible(this.showLessButton);
-    }
-
-    async clickShowMoreButtonUntilNotDisplayed(): Promise<void> {
-        const visible = await this.showMoreButton.isDisplayed();
-        if (visible) {
-            await BrowserActions.click(this.showMoreButton);
-            await this.clickShowMoreButtonUntilNotDisplayed();
-        }
-    }
-
-    async clickShowLessButtonUntilNotDisplayed(): Promise<void> {
-        const visible = await this.showLessButton.isDisplayed();
-        if (visible) {
-            await BrowserActions.click(this.showLessButton);
-            await this.clickShowLessButtonUntilNotDisplayed();
-        }
+    checkDeleteTagFromTagListByNodeIdIsNotDisplayed(name: string): Promise<void> {
+        return TestElement.byId('tag_chips_delete_' + name).waitNotVisible();
     }
 }

--- a/e2e/content-services/permissions/permissions-component.e2e.ts
+++ b/e2e/content-services/permissions/permissions-component.e2e.ts
@@ -148,7 +148,7 @@ describe('Permissions Component', () => {
         });
 
         it('[C286272] Should be able to see results when searching for a user', async () => {
-            await permissionsPage.checkAddPermissionButtonIsDisplayed();
+            await permissionsPage.addPermissionButton.waitVisible();
             await permissionsPage.addPermissionsDialog.clickAddPermissionButton();
             await permissionsPage.addPermissionsDialog.checkAddPermissionDialogIsDisplayed();
             await permissionsPage.addPermissionsDialog.checkSearchUserInputIsDisplayed();
@@ -157,7 +157,7 @@ describe('Permissions Component', () => {
         });
 
         it('[C276979] Should be able to give permissions to a group of people', async () => {
-            await permissionsPage.checkAddPermissionButtonIsDisplayed();
+            await permissionsPage.addPermissionButton.waitVisible();
             await permissionsPage.addPermissionsDialog.clickAddPermissionButton();
             await permissionsPage.addPermissionsDialog.checkAddPermissionDialogIsDisplayed();
             await permissionsPage.addPermissionsDialog.checkSearchUserInputIsDisplayed();
@@ -168,7 +168,7 @@ describe('Permissions Component', () => {
         });
 
         it('[C277100] Should display EVERYONE group in the search result set', async () => {
-            await permissionsPage.checkAddPermissionButtonIsDisplayed();
+            await permissionsPage.addPermissionButton.waitVisible();
             await permissionsPage.addPermissionsDialog.clickAddPermissionButton();
             await permissionsPage.addPermissionsDialog.checkAddPermissionDialogIsDisplayed();
             await permissionsPage.addPermissionsDialog.checkSearchUserInputIsDisplayed();
@@ -192,7 +192,7 @@ describe('Permissions Component', () => {
             await contentServicesPage.checkSelectedSiteIsDisplayed('My files');
             await contentList.rightClickOnRow(fileModel.name);
             await contentServicesPage.pressContextMenuActionNamed('Permission');
-            await permissionsPage.checkAddPermissionButtonIsDisplayed();
+            await permissionsPage.addPermissionButton.waitVisible();
             await permissionsPage.addPermissionsDialog.clickAddPermissionButton();
             await permissionsPage.addPermissionsDialog.checkAddPermissionDialogIsDisplayed();
             await permissionsPage.addPermissionsDialog.checkSearchUserInputIsDisplayed();
@@ -377,7 +377,7 @@ describe('Permissions Component', () => {
             await contentList.rightClickOnRow('RoleConsumer' + fileModel.name);
             await contentServicesPage.pressContextMenuActionNamed('Permission');
             await permissionsPage.addPermissionsDialog.checkPermissionInheritedButtonIsDisplayed();
-            await permissionsPage.checkAddPermissionButtonIsDisplayed();
+            await permissionsPage.addPermissionButton.waitVisible();
             await permissionsPage.addPermissionsDialog.clickPermissionInheritedButton();
             await expect(await notificationPage.getSnackBarMessage()).toEqual('You are not allowed to change permissions');
             await permissionsPage.addPermissionsDialog.clickAddPermissionButton();

--- a/e2e/content-services/permissions/site-permissions.e2e.ts
+++ b/e2e/content-services/permissions/site-permissions.e2e.ts
@@ -360,7 +360,7 @@ describe('Permissions Component', () => {
             await navigationBarPage.openContentServicesFolder(privateSite.entry.guid);
 
             await contentServicesPage.versionManagerContent('privateSite' + fileModel.name);
-            await BrowserActions.click(versionManagePage.showNewVersionButton);
+            await versionManagePage.showNewVersionButton.click();
             await versionManagePage.uploadNewVersionFile(newVersionFile.location);
 
             await versionManagePage.checkFileVersionExist('1.1');

--- a/e2e/content-services/permissions/site-permissions.e2e.ts
+++ b/e2e/content-services/permissions/site-permissions.e2e.ts
@@ -179,7 +179,7 @@ describe('Permissions Component', () => {
             await contentServicesPage.pressContextMenuActionNamed('Permission');
 
             await permissionsPage.addPermissionsDialog.checkPermissionInheritedButtonIsDisplayed();
-            await permissionsPage.checkAddPermissionButtonIsDisplayed();
+            await permissionsPage.addPermissionButton.waitVisible();
 
             await browser.sleep(5000);
 

--- a/e2e/content-services/tag-component.e2e.ts
+++ b/e2e/content-services/tag-component.e2e.ts
@@ -80,14 +80,14 @@ describe('Tag component', () => {
 
     it('[C260374] Should NOT be possible to add a new tag without Node ID', async () => {
         await expect(await tagPage.getNodeId()).toEqual('');
-        await expect(await tagPage.getNewTagPlaceholder()).toEqual('New Tag');
+        await expect(await tagPage.newTagInput.getAttribute('data-placeholder')).toEqual('New Tag');
         await expect(await tagPage.addTagButtonIsEnabled()).toEqual(false);
-        await tagPage.checkTagListIsEmpty();
-        await tagPage.checkTagListByNodeIdIsEmpty();
-        await tagPage.addNewTagInput('a');
+        await tagPage.tagListRow.waitNotVisible();
+        await tagPage.tagListByNodeIdRow.waitNotVisible();
+        await tagPage.newTagInput.typeText('a');
 
         await expect(await tagPage.addTagButtonIsEnabled()).toEqual(false);
-        await expect(await tagPage.getNewTagInput()).toEqual('a');
+        await expect(await tagPage.newTagInput.getAttribute('value')).toEqual('a');
     });
 
     it('[C268151] Should be possible to add a new tag to a Node', async () => {
@@ -103,7 +103,7 @@ describe('Tag component', () => {
         await tagPage.addTag(sameTag);
         await tagPage.checkTagIsDisplayedInTagList(sameTag);
         await tagPage.addTag(sameTag);
-        await expect(await tagPage.getErrorMessage()).toEqual('Tag already exists');
+        await expect(await tagPage.errorMessage.getText()).toEqual('Tag already exists');
     });
 
     it('[C260375] Should be possible to delete a tag', async () => {
@@ -141,7 +141,7 @@ describe('Tag component', () => {
         await tagPage.checkTagIsDisplayedInTagListByNodeId(tagList[3]);
         await tagPage.checkDeleteTagFromTagListByNodeIdIsDisplayed(tagList[3]);
 
-        await tagPage.clickShowDeleteButtonSwitch();
+        await tagPage.showDeleteButton.click();
 
         await tagPage.checkDeleteTagFromTagListByNodeIdIsNotDisplayed(tagList[3]);
     });
@@ -149,16 +149,16 @@ describe('Tag component', () => {
     it('[C286472] Should be able to click Show more/less button on List Tags Content Services', async () => {
         await tagPage.insertNodeId(pdfFileModel.id);
 
-        await tagPage.checkShowMoreButtonIsDisplayed();
-        await tagPage.checkShowLessButtonIsNotDisplayed();
+        await tagPage.showMoreButton.waitVisible();
+        await tagPage.showLessButton.waitNotVisible();
 
-        await expect(await tagPage.checkTagsOnList()).toEqual(10);
+        await expect(await tagPage.tagsOnPage.count()).toEqual(10);
 
-        await tagPage.clickShowMoreButton();
-        await tagPage.checkShowLessButtonIsDisplayed();
+        await tagPage.showMoreButton.click();
+        await tagPage.showLessButton.waitVisible();
 
-        await tagPage.clickShowLessButton();
-        await tagPage.checkShowLessButtonIsNotDisplayed();
+        await tagPage.showLessButton.click();
+        await tagPage.showLessButton.waitNotVisible();
     });
 
 });

--- a/e2e/content-services/upload/upload-dialog.e2e.ts
+++ b/e2e/content-services/upload/upload-dialog.e2e.ts
@@ -15,14 +15,7 @@
  * limitations under the License.
  */
 
-import {
-    ApiService,
-    BrowserActions,
-    LoginPage,
-    UploadActions,
-    UserModel,
-    UsersActions
-} from '@alfresco/adf-testing';
+import { ApiService, LoginPage, UploadActions, UserModel, UsersActions } from '@alfresco/adf-testing';
 import { ContentServicesPage } from '../../core/pages/content-services.page';
 import { UploadDialogPage } from '../../core/pages/dialog/upload-dialog.page';
 import { UploadTogglesPage } from '../../core/pages/dialog/upload-toggles.page';
@@ -44,25 +37,27 @@ describe('Upload component', () => {
 
     let acsUser: UserModel;
 
+    const FILES = browser.params.resources.Files;
+
     const firstPdfFileModel = new FileModel({
-        'name': browser.params.resources.Files.ADF_DOCUMENTS.PDF_B.file_name,
-        'location': browser.params.resources.Files.ADF_DOCUMENTS.PDF_B.file_location
+        'name': FILES.ADF_DOCUMENTS.PDF_B.file_name,
+        'location': FILES.ADF_DOCUMENTS.PDF_B.file_location
     });
     const docxFileModel = new FileModel({
-        'name': browser.params.resources.Files.ADF_DOCUMENTS.DOCX.file_name,
-        'location': browser.params.resources.Files.ADF_DOCUMENTS.DOCX.file_location
+        'name': FILES.ADF_DOCUMENTS.DOCX.file_name,
+        'location': FILES.ADF_DOCUMENTS.DOCX.file_location
     });
     const pdfFileModel = new FileModel({
-        'name': browser.params.resources.Files.ADF_DOCUMENTS.PDF.file_name,
-        'location': browser.params.resources.Files.ADF_DOCUMENTS.PDF.file_location
+        'name': FILES.ADF_DOCUMENTS.PDF.file_name,
+        'location': FILES.ADF_DOCUMENTS.PDF.file_location
     });
     const pngFileModelTwo = new FileModel({
-        'name': browser.params.resources.Files.ADF_DOCUMENTS.PNG_B.file_name,
-        'location': browser.params.resources.Files.ADF_DOCUMENTS.PNG_B.file_location
+        'name': FILES.ADF_DOCUMENTS.PNG_B.file_name,
+        'location': FILES.ADF_DOCUMENTS.PNG_B.file_location
     });
     const pngFileModel = new FileModel({
-        'name': browser.params.resources.Files.ADF_DOCUMENTS.PNG.file_name,
-        'location': browser.params.resources.Files.ADF_DOCUMENTS.PNG.file_location
+        'name': FILES.ADF_DOCUMENTS.PNG.file_name,
+        'location': FILES.ADF_DOCUMENTS.PNG.file_location
     });
     const filesLocation = [pdfFileModel.location, docxFileModel.location, pngFileModel.location, firstPdfFileModel.location];
     const filesName = [pdfFileModel.name, docxFileModel.name, pngFileModel.name, firstPdfFileModel.name];
@@ -90,8 +85,7 @@ describe('Upload component', () => {
     });
 
     it('[C260143] Should be possible to maximize/minimize the upload dialog', async () => {
-        await contentServicesPage
-            .uploadFile(docxFileModel.location);
+        await contentServicesPage.uploadFile(docxFileModel.location);
         await contentServicesPage.checkContentIsDisplayed(docxFileModel.name);
 
         await uploadDialog.fileIsUploaded(docxFileModel.name);
@@ -113,8 +107,7 @@ describe('Upload component', () => {
     });
 
     it('[C291902] Should be shown upload counter display in dialog box', async () => {
-        await contentServicesPage
-            .uploadFile(docxFileModel.location);
+        await contentServicesPage.uploadFile(docxFileModel.location);
         await contentServicesPage.checkContentIsDisplayed(docxFileModel.name);
 
         await uploadDialog.fileIsUploaded(docxFileModel.name);
@@ -174,7 +167,7 @@ describe('Upload component', () => {
         await contentServicesPage.checkContentIsDisplayed(docxFileModel.name);
 
         await contentServicesPage.versionManagerContent(docxFileModel.name);
-        await BrowserActions.click(versionManagePage.showNewVersionButton);
+        await versionManagePage.showNewVersionButton.click();
         await versionManagePage.uploadNewVersionFile(pngFileModel.location);
         await versionManagePage.closeVersionDialog();
 
@@ -183,5 +176,4 @@ describe('Upload component', () => {
         await uploadDialog.clickOnCloseButton();
         await uploadDialog.dialogIsNotDisplayed();
     });
-
 });

--- a/e2e/content-services/version/version-actions.e2e.ts
+++ b/e2e/content-services/version/version-actions.e2e.ts
@@ -98,7 +98,7 @@ describe('Version component actions', () => {
     });
 
     it('[C280005] Should be showed all the default action when you have more then one version', async () => {
-        await BrowserActions.click(versionManagePage.showNewVersionButton);
+        await versionManagePage.showNewVersionButton.click();
 
         await versionManagePage.uploadNewVersionFile(fileModelVersionTwo.location);
 
@@ -129,7 +129,7 @@ describe('Version component actions', () => {
     });
 
     it('[C280006] Should be possible prevent a version to be deleted when click on No on the confirm dialog', async () => {
-        await BrowserActions.click(versionManagePage.showNewVersionButton);
+        await versionManagePage.showNewVersionButton.click();
 
         await versionManagePage.uploadNewVersionFile(fileModelVersionTwo.location);
 
@@ -169,7 +169,7 @@ describe('Version component actions', () => {
         await browser.refresh();
         await contentServicesPage.versionManagerContent(txtFileModel.name);
 
-        await BrowserActions.click(versionManagePage.showNewVersionButton);
+        await versionManagePage.showNewVersionButton.click();
 
         await browser.executeScript(' setTimeout(() => {document.querySelector("div[data-automation-id=\'cancel-upload-progress\']").click();}, 1000)');
         await versionManagePage.uploadNewVersionFile(bigFileToCancel.location);

--- a/e2e/content-services/version/version-actions.e2e.ts
+++ b/e2e/content-services/version/version-actions.e2e.ts
@@ -122,7 +122,7 @@ describe('Version component actions', () => {
     it('[C272819] Should be possible delete a version when click on delete version action', async () => {
         await versionManagePage.deleteFileVersion('1.1');
 
-        await versionManagePage.clickAcceptConfirm();
+        await versionManagePage.confirmAccept.click();
 
         await versionManagePage.checkFileVersionNotExist('1.1');
         await versionManagePage.checkFileVersionExist('1.0');
@@ -132,12 +132,9 @@ describe('Version component actions', () => {
         await versionManagePage.showNewVersionButton.click();
 
         await versionManagePage.uploadNewVersionFile(fileModelVersionTwo.location);
-
         await versionManagePage.checkFileVersionExist('1.1');
-
         await versionManagePage.deleteFileVersion('1.1');
-
-        await versionManagePage.clickCancelConfirm();
+        await versionManagePage.confirmCancel.click();
 
         await versionManagePage.checkFileVersionExist('1.1');
         await versionManagePage.checkFileVersionExist('1.0');

--- a/e2e/content-services/version/version-permissions.e2e.ts
+++ b/e2e/content-services/version/version-permissions.e2e.ts
@@ -159,7 +159,7 @@ describe('Version component permissions', () => {
             await expect(await versionManagePage.getFileVersionDate('1.1')).not.toBeUndefined();
 
             await versionManagePage.deleteFileVersion('1.1');
-            await versionManagePage.clickAcceptConfirm();
+            await versionManagePage.confirmAccept.click();
 
             await versionManagePage.checkFileVersionNotExist('1.1');
 
@@ -230,7 +230,7 @@ describe('Version component permissions', () => {
             await expect(await versionManagePage.getFileVersionDate('1.1')).not.toBeUndefined();
 
             await versionManagePage.deleteFileVersion('1.1');
-            await versionManagePage.clickAcceptConfirm();
+            await versionManagePage.confirmAccept.click();
 
             await versionManagePage.checkFileVersionNotExist('1.1');
 
@@ -284,7 +284,7 @@ describe('Version component permissions', () => {
             await expect(await versionManagePage.getFileVersionDate('1.1')).not.toBeUndefined();
 
             await versionManagePage.deleteFileVersion('1.1');
-            await versionManagePage.clickAcceptConfirm();
+            await versionManagePage.confirmAccept.click();
 
             await versionManagePage.checkFileVersionNotExist('1.1');
 

--- a/e2e/content-services/version/version-permissions.e2e.ts
+++ b/e2e/content-services/version/version-permissions.e2e.ts
@@ -18,7 +18,6 @@
 import { browser, by, element } from 'protractor';
 import {
     ApiService,
-    BrowserActions,
     LoginPage,
     NotificationHistoryPage,
     StringUtil,
@@ -152,8 +151,7 @@ describe('Version component permissions', () => {
         it('[C277200] should a user with Manager permission be able to upload a new version for a file with different creator', async () => {
             await contentServices.versionManagerContent(differentCreatorFile.name);
 
-            await BrowserActions.click(versionManagePage.showNewVersionButton);
-
+            await versionManagePage.showNewVersionButton.click();
             await versionManagePage.uploadNewVersionFile(newVersionFile.location);
 
             await versionManagePage.checkFileVersionExist('1.1');
@@ -224,8 +222,7 @@ describe('Version component permissions', () => {
         it('[C277177] Should a user with Contributor permission be able to upload a new version for the created file', async () => {
             await contentServices.versionManagerContent(sameCreatorFile.name);
 
-            await BrowserActions.click(versionManagePage.showNewVersionButton);
-
+            await versionManagePage.showNewVersionButton.click();
             await versionManagePage.uploadNewVersionFile(newVersionFile.location);
 
             await versionManagePage.checkFileVersionExist('1.1');
@@ -279,8 +276,7 @@ describe('Version component permissions', () => {
         it('[C277195] Should a user with Collaborator permission be able to upload a new version for the created file', async () => {
             await contentServices.versionManagerContent(sameCreatorFile.name);
 
-            await BrowserActions.click(versionManagePage.showNewVersionButton);
-
+            await versionManagePage.showNewVersionButton.click();
             await versionManagePage.uploadNewVersionFile(newVersionFile.location);
 
             await versionManagePage.checkFileVersionExist('1.1');
@@ -300,8 +296,7 @@ describe('Version component permissions', () => {
         it('[C277199] should a user with Collaborator permission be able to upload a new version for a file with different creator', async () => {
             await contentServices.versionManagerContent(differentCreatorFile.name);
 
-            await BrowserActions.click(versionManagePage.showNewVersionButton);
-
+            await versionManagePage.showNewVersionButton.click();
             await versionManagePage.uploadNewVersionFile(newVersionFile.location);
 
             await versionManagePage.checkFileVersionExist('1.1');

--- a/e2e/content-services/version/version-properties.e2e.ts
+++ b/e2e/content-services/version/version-properties.e2e.ts
@@ -18,7 +18,6 @@
 import { browser, by, element } from 'protractor';
 import {
     ApiService,
-    BrowserActions,
     BrowserVisibility,
     LoginPage,
     UploadActions,
@@ -87,9 +86,9 @@ describe('Version Properties', () => {
 
     it('[C279994] Should show/hide upload new version button when readOnly is true/false', async () => {
         await versionManagePage.disableReadOnly();
-        await BrowserVisibility.waitUntilElementIsVisible(versionManagePage.showNewVersionButton);
+        await versionManagePage.showNewVersionButton.waitVisible();
         await versionManagePage.enableReadOnly();
-        await BrowserVisibility.waitUntilElementIsNotVisible(versionManagePage.showNewVersionButton);
+        await versionManagePage.showNewVersionButton.waitNotVisible();
         await BrowserVisibility.waitUntilElementIsNotVisible(versionManagePage.uploadNewVersionButton);
     });
 
@@ -109,7 +108,7 @@ describe('Version Properties', () => {
 
     it('[C269085] Should show/hide comments when showComments true/false', async () => {
         await versionManagePage.enableComments();
-        await BrowserActions.click(versionManagePage.showNewVersionButton);
+        await versionManagePage.showNewVersionButton.click();
         await versionManagePage.enterCommentText('Example comment text');
         await versionManagePage.uploadNewVersionFile(fileModelVersionTwo.location);
         await versionManagePage.checkFileVersionExist('1.1');

--- a/e2e/content-services/version/version-properties.e2e.ts
+++ b/e2e/content-services/version/version-properties.e2e.ts
@@ -89,7 +89,7 @@ describe('Version Properties', () => {
         await versionManagePage.showNewVersionButton.waitVisible();
         await versionManagePage.enableReadOnly();
         await versionManagePage.showNewVersionButton.waitNotVisible();
-        await BrowserVisibility.waitUntilElementIsNotVisible(versionManagePage.uploadNewVersionButton);
+        await versionManagePage.uploadNewVersionButton.waitNotVisible();
     });
 
     it('[C272817] Should NOT be present the download action when allowDownload property is false', async () => {
@@ -109,7 +109,7 @@ describe('Version Properties', () => {
     it('[C269085] Should show/hide comments when showComments true/false', async () => {
         await versionManagePage.enableComments();
         await versionManagePage.showNewVersionButton.click();
-        await versionManagePage.enterCommentText('Example comment text');
+        await versionManagePage.commentText.typeText('Example comment text');
         await versionManagePage.uploadNewVersionFile(fileModelVersionTwo.location);
         await versionManagePage.checkFileVersionExist('1.1');
         await expect(await versionManagePage.getFileVersionComment('1.1')).toEqual('Example comment text');

--- a/e2e/content-services/version/version-smoke-tests.e2e.ts
+++ b/e2e/content-services/version/version-smoke-tests.e2e.ts
@@ -90,7 +90,7 @@ describe('Version component', () => {
    });
 
     it('[C272768] Should be visible the first file version when you upload a file', async () => {
-        await versionManagePage.checkUploadNewVersionsButtonIsDisplayed();
+        await versionManagePage.showNewVersionButton.waitVisible();
 
         await versionManagePage.checkFileVersionExist('1.0');
         await expect(await versionManagePage.getFileVersionName('1.0')).toEqual(txtFileModel.name);
@@ -98,7 +98,7 @@ describe('Version component', () => {
     });
 
     it('[C279995] Should show/hide the new upload file options when click on add New version/cancel button', async () => {
-        await BrowserActions.click(versionManagePage.showNewVersionButton);
+        await versionManagePage.showNewVersionButton.click();
 
         await BrowserVisibility.waitUntilElementIsVisible(versionManagePage.cancelButton);
         await BrowserVisibility.waitUntilElementIsVisible(versionManagePage.majorRadio);
@@ -116,11 +116,11 @@ describe('Version component', () => {
         await BrowserVisibility.waitUntilElementIsNotVisible(versionManagePage.commentText);
         await BrowserVisibility.waitUntilElementIsNotVisible(versionManagePage.uploadNewVersionButton);
 
-        await BrowserVisibility.waitUntilElementIsVisible(versionManagePage.showNewVersionButton);
+        await versionManagePage.showNewVersionButton.waitVisible();
     });
 
     it('[C260244] Should show the version history when select a file with multiple version', async () => {
-        await BrowserActions.click(versionManagePage.showNewVersionButton);
+        await versionManagePage.showNewVersionButton.click();
         await versionManagePage.uploadNewVersionFile(fileModelVersionTwo.location);
 
         await versionManagePage.checkFileVersionExist('1.0');
@@ -133,7 +133,7 @@ describe('Version component', () => {
     });
 
     it('[C269084] Should be possible add a comment when add a new version', async () => {
-        await BrowserActions.click(versionManagePage.showNewVersionButton);
+        await versionManagePage.showNewVersionButton.click();
         await versionManagePage.enterCommentText('Example comment text');
         await versionManagePage.uploadNewVersionFile(fileModelVersionThree.location);
 
@@ -144,7 +144,7 @@ describe('Version component', () => {
     });
 
     it('[C275719] Should be possible preview the file when you add a new version', async () => {
-        await BrowserActions.click(versionManagePage.showNewVersionButton);
+        await versionManagePage.showNewVersionButton.click();
         await versionManagePage.clickMajorChange();
 
         await versionManagePage.uploadNewVersionFile(fileModelVersionFor.location);
@@ -152,7 +152,7 @@ describe('Version component', () => {
         await versionManagePage.checkFileVersionExist('2.0');
         await expect(await versionManagePage.getFileVersionName('2.0')).toEqual(fileModelVersionFor.name);
 
-        await BrowserActions.click(versionManagePage.showNewVersionButton);
+        await versionManagePage.showNewVersionButton.click();
         await versionManagePage.clickMinorChange();
 
         await versionManagePage.uploadNewVersionFile(fileModelVersionFive.location);

--- a/e2e/content-services/version/version-smoke-tests.e2e.ts
+++ b/e2e/content-services/version/version-smoke-tests.e2e.ts
@@ -104,7 +104,7 @@ describe('Version component', () => {
         await versionManagePage.majorRadio.waitNotVisible();
         await versionManagePage.minorRadio.waitNotVisible();
         await versionManagePage.commentText.waitNotVisible();
-        await versionManagePage.uploadNewVersionButton.waitVisible();
+        await versionManagePage.uploadNewVersionButton.waitNotVisible();
 
         await versionManagePage.showNewVersionButton.waitVisible();
     });

--- a/e2e/content-services/version/version-smoke-tests.e2e.ts
+++ b/e2e/content-services/version/version-smoke-tests.e2e.ts
@@ -16,15 +16,7 @@
  */
 
 import { browser } from 'protractor';
-import {
-    ApiService,
-    BrowserActions,
-    BrowserVisibility,
-    LoginPage,
-    UploadActions,
-    UserModel,
-    UsersActions
-} from '@alfresco/adf-testing';
+import { ApiService, LoginPage, UploadActions, UserModel, UsersActions } from '@alfresco/adf-testing';
 import { ContentServicesPage } from '../../core/pages/content-services.page';
 import { VersionManagePage } from '../../core/pages/version-manager.page';
 import { FileModel } from '../../models/ACS/file.model';
@@ -100,21 +92,19 @@ describe('Version component', () => {
     it('[C279995] Should show/hide the new upload file options when click on add New version/cancel button', async () => {
         await versionManagePage.showNewVersionButton.click();
 
-        await BrowserVisibility.waitUntilElementIsVisible(versionManagePage.cancelButton);
-        await BrowserVisibility.waitUntilElementIsVisible(versionManagePage.majorRadio);
-        await BrowserVisibility.waitUntilElementIsVisible(versionManagePage.minorRadio);
-        await BrowserVisibility.waitUntilElementIsVisible(versionManagePage.cancelButton);
-        await BrowserVisibility.waitUntilElementIsVisible(versionManagePage.commentText);
-        await BrowserVisibility.waitUntilElementIsVisible(versionManagePage.uploadNewVersionButton);
+        await versionManagePage.cancelButton.waitVisible();
+        await versionManagePage.majorRadio.waitVisible();
+        await versionManagePage.minorRadio.waitVisible();
+        await versionManagePage.commentText.waitVisible();
+        await versionManagePage.uploadNewVersionButton.waitVisible();
 
-        await BrowserActions.click(versionManagePage.cancelButton);
+        await versionManagePage.cancelButton.click();
 
-        await BrowserVisibility.waitUntilElementIsNotVisible(versionManagePage.cancelButton);
-        await BrowserVisibility.waitUntilElementIsNotVisible(versionManagePage.majorRadio);
-        await BrowserVisibility.waitUntilElementIsNotVisible(versionManagePage.minorRadio);
-        await BrowserVisibility.waitUntilElementIsNotVisible(versionManagePage.cancelButton);
-        await BrowserVisibility.waitUntilElementIsNotVisible(versionManagePage.commentText);
-        await BrowserVisibility.waitUntilElementIsNotVisible(versionManagePage.uploadNewVersionButton);
+        await versionManagePage.cancelButton.waitNotVisible();
+        await versionManagePage.majorRadio.waitNotVisible();
+        await versionManagePage.minorRadio.waitNotVisible();
+        await versionManagePage.commentText.waitNotVisible();
+        await versionManagePage.uploadNewVersionButton.waitVisible();
 
         await versionManagePage.showNewVersionButton.waitVisible();
     });
@@ -134,7 +124,7 @@ describe('Version component', () => {
 
     it('[C269084] Should be possible add a comment when add a new version', async () => {
         await versionManagePage.showNewVersionButton.click();
-        await versionManagePage.enterCommentText('Example comment text');
+        await versionManagePage.commentText.typeText('Example comment text');
         await versionManagePage.uploadNewVersionFile(fileModelVersionThree.location);
 
         await versionManagePage.checkFileVersionExist('1.2');
@@ -145,7 +135,7 @@ describe('Version component', () => {
 
     it('[C275719] Should be possible preview the file when you add a new version', async () => {
         await versionManagePage.showNewVersionButton.click();
-        await versionManagePage.clickMajorChange();
+        await versionManagePage.majorRadio.click();
 
         await versionManagePage.uploadNewVersionFile(fileModelVersionFor.location);
 
@@ -153,7 +143,7 @@ describe('Version component', () => {
         await expect(await versionManagePage.getFileVersionName('2.0')).toEqual(fileModelVersionFor.name);
 
         await versionManagePage.showNewVersionButton.click();
-        await versionManagePage.clickMinorChange();
+        await versionManagePage.minorRadio.click();
 
         await versionManagePage.uploadNewVersionFile(fileModelVersionFive.location);
 

--- a/e2e/core/pages/content-services.page.ts
+++ b/e2e/core/pages/content-services.page.ts
@@ -381,7 +381,7 @@ export class ContentServicesPage {
 
     async openCreateLibraryDialog(): Promise<void> {
         await BrowserActions.click(this.createLibraryButton);
-        await this.createLibraryDialog.waitForDialogToOpen();
+        await this.createLibraryDialog.libraryDialog.waitVisible();
     }
 
     async createNewFolder(folderName: string): Promise<void> {

--- a/e2e/core/pages/dialog/create-library-dialog.page.ts
+++ b/e2e/core/pages/dialog/create-library-dialog.page.ts
@@ -15,140 +15,30 @@
  * limitations under the License.
  */
 
-import { by, element, protractor } from 'protractor';
-import { BrowserVisibility, BrowserActions } from '@alfresco/adf-testing';
+import { by, element } from 'protractor';
+import { BrowserActions, TestElement } from '@alfresco/adf-testing';
 
 export class CreateLibraryDialogPage {
-    libraryDialog = element(by.css('[role="dialog"]'));
-    libraryTitle = element(by.css('.adf-library-dialog>h2'));
-    libraryNameField = element(by.css('input[formcontrolname="title"]'));
-    libraryIdField = element(by.css('input[formcontrolname="id"]'));
-    libraryDescriptionField = element(by.css('textarea[formcontrolname="description"]'));
-    publicRadioButton = element(by.css('[data-automation-id="PUBLIC"]>label'));
-    privateRadioButton = element(by.css('[data-automation-id="PRIVATE"]>label'));
-    moderatedRadioButton = element(by.css('[data-automation-id="MODERATED"]>label'));
-    cancelButton = element(by.css('button[data-automation-id="cancel-library-id"]'));
-    createButton = element(by.css('button[data-automation-id="create-library-id"]'));
-    errorMessage = element(by.css('.mat-dialog-content .mat-error'));
+    libraryDialog = TestElement.byCss('[role="dialog"]');
+    libraryTitle = TestElement.byCss('.adf-library-dialog>h2');
+    libraryNameField = TestElement.byCss('input[formcontrolname="title"]');
+    libraryIdField = TestElement.byCss('input[formcontrolname="id"]');
+    libraryDescriptionField = TestElement.byCss('textarea[formcontrolname="description"]');
+    publicRadioButton = TestElement.byCss('[data-automation-id="PUBLIC"]>label');
+    privateRadioButton = TestElement.byCss('[data-automation-id="PRIVATE"]>label');
+    moderatedRadioButton = TestElement.byCss('[data-automation-id="MODERATED"]>label');
+    cancelButton = TestElement.byCss('button[data-automation-id="cancel-library-id"]');
+    createButton = TestElement.byCss('button[data-automation-id="create-library-id"]');
+    errorMessage = TestElement.byCss('.mat-dialog-content .mat-error');
     errorMessages = element.all(by.css('.mat-dialog-content .mat-error'));
-    libraryNameHint = element(by.css('adf-library-dialog .mat-hint'));
+    libraryNameHint = TestElement.byCss('adf-library-dialog .mat-hint');
 
     async getSelectedRadio(): Promise<string> {
         const radio = element(by.css('.mat-radio-button[class*="checked"]'));
         return BrowserActions.getText(radio);
     }
 
-    async waitForDialogToOpen(): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.libraryDialog);
-    }
-
-    async waitForDialogToClose(): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsNotPresent(this.libraryDialog, 60000);
-    }
-
-    async isDialogOpen(): Promise<any> {
-        return BrowserVisibility.waitUntilElementIsVisible(this.libraryDialog);
-    }
-
-    async getTitle(): Promise<string> {
-        return BrowserActions.getText(this.libraryTitle);
-    }
-
-    async waitUntilLibraryIdTextHasValue(value: string): Promise<void> {
-        await BrowserVisibility.waitUntilElementHasValue(this.libraryIdField, value);
-    }
-
-    async waitErrorMessageIsDisplayed(): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.errorMessage, 60000);
-    }
-
-    async getErrorMessage(): Promise<string> {
-        return BrowserActions.getText(this.errorMessage);
-    }
-
     async getErrorMessages(position: number): Promise<string> {
         return BrowserActions.getText(this.errorMessages.get(position));
-    }
-
-    async waitForLibraryNameHint(): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.libraryNameHint);
-    }
-
-    async getLibraryNameHint(): Promise<string> {
-        return BrowserActions.getText(this.libraryNameHint);
-    }
-
-    async isNameDisplayed(): Promise<boolean> {
-        return this.libraryNameField.isDisplayed();
-    }
-
-    async isLibraryIdDisplayed(): Promise<boolean> {
-        return this.libraryIdField.isDisplayed();
-    }
-
-    async isDescriptionDisplayed(): Promise<boolean> {
-        return this.libraryDescriptionField.isDisplayed();
-    }
-
-    async isPublicDisplayed(): Promise<boolean> {
-        return this.publicRadioButton.isDisplayed();
-    }
-
-    async isModeratedDisplayed(): Promise<boolean> {
-        return this.moderatedRadioButton.isDisplayed();
-    }
-
-    async isPrivateDisplayed(): Promise<boolean> {
-        return this.privateRadioButton.isDisplayed();
-    }
-
-    async isCreateEnabled(): Promise<boolean> {
-        return this.createButton.isEnabled();
-    }
-
-    async isCancelEnabled(): Promise<boolean> {
-        return this.cancelButton.isEnabled();
-    }
-
-    async clickCreate(): Promise<void> {
-        await BrowserActions.click(this.createButton);
-    }
-
-    async clickCancel(): Promise<void> {
-        await BrowserActions.click(this.cancelButton);
-    }
-
-    async typeLibraryName(libraryName: string): Promise<void> {
-        await BrowserActions.clearSendKeys(this.libraryNameField, libraryName);
-    }
-
-    async typeLibraryId(libraryId: string): Promise<void> {
-        await BrowserActions.clearSendKeys(this.libraryIdField, libraryId);
-    }
-
-    async typeLibraryDescription(libraryDescription: string): Promise<void> {
-        await BrowserActions.clearSendKeys(this.libraryDescriptionField, libraryDescription);
-    }
-
-    async clearLibraryName(): Promise<void> {
-        await this.libraryNameField.clear();
-        await this.libraryNameField.sendKeys(' ', protractor.Key.CONTROL, 'a', protractor.Key.NULL, protractor.Key.BACK_SPACE);
-    }
-
-    async clearLibraryId(): Promise<void> {
-        await this.libraryIdField.clear();
-        await this.libraryIdField.sendKeys(' ', protractor.Key.CONTROL, 'a', protractor.Key.NULL, protractor.Key.BACK_SPACE);
-    }
-
-    async selectPublic(): Promise<void> {
-        await BrowserActions.click(this.publicRadioButton);
-    }
-
-    async selectPrivate(): Promise<void> {
-        await BrowserActions.click(this.privateRadioButton);
-    }
-
-    async selectModerated(): Promise<void> {
-        await BrowserActions.click(this.moderatedRadioButton);
     }
 }

--- a/e2e/core/pages/version-manager.page.ts
+++ b/e2e/core/pages/version-manager.page.ts
@@ -24,8 +24,8 @@ export class VersionManagePage {
     togglePage = new TogglePage();
 
     showNewVersionButton = TestElement.byId('adf-show-version-upload-button');
-    uploadNewVersionInput = TestElement.byCss('adf-upload-version-button input[data-automation-id="upload-single-file"]');
-    uploadNewVersionButton = TestElement.byCss('adf-upload-version-button');
+    uploadNewVersionInput = TestElement.byCss('.adf-upload-version-button input[data-automation-id="upload-single-file"]');
+    uploadNewVersionButton = TestElement.byCss('.adf-upload-version-button');
     uploadNewVersionContainer = TestElement.byId('adf-new-version-uploader-container');
     cancelButton = TestElement.byId('adf-new-version-cancel');
     majorRadio = TestElement.byId('adf-new-version-major');

--- a/e2e/core/pages/version-manager.page.ts
+++ b/e2e/core/pages/version-manager.page.ts
@@ -16,14 +16,14 @@
  */
 
 import * as path from 'path';
-import { BrowserActions, BrowserVisibility, TogglePage } from '@alfresco/adf-testing';
+import { BrowserActions, BrowserVisibility, TestElement, TogglePage } from '@alfresco/adf-testing';
 import { browser, by, element, ElementFinder } from 'protractor';
 
 export class VersionManagePage {
 
     togglePage = new TogglePage();
 
-    showNewVersionButton = element(by.id('adf-show-version-upload-button'));
+    showNewVersionButton = TestElement.byId('adf-show-version-upload-button');
     uploadNewVersionInput = element(by.css('adf-upload-version-button input[data-automation-id="upload-single-file"]'));
     uploadNewVersionButton = element(by.css('adf-upload-version-button'));
     uploadNewVersionContainer = element(by.id('adf-new-version-uploader-container'));
@@ -35,10 +35,6 @@ export class VersionManagePage {
     downloadSwitch = element(by.id('adf-version-manager-switch-download'));
     commentsSwitch = element(by.id('adf-version-manager-switch-comments'));
 
-    async checkUploadNewVersionsButtonIsDisplayed(): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.showNewVersionButton);
-    }
-
     async checkCancelButtonIsDisplayed(): Promise<void> {
         await BrowserVisibility.waitUntilElementIsVisible(this.cancelButton);
     }
@@ -46,7 +42,7 @@ export class VersionManagePage {
     async uploadNewVersionFile(fileLocation: string): Promise<void> {
         await BrowserVisibility.waitUntilElementIsPresent(this.uploadNewVersionInput);
         await this.uploadNewVersionInput.sendKeys(path.resolve(path.join(browser.params.testConfig.main.rootPath, fileLocation)));
-        await BrowserVisibility.waitUntilElementIsVisible(this.showNewVersionButton);
+        await this.showNewVersionButton.waitVisible();
     }
 
     async getFileVersionName(version: string): Promise<string> {

--- a/e2e/core/pages/version-manager.page.ts
+++ b/e2e/core/pages/version-manager.page.ts
@@ -16,72 +16,53 @@
  */
 
 import * as path from 'path';
-import { BrowserActions, BrowserVisibility, TestElement, TogglePage } from '@alfresco/adf-testing';
-import { browser, by, element, ElementFinder } from 'protractor';
+import { BrowserActions, TestElement, TogglePage } from '@alfresco/adf-testing';
+import { browser, by, element } from 'protractor';
 
 export class VersionManagePage {
 
     togglePage = new TogglePage();
 
     showNewVersionButton = TestElement.byId('adf-show-version-upload-button');
-    uploadNewVersionInput = element(by.css('adf-upload-version-button input[data-automation-id="upload-single-file"]'));
-    uploadNewVersionButton = element(by.css('adf-upload-version-button'));
-    uploadNewVersionContainer = element(by.id('adf-new-version-uploader-container'));
-    cancelButton = element(by.id('adf-new-version-cancel'));
-    majorRadio = element(by.id('adf-new-version-major'));
-    minorRadio = element(by.id('adf-new-version-minor'));
-    commentText = element(by.id('adf-new-version-text-area'));
+    uploadNewVersionInput = TestElement.byCss('adf-upload-version-button input[data-automation-id="upload-single-file"]');
+    uploadNewVersionButton = TestElement.byCss('adf-upload-version-button');
+    uploadNewVersionContainer = TestElement.byId('adf-new-version-uploader-container');
+    cancelButton = TestElement.byId('adf-new-version-cancel');
+    majorRadio = TestElement.byId('adf-new-version-major');
+    minorRadio = TestElement.byId('adf-new-version-minor');
+    commentText = TestElement.byId('adf-new-version-text-area');
     readOnlySwitch = element(by.id('adf-version-manager-switch-readonly'));
     downloadSwitch = element(by.id('adf-version-manager-switch-download'));
     commentsSwitch = element(by.id('adf-version-manager-switch-comments'));
-
-    async checkCancelButtonIsDisplayed(): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.cancelButton);
-    }
+    confirmAccept = TestElement.byId('adf-confirm-accept');
+    confirmCancel = TestElement.byId('adf-confirm-cancel');
 
     async uploadNewVersionFile(fileLocation: string): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsPresent(this.uploadNewVersionInput);
-        await this.uploadNewVersionInput.sendKeys(path.resolve(path.join(browser.params.testConfig.main.rootPath, fileLocation)));
+        const filePath = path.resolve(path.join(browser.params.testConfig.main.rootPath, fileLocation));
+
+        await this.uploadNewVersionInput.waitPresent();
+        await this.uploadNewVersionInput.elementFinder.sendKeys(filePath);
         await this.showNewVersionButton.waitVisible();
     }
 
-    async getFileVersionName(version: string): Promise<string> {
-        const fileElement = element(by.css(`[id="adf-version-list-item-name-${version}"]`));
-        return BrowserActions.getText(fileElement);
+    getFileVersionName(version: string): Promise<string> {
+        return TestElement.byCss(`[id="adf-version-list-item-name-${version}"]`).getText();
     }
 
-    async checkFileVersionExist(version: string): Promise<void> {
-        const fileVersion = element(by.id(`adf-version-list-item-version-${version}`));
-        await BrowserVisibility.waitUntilElementIsVisible(fileVersion);
+    checkFileVersionExist(version: string): Promise<void> {
+        return TestElement.byId(`adf-version-list-item-version-${version}`).waitVisible();
     }
 
-    async checkFileVersionNotExist(version: string): Promise<void> {
-        const fileVersion = element(by.id(`adf-version-list-item-version-${version}`));
-        await BrowserVisibility.waitUntilElementIsNotVisible(fileVersion);
+    checkFileVersionNotExist(version: string): Promise<void> {
+        return TestElement.byId(`adf-version-list-item-version-${version}`).waitNotVisible();
     }
 
-    async getFileVersionComment(version: string): Promise<string> {
-        const fileComment = element(by.id(`adf-version-list-item-comment-${version}`));
-        return BrowserActions.getText(fileComment);
+    getFileVersionComment(version: string): Promise<string> {
+        return TestElement.byId(`adf-version-list-item-comment-${version}`).getText();
     }
 
-    async getFileVersionDate(version: string): Promise<string> {
-        const fileDate = element(by.id(`adf-version-list-item-date-${version}`));
-        return BrowserActions.getText(fileDate);
-    }
-
-    async enterCommentText(text: string): Promise<void> {
-        await BrowserActions.clearSendKeys(this.commentText, text);
-    }
-
-    async clickMajorChange(): Promise<void> {
-        const radioMajor = element(by.id(`adf-new-version-major`));
-        await BrowserActions.click(radioMajor);
-    }
-
-    async clickMinorChange(): Promise<void> {
-        const radioMinor = element(by.id(`adf-new-version-minor`));
-        await BrowserActions.click(radioMinor);
+    getFileVersionDate(version: string): Promise<string> {
+        return TestElement.byId(`adf-version-list-item-date-${version}`).getText();
     }
 
     /**
@@ -128,16 +109,8 @@ export class VersionManagePage {
     }
 
     async clickActionButton(version: string): Promise<void> {
-        await BrowserActions.click(element(by.id(`adf-version-list-action-menu-button-${version}`)));
-        await BrowserVisibility.waitUntilElementIsVisible(element(by.css('.cdk-overlay-container .mat-menu-content')));
-    }
-
-    async clickAcceptConfirm(): Promise<void> {
-        await BrowserActions.click(element(by.id(`adf-confirm-accept`)));
-    }
-
-    async clickCancelConfirm(): Promise<void> {
-        await BrowserActions.click(element(by.id(`adf-confirm-cancel`)));
+        await TestElement.byId(`adf-version-list-action-menu-button-${version}`).click();
+        await TestElement.byCss('.cdk-overlay-container .mat-menu-content').waitVisible();
     }
 
     async closeActionsMenu(): Promise<void> {
@@ -145,44 +118,48 @@ export class VersionManagePage {
     }
 
     async closeDisabledActionsMenu(): Promise<void> {
-        const container = element(by.css('div.cdk-overlay-backdrop.cdk-overlay-transparent-backdrop.cdk-overlay-backdrop-showing'));
+        const container = TestElement.byCss('div.cdk-overlay-backdrop.cdk-overlay-transparent-backdrop.cdk-overlay-backdrop-showing');
         await BrowserActions.closeDisabledMenu();
-        await BrowserVisibility.waitUntilElementIsNotVisible(container);
+        await container.waitNotVisible();
     }
 
     async downloadFileVersion(version: string): Promise<void> {
         await this.clickActionButton(version);
-        const downloadButton = element(by.id(`adf-version-list-action-download-${version}`));
-        await BrowserActions.click(downloadButton);
-        await BrowserVisibility.waitUntilElementIsNotVisible(downloadButton);
+
+        const downloadButton = TestElement.byId(`adf-version-list-action-download-${version}`);
+        await downloadButton.click();
+        await downloadButton.waitNotVisible();
     }
 
     async deleteFileVersion(version: string): Promise<void> {
         await this.clickActionButton(version);
-        const deleteButton = element(by.id(`adf-version-list-action-delete-${version}`));
-        await BrowserActions.click(deleteButton);
+
+        const deleteButton = TestElement.byId(`adf-version-list-action-delete-${version}`);
+        await deleteButton.click();
     }
 
     async restoreFileVersion(version: string): Promise<void> {
         await this.clickActionButton(version);
-        const restoreButton = element(by.id(`adf-version-list-action-restore-${version}`));
-        await BrowserActions.click(restoreButton);
+
+        const restoreButton = TestElement.byId(`adf-version-list-action-restore-${version}`);
+        await restoreButton.click();
     }
 
     async viewFileVersion(version): Promise<void> {
         await this.clickActionButton(version);
-        const viewButton: ElementFinder = element(by.id(`adf-version-list-action-view-${version}`));
-        await BrowserActions.click(viewButton);
+
+        const viewButton = TestElement.byId(`adf-version-list-action-view-${version}`);
+        await viewButton.click();
     }
 
     async checkActionsArePresent(version: string): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(element(by.id(`adf-version-list-action-download-${version}`)));
-        await BrowserVisibility.waitUntilElementIsVisible(element(by.id(`adf-version-list-action-delete-${version}`)));
-        await BrowserVisibility.waitUntilElementIsVisible(element(by.id(`adf-version-list-action-restore-${version}`)));
+        await TestElement.byId(`adf-version-list-action-download-${version}`).waitVisible();
+        await TestElement.byId(`adf-version-list-action-delete-${version}`).waitVisible();
+        await TestElement.byId(`adf-version-list-action-restore-${version}`).waitVisible();
     }
 
     async closeVersionDialog(): Promise<void> {
         await BrowserActions.closeMenuAndDialogs();
-        await BrowserVisibility.waitUntilElementIsNotVisible(this.uploadNewVersionContainer);
+        await this.uploadNewVersionContainer.waitNotVisible();
     }
 }

--- a/e2e/core/viewer/viewer-content-services-component.e2e.ts
+++ b/e2e/core/viewer/viewer-content-services-component.e2e.ts
@@ -442,8 +442,7 @@ describe('Content Services Viewer', () => {
         await viewerPage.viewFile(originalFileName);
         await viewerPage.clickCloseButton();
         await contentServicesPage.versionManagerContent(originalFileName);
-        await versionManagePage.checkUploadNewVersionsButtonIsDisplayed();
-        await BrowserActions.click(versionManagePage.showNewVersionButton);
+        await versionManagePage.showNewVersionButton.click();
         await versionManagePage.uploadNewVersionFile(newVersionLocation);
         await versionManagePage.closeActionsMenu();
         await versionManagePage.closeVersionDialog();

--- a/e2e/core/viewer/viewer-custom-toolbar-info-drawer.e2e.ts
+++ b/e2e/core/viewer/viewer-custom-toolbar-info-drawer.e2e.ts
@@ -16,7 +16,7 @@
  */
 
 import { browser } from 'protractor';
-import { ApiService, BrowserActions, FileBrowserUtil, LoginPage, UploadActions, UserModel, UsersActions, ViewerPage } from '@alfresco/adf-testing';
+import { ApiService, FileBrowserUtil, LoginPage, UploadActions, UserModel, UsersActions, ViewerPage } from '@alfresco/adf-testing';
 import { ContentServicesPage } from '../../core/pages/content-services.page';
 import { FileModel } from '../../models/ACS/file.model';
 import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
@@ -94,7 +94,7 @@ describe('Viewer', () => {
 
     it('[C362242] Should the Viewer be able to view a previous version of a file', async () => {
         await contentServicesPage.versionManagerContent(txtFileInfo.name);
-        await BrowserActions.click(versionManagePage.showNewVersionButton);
+        await versionManagePage.showNewVersionButton.click();
         await versionManagePage.uploadNewVersionFile(fileModelVersionTwo.location);
         await versionManagePage.closeVersionDialog();
         await contentServicesPage.doubleClickRow(txtFileUploaded.entry.name);

--- a/e2e/process-services-cloud/pages/tasks-cloud-demo.page.ts
+++ b/e2e/process-services-cloud/pages/tasks-cloud-demo.page.ts
@@ -20,15 +20,14 @@ import {
     TogglePage,
     TaskFiltersCloudComponentPage,
     EditTaskFilterCloudComponentPage,
-    BrowserVisibility,
     TaskListCloudComponentPage,
-    BrowserActions, DropdownPage, Logger
+    BrowserActions, DropdownPage, Logger, TestElement
 } from '@alfresco/adf-testing';
 
 export class TasksCloudDemoPage {
 
-    createButton = element(by.css('button[data-automation-id="create-button"'));
-    newTaskButton = element(by.css('button[data-automation-id="btn-start-task"]'));
+    createButton = TestElement.byCss('button[data-automation-id="create-button"');
+    newTaskButton = TestElement.byCss('button[data-automation-id="btn-start-task"]');
     settingsButton = element.all(by.cssContainingText('div[class*="mat-tab-label"] .mat-tab-labels div', 'Settings')).first();
     appButton = element.all(by.cssContainingText('div[class*="mat-tab-label"] .mat-tab-labels div', 'App')).first();
     displayTaskDetailsToggle = element(by.css('mat-slide-toggle[data-automation-id="taskDetailsRedirection"]'));
@@ -40,13 +39,13 @@ export class TasksCloudDemoPage {
     selectedRows = element(by.xpath("//div[text()=' Selected Rows: ']"));
     noOfSelectedRows = element.all(by.xpath("//div[text()=' Selected Rows: ']//li"));
     addActionTitle = element(by.cssContainingText('.mat-card-title', 'Add Action'));
-    keyInputField = element(by.css('input[data-placeholder="Key"]'));
-    titleInputField = element(by.css('input[data-placeholder="Title"]'));
-    iconInputField = element(by.css('input[data-placeholder="Icon"]'));
-    addActionButton = element(by.cssContainingText('button span', 'Add'));
-    disableCheckbox = element(by.css(`mat-checkbox[formcontrolname='disabled']`));
-    visibleCheckbox = element(by.css(`mat-checkbox[formcontrolname='visible']`));
-
+    keyInputField = TestElement.byCss('input[data-placeholder="Key"]');
+    titleInputField = TestElement.byCss('input[data-placeholder="Title"]');
+    iconInputField = TestElement.byCss('input[data-placeholder="Icon"]');
+    addActionButton = TestElement.byText('button span', 'Add');
+    disableCheckbox = TestElement.byCss(`mat-checkbox[formcontrolname='disabled']`);
+    visibleCheckbox = TestElement.byCss(`mat-checkbox[formcontrolname='visible']`);
+    spinner = TestElement.byTag('mat-progress-spinner');
     modeDropdown = new DropdownPage(element(by.css('mat-form-field[data-automation-id="selectionMode"]')));
 
     togglePage = new TogglePage();
@@ -83,14 +82,14 @@ export class TasksCloudDemoPage {
     }
 
     async openNewTaskForm(): Promise<void> {
-        await BrowserActions.click(this.createButton);
+        await this.createButton.click();
         await BrowserActions.clickExecuteScript('button[data-automation-id="btn-start-task"]');
     }
 
     async clickSettingsButton(): Promise<void> {
         await BrowserActions.click(this.settingsButton);
         await browser.sleep(400);
-        await BrowserVisibility.waitUntilElementIsVisible(this.multiSelectionToggle);
+        await new TestElement(this.multiSelectionToggle).waitVisible();
         await this.modeDropdown.checkDropdownIsClickable();
     }
 
@@ -103,8 +102,8 @@ export class TasksCloudDemoPage {
         await this.modeDropdown.selectOption(mode);
     }
 
-    async checkSelectedRowsIsDisplayed(): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.selectedRows);
+    checkSelectedRowsIsDisplayed(): Promise<void> {
+        return new TestElement(this.selectedRows).waitVisible();
     }
 
     async getNoOfSelectedRows(): Promise<number> {
@@ -118,72 +117,66 @@ export class TasksCloudDemoPage {
         return BrowserActions.getText(row);
     }
 
-    async addActionIsDisplayed(): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.addActionTitle);
+    addActionIsDisplayed(): Promise<void> {
+        return new TestElement(this.addActionTitle).waitVisible();
     }
 
     async addAction(text: string): Promise<void> {
-        await BrowserActions.clearSendKeys(this.keyInputField, text);
-        await BrowserActions.clearSendKeys(this.titleInputField, text);
-        await BrowserActions.clearSendKeys(this.iconInputField, text);
-        await BrowserActions.click(this.addActionButton);
+        await this.keyInputField.typeText(text);
+        await this.titleInputField.typeText(text);
+        await this.iconInputField.typeText(text);
+        await this.addActionButton.click();
     }
 
     async addDisabledAction(text: string): Promise<void> {
-        await BrowserActions.clearSendKeys(this.keyInputField, text);
-        await BrowserActions.clearSendKeys(this.titleInputField, text);
-        await BrowserActions.clearSendKeys(this.iconInputField, text);
-        await BrowserActions.click(this.disableCheckbox);
-        await BrowserActions.click(this.addActionButton);
+        await this.keyInputField.typeText(text);
+        await this.titleInputField.typeText(text);
+        await this.iconInputField.typeText(text);
+        await this.disableCheckbox.click();
+        await this.addActionButton.click();
     }
 
     async addInvisibleAction(text: string): Promise<void> {
-        await BrowserActions.clearSendKeys(this.keyInputField, text);
-        await BrowserActions.clearSendKeys(this.titleInputField, text);
-        await BrowserActions.clearSendKeys(this.iconInputField, text);
-        await BrowserActions.click(this.visibleCheckbox);
-        await BrowserActions.click(this.addActionButton);
+        await this.keyInputField.typeText(text);
+        await this.titleInputField.typeText(text);
+        await this.iconInputField.typeText(text);
+        await this.visibleCheckbox.click();
+        await this.addActionButton.click();
     }
 
-    async actionAdded(action: string): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(element(by.cssContainingText(`mat-chip`, action)));
+    actionAdded(action: string): Promise<void> {
+        return TestElement.byText(`mat-chip`, action).waitVisible();
     }
 
     async checkActionExecuted(taskId: string, action: string): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(element(by.cssContainingText(`span`, 'Action Menu:')));
-        await BrowserVisibility.waitUntilElementIsVisible(element(by.cssContainingText(`span`, 'Context Menu:')));
-        await BrowserVisibility.waitUntilElementIsVisible(element(by.cssContainingText(`span`, 'Task ID: ' + taskId)));
-        await BrowserVisibility.waitUntilElementIsVisible(element(by.cssContainingText(`span`, 'Action Type: ' + action)));
+        await TestElement.byText(`span`, 'Action Menu:').waitVisible();
+        await TestElement.byText(`span`, 'Context Menu:').waitVisible();
+        await TestElement.byText(`span`, 'Task ID: ' + taskId).waitVisible();
+        await TestElement.byText(`span`, 'Action Type: ' + action).waitVisible();
     }
 
     async clickStartNewTaskButton() {
-        await BrowserActions.click(this.createButton);
-        await BrowserActions.click(this.newTaskButton);
+        await this.createButton.click();
+        await this.newTaskButton.click();
     }
 
     async waitTillContentLoaded(): Promise<void> {
-        if (this.isSpinnerPresent()) {
+        if (await this.isSpinnerPresent()) {
             Logger.log('wait loading spinner disappear');
-            await BrowserVisibility.waitUntilElementIsNotPresent(element(by.tagName('mat-progress-spinner')));
+            await this.spinner.waitNotPresent();
         }  else {
             try {
                 Logger.log('wait loading spinner is present');
-                await BrowserVisibility.waitUntilElementIsPresent(element(by.tagName('mat-progress-spinner')));
-            } catch (error) {
-            }
+                await this.spinner.waitPresent();
+            } catch {}
         }
     }
 
     private async isSpinnerPresent(): Promise<boolean> {
-        let isSpinnerPresent;
-
         try {
-            isSpinnerPresent = await element(by.tagName('mat-progress-spinner')).isDisplayed();
-        } catch (error) {
-            isSpinnerPresent = false;
+            return await this.spinner.isDisplayed();
+        } catch {
+            return false;
         }
-
-        return isSpinnerPresent;
     }
-
 }

--- a/e2e/process-services/empty-process-list-component.e2e.ts
+++ b/e2e/process-services/empty-process-list-component.e2e.ts
@@ -71,7 +71,7 @@ describe('Empty Process List Test', () => {
 
         await expect(await processFiltersPage.numberOfProcessRows()).toEqual(1);
 
-        await processDetailsPage.checkProcessDetailsCard();
+        await processDetailsPage.propertiesList.waitVisible();
         await navigationBarPage.navigateToProcessServicesPage();
         await processServicesPage.checkApsContainer();
         await (await processServicesPage.goToApp(simpleAppWithUserForm.title)).clickProcessButton();
@@ -86,6 +86,6 @@ describe('Empty Process List Test', () => {
 
         await expect(await processFiltersPage.numberOfProcessRows()).toEqual(1);
 
-        await processDetailsPage.checkProcessDetailsCard();
+        await processDetailsPage.propertiesList.waitVisible();
     });
 });

--- a/e2e/process-services/form-people-widget.e2e.ts
+++ b/e2e/process-services/form-people-widget.e2e.ts
@@ -80,7 +80,7 @@ describe('Form widgets - People ', () => {
 
     it('[C286577] Should be able to start a process with people widget', async () => {
         await startProcess.clickFormStartProcessButton();
-        await processDetailsPage.clickOnActiveTask();
+        await processDetailsPage.activeTask.click();
 
         const taskId = await taskDetails.getId();
         const taskForm: any = await apiService.getInstance().activiti.taskApi.getTaskForm(taskId);
@@ -92,7 +92,7 @@ describe('Form widgets - People ', () => {
         await startProcess.enterProcessName(app.processName);
         await startProcess.clickFormStartProcessButton();
 
-        await processDetailsPage.clickOnActiveTask();
+        await processDetailsPage.activeTask.click();
         await taskDetails.checkCompleteFormButtonIsDisplayed();
         await taskDetails.clickCompleteFormTask();
 
@@ -100,7 +100,7 @@ describe('Form widgets - People ', () => {
         await processFiltersPage.clickCompletedFilterButton();
         await processFiltersPage.selectFromProcessList(app.processName);
 
-        await processDetailsPage.clickOnCompletedTask();
+        await processDetailsPage.completedTask.click();
 
         const taskId = await taskDetails.getId();
         const taskForm: any = await apiService.getInstance().activiti.taskApi.getTaskForm(taskId);

--- a/e2e/process-services/pages/process-details.page.ts
+++ b/e2e/process-services/pages/process-details.page.ts
@@ -15,32 +15,32 @@
  * limitations under the License.
  */
 
-import { by, element, protractor } from 'protractor';
-import { BrowserVisibility, BrowserActions, ProcessInstanceHeaderPage } from '@alfresco/adf-testing';
+import { protractor } from 'protractor';
+import { ProcessInstanceHeaderPage, TestElement } from '@alfresco/adf-testing';
 
 export class ProcessDetailsPage {
     processInstanceHeaderPage = new ProcessInstanceHeaderPage();
-    processTitle = element(by.css('.mat-card-title'));
-    processDetailsMessage = element(by.css('adf-process-instance-details div'));
-    showDiagramButtonDisabled = element(by.css('button[id="show-diagram-button"][disabled]'));
-    propertiesList = element(by.css('.adf-property-list'));
-    showDiagramButton = element(by.id('show-diagram-button'));
-    diagramCanvas = element(by.css('svg[xmlns="http://www.w3.org/2000/svg"]'));
-    backButton = element(by.css('app-show-diagram button.mat-mini-fab.mat-accent'));
-    commentInput = element(by.id('comment-input'));
-    auditLogButton = element(by.css('button[adf-process-audit]'));
-    auditLogEmptyListMessage = element(by.css('.app-empty-list-header'));
-    cancelProcessButton = element(by.css('div[data-automation-id="header-status"] > button'));
-    activeTask = element(by.css('div[data-automation-id="active-tasks"]'));
-    completedTask = element(by.css('div[data-automation-id="completed-tasks"]'));
-    taskTitle = element(by.css('.adf-activiti-task-details__header'));
+    processTitle = TestElement.byCss('.mat-card-title');
+    processDetailsMessage = TestElement.byCss('adf-process-instance-details div');
+    showDiagramButtonDisabled = TestElement.byCss('button[id="show-diagram-button"][disabled]');
+    propertiesList = TestElement.byCss('.adf-property-list');
+    showDiagramButton = TestElement.byId('show-diagram-button');
+    diagramCanvas = TestElement.byCss('svg[xmlns="http://www.w3.org/2000/svg"]');
+    backButton = TestElement.byCss('app-show-diagram button.mat-mini-fab.mat-accent');
+    commentInput = TestElement.byId('comment-input');
+    auditLogButton = TestElement.byCss('button[adf-process-audit]');
+    auditLogEmptyListMessage = TestElement.byCss('.app-empty-list-header');
+    cancelProcessButton = TestElement.byCss('div[data-automation-id="header-status"] > button');
+    activeTask = TestElement.byCss('div[data-automation-id="active-tasks"]');
+    completedTask = TestElement.byCss('div[data-automation-id="completed-tasks"]');
+    taskTitle = TestElement.byCss('.adf-activiti-task-details__header');
 
     checkProcessTitleIsDisplayed(): Promise<string> {
-        return BrowserActions.getText(this.processTitle);
+        return this.processTitle.getText();
     }
 
     checkProcessDetailsMessage(): Promise<string> {
-        return BrowserActions.getText(this.processDetailsMessage);
+        return this.processDetailsMessage.getText();
     }
 
     async checkProcessHeaderDetailsAreVisible(): Promise<void> {
@@ -80,52 +80,18 @@ export class ProcessDetailsPage {
     }
 
     async clickShowDiagram(): Promise<void> {
-        await BrowserActions.click(this.showDiagramButton);
-        await BrowserVisibility.waitUntilElementIsVisible(this.diagramCanvas);
-        await BrowserActions.click(this.backButton);
-
-    }
-
-    async checkShowDiagramIsDisabled(): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.showDiagramButtonDisabled);
+        await this.showDiagramButton.click();
+        await this.diagramCanvas.waitVisible();
+        await this.backButton.click();
     }
 
     async addComment(comment: string): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.commentInput);
-        await this.commentInput.sendKeys(comment);
-        await this.commentInput.sendKeys(protractor.Key.ENTER);
+        await this.commentInput.waitVisible();
+        await this.commentInput.elementFinder.sendKeys(comment);
+        await this.commentInput.elementFinder.sendKeys(protractor.Key.ENTER);
     }
 
-    async checkCommentIsDisplayed(comment: string): Promise<void> {
-        const commentInserted = element(by.cssContainingText('div[id="comment-message"]', comment));
-        await BrowserVisibility.waitUntilElementIsVisible(commentInserted);
-    }
-
-    async clickAuditLogButton(): Promise<void> {
-        await BrowserActions.click(this.auditLogButton);
-    }
-
-    getEmptyMessage(): Promise<string> {
-        return BrowserActions.getText(this.auditLogEmptyListMessage);
-    }
-
-    async clickCancelProcessButton(): Promise<void> {
-        await BrowserActions.click(this.cancelProcessButton);
-    }
-
-    async clickOnActiveTask(): Promise<void> {
-        await BrowserActions.click(this.activeTask);
-    }
-
-    async clickOnCompletedTask(): Promise<void> {
-        await BrowserActions.click(this.completedTask);
-    }
-
-    async checkActiveTaskTitleIsDisplayed(): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.taskTitle);
-    }
-
-    async checkProcessDetailsCard(): Promise<void> {
-        await BrowserVisibility.waitUntilElementIsVisible(this.propertiesList);
+    checkCommentIsDisplayed(comment: string): Promise<void> {
+        return TestElement.byText('div[id="comment-message"]', comment).waitVisible();
     }
 }

--- a/e2e/process-services/process-attachment-list-action-menu.e2e.ts
+++ b/e2e/process-services/process-attachment-list-action-menu.e2e.ts
@@ -137,7 +137,7 @@ describe('Attachment list action menu for processes', () => {
         await attachmentListPage.clickAttachFileButton(pngFile.location);
         await attachmentListPage.checkFileIsAttached(pngFile.name);
 
-        await processDetailsPage.clickCancelProcessButton();
+        await processDetailsPage.cancelProcessButton.click();
         await processFiltersPage.clickCompletedFilterButton();
 
         await processDetailsPage.checkProcessTitleIsDisplayed();

--- a/e2e/process-services/process-filters-component.e2e.ts
+++ b/e2e/process-services/process-filters-component.e2e.ts
@@ -93,7 +93,7 @@ describe('Process Filters Test', () => {
         await startProcessPage.enterProcessName(processTitle.completed);
         await startProcessPage.clickFormStartProcessButton();
 
-        await processDetailsPage.clickCancelProcessButton();
+        await processDetailsPage.cancelProcessButton.click();
         await navigationBarPage.navigateToProcessServicesPage();
 
         await processServicesPage.goToApp(app.title);
@@ -109,7 +109,7 @@ describe('Process Filters Test', () => {
         await processFiltersPage.checkFilterIsHighlighted(processFilter.running);
         await processFiltersPage.selectFromProcessList(processTitle.running);
 
-        await processDetailsPage.checkProcessDetailsCard();
+        await processDetailsPage.propertiesList.waitVisible();
     });
 
     it('[C280063] Should both the new created process and a completed one to be displayed when clicking on All filter', async () => {
@@ -121,7 +121,7 @@ describe('Process Filters Test', () => {
         await processFiltersPage.checkFilterIsHighlighted(processFilter.all);
         await processFiltersPage.selectFromProcessList(processTitle.running);
         await processFiltersPage.selectFromProcessList(processTitle.completed);
-        await processDetailsPage.checkProcessDetailsCard();
+        await processDetailsPage.propertiesList.waitVisible();
     });
 
     it('[C280064] Should the completed process be displayed when clicking on Completed filter', async () => {
@@ -132,7 +132,7 @@ describe('Process Filters Test', () => {
         await processFiltersPage.clickCompletedFilterButton();
         await processFiltersPage.checkFilterIsHighlighted(processFilter.completed);
         await processFiltersPage.selectFromProcessList(processTitle.completed);
-        await processDetailsPage.checkProcessDetailsCard();
+        await processDetailsPage.propertiesList.waitVisible();
     });
 
     it('[C280407] Should be able to access the filters with URL', async () => {
@@ -170,14 +170,14 @@ describe('Process Filters Test', () => {
         await startProcessPage.clickFormStartProcessButton();
         await processListDemoPage.checkProcessIsDisplayed(processTitle.canceled);
 
-        await processDetailsPage.clickCancelProcessButton();
+        await processDetailsPage.cancelProcessButton.click();
         await processListDemoPage.checkProcessIsNotDisplayed(processTitle.canceled);
 
         await processFiltersPage.clickCompletedFilterButton();
         await processFiltersPage.checkFilterIsHighlighted(processFilter.completed);
         await processListDemoPage.checkProcessIsDisplayed(processTitle.canceled);
         await processFiltersPage.selectFromProcessList(processTitle.canceled);
-        await processDetailsPage.checkProcessDetailsCard();
+        await processDetailsPage.propertiesList.waitVisible();
     });
 
     it('[C213262] Default process filters', async () => {
@@ -193,7 +193,7 @@ describe('Process Filters Test', () => {
 
         await processListDemoPage.checkProcessIsDisplayed(processTitle.one);
         await processFiltersPage.checkFilterIsHighlighted(processFilter.running);
-        await processDetailsPage.checkProcessDetailsCard();
+        await processDetailsPage.propertiesList.waitVisible();
         await checkProcessInfoDrawer({  name: processTitle.one });
 
         await processFiltersPage.clickCreateProcessButton();
@@ -205,7 +205,7 @@ describe('Process Filters Test', () => {
         await processListDemoPage.checkProcessIsDisplayed(processTitle.one);
         await processListDemoPage.checkProcessIsDisplayed(processTitle.two);
 
-        await processDetailsPage.clickCancelProcessButton();
+        await processDetailsPage.cancelProcessButton.click();
         await processListDemoPage.checkProcessIsNotDisplayed(processTitle.canceled);
 
         await processFiltersPage.clickCompletedFilterButton();

--- a/e2e/process-services/start-process-component.e2e.ts
+++ b/e2e/process-services/start-process-component.e2e.ts
@@ -323,7 +323,7 @@ describe('Start Process Component', () => {
                 await startProcessPage.clickFormStartProcessButton();
                 await processFiltersPage.clickRunningFilterButton();
                 await processFiltersPage.selectFromProcessList('Audit Log');
-                await processDetailsPage.clickAuditLogButton();
+                await processDetailsPage.auditLogButton.click();
 
                 await FileBrowserUtil.isFileDownloaded(auditLogFile);
             });
@@ -375,8 +375,8 @@ describe('Start Process Component', () => {
                 await startProcessPage.clickFormStartProcessButton();
                 await processFiltersPage.clickRunningFilterButton();
                 await processFiltersPage.selectFromProcessList('Active Task');
-                await processDetailsPage.clickOnActiveTask();
-                await processDetailsPage.checkActiveTaskTitleIsDisplayed();
+                await processDetailsPage.activeTask.click();
+                await processDetailsPage.taskTitle.waitVisible();
             });
 
             it('[C260457] Should display process in Completed when cancelled', async () => {
@@ -391,10 +391,10 @@ describe('Start Process Component', () => {
                 await startProcessPage.clickFormStartProcessButton();
                 await processFiltersPage.clickRunningFilterButton();
                 await processFiltersPage.selectFromProcessList('Cancel Process');
-                await processDetailsPage.clickCancelProcessButton();
+                await processDetailsPage.cancelProcessButton.click();
                 await processFiltersPage.clickCompletedFilterButton();
                 await processFiltersPage.selectFromProcessList('Cancel Process');
-                await processDetailsPage.checkShowDiagramIsDisabled();
+                await processDetailsPage.showDiagramButtonDisabled.waitVisible();
             });
 
             it('[C260461] Should be possible to add a comment on a completed/canceled process', async () => {
@@ -407,7 +407,7 @@ describe('Start Process Component', () => {
                 await startProcessPage.clickFormStartProcessButton();
                 await processFiltersPage.clickRunningFilterButton();
                 await processFiltersPage.selectFromProcessList('Comment Process 2');
-                await processDetailsPage.clickCancelProcessButton();
+                await processDetailsPage.cancelProcessButton.click();
                 await processFiltersPage.clickCompletedFilterButton();
                 await processFiltersPage.selectFromProcessList('Comment Process 2');
                 await processDetailsPage.addComment('goodbye');
@@ -424,7 +424,7 @@ describe('Start Process Component', () => {
                 await startProcessPage.clickFormStartProcessButton();
                 await processFiltersPage.clickRunningFilterButton();
                 await processFiltersPage.selectFromProcessList('File');
-                await processDetailsPage.clickCancelProcessButton();
+                await processDetailsPage.cancelProcessButton.click();
                 await processFiltersPage.clickCompletedFilterButton();
                 await processFiltersPage.selectFromProcessList('File');
                 await attachmentListPage.checkAttachFileButtonIsNotDisplayed();
@@ -531,7 +531,7 @@ describe('Start Process Component', () => {
             await processServiceTabBarPage.clickProcessButton();
             await processFiltersPage.clickCompletedFilterButton();
             await processFiltersPage.selectFromProcessList('Test Process');
-            await expect(await processDetailsPage.getEmptyMessage()).toBe('This list is empty');
+            await expect(await processDetailsPage.auditLogEmptyListMessage.getText()).toBe('This list is empty');
         });
     });
 

--- a/e2e/process-services/stencil.e2e.ts
+++ b/e2e/process-services/stencil.e2e.ts
@@ -83,7 +83,7 @@ describe('Stencil', () => {
         await processListDemoPage.checkProcessIsDisplayed(name);
         await processFiltersPage.selectFromProcessList(name);
 
-        await processDetailsPage.clickOnActiveTask();
+        await processDetailsPage.activeTask.click();
         await taskPage.tasksListPage().checkTaskListIsLoaded();
         await taskPage.taskDetails().clickCompleteTask();
 

--- a/e2e/process-services/task-assignee.e2e.ts
+++ b/e2e/process-services/task-assignee.e2e.ts
@@ -99,7 +99,7 @@ describe('Task Assignee', () => {
             await processFiltersPage.clickNewProcessDropdown();
             await startProcessPage.startProcess(name, app.processNames[0]);
             await processFiltersPage.selectFromProcessList(name);
-            await processDetailsPage.clickOnActiveTask();
+            await processDetailsPage.activeTask.click();
 
             await taskPage.tasksListPage().checkContentIsDisplayed(app.userTasks.simple.one);
             await taskPage.tasksListPage().selectRow(app.userTasks.simple.one);

--- a/lib/content-services/src/lib/upload/components/upload-version-button.component.ts
+++ b/lib/content-services/src/lib/upload/components/upload-version-button.component.ts
@@ -27,7 +27,8 @@ import { UploadButtonComponent } from './upload-button.component';
     viewProviders: [
         { provide: EXTENDIBLE_COMPONENT, useExisting: forwardRef(() => UploadVersionButtonComponent) }
     ],
-    encapsulation: ViewEncapsulation.None
+    encapsulation: ViewEncapsulation.None,
+    host: { class: 'adf-upload-version-button' }
 })
 export class UploadVersionButtonComponent extends UploadButtonComponent implements OnChanges, OnInit {
 

--- a/lib/testing/src/lib/core/public-api.ts
+++ b/lib/testing/src/lib/core/public-api.ts
@@ -20,3 +20,4 @@ export * from './pages/public-api';
 export * from './models/public-api';
 export * from './dialog/public-api';
 export * from './utils/public-api';
+export * from './test-element';

--- a/lib/testing/src/lib/core/test-element.ts
+++ b/lib/testing/src/lib/core/test-element.ts
@@ -26,6 +26,10 @@ export class TestElement {
         return new TestElement(element(by.css(selector)));
     }
 
+    static byText(selector: string, text: string): TestElement {
+        return new TestElement(element(by.cssContainingText(selector, text)));
+    }
+
     async click() {
         return BrowserActions.click(this.elementFinder);
     }

--- a/lib/testing/src/lib/core/test-element.ts
+++ b/lib/testing/src/lib/core/test-element.ts
@@ -34,6 +34,10 @@ export class TestElement {
         return new TestElement(element(by.cssContainingText(selector, text)));
     }
 
+    static byTag(selector: string): TestElement {
+        return new TestElement(element(by.tagName(selector)));
+    }
+
     async click() {
         return BrowserActions.click(this.elementFinder);
     }

--- a/lib/testing/src/lib/core/test-element.ts
+++ b/lib/testing/src/lib/core/test-element.ts
@@ -22,6 +22,10 @@ import { BrowserVisibility } from './utils/browser-visibility';
 export class TestElement {
     constructor(public elementFinder: ElementFinder) {}
 
+    static byId(id: string): TestElement {
+        return new TestElement(element(by.id(id)));
+    }
+
     static byCss(selector: string): TestElement {
         return new TestElement(element(by.css(selector)));
     }
@@ -38,6 +42,10 @@ export class TestElement {
         return BrowserVisibility.waitUntilElementIsVisible(this.elementFinder, waitTimeout);
     }
 
+    async waitNotVisible(waitTimeout?: number) {
+        return BrowserVisibility.waitUntilElementIsNotVisible(this.elementFinder, waitTimeout);
+    }
+
     async waitNotPresent(waitTimeout?: number) {
         return BrowserVisibility.waitUntilElementIsNotPresent(this.elementFinder, waitTimeout);
     }
@@ -52,6 +60,11 @@ export class TestElement {
 
     async isDisplayed(): Promise<boolean> {
         return this.elementFinder.isDisplayed();
+    }
+
+    async getAttribute(name: string): Promise<string> {
+        await this.waitVisible();
+        return this.elementFinder.getAttribute(name);
     }
 
     async getText(): Promise<string> {

--- a/lib/testing/src/lib/core/test-element.ts
+++ b/lib/testing/src/lib/core/test-element.ts
@@ -1,0 +1,65 @@
+/*!
+ * @license
+ * Copyright 2019 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { by, element, ElementFinder, protractor } from 'protractor';
+import { BrowserActions } from './utils/browser-actions';
+import { BrowserVisibility } from './utils/browser-visibility';
+
+export class TestElement {
+    constructor(public elementFinder: ElementFinder) {}
+
+    static byCss(selector: string): TestElement {
+        return new TestElement(element(by.css(selector)));
+    }
+
+    async click() {
+        return BrowserActions.click(this.elementFinder);
+    }
+
+    async waitVisible(waitTimeout?: number) {
+        return BrowserVisibility.waitUntilElementIsVisible(this.elementFinder, waitTimeout);
+    }
+
+    async waitNotPresent(waitTimeout?: number) {
+        return BrowserVisibility.waitUntilElementIsNotPresent(this.elementFinder, waitTimeout);
+    }
+
+    async waitHasValue(value: string) {
+        return BrowserVisibility.waitUntilElementHasValue(this.elementFinder, value);
+    }
+
+    async isEnabled(): Promise<boolean> {
+        return this.elementFinder.isEnabled();
+    }
+
+    async isDisplayed(): Promise<boolean> {
+        return this.elementFinder.isDisplayed();
+    }
+
+    async getText(): Promise<string> {
+        return BrowserActions.getText(this.elementFinder);
+    }
+
+    async typeText(text: string) {
+        return BrowserActions.clearSendKeys(this.elementFinder, text);
+    }
+
+    async clearInput() {
+        await this.elementFinder.clear();
+        await this.elementFinder.sendKeys(' ', protractor.Key.CONTROL, 'a', protractor.Key.NULL, protractor.Key.BACK_SPACE);
+    }
+}

--- a/lib/testing/src/lib/core/test-element.ts
+++ b/lib/testing/src/lib/core/test-element.ts
@@ -46,6 +46,10 @@ export class TestElement {
         return BrowserVisibility.waitUntilElementIsNotVisible(this.elementFinder, waitTimeout);
     }
 
+    async waitPresent(waitTimeout?: number) {
+        return BrowserVisibility.waitUntilElementIsPresent(this.elementFinder, waitTimeout);
+    }
+
     async waitNotPresent(waitTimeout?: number) {
         return BrowserVisibility.waitUntilElementIsNotPresent(this.elementFinder, waitTimeout);
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Right now, we have a lot of code duplication in e2e page classes to perform same primitive operations like: `click`, `input`, `wait`, `reset`, etc. 

**Example**

```ts
// BAD DESIGN
async clickCloseButton(): Promise<void> {
   await BrowserActions.click(this.closeButton);
}

// BAD DESIGN
async clickCreate(): Promise<void> {	
  await BrowserActions.click(this.createButton);	
}	

// BAD DESIGN
async clickCancel(): Promise<void> {	
  await BrowserActions.click(this.cancelButton);	
}

// BAD DESIGN
async checkDialogIsDisplayed(): Promise<void> {
  await BrowserVisibility.waitUntilElementIsVisible(this.dialog);
}

// BAD DESIGN
async checkDialogIsNotDisplayed(): Promise<void> {
  await BrowserVisibility.waitUntilElementIsNotVisible(this.dialog);
}
```

**What is the new behaviour?**

> IMPORTANT: This PR provides only basic refactoring of several test pages to demonstrate the amount of code that can be reduced if the prototype is approved.

Introduces `TestElement` wrapper that facilitates writing custom API for protractor elements and greatly reduces code noise in e2e pages:

```ts
const button = TestElement.byCss('#button');
await button.click();
```

The `TestElement.click` method already incorporates calls to BrowserActions, so developers no longer need duplicating code just to click the button.

**TestElement API**:

The prototype provides proxy methods for the following frequently used API:

* `byCss` => `element(by.css(selector))`
* `byId` => `element(by.id(id))`
* `byText` => `element(by.cssContainingText(selector, text))`
* `click` => `BrowserActions.click`
* `waitVisible` => `BrowserVisibility.waitUntilElementIsVisible`
* `waitNotPresent` => `BrowserVisibility.waitUntilElementIsNotPresent`
* `waitHasValue` => `BrowserVisibility.waitUntilElementHasValue`
* `isEnabled` => `ElementFinder.isEnabled`
* `isDisplayed` => `ElementFinder.isDisplayed`
* `getText` => `BrowserActions.getText`
* `typeText` => `BrowserActions.clearSendKeys`
* `clearInput` => `ElementFinder.clear` + `ElementFinder.sendKeys`

> More APIs or helper methods can be provided on demand

**Benefits**

- significant reduction of duplicated methods in e2e
- greatly reduced `imports` section (no need importing Protractor of numerous ADF helper classes)
- better maintenance (single class to fix)

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
