### PR TITLE
[AAE-5122] Change mouse event to leave in tooltip card

### DIFF
--- a/lib/core/directives/tooltip-card/tooltip-card.component.ts
+++ b/lib/core/directives/tooltip-card/tooltip-card.component.ts
@@ -26,10 +26,10 @@ import { DomSanitizer } from '@angular/platform-browser';
         trigger('tooltip', [
             transition(':enter', [
                 style({ opacity: 0 }),
-                animate(500, style({ opacity: 1 }))
+                animate(200, style({ opacity: 1 }))
             ]),
             transition(':leave', [
-                animate(500, style({ opacity: 0 }))
+                animate(200, style({ opacity: 0 }))
 
             ])
         ])

--- a/lib/core/directives/tooltip-card/tooltip-card.directive.spec.ts
+++ b/lib/core/directives/tooltip-card/tooltip-card.directive.spec.ts
@@ -91,7 +91,7 @@ describe('TooltipCardDirective', () => {
         let tooltipCard = overlay.querySelector<HTMLElement>('div.adf-tooltip-card');
         expect(tooltipCard).not.toBeNull();
 
-        span.triggerEventHandler('mouseout', {});
+        span.triggerEventHandler('mouseleave', {});
         fixture.detectChanges();
         tooltipCard = overlay.querySelector<HTMLElement>('div.adf-tooltip-card');
         expect(tooltipCard).toBeNull();

--- a/lib/core/directives/tooltip-card/tooltip-card.directive.ts
+++ b/lib/core/directives/tooltip-card/tooltip-card.directive.ts
@@ -70,7 +70,7 @@ export class TooltipCardDirective implements OnInit, OnDestroy {
         tooltipRef.instance.htmlContent = this.htmlContent;
     }
 
-    @HostListener('mouseout')
+    @HostListener('mouseleave')
     hide() {
         this.overlayRef.detach();
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
When the tooltip card is attached to an element, if that element has children and the mouse cursor is moved inside the parent to a child, the `mouseout` event is fired, and the tooltip is hidden.


**What is the new behaviour?**
We use the `mouseleave` event so only when the mouse cursor leave the parent, the tooltip card is hidden, but the user can move the cursor inside the parent and the tooltip is still there



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
