### PR TITLE
[ACA-4370] Refresh filter counter on filter click

### DIFF
--- a/lib/process-services-cloud/src/lib/services/notification-cloud.service.spec.ts
+++ b/lib/process-services-cloud/src/lib/services/notification-cloud.service.spec.ts
@@ -16,7 +16,7 @@
  */
 
 import { TestBed, async } from '@angular/core/testing';
-import { setupTestBed } from '@alfresco/adf-core';
+import { AlfrescoApiService, setupTestBed } from '@alfresco/adf-core';
 import { ProcessServiceCloudTestingModule } from '../testing/process-service-cloud.testing.module';
 import { TranslateModule } from '@ngx-translate/core';
 import { NotificationCloudService } from './notification-cloud.service';
@@ -27,6 +27,7 @@ describe('NotificationCloudService', () => {
     let apollo: Apollo;
     let apolloCreateSpy;
     let apolloSubscribeSpy;
+    let apiService: AlfrescoApiService;
     const useMock = {
         subscribe() {}
     };
@@ -42,6 +43,12 @@ describe('NotificationCloudService', () => {
         }
     `;
 
+    const apiServiceMock = {
+        oauth2Auth: {
+            token: '1234567'
+        }
+    };
+
     setupTestBed({
         imports: [
             TranslateModule.forRoot(),
@@ -52,7 +59,9 @@ describe('NotificationCloudService', () => {
     beforeEach(async(() => {
         service = TestBed.inject(NotificationCloudService);
         apollo = TestBed.inject(Apollo);
+        apiService = TestBed.inject(AlfrescoApiService);
 
+        spyOn(apiService, 'getInstance').and.returnValue(apiServiceMock);
         service.appsListening = [];
         apolloCreateSpy = spyOn(apollo, 'createNamed');
         apolloSubscribeSpy = spyOn(apollo, 'use').and.returnValue(useMock);

--- a/lib/process-services-cloud/src/lib/services/notification-cloud.service.ts
+++ b/lib/process-services-cloud/src/lib/services/notification-cloud.service.ts
@@ -22,7 +22,7 @@ import { WebSocketLink } from '@apollo/client/link/ws';
 import { onError } from '@apollo/client/link/error';
 import { getMainDefinition } from '@apollo/client/utilities';
 import { Injectable } from '@angular/core';
-import { StorageService, AppConfigService, AlfrescoApiService } from '@alfresco/adf-core';
+import { AppConfigService, AlfrescoApiService } from '@alfresco/adf-core';
 import { BaseCloudService } from './base-cloud.service';
 
 @Injectable({
@@ -35,8 +35,7 @@ export class NotificationCloudService extends BaseCloudService {
     constructor(apiService: AlfrescoApiService,
                 appConfigService: AppConfigService,
                 public apollo: Apollo,
-                private http: HttpLink,
-                private storageService: StorageService) {
+                private http: HttpLink) {
         super(apiService, appConfigService);
     }
 
@@ -62,7 +61,7 @@ export class NotificationCloudService extends BaseCloudService {
                     lazy: true,
                     connectionParams: {
                         kaInterval: 2000,
-                        'X-Authorization': 'Bearer ' + this.storageService.getItem('access_token')
+                        'X-Authorization': 'Bearer ' + this.apiService.getInstance().oauth2Auth.token
                     }
                 }
             });
@@ -85,7 +84,7 @@ export class NotificationCloudService extends BaseCloudService {
                                 operation.setContext({
                                     headers: {
                                         ...oldHeaders,
-                                        'X-Authorization': 'Bearer ' + this.storageService.getItem('access_token')
+                                        'X-Authorization': 'Bearer ' + this.apiService.getInstance().oauth2Auth.token
                                     }
                                 });
                                 forward(operation);

--- a/lib/process-services-cloud/src/lib/task/task-filters/components/task-filters-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/task/task-filters/components/task-filters-cloud.component.spec.ts
@@ -51,6 +51,7 @@ describe('TaskFiltersCloudComponent', () => {
 
     let component: TaskFiltersCloudComponent;
     let fixture: ComponentFixture<TaskFiltersCloudComponent>;
+    let getTaskFilterCounterSpy;
 
     setupTestBed({
         imports: [
@@ -68,7 +69,7 @@ describe('TaskFiltersCloudComponent', () => {
         component = fixture.componentInstance;
 
         taskFilterService = TestBed.inject(TaskFilterCloudService);
-        spyOn(taskFilterService, 'getTaskFilterCounter').and.returnValue(of(11));
+        getTaskFilterCounterSpy = spyOn(taskFilterService, 'getTaskFilterCounter').and.returnValue(of(11));
         spyOn(taskFilterService, 'getTaskNotificationSubscription').and.returnValue(of(taskNotifications));
     });
 
@@ -421,6 +422,23 @@ describe('TaskFiltersCloudComponent', () => {
                 updatedFilterCounters = fixture.debugElement.queryAll(By.css('span.adf-active'));
                 expect(updatedFilterCounters.length).toBe(0);
             });
+        });
+    }));
+
+    it('should update filter counter when filter is selected', fakeAsync(() => {
+        spyOn(taskFilterService, 'getTaskListFilters').and.returnValue(fakeGlobalFilterObservable);
+        component.appName = 'my-app-1';
+        component.ngOnInit();
+        tick(5000);
+        fixture.detectChanges();
+        component.showIcons = true;
+        fixture.whenStable().then(() => {
+            fixture.detectChanges();
+            const filterButton = fixture.debugElement.nativeElement.querySelector(`[data-automation-id="${fakeGlobalFilter[0].key}_filter"]`);
+            filterButton.click();
+
+            fixture.detectChanges();
+            expect(getTaskFilterCounterSpy).toHaveBeenCalledWith(fakeGlobalFilter[0]);
         });
     }));
 });

--- a/lib/process-services-cloud/src/lib/task/task-filters/components/task-filters-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-filters/components/task-filters-cloud.component.ts
@@ -88,11 +88,13 @@ export class TaskFiltersCloudComponent extends BaseTaskFiltersCloudComponent imp
     }
 
     updateFilterCounters() {
-        this.filters.forEach((filter) => {
-            if (filter.showCounter) {
-                this.counters$[filter.key] = this.taskFilterCloudService.getTaskFilterCounter(filter);
-            }
-        });
+        this.filters.forEach((filter: TaskFilterCloudModel) => this.updateFilterCounter(filter));
+    }
+
+    updateFilterCounter(filter: TaskFilterCloudModel) {
+        if (filter?.showCounter) {
+            this.counters$[filter.key] = this.taskFilterCloudService.getTaskFilterCounter(filter);
+        }
     }
 
     initFilterCounterNotifications() {
@@ -155,6 +157,7 @@ export class TaskFiltersCloudComponent extends BaseTaskFiltersCloudComponent imp
     public onFilterClick(filter: FilterParamsModel) {
         if (filter) {
             this.selectFilter(filter);
+            this.updateFilterCounter(this.currentFilter);
             this.filterClicked.emit(this.currentFilter);
         } else {
             this.currentFilter = undefined;

--- a/lib/process-services-cloud/src/lib/task/task-filters/services/task-filter-cloud.service.ts
+++ b/lib/process-services-cloud/src/lib/task/task-filters/services/task-filter-cloud.service.ts
@@ -253,7 +253,8 @@ export class TaskFilterCloudService extends BaseCloudService {
             const queryParams = {
                 assignee: taskFilter.assignee,
                 status: taskFilter.status,
-                appName: taskFilter.appName
+                appName: taskFilter.appName,
+                maxItems: 1
             };
             return this.get<TaskCloudNodePaging>(queryUrl, queryParams).pipe(
                 map((tasks) => tasks.list.pagination.totalItems)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ACA-4370


**What is the new behaviour?**
We should refresh the counter of filter click to sync this component with the task list’s pagination. This way, the counter always reflects reality and shows the correct number when clicking on it. This issue fixes problems like this, where the counter is showing 2 and the task list is showing 0.
![image (150)](https://user-images.githubusercontent.com/18293044/112808250-b279dd80-9070-11eb-9aeb-acd6311f1730.png)



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
