### PR TITLE
[AAE-4637] Fix varying height of dialog when clicking on the Upload from your device tab

### DIFF
--- a/lib/content-services/src/lib/content-node-selector/content-node-selector.component.scss
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector.component.scss
@@ -10,12 +10,27 @@
             }
         }
 
+        .mat-tab-body-wrapper {
+            flex-grow: 1;
+        }
+
+        .mat-tab-body-content {
+            display: flex;
+            flex-direction: column;
+        }
+
+        adf-upload-drag-area {
+            flex-grow: 1;
+        }
+
         .adf-upload-dialog {
 
             &__content {
-                max-height: 64%;
+                max-height: unset;
             }
 
+            display: flex;
+            flex-direction: column;
             height: 100%;
             width: 100%;
             position: unset;
@@ -23,12 +38,15 @@
         }
 
         .adf-upload-dialog-container {
-            height: 456px;
+            flex-grow: 1;
+            height: 100%;
         }
     }
 
     .adf-content-node-selector-dialog {
         &-content {
+            height: 465px;
+            max-height: 80vh;
             padding-left: 24px;
             padding-right: 24px;
         }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Each tab has a different content height meaning that switching between them visibly changes the height of the dialog. Space in between the _Cancel Uploads_ button and the bottom of the dialog.

**What is the new behaviour?**

The content covers the same height. No variation in height between the two tabs is perceived. The space under the _Cancel Uploads_ button has been removed.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
