### PR TITLE
[AAE-4295] E2E - Add retry api calls for delete descriptor and application

### DIFF
--- a/lib/testing/src/lib/process-services-cloud/actions/application.ts
+++ b/lib/testing/src/lib/process-services-cloud/actions/application.ts
@@ -19,6 +19,7 @@ import { E2eRequestApiHelper } from '../../core/actions/e2e-request-api.helper';
 import { Logger } from '../../core/utils/logger';
 import { ResultSetPaging } from '@alfresco/js-api';
 import { ApiService } from '../../core/actions/api.service';
+import { ApiUtil } from '../../core/actions/api.util';
 
 export class Application {
 
@@ -40,8 +41,25 @@ export class Application {
     }
 
     async undeploy(applicationName: string): Promise<any> {
-        await this.requestApiHelper.delete(`${this.endPoint}${applicationName}`);
-        Logger.info(`[Application] Application ${applicationName} was undeployed successfully.`);
+        const isApplicationUndeployed = (response: any) => {
+            if (JSON.stringify(response) === '{}') {
+                Logger.info(`[Application] Application was undeployed successfully`);
+                return true;
+            } else {
+                Logger.warn(`[Application] Application was not undeployed`);
+                return false;
+            }
+        };
+
+        const apiCall = async () => {
+            try {
+                Logger.info(`[Application] Undeploy application ${applicationName} ...`);
+                return this.requestApiHelper.delete(`${this.endPoint}${applicationName}`);
+            } catch (error) {
+                Logger.error(`[Application] Undeploy application ${applicationName} failed with error: ${error.message}`);
+            }
+        };
+        return ApiUtil.waitForApi(apiCall, isApplicationUndeployed, 10, 3000);
     }
 
     async deleteDescriptor(name: string): Promise<void> {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe: Retry api calls for e2e tests


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
