### PR TITLE
Revert "[MNT-22063] - fix form cloud layout"

### DIFF
--- a/lib/core/form/components/widgets/container/container.widget.scss
+++ b/lib/core/form/components/widgets/container/container.widget.scss
@@ -45,9 +45,7 @@
             display: flex;
             flex-direction: column;
             align-items: flex-start;
-            flex: auto;
-            padding: 0 8px;
-            min-width: 0.3%;
+            flex: 1 0 auto;
         }
 
         .adf-grid-list-column-view-item {
@@ -55,10 +53,7 @@
             flex-grow: 1;
             box-sizing: border-box;
             padding-left: 1%;
-            min-height: 100px;
-            display: flex;
             padding-right: 1%;
-            align-items: center;
         }
 
         .adf-grid-list {

--- a/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.scss
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.scss
@@ -52,6 +52,8 @@
     &-attach-widget {
         width: 100%;
         word-break: break-all;
+        padding: 0.4375em 0;
+        border-top: 0.84375em solid transparent;
     }
 
     &-attach-widget__icon {

--- a/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.scss
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.scss
@@ -1,15 +1,11 @@
 .adf {
     &-dropdown-widget {
         width: 100%;
-        padding: 0 4px;
+        margin-top: 13px;
 
         .adf-select {
             padding-top: 0 !important;
             width: 100%;
-        }
-
-        .adf-label {
-            display: block;
         }
 
         .mat-select-value-text {


### PR DESCRIPTION
Reverts Alfresco/alfresco-ng2-components#6529
This PR introduces a regression with hidden field, when the mode is set to not have spaces for hidden fields. The form mode can be easily changed to use the grid instead for fixing this whilst we need a better solution for the flexible layout to show complex form correctly