### PR TITLE
Abn content fixes

### DIFF
--- a/docs/content-services/components/document-list.component.md
+++ b/docs/content-services/components/document-list.component.md
@@ -473,7 +473,7 @@ Now you can access Document List properties or call methods directly:
 console.log(documentList.currentFolderId);
 ```
 
-**Important note**:\\
+**Important note**:
 You must not access child components any earlier in the component lifecycle than
 the `AfterViewInit` state. Any UI click (buttons, links, etc.) event handlers are fine but
 an earlier event like `ngOnInit` is not.

--- a/docs/core/services/auth-guard-sso-role.service.md
+++ b/docs/core/services/auth-guard-sso-role.service.md
@@ -31,7 +31,7 @@ const appRoutes: Routes = [
 ```
 
 If the user now clicks on a link or button that follows this route, they will be not able to access this content if they do not have the Realms roles.
-<br>**Note**: An additional role ALFRESCO_ADMINISTRATORS can be used in the roles array, which will result in checking whether the logged in user has Content Admin capabilities or not, as this role is not part of the JWT token it will call a Content API to determine it.
+<br />**Note**: An additional role ALFRESCO_ADMINISTRATORS can be used in the roles array, which will result in checking whether the logged in user has Content Admin capabilities or not, as this role is not part of the JWT token it will call a Content API to determine it.
 
 
 Client role Example

--- a/docs/core/services/process-content.service.md
+++ b/docs/core/services/process-content.service.md
@@ -120,7 +120,7 @@ export class SomePageComponent implements OnInit {
 ```
 
 In the above sample code the `file` is uploaded via an HTML input element.
-The `processInstanceId` refers to a process instance ID for a running process in APS.\\
+The `processInstanceId` refers to a process instance ID for a running process in APS.
 The returned `relContent` object looks like in this sample:
 
     Related content:     


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)

I'm afraid I don't have an issue ID, just requests passed on to me by Alex Truby from the Alfresco marketing folks that they'd like the ABN builds to work again.

> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

Only documentation updates.

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [x] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

All 3 changes related to syntax that currently breaks the Alfresco Builder Network site builds. 

The double backslashes render as a single backslash in Github, and I suspect are mistakes anyway.

The non-self-closing `br` tag works fine with Github's fairly forgiving markdown parser, but not the MDX parser used on the ABN.

**What is the new behaviour?**

The single backslashes rendered on Github are removed, the `br` renders as it did before.

Meanwhile, the ABN builds are restored and the docs in this site will once again be accurately reflected there (they were last updated in February).

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
