### PR TITLE
[AAE-4428] Add selected file counter to attach file widget

### DIFF
--- a/docs/content-services/directives/node-counter.directive.md
+++ b/docs/content-services/directives/node-counter.directive.md
@@ -1,0 +1,28 @@
+---
+Title: Node Counter directive
+Added: v4.4.0
+Status: Active
+Last reviewed: 2021-04-15
+---
+
+# [Node Counter directive](../../../lib/content-services/src/lib/directives/node-counter.directive.ts "Defined in node-counter.directive.ts")
+
+Appends a counter to an element.
+
+## Basic Usage
+
+```html
+<adf-toolbar>
+    <adf-toolbar-title [adf-node-counter]="getSelectedCount()">
+        ...
+    </adf-toolbar-title>
+</adf-toolbar>
+```
+
+## Class members
+
+### Properties
+
+| Name | Type | Default value | Description |
+| ---- | ---- | ------------- | ----------- |
+| counter | `number` |  | Number of nodes selected. |

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.html
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.html
@@ -59,7 +59,7 @@
             </adf-dropdown-breadcrumb>
             <div
                 data-automation-id="content-node-selector-selected-counter">
-                {{ getSelectedCountTranslation() }}
+                {{ 'NODE_SELECTOR.SELECTED_COUNT' | translate: { count: getSelectedCount() } }}
             </div>
         </adf-toolbar-title>
     </adf-toolbar>

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.html
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.html
@@ -57,6 +57,10 @@
                 [root]="breadcrumbFolderTitle"
                 data-automation-id="content-node-selector-content-breadcrumb">
             </adf-dropdown-breadcrumb>
+            <div
+                data-automation-id="content-node-selector-selected-counter">
+                {{ getSelectedCountTranslation() }}
+            </div>
         </adf-toolbar-title>
     </adf-toolbar>
 

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.html
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.html
@@ -43,7 +43,7 @@
         </adf-search-panel>
         <div class="adf-content-node-selector-document-list-container">
     <adf-toolbar>
-        <adf-toolbar-title>
+        <adf-toolbar-title [adf-node-counter]="getSelectedCount()">
             <ng-container *ngIf="!showBreadcrumbs()">
                 <span role="heading" aria-level="3" class="adf-search-results-label">{{ 'NODE_SELECTOR.SEARCH_RESULTS' | translate }}</span>
             </ng-container>
@@ -57,10 +57,6 @@
                 [root]="breadcrumbFolderTitle"
                 data-automation-id="content-node-selector-content-breadcrumb">
             </adf-dropdown-breadcrumb>
-            <div
-                data-automation-id="content-node-selector-selected-counter">
-                {{ 'NODE_SELECTOR.SELECTED_COUNT' | translate: { count: getSelectedCount() } }}
-            </div>
         </adf-toolbar-title>
     </adf-toolbar>
 

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.spec.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.spec.ts
@@ -1378,6 +1378,18 @@ describe('ContentNodeSelectorPanelComponent', () => {
 
                 expect(component.getSelectedCount()).toBe(0);
             });
+
+            it('should have injected the counter text', () => {
+                fixture.detectChanges();
+                fixture.whenStable().then(() => {
+                    const breadcrumb = fixture.debugElement.query(By.directive(DropdownBreadcrumbComponent));
+                    expect(breadcrumb).not.toBeNull('Breadcrumb not found');
+
+                    const counterElement = fixture.debugElement.query(By.css('[data-automation-id="content-node-selector-selected-counter"]'));
+                    expect(counterElement).not.toBeNull();
+                    expect(counterElement.nativeElement.innerText).toBe('NODE_SELECTOR.SELECTED_COUNT');
+                });
+            });
         });
     });
 });

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.spec.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.spec.ts
@@ -1360,5 +1360,24 @@ describe('ContentNodeSelectorPanelComponent', () => {
                 expect(component.sorting).toEqual(['createdAt', 'desc']);
             });
         });
+
+        describe('Selected nodes counter', () => {
+            it('should getSelectedCount return 0 by default', () => {
+                expect(component.getSelectedCount()).toBe(0);
+            });
+
+            it('should getSelectedCount return 1 when node is selected', () => {
+                component.onCurrentSelection([{ entry: new Node({ id: 'fake' }) }]);
+
+                expect(component.getSelectedCount()).toBe(1);
+            });
+
+            it('should getSelectedCount return 0 when the chosen nodes are reset', () => {
+                component.onCurrentSelection([{ entry: new Node({ id: 'fake' }) }]);
+                component.resetChosenNode();
+
+                expect(component.getSelectedCount()).toBe(0);
+            });
+        });
     });
 });

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.spec.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.spec.ts
@@ -1378,18 +1378,6 @@ describe('ContentNodeSelectorPanelComponent', () => {
 
                 expect(component.getSelectedCount()).toBe(0);
             });
-
-            it('should have injected the counter text', () => {
-                fixture.detectChanges();
-                fixture.whenStable().then(() => {
-                    const breadcrumb = fixture.debugElement.query(By.directive(DropdownBreadcrumbComponent));
-                    expect(breadcrumb).not.toBeNull('Breadcrumb not found');
-
-                    const counterElement = fixture.debugElement.query(By.css('[data-automation-id="content-node-selector-selected-counter"]'));
-                    expect(counterElement).not.toBeNull();
-                    expect(counterElement.nativeElement.innerText).toBe('NODE_SELECTOR.SELECTED_COUNT');
-                });
-            });
         });
     });
 });

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.spec.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.spec.ts
@@ -372,6 +372,7 @@ describe('ContentNodeSelectorPanelComponent', () => {
             beforeEach(() => {
                 const documentListService = TestBed.inject(DocumentListService);
                 const expectedDefaultFolderNode = <NodeEntry> { entry: { path: { elements: [] } } };
+                component.isSelectionValid = (node: Node) => node.isFile;
 
                 spyOn(documentListService, 'getFolderNode').and.returnValue(of(expectedDefaultFolderNode));
                 spyOn(documentListService, 'getFolder').and.returnValue(of({
@@ -1026,6 +1027,14 @@ describe('ContentNodeSelectorPanelComponent', () => {
                 spyOn(sitesService, 'getSites').and.returnValue(of({ list: { entries: [] } }));
             });
 
+            it('should the selection become the currently navigated folder when the folder loads (Acts as destination for cases like copy action)', () => {
+                const fakeFolderNode = <Node> { id: 'fakeNodeId', isFolder: true };
+                component.documentList.folderNode = fakeFolderNode;
+                component.onFolderLoaded();
+
+                expect(component.chosenNode).toEqual([fakeFolderNode]);
+            });
+
             describe('in the case when isSelectionValid is a custom function for checking permissions,', () => {
 
                 beforeEach(() => {
@@ -1367,13 +1376,13 @@ describe('ContentNodeSelectorPanelComponent', () => {
             });
 
             it('should getSelectedCount return 1 when node is selected', () => {
-                component.onCurrentSelection([{ entry: new Node({ id: 'fake' }) }]);
+                component.onCurrentSelection([{ entry: new Node({ id: 'fake', isFile: true }) }]);
 
                 expect(component.getSelectedCount()).toBe(1);
             });
 
             it('should getSelectedCount return 0 when the chosen nodes are reset', () => {
-                component.onCurrentSelection([{ entry: new Node({ id: 'fake' }) }]);
+                component.onCurrentSelection([{ entry: new Node({ id: 'fake', isFile: true }) }]);
                 component.resetChosenNode();
 
                 expect(component.getSelectedCount()).toBe(0);

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.ts
@@ -550,9 +550,12 @@ export class ContentNodeSelectorPanelComponent implements OnInit, OnDestroy {
     }
 
     /**
-     * Emits when the folder is loaded
+     * Attempts to set the currently loaded node
      */
     onFolderLoaded(): void {
+        if (!this.showingSearchResults) {
+            this.attemptNodeSelection(this.documentList.folderNode);
+        }
         this.folderLoaded.emit();
     }
 
@@ -575,6 +578,17 @@ export class ContentNodeSelectorPanelComponent implements OnInit, OnDestroy {
 
         if (this.searchTerm.length > 0) {
             this.queryBuilderService.update();
+        }
+    }
+
+    /**
+     * Selects node as chosen if it has the right permission, clears the selection otherwise
+     *
+     * @param entry
+     */
+    private attemptNodeSelection(entry: Node): void {
+        if (entry && this.isSelectionValid(entry)) {
+            this.chosenNode = [entry];
         }
     }
 

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.ts
@@ -282,7 +282,11 @@ export class ContentNodeSelectorPanelComponent implements OnInit, OnDestroy {
     }
 
     getSelectedCountTranslation(): string {
-        return this.translation.instant(`NODE_SELECTOR.SELECTED_COUNT`, { count: this.chosenNode?.length || 0 });
+        return this.translation.instant(`NODE_SELECTOR.SELECTED_COUNT`, { count: this.getSelectedCount() });
+    }
+
+    getSelectedCount(): number {
+        return this.chosenNode?.length || 0;
     }
 
     ngOnInit() {

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.ts
@@ -37,7 +37,8 @@ import {
     FileUploadCompleteEvent,
     FileUploadDeleteEvent,
     AppConfigService,
-    DataSorting
+    DataSorting,
+    TranslationService
 } from '@alfresco/adf-core';
 import { FormControl } from '@angular/forms';
 import { Node, NodePaging, Pagination, SiteEntry, SitePaging, NodeEntry, QueryBody, RequestScope } from '@alfresco/js-api';
@@ -267,7 +268,8 @@ export class ContentNodeSelectorPanelComponent implements OnInit, OnDestroy {
                 private uploadService: UploadService,
                 private sitesService: SitesService,
                 private appConfigService: AppConfigService,
-                private contentNodeSelectorPanelService: ContentNodeSelectorPanelService) {
+                private contentNodeSelectorPanelService: ContentNodeSelectorPanelService,
+                private translation: TranslationService) {
     }
 
     set chosenNode(value: Node[]) {
@@ -277,6 +279,10 @@ export class ContentNodeSelectorPanelComponent implements OnInit, OnDestroy {
 
     get chosenNode() {
         return this._chosenNode;
+    }
+
+    getSelectedCountTranslation(): string {
+        return this.translation.instant(`NODE_SELECTOR.SELECTED_COUNT`, { count: this.chosenNode?.length || 0 });
     }
 
     ngOnInit() {

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.ts
@@ -550,12 +550,9 @@ export class ContentNodeSelectorPanelComponent implements OnInit, OnDestroy {
     }
 
     /**
-     * Attempts to set the currently loaded node
+     * Emits when the folder is loaded
      */
     onFolderLoaded(): void {
-        if (!this.showingSearchResults) {
-            this.attemptNodeSelection(this.documentList.folderNode);
-        }
         this.folderLoaded.emit();
     }
 
@@ -578,17 +575,6 @@ export class ContentNodeSelectorPanelComponent implements OnInit, OnDestroy {
 
         if (this.searchTerm.length > 0) {
             this.queryBuilderService.update();
-        }
-    }
-
-    /**
-     * Selects node as chosen if it has the right permission, clears the selection otherwise
-     *
-     * @param entry
-     */
-    private attemptNodeSelection(entry: Node): void {
-        if (entry && this.isSelectionValid(entry)) {
-            this.chosenNode = [entry];
         }
     }
 

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.ts
@@ -37,8 +37,7 @@ import {
     FileUploadCompleteEvent,
     FileUploadDeleteEvent,
     AppConfigService,
-    DataSorting,
-    TranslationService
+    DataSorting
 } from '@alfresco/adf-core';
 import { FormControl } from '@angular/forms';
 import { Node, NodePaging, Pagination, SiteEntry, SitePaging, NodeEntry, QueryBody, RequestScope } from '@alfresco/js-api';
@@ -268,8 +267,7 @@ export class ContentNodeSelectorPanelComponent implements OnInit, OnDestroy {
                 private uploadService: UploadService,
                 private sitesService: SitesService,
                 private appConfigService: AppConfigService,
-                private contentNodeSelectorPanelService: ContentNodeSelectorPanelService,
-                private translation: TranslationService) {
+                private contentNodeSelectorPanelService: ContentNodeSelectorPanelService) {
     }
 
     set chosenNode(value: Node[]) {
@@ -279,10 +277,6 @@ export class ContentNodeSelectorPanelComponent implements OnInit, OnDestroy {
 
     get chosenNode() {
         return this._chosenNode;
-    }
-
-    getSelectedCountTranslation(): string {
-        return this.translation.instant(`NODE_SELECTOR.SELECTED_COUNT`, { count: this.getSelectedCount() });
     }
 
     getSelectedCount(): number {

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector.component.html
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector.component.html
@@ -45,7 +45,7 @@
                 ></adf-dropdown-breadcrumb>
                 <div
                     data-automation-id="content-node-selector-upload-selected-counter">
-                    {{ getSelectedCountTranslation() }}
+                    {{ 'NODE_SELECTOR.SELECTED_COUNT' | translate: { count: getSelectedCount() } }}
                 </div>
             </adf-toolbar-title>
         </adf-toolbar>

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector.component.html
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector.component.html
@@ -43,6 +43,10 @@
                     [readOnly]="true"
                     data-automation-id="content-node-selector-upload-breadcrumb"
                 ></adf-dropdown-breadcrumb>
+                <div
+                    data-automation-id="content-node-selector-upload-selected-counter">
+                    {{ getSelectedCountTranslation() }}
+                </div>
             </adf-toolbar-title>
         </adf-toolbar>
         <ng-template mat-tab-label>

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector.component.html
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector.component.html
@@ -35,7 +35,7 @@
     <mat-tab *ngIf="canPerformLocalUpload()"
              [disabled]="isNotAllowedToUpload()">
         <adf-toolbar>
-            <adf-toolbar-title>
+            <adf-toolbar-title [adf-node-counter]="getSelectedCount()">
                 <adf-dropdown-breadcrumb
                     class="adf-content-node-selector-content-breadcrumb"
                     [folderNode]="breadcrumbFolderNode"
@@ -43,10 +43,6 @@
                     [readOnly]="true"
                     data-automation-id="content-node-selector-upload-breadcrumb"
                 ></adf-dropdown-breadcrumb>
-                <div
-                    data-automation-id="content-node-selector-upload-selected-counter">
-                    {{ 'NODE_SELECTOR.SELECTED_COUNT' | translate: { count: getSelectedCount() } }}
-                </div>
             </adf-toolbar-title>
         </adf-toolbar>
         <ng-template mat-tab-label>

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector.component.scss
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector.component.scss
@@ -26,6 +26,10 @@
         .adf-upload-dialog-container {
             height: 456px;
         }
+
+        .adf-toolbar-title {
+            place-items: center;
+        }
     }
 
     .adf-content-node-selector-dialog {

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector.component.spec.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector.component.spec.ts
@@ -30,7 +30,7 @@ import { ShareDataRow } from '../document-list';
 import { TranslateModule } from '@ngx-translate/core';
 import { UploadModule } from '../upload';
 import { ContentNodeSelectorPanelComponent } from './content-node-selector-panel.component';
-import {DropdownBreadcrumbComponent} from "../breadcrumb";
+import { DropdownBreadcrumbComponent } from "../breadcrumb";
 
 describe('ContentNodeSelectorComponent', () => {
     let component: ContentNodeSelectorComponent;

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector.component.spec.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector.component.spec.ts
@@ -30,6 +30,7 @@ import { ShareDataRow } from '../document-list';
 import { TranslateModule } from '@ngx-translate/core';
 import { UploadModule } from '../upload';
 import { ContentNodeSelectorPanelComponent } from './content-node-selector-panel.component';
+import {DropdownBreadcrumbComponent} from "../breadcrumb";
 
 describe('ContentNodeSelectorComponent', () => {
     let component: ContentNodeSelectorComponent;
@@ -445,6 +446,18 @@ describe('ContentNodeSelectorComponent', () => {
             component.onSelect([new Node({ id: 'fake' })]);
 
             expect(component.getSelectedCount()).toBe(1);
+        });
+
+        it('should have injected the counter text', () => {
+            fixture.detectChanges();
+            fixture.whenStable().then(() => {
+                const breadcrumb = fixture.debugElement.query(By.directive(DropdownBreadcrumbComponent));
+                expect(breadcrumb).not.toBeNull('Breadcrumb not found');
+
+                const counterElement = fixture.debugElement.query(By.css('[data-automation-id="content-node-selector-upload-selected-counter"]'));
+                expect(counterElement).not.toBeNull();
+                expect(counterElement.nativeElement.innerText).toBe('NODE_SELECTOR.SELECTED_COUNT');
+            });
         });
     });
 });

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector.component.spec.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector.component.spec.ts
@@ -30,7 +30,6 @@ import { ShareDataRow } from '../document-list';
 import { TranslateModule } from '@ngx-translate/core';
 import { UploadModule } from '../upload';
 import { ContentNodeSelectorPanelComponent } from './content-node-selector-panel.component';
-import { DropdownBreadcrumbComponent } from "../breadcrumb";
 
 describe('ContentNodeSelectorComponent', () => {
     let component: ContentNodeSelectorComponent;
@@ -451,9 +450,6 @@ describe('ContentNodeSelectorComponent', () => {
         it('should have injected the counter text', () => {
             fixture.detectChanges();
             fixture.whenStable().then(() => {
-                const breadcrumb = fixture.debugElement.query(By.directive(DropdownBreadcrumbComponent));
-                expect(breadcrumb).not.toBeNull('Breadcrumb not found');
-
                 const counterElement = fixture.debugElement.query(By.css('[data-automation-id="content-node-selector-upload-selected-counter"]'));
                 expect(counterElement).not.toBeNull();
                 expect(counterElement.nativeElement.innerText).toBe('NODE_SELECTOR.SELECTED_COUNT');

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector.component.spec.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector.component.spec.ts
@@ -435,4 +435,16 @@ describe('ContentNodeSelectorComponent', () => {
             expect(emptyListTemplate).toBeNull();
         });
     });
+
+    describe('Selected nodes counter', () => {
+        it('should getSelectedCount return 0 by default', () => {
+            expect(component.getSelectedCount()).toBe(0);
+        });
+
+        it('should getSelectedCount return 1 when a node is selected', () => {
+            component.onSelect([new Node({ id: 'fake' })]);
+
+            expect(component.getSelectedCount()).toBe(1);
+        });
+    });
 });

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector.component.spec.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector.component.spec.ts
@@ -446,14 +446,5 @@ describe('ContentNodeSelectorComponent', () => {
 
             expect(component.getSelectedCount()).toBe(1);
         });
-
-        it('should have injected the counter text', () => {
-            fixture.detectChanges();
-            fixture.whenStable().then(() => {
-                const counterElement = fixture.debugElement.query(By.css('[data-automation-id="content-node-selector-upload-selected-counter"]'));
-                expect(counterElement).not.toBeNull();
-                expect(counterElement.nativeElement.innerText).toBe('NODE_SELECTOR.SELECTED_COUNT');
-            });
-        });
     });
 });

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector.component.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector.component.ts
@@ -107,10 +107,6 @@ export class ContentNodeSelectorComponent implements OnInit {
         return this.translation.instant(`NODE_SELECTOR.${action}_ITEM`, { name: this.translation.instant(name) });
     }
 
-    getSelectedCountTranslation(): string {
-        return this.translation.instant(`NODE_SELECTOR.SELECTED_COUNT`, { count: this.getSelectedCount() });
-    }
-
     getSelectedCount(): number {
         return this.chosenNode?.length || 0;
     }

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector.component.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector.component.ts
@@ -108,7 +108,11 @@ export class ContentNodeSelectorComponent implements OnInit {
     }
 
     getSelectedCountTranslation(): string {
-        return this.translation.instant(`NODE_SELECTOR.SELECTED_COUNT`, { count: this.chosenNode?.length || 0 });
+        return this.translation.instant(`NODE_SELECTOR.SELECTED_COUNT`, { count: this.getSelectedCount() });
+    }
+
+    getSelectedCount(): number {
+        return this.chosenNode?.length || 0;
     }
 
     isMultipleSelection(): boolean {

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector.component.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector.component.ts
@@ -107,6 +107,10 @@ export class ContentNodeSelectorComponent implements OnInit {
         return this.translation.instant(`NODE_SELECTOR.${action}_ITEM`, { name: this.translation.instant(name) });
     }
 
+    getSelectedCountTranslation(): string {
+        return this.translation.instant(`NODE_SELECTOR.SELECTED_COUNT`, { count: this.chosenNode?.length || 0 });
+    }
+
     isMultipleSelection(): boolean {
         return this.data.selectionMode === 'multiple';
     }

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector.module.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector.module.ts
@@ -30,6 +30,7 @@ import { DocumentListModule } from '../document-list/document-list.module';
 import { NameLocationCellComponent } from './name-location-cell/name-location-cell.component';
 import { UploadModule } from '../upload/upload.module';
 import { SearchQueryBuilderService } from '../search/search-query-builder.service';
+import { ContentDirectiveModule } from "../directives/content-directive.module";
 
 @NgModule({
     imports: [
@@ -42,7 +43,8 @@ import { SearchQueryBuilderService } from '../search/search-query-builder.servic
         BreadcrumbModule,
         SearchModule,
         DocumentListModule,
-        UploadModule
+        UploadModule,
+        ContentDirectiveModule
     ],
     exports: [
         ContentNodeSelectorPanelComponent,

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector.module.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector.module.ts
@@ -30,7 +30,7 @@ import { DocumentListModule } from '../document-list/document-list.module';
 import { NameLocationCellComponent } from './name-location-cell/name-location-cell.component';
 import { UploadModule } from '../upload/upload.module';
 import { SearchQueryBuilderService } from '../search/search-query-builder.service';
-import { ContentDirectiveModule } from "../directives/content-directive.module";
+import { ContentDirectiveModule } from '../directives/content-directive.module';
 
 @NgModule({
     imports: [

--- a/lib/content-services/src/lib/directives/content-directive.module.ts
+++ b/lib/content-services/src/lib/directives/content-directive.module.ts
@@ -18,19 +18,25 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { MaterialModule } from '../material.module';
+import { TranslateModule } from "@ngx-translate/core";
 
 import { NodeLockDirective } from './node-lock.directive';
+import { NodeCounterComponent, NodeCounterDirective } from "./node-counter.directive";
 
 @NgModule({
     imports: [
         CommonModule,
-        MaterialModule
+        MaterialModule,
+        TranslateModule
     ],
     declarations: [
-        NodeLockDirective
+        NodeLockDirective,
+        NodeCounterDirective,
+        NodeCounterComponent
     ],
     exports: [
-        NodeLockDirective
+        NodeLockDirective,
+        NodeCounterDirective
     ]
 })
 export class ContentDirectiveModule {

--- a/lib/content-services/src/lib/directives/content-directive.module.ts
+++ b/lib/content-services/src/lib/directives/content-directive.module.ts
@@ -18,10 +18,10 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { MaterialModule } from '../material.module';
-import { TranslateModule } from "@ngx-translate/core";
+import { TranslateModule } from '@ngx-translate/core';
 
 import { NodeLockDirective } from './node-lock.directive';
-import { NodeCounterComponent, NodeCounterDirective } from "./node-counter.directive";
+import { NodeCounterComponent, NodeCounterDirective } from './node-counter.directive';
 
 @NgModule({
     imports: [

--- a/lib/content-services/src/lib/directives/node-counter.directive.spec.ts
+++ b/lib/content-services/src/lib/directives/node-counter.directive.spec.ts
@@ -1,0 +1,56 @@
+/*!
+ * @license
+ * Copyright 2019 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NodeCounterDirective, NodeCounterComponent } from './node-counter.directive';
+import { By } from '@angular/platform-browser';
+import { TranslateModule } from '@ngx-translate/core';
+
+@Component({
+    template: `<div [adf-node-counter]="count"></div>`
+})
+class TestComponent {
+    count: number = 0;
+}
+
+describe('NodeCounterDirective', () => {
+    let fixture: ComponentFixture<TestComponent>;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [
+                TranslateModule.forRoot()
+            ],
+            declarations: [
+                NodeCounterDirective,
+                NodeCounterComponent,
+                TestComponent
+            ]
+        });
+        fixture = TestBed.createComponent(TestComponent);
+        fixture.detectChanges();
+    });
+
+    it('should display the counter component', () => {
+        fixture.whenStable().then(() => {
+            const counterElement = fixture.debugElement.query(By.css('adf-node-counter'));
+            expect(counterElement).not.toBeNull();
+            expect(counterElement.nativeElement.innerText).toBe('NODE_COUNTER.SELECTED_COUNT');
+        });
+    });
+});

--- a/lib/content-services/src/lib/directives/node-counter.directive.ts
+++ b/lib/content-services/src/lib/directives/node-counter.directive.ts
@@ -1,6 +1,6 @@
 /*!
  * @license
- * Copyright 2021 Alfresco Software, Ltd.
+ * Copyright 2019 Alfresco Software, Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import {Directive, Input, Component, OnInit, OnChanges, ComponentFactoryResolver, ViewContainerRef } from '@angular/core';
+import { Directive, Input, Component, OnInit, OnChanges, ComponentFactoryResolver, ViewContainerRef } from '@angular/core';
 
 @Directive({
     selector: '[adf-node-counter]'
@@ -51,5 +51,5 @@ export class NodeCounterDirective implements OnInit, OnChanges {
     `
 })
 export class NodeCounterComponent {
-    counter: number
+    counter: number;
 }

--- a/lib/content-services/src/lib/directives/node-counter.directive.ts
+++ b/lib/content-services/src/lib/directives/node-counter.directive.ts
@@ -1,0 +1,55 @@
+/*!
+ * @license
+ * Copyright 2021 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {Directive, Input, Component, OnInit, OnChanges, ComponentFactoryResolver, ViewContainerRef } from '@angular/core';
+
+@Directive({
+    selector: '[adf-node-counter]'
+})
+export class NodeCounterDirective implements OnInit, OnChanges {
+    @Input('adf-node-counter')
+    counter: number;
+
+    componentRef: NodeCounterComponent;
+
+    constructor(
+        private resolver: ComponentFactoryResolver,
+        public viewContainerRef: ViewContainerRef
+    ) {}
+
+    ngOnInit() {
+        const componentFactory = this.resolver.resolveComponentFactory(NodeCounterComponent);
+        this.componentRef = this.viewContainerRef.createComponent(componentFactory).instance;
+        this.componentRef.counter = this.counter;
+    }
+
+    ngOnChanges() {
+        if (this.componentRef) {
+            this.componentRef.counter = this.counter;
+        }
+    }
+}
+
+@Component({
+    selector: 'adf-node-counter',
+    template: `
+        <div>{{ 'NODE_COUNTER.SELECTED_COUNT' | translate: { count: counter } }}</div>
+    `
+})
+export class NodeCounterComponent {
+    counter: number
+}

--- a/lib/content-services/src/lib/i18n/en.json
+++ b/lib/content-services/src/lib/i18n/en.json
@@ -90,7 +90,8 @@
     "UPLOAD_BUTTON_SEARCH_WARNING_MESSAGE": "You can't upload a file whilst a search is still running",
     "UPLOAD_BUTTON_PERMISSION_WARNING_MESSAGE": "User doesn't have permission to upload content to the folder",
     "REPOSITORY": "Repository",
-    "UPLOAD_FROM_DEVICE": "Upload from your device"
+    "UPLOAD_FROM_DEVICE": "Upload from your device",
+    "SELECTED_COUNT": "{{ count }} selected"
   },
   "OPERATION": {
     "SUCCESS": {

--- a/lib/content-services/src/lib/i18n/en.json
+++ b/lib/content-services/src/lib/i18n/en.json
@@ -90,8 +90,7 @@
     "UPLOAD_BUTTON_SEARCH_WARNING_MESSAGE": "You can't upload a file whilst a search is still running",
     "UPLOAD_BUTTON_PERMISSION_WARNING_MESSAGE": "User doesn't have permission to upload content to the folder",
     "REPOSITORY": "Repository",
-    "UPLOAD_FROM_DEVICE": "Upload from your device",
-    "SELECTED_COUNT": "{{ count }} selected"
+    "UPLOAD_FROM_DEVICE": "Upload from your device"
   },
   "OPERATION": {
     "SUCCESS": {
@@ -475,5 +474,8 @@
        "OVER-TABLE-MESSAGE" : "Select property aspects",
        "SELECTED": "Selected"
     }
+  },
+  "NODE_COUNTER": {
+    "SELECTED_COUNT": "{{ count }} selected"
   }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

No way to tell exactly how many files are selected without counting them manually.

**What is the new behaviour?**

A counter in the toolbar to the right of the breadcrumb with the number of files selected is displayed.
![image](https://user-images.githubusercontent.com/26234396/112979564-a5ccb680-9150-11eb-8bf5-6368fd22d6cf.png)

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
