### PR TITLE
[AAE-4569] Added readOnly property to breadcrumb components

### DIFF
--- a/docs/content-services/components/breadcrumb.component.md
+++ b/docs/content-services/components/breadcrumb.component.md
@@ -31,6 +31,7 @@ Indicates the current position within a navigation hierarchy.
 | rootId | `string` | null | (optional) The id of the root element. You can use this property to set a custom element the breadcrumb should start with. |
 | target | [`DocumentListComponent`](../../content-services/components/document-list.component.md) |  | (optional) [Document List component](../../content-services/components/document-list.component.md) to operate with. The list will update when the breadcrumb is clicked. |
 | transform | `Function` |  | Transformation to be performed on the chosen/folder node before building the breadcrumb UI. Can be useful when custom formatting is needed for the breadcrumb. You can change the path elements from the node that are used to build the breadcrumb using this function. |
+| readOnly | `boolean` | false | Prevents changing the active node |
 
 ### Events
 

--- a/docs/content-services/components/dropdown-breadcrumb.component.md
+++ b/docs/content-services/components/dropdown-breadcrumb.component.md
@@ -32,6 +32,7 @@ Indicates the current position within a navigation hierarchy using a dropdown me
 | rootId | `string` | null | (optional) The id of the root element. You can use this property to set a custom element the breadcrumb should start with. |
 | target | [`DocumentListComponent`](../../content-services/components/document-list.component.md) |  | (optional) [Document List component](../../content-services/components/document-list.component.md) to operate with. The list will update when the breadcrumb is clicked. |
 | transform | `Function` |  | Transformation to be performed on the chosen/folder node before building the breadcrumb UI. Can be useful when custom formatting is needed for the breadcrumb. You can change the path elements from the node that are used to build the breadcrumb using this function. |
+| readOnly | `boolean` | false | Prevents changing the active node |
 
 ### Events
 

--- a/lib/content-services/src/lib/breadcrumb/breadcrumb.component.html
+++ b/lib/content-services/src/lib/breadcrumb/breadcrumb.component.html
@@ -33,6 +33,7 @@
             (click)="onRoutePathClick(node, $event)"
             (onSelectionChange)="onRoutePathClick(node, $event)"
             class="adf-breadcrumb-path-option"
+            [disabled]="readOnly"
         >
             {{ node.name | translate }}
         </mat-option>
@@ -41,7 +42,7 @@
     <div
         *ngFor="let item of lastNodes; let last = last"
         [class.adf-active]="last"
-        [ngSwitch]="last"
+        [ngSwitch]="last || readOnly"
         title="{{ item.name | translate }}"
         class="adf-breadcrumb-item">
         <a

--- a/lib/content-services/src/lib/breadcrumb/breadcrumb.component.html
+++ b/lib/content-services/src/lib/breadcrumb/breadcrumb.component.html
@@ -42,11 +42,11 @@
     <div
         *ngFor="let item of lastNodes; let last = last"
         [class.adf-active]="last"
-        [ngSwitch]="last || readOnly"
+        [ngSwitch]="breadcrumbItemIsAnchor(last)"
         title="{{ item.name | translate }}"
         class="adf-breadcrumb-item">
         <a
-            *ngSwitchDefault
+            *ngSwitchCase="true"
             href="#"
             [attr.data-automation-id]="'breadcrumb_' + item.name"
             class="adf-breadcrumb-item-anchor"
@@ -55,7 +55,7 @@
             {{ item.name | translate }}
         </a>
 
-        <div *ngSwitchCase="true" class="adf-breadcrumb-item-current" role="heading" aria-level="2"
+        <div *ngSwitchDefault class="adf-breadcrumb-item-current" role="heading" aria-level="2"
             aria-current="location">
             {{ item.name | translate }}
         </div>

--- a/lib/content-services/src/lib/breadcrumb/breadcrumb.component.spec.ts
+++ b/lib/content-services/src/lib/breadcrumb/breadcrumb.component.spec.ts
@@ -160,6 +160,19 @@ describe('Breadcrumb', () => {
 
             expect(documentListComponent.navigateTo).toHaveBeenCalledWith('folder1');
         });
+
+        it('should not navigate if component is read-only', () => {
+            spyOn(documentListComponent, 'navigateTo').and.stub();
+
+            component.target = documentListComponent;
+            component.readOnly = true;
+            component.ngOnInit();
+
+            documentListComponent.$folderNode.next(folderNode);
+            component.onRoutePathClick(component.route[0]);
+
+            expect(documentListComponent.navigateTo).not.toHaveBeenCalled();
+        });
     });
 
     it('should not parse the route when node not provided', () => {

--- a/lib/content-services/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/lib/content-services/src/lib/breadcrumb/breadcrumb.component.ts
@@ -92,6 +92,10 @@ export class BreadcrumbComponent implements OnInit, OnChanges, OnDestroy {
         return !!this.root;
     }
 
+    /** If true, prevents the user from navigating away from the active node. */
+    @Input()
+    readOnly: boolean = false;
+
     /** Emitted when the user clicks on a breadcrumb. */
     @Output()
     navigate = new EventEmitter<PathElementEntity>();
@@ -183,7 +187,7 @@ export class BreadcrumbComponent implements OnInit, OnChanges, OnDestroy {
             event.preventDefault();
         }
 
-        if (route) {
+        if (route && !this.readOnly) {
             this.navigate.emit(route);
 
             if (this.target) {

--- a/lib/content-services/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/lib/content-services/src/lib/breadcrumb/breadcrumb.component.ts
@@ -182,6 +182,10 @@ export class BreadcrumbComponent implements OnInit, OnChanges, OnDestroy {
         return position;
     }
 
+    breadcrumbItemIsAnchor(lastItem) {
+        return !this.readOnly && !lastItem;
+    }
+
     onRoutePathClick(route: PathElementEntity, event?: Event): void {
         if (event && event.type === 'click') {
             event.preventDefault();

--- a/lib/content-services/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/lib/content-services/src/lib/breadcrumb/breadcrumb.component.ts
@@ -182,7 +182,7 @@ export class BreadcrumbComponent implements OnInit, OnChanges, OnDestroy {
         return position;
     }
 
-    breadcrumbItemIsAnchor(lastItem) {
+    breadcrumbItemIsAnchor(lastItem): boolean {
         return !this.readOnly && !lastItem;
     }
 

--- a/lib/content-services/src/lib/breadcrumb/dropdown-breadcrumb.component.html
+++ b/lib/content-services/src/lib/breadcrumb/dropdown-breadcrumb.component.html
@@ -25,7 +25,8 @@
                 (click)="onRoutePathClick(node, $event)"
                 (onSelectionChange)="onRoutePathClick(node, $event)"
                 class="adf-dropdown-breadcrumb-path-option"
-                data-automation-class="dropdown-breadcrumb-path-option">
+                data-automation-class="dropdown-breadcrumb-path-option"
+                [disabled]="readOnly">
                 {{ node.name | translate }}
             </mat-option>
         </mat-select>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

**What is the new behaviour?**

Given a readOnly property set to true, the breadcrumb and dropdown-breadcrumb components cannot be clicked on to navigate to different nodes.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
