### PR TITLE
[ACA-4308] More flexible content-node-selector-dialog-content height to avoid scrollbar

### DIFF
--- a/lib/content-services/src/lib/content-node-selector/content-node-selector.component.html
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector.component.html
@@ -7,7 +7,8 @@
 <mat-tab-group class="adf-content-node-selector-dialog-content"
                mat-align-tabs="start"
                (selectedIndexChange)="onTabSelectionChange($event)"
-               [class.adf-content-node-selector-headless-tabs]="!canPerformLocalUpload()">
+               [class.adf-content-node-selector-headless-tabs]="!canPerformLocalUpload()"
+               dynamicHeight>
     <mat-tab label="{{ 'NODE_SELECTOR.REPOSITORY' | translate }}">
             <adf-content-node-selector-panel
                 [currentFolderId]="data?.currentFolderId"

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector.component.scss
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector.component.scss
@@ -45,8 +45,8 @@
 
     .adf-content-node-selector-dialog {
         &-content {
-            height: 465px;
-            max-height: 80vh;
+            min-height: 465px;
+            max-height: 70vh;
             padding-left: 24px;
             padding-right: 24px;
         }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Scrollbar appears when height of content-node-selector-dialog-content is greater than its css defined value.

**What is the new behaviour?**

Changed to min-height to allow for more flexible content. Addition of a dynamicHeight property to smoothen out the change of height between tabs in case both heights are not the same.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
