### PR TITLE
[AAE-4985] - Make SSO Role Service accept a content admin role that is not part of the JWT token

### DIFF
--- a/docs/core/services/auth-guard-sso-role.service.md
+++ b/docs/core/services/auth-guard-sso-role.service.md
@@ -31,6 +31,7 @@ const appRoutes: Routes = [
 ```
 
 If the user now clicks on a link or button that follows this route, they will be not able to access this content if they do not have the Realms roles.
+<br>**Note**: An additional role ACS_ADMIN can be used in the roles array, which will result in checking whether the logged in user has ACS Admin capabilities or not, as this role is not part of the JWT token it will call an ACS API to determine it.
 
 
 Client role Example 

--- a/docs/core/services/auth-guard-sso-role.service.md
+++ b/docs/core/services/auth-guard-sso-role.service.md
@@ -31,10 +31,10 @@ const appRoutes: Routes = [
 ```
 
 If the user now clicks on a link or button that follows this route, they will be not able to access this content if they do not have the Realms roles.
-<br>**Note**: An additional role ACS_ADMIN can be used in the roles array, which will result in checking whether the logged in user has ACS Admin capabilities or not, as this role is not part of the JWT token it will call an ACS API to determine it.
+<br>**Note**: An additional role ALFRESCO_ADMINISTRATORS can be used in the roles array, which will result in checking whether the logged in user has Content Admin capabilities or not, as this role is not part of the JWT token it will call a Content API to determine it.
 
 
-Client role Example 
+Client role Example
 ```ts
 const appRoutes: Routes = [
     ...

--- a/e2e/protractor.excludes.json
+++ b/e2e/protractor.excludes.json
@@ -5,5 +5,7 @@
   "C279931": "login problem APS not basic",
   "C279930": "login problem APS not basic",
   "C593560": "https://alfresco.atlassian.net/browse/ADF-5366",
+  "C269081": "https://alfresco.atlassian.net/browse/ADF-5385",
+  "C272819": "https://alfresco.atlassian.net/browse/ADF-5385",
   "C290069": "https://alfresco.atlassian.net/browse/ADF-5387"
 }

--- a/lib/core/mock/ecm-user.service.mock.ts
+++ b/lib/core/mock/ecm-user.service.mock.ts
@@ -101,13 +101,22 @@ export const createNewPersonMock = {
     email: 'fakeEcm@ecmUser.com'
 };
 
-export function getMockAcsUserWithCapabilities(isAdmin: boolean, isGuest: boolean, isMutable: boolean): PersonEntry {
+export function getFakeUserWithContentAdminCapability(): PersonEntry {
     const fakeEcmUserWithAdminCapabilities = {
         ...fakeEcmUser,
         capabilities: {
-            isAdmin,
-            isGuest,
-            isMutable
+            isAdmin: true
+        }
+    };
+    const mockPerson = new Person(fakeEcmUserWithAdminCapabilities);
+    return { entry: mockPerson };
+}
+
+export function getFakeUserWithContentUserCapability(): PersonEntry {
+    const fakeEcmUserWithAdminCapabilities = {
+        ...fakeEcmUser,
+        capabilities: {
+            isAdmin: false
         }
     };
     const mockPerson = new Person(fakeEcmUserWithAdminCapabilities);

--- a/lib/core/mock/ecm-user.service.mock.ts
+++ b/lib/core/mock/ecm-user.service.mock.ts
@@ -16,6 +16,7 @@
  */
 
 import { EcmCompanyModel } from '../models/ecm-company.model';
+import { PersonEntry, Person } from '@alfresco/js-api';
 
 export let fakeEcmCompany: EcmCompanyModel = {
     organization: 'company-fake-name',
@@ -99,3 +100,16 @@ export const createNewPersonMock = {
     password: 'fake-avatar-id',
     email: 'fakeEcm@ecmUser.com'
 };
+
+export function getMockAcsUserWithCapabilities(isAdmin: boolean, isGuest: boolean, isMutable: boolean): PersonEntry {
+    const fakeEcmUserWithAdminCapabilities = {
+        ...fakeEcmUser,
+        capabilities: {
+            isAdmin,
+            isGuest,
+            isMutable
+        }
+    };
+    const mockPerson = new Person(fakeEcmUserWithAdminCapabilities);
+    return { entry: mockPerson };
+}

--- a/lib/core/services/auth-guard-sso-role.service.spec.ts
+++ b/lib/core/services/auth-guard-sso-role.service.spec.ts
@@ -193,6 +193,10 @@ describe('Auth Guard SSO role service', () => {
 
     describe('Content Admin', () => {
 
+        afterEach(() => {
+           peopleContentService.hasContentAdminRole = undefined;
+        });
+
         it('Should give access to a content section (ALFRESCO_ADMINISTRATORS) when the user has content admin capability', async () => {
             spyOn(peopleContentService, 'getCurrentPerson').and.returnValue(of(getFakeUserWithContentAdminCapability()));
 

--- a/lib/core/services/auth-guard-sso-role.service.spec.ts
+++ b/lib/core/services/auth-guard-sso-role.service.spec.ts
@@ -194,7 +194,7 @@ describe('Auth Guard SSO role service', () => {
     describe('Content Admin', () => {
 
         afterEach(() => {
-           peopleContentService.hasContentAdminRole = undefined;
+           peopleContentService.hasCheckedIsContentAdmin = false;
         });
 
         it('Should give access to a content section (ALFRESCO_ADMINISTRATORS) when the user has content admin capability', async () => {

--- a/lib/core/services/auth-guard-sso-role.service.ts
+++ b/lib/core/services/auth-guard-sso-role.service.ts
@@ -19,16 +19,12 @@ import { Injectable } from '@angular/core';
 import { JwtHelperService } from './jwt-helper.service';
 import { ActivatedRouteSnapshot, CanActivate, Router } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
-import { PeopleContentService } from './people-content.service';
-import { PersonEntry } from '@alfresco/js-api';
+import { ContentGroups, PeopleContentService } from './people-content.service';
 
 @Injectable({
     providedIn: 'root'
 })
 export class AuthGuardSsoRoleService implements CanActivate {
-    acsAdminRole = 'ACS_ADMIN';
-    hasAcsAdminRole: boolean;
-
     constructor(private jwtHelperService: JwtHelperService,
                 private router: Router,
                 private dialog: MatDialog,
@@ -43,10 +39,8 @@ export class AuthGuardSsoRoleService implements CanActivate {
         if (route.data) {
             if (route.data['roles']) {
                 const rolesToCheck: string[] = route.data['roles'];
-                if (this.hasAcsAdminRole === undefined && rolesToCheck.includes(this.acsAdminRole)) {
-                    this.hasAcsAdminRole = await this.isAcsAdmin();
-                }
-                hasRealmRole = this.jwtHelperService.hasRealmRoles(rolesToCheck) || this.hasAcsAdminRole;
+                const isContentAdmin = rolesToCheck.includes(ContentGroups.ALFRESCO_ADMINISTRATORS) ? await this.peopleContentService.isContentAdmin() : false;
+                hasRealmRole = this.jwtHelperService.hasRealmRoles(rolesToCheck) || isContentAdmin;
             }
 
             if (route.data['clientRoles']) {
@@ -67,10 +61,5 @@ export class AuthGuardSsoRoleService implements CanActivate {
         }
 
         return hasRole;
-    }
-
-    async isAcsAdmin(): Promise<boolean> {
-        const user: PersonEntry = await this.peopleContentService.getCurrentPerson().toPromise();
-        return user?.entry?.capabilities?.isAdmin;
     }
 }

--- a/lib/core/services/auth-guard-sso-role.service.ts
+++ b/lib/core/services/auth-guard-sso-role.service.ts
@@ -26,7 +26,7 @@ import { PeopleContentService } from './people-content.service';
 })
 export class AuthGuardSsoRoleService implements CanActivate {
     acsAdminRole = 'ACS_ADMIN';
-    hasAcsAdminRole = false;
+    hasAcsAdminRole: boolean;
 
     constructor(private jwtHelperService: JwtHelperService,
                 private router: Router,
@@ -42,7 +42,7 @@ export class AuthGuardSsoRoleService implements CanActivate {
         if (route.data) {
             if (route.data['roles']) {
                 const rolesToCheck: string[] = route.data['roles'];
-                if (rolesToCheck.includes(this.acsAdminRole)) {
+                if (this.hasAcsAdminRole === undefined && rolesToCheck.includes(this.acsAdminRole)) {
                     this.hasAcsAdminRole = await this.isAcsAdmin();
                 }
                 hasRealmRole = this.jwtHelperService.hasRealmRoles(rolesToCheck) || this.hasAcsAdminRole;

--- a/lib/core/services/auth-guard-sso-role.service.ts
+++ b/lib/core/services/auth-guard-sso-role.service.ts
@@ -20,6 +20,7 @@ import { JwtHelperService } from './jwt-helper.service';
 import { ActivatedRouteSnapshot, CanActivate, Router } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 import { PeopleContentService } from './people-content.service';
+import { PersonEntry } from '@alfresco/js-api';
 
 @Injectable({
     providedIn: 'root'
@@ -69,7 +70,7 @@ export class AuthGuardSsoRoleService implements CanActivate {
     }
 
     async isAcsAdmin(): Promise<boolean> {
-        const user = await this.peopleContentService.getCurrentPerson().toPromise();
-        return user?.entry?.capabilities?.isAdmin || false;
+        const user: PersonEntry = await this.peopleContentService.getCurrentPerson().toPromise();
+        return user?.entry?.capabilities?.isAdmin;
     }
 }

--- a/lib/core/services/people-content.service.spec.ts
+++ b/lib/core/services/people-content.service.spec.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { fakeEcmUser, createNewPersonMock } from '../mock/ecm-user.service.mock';
+import { fakeEcmUser, createNewPersonMock, getFakeUserWithContentAdminCapability } from '../mock/ecm-user.service.mock';
 import { AlfrescoApiServiceMock } from '../mock/alfresco-api.service.mock';
 import { CoreTestingModule } from '../testing/core.testing.module';
 import { PeopleContentService } from './people-content.service';
@@ -24,6 +24,7 @@ import { setupTestBed } from '../testing/setup-test-bed';
 import { TranslateModule } from '@ngx-translate/core';
 import { TestBed } from '@angular/core/testing';
 import { LogService } from './log.service';
+import { of } from 'rxjs';
 
 describe('PeopleContentService', () => {
 
@@ -100,5 +101,17 @@ describe('PeopleContentService', () => {
             expect(logErrorSpy).toHaveBeenCalledWith({ message: 'failed to create new person' });
             done();
         });
+    });
+
+    it('Should make the api call to check if the user is a content admin only once', async () => {
+        const getCurrentPersonSpy = spyOn(service.peopleApi, 'getPerson').and.returnValue(of(getFakeUserWithContentAdminCapability()));
+
+        expect(await service.isContentAdmin()).toBe(true);
+        expect(getCurrentPersonSpy.calls.count()).toEqual(1);
+
+        await service.isContentAdmin();
+
+        expect(await service.isContentAdmin()).toBe(true);
+        expect(getCurrentPersonSpy.calls.count()).toEqual(1);
     });
 });

--- a/lib/core/services/people-content.service.ts
+++ b/lib/core/services/people-content.service.ts
@@ -23,10 +23,15 @@ import { PersonEntry, PeopleApi, PersonBodyCreate } from '@alfresco/js-api';
 import { EcmUserModel } from '../models/ecm-user.model';
 import { LogService } from './log.service';
 
+export enum ContentGroups {
+    ALFRESCO_ADMINISTRATORS = 'ALFRESCO_ADMINISTRATORS'
+}
+
 @Injectable({
     providedIn: 'root'
 })
 export class PeopleContentService {
+    private hasContentAdminRole: boolean;
 
     private _peopleApi: PeopleApi;
 
@@ -60,6 +65,7 @@ export class PeopleContentService {
     /**
      * Creates new person.
      * @param newPerson Object containing the new person details.
+     * @param opts Optional parameters
      * @returns Created new person
      */
     createPerson(newPerson: PersonBodyCreate, opts?: any): Observable<EcmUserModel> {
@@ -67,6 +73,14 @@ export class PeopleContentService {
             map((res: PersonEntry) => <EcmUserModel> res?.entry),
             catchError((error) => this.handleError(error))
         );
+    }
+
+    async isContentAdmin(): Promise<boolean> {
+        if (this.hasContentAdminRole === undefined) {
+            const user: PersonEntry = await this.getCurrentPerson().toPromise();
+            this.hasContentAdminRole = user?.entry?.capabilities?.isAdmin;
+        }
+        return this.hasContentAdminRole;
     }
 
     private handleError(error: any) {

--- a/lib/core/services/people-content.service.ts
+++ b/lib/core/services/people-content.service.ts
@@ -31,7 +31,7 @@ export enum ContentGroups {
     providedIn: 'root'
 })
 export class PeopleContentService {
-    private hasContentAdminRole: boolean;
+    hasContentAdminRole: boolean;
 
     private _peopleApi: PeopleApi;
 

--- a/lib/core/services/people-content.service.ts
+++ b/lib/core/services/people-content.service.ts
@@ -31,7 +31,8 @@ export enum ContentGroups {
     providedIn: 'root'
 })
 export class PeopleContentService {
-    hasContentAdminRole: boolean;
+    private hasContentAdminRole: boolean = false;
+    hasCheckedIsContentAdmin: boolean = false;
 
     private _peopleApi: PeopleApi;
 
@@ -76,9 +77,10 @@ export class PeopleContentService {
     }
 
     async isContentAdmin(): Promise<boolean> {
-        if (this.hasContentAdminRole === undefined) {
+        if (!this.hasCheckedIsContentAdmin) {
             const user: PersonEntry = await this.getCurrentPerson().toPromise();
             this.hasContentAdminRole = user?.entry?.capabilities?.isAdmin;
+            this.hasCheckedIsContentAdmin = true;
         }
         return this.hasContentAdminRole;
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [X] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [X] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/AAE-4985


**What is the new behaviour?**
In a new feature, there is the need of checking if the logged in user is an ACS Admin user or not using this service. This information can not become part of the JWT token right now, which means we need to call an ACS API to check that inside this service as it currently completely relies on the JWT token. With the new behaviour it will make an API call to check that the user is an ACS Admin or not, when in the roles array we have the ALFRESCO_ADMINISTRATORS included. 

Example:
`router.data = { 'roles': ['ALFRESCO_ADMINISTRATORS'] };`
 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
