### PR TITLE
[ACA-4361] should be able to change permission if search service is down

### DIFF
--- a/lib/content-services/src/lib/permission-manager/services/node-permission.service.spec.ts
+++ b/lib/content-services/src/lib/permission-manager/services/node-permission.service.spec.ts
@@ -19,7 +19,7 @@ import { async, TestBed } from '@angular/core/testing';
 import { NodePermissionService } from './node-permission.service';
 import { SearchService, NodesApiService, setupTestBed } from '@alfresco/adf-core';
 import { Node, PermissionElement } from '@alfresco/js-api';
-import { of } from 'rxjs';
+import {of, throwError} from 'rxjs';
 import { fakeEmptyResponse, fakeNodeWithOnlyLocally, fakeSiteRoles, fakeSiteNodeResponse,
          fakeNodeToRemovePermission, fakeNodeWithoutPermissions } from '../../mock/permission-list.component.mock';
 import { fakeAuthorityResults } from '../../mock/add-permission.component.mock';
@@ -230,6 +230,17 @@ describe('NodePermissionService', () => {
             expect(node).toBe(fakeNodeCopy);
             expect(roles.length).toBe(4);
             expect(roles[0].role).toBe('SiteCollaborator');
+        });
+    }));
+
+    it('should give node role if search API failed', async(() => {
+        const fakeNodeCopy = JSON.parse(JSON.stringify(fakeNodeWithOnlyLocally));
+        spyOn(nodeService, 'getNode').and.returnValue(of(fakeNodeCopy));
+        spyOn(searchApiService, 'searchByQueryBody').and.returnValue(throwError('search service down'));
+        service.getNodeWithRoles('node-id').subscribe(({ node, roles }) => {
+            expect(node).toBe(fakeNodeCopy);
+            expect(roles.length).toBe(5);
+            expect(roles[0].role).toBe('Contributor');
         });
     }));
 });

--- a/lib/content-services/src/lib/permission-manager/services/node-permission.service.spec.ts
+++ b/lib/content-services/src/lib/permission-manager/services/node-permission.service.spec.ts
@@ -233,7 +233,7 @@ describe('NodePermissionService', () => {
         });
     }));
 
-    it('should give node role if search API failed', async(() => {
+    it('should provide node and default role if search API failed', async(() => {
         const fakeNodeCopy = JSON.parse(JSON.stringify(fakeNodeWithOnlyLocally));
         spyOn(nodeService, 'getNode').and.returnValue(of(fakeNodeCopy));
         spyOn(searchApiService, 'searchByQueryBody').and.returnValue(throwError('search service down'));

--- a/lib/content-services/src/lib/permission-manager/services/node-permission.service.spec.ts
+++ b/lib/content-services/src/lib/permission-manager/services/node-permission.service.spec.ts
@@ -19,7 +19,7 @@ import { async, TestBed } from '@angular/core/testing';
 import { NodePermissionService } from './node-permission.service';
 import { SearchService, NodesApiService, setupTestBed } from '@alfresco/adf-core';
 import { Node, PermissionElement } from '@alfresco/js-api';
-import {of, throwError} from 'rxjs';
+import { of, throwError } from 'rxjs';
 import { fakeEmptyResponse, fakeNodeWithOnlyLocally, fakeSiteRoles, fakeSiteNodeResponse,
          fakeNodeToRemovePermission, fakeNodeWithoutPermissions } from '../../mock/permission-list.component.mock';
 import { fakeAuthorityResults } from '../../mock/add-permission.component.mock';

--- a/lib/content-services/src/lib/permission-manager/services/node-permission.service.ts
+++ b/lib/content-services/src/lib/permission-manager/services/node-permission.service.ts
@@ -19,7 +19,7 @@ import { AlfrescoApiService, NodesApiService, SearchService, TranslationService 
 import { Group, GroupMemberEntry, GroupMemberPaging, Node, PathElement, PermissionElement, Person, QueryBody } from '@alfresco/js-api';
 import { Injectable } from '@angular/core';
 import { forkJoin, from, Observable, of, throwError } from 'rxjs';
-import { map, switchMap } from 'rxjs/operators';
+import {catchError, map, switchMap} from 'rxjs/operators';
 import { PermissionDisplayModel } from '../models/permission.model';
 import { RoleModel } from '../models/role.model';
 
@@ -278,7 +278,8 @@ export class NodePermissionService {
                      node: of(node),
                      roles: this.getNodeRoles(node)
                           .pipe(
-                             map(_roles => _roles.map(role => ({ role, label: role }))
+                              catchError(() => of(node.permissions?.settable)),
+                              map(_roles => _roles.map(role => ({ role, label: role }))
                           )
                        )
                     });

--- a/lib/content-services/src/lib/permission-manager/services/node-permission.service.ts
+++ b/lib/content-services/src/lib/permission-manager/services/node-permission.service.ts
@@ -19,7 +19,7 @@ import { AlfrescoApiService, NodesApiService, SearchService, TranslationService 
 import { Group, GroupMemberEntry, GroupMemberPaging, Node, PathElement, PermissionElement, Person, QueryBody } from '@alfresco/js-api';
 import { Injectable } from '@angular/core';
 import { forkJoin, from, Observable, of, throwError } from 'rxjs';
-import {catchError, map, switchMap} from 'rxjs/operators';
+import { catchError, map, switchMap } from 'rxjs/operators';
 import { PermissionDisplayModel } from '../models/permission.model';
 import { RoleModel } from '../models/role.model';
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

If seach service is down we are showing error template

**What is the new behaviour?**

We should be able to update the update permission if search service down


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
