### PR TITLE
[ADF-5400] PDF viewer - The document page from the thumbnail pane is not highlighted

### DIFF
--- a/lib/core/viewer/components/pdf-viewer-thumbnails.component.scss
+++ b/lib/core/viewer/components/pdf-viewer-thumbnails.component.scss
@@ -28,5 +28,9 @@
         &__thumb:hover {
             box-shadow: 0 0 5px 0 $black-87-opacity;
         }
+
+        &__thumb--selected {
+            border: 2px solid mat-color($alfresco-ecm-blue, A200);
+        }
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
[ADF-5400](https://alfresco.atlassian.net/browse/ADF-5400)


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
