### PR TITLE
[ACA-4262] Content node selector - show 2 tabs only in cloud attach f…

### DIFF
--- a/lib/content-services/src/lib/content-node-selector/content-node-selector.component.html
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector.component.html
@@ -4,7 +4,10 @@
     <h2>{{title}}</h2>
 </header>
 
-<mat-tab-group class="adf-content-node-selector-dialog-content" (selectedIndexChange)="onTabSelectionChange($event)" mat-align-tabs="start">
+<mat-tab-group class="adf-content-node-selector-dialog-content"
+               mat-align-tabs="start"
+               (selectedIndexChange)="onTabSelectionChange($event)"
+               [class.adf-content-node-selector-headless-tabs]="!canPerformLocalUpload()">
     <mat-tab label="{{ 'NODE_SELECTOR.FILE_SERVER' | translate }}">
             <adf-content-node-selector-panel
                 [currentFolderId]="data?.currentFolderId"
@@ -29,15 +32,15 @@
                 (navigationChange)="onNavigationChange($event)">
             </adf-content-node-selector-panel>
     </mat-tab>
-    <mat-tab *ngIf="data?.showLocalUploadButton"
+    <mat-tab *ngIf="canPerformLocalUpload()"
              label="{{ 'NODE_SELECTOR.UPLOAD_FROM_DEVICE' | translate }}"
              [disabled]="isNotAllowedToUpload()">
     </mat-tab>
 </mat-tab-group>
 
 <mat-dialog-actions>
-    <div *ngIf="isLocalUploadTabSelected()">
-        <ng-container *ngIf="data?.showLocalUploadButton">
+    <div>
+        <ng-container *ngIf="isUploadEnabled()">
             <adf-upload-button
                 [staticTitle]="'FORM.FIELD.UPLOAD' | translate "
                 [multipleFiles]="isMultipleSelection()"

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector.component.scss
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector.component.scss
@@ -3,6 +3,14 @@
     $foreground: map-get($theme, foreground);
     $background: map-get($theme, background);
 
+    adf-content-node-selector {
+        .adf-content-node-selector-headless-tabs {
+            .mat-tab-header {
+                display: none;
+            }
+        }
+    }
+
     .adf-content-node-selector-dialog {
         &-content {
             padding-left: 24px;

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector.component.spec.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector.component.spec.ts
@@ -371,5 +371,21 @@ describe('ContentNodeSelectorComponent', () => {
 
             expect(component.isLocalUploadTabSelected()).toEqual(true);
         });
+
+        it('should tabs be headless when local upload is not enabled', () => {
+           component.data.showLocalUploadButton = false;
+           fixture.detectChanges();
+           const tabGroup = fixture.debugElement.queryAll(By.css('.adf-content-node-selector-headless-tabs'))[0];
+
+           expect(tabGroup).not.toBe(undefined);
+        });
+
+        it('should tabs show headers when local upload is enabled', () => {
+            component.data.showLocalUploadButton = true;
+            fixture.detectChanges();
+            const tabGroup = fixture.debugElement.queryAll(By.css('.adf-content-node-selector-headless-tabs'))[0];
+
+            expect(tabGroup).toBe(undefined);
+        });
     });
 });

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector.component.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector.component.ts
@@ -137,4 +137,13 @@ export class ContentNodeSelectorComponent implements OnInit {
     isLocalUploadTabSelected (): boolean {
         return this.selectedTabIndex === 1;
     }
+
+    isUploadEnabled(): boolean {
+        return this.canPerformLocalUpload() && this.isLocalUploadTabSelected();
+    }
+
+    canPerformLocalUpload(): boolean {
+        return this.data?.showLocalUploadButton;
+    }
+
 }


### PR DESCRIPTION
…ile widget

**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ACA-4262


**What is the new behaviour?**
Tabs are visible only in attach file widget cloud


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
