### PR TITLE
[MNT-22207] - resetting query fragment when clicking Reset all button…

### DIFF
--- a/lib/content-services/src/lib/search/components/search-filter/search-filter.component.spec.ts
+++ b/lib/content-services/src/lib/search/components/search-filter/search-filter.component.spec.ts
@@ -988,6 +988,15 @@ describe('SearchFilterComponent', () => {
             expect(component.selectFacetBucket).toHaveBeenCalledTimes(2);
         });
 
+        it('should reset the query fragments when reset All is clicked', () => {
+            component.queryBuilder.queryFragments = { 'fragment1' : 'value1'};
+            component.responseFacets = [];
+            spyOn(queryBuilder, 'resetToDefaults').and.stub();
+            component.resetAll();
+            expect(component.queryBuilder.queryFragments).toEqual({});
+            expect(queryBuilder.resetToDefaults).toHaveBeenCalled();
+        });
+
     });
 });
 

--- a/lib/content-services/src/lib/search/components/search-filter/search-filter.component.ts
+++ b/lib/content-services/src/lib/search/components/search-filter/search-filter.component.ts
@@ -178,8 +178,14 @@ export class SearchFilterComponent implements OnInit, OnDestroy {
         this.queryBuilder.update();
     }
 
+    resetQueryFragments() {
+        this.queryBuilder.queryFragments = {};
+        this.queryBuilder.resetToDefaults();
+    }
+
     resetAll() {
         this.resetAllSelectedBuckets();
+        this.resetQueryFragments();
         this.responseFacets = null;
     }
 


### PR DESCRIPTION
… on search filters

**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Query fragment are not reset when clicking reset all


**What is the new behaviour?**
Query fragment are  reset when clicking reset all


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
