### PR TITLE
[ADF-5363] - when aspects has no name we will show the id instead

### DIFF
--- a/lib/content-services/src/lib/aspect-list/aspect-list.component.html
+++ b/lib/content-services/src/lib/aspect-list/aspect-list.component.html
@@ -1,18 +1,18 @@
 <div id="aspect-list-container" class="adf-aspect-list-container" *ngIf="aspects$ | async as aspects; else loading">
     <mat-accordion class="adf-accordion-aspect-list">
-        <mat-expansion-panel *ngFor="let aspect of aspects; let colIndex = index" [id]="'aspect-list-'+(aspect?.entry?.title ? aspect?.entry?.title : aspect?.entry?.id.replace(':', '-'))">
-            <mat-expansion-panel-header [id]="'aspect-list-'+(aspect?.entry?.title ? aspect?.entry?.title : aspect?.entry?.id.replace(':', '-'))+'header'">
+        <mat-expansion-panel *ngFor="let aspect of aspects; let colIndex = index" [id]="'aspect-list-'+getId(aspect)">
+            <mat-expansion-panel-header [id]="'aspect-list-'+(getId(aspect))+'header'">
                 <mat-panel-title>
                     <mat-checkbox class="adf-aspect-list-check-button" [id]="'aspect-list-'+colIndex+'-check'"
                                   [checked]="nodeAspects?.includes(aspect?.entry?.id)"
                                   (click)="onCheckBoxClick($event)"
                                   (change)="onChange($event, aspect?.entry?.id)">
                     </mat-checkbox>
-                    <p class="adf-aspect-list-element-title">{{aspect?.entry?.title ? aspect?.entry?.title : aspect?.entry?.id}}</p>
+                    <p class="adf-aspect-list-element-title">{{getTitle(aspect)}}</p>
                 </mat-panel-title>
                 <mat-panel-description [id]="'aspect-list-'+colIndex+'-title'"
-                                        [matTooltip]="(aspect?.entry?.title ? aspect?.entry?.title : aspect?.entry?.id)">
-                    {{aspect?.entry?.title ? aspect?.entry?.title : aspect?.entry?.id}}
+                                        [matTooltip]="getTitle(aspect)">
+                    {{getTitle(aspect)}}
                 </mat-panel-description>
             </mat-expansion-panel-header>
             <p class="adf-property-paragraph" [id]="'aspect-list-'+colIndex+'-description'"> {{aspect?.entry?.description}}</p>

--- a/lib/content-services/src/lib/aspect-list/aspect-list.component.html
+++ b/lib/content-services/src/lib/aspect-list/aspect-list.component.html
@@ -1,18 +1,18 @@
 <div id="aspect-list-container" class="adf-aspect-list-container" *ngIf="aspects$ | async as aspects; else loading">
     <mat-accordion class="adf-accordion-aspect-list">
-        <mat-expansion-panel *ngFor="let aspect of aspects; let colIndex = index" [id]="'aspect-list-'+aspect?.entry?.title">
-            <mat-expansion-panel-header [id]="'aspect-list-'+aspect?.entry?.title+'header'">
+        <mat-expansion-panel *ngFor="let aspect of aspects; let colIndex = index" [id]="'aspect-list-'+(aspect?.entry?.title ? aspect?.entry?.title : aspect?.entry?.id.replace(':', '-'))">
+            <mat-expansion-panel-header [id]="'aspect-list-'+(aspect?.entry?.title ? aspect?.entry?.title : aspect?.entry?.id.replace(':', '-'))+'header'">
                 <mat-panel-title>
                     <mat-checkbox class="adf-aspect-list-check-button" [id]="'aspect-list-'+colIndex+'-check'"
                                   [checked]="nodeAspects?.includes(aspect?.entry?.id)"
                                   (click)="onCheckBoxClick($event)"
                                   (change)="onChange($event, aspect?.entry?.id)">
                     </mat-checkbox>
