### PR TITLE
[ADF-5362] - showing in the confirm dialog only the propery of the cu…

### DIFF
--- a/lib/content-services/src/lib/content-type/content-type-dialog.component.html
+++ b/lib/content-services/src/lib/content-type/content-type-dialog.component.html
@@ -12,8 +12,8 @@
                         {{'CORE.METADATA.CONTENT_TYPE.DIALOG.VIEW_DETAILS' | translate}}
                     </mat-panel-title>
                 </mat-expansion-panel-header>
-                <table mat-table [dataSource]="currentContentType?.entry?.properties"
-                    *ngIf="currentContentType?.entry?.properties?.length > 0" class="adf-content-type-table">
+                <table mat-table [dataSource]="typeProperties"
+                    *ngIf="typeProperties?.length > 0" class="adf-content-type-table">
                     <ng-container matColumnDef="name">
                         <th mat-header-cell *matHeaderCellDef> {{'CORE.METADATA.CONTENT_TYPE.DIALOG.PROPERTY.NAME' |
                             translate}} </th>

--- a/lib/content-services/src/lib/content-type/content-type-dialog.component.spec.ts
+++ b/lib/content-services/src/lib/content-type/content-type-dialog.component.spec.ts
@@ -29,7 +29,7 @@ const elementCustom: TypeEntry = {
     entry: {
         id: 'ck:pippobaudo',
         title: 'PIPPO-BAUDO',
-        model: {id:'what', namespacePrefix : 'ck'},
+        model: { id: 'what', namespacePrefix: 'ck' },
         description: 'Doloro reaepgfihawpefih peahfa powfj p[qwofhjaq[ fq[owfj[qowjf[qowfgh[qowh f[qowhfj [qwohf',
         parentId: 'cm:content',
         properties: [

--- a/lib/content-services/src/lib/content-type/content-type-dialog.component.spec.ts
+++ b/lib/content-services/src/lib/content-type/content-type-dialog.component.spec.ts
@@ -29,9 +29,20 @@ const elementCustom: TypeEntry = {
     entry: {
         id: 'ck:pippobaudo',
         title: 'PIPPO-BAUDO',
+        model: {id:'what', namespacePrefix : 'ck'},
         description: 'Doloro reaepgfihawpefih peahfa powfj p[qwofhjaq[ fq[owfj[qowjf[qowfgh[qowh f[qowhfj [qwohf',
         parentId: 'cm:content',
         properties: [
+            {
+                id: 'lm:PropA',
+                dataType: 'lm:notshowed',
+                defaultValue: 'I NEVER show uP',
+                description: 'A inherited property',
+                isMandatory: false,
+                isMandatoryEnforced: false,
+                isMultiValued: false,
+                title: 'PropertyHidden'
+            },
             {
                 id: 'ck:PropA',
                 dataType: 'ck:propA',
@@ -135,7 +146,7 @@ describe('Content Type Dialog Component', () => {
         fixture.detectChanges();
     });
 
-    it('should show the property of the aspect', async () => {
+    it('should show the property with the aspect prefix not the inherited ones', async () => {
         const showPropertyAccordon: HTMLButtonElement = fixture.nativeElement.querySelector('.adf-content-type-accordion .mat-expansion-panel-header');
         expect(showPropertyAccordon).toBeDefined();
         showPropertyAccordon.click();

--- a/lib/content-services/src/lib/content-type/content-type-dialog.component.ts
+++ b/lib/content-services/src/lib/content-type/content-type-dialog.component.ts
@@ -35,6 +35,7 @@ export class ContentTypeDialogComponent implements OnInit {
     confirmMessage: string;
 
     currentContentType: TypeEntry;
+    typeProperties: any[] = [];
 
     propertyColumns: string[] = ['name', 'title', 'dataType'];
 
@@ -48,6 +49,7 @@ export class ContentTypeDialogComponent implements OnInit {
 
         this.contentTypeService.getContentTypeByPrefix(this.nodeType).subscribe((contentTypeEntry) => {
             this.currentContentType = contentTypeEntry;
+            this.typeProperties = this.currentContentType.entry.properties.filter((property) => property.id.startsWith(this.currentContentType.entry.model.namespacePrefix));
         });
     }
 


### PR DESCRIPTION
…stom type not the inherited ones

**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
We show, when selecting a type, the properties of the new content type and the inherited ones.


**What is the new behaviour?**
We show, when selecting a type, only  the properties of the new content type


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
