### PR TITLE
[ADF-5380] Check Acs status in aps init script

### DIFF
--- a/lib/cli/scripts/init-aps-env.ts
+++ b/lib/cli/scripts/init-aps-env.ts
@@ -140,6 +140,7 @@ async function checkEnv() {
             checkEnv();
         }
     }
+    await checkAcsEnv();
 }
 
 async function hasDefaultTenant(tenantId, tenantName) {
@@ -433,4 +434,25 @@ async function downloadLicenseFile(apsLicensePath) {
 function sleep(delay) {
     const start = new Date().getTime();
     while (new Date().getTime() < start + delay) {  }
+}
+
+async function checkAcsEnv() {
+    try {
+        const repositoryEntry = await alfrescoJsApiRepo.oauth2Auth.callCustomApi(
+            `${program.host}/alfresco/api/discovery`,
+            'GET',
+            {},
+            {},
+            {},
+            {},
+            {},
+            ['application/json'],
+            ['application/json']
+        );
+        const repositoryStatus = repositoryEntry?.entry?.repository?.status;
+        logger.info(`ACS repository is runnig. Status: ${JSON.stringify(repositoryStatus)}`);
+    } catch (e) {
+        logger.error('ACS is not reachable. Terminating');
+        process.exit(1);
+    }
 }

--- a/lib/cli/scripts/init-aps-env.ts
+++ b/lib/cli/scripts/init-aps-env.ts
@@ -450,7 +450,7 @@ async function checkAcsEnv() {
             ['application/json']
         );
         const repositoryStatus = repositoryEntry?.entry?.repository?.status;
-        logger.info(`ACS repository is runnig. Status: ${JSON.stringify(repositoryStatus)}`);
+        logger.info(`ACS repository is running. Status: ${JSON.stringify(repositoryStatus)}`);
     } catch (e) {
         logger.error('ACS is not reachable. Terminating');
         process.exit(1);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
The init-aps-env script doesn't check that ACS is reachable before authorising the content on activiti-app. So sometimes it happens that it fails when trying to authorize users if there are problems with ACS. Right now, that is not clear from the logs.


**What is the new behaviour?**
The init script checks that ACS is reachable before starting the init of the env. If ACS is not reachable the init of the env will fail. So It now supposes that there is always a running instance of ACS and fails with a clear message before creating repositories and authorizing the users

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
