### PR TITLE
[AAE-4879] Detach tooltip card when directive is destroyed

### DIFF
--- a/lib/core/directives/tooltip-card/tooltip-card.directive.spec.ts
+++ b/lib/core/directives/tooltip-card/tooltip-card.directive.spec.ts
@@ -96,4 +96,17 @@ describe('TooltipCardDirective', () => {
         tooltipCard = overlay.querySelector<HTMLElement>('div.adf-tooltip-card');
         expect(tooltipCard).toBeNull();
     });
+
+    it('should hide tooltip-card on destroy', () => {
+        const span = fixture.debugElement.query(By.css('span.test-component'));
+        span.triggerEventHandler('mouseenter', {});
+        fixture.detectChanges();
+        let tooltipCard = overlay.querySelector<HTMLElement>('div.adf-tooltip-card');
+        expect(tooltipCard).not.toBeNull();
+
+        fixture.componentInstance.directive.ngOnDestroy();
+        fixture.detectChanges();
+        tooltipCard = overlay.querySelector<HTMLElement>('div.adf-tooltip-card');
+        expect(tooltipCard).toBeNull();
+    });
 });

--- a/lib/core/directives/tooltip-card/tooltip-card.directive.ts
+++ b/lib/core/directives/tooltip-card/tooltip-card.directive.ts
@@ -14,13 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ComponentRef, Directive, ElementRef, HostListener, Input, OnInit } from '@angular/core';
+import { ComponentRef, Directive, ElementRef, HostListener, Input, OnDestroy, OnInit } from '@angular/core';
 import { Overlay, OverlayPositionBuilder, OverlayRef } from '@angular/cdk/overlay';
 import { ComponentPortal } from '@angular/cdk/portal';
 import { TooltipCardComponent } from './tooltip-card.component';
 
 @Directive({ selector: '[adf-tooltip-card]' })
-export class TooltipCardDirective implements OnInit {
+export class TooltipCardDirective implements OnInit, OnDestroy {
 
     @Input('adf-tooltip-card') text = '';
     @Input() image = '';
@@ -39,6 +39,10 @@ export class TooltipCardDirective implements OnInit {
         private overlay: Overlay,
         private overlayPositionBuilder: OverlayPositionBuilder,
         private elementRef: ElementRef) {
+    }
+
+    ngOnDestroy(): void {
+        this.hide();
     }
 
     ngOnInit(): void {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [X] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
If the tooltip card is being displayed and the element to which it is attached is deleted, the card remains there forever


**What is the new behaviour?**
Hide the card on element destroy



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
