### PR TITLE
[ACA-2864] Site Managers are not able to disable inherit permissions …

### DIFF
--- a/lib/content-services/src/lib/mock/permission-list.component.mock.ts
+++ b/lib/content-services/src/lib/mock/permission-list.component.mock.ts
@@ -125,7 +125,7 @@ export const fakeNodeInheritedOnly = {
           {
             'id': 'e002c740-b8f9-482a-a554-8fff4e4c9dc0',
             'name': 'testsite',
-            'nodeType': 'si:site'
+            'nodeType': 'st:site'
           },
           {
             'id': '71626fae-0c04-4d0c-a129-20fa4c178716',
@@ -578,5 +578,85 @@ export const fakeEmptyResponse: any = {
         },
         'context': {},
         'entries': []
+    }
+};
+
+export const fakeNodeLocalSiteManager = {
+    'allowableOperations': [ 'updatePermissions' ],
+    'aspectNames': [
+        'cm:auditable',
+        'cm:taggable',
+        'cm:author',
+        'cm:titled',
+        'app:uifacets'
+    ],
+    'createdAt': '2017-11-16T16:29:38.638+0000',
+    'path': {
+        'name': '/Company Home/Sites/testsite/documentLibrary',
+        'isComplete': true,
+        'elements': [
+            {
+                'id': '2be275a1-b00d-4e45-83d8-66af43ac2252',
+                'name': 'Company Home'
+            },
+            {
+                'id': '1be10a97-6eb9-4b60-b6c6-1673900e9631',
+                'name': 'Sites'
+            },
+            {
+                'id': 'e002c740-b8f9-482a-a554-8fff4e4c9dc0',
+                'name': 'testsite',
+                'nodeType': 'st:site'
+            },
+            {
+                'id': '71626fae-0c04-4d0c-a129-20fa4c178716',
+                'name': 'documentLibrary'
+            }
+        ]
+    },
+    'isFolder': true,
+    'isFile': false,
+    'createdByUser': {
+        'id': 'System',
+        'displayName': 'System'
+    },
+    'modifiedAt': '2018-03-21T03:17:58.783+0000',
+    'permissions': {
+        'locallySet': [
+            {
+                'authorityId': 'GROUP_site_testsite_SiteManager',
+                'name': 'SiteManager',
+                'accessStatus': 'ALLOWED'
+            },
+            {
+                'authorityId': 'superadminuser',
+                'name': 'SiteCollaborator',
+                'accessStatus': 'ALLOWED'
+            }
+        ],
+        'settable': [
+            'Contributor',
+            'Collaborator',
+            'Coordinator',
+            'Editor',
+            'Consumer'
+        ],
+        'isInheritanceEnabled': false
+    },
+    'modifiedByUser': {
+        'id': 'admin',
+        'displayName': 'PedroH Hernandez'
+    },
+    'name': 'test',
+    'id': 'f472543f-7218-403d-917b-7a5861257244',
+    'nodeType': 'cm:folder',
+    'properties': {
+        'cm:title': 'test',
+        'cm:author': 'yagud',
+        'cm:taggable': [
+            'e8c8fbba-03ba-4fa6-86b1-f7ad7c296409'
+        ],
+        'cm:description': 'sleepery',
+        'app:icon': 'space-icon-default'
     }
 };

--- a/lib/content-services/src/lib/mock/permission-list.component.mock.ts
+++ b/lib/content-services/src/lib/mock/permission-list.component.mock.ts
@@ -124,7 +124,8 @@ export const fakeNodeInheritedOnly = {
           },
           {
             'id': 'e002c740-b8f9-482a-a554-8fff4e4c9dc0',
-            'name': 'testsite'
+            'name': 'testsite',
+            'nodeType': 'si:site'
           },
           {
             'id': '71626fae-0c04-4d0c-a129-20fa4c178716',

--- a/lib/content-services/src/lib/permission-manager/components/permission-container/permission-container.component.html
+++ b/lib/content-services/src/lib/permission-manager/components/permission-container/permission-container.component.html
@@ -34,7 +34,7 @@
             key="name"
             sortable="false">
             <ng-template let-entry="$implicit">
-                <adf-user-role-column [readonly]="isReadOnly"
+                <adf-user-role-column [readonly]="entry.row.obj.readonly || isReadOnly"
                                       [placeholder]="entry.data.getValue(entry.row, entry.col)"
                                       [value]="entry.data.getValue(entry.row, entry.col)"
                                       [roles]="roles"
@@ -59,6 +59,7 @@
         <data-column class="adf-datatable-cell adf-delete-permission-column" key="" *ngIf="!isReadOnly" [sortable]="false">
             <ng-template let-entry="$implicit">
                 <button mat-icon-button
+                        [disabled]="entry.row.obj.readonly"
                         (click)="removePermission($event, entry.row.obj)"
                         [attr.data-automation-id]="'adf-delete-permission-button-' + entry.row.obj.authorityId">
                     <mat-icon>delete_outline</mat-icon>

--- a/lib/content-services/src/lib/permission-manager/components/permission-list/permission-list.component.spec.ts
+++ b/lib/content-services/src/lib/permission-manager/components/permission-list/permission-list.component.spec.ts
@@ -25,6 +25,7 @@ import { NodePermissionService } from '../../services/node-permission.service';
 import {
     fakeEmptyResponse,
     fakeNodeInheritedOnly,
+    fakeNodeLocalSiteManager,
     fakeNodeWithOnlyLocally,
     fakeNodeWithoutPermissions,
     fakeNodeWithPermissions,
@@ -206,6 +207,19 @@ describe('PermissionListComponent', () => {
             expect(options[3].nativeElement.innerText).toContain('ADF.ROLES.SITEMANAGER');
         });
 
+        it('should show readonly member for site manager to toggle the inherit permission', async() => {
+            getNodeSpy.and.returnValue(of(fakeNodeLocalSiteManager));
+            component.ngOnInit();
+
+            await fixture.detectChanges();
+            expect(element.querySelector('adf-user-name-column').textContent).toContain('GROUP_site_testsite_SiteManager');
+            expect(element.querySelector('#adf-select-role-permission').textContent).toContain('ADF.ROLES.SITEMANAGER');
+            const deleteButton: HTMLButtonElement = element.querySelector('[data-automation-id="adf-delete-permission-button-GROUP_site_testsite_SiteManager"]');
+            expect(deleteButton.disabled).toBe(true);
+            const otherDeleteButton: HTMLButtonElement = element.querySelector('[data-automation-id="adf-delete-permission-button-superadminuser"]');
+            expect(otherDeleteButton.disabled).toBe(false);
+        });
+
         it('should update the role when another value is chosen',  async () => {
             spyOn(nodeService, 'updateNode').and.returnValue(of({id: 'fake-uwpdated-node'}));
             searchQuerySpy.and.returnValue(of(fakeEmptyResponse));
@@ -236,8 +250,8 @@ describe('PermissionListComponent', () => {
             expect(element.querySelector('adf-user-name-column').textContent).toContain('GROUP_EVERYONE');
             expect(element.querySelector('#adf-select-role-permission').textContent).toContain('Contributor');
 
-            const showButton: HTMLButtonElement = element.querySelector('[data-automation-id="adf-delete-permission-button-GROUP_EVERYONE"]');
-            showButton.click();
+            const deleteButton: HTMLButtonElement = element.querySelector('[data-automation-id="adf-delete-permission-button-GROUP_EVERYONE"]');
+            deleteButton.click();
             fixture.detectChanges();
 
             expect(nodeService.updateNode).toHaveBeenCalledWith('f472543f-7218-403d-917b-7a5861257244', { permissions: { locallySet: [ ] } });

--- a/lib/content-services/src/lib/permission-manager/components/permission-list/permission-list.component.ts
+++ b/lib/content-services/src/lib/permission-manager/components/permission-list/permission-list.component.ts
@@ -56,7 +56,7 @@ export class PermissionListComponent {
     }
 
     onSelect(selections: ObjectDataRow[]) {
-        this.selectedPermissions = selections.map((selection) => selection['obj']);
+        this.selectedPermissions = selections.map((selection) => selection['obj']).filter((permission) => !permission.readonly);
     }
 
     deleteSelection() {

--- a/lib/content-services/src/lib/permission-manager/components/permission-list/permission-list.service.spec.ts
+++ b/lib/content-services/src/lib/permission-manager/components/permission-list/permission-list.service.spec.ts
@@ -22,7 +22,7 @@ import { of, throwError } from 'rxjs';
 import { PermissionListService } from './permission-list.service';
 import { ContentTestingModule } from '../../../testing/content.testing.module';
 import { NodePermissionService } from '../../services/node-permission.service';
-import { fakeNodeInheritedOnly, fakeNodeWithOnlyLocally } from '../../../mock/permission-list.component.mock';
+import { fakeNodeInheritedOnly, fakeNodeLocalSiteManager, fakeNodeWithOnlyLocally } from '../../../mock/permission-list.component.mock';
 import { PermissionDisplayModel } from '../../models/permission.model';
 
 describe('PermissionListService', () => {
@@ -82,30 +82,36 @@ describe('PermissionListService', () => {
             expect(notificationService.showError).toHaveBeenCalledWith('PERMISSION_MANAGER.ERROR.NOT-ALLOWED');
         });
 
-        it('should include the local permission before toggle', () => {
-            const node = JSON.parse(JSON.stringify(fakeNodeInheritedOnly)), event = { source: { checked: true } };
-            const updateNode = JSON.parse(JSON.stringify(fakeNodeInheritedOnly));
-            updateNode.permissions.isInheritanceEnabled = false;
+        it('should include the local permission before toggle', (done) => {
+            const node = JSON.parse(JSON.stringify(fakeNodeInheritedOnly)), event = { source: { checked: false } };
             spyOn(nodePermissionService, 'getNodeWithRoles').and.returnValue(of({node , roles: []}));
             spyOn(nodePermissionService, 'updatePermissions').and.returnValue(of(null));
-            spyOn(nodesApiService, 'updateNode').and.returnValue(of(updateNode));
+            spyOn(nodesApiService, 'updateNode').and.returnValue(of(JSON.parse(JSON.stringify(fakeNodeLocalSiteManager))));
             service.fetchPermission('fetch node');
 
+            const subscription = service.data$.subscribe(({ localPermissions }) => {
+                expect(localPermissions[0].authorityId).toBe('GROUP_site_testsite_SiteManager');
+                expect(localPermissions[0].readonly).toBe(true);
+                expect(localPermissions[1].authorityId).toBe('superadminuser');
+                expect(localPermissions[1].readonly).toBe(undefined);
+                expect(nodePermissionService.updatePermissions).toHaveBeenCalled();
+                expect(nodesApiService.updateNode).toHaveBeenCalled();
+                expect(notificationService.showInfo).toHaveBeenCalledWith('PERMISSION_MANAGER.MESSAGE.INHERIT-DISABLE-SUCCESS');
+                subscription.unsubscribe();
+                done();
+            });
             service.toggleInherited(event as any);
-            expect(nodePermissionService.updatePermissions).toHaveBeenCalled();
-            expect(nodesApiService.updateNode).toHaveBeenCalled();
-            expect(notificationService.showInfo).toHaveBeenCalledWith('PERMISSION_MANAGER.MESSAGE.INHERIT-DISABLE-SUCCESS');
         });
 
         it('should not update local permission before toggle', () => {
-            const node = JSON.parse(JSON.stringify(fakeNodeInheritedOnly)), event = { source: { checked: true } };
+            const node = JSON.parse(JSON.stringify(fakeNodeInheritedOnly)), event = { source: { checked: false } };
             const updateNode = JSON.parse(JSON.stringify(fakeNodeInheritedOnly));
-            node.permissions.localySet = [{
+            node.permissions.locallySet = [{
                 'authorityId': 'GROUP_site_testsite_SiteManager',
                 'name': 'SiteManager',
                 'accessStatus': 'ALLOWED'
             }];
-            node.permissions.isInheritanceEnabled = true;
+            updateNode.permissions.isInheritanceEnabled = false;
             spyOn(nodePermissionService, 'getNodeWithRoles').and.returnValue(of({node , roles: []}));
             spyOn(nodePermissionService, 'updatePermissions').and.returnValue(of(null));
             spyOn(nodesApiService, 'updateNode').and.returnValue(of(updateNode));
@@ -114,11 +120,12 @@ describe('PermissionListService', () => {
             service.toggleInherited(event as any);
             expect(nodePermissionService.updatePermissions).not.toHaveBeenCalled();
             expect(nodesApiService.updateNode).toHaveBeenCalled();
-            expect(notificationService.showInfo).toHaveBeenCalledWith('PERMISSION_MANAGER.MESSAGE.INHERIT-ENABLE-SUCCESS');
+            expect(notificationService.showInfo).toHaveBeenCalledWith('PERMISSION_MANAGER.MESSAGE.INHERIT-DISABLE-SUCCESS');
         });
 
         it('should show message for errored toggle', () => {
             const node = JSON.parse(JSON.stringify(fakeNodeInheritedOnly)), event = { source: { checked: false } };
+            node.permissions.isInheritanceEnabled = true;
             spyOn(nodesApiService, 'updateNode').and.returnValue(throwError('Failed to update'));
             spyOn(nodePermissionService, 'getNodeWithRoles').and.returnValue(of({node , roles: []}));
             service.fetchPermission('fetch node');

--- a/lib/content-services/src/lib/permission-manager/components/permission-list/permission-list.service.ts
+++ b/lib/content-services/src/lib/permission-manager/components/permission-list/permission-list.service.ts
@@ -45,7 +45,7 @@ export class PermissionListService {
                 node,
                 roles,
                 localPermissions,
-                inheritedPermissions: this.nodePermissionService.getInheritedPermission(node),
+                inheritedPermissions: this.nodePermissionService.getInheritedPermission(node)
             };
         })
     );
@@ -191,7 +191,7 @@ export class PermissionListService {
             .subscribe((node) => {
                     this.notificationService.showInfo('PERMISSION_MANAGER.MESSAGE.PERMISSION-DELETE-SUCCESS');
                     if (!node.permissions.locallySet) {
-                       node.permissions.locallySet = []
+                       node.permissions.locallySet = [];
                     }
                     this.reloadNode(node);
                 },
@@ -226,7 +226,7 @@ export class PermissionListService {
         }
 
         if (!hasLocalManagerPermission && authorityId) {
-            return authorityId
+            return authorityId;
         }
         return null;
     }

--- a/lib/content-services/src/lib/permission-manager/components/permission-list/permission-list.service.ts
+++ b/lib/content-services/src/lib/permission-manager/components/permission-list/permission-list.service.ts
@@ -52,6 +52,7 @@ export class PermissionListService {
 
     private node: Node;
     private roles: RoleModel[];
+    private SITE_MANAGER_ROLE = 'SiteManager';
 
     constructor(
         private nodeService: NodesApiService,
@@ -88,7 +89,7 @@ export class PermissionListService {
             if (authorityId) {
                 const permissions = [
                     ...(this.node.permissions.locallySet || []),
-                    { authorityId, name: 'SiteManager', accessStatus: 'ALLOWED' }
+                    { authorityId, name: this.SITE_MANAGER_ROLE, accessStatus: 'ALLOWED' }
                 ];
                 updateLocalPermission$ = this.nodePermissionService.updatePermissions(this.node, permissions);
             }
@@ -205,7 +206,7 @@ export class PermissionListService {
     private buildUpdatedPermission(role: string, permission: PermissionElement): PermissionElement {
         return {
             accessStatus: permission.accessStatus,
-            name:  this.canUpdateThePermission(this.node, permission) ? role :  permission.name,
+            name: this.canUpdateThePermission(this.node, permission) ? role :  permission.name,
             authorityId: permission.authorityId
         };
     }
@@ -221,8 +222,8 @@ export class PermissionListService {
         const sitePath = node.path.elements.find((path) => path.nodeType === 'st:site');
         let hasLocalManagerPermission = false, authorityId: string;
         if (sitePath) {
-            authorityId = `GROUP_site_${sitePath.name}_SiteManager`;
-            hasLocalManagerPermission = !!node.permissions.locallySet?.find((permission) => permission.authorityId === authorityId && permission.name === 'SiteManager');
+            authorityId = `GROUP_site_${sitePath.name}_${this.SITE_MANAGER_ROLE}`;
+            hasLocalManagerPermission = !!node.permissions.locallySet?.find((permission) => permission.authorityId === authorityId && permission.name === this.SITE_MANAGER_ROLE);
         }
 
         if (!hasLocalManagerPermission && authorityId) {
@@ -243,8 +244,8 @@ export class PermissionListService {
     canUpdateThePermission(node: Node, permission: PermissionElement): boolean {
         const sitePath = node.path.elements.find((path) => path.nodeType === 'st:site');
         if (!node.permissions.isInheritanceEnabled && sitePath) {
-           const authorityId = `GROUP_site_${sitePath.name}_SiteManager`;
-           return !(permission.authorityId === authorityId && permission.name === 'SiteManager');
+           const authorityId = `GROUP_site_${sitePath.name}_${this.SITE_MANAGER_ROLE}`;
+           return !(permission.authorityId === authorityId && permission.name === this.SITE_MANAGER_ROLE);
         }
         return true;
     }

--- a/lib/content-services/src/lib/permission-manager/models/permission.model.ts
+++ b/lib/content-services/src/lib/permission-manager/models/permission.model.ts
@@ -24,6 +24,7 @@ export class PermissionDisplayModel implements PermissionElement {
     accessStatus?: PermissionElement.AccessStatusEnum;
     isInherited: boolean = false;
     icon: string;
+    readonly?: boolean;
 
     constructor(obj?: any) {
         if (obj) {


### PR DESCRIPTION
…in DW/ACA

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ACA-2864

Sitemanger can't toggle Inherit permission

**What is the new behaviour?**

fixed the problem

What is the fix?
We should include the site_manger group to node before toggling the inherit permission

why are you doing this hack?
As soon as we toggle the inherit permission user can't get the access to the node. so we should include to the locallyset before toggling the inherit permission. so backend is not letting the user to do



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
