### PR TITLE
[ADF-5349] Add Web Socket Host to Host configuration

### DIFF
--- a/demo-shell/src/app.config.json
+++ b/demo-shell/src/app.config.json
@@ -3,6 +3,7 @@
   "ecmHost": "{protocol}//{hostname}{:port}",
   "bpmHost": "{protocol}//{hostname}{:port}",
   "identityHost": "{protocol}//{hostname}{:port}/auth/admin/realms/alfresco",
+  "webSocketHost": "{protocol}//{hostname}{:port}",
   "loginRoute": "login",
   "providers": "ALL",
   "contextRootBpm": "activiti-app",

--- a/lib/core/app-config/app-config.service.ts
+++ b/lib/core/app-config/app-config.service.ts
@@ -40,7 +40,8 @@ export enum AppConfigValues {
     AUTH_WITH_CREDENTIALS = 'auth.withCredentials',
     APPLICATION = 'application',
     STORAGE_PREFIX = 'application.storagePrefix',
-    NOTIFY_DURATION = 'notificationDefaultDuration'
+    NOTIFY_DURATION = 'notificationDefaultDuration',
+    WEB_SOCKET_HOST = 'webSocketHost'
 }
 
 export enum Status {

--- a/lib/core/i18n/en.json
+++ b/lib/core/i18n/en.json
@@ -169,7 +169,9 @@
       "SILENT": "Silent Login",
       "SCOPE": "Scope",
       "CLIENT": "Client ID",
-      "PUBLIC_URLS" : "Public urls silent Login"
+      "PUBLIC_URLS" : "Public urls silent Login",
+      "IDENTITY_HOST": "Identity Host",
+      "WEB_SOCKET_HOST": "Web Socket Host"
     },
     "CARDVIEW": {
       "KEYVALUEPAIRS": {

--- a/lib/core/settings/host-settings.component.html
+++ b/lib/core/settings/host-settings.component.html
@@ -58,8 +58,8 @@
 
             <ng-container *ngIf="isOAUTH()">
                 <mat-card-content>
-                    <mat-form-field class="adf-full-width" floatLabel="Identity Host">
-                        <mat-label>Identity Host</mat-label>
+                    <mat-form-field class="adf-full-width" floatLabel="{{'CORE.HOST_SETTINGS.WEB_SOCKET_HOST' | translate }}">
+                        <mat-label>{{'CORE.HOST_SETTINGS.WEB_SOCKET_HOST' | translate }}</mat-label>
                         <input matInput name="identityHost" id="identityHost" formControlName="identityHost"
                                 placeholder="http(s)://host|ip:port(/path)">
                         <mat-error *ngIf="identityHost.hasError('pattern')">
@@ -70,6 +70,17 @@
                         </mat-error>
                     </mat-form-field>
                 </mat-card-content>
+                <mat-form-field class="adf-full-width" floatLabel="{{'CORE.HOST_SETTINGS.WEB_SOCKET_HOST' | translate }}">
+                    <mat-label>{{'CORE.HOST_SETTINGS.WEB_SOCKET_HOST' | translate }}</mat-label>
+                    <input matInput name="webSocketHost" id="webSocketHost" formControlName="webSocketHost"
+                           placeholder="ws(s)://host|ip:port(/path)">
+                    <mat-error *ngIf="webSocketHost.hasError('pattern')">
+                        {{ 'CORE.HOST_SETTINGS.NOT_VALID'| translate }}
+                    </mat-error>
+                    <mat-error *ngIf="webSocketHost.hasError('required')">
+                        {{ 'CORE.HOST_SETTINGS.REQUIRED'| translate }}
+                    </mat-error>
+                </mat-form-field>
             </ng-container>
 
             <ng-container *ngIf="isOAUTH()">

--- a/lib/core/settings/host-settings.component.spec.ts
+++ b/lib/core/settings/host-settings.component.spec.ts
@@ -275,6 +275,7 @@ describe('HostSettingsComponent', () => {
         let bpmUrlInput;
         let ecmUrlInput;
         let identityUrlInput;
+        let webSocketUrlInput;
         let oauthHostUrlInput;
         let clientIdInput;
 
@@ -296,6 +297,7 @@ describe('HostSettingsComponent', () => {
             bpmUrlInput = element.querySelector('#bpmHost');
             ecmUrlInput = element.querySelector('#ecmHost');
             identityUrlInput = element.querySelector('#identityHost');
+            webSocketUrlInput = element.querySelector('#webSocketHost');
             oauthHostUrlInput = element.querySelector('#oauthHost');
             clientIdInput = element.querySelector('#clientId');
         });
@@ -306,8 +308,9 @@ describe('HostSettingsComponent', () => {
 
         it('should have a valid form when the urls are correct', (done) => {
             const urlBpm = 'http://localhost:9999/bpm';
-            const urlEcm = 'http://localhost:9999/bpm';
+            const urlEcm = 'http://localhost:9999/ecm';
             const urlIdentity = 'http://localhost:9999/identity';
+            const urlWS = 'wss://localhost:9999';
 
             component.form.statusChanges.subscribe((status: string) => {
                 expect(status).toEqual('VALID');
@@ -315,13 +318,10 @@ describe('HostSettingsComponent', () => {
             });
 
             ecmUrlInput.value = urlEcm;
-            ecmUrlInput.dispatchEvent(new Event('input'));
-
             bpmUrlInput.value = urlBpm;
-            bpmUrlInput.dispatchEvent(new Event('input'));
-
             identityUrlInput.value = urlIdentity;
-            identityUrlInput.dispatchEvent(new Event('input'));
+            webSocketUrlInput.value = urlWS;
+            webSocketUrlInput.dispatchEvent(new Event('input'));
         });
 
         it('should have an invalid form when the url inserted is wrong', (done) => {
@@ -383,6 +383,19 @@ describe('HostSettingsComponent', () => {
 
             clientIdInput.value = '';
             clientIdInput.dispatchEvent(new Event('input'));
+        });
+
+        it('should have an invalid form when the webSocketHost is wrong', (done) => {
+            const wsHostUrl = 'wrong';
+
+            component.form.statusChanges.subscribe((status: string) => {
+                expect(status).toEqual('INVALID');
+                expect(component.webSocketHost.hasError('pattern')).toBeTruthy();
+                done();
+            });
+
+            webSocketUrlInput.value = wsHostUrl;
+            webSocketUrlInput.dispatchEvent(new Event('input'));
         });
    });
 });

--- a/lib/core/settings/host-settings.component.ts
+++ b/lib/core/settings/host-settings.component.ts
@@ -35,6 +35,7 @@ import { ENTER } from '@angular/cdk/keycodes';
 export class HostSettingsComponent implements OnInit {
 
     HOST_REGEX: string = '^(http|https):\/\/.*[^/]$';
+    WS_HOST_REGEX: string = '^(ws|wss):\/\/.*[^/]$';
 
     /**
      * Tells the component which provider options are available. Possible valid values
@@ -84,15 +85,18 @@ export class HostSettingsComponent implements OnInit {
         if (authType === 'OAUTH') {
             this.addOAuthFormGroup();
             this.addIdentityHostFormControl();
+            this.addWebSocketHostFormControl();
         }
 
         this.form.get('authType').valueChanges.subscribe((value) => {
             if (value === 'BASIC') {
                 this.form.removeControl('oauthConfig');
                 this.form.removeControl('identityHost');
+                this.form.removeControl('webSocketHost');
             } else {
                 this.addOAuthFormGroup();
                 this.addIdentityHostFormControl();
+                this.addWebSocketHostFormControl();
             }
         });
 
@@ -129,6 +133,11 @@ export class HostSettingsComponent implements OnInit {
         this.form.addControl('identityHost', identityHostFormControl);
     }
 
+    private addWebSocketHostFormControl() {
+        const webSocketHostFormControl = this.createWebSocketFormControl();
+        this.form.addControl('webSocketHost', webSocketHostFormControl);
+    }
+
     private addECMFormControl() {
         if ((this.isECM() || this.isALL()) && !this.ecmHost) {
             const ecmFormControl = this.createECMFormControl();
@@ -158,6 +167,10 @@ export class HostSettingsComponent implements OnInit {
 
     private createIdentityFormControl(): AbstractControl {
         return new FormControl(this.appConfig.get<string>(AppConfigValues.IDENTITY_HOST), [Validators.required, Validators.pattern(this.HOST_REGEX)]);
+    }
+
+    private createWebSocketFormControl(): AbstractControl {
+        return new FormControl(this.appConfig.get<string>(AppConfigValues.WEB_SOCKET_HOST), [Validators.required, Validators.pattern(this.WS_HOST_REGEX)]);
     }
 
     private createECMFormControl(): AbstractControl {
@@ -204,6 +217,7 @@ export class HostSettingsComponent implements OnInit {
 
         this.storageService.setItem(AppConfigValues.OAUTHCONFIG, JSON.stringify(values.oauthConfig));
         this.storageService.setItem(AppConfigValues.IDENTITY_HOST, values.identityHost);
+        this.storageService.setItem(AppConfigValues.WEB_SOCKET_HOST, values.webSocketHost);
     }
 
     private saveBPMValues(values: any) {
@@ -248,6 +262,10 @@ export class HostSettingsComponent implements OnInit {
 
     get identityHost(): AbstractControl {
         return this.form.get('identityHost');
+    }
+
+    get webSocketHost(): AbstractControl {
+        return this.form.get('webSocketHost');
     }
 
     get clientId(): AbstractControl {

--- a/lib/process-services-cloud/src/lib/services/notification-cloud.service.ts
+++ b/lib/process-services-cloud/src/lib/services/notification-cloud.service.ts
@@ -39,8 +39,8 @@ export class NotificationCloudService extends BaseCloudService {
         super(apiService, appConfigService);
     }
 
-    private getUrlDomain(appName: string) {
-        return this.getBasePath(appName).split('://')[1];
+    private get webSocketHost() {
+        return this.appConfigService.get('webSocketHost', '');
     }
 
     initNotificationsForApp(appName: string) {
@@ -51,7 +51,7 @@ export class NotificationCloudService extends BaseCloudService {
             });
 
             const webSocketLink = new WebSocketLink({
-                uri: `wss://${this.getUrlDomain(appName)}/notifications/ws/graphql`,
+                uri: `${this.webSocketHost}/${appName}/notifications/ws/graphql`,
                 options: {
                     reconnect: true,
                     lazy: true,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ADF-5349


**What is the new behaviour?**
In order to allow other apps to make use of the websockets on development we need to add this new property to the app.config.json so that it can be configured as the other host urls. 

Until know we were creating this wb based on the bpmHost so that there is no need to specify it. While this works for ADF it doesn't for apps loading this variables from a .env file.

Adding it would ensure that these apps can also use notifications on development when deploy locally.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
