### PR TITLE
[ADF-5372] - fixed wrong result pipe

### DIFF
--- a/lib/core/pipes/file-size.pipe.spec.ts
+++ b/lib/core/pipes/file-size.pipe.spec.ts
@@ -44,6 +44,7 @@ describe('FileSizePipe', () => {
     it('returns empty string with invalid input', () => {
         expect(pipe.transform(null)).toBe('');
         expect(pipe.transform(undefined)).toBe('');
+        expect(pipe.transform(NaN)).toBe('');
     });
 
     it('should convert value to Bytes', () => {

--- a/lib/core/pipes/file-size.pipe.ts
+++ b/lib/core/pipes/file-size.pipe.ts
@@ -32,7 +32,7 @@ export class FileSizePipe implements PipeTransform {
             return '';
         }
 
-        const bytes = parseInt(paramByte);
+        const bytes = parseInt(paramByte, 10);
         if (isNaN(bytes)) {
             return '';
         }

--- a/lib/core/pipes/file-size.pipe.ts
+++ b/lib/core/pipes/file-size.pipe.ts
@@ -27,8 +27,13 @@ export class FileSizePipe implements PipeTransform {
     constructor(private translation: TranslationService) {
     }
 
-    transform(bytes: number, decimals: number = 2): string {
-        if (bytes == null) {
+    transform(paramByte: any, decimals: number = 2): string {
+        if (paramByte == null) {
+            return '';
+        }
+
+        const bytes = parseInt(paramByte);
+        if (isNaN(bytes)) {
             return '';
         }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Pipe get an empty string whilst used on a template so this makes all the checks fail


**What is the new behaviour?**
We assume we got a random type from the pipe method and then we force the parsing into int and improved the check avoiding NaN.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
