### PR TITLE
Revert "[ADF-5346] DocumentList - header is not scrollable when the width of the browser is small"

### DIFF
--- a/lib/core/datatable/components/datatable/datatable.component.scss
+++ b/lib/core/datatable/components/datatable/datatable.component.scss
@@ -604,7 +604,6 @@
     .adf-sticky-header {
         border-top: 0;
         height: 100%;
-        overflow-y: scroll;
 
         .adf-datatable-header {
             display: block;
@@ -616,6 +615,7 @@
         .adf-datatable-body {
             display: block;
             flex: 1;
+            overflow-y: scroll;
             margin-top: -1px;
         }
     }


### PR DESCRIPTION
Reverts Alfresco/alfresco-ng2-components#6730

ADF data table sticky header affected. 