### PR TITLE
[AAE-4997] [APA] Process dropdown filter gets collapsed when the edit process filter component refreshes

### DIFF
--- a/lib/process-services-cloud/src/lib/common/date-range-filter/date-range-filter.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/common/date-range-filter/date-range-filter.component.spec.ts
@@ -24,6 +24,7 @@ import { MatSelectChange } from '@angular/material/select';
 import { DateCloudFilterType } from '../../models/date-cloud-filter.model';
 import { DateRangeFilterService } from './date-range-filter.service';
 import moment from 'moment-es6';
+import { of } from 'rxjs';
 
 describe('DateRangeFilterComponent', () => {
     let component: DateRangeFilterComponent;
@@ -47,7 +48,7 @@ describe('DateRangeFilterComponent', () => {
             label: 'mock-filter',
             value: null,
             type: 'dateRange',
-            options: null
+            options$: of([])
         };
         fixture.detectChanges();
     });

--- a/lib/process-services-cloud/src/lib/common/date-range-filter/date-range-filter.component.ts
+++ b/lib/process-services-cloud/src/lib/common/date-range-filter/date-range-filter.component.ts
@@ -17,7 +17,7 @@
 
 import { Component, Input, EventEmitter, Output } from '@angular/core';
 import { MatSelectChange } from '@angular/material/select';
-import { ProcessFilterProperties, ProcessFilterOptions } from '../../process/process-filters/models/process-filter-cloud.model';
+import { ProcessFilterProperties, DropdownOption } from '../../process/process-filters/models/process-filter-cloud.model';
 import { FormGroup, FormControl } from '@angular/forms';
 import { DateRangeFilter, DateCloudFilterType } from '../../models/date-cloud-filter.model';
 import moment from 'moment-es6';
@@ -42,7 +42,7 @@ import moment from 'moment-es6';
     dateTypeChange = new EventEmitter<DateCloudFilterType>();
 
     type: DateCloudFilterType;
-    filteredProperties: ProcessFilterOptions[] = [];
+    filteredProperties: DropdownOption[] = [];
     dateRangeForm = new FormGroup({
         from: new FormControl(),
         to: new FormControl()
@@ -114,7 +114,7 @@ import moment from 'moment-es6';
         ];
     }
 
-    private createDefaultDateOptions(): ProcessFilterOptions[] {
+    private createDefaultDateOptions(): DropdownOption[] {
         return  [
             {
                 value: DateCloudFilterType.NO_DATE,

--- a/lib/process-services-cloud/src/lib/process/process-filters/components/edit-process-filter-cloud.component.html
+++ b/lib/process-services-cloud/src/lib/process/process-filters/components/edit-process-filter-cloud.component.html
@@ -30,7 +30,7 @@
                                 [formControlName]="processFilterProperty.key"
                                 [attr.data-automation-id]="'adf-cloud-edit-process-property-' + processFilterProperty.key">
                                 <mat-option
-                                    *ngFor="let propertyOption of processFilterProperty.options | async"
+                                    *ngFor="let propertyOption of processFilterProperty.options$ | async"
                                     [value]="propertyOption.value"
                                     [attr.data-automation-id]="'adf-cloud-edit-process-property-options-' + processFilterProperty.key"
                                 >{{ propertyOption.label | translate }}</mat-option>
@@ -42,7 +42,7 @@
                                 [formControlName]="processFilterProperty.key"
                                 [attr.data-automation-id]="'adf-cloud-edit-process-property-' + processFilterProperty.key"
                                 [multiple]="true">
-                                <mat-option *ngFor="let propertyOption of processFilterProperty.options | async" [value]="propertyOption.value" [attr.data-automation-id]="'adf-cloud-edit-process-property-options-' + processFilterProperty.key">
+                                <mat-option *ngFor="let propertyOption of processFilterProperty.options$ | async" [value]="propertyOption.value" [attr.data-automation-id]="'adf-cloud-edit-process-property-options-' + processFilterProperty.key">
                                     {{ propertyOption.label | translate }}
                                 </mat-option>
                             </mat-select>

--- a/lib/process-services-cloud/src/lib/process/process-filters/components/edit-process-filter-cloud.component.html
+++ b/lib/process-services-cloud/src/lib/process/process-filters/components/edit-process-filter-cloud.component.html
@@ -30,7 +30,7 @@
                                 [formControlName]="processFilterProperty.key"
                                 [attr.data-automation-id]="'adf-cloud-edit-process-property-' + processFilterProperty.key">
                                 <mat-option
-                                    *ngFor="let propertyOption of processFilterProperty.options"
+                                    *ngFor="let propertyOption of processFilterProperty.options | async"
                                     [value]="propertyOption.value"
                                     [attr.data-automation-id]="'adf-cloud-edit-process-property-options-' + processFilterProperty.key"
                                 >{{ propertyOption.label | translate }}</mat-option>
@@ -42,7 +42,7 @@
                                 [formControlName]="processFilterProperty.key"
                                 [attr.data-automation-id]="'adf-cloud-edit-process-property-' + processFilterProperty.key"
                                 [multiple]="true">
-                                <mat-option *ngFor="let propertyOption of processFilterProperty.options" [value]="propertyOption.value" [attr.data-automation-id]="'adf-cloud-edit-process-property-options-' + processFilterProperty.key">
+                                <mat-option *ngFor="let propertyOption of processFilterProperty.options | async" [value]="propertyOption.value" [attr.data-automation-id]="'adf-cloud-edit-process-property-options-' + processFilterProperty.key">
                                     {{ propertyOption.label | translate }}
                                 </mat-option>
                             </mat-select>

--- a/lib/process-services-cloud/src/lib/process/process-filters/components/edit-process-filter-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/process/process-filters/components/edit-process-filter-cloud.component.spec.ts
@@ -456,7 +456,7 @@ describe('EditProcessFilterCloudComponent', () => {
         });
     }));
 
-    it('should not be able to call an API to fetch running apps, appVersions and processDefinitions when chaning filter properties except appName', async () => {
+    it('should not be able to call an API to fetch running apps, appVersions and processDefinitions when changing filter properties except appName', async () => {
         fixture.detectChanges();
         const applicationVersionsSpy = spyOn(processService, 'getApplicationVersions').and.callThrough();
         const processDefinitionSpy = spyOn(processService, 'getProcessDefinitions').and.callThrough();
@@ -465,8 +465,9 @@ describe('EditProcessFilterCloudComponent', () => {
         component.applicationNames = [{ label: 'mock-app-name', value: 'mock-app-name' } ]
         component.appVersionOptions = [{ label: '1', value: '1' }];
         component.processDefinitionNames = [{ label: 'process-def-name', value: 'process-def-name' }];
+        component.processFilter = fakeFilter;
         fixture.detectChanges();
-        const processNameController = component.editProcessFilterForm.get('processName');
+        const processNameController = component.editProcessFilterForm.get('processDefinitionName');
         processNameController.setValue('invoiceProcess');
         fixture.detectChanges();
         await fixture.whenStable();

--- a/lib/process-services-cloud/src/lib/process/process-filters/components/edit-process-filter-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/process/process-filters/components/edit-process-filter-cloud.component.ts
@@ -222,7 +222,6 @@ export class EditProcessFilterCloudComponent implements OnInit, OnChanges, OnDes
             .getFilterById(this.appName, this.id)
             .pipe(finalize(() => this.isLoading = false))
             .subscribe(response => {
-                console.log('I cucking called on every time');
                 this.processFilter = new ProcessFilterCloudModel(
                     Object.assign({}, response || {}, this.processFilter || {})
                 );
@@ -260,8 +259,7 @@ export class EditProcessFilterCloudComponent implements OnInit, OnChanges, OnDes
     onAppNameChange() {
         const appNameController = this.editProcessFilterForm?.get('appName');
         if(appNameController) {
-            appNameController.valueChanges.subscribe((res) => {
-                console.log('called', res);
+            appNameController.valueChanges.subscribe(() => {
                 this.resetAppVersionsAndProcessDefinitionsOnAppNameChange();
             })
         }

--- a/lib/process-services-cloud/src/lib/process/process-filters/components/edit-process-filter-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/process/process-filters/components/edit-process-filter-cloud.component.ts
@@ -142,6 +142,7 @@ export class EditProcessFilterCloudComponent implements OnInit, OnChanges, OnDes
     private onDestroy$ = new Subject<boolean>();
     isLoading: boolean = false;
     private filterChangeSub: Subscription;
+    private appNameChangeSub: Subscription;
 
     currentAppVersions$ = new BehaviorSubject([]);
     runningApps$ = new BehaviorSubject([]);
@@ -245,9 +246,13 @@ export class EditProcessFilterCloudComponent implements OnInit, OnChanges, OnDes
     }
 
     onAppNameChange() {
+        if (this.appNameChangeSub) {
+            this.appNameChangeSub.unsubscribe();
+            this.appNameChangeSub = null;
+        }
         const appNameController = this.editProcessFilterForm?.get('appName');
         if (appNameController) {
-            appNameController.valueChanges.subscribe((appName) => {
+            this.appNameChangeSub = appNameController.valueChanges.subscribe((appName) => {
                 this.fetchAppVersionsAndProcessDefinitions(appName);
             });
         }

--- a/lib/process-services-cloud/src/lib/process/process-filters/components/edit-process-filter-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/process/process-filters/components/edit-process-filter-cloud.component.ts
@@ -144,9 +144,9 @@ export class EditProcessFilterCloudComponent implements OnInit, OnChanges, OnDes
     private filterChangeSub: Subscription;
     private appNameChangeSub: Subscription;
 
-    currentAppVersions$ = new BehaviorSubject([]);
-    runningApps$ = new BehaviorSubject([]);
-    currentAppProcessDefinitions$ = new BehaviorSubject([]);
+    private currentAppVersions$ = new BehaviorSubject([]);
+    private runningApps$ = new BehaviorSubject([]);
+    private currentAppProcessDefinitions$ = new BehaviorSubject([]);
 
     constructor(
         private formBuilder: FormBuilder,
@@ -657,7 +657,7 @@ export class EditProcessFilterCloudComponent implements OnInit, OnChanges, OnDes
                 type: 'select',
                 key: 'appName',
                 value: filterModel.appName || '',
-                options: this.runningApps$.asObservable()
+                options$: this.runningApps$.asObservable()
             },
             {
                 label: 'ADF_CLOUD_EDIT_PROCESS_FILTER.LABEL.APP_VERSION',
@@ -670,7 +670,7 @@ export class EditProcessFilterCloudComponent implements OnInit, OnChanges, OnDes
                 type: 'multi-select',
                 key: 'appVersionMultiple',
                 value: appVersionMultiple,
-                options: this.currentAppVersions$.asObservable()
+                options$: this.currentAppVersions$.asObservable()
             },
             {
                 label: 'ADF_CLOUD_EDIT_PROCESS_FILTER.LABEL.PROCESS_INS_ID',
@@ -689,14 +689,14 @@ export class EditProcessFilterCloudComponent implements OnInit, OnChanges, OnDes
                 type: 'select',
                 key: 'processDefinitionName',
                 value: filterModel.processDefinitionName || '',
-                options: this.currentAppProcessDefinitions$.asObservable()
+                options$: this.currentAppProcessDefinitions$.asObservable()
             },
             {
                 label: 'ADF_CLOUD_EDIT_PROCESS_FILTER.LABEL.STATUS',
                 type: 'select',
                 key: 'status',
                 value: filterModel.status || this.status[0].value,
-                options: of(this.status)
+                options$: of(this.status)
             },
             {
                 label: 'ADF_CLOUD_EDIT_PROCESS_FILTER.LABEL.PROCESS_DEF_ID',
@@ -715,14 +715,14 @@ export class EditProcessFilterCloudComponent implements OnInit, OnChanges, OnDes
                 type: 'select',
                 key: 'sort',
                 value: filterModel.sort || this.createSortProperties[0].value,
-                options: of(this.createSortProperties)
+                options$: of(this.createSortProperties)
             },
             {
                 label: 'ADF_CLOUD_EDIT_PROCESS_FILTER.LABEL.DIRECTION',
                 type: 'select',
                 key: 'order',
                 value: filterModel.order || this.directions[0].value,
-                options: of(this.directions)
+                options$: of(this.directions)
             },
             {
                 label: 'ADF_CLOUD_EDIT_PROCESS_FILTER.LABEL.COMPLETED_DATE',

--- a/lib/process-services-cloud/src/lib/process/process-filters/components/edit-process-filter-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/process/process-filters/components/edit-process-filter-cloud.component.ts
@@ -30,6 +30,8 @@ import { ProcessFilterCloudService } from '../services/process-filter-cloud.serv
 import { ProcessFilterDialogCloudComponent } from './process-filter-dialog-cloud.component';
 import { ProcessCloudService } from '../../services/process-cloud.service';
 import { DateCloudFilterType, DateRangeFilter } from '../../../models/date-cloud-filter.model';
+import { ProcessDefinitionCloud } from 'process-services-cloud/src/lib/models/process-definition-cloud.model';
+import { ApplicationInstanceModel } from 'process-services-cloud/src/lib/app/models/application-instance.model';
 
 export interface DropdownOption {
     value: string;
@@ -391,8 +393,8 @@ export class EditProcessFilterCloudComponent implements OnInit, OnChanges, OnDes
         if (!this.applicationNames.length) {
             this.appsProcessCloudService
             .getDeployedApplicationsByStatus('RUNNING', this.role).pipe(
-                map((response) => {
-                    let result = [];
+                map((response: ApplicationInstanceModel[]) => {
+                    let result: DropdownOption[] = [];
                     if (response?.length) {
                         result = response.map((res) => {
                             return {label: res.name, value: res.name }
@@ -410,8 +412,8 @@ export class EditProcessFilterCloudComponent implements OnInit, OnChanges, OnDes
     getProcessDefinitions() {
         if(!this.processDefinitionNames.length) {
             this.processCloudService.getProcessDefinitions(this.appName).pipe(
-            map((response) => {
-                let result = [this.allProcessDefinitionNamesOption];
+            map((response: ProcessDefinitionCloud[]) => {
+                let result: DropdownOption[] = [];
                 if (response?.length) {
                     result = response.map((res) => {
                         return { label: res.name, value: res.name }
@@ -419,7 +421,7 @@ export class EditProcessFilterCloudComponent implements OnInit, OnChanges, OnDes
                 }
                 return result;
             })).subscribe((processDefinitions: DropdownOption[]) => {
-                this.processDefinitionNames.push(...processDefinitions);
+                this.processDefinitionNames.push(...<DropdownOption[]> [this.allProcessDefinitionNamesOption, ...processDefinitions]);
             });
         }
     }

--- a/lib/process-services-cloud/src/lib/process/process-filters/mock/process-filters-cloud.mock.ts
+++ b/lib/process-services-cloud/src/lib/process/process-filters/mock/process-filters-cloud.mock.ts
@@ -15,8 +15,9 @@
  * limitations under the License.
  */
 
+import { ApplicationVersionModel } from '../../../models/application-version.model';
 import { ProcessFilterCloudModel } from '../models/process-filter-cloud.model';
-import { DateCloudFilterType } from '../../../../..';
+import { DateCloudFilterType } from '../../../models/date-cloud-filter.model';
 
 export const fakeProcessCloudFilters = [
     {
@@ -75,33 +76,35 @@ export const mockProcessFilters = [
     })
 ];
 
-export const fakeProcessFilter: ProcessFilterCloudModel = new ProcessFilterCloudModel({
-    name: 'MOCK_PROCESS_NAME_1',
-    id: '1',
-    key: 'all-mock-process',
-    icon: 'adjust',
-    appName: 'mock-appName',
-    sort: 'startDate',
-    status: 'MOCK_ALL',
-    order: 'DESC',
-    index: 2,
-    processName: 'process-name',
-    processDefinitionName: 'process-def-name',
-    processInstanceId: 'processinstanceid',
-    initiator: 'mockuser',
-    processDefinitionId: 'processDefid',
-    processDefinitionKey: 'processDefKey',
-    lastModified: null,
-    lastModifiedTo: null,
-    lastModifiedFrom: null,
-    completedDateType: DateCloudFilterType.NO_DATE,
-    startedDateType: DateCloudFilterType.NO_DATE,
-    _completedFrom: null,
-    _completedTo: null,
-    startedDate: null,
-    _startFrom: null,
-    _startTo: null
-});
+export const fakeProcessFilter: ProcessFilterCloudModel = new ProcessFilterCloudModel(
+    {
+        name: 'MOCK_PROCESS_NAME_1',
+        id: '1',
+        key: 'all-mock-process',
+        icon: 'adjust',
+        appName: 'mock-appName',
+        sort: 'startDate',
+        status: 'MOCK_ALL',
+        order: 'DESC',
+        index: 2,
+        processName: 'process-name',
+        processDefinitionName: 'process-def-name',
+        processInstanceId: 'processinstanceid',
+        initiator: 'mockuser',
+        processDefinitionId: 'processDefid',
+        processDefinitionKey: 'processDefKey',
+        lastModified: null,
+        lastModifiedTo: null,
+        lastModifiedFrom: null,
+        completedDateType: DateCloudFilterType.NO_DATE,
+        startedDateType: DateCloudFilterType.NO_DATE,
+        _completedFrom: null,
+        _completedTo: null,
+        startedDate: null,
+        _startFrom: null,
+        _startTo: null
+    }
+);
 
 export const fakeProcessCloudFilterEntries = {
     list: {
@@ -167,3 +170,39 @@ export const fakeProcessCloudFilterWithDifferentEntries = {
         }
     }
 };
+
+export const mockAppVersionOptions = [
+    { label: 'mock-version-1-name', value: 'mock-version-1-name' },
+    { label: 'mock-version-2-name', value: 'mock-version-2-name' }
+];
+
+export const mockProcessDefinitionOptions = [
+    { label: 'process-def-one-name', value: 'process-def-one-name' },
+    { label: 'process-def-two-name', value: 'process-def-two-name' }
+];
+
+export const mockAppVersion1: ApplicationVersionModel = {
+    entry: {
+        id: 'mock-version-1-id',
+        name: 'mock-version-1-name',
+        version: '1'
+    }
+};
+
+export const mockAppVersion2: ApplicationVersionModel = {
+    entry: {
+        id: 'mock-version-2-id',
+        name: 'mock-version-2-name',
+        version: '2'
+    }
+};
+
+export const mockProcessDefinitionList = [
+    { id: 'process-deff-one-id', name: 'process-def-one-name' },
+    { id: 'process-deff-two-id', name: 'process-deff-two-name' }
+];
+
+export const mockRunningAppsList = [
+    { id: 'app-one-id', name: 'app-one-name' },
+    { id: 'app-two-id', name: 'app-two-name' }
+];

--- a/lib/process-services-cloud/src/lib/process/process-filters/models/process-filter-cloud.model.ts
+++ b/lib/process-services-cloud/src/lib/process/process-filters/models/process-filter-cloud.model.ts
@@ -192,7 +192,7 @@ export interface ProcessFilterProperties {
     value?: any;
     key?: string;
     attributes?: { [key: string]: string; };
-    options?: Observable<any[]>;
+    options$?: Observable<any[]>;
     dateFilterOptions?: DateCloudFilterType[];
     selectionMode?: ComponentSelectionMode;
 }

--- a/lib/process-services-cloud/src/lib/process/process-filters/models/process-filter-cloud.model.ts
+++ b/lib/process-services-cloud/src/lib/process/process-filters/models/process-filter-cloud.model.ts
@@ -17,6 +17,7 @@
 import { DateCloudFilterType } from '../../../models/date-cloud-filter.model';
 import { DateRangeFilterService } from '../../../common/date-range-filter/date-range-filter.service';
 import { ComponentSelectionMode } from '../../../types';
+import { Observable } from 'rxjs';
 
 export class ProcessFilterCloudModel {
 
@@ -180,9 +181,9 @@ export interface ProcessFilterAction {
     filter?: ProcessFilterCloudModel;
 }
 
-export interface ProcessFilterOptions {
-    label?: string;
-    value?: string | object;
+export interface DropdownOption {
+    value: string;
+    label: string;
 }
 
 export interface ProcessFilterProperties {
@@ -191,7 +192,7 @@ export interface ProcessFilterProperties {
     value?: any;
     key?: string;
     attributes?: { [key: string]: string; };
-    options?: ProcessFilterOptions[];
+    options?: Observable<any[]>;
     dateFilterOptions?: DateCloudFilterType[];
     selectionMode?: ComponentSelectionMode;
 }

--- a/lib/process-services-cloud/src/lib/process/process-filters/services/process-filter-cloud.service.ts
+++ b/lib/process-services-cloud/src/lib/process/process-filters/services/process-filter-cloud.service.ts
@@ -361,7 +361,7 @@ export class ProcessFilterCloudService {
         ];
     }
 
-    fetchRunningApplications(status: string, role: string) {
+    fetchRunningApplications(status: string, role: string): Observable<DropdownOption[]> {
         return this.appsProcessCloudService.getDeployedApplicationsByStatus(status, role).pipe(
                     map((response: any[]) => {
                         const applications: DropdownOption[] = [];
@@ -371,11 +371,12 @@ export class ProcessFilterCloudService {
                             });
                         }
                         return applications;
-                    })
+                    }),
+                    catchError((err) => this.handleProcessError(err))
                 );
     }
 
-    fetchApplicationVersions(appName: string) {
+    fetchApplicationVersions(appName: string): Observable<DropdownOption[]> {
         return this.processCloudService.getApplicationVersions(appName).pipe(
                     map((response: ApplicationVersionModel[]) => {
                         const appVersions: DropdownOption[] = [];
@@ -385,22 +386,24 @@ export class ProcessFilterCloudService {
                             });
                         }
                         return appVersions;
-                    })
+                    }),
+                    catchError((err) => this.handleProcessError(err))
                 );
     }
 
-    fetchProcessDefinitions(appName: string) {
+    fetchProcessDefinitions(appName: string): Observable<DropdownOption[]> {
         const allProcessDefinitionNamesOption: DropdownOption = { label: 'ADF_CLOUD_PROCESS_FILTERS.STATUS.ALL', value: '' };
         return this.processCloudService.getProcessDefinitions(appName).pipe(
-                map((response: any[]) => {
-                    const processDefinitions: DropdownOption[] = [];
-                    if (response?.length) {
-                        response.forEach(res => {
-                            processDefinitions.push( { label: res.name, value: res.name });
-                        });
-                    }
-                    return [ allProcessDefinitionNamesOption, ...processDefinitions];
-                })
-            );
+                    map((response: any[]) => {
+                        const processDefinitions: DropdownOption[] = [];
+                        if (response?.length) {
+                            response.forEach(res => {
+                                processDefinitions.push( { label: res.name, value: res.name });
+                            });
+                        }
+                        return [ allProcessDefinitionNamesOption, ...processDefinitions];
+                    }),
+                    catchError((err) => this.handleProcessError(err))
+                );
     }
 }

--- a/lib/process-services-cloud/src/lib/process/process-filters/services/process-filter-cloud.service.ts
+++ b/lib/process-services-cloud/src/lib/process/process-filters/services/process-filter-cloud.service.ts
@@ -24,7 +24,7 @@ import { PROCESS_FILTERS_SERVICE_TOKEN } from '../../../services/cloud-token.ser
 import { PreferenceCloudServiceInterface } from '../../../services/preference-cloud.interface';
 import { ProcessCloudService } from '../../services/process-cloud.service';
 import { AppsProcessCloudService } from '../../../app/services/apps-process-cloud.service';
-import { ApplicationVersionModel } from 'process-services-cloud/src/lib/models/application-version.model';
+import { ApplicationVersionModel } from '../../../models/application-version.model';
 @Injectable({
     providedIn: 'root'
 })
@@ -388,7 +388,6 @@ export class ProcessFilterCloudService {
                     })
                 );
     }
-
 
     fetchProcessDefinitions(appName: string) {
         const allProcessDefinitionNamesOption: DropdownOption = { label: 'ADF_CLOUD_PROCESS_FILTERS.STATUS.ALL', value: '' };


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://alfresco.atlassian.net/browse/AAE-4997

1. On Process definition select the process edit filter component refreshes.
2. Edit process filter component is fetching running apps, app versions and process-definitions whenever filter properties changed. 
3. version drop down displays duplicated options. 

**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
