### PR TITLE
[ACA-4202] - forcing firefox to ignore cache when document version ha…

### DIFF
--- a/lib/core/viewer/components/pdf-viewer.component.ts
+++ b/lib/core/viewer/components/pdf-viewer.component.ts
@@ -68,6 +68,9 @@ export class PdfViewerComponent implements OnChanges, OnDestroy {
     @Input()
     thumbnailsTemplate: TemplateRef<any> = null;
 
+    @Input()
+    cacheType: string = '';
+
     @Output()
     rendered = new EventEmitter<any>();
 
@@ -161,6 +164,11 @@ export class PdfViewerComponent implements OnChanges, OnDestroy {
                 url: urlFile.currentValue,
                 withCredentials: this.appConfigService.get<boolean>('auth.withCredentials', undefined)
             };
+            if (this.cacheType) {
+                pdfSource.httpHeaders = {
+                    'Cache-Control': this.cacheType,
+                }
+            }
             this.executePdf(pdfSource);
         }
 

--- a/lib/core/viewer/components/pdf-viewer.component.ts
+++ b/lib/core/viewer/components/pdf-viewer.component.ts
@@ -166,8 +166,8 @@ export class PdfViewerComponent implements OnChanges, OnDestroy {
             };
             if (this.cacheType) {
                 pdfSource.httpHeaders = {
-                    'Cache-Control': this.cacheType,
-                }
+                    'Cache-Control': this.cacheType
+                };
             }
             this.executePdf(pdfSource);
         }

--- a/lib/core/viewer/components/viewer.component.html
+++ b/lib/core/viewer/components/viewer.component.html
@@ -212,6 +212,7 @@
                                             [blobFile]="blobFile"
                                             [urlFile]="urlFileContent"
                                             [nameFile]="displayName"
+                                            [cacheType]="cacheTypeForContent"
                                             (error)="onUnsupportedFile()"></adf-pdf-viewer>
                         </ng-container>
 

--- a/lib/core/viewer/components/viewer.component.ts
+++ b/lib/core/viewer/components/viewer.component.ts
@@ -224,6 +224,7 @@ export class ViewerComponent implements OnChanges, OnInit, OnDestroy {
     viewerExtensions: Array<ViewerExtensionRef> = [];
 
     private cacheBusterNumber;
+    cacheTypeForContent = '';
 
     // Extensions that are supported by the Viewer without conversion
     private extensions = {
@@ -278,6 +279,7 @@ export class ViewerComponent implements OnChanges, OnInit, OnDestroy {
 
         this.closeOverlayManager();
         this.loadExtensions();
+        this.cacheTypeForContent = '';
     }
 
     private loadExtensions() {
@@ -299,6 +301,7 @@ export class ViewerComponent implements OnChanges, OnInit, OnDestroy {
 
     private onNodeUpdated(node: Node) {
         if (node && node.id === this.nodeId) {
+            this.cacheTypeForContent = 'no-cache';
             this.generateCacheBusterNumber();
             this.isLoading = true;
             this.setUpNodeFile(node).then(() => {


### PR DESCRIPTION
…s changed

**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Only for Firefox whenever the user updates a new version with the same name of a doc document whilst viewing it, the document is not refreshed but it's taken from the FF cache.


**What is the new behaviour?**
Whenever a new version steps in, we set the header of pdf-js to 'no-cache' and this will force the browser to actual fetch the new version


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://alfresco.atlassian.net/browse/ACA-4202