### PR TITLE
[AAE-3543] Attach button enabled only when all files uploaded

### DIFF
--- a/lib/content-services/src/lib/content-node-selector/content-node-selector.component.html
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector.component.html
@@ -80,7 +80,7 @@
         </button>
 
         <button mat-button
-                [disabled]="!hasNodeSelected()"
+                [disabled]="isChooseButtonDisabled()"
                 class="adf-choose-action"
                 (click)="onClick()"
                 data-automation-id="content-node-selector-actions-choose">{{ buttonActionName | translate }}

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector.component.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector.component.ts
@@ -17,7 +17,7 @@
 
 import { Component, Inject, OnInit, ViewEncapsulation } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
-import { TranslationService, NotificationService, AllowableOperationsEnum, ContentService } from '@alfresco/adf-core';
+import { TranslationService, NotificationService, AllowableOperationsEnum, ContentService, UploadService } from '@alfresco/adf-core';
 import { Node } from '@alfresco/js-api';
 
 import { ContentNodeSelectorComponentData } from './content-node-selector.component-data.interface';
@@ -44,6 +44,7 @@ export class ContentNodeSelectorComponent implements OnInit {
     constructor(private translation: TranslationService,
                 private contentService: ContentService,
                 private notificationService: NotificationService,
+                private uploadService: UploadService,
                 private dialog: MatDialogRef<ContentNodeSelectorComponent>,
                 @Inject(MAT_DIALOG_DATA) public data: ContentNodeSelectorComponentData) {
         this.action = data.actionName ? data.actionName.toUpperCase() : 'CHOOSE';
@@ -105,6 +106,10 @@ export class ContentNodeSelectorComponent implements OnInit {
 
     onError(error) {
         this.notificationService.showError(error);
+    }
+
+    isChooseButtonDisabled(): boolean {
+        return !this.uploadService.isQueueFinishedUploading() || !this.hasNodeSelected();
     }
 
     hasNodeSelected(): boolean {

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector.component.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector.component.ts
@@ -109,7 +109,7 @@ export class ContentNodeSelectorComponent implements OnInit {
     }
 
     isChooseButtonDisabled(): boolean {
-        return !this.uploadService.isQueueFinishedUploading() || !this.hasNodeSelected();
+        return this.uploadService.isUploading() || !this.hasNodeSelected();
     }
 
     hasNodeSelected(): boolean {

--- a/lib/core/services/upload.service.spec.ts
+++ b/lib/core/services/upload.service.spec.ts
@@ -105,6 +105,34 @@ describe('UploadService', () => {
         expect(service.getQueue().length).toEqual(2);
     });
 
+    it('should have the queue finished uploading if all files are complete, cancelled, aborted, errored or deleted', () => {
+        const file1 = new FileModel(<File> { name: 'fake-file-1', size: 10 });
+        const file2 = new FileModel(<File> { name: 'fake-file-2', size: 20 });
+        const file3 = new FileModel(<File> { name: 'fake-file-3', size: 30 });
+        const file4 = new FileModel(<File> { name: 'fake-file-4', size: 40 });
+        const file5 = new FileModel(<File> { name: 'fake-file-5', size: 50 });
+        file1.status = FileUploadStatus.Complete;
+        file2.status = FileUploadStatus.Cancelled;
+        file3.status = FileUploadStatus.Aborted;
+        file4.status = FileUploadStatus.Error;
+        file5.status = FileUploadStatus.Deleted;
+        service.addToQueue(file1, file2, file3, file4, file5);
+        expect(service.isQueueFinishedUploading()).toBe(true);
+    });
+
+    it('should not have the queue finished uploading if some files are still pending, starting, in progress or uploading', () => {
+        const file1 = new FileModel(<File> { name: 'fake-file-1', size: 10 });
+        const file2 = new FileModel(<File> { name: 'fake-file-2', size: 20 });
+        service.addToQueue(file1, file2);
+        file1.status = FileUploadStatus.Complete;
+        file2.status = FileUploadStatus.Pending;
+        expect(service.isQueueFinishedUploading()).toBe(false);
+        file2.status = FileUploadStatus.Starting;
+        expect(service.isQueueFinishedUploading()).toBe(false);
+        file2.status = FileUploadStatus.Progress;
+        expect(service.isQueueFinishedUploading()).toBe(false);
+    });
+
     it('should skip hidden macOS files', () => {
         const file1 = new FileModel(new File([''], '.git'));
         const file2 = new FileModel(new File([''], 'readme.md'));

--- a/lib/core/services/upload.service.spec.ts
+++ b/lib/core/services/upload.service.spec.ts
@@ -120,7 +120,7 @@ describe('UploadService', () => {
         expect(service.isQueueFinishedUploading()).toBe(true);
     });
 
-    it('should not have the queue finished uploading if some files are still pending, starting, in progress or uploading', () => {
+    it('should not have the queue finished uploading if some files are still pending, starting or in progress', () => {
         const file1 = new FileModel(<File> { name: 'fake-file-1', size: 10 });
         const file2 = new FileModel(<File> { name: 'fake-file-2', size: 20 });
         service.addToQueue(file1, file2);

--- a/lib/core/services/upload.service.spec.ts
+++ b/lib/core/services/upload.service.spec.ts
@@ -105,7 +105,7 @@ describe('UploadService', () => {
         expect(service.getQueue().length).toEqual(2);
     });
 
-    it('should have the queue finished uploading if all files are complete, cancelled, aborted, errored or deleted', () => {
+    it('should not have the queue uploading if all files are complete, cancelled, aborted, errored or deleted', () => {
         const file1 = new FileModel(<File> { name: 'fake-file-1', size: 10 });
         const file2 = new FileModel(<File> { name: 'fake-file-2', size: 20 });
         const file3 = new FileModel(<File> { name: 'fake-file-3', size: 30 });
@@ -117,20 +117,20 @@ describe('UploadService', () => {
         file4.status = FileUploadStatus.Error;
         file5.status = FileUploadStatus.Deleted;
         service.addToQueue(file1, file2, file3, file4, file5);
-        expect(service.isQueueFinishedUploading()).toBe(true);
+        expect(service.isUploading()).toBe(false);
     });
 
-    it('should not have the queue finished uploading if some files are still pending, starting or in progress', () => {
+    it('should have the queue still uploading if some files are still pending, starting or in progress', () => {
         const file1 = new FileModel(<File> { name: 'fake-file-1', size: 10 });
         const file2 = new FileModel(<File> { name: 'fake-file-2', size: 20 });
         service.addToQueue(file1, file2);
         file1.status = FileUploadStatus.Complete;
         file2.status = FileUploadStatus.Pending;
-        expect(service.isQueueFinishedUploading()).toBe(false);
+        expect(service.isUploading()).toBe(true);
         file2.status = FileUploadStatus.Starting;
-        expect(service.isQueueFinishedUploading()).toBe(false);
+        expect(service.isUploading()).toBe(true);
         file2.status = FileUploadStatus.Progress;
-        expect(service.isQueueFinishedUploading()).toBe(false);
+        expect(service.isUploading()).toBe(true);
     });
 
     it('should skip hidden macOS files', () => {

--- a/lib/core/services/upload.service.spec.ts
+++ b/lib/core/services/upload.service.spec.ts
@@ -111,24 +111,31 @@ describe('UploadService', () => {
         const file3 = new FileModel(<File> { name: 'fake-file-3', size: 30 });
         const file4 = new FileModel(<File> { name: 'fake-file-4', size: 40 });
         const file5 = new FileModel(<File> { name: 'fake-file-5', size: 50 });
+
         file1.status = FileUploadStatus.Complete;
         file2.status = FileUploadStatus.Cancelled;
         file3.status = FileUploadStatus.Aborted;
         file4.status = FileUploadStatus.Error;
         file5.status = FileUploadStatus.Deleted;
+
         service.addToQueue(file1, file2, file3, file4, file5);
+
         expect(service.isUploading()).toBe(false);
     });
 
     it('should have the queue still uploading if some files are still pending, starting or in progress', () => {
         const file1 = new FileModel(<File> { name: 'fake-file-1', size: 10 });
         const file2 = new FileModel(<File> { name: 'fake-file-2', size: 20 });
+
         service.addToQueue(file1, file2);
+
         file1.status = FileUploadStatus.Complete;
         file2.status = FileUploadStatus.Pending;
         expect(service.isUploading()).toBe(true);
+
         file2.status = FileUploadStatus.Starting;
         expect(service.isUploading()).toBe(true);
+
         file2.status = FileUploadStatus.Progress;
         expect(service.isUploading()).toBe(true);
     });

--- a/lib/core/services/upload.service.ts
+++ b/lib/core/services/upload.service.ts
@@ -88,18 +88,14 @@ export class UploadService {
     }
 
     /**
-     * Checks whether the service is uploading a file.
-     * @returns True if a file is uploading, false otherwise
+     * Checks whether the service still has files uploading or awaiting upload.
+     * @returns True if files in the queue are still uploading, false otherwise
      */
     isUploading(): boolean {
-        return !!this.activeTask;
-    }
-
-    isQueueFinishedUploading(): boolean {
         const finishedFileStates = [FileUploadStatus.Complete, FileUploadStatus.Cancelled, FileUploadStatus.Aborted, FileUploadStatus.Error, FileUploadStatus.Deleted];
-        return this.queue.reduce((finishedUploading: boolean, currentFile: FileModel) => {
-            return finishedUploading && finishedFileStates.indexOf(currentFile.status) > -1;
-        }, true);
+        return this.queue.reduce((stillUploading: boolean, currentFile: FileModel) => {
+            return stillUploading || finishedFileStates.indexOf(currentFile.status) === -1;
+        }, false);
     }
 
     /**

--- a/lib/core/services/upload.service.ts
+++ b/lib/core/services/upload.service.ts
@@ -95,6 +95,13 @@ export class UploadService {
         return !!this.activeTask;
     }
 
+    isQueueFinishedUploading(): boolean {
+        const finishedFileStates = [FileUploadStatus.Complete, FileUploadStatus.Aborted, FileUploadStatus.Error, FileUploadStatus.Deleted];
+        return this.queue.reduce((finishedUploading, currentFile) => {
+            return finishedUploading && finishedFileStates.indexOf(currentFile.status) > -1;
+        }, true);
+    }
+
     /**
      * Gets the file Queue
      * @returns Array of files that form the queue

--- a/lib/core/services/upload.service.ts
+++ b/lib/core/services/upload.service.ts
@@ -96,8 +96,8 @@ export class UploadService {
     }
 
     isQueueFinishedUploading(): boolean {
-        const finishedFileStates = [FileUploadStatus.Complete, FileUploadStatus.Aborted, FileUploadStatus.Error, FileUploadStatus.Deleted];
-        return this.queue.reduce((finishedUploading, currentFile) => {
+        const finishedFileStates = [FileUploadStatus.Complete, FileUploadStatus.Cancelled, FileUploadStatus.Aborted, FileUploadStatus.Error, FileUploadStatus.Deleted];
+        return this.queue.reduce((finishedUploading: boolean, currentFile: FileModel) => {
             return finishedUploading && finishedFileStates.indexOf(currentFile.status) > -1;
         }, true);
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

The "Apply" button in the attach file dialog is always enabled as long as a file is selected, even if there are still files being uploaded.

**What is the new behaviour?**

As long as the queue of files hasn't finished uploading, the "Apply" button will be disabled.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
