### PR TITLE
[AAE-4697] Restrict content node selector breadcrumb when destination folder path is wrong

### DIFF
--- a/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.spec.ts
@@ -57,7 +57,9 @@ import {
     mockAllFileSourceWithStaticPathType,
     formVariables,
     processVariables,
-    mockAllFileSourceWithRenamedFolderVariablePathType
+    mockAllFileSourceWithRenamedFolderVariablePathType,
+    allSourceParamsWithWrongRelativePath,
+    allSourceParamsWithRelativePath
 } from '../../../mocks/attach-file-cloud-widget.mock';
 import { ProcessServiceCloudTestingModule } from '../../../../testing/process-service-cloud.testing.module';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
@@ -225,6 +227,46 @@ describe('AttachFileCloudWidgetComponent', () => {
             expect(widget.rootNodeId).toEqual('mock-node-id');
         });
 
+        it('should be able to fetch nodeId based on given alias if the relative path is wrong', async () => {
+            const fetchNodeIdFromRelativePathSpy = spyOn(contentCloudNodeSelectorService, 'fetchNodeIdFromRelativePath').and.returnValue(new Promise((reject) => reject(undefined)));
+            const fetchAliasNodeIdSpy = spyOn(contentCloudNodeSelectorService, 'fetchAliasNodeId').and.returnValue(mockNodeId);
+
+            createUploadWidgetField(new FormModel(), 'attach-file-alfresco', [], allSourceParamsWithWrongRelativePath);
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            clickOnAttachFileWidget('attach-file-alfresco');
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            const alias = '-shared-';
+            const opt = { relativePath: '/wrongRelativePath' };
+
+            expect(fetchNodeIdFromRelativePathSpy).toHaveBeenCalledWith(alias, opt);
+            expect(fetchAliasNodeIdSpy).toHaveBeenCalledWith(alias);
+            expect(widget.rootNodeId).toEqual('mock-node-id');
+        });
+
+        it('should be able to fetch relativePath nodeId if the given relative path is correct', async () => {
+            const fetchNodeIdFromRelativePathSpy = spyOn(contentCloudNodeSelectorService, 'fetchNodeIdFromRelativePath').and.returnValue(mockNodeId);
+            const fetchAliasNodeIdSpy = spyOn(contentCloudNodeSelectorService, 'fetchAliasNodeId');
+
+            createUploadWidgetField(new FormModel(), 'attach-file-alfresco', [], allSourceParamsWithRelativePath);
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            clickOnAttachFileWidget('attach-file-alfresco');
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            const alias = '-shared-';
+            const opt = { relativePath: '/myfiles' };
+
+            expect(fetchNodeIdFromRelativePathSpy).toHaveBeenCalledWith(alias, opt);
+            expect(fetchAliasNodeIdSpy).not.toHaveBeenCalledWith(alias);
+            expect(widget.rootNodeId).toEqual('mock-node-id');
+        });
+
         it('should be able to use mapped string variable value if the destinationFolderPath set to string type variable', async () => {
             const fetchNodeIdFromRelativePathSpy = spyOn(contentCloudNodeSelectorService, 'fetchNodeIdFromRelativePath').and.returnValue(mockNodeIdBasedOnStringVariableValue);
 
@@ -244,7 +286,7 @@ describe('AttachFileCloudWidgetComponent', () => {
         });
 
         it('should be able to use default location if mapped string variable value is undefined/empty', async () => {
-            const fetchNodeIdFromRelativePathSpy = spyOn(contentCloudNodeSelectorService, 'fetchNodeIdFromRelativePath').and.returnValue(mockNodeId);
+            const fetchAliasNodeIdSpy = spyOn(contentCloudNodeSelectorService, 'fetchAliasNodeId').and.returnValue(mockNodeId);
             createUploadWidgetField(new FormModel(), 'attach-file-alfresco', [], allSourceWithStringTypeEmptyValue);
             fixture.detectChanges();
             await fixture.whenStable();
@@ -254,9 +296,8 @@ describe('AttachFileCloudWidgetComponent', () => {
             await fixture.whenStable();
 
             const alias = '-my-';
-            const opt = { relativePath: '' };
 
-            expect(fetchNodeIdFromRelativePathSpy).toHaveBeenCalledWith(alias, opt);
+            expect(fetchAliasNodeIdSpy).toHaveBeenCalledWith(alias);
             expect(widget.rootNodeId).toEqual('mock-node-id');
         });
 
@@ -275,7 +316,7 @@ describe('AttachFileCloudWidgetComponent', () => {
         });
 
         it('should be able to use default location if the mapped folder variable value is undefined/empty', async () => {
-            const fetchNodeIdFromRelativePathSpy = spyOn(contentCloudNodeSelectorService, 'fetchNodeIdFromRelativePath').and.returnValue(mockNodeId);
+            const fetchAliasNodeIdSpy = spyOn(contentCloudNodeSelectorService, 'fetchAliasNodeId').and.returnValue(mockNodeId);
 
             createUploadWidgetField(new FormModel(), 'attach-file-alfresco', [], allSourceWithFolderTypeEmptyValue);
             fixture.detectChanges();
@@ -285,9 +326,8 @@ describe('AttachFileCloudWidgetComponent', () => {
             await fixture.whenStable();
 
             const alias = '-my-';
-            const opt = { relativePath: '' };
 
-            expect(fetchNodeIdFromRelativePathSpy).toHaveBeenCalledWith(alias, opt);
+            expect(fetchAliasNodeIdSpy).toHaveBeenCalledWith(alias);
             expect(widget.rootNodeId).toBe('mock-node-id');
         });
 
@@ -384,7 +424,7 @@ describe('AttachFileCloudWidgetComponent', () => {
 
         describe('FilesSource', () => {
             it('Should be able to fetch nodeId of default user alias (-my-) if fileSource set only to Alfresco Content', async () => {
-                const fetchNodeIdFromRelativePathSpy = spyOn(contentCloudNodeSelectorService, 'fetchNodeIdFromRelativePath').and.returnValue(mockNodeId);
+                const fetchAliasNodeIdSpy = spyOn(contentCloudNodeSelectorService, 'fetchAliasNodeId').and.returnValue(mockNodeId);
                 createUploadWidgetField(new FormModel(), 'attach-file-alfresco', [], contentSourceParam, false);
                 fixture.detectChanges();
                 await fixture.whenStable();
@@ -393,15 +433,14 @@ describe('AttachFileCloudWidgetComponent', () => {
                 await fixture.whenStable();
 
                 const alias = '-my-';
-                const opt = { relativePath: '' };
 
-                expect(fetchNodeIdFromRelativePathSpy).toHaveBeenCalledWith(alias, opt);
+                expect(fetchAliasNodeIdSpy).toHaveBeenCalledWith(alias);
                 expect(widget.rootNodeId).toEqual('mock-node-id');
                 expect(openUploadFileDialogSpy).toHaveBeenCalledWith('mock-node-id', 'single', false, true);
             });
 
             it('Should be able to fetch nodeId of default user alias (-my-) if fileSource set to multiple upload for Alfresco Content', async () => {
-                const fetchNodeIdFromRelativePathSpy = spyOn(contentCloudNodeSelectorService, 'fetchNodeIdFromRelativePath').and.returnValue(mockNodeId);
+                const fetchAliasNodeIdSpy = spyOn(contentCloudNodeSelectorService, 'fetchAliasNodeId').and.returnValue(mockNodeId);
 
                 createUploadWidgetField(new FormModel(), 'attach-file-alfresco', [], contentSourceParam, true);
                 fixture.detectChanges();
@@ -411,9 +450,8 @@ describe('AttachFileCloudWidgetComponent', () => {
                 await fixture.whenStable();
 
                 const alias = '-my-';
-                const opt = { relativePath: '' };
 
-                expect(fetchNodeIdFromRelativePathSpy).toHaveBeenCalledWith(alias, opt);
+                expect(fetchAliasNodeIdSpy).toHaveBeenCalledWith(alias);
                 expect(widget.rootNodeId).toEqual('mock-node-id');
                 expect(openUploadFileDialogSpy).toHaveBeenCalledWith('mock-node-id', 'multiple', false, true);
             });

--- a/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.ts
@@ -152,14 +152,16 @@ export class AttachFileCloudWidgetComponent extends UploadCloudWidgetComponent i
 
         if (!rootNodeId) {
             let nodeId: string;
-            if (destinationFolderPath.path) {
-                nodeId = await this.contentNodeSelectorService.fetchNodeIdFromRelativePath(destinationFolderPath.alias, { relativePath: destinationFolderPath.path });
+            try {
+                if (destinationFolderPath.path) {
+                    nodeId = await this.contentNodeSelectorService.fetchNodeIdFromRelativePath(destinationFolderPath.alias, { relativePath: destinationFolderPath.path });
+                }
+                if (!nodeId) {
+                    nodeId = await this.contentNodeSelectorService.fetchAliasNodeId(destinationFolderPath.alias);
+                }
+            } catch (error) {
+                this.logService.error(error);
             }
-
-            if (!nodeId) {
-                nodeId = await this.contentNodeSelectorService.fetchAliasNodeId(destinationFolderPath.alias);
-            }
-
             rootNodeId = nodeId ? nodeId : destinationFolderPath.alias;
         }
 

--- a/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.ts
@@ -151,21 +151,27 @@ export class AttachFileCloudWidgetComponent extends UploadCloudWidgetComponent i
         }
 
         if (!rootNodeId) {
-            let nodeId: string;
             try {
-                if (destinationFolderPath.path) {
-                    nodeId = await this.contentNodeSelectorService.fetchNodeIdFromRelativePath(destinationFolderPath.alias, { relativePath: destinationFolderPath.path });
-                }
-                if (!nodeId) {
-                    nodeId = await this.contentNodeSelectorService.fetchAliasNodeId(destinationFolderPath.alias);
-                }
+                const nodeId = await this.getNodeIdBasedOnPath(destinationFolderPath);
+                rootNodeId = nodeId ? nodeId : destinationFolderPath.alias;
             } catch (error) {
                 this.logService.error(error);
             }
-            rootNodeId = nodeId ? nodeId : destinationFolderPath.alias;
         }
 
         return rootNodeId;
+    }
+
+    private async getNodeIdBasedOnPath(destinationFolderPath: DestinationFolderPathModel) {
+        let nodeId: string;
+        if (destinationFolderPath.path) {
+            nodeId = await this.contentNodeSelectorService.fetchNodeIdFromRelativePath(destinationFolderPath.alias, { relativePath: destinationFolderPath.path });
+        }
+        if (!nodeId) {
+            nodeId = await this.contentNodeSelectorService.fetchAliasNodeId(destinationFolderPath.alias);
+        }
+
+        return nodeId;
     }
 
     getAliasAndRelativePathFromDestinationFolderPath(destinationFolderPath: string): DestinationFolderPathModel {

--- a/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.ts
@@ -151,7 +151,15 @@ export class AttachFileCloudWidgetComponent extends UploadCloudWidgetComponent i
         }
 
         if (!rootNodeId) {
-            const nodeId = await this.contentNodeSelectorService.fetchNodeIdFromRelativePath(destinationFolderPath.alias, { relativePath: destinationFolderPath.path });
+            let nodeId: string;
+            if (destinationFolderPath.path) {
+                nodeId = await this.contentNodeSelectorService.fetchNodeIdFromRelativePath(destinationFolderPath.alias, { relativePath: destinationFolderPath.path });
+            }
+
+            if (!nodeId) {
+                nodeId = await this.contentNodeSelectorService.fetchAliasNodeId(destinationFolderPath.alias);
+            }
+
             rootNodeId = nodeId ? nodeId : destinationFolderPath.alias;
         }
 

--- a/lib/process-services-cloud/src/lib/form/mocks/attach-file-cloud-widget.mock.ts
+++ b/lib/process-services-cloud/src/lib/form/mocks/attach-file-cloud-widget.mock.ts
@@ -68,6 +68,28 @@ export const menuTestSourceParam = {
     }
 };
 
+export const allSourceParamsWithWrongRelativePath = {
+    fileSource: {
+        name: 'all file sources',
+        serviceId: FileSourceTypes.ALL_FILE_SOURCES_SERVICE_ID,
+        destinationFolderPath: {
+            value: '-shared-/wrongRelativePath',
+            type: DestinationFolderPathType.STATIC_TYPE
+        }
+    }
+};
+
+export const allSourceParamsWithRelativePath = {
+    fileSource: {
+        name: 'all file sources',
+        serviceId: FileSourceTypes.ALL_FILE_SOURCES_SERVICE_ID,
+        destinationFolderPath: {
+            value: '-shared-/myfiles',
+            type: DestinationFolderPathType.STATIC_TYPE
+        }
+    }
+};
+
 export const allSourceParams = {
     fileSource: {
         name: 'all file sources',

--- a/lib/process-services-cloud/src/lib/form/services/content-cloud-node-selector.service.ts
+++ b/lib/process-services-cloud/src/lib/form/services/content-cloud-node-selector.service.ts
@@ -54,11 +54,17 @@ export class ContentCloudNodeSelectorService {
   }
 
     async fetchNodeIdFromRelativePath(alias: string, opts: { relativePath: string }): Promise<string> {
-        const nodeEntry: any = await this.apiService.getInstance().node
-            .getNode(alias, opts)
-            .catch((err) => this.handleError(err));
+        const relativePathNodeEntry = await this.fetchNodeId(alias, opts);
+        return relativePathNodeEntry?.entry?.id;
+    }
 
+    async fetchAliasNodeId(alias: string): Promise<string> {
+        const nodeEntry = await this.fetchNodeId(alias);
         return nodeEntry?.entry?.id;
+    }
+
+    async fetchNodeId(alias: string, opts?: { relativePath: string }): Promise<any> {
+        return this.apiService.getInstance().node.getNode(alias, opts).catch((err) => this.handleError(err));
     }
 
   private openContentNodeDialog(data: ContentNodeSelectorComponentData, currentPanelClass: string, chosenWidth: string) {

--- a/lib/process-services-cloud/src/lib/form/services/content-cloud-node-selector.service.ts
+++ b/lib/process-services-cloud/src/lib/form/services/content-cloud-node-selector.service.ts
@@ -54,17 +54,17 @@ export class ContentCloudNodeSelectorService {
   }
 
     async fetchNodeIdFromRelativePath(alias: string, opts: { relativePath: string }): Promise<string> {
-        const relativePathNodeEntry = await this.fetchNodeId(alias, opts);
+        const relativePathNodeEntry: any = await this.apiService.getInstance().node
+        .getNode(alias, opts)
+        .catch((err) => this.handleError(err));
         return relativePathNodeEntry?.entry?.id;
     }
 
     async fetchAliasNodeId(alias: string): Promise<string> {
-        const aliasNodeEntry = await this.fetchNodeId(alias);
+        const aliasNodeEntry: any = await this.apiService.getInstance().node
+        .getNode(alias)
+        .catch((err) => this.handleError(err));
         return aliasNodeEntry?.entry?.id;
-    }
-
-    async fetchNodeId(alias: string, opts?: { relativePath: string }): Promise<any> {
-        return this.apiService.getInstance().node.getNode(alias, opts).catch((err) => this.handleError(err));
     }
 
   private openContentNodeDialog(data: ContentNodeSelectorComponentData, currentPanelClass: string, chosenWidth: string) {

--- a/lib/process-services-cloud/src/lib/form/services/content-cloud-node-selector.service.ts
+++ b/lib/process-services-cloud/src/lib/form/services/content-cloud-node-selector.service.ts
@@ -59,8 +59,8 @@ export class ContentCloudNodeSelectorService {
     }
 
     async fetchAliasNodeId(alias: string): Promise<string> {
-        const nodeEntry = await this.fetchNodeId(alias);
-        return nodeEntry?.entry?.id;
+        const aliasNodeEntry = await this.fetchNodeId(alias);
+        return aliasNodeEntry?.entry?.id;
     }
 
     async fetchNodeId(alias: string, opts?: { relativePath: string }): Promise<any> {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://alfresco.atlassian.net/browse/AAE-4697

**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
