### PR TITLE
[MNT-22236] update e2e to reflect permission i18n support

### DIFF
--- a/e2e/content-services/components/comment-component.e2e.ts
+++ b/e2e/content-services/components/comment-component.e2e.ts
@@ -193,7 +193,9 @@ describe('Comment', () => {
         afterAll(async () => {
             await apiService.loginWithProfile('admin');
             await uploadActions.deleteFileOrFolder(pngUploadedFile.entry.id);
-            await apiService.getInstance().core.sitesApi.deleteSite(site.entry.id, { permanent: true });
+
+            const sitesApi = new SitesApi(apiService.getInstance());
+            await sitesApi.deleteSite(site.entry.id, { permanent: true });
         });
 
         it('[C290147] Should NOT be able to add comments to a site file with Consumer permissions', async () => {

--- a/e2e/content-services/components/comment-component.e2e.ts
+++ b/e2e/content-services/components/comment-component.e2e.ts
@@ -30,6 +30,7 @@ import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
 import { FileModel } from '../../models/ACS/file.model';
 import { browser } from 'protractor';
 import CONSTANTS = require('../../util/constants');
+import { SitesApi, SiteEntry } from '@alfresco/js-api';
 
 describe('Comment', () => {
 
@@ -165,17 +166,19 @@ describe('Comment', () => {
     });
 
     describe('Consumer Permissions', () => {
-        let site, pngUploadedFile;
+        let site: SiteEntry;
+        let pngUploadedFile;
 
         beforeAll(async () => {
             await apiService.loginWithProfile('admin');
 
-            site = await apiService.getInstance().core.sitesApi.createSite({
+            const sitesApi = new SitesApi(apiService.getInstance());
+            site = await sitesApi.createSite({
                 title: StringUtil.generateRandomString(8),
                 visibility: 'PUBLIC'
             });
 
-            await apiService.getInstance().core.sitesApi.addSiteMember(site.entry.id, {
+            await sitesApi.createSiteMembership(site.entry.id, {
                 id: acsUser.username,
                 role: CONSTANTS.CS_USER_ROLES.CONSUMER
             });

--- a/e2e/content-services/components/lock-file.e2e.ts
+++ b/e2e/content-services/components/lock-file.e2e.ts
@@ -86,8 +86,8 @@ describe('Lock File', () => {
     afterAll(async () => {
         await apiService.loginWithProfile('admin');
         try {
-
-            await apiService.getInstance().core.sitesApi.deleteSite(site.entry.id, { permanent: true });
+            const sitesApi = new SitesApi(apiService.getInstance());
+            await sitesApi.deleteSite(site.entry.id, { permanent: true });
         } catch (e) {
         }
     });

--- a/e2e/content-services/components/lock-file.e2e.ts
+++ b/e2e/content-services/components/lock-file.e2e.ts
@@ -29,7 +29,7 @@ import { ContentServicesPage } from '../../core/pages/content-services.page';
 import { LockFilePage } from '../../content-services/pages/lock-file.page';
 import { FileModel } from '../../models/ACS/file.model';
 import { browser } from 'protractor';
-import { NodeEntry } from '@alfresco/js-api';
+import { NodeEntry, SitesApi } from '@alfresco/js-api';
 import CONSTANTS = require('../../util/constants');
 
 describe('Lock File', () => {
@@ -66,7 +66,9 @@ describe('Lock File', () => {
 
         await apiService.login(adminUser.username, adminUser.password);
 
-        site = await apiService.getInstance().core.sitesApi.createSite({
+        const sitesApi = new SitesApi(apiService.getInstance());
+
+        site = await sitesApi.createSite({
             title: StringUtil.generateRandomString(),
             visibility: 'PRIVATE'
         });
@@ -75,7 +77,7 @@ describe('Lock File', () => {
 
         documentLibrary = resultNode.list.entries[0].entry.id;
 
-        await apiService.getInstance().core.sitesApi.addSiteMember(site.entry.id, {
+        await sitesApi.createSiteMembership(site.entry.id, {
             id: managerUser.username,
             role: CONSTANTS.CS_USER_ROLES.MANAGER
         });

--- a/e2e/content-services/components/site-permissions.e2e.ts
+++ b/e2e/content-services/components/site-permissions.e2e.ts
@@ -199,10 +199,10 @@ describe('Permissions Component', () => {
             const roleDropdownOptions = permissionsPage.addPermissionsDialog.getRoleDropdownOptions();
 
             await expect(await roleDropdownOptions.count()).toBe(4);
-            await expect(await BrowserActions.getText(roleDropdownOptions.get(0))).toBe(CONSTANTS.CS_USER_ROLES.COLLABORATOR);
-            await expect(await BrowserActions.getText(roleDropdownOptions.get(1))).toBe(CONSTANTS.CS_USER_ROLES.CONSUMER);
-            await expect(await BrowserActions.getText(roleDropdownOptions.get(2))).toBe(CONSTANTS.CS_USER_ROLES.CONTRIBUTOR);
-            await expect(await BrowserActions.getText(roleDropdownOptions.get(3))).toBe(CONSTANTS.CS_USER_ROLES.MANAGER);
+            await expect(await BrowserActions.getText(roleDropdownOptions.get(0))).toBe(CONSTANTS.CS_USER_ROLES_I18N.COLLABORATOR);
+            await expect(await BrowserActions.getText(roleDropdownOptions.get(1))).toBe(CONSTANTS.CS_USER_ROLES_I18N.CONSUMER);
+            await expect(await BrowserActions.getText(roleDropdownOptions.get(2))).toBe(CONSTANTS.CS_USER_ROLES_I18N.CONTRIBUTOR);
+            await expect(await BrowserActions.getText(roleDropdownOptions.get(3))).toBe(CONSTANTS.CS_USER_ROLES_I18N.MANAGER);
         });
     });
 

--- a/e2e/content-services/components/site-permissions.e2e.ts
+++ b/e2e/content-services/components/site-permissions.e2e.ts
@@ -156,8 +156,10 @@ describe('Permissions Component', () => {
 
     afterAll(async () => {
         await apiService.loginWithProfile('admin');
-        await apiService.getInstance().core.sitesApi.deleteSite(publicSite.entry.id, { permanent: true });
-        await apiService.getInstance().core.sitesApi.deleteSite(privateSite.entry.id, { permanent: true });
+
+        const sitesApi = new SitesApi(apiService.getInstance());
+        await sitesApi.deleteSite(publicSite.entry.id, { permanent: true });
+        await sitesApi.deleteSite(privateSite.entry.id, { permanent: true });
     });
 
     describe('Role Site Dropdown', () => {

--- a/e2e/content-services/components/site-permissions.e2e.ts
+++ b/e2e/content-services/components/site-permissions.e2e.ts
@@ -35,6 +35,7 @@ import { UploadDialogPage } from '../../core/pages/dialog/upload-dialog.page';
 import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
 import { VersionManagePage } from '../../core/pages/version-manager.page';
 import CONSTANTS = require('../../util/constants');
+import { SitesApi } from '@alfresco/js-api';
 
 describe('Permissions Component', () => {
 
@@ -104,33 +105,34 @@ describe('Permissions Component', () => {
         folderName = `MEESEEKS_${StringUtil.generateRandomString(5)}`;
 
         const publicSiteBody = { visibility: 'PUBLIC', title: publicSiteName };
-
         const privateSiteBody = { visibility: 'PRIVATE', title: privateSiteName };
 
-        publicSite = await apiService.getInstance().core.sitesApi.createSite(publicSiteBody);
-        privateSite = await apiService.getInstance().core.sitesApi.createSite(privateSiteBody);
+        const sitesApi = new SitesApi(apiService.getInstance());
 
-        await apiService.getInstance().core.sitesApi.addSiteMember(publicSite.entry.id, {
+        publicSite = await sitesApi.createSite(publicSiteBody);
+        privateSite = await sitesApi.createSite(privateSiteBody);
+
+        await sitesApi.createSiteMembership(publicSite.entry.id, {
             id: siteConsumerUser.username,
             role: CONSTANTS.CS_USER_ROLES.CONSUMER
         });
 
-        await apiService.getInstance().core.sitesApi.addSiteMember(publicSite.entry.id, {
+        await sitesApi.createSiteMembership(publicSite.entry.id, {
             id: collaboratorUser.username,
             role: CONSTANTS.CS_USER_ROLES.COLLABORATOR
         });
 
-        await apiService.getInstance().core.sitesApi.addSiteMember(publicSite.entry.id, {
+        await sitesApi.createSiteMembership(publicSite.entry.id, {
             id: contributorUser.username,
             role: CONSTANTS.CS_USER_ROLES.CONTRIBUTOR
         });
 
-        await apiService.getInstance().core.sitesApi.addSiteMember(publicSite.entry.id, {
+        await sitesApi.createSiteMembership(publicSite.entry.id, {
             id: managerUser.username,
             role: CONSTANTS.CS_USER_ROLES.MANAGER
         });
 
-        await apiService.getInstance().core.sitesApi.addSiteMember(privateSite.entry.id, {
+        await sitesApi.createSiteMembership(privateSite.entry.id, {
             id: managerUser.username,
             role: CONSTANTS.CS_USER_ROLES.MANAGER
         });

--- a/e2e/content-services/components/site-permissions.e2e.ts
+++ b/e2e/content-services/components/site-permissions.e2e.ts
@@ -196,7 +196,7 @@ describe('Permissions Component', () => {
             await permissionsPage.addPermissionsDialog.clickUserOrGroup(consumerUser.firstName);
             await permissionsPage.addPermissionsDialog.checkUserIsAdded(consumerUser.username);
 
-            await expect(await permissionsPage.addPermissionsDialog.getRoleCellValue(consumerUser.username)).toEqual('SiteCollaborator');
+            await expect(await permissionsPage.addPermissionsDialog.getRoleCellValue(consumerUser.username)).toEqual(CONSTANTS.CS_USER_ROLES_I18N.COLLABORATOR);
 
             await permissionsPage.addPermissionsDialog.clickRoleDropdownByUserOrGroupName(consumerUser.username);
 

--- a/e2e/content-services/components/unshare-file.e2e.ts
+++ b/e2e/content-services/components/unshare-file.e2e.ts
@@ -27,7 +27,7 @@ import {
     UserModel,
     UsersActions
 } from '@alfresco/adf-testing';
-import { NodeEntry } from '@alfresco/js-api';
+import { NodeEntry, SitesApi } from '@alfresco/js-api';
 import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
 import { ContentServicesPage } from '../../core/pages/content-services.page';
 import { ShareDialogPage } from '../../core/pages/dialog/share-dialog.page';
@@ -77,11 +77,13 @@ describe('Unshare file', () => {
             }
         };
 
-        shareFilesSite = await apiService.getInstance().core.sitesApi.createSite(site);
+        const sitesApi = new SitesApi(apiService.getInstance());
 
-        const docLibId = (await apiService.getInstance().core.sitesApi.getSiteContainers(siteName)).list.entries[0].entry.id;
+        shareFilesSite = await sitesApi.createSite(site);
+
+        const docLibId = (await sitesApi.listSiteContainers(siteName)).list.entries[0].entry.id;
         const testFile1Id = (await apiService.getInstance().core.nodesApi.addNode(docLibId, nodeBody)).entry.id;
-        await apiService.getInstance().core.sitesApi.addSiteMember(siteName, {
+        await sitesApi.createSiteMembership(siteName, {
             id: acsUser.username,
             role: CONSTANTS.CS_USER_ROLES.CONSUMER
         });
@@ -102,7 +104,9 @@ describe('Unshare file', () => {
 
     afterAll(async () => {
         await navigationBarPage.clickLogoutButton();
-        await apiService.getInstance().core.sitesApi.deleteSite(shareFilesSite.entry.id, { permanent: true });
+
+        const sitesApi = new SitesApi(apiService.getInstance());
+        await sitesApi.deleteSite(shareFilesSite.entry.id, { permanent: true });
     });
 
     describe('with permission', () => {

--- a/e2e/content-services/directives/create-library-directive.e2e.ts
+++ b/e2e/content-services/directives/create-library-directive.e2e.ts
@@ -20,6 +20,7 @@ import { ContentServicesPage } from '../../core/pages/content-services.page';
 import { CreateLibraryDialogPage } from '../../core/pages/dialog/create-library-dialog.page';
 import { CustomSourcesPage } from '../../core/pages/custom-sources.page';
 import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
+import { SitesApi } from '@alfresco/js-api';
 
 describe('Create library directive', () => {
 
@@ -45,7 +46,9 @@ describe('Create library directive', () => {
         await apiService.loginWithProfile('admin');
 
         acsUser = await usersActions.createUser();
-        createSite = await apiService.getInstance().core.sitesApi.createSite({
+
+        const sitesApi = new SitesApi(apiService.getInstance());
+        createSite = await sitesApi.createSite({
             title: StringUtil.generateRandomString(20).toLowerCase(),
             visibility: 'PUBLIC'
         });
@@ -55,7 +58,10 @@ describe('Create library directive', () => {
 
     afterAll(async () => {
         await apiService.loginWithProfile('admin');
-        await apiService.getInstance().core.sitesApi.deleteSite(createSite.entry.id, { permanent: true });
+
+        const sitesApi = new SitesApi(apiService.getInstance());
+        await sitesApi.deleteSite(createSite.entry.id, { permanent: true });
+
         await navigationBarPage.clickLogoutButton();
     });
 

--- a/e2e/content-services/directives/delete-directive.e2e.ts
+++ b/e2e/content-services/directives/delete-directive.e2e.ts
@@ -31,6 +31,7 @@ import {
 import { browser } from 'protractor';
 import { FolderModel } from '../../models/ACS/folder.model';
 import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
+import { SitesApi } from '@alfresco/js-api';
 
 describe('Delete Directive', () => {
 
@@ -234,12 +235,14 @@ describe('Delete Directive', () => {
         beforeAll(async () => {
             await apiService.login(acsUser.username, acsUser.password);
 
-            createdSite = await apiService.getInstance().core.sitesApi.createSite({
+            const sitesApi = new SitesApi(apiService.getInstance());
+
+            createdSite = await sitesApi.createSite({
                 title: StringUtil.generateRandomString(20).toLowerCase(),
                 visibility: 'PRIVATE'
             });
 
-            await apiService.getInstance().core.sitesApi.addSiteMember(createdSite.entry.id, {
+            await sitesApi.createSiteMembership(createdSite.entry.id, {
                 id: secondAcsUser.username,
                 role: 'SiteCollaborator'
             });
@@ -266,7 +269,8 @@ describe('Delete Directive', () => {
 
         afterAll(async () => {
             try {
-                await apiService.getInstance().core.sitesApi.deleteSite(createdSite.entry.id, { permanent: true });
+                const sitesApi = new SitesApi(apiService.getInstance());
+                await sitesApi.deleteSite(createdSite.entry.id, { permanent: true });
             } catch (error) {}
             await navigationBarPage.clickLogoutButton();
         });

--- a/e2e/content-services/document-list/document-list-copy-move-actions.e2e.ts
+++ b/e2e/content-services/document-list/document-list-copy-move-actions.e2e.ts
@@ -31,6 +31,7 @@ import { ContentServicesPage } from '../../core/pages/content-services.page';
 import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
 import { FileModel } from '../../models/ACS/file.model';
 import CONSTANTS = require('../../util/constants');
+import { SitesApi } from '@alfresco/js-api';
 
 describe('Document List Component', () => {
 
@@ -66,11 +67,13 @@ describe('Document List Component', () => {
         await apiService.loginWithProfile('admin');
         await usersActions.createUser(acsUser);
         await usersActions.createUser(anotherAcsUser);
-        site = await apiService.getInstance().core.sitesApi.createSite({
+
+        const sitesApi = new SitesApi(apiService.getInstance());
+        site = await sitesApi.createSite({
             title: StringUtil.generateRandomString(8),
             visibility: 'PUBLIC'
         });
-        await apiService.getInstance().core.sitesApi.addSiteMember(site.entry.id, {
+        await sitesApi.createSiteMembership(site.entry.id, {
             id: anotherAcsUser.username,
             role: CONSTANTS.CS_USER_ROLES.COLLABORATOR
         });
@@ -106,7 +109,9 @@ describe('Document List Component', () => {
         await uploadActions.deleteFileOrFolder(uploadedFile.entry.id);
         await uploadActions.deleteFileOrFolder(sourceFolder.entry.id);
         await uploadActions.deleteFileOrFolder(destinationFolder.entry.id);
-        await apiService.getInstance().core.sitesApi.deleteSite(site.entry.id, { permanent: true });
+
+        const sitesApi = new SitesApi(apiService.getInstance());
+        await sitesApi.deleteSite(site.entry.id, { permanent: true });
     });
 
     describe('Document List Component - Actions Move and Copy', () => {

--- a/e2e/content-services/document-list/document-list-permissions.e2e.ts
+++ b/e2e/content-services/document-list/document-list-permissions.e2e.ts
@@ -19,6 +19,7 @@ import { browser } from 'protractor';
 import { ContentServicesPage } from '../../core/pages/content-services.page';
 import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
 import { ApiService, BrowserActions, ErrorPage, LoginPage, StringUtil, UsersActions } from '@alfresco/adf-testing';
+import { SitesApi } from '@alfresco/js-api';
 
 describe('Document List Component', () => {
 
@@ -41,7 +42,8 @@ describe('Document List Component', () => {
 
             acsUser = await usersActions.createUser();
 
-            privateSite = await apiService.getInstance().core.sitesApi.createSite(privateSiteBody);
+            const sitesApi = new SitesApi(apiService.getInstance());
+            privateSite = sitesApi.createSite(privateSiteBody);
 
             await loginPage.login(acsUser.username, acsUser.password);
         });
@@ -49,7 +51,9 @@ describe('Document List Component', () => {
         afterAll(async () => {
             await apiService.loginWithProfile('admin');
             await navigationBarPage.clickLogoutButton();
-            await apiService.getInstance().core.sitesApi.deleteSite(privateSite.entry.id, { permanent: true });
+
+            const sitesApi = new SitesApi(apiService.getInstance());
+            await sitesApi.deleteSite(privateSite.entry.id, { permanent: true });
         });
 
         it('[C217334] Should display a message when accessing file without permissions', async () => {

--- a/e2e/content-services/document-list/document-list-permissions.e2e.ts
+++ b/e2e/content-services/document-list/document-list-permissions.e2e.ts
@@ -43,7 +43,7 @@ describe('Document List Component', () => {
             acsUser = await usersActions.createUser();
 
             const sitesApi = new SitesApi(apiService.getInstance());
-            privateSite = sitesApi.createSite(privateSiteBody);
+            privateSite = await sitesApi.createSite(privateSiteBody);
 
             await loginPage.login(acsUser.username, acsUser.password);
         });

--- a/e2e/content-services/metadata/metadata-permissions.e2e.ts
+++ b/e2e/content-services/metadata/metadata-permissions.e2e.ts
@@ -29,6 +29,7 @@ import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
 import { FileModel } from '../../models/ACS/file.model';
 import { browser } from 'protractor';
 import CONSTANTS = require('../../util/constants');
+import { SitesApi } from '@alfresco/js-api';
 
 describe('permissions', () => {
 
@@ -71,22 +72,24 @@ describe('permissions', () => {
         await usersActions.createUser(collaboratorUser);
         await usersActions.createUser(contributorUser);
 
-        site = await apiService.getInstance().core.sitesApi.createSite({
+        const sitesApi = new SitesApi(apiService.getInstance());
+
+        site = await sitesApi.createSite({
             title: StringUtil.generateRandomString(),
             visibility: 'PUBLIC'
         });
 
-        await apiService.getInstance().core.sitesApi.addSiteMember(site.entry.id, {
+        await sitesApi.createSiteMembership(site.entry.id, {
             id: consumerUser.username,
             role: CONSTANTS.CS_USER_ROLES.CONSUMER
         });
 
-        await apiService.getInstance().core.sitesApi.addSiteMember(site.entry.id, {
+        await sitesApi.createSiteMembership(site.entry.id, {
             id: collaboratorUser.username,
             role: CONSTANTS.CS_USER_ROLES.COLLABORATOR
         });
 
-        await apiService.getInstance().core.sitesApi.addSiteMember(site.entry.id, {
+        await sitesApi.createSiteMembership(site.entry.id, {
             id: contributorUser.username,
             role: CONSTANTS.CS_USER_ROLES.CONTRIBUTOR
         });
@@ -96,7 +99,9 @@ describe('permissions', () => {
 
     afterAll(async () => {
         await apiService.loginWithProfile('admin');
-        await apiService.getInstance().core.sitesApi.deleteSite(site.entry.id, { permanent: true });
+
+        const sitesApi = new SitesApi(apiService.getInstance());
+        await sitesApi.deleteSite(site.entry.id, { permanent: true });
     });
 
     afterEach(async () => {

--- a/e2e/content-services/upload/user-permission.e2e.ts
+++ b/e2e/content-services/upload/user-permission.e2e.ts
@@ -22,6 +22,7 @@ import { UploadDialogPage } from '../../core/pages/dialog/upload-dialog.page';
 import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
 import { FileModel } from '../../models/ACS/file.model';
 import CONSTANTS = require('../../util/constants');
+import { SitesApi } from '@alfresco/js-api';
 
 describe('Upload - User permission', () => {
 
@@ -59,30 +60,34 @@ describe('Upload - User permission', () => {
     });
 
     beforeEach(async () => {
-        consumerSite = await apiService.getInstance().core.sitesApi.createSite({
+        const sitesApi = new SitesApi(apiService.getInstance());
+
+        consumerSite = await sitesApi.createSite({
             title: StringUtil.generateRandomString(),
             visibility: 'PUBLIC'
         });
 
-        managerSite = await apiService.getInstance().core.sitesApi.createSite({
+        managerSite = await sitesApi.createSite({
             title: StringUtil.generateRandomString(),
             visibility: 'PUBLIC'
         });
 
-        await apiService.getInstance().core.sitesApi.addSiteMember(consumerSite.entry.id, {
+        await sitesApi.createSiteMembership(consumerSite.entry.id, {
             id: acsUser.username,
             role: CONSTANTS.CS_USER_ROLES.CONSUMER
         });
 
-        await apiService.getInstance().core.sitesApi.addSiteMember(managerSite.entry.id, {
+        await sitesApi.createSiteMembership(managerSite.entry.id, {
             id: acsUser.username,
             role: CONSTANTS.CS_USER_ROLES.MANAGER
         });
     });
 
     afterEach(async () => {
-        await apiService.getInstance().core.sitesApi.deleteSite(managerSite.entry.id, { permanent: true });
-        await apiService.getInstance().core.sitesApi.deleteSite(consumerSite.entry.id, { permanent: true });
+        const sitesApi = new SitesApi(apiService.getInstance());
+
+        await sitesApi.deleteSite(managerSite.entry.id, { permanent: true });
+        await sitesApi.deleteSite(consumerSite.entry.id, { permanent: true });
     });
 
     describe('Consumer permissions', () => {

--- a/e2e/content-services/upload/version-permissions.e2e.ts
+++ b/e2e/content-services/upload/version-permissions.e2e.ts
@@ -31,6 +31,7 @@ import { UploadDialogPage } from '../../core/pages/dialog/upload-dialog.page';
 import { ContentServicesPage } from '../../core/pages/content-services.page';
 import { FileModel } from '../../models/ACS/file.model';
 import CONSTANTS = require('../../util/constants');
+import { SitesApi } from '@alfresco/js-api';
 
 describe('Version component permissions', () => {
 
@@ -78,32 +79,34 @@ describe('Version component permissions', () => {
         await usersActions.createUser(managerUser);
         await usersActions.createUser(fileCreatorUser);
 
-        site = await apiService.getInstance().core.sitesApi.createSite({
+        const sitesApi = new SitesApi(apiService.getInstance());
+
+        site = await sitesApi.createSite({
             title: StringUtil.generateRandomString(),
             visibility: 'PUBLIC'
         });
 
-        await apiService.getInstance().core.sitesApi.addSiteMember(site.entry.id, {
+        await sitesApi.createSiteMembership(site.entry.id, {
             id: consumerUser.username,
             role: CONSTANTS.CS_USER_ROLES.CONSUMER
         });
 
-        await apiService.getInstance().core.sitesApi.addSiteMember(site.entry.id, {
+        await sitesApi.createSiteMembership(site.entry.id, {
             id: collaboratorUser.username,
             role: CONSTANTS.CS_USER_ROLES.COLLABORATOR
         });
 
-        await apiService.getInstance().core.sitesApi.addSiteMember(site.entry.id, {
+        await sitesApi.createSiteMembership(site.entry.id, {
             id: contributorUser.username,
             role: CONSTANTS.CS_USER_ROLES.CONTRIBUTOR
         });
 
-        await apiService.getInstance().core.sitesApi.addSiteMember(site.entry.id, {
+        await sitesApi.createSiteMembership(site.entry.id, {
             id: managerUser.username,
             role: CONSTANTS.CS_USER_ROLES.MANAGER
         });
 
-        await apiService.getInstance().core.sitesApi.addSiteMember(site.entry.id, {
+        await sitesApi.createSiteMembership(site.entry.id, {
             id: fileCreatorUser.username,
             role: CONSTANTS.CS_USER_ROLES.MANAGER
         });
@@ -123,7 +126,9 @@ describe('Version component permissions', () => {
 
     afterAll(async () => {
         await apiService.loginWithProfile('admin');
-        await apiService.getInstance().core.sitesApi.deleteSite(site.entry.id, { permanent: true });
+
+        const sitesApi = new SitesApi(apiService.getInstance());
+        await sitesApi.deleteSite(site.entry.id, { permanent: true });
     });
 
     describe('Manager', () => {

--- a/e2e/core/viewer/file-extensions/viewer-archive.component.e2e.ts
+++ b/e2e/core/viewer/file-extensions/viewer-archive.component.e2e.ts
@@ -29,6 +29,7 @@ import { ContentServicesPage } from '../../../core/pages/content-services.page';
 import { FolderModel } from '../../../models/ACS/folder.model';
 import { NavigationBarPage } from '../../../core/pages/navigation-bar.page';
 import CONSTANTS = require('../../../util/constants');
+import { SitesApi } from '@alfresco/js-api';
 
 describe('Viewer', () => {
 
@@ -52,11 +53,14 @@ describe('Viewer', () => {
     beforeAll(async () => {
         await apiService.loginWithProfile('admin');
         await usersActions.createUser(acsUser);
-        site = await apiService.getInstance().core.sitesApi.createSite({
+
+        const sitesApi = new SitesApi(apiService.getInstance());
+
+        site = await sitesApi.createSite({
             title: StringUtil.generateRandomString(8),
             visibility: 'PUBLIC'
         });
-        await apiService.getInstance().core.sitesApi.addSiteMember(site.entry.id, {
+        await sitesApi.createSiteMembership(site.entry.id, {
             id: acsUser.username,
             role: CONSTANTS.CS_USER_ROLES.MANAGER
         });
@@ -65,7 +69,10 @@ describe('Viewer', () => {
 
     afterAll(async () => {
         await apiService.loginWithProfile('admin');
-        await apiService.getInstance().core.sitesApi.deleteSite(site.entry.id, { permanent: true });
+
+        const sitesApi = new SitesApi(apiService.getInstance());
+        await sitesApi.deleteSite(site.entry.id, { permanent: true });
+
         await navigationBarPage.clickLogoutButton();
     });
 

--- a/e2e/core/viewer/file-extensions/viewer-component.e2e.ts
+++ b/e2e/core/viewer/file-extensions/viewer-component.e2e.ts
@@ -30,6 +30,7 @@ import { FileModel } from '../../../models/ACS/file.model';
 import { FolderModel } from '../../../models/ACS/folder.model';
 import { NavigationBarPage } from '../../../core/pages/navigation-bar.page';
 import CONSTANTS = require('../../../util/constants');
+import { SitesApi } from '@alfresco/js-api';
 
 describe('Viewer', () => {
 
@@ -63,12 +64,14 @@ describe('Viewer', () => {
         await apiService.loginWithProfile('admin');
         await usersActions.createUser(acsUser);
 
-        site = await apiService.getInstance().core.sitesApi.createSite({
+        const sitesApi = new SitesApi(apiService.getInstance());
+
+        site = await sitesApi.createSite({
             title: StringUtil.generateRandomString(8),
             visibility: 'PUBLIC'
         });
 
-        await apiService.getInstance().core.sitesApi.addSiteMember(site.entry.id, {
+        await sitesApi.createSiteMembership(site.entry.id, {
             id: acsUser.username,
             role: CONSTANTS.CS_USER_ROLES.MANAGER
         });
@@ -80,7 +83,9 @@ describe('Viewer', () => {
 
     afterAll(async () => {
         await apiService.loginWithProfile('admin');
-        await apiService.getInstance().core.sitesApi.deleteSite(site.entry.id, { permanent: true });
+
+        const sitesApi = new SitesApi(apiService.getInstance());
+        await sitesApi.deleteSite(site.entry.id, { permanent: true });
     });
 
     it('[C272813] Should be redirected to site when opening and closing a file in a site', async () => {

--- a/e2e/core/viewer/file-extensions/viewer-excel.component.e2e.ts
+++ b/e2e/core/viewer/file-extensions/viewer-excel.component.e2e.ts
@@ -28,6 +28,7 @@ import {
 import { ContentServicesPage } from '../../../core/pages/content-services.page';
 import { FolderModel } from '../../../models/ACS/folder.model';
 import CONSTANTS = require('../../../util/constants');
+import { SitesApi } from '@alfresco/js-api';
 
 describe('Viewer', () => {
 
@@ -50,12 +51,14 @@ describe('Viewer', () => {
         await apiService.loginWithProfile('admin');
         await usersActions.createUser(acsUser);
 
-        site = await apiService.getInstance().core.sitesApi.createSite({
+        const sitesApi = new SitesApi(apiService.getInstance());
+
+        site = await sitesApi.createSite({
             title: StringUtil.generateRandomString(8),
             visibility: 'PUBLIC'
         });
 
-        await apiService.getInstance().core.sitesApi.addSiteMember(site.entry.id, {
+        await sitesApi.createSiteMembership(site.entry.id, {
             id: acsUser.username,
             role: CONSTANTS.CS_USER_ROLES.MANAGER
         });
@@ -65,7 +68,9 @@ describe('Viewer', () => {
 
     afterAll(async () => {
         await apiService.loginWithProfile('admin');
-        await apiService.getInstance().core.sitesApi.deleteSite(site.entry.id, { permanent: true });
+
+        const sitesApi = new SitesApi(apiService.getInstance());
+        await sitesApi.deleteSite(site.entry.id, { permanent: true });
     });
 
     describe('Excel Folder Uploaded', () => {

--- a/e2e/core/viewer/file-extensions/viewer-image.component.e2e.ts
+++ b/e2e/core/viewer/file-extensions/viewer-image.component.e2e.ts
@@ -28,6 +28,7 @@ import {
 import { ContentServicesPage } from '../../../core/pages/content-services.page';
 import { FolderModel } from '../../../models/ACS/folder.model';
 import CONSTANTS = require('../../../util/constants');
+import { SitesApi } from '@alfresco/js-api';
 
 describe('Viewer', () => {
 
@@ -56,12 +57,14 @@ describe('Viewer', () => {
         await apiService.loginWithProfile('admin');
         await usersActions.createUser(acsUser);
 
-        site = await apiService.getInstance().core.sitesApi.createSite({
+        const sitesApi = new SitesApi(apiService.getInstance());
+
+        site = await sitesApi.createSite({
             title: StringUtil.generateRandomString(8),
             visibility: 'PUBLIC'
         });
 
-        await apiService.getInstance().core.sitesApi.addSiteMember(site.entry.id, {
+        await sitesApi.createSiteMembership(site.entry.id, {
             id: acsUser.username,
             role: CONSTANTS.CS_USER_ROLES.MANAGER
         });
@@ -71,7 +74,9 @@ describe('Viewer', () => {
 
     afterAll(async () => {
         await apiService.loginWithProfile('admin');
-        await apiService.getInstance().core.sitesApi.deleteSite(site.entry.id, { permanent: true });
+
+        const sitesApi = new SitesApi(apiService.getInstance());
+        await sitesApi.deleteSite(site.entry.id, { permanent: true });
     });
 
     describe('Image Folder Uploaded', () => {

--- a/e2e/core/viewer/file-extensions/viewer-powerpoint.component.e2e.ts
+++ b/e2e/core/viewer/file-extensions/viewer-powerpoint.component.e2e.ts
@@ -28,6 +28,7 @@ import { ContentServicesPage } from '../../../core/pages/content-services.page';
 import { FolderModel } from '../../../models/ACS/folder.model';
 import { browser } from 'protractor';
 import CONSTANTS = require('../../../util/constants');
+import { SitesApi } from '@alfresco/js-api';
 
 describe('Viewer', () => {
 
@@ -52,12 +53,14 @@ describe('Viewer', () => {
         await apiService.loginWithProfile('admin');
         await usersActions.createUser(acsUser);
 
-        site = await apiService.getInstance().core.sitesApi.createSite({
+        const sitesApi = new SitesApi(apiService.getInstance());
+
+        site = await sitesApi.createSite({
             title: StringUtil.generateRandomString(8),
             visibility: 'PUBLIC'
         });
 
-        await apiService.getInstance().core.sitesApi.addSiteMember(site.entry.id, {
+        await sitesApi.createSiteMembership(site.entry.id, {
             id: acsUser.username,
             role: CONSTANTS.CS_USER_ROLES.MANAGER
         });
@@ -67,7 +70,9 @@ describe('Viewer', () => {
 
     afterAll(async () => {
         await apiService.loginWithProfile('admin');
-        await apiService.getInstance().core.sitesApi.deleteSite(site.entry.id, { permanent: true });
+
+        const sitesApi = new SitesApi(apiService.getInstance());
+        await sitesApi.deleteSite(site.entry.id, { permanent: true });
     });
 
     describe('PowerPoint Folder Uploaded', () => {

--- a/e2e/core/viewer/file-extensions/viewer-text.component.e2e.ts
+++ b/e2e/core/viewer/file-extensions/viewer-text.component.e2e.ts
@@ -28,6 +28,7 @@ import {
 import { ContentServicesPage } from '../../../core/pages/content-services.page';
 import { FolderModel } from '../../../models/ACS/folder.model';
 import CONSTANTS = require('../../../util/constants');
+import { SitesApi } from '@alfresco/js-api';
 
 describe('Viewer', () => {
 
@@ -50,12 +51,14 @@ describe('Viewer', () => {
         await apiService.loginWithProfile('admin');
         await usersActions.createUser(acsUser);
 
-        site = await apiService.getInstance().core.sitesApi.createSite({
+        const sitesApi = new SitesApi(apiService.getInstance());
+
+        site = await sitesApi.createSite({
             title: StringUtil.generateRandomString(8),
             visibility: 'PUBLIC'
         });
 
-        await apiService.getInstance().core.sitesApi.addSiteMember(site.entry.id, {
+        await sitesApi.createSiteMembership(site.entry.id, {
             id: acsUser.username,
             role: CONSTANTS.CS_USER_ROLES.MANAGER
         });
@@ -65,7 +68,9 @@ describe('Viewer', () => {
 
     afterAll(async () => {
         await apiService.loginWithProfile('admin');
-        await apiService.getInstance().core.sitesApi.deleteSite(site.entry.id, { permanent: true });
+
+        const sitesApi = new SitesApi(apiService.getInstance());
+        await sitesApi.deleteSite(site.entry.id, { permanent: true });
     });
 
     describe('Text Folder Uploaded', () => {

--- a/e2e/core/viewer/file-extensions/viewer-word.component.e2e.ts
+++ b/e2e/core/viewer/file-extensions/viewer-word.component.e2e.ts
@@ -29,6 +29,7 @@ import { ContentServicesPage } from '../../../core/pages/content-services.page';
 import { FolderModel } from '../../../models/ACS/folder.model';
 import { NavigationBarPage } from '../../../core/pages/navigation-bar.page';
 import CONSTANTS = require('../../../util/constants');
+import { SitesApi } from '@alfresco/js-api';
 
 describe('Viewer', () => {
 
@@ -52,12 +53,14 @@ describe('Viewer', () => {
         await apiService.loginWithProfile('admin');
         await usersActions.createUser(acsUser);
 
-        site = await apiService.getInstance().core.sitesApi.createSite({
+        const sitesApi = new SitesApi(apiService.getInstance());
+
+        site = await sitesApi.createSite({
             title: StringUtil.generateRandomString(8),
             visibility: 'PUBLIC'
         });
 
-        await apiService.getInstance().core.sitesApi.addSiteMember(site.entry.id, {
+        await sitesApi.createSiteMembership(site.entry.id, {
             id: acsUser.username,
             role: CONSTANTS.CS_USER_ROLES.MANAGER
         });
@@ -67,7 +70,10 @@ describe('Viewer', () => {
 
     afterAll(async () => {
         await apiService.loginWithProfile('admin');
-        await apiService.getInstance().core.sitesApi.deleteSite(site.entry.id, { permanent: true });
+
+        const sitesApi = new SitesApi(apiService.getInstance());
+        await sitesApi.deleteSite(site.entry.id, { permanent: true });
+
         await navigationBarPage.clickLogoutButton();
     });
 

--- a/e2e/core/viewer/viewer-share-content.ts
+++ b/e2e/core/viewer/viewer-share-content.ts
@@ -31,6 +31,7 @@ import { ShareDialogPage } from '../../core/pages/dialog/share-dialog.page';
 import { FileModel } from '../../models/ACS/file.model';
 import { browser } from 'protractor';
 import CONSTANTS = require('../../util/constants');
+import { SitesApi } from '@alfresco/js-api';
 
 describe('Viewer', () => {
 
@@ -65,12 +66,14 @@ describe('Viewer', () => {
         await apiService.loginWithProfile('admin');
         await usersActions.createUser(acsUser);
 
-        site = await apiService.getInstance().core.sitesApi.createSite({
+        const sitesApi = new SitesApi(apiService.getInstance());
+
+        site = await sitesApi.createSite({
             title: StringUtil.generateRandomString(8),
             visibility: 'PUBLIC'
         });
 
-        await apiService.getInstance().core.sitesApi.addSiteMember(site.entry.id, {
+        await sitesApi.createSiteMembership(site.entry.id, {
             id: acsUser.username,
             role: CONSTANTS.CS_USER_ROLES.MANAGER
         });
@@ -88,7 +91,8 @@ describe('Viewer', () => {
 
     afterAll(async () => {
         await apiService.loginWithProfile('admin');
-        await apiService.getInstance().core.sitesApi.deleteSite(site.entry.id, { permanent: true });
+        const sitesApi = new SitesApi(apiService.getInstance());
+        await sitesApi.deleteSite(site.entry.id, { permanent: true });
         await apiService.login(acsUser.username, acsUser.password);
         await uploadActions.deleteFileOrFolder(wordFileUploaded.entry.id);
     });

--- a/e2e/search/search-multiselect.e2e.ts
+++ b/e2e/search/search-multiselect.e2e.ts
@@ -59,7 +59,8 @@ describe('Search Component - Multi-Select Facet', () => {
 
             await apiService.login(acsUser.username, acsUser.password);
 
-            site = await apiService.getInstance().core.sitesApi.createSite({
+            const sitesApi = new SitesApi(apiService.getInstance());
+            site = await sitesApi.createSite({
                 title: StringUtil.generateRandomString(8),
                 visibility: 'PUBLIC'
             });
@@ -97,7 +98,8 @@ describe('Search Component - Multi-Select Facet', () => {
                 uploadActions.deleteFileOrFolder(txtFileSite.entry.id)
             ]);
 
-            await apiService.getInstance().core.sitesApi.deleteSite(site.entry.id, { permanent: true });
+            const sitesApi = new SitesApi(apiService.getInstance());
+            await sitesApi.deleteSite(site.entry.id, { permanent: true });
             await navigationBarPage.clickLogoutButton();
         });
 
@@ -214,7 +216,8 @@ describe('Search Component - Multi-Select Facet', () => {
 
             await apiService.login(acsUser.username, acsUser.password);
 
-            site = await apiService.getInstance().core.sitesApi.createSite({
+            const sitesApi = new SitesApi(apiService.getInstance());
+            site = await sitesApi.createSite({
                 title: StringUtil.generateRandomString(8),
                 visibility: 'PUBLIC'
             });

--- a/e2e/search/search-multiselect.e2e.ts
+++ b/e2e/search/search-multiselect.e2e.ts
@@ -23,6 +23,7 @@ import { SearchFiltersPage } from './pages/search-filters.page';
 import { FileModel } from '../models/ACS/file.model';
 import { NavigationBarPage } from '../core/pages/navigation-bar.page';
 import CONSTANTS = require('../util/constants');
+import { SitesApi } from '@alfresco/js-api';
 
 describe('Search Component - Multi-Select Facet', () => {
     const loginPage = new LoginPage();
@@ -151,12 +152,14 @@ describe('Search Component - Multi-Select Facet', () => {
 
             await apiService.login(userUploadingTxt.username, userUploadingTxt.password);
 
-            site = await apiService.getInstance().core.sitesApi.createSite({
+            const sitesApi = new SitesApi(apiService.getInstance());
+
+            site = await sitesApi.createSite({
                 title: StringUtil.generateRandomString(8),
                 visibility: 'PUBLIC'
             });
 
-            await apiService.getInstance().core.sitesApi.addSiteMember(site.entry.id, {
+            await sitesApi.createSiteMembership(site.entry.id, {
                 id: userUploadingImg.username,
                 role: CONSTANTS.CS_USER_ROLES.MANAGER
             });
@@ -232,7 +235,9 @@ describe('Search Component - Multi-Select Facet', () => {
         afterAll(async () => {
             await apiService.loginWithProfile('admin');
             await uploadActions.deleteFileOrFolder(txtFile.entry.id);
-            await apiService.getInstance().core.sitesApi.deleteSite(site.entry.id, { permanent: true });
+
+            const sitesApi = new SitesApi(apiService.getInstance());
+            await sitesApi.deleteSite(site.entry.id, { permanent: true });
         });
 
         it('[C280058] Should update filter facets items number when another filter facet item is selected', async () => {

--- a/e2e/util/constants.js
+++ b/e2e/util/constants.js
@@ -146,6 +146,14 @@ exports.CS_USER_ROLES = {
     MANAGER: 'SiteManager'
 };
 
+// en-US version of the Site Role titles
+exports.CS_USER_ROLES_I18N = {
+    CONSUMER: 'Site Consumer',
+    COLLABORATOR: 'Site Collaborator',
+    CONTRIBUTOR: 'Site Contributor',
+    MANAGER: 'Site Manager'
+}
+
 exports.SERVICE_TASK_STATUS = {
     ALL:'ALL',
     STARTED:'STARTED',


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

- fix the e2e
- remove some deprecated uses of the js-api 

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://alfresco.atlassian.net/browse/MNT-22236