### PR TITLE
[ACA-4213] - Fix search datetime range in different timezones

### DIFF
--- a/lib/content-services/src/lib/search/components/search-datetime-range/search-datetime-range.component.spec.ts
+++ b/lib/content-services/src/lib/search/components/search-datetime-range/search-datetime-range.component.spec.ts
@@ -124,7 +124,7 @@ describe('SearchDatetimeRangeComponent', () => {
         expect(context.update).toHaveBeenCalled();
     });
 
-    it('should update query builder on value changes', () => {
+    it('should update the query in UTC format when values change', () => {
         const context: any = {
             queryFragments: {},
             update() {
@@ -143,10 +143,7 @@ describe('SearchDatetimeRangeComponent', () => {
             to: toDatetime
         }, true);
 
-        const startDate = moment(fromDatetime).startOf('minute').format();
-        const endDate = moment(toDatetime).endOf('minute').format();
-
-        const expectedQuery = `cm:created:['${startDate}' TO '${endDate}']`;
+        const expectedQuery = `cm:created:['2016-10-16T12:30:00Z' TO '2017-10-16T20:00:59Z']`;
 
         expect(context.queryFragments[component.id]).toEqual(expectedQuery);
         expect(context.update).toHaveBeenCalled();

--- a/lib/content-services/src/lib/search/components/search-datetime-range/search-datetime-range.component.spec.ts
+++ b/lib/content-services/src/lib/search/components/search-datetime-range/search-datetime-range.component.spec.ts
@@ -149,6 +149,33 @@ describe('SearchDatetimeRangeComponent', () => {
         expect(context.update).toHaveBeenCalled();
     });
 
+    it('should be able to update the query in UTC format from a GMT format', () => {
+        const context: any = {
+            queryFragments: {},
+            update() {
+            }
+        };
+        const fromInGmt = '2021-02-24T17:00:00+02:00';
+        const toInGmt = '2021-02-28T15:00:00+02:00';
+
+        component.id = 'createdDateRange';
+        component.context = context;
+        component.settings = { field: 'cm:created' };
+
+        spyOn(context, 'update').and.stub();
+
+        fixture.detectChanges();
+        component.apply({
+            from: fromInGmt,
+            to: toInGmt
+        }, true);
+
+        const expectedQuery = `cm:created:['2021-02-24T15:00:00Z' TO '2021-02-28T13:00:59Z']`;
+
+        expect(context.queryFragments[component.id]).toEqual(expectedQuery);
+        expect(context.update).toHaveBeenCalled();
+    });
+
     it('should show datetime-format error when an invalid datetime is set', async () => {
         fixture.detectChanges();
         component.onChangedHandler({ value: '10/14/2020 10:00:00 PM' }, component.from);

--- a/lib/content-services/src/lib/search/components/search-datetime-range/search-datetime-range.component.ts
+++ b/lib/content-services/src/lib/search/components/search-datetime-range/search-datetime-range.component.ts
@@ -130,8 +130,8 @@ export class SearchDatetimeRangeComponent implements SearchWidget, OnInit, OnDes
         if (isValid && this.id && this.context && this.settings && this.settings.field) {
             this.isActive = true;
 
-            const start = moment(model.from).startOf('minute').format();
-            const end = moment(model.to).endOf('minute').format();
+            const start = moment.utc(model.from).startOf('minute').format();
+            const end = moment.utc(model.to).endOf('minute').format();
 
             this.context.queryFragments[this.id] = `${this.settings.field}:['${start}' TO '${end}']`;
             this.context.update();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ACA-4213


**What is the new behaviour?**
The BE search API accepts only datetimes in UTC format therefore we need to convert the datetime to UTC before sending it to the backend


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