-                    <p class="adf-aspect-list-element-title">{{aspect?.entry?.title}}</p>
+                    <p class="adf-aspect-list-element-title">{{aspect?.entry?.title ? aspect?.entry?.title : aspect?.entry?.id}}</p>
                 </mat-panel-title>
                 <mat-panel-description [id]="'aspect-list-'+colIndex+'-title'"
-                                        [matTooltip]="aspect?.entry?.title">
-                    {{aspect?.entry?.title}}
+                                        [matTooltip]="(aspect?.entry?.title ? aspect?.entry?.title : aspect?.entry?.id)">
+                    {{aspect?.entry?.title ? aspect?.entry?.title : aspect?.entry?.id}}
                 </mat-panel-description>
             </mat-expansion-panel-header>
             <p class="adf-property-paragraph" [id]="'aspect-list-'+colIndex+'-description'"> {{aspect?.entry?.description}}</p>

--- a/lib/content-services/src/lib/aspect-list/aspect-list.component.spec.ts
+++ b/lib/content-services/src/lib/aspect-list/aspect-list.component.spec.ts
@@ -68,7 +68,7 @@ const aspectListMock: AspectEntry[] = [{
 
 const customAspectListMock: AspectEntry[] = [{
     entry: {
-        parentId: 'cst:customAspect',
+        parentId: 'cst:parentAspect',
         id: 'cst:customAspect',
         description: 'Custom Aspect with random description',
         title: 'CustomAspect',
@@ -88,7 +88,7 @@ const customAspectListMock: AspectEntry[] = [{
 },
 {
     entry: {
-        parentId: 'cst:nonamedAspect',
+        parentId: 'cst:commonaspect',
         id: 'cst:nonamedAspect',
         description: '',
         title: '',

--- a/lib/content-services/src/lib/aspect-list/aspect-list.component.spec.ts
+++ b/lib/content-services/src/lib/aspect-list/aspect-list.component.spec.ts
@@ -85,6 +85,21 @@ const customAspectListMock: AspectEntry[] = [{
             }
         ]
     }
+},
+{
+    entry: {
+        parentId: 'cst:nonamedAspect',
+        id: 'cst:nonamedAspect',
+        description: '',
+        title: '',
+        properties: [
+            {
+                id: 'channelPassword',
+                title: 'The authenticated channel password',
+                dataType: 'd:propA'
+            }
+        ]
+    }
 }];
 
 describe('AspectListComponent', () => {
@@ -149,6 +164,13 @@ describe('AspectListComponent', () => {
             expect(firstElement).toBeDefined();
             expect(secondElement).not.toBeNull();
             expect(secondElement).toBeDefined();
+        });
+
+        it('should show aspect id when name or title is not set', () => {
+            const noNameAspect: HTMLElement = fixture.nativeElement.querySelector('#aspect-list-cst-nonamedAspect .adf-aspect-list-element-title');
+            expect(noNameAspect).toBeDefined();
+            expect(noNameAspect).not.toBeNull();
+            expect(noNameAspect.innerText).toBe('cst:nonamedAspect');
         });
 
         it('should show the details when a row is clicked', () => {

--- a/lib/content-services/src/lib/aspect-list/aspect-list.component.ts
+++ b/lib/content-services/src/lib/aspect-list/aspect-list.component.ts
@@ -101,4 +101,12 @@ export class AspectListComponent implements OnInit, OnDestroy {
         this.nodeAspects = [];
         this.valueChanged.emit(this.nodeAspects);
     }
+
+    getId(aspect: any): string {
+        return aspect?.entry?.title ? aspect?.entry?.title : aspect?.entry?.id.replace(':', '-');
+    }
+
+    getTitle(aspect: any): string {
+        return aspect?.entry?.title ? aspect?.entry?.title : aspect?.entry?.id;
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Aspect with no name set shows empty row


**What is the new behaviour?**
Aspect with no name set will shot on the list with id


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
