### PR TITLE
[ADF-5341] Add Apollo direct dependencies

### DIFF
--- a/lib/process-services-cloud/ng-package.json
+++ b/lib/process-services-cloud/ng-package.json
@@ -13,5 +13,10 @@
       "moment-es6": "moment-es6",
       "@ngx-translate/core": "@ngx-translate/core"
     }
-  }
+  },
+  "whitelistedNonPeerDependencies": [
+    "@apollo/client",
+    "apollo-angular",
+    "subscriptions-transport-ws"
+  ]
 }

--- a/lib/process-services-cloud/package.json
+++ b/lib/process-services-cloud/package.json
@@ -1,38 +1,40 @@
 {
-  "name": "@alfresco/adf-process-services-cloud",
-  "description": "Alfresco ADF process services cloud",
-  "version": "4.2.0",
-  "author": "Alfresco Software, Ltd.",
-  "main": "bundles/adf-process-services-cloud.js",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/Alfresco/alfresco-ng2-components.git"
-  },
-  "bugs": {
-    "url": "https://github.com/Alfresco/alfresco-ng2-components/issues"
-  },
-  "peerDependencies": {
-    "@angular/animations": ">=10.0.2",
-    "@angular/common": ">=10.0.2",
-    "@angular/core": ">=10.0.2",
-    "@angular/flex-layout": ">=10.0.0-beta.32",
-    "@angular/forms": ">=10.0.2",
-    "@angular/material": ">=10.0.1",
-    "@alfresco/js-api": "4.3.0-3224",
-    "@alfresco/adf-core": "4.2.0",
-    "@alfresco/adf-content-services": "4.2.0",
-    "@apollo/client": "^3.3.7",
-    "@ngx-translate/core": ">=13.0.0",
-    "apollo-angular": "^2.2.0",
-    "moment": ">=2.22.2",
-    "subscriptions-transport-ws": "^0.9.18"
-  },
-  "keywords": [
-    "process-services-cloud",
-    "alfresco-component",
-    "angular",
-    "activiti",
-    "components"
-  ],
-  "license": "Apache-2.0"
+    "name": "@alfresco/adf-process-services-cloud",
+    "description": "Alfresco ADF process services cloud",
+    "version": "4.2.0",
+    "author": "Alfresco Software, Ltd.",
+    "main": "bundles/adf-process-services-cloud.js",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Alfresco/alfresco-ng2-components.git"
+    },
+    "bugs": {
+        "url": "https://github.com/Alfresco/alfresco-ng2-components/issues"
+    },
+    "dependencies": {
+      "@apollo/client": "3.3.7",
+      "apollo-angular": "2.2.0",
+      "subscriptions-transport-ws": "0.9.18"
+    },
+    "peerDependencies": {
+        "@angular/animations": ">=10.0.2",
+        "@angular/common": ">=10.0.2",
+        "@angular/core": ">=10.0.2",
+        "@angular/flex-layout": ">=10.0.0-beta.32",
+        "@angular/forms": ">=10.0.2",
+        "@angular/material": ">=10.0.1",
+        "@alfresco/js-api": "4.2.0",
+        "@alfresco/adf-core": "4.2.0",
+        "@alfresco/adf-content-services": "4.2.0",
+        "@ngx-translate/core": ">=13.0.0",
+        "moment": ">=2.22.2"
+    },
+    "keywords": [
+        "process-services-cloud",
+        "alfresco-component",
+        "angular",
+        "activiti",
+        "components"
+    ],
+    "license": "Apache-2.0"
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ADF-5341


**What is the new behaviour?**
At the moment, Apollo is a peer dependency of @alfresco/adf-process-service-cloud. which means that the user of the app that makes use of it has to manually install them to build the packages correctly.

Using the direct dependency the apollo package and apollo client will be installed automatically in the package.json if the @alfresco/adf-process-service-cloud is present.



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
