### PR TITLE
[ATS-873] Fix Subtitles in audio files

### DIFF
--- a/lib/core/viewer/components/media-player.component.html
+++ b/lib/core/viewer/components/media-player.component.html
@@ -1,4 +1,4 @@
-<video controls>
+<video controls [ngClass]="{'adf-audio-file': mimeType.startsWith('audio')}">
     <source [src]="urlFile" [type]="mimeType" (error)="onMediaPlayerError()"/>
     <track *ngFor="let track of tracks" [kind]="track.kind" [label]="track.label" [srclang]="track.srclang" [src]="track.src"/>
 </video>

--- a/lib/core/viewer/components/media-player.component.html
+++ b/lib/core/viewer/components/media-player.component.html
@@ -1,4 +1,4 @@
-<video controls [ngClass]="{'adf-audio-file': mimeType.startsWith('audio')}">
+<video controls [ngClass]="{'adf-audio-file': mimeType && mimeType.startsWith('audio')}">
     <source [src]="urlFile" [type]="mimeType" (error)="onMediaPlayerError()"/>
     <track *ngFor="let track of tracks" [kind]="track.kind" [label]="track.label" [srclang]="track.srclang" [src]="track.src"/>
 </video>

--- a/lib/core/viewer/components/media-player.component.scss
+++ b/lib/core/viewer/components/media-player.component.scss
@@ -7,4 +7,9 @@
         max-height: 90vh;
         max-width: 100%;
     }
+
+    video.adf-audio-file::-webkit-media-text-track-display {
+        -webkit-transform: translateY(-50%) !important;
+        transform: translateY(-50%) !important;
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [X] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
The subtitles for audio files are displayed under the media controls. For video files, everything is working as expected


**What is the new behaviour?**
The subtitles are displayed in the middle of the screen. For video files, we do nothing and go with the current behaviour


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
