### PR TITLE
[ACA-4445] - disabled edit aspect button on content card for ACS vers…

### DIFF
--- a/lib/content-services/src/lib/content-metadata/components/content-metadata-card/content-metadata-card.component.html
+++ b/lib/content-services/src/lib/content-metadata/components/content-metadata-card/content-metadata-card.component.html
@@ -13,7 +13,7 @@
     </mat-card-content>
     <mat-card-footer class="adf-content-metadata-card-footer" fxLayout="row" fxLayoutAlign="space-between stretch">
         <div>
-            <button *ngIf="!readOnly && hasAllowableOperations()"
+            <button *ngIf="isEditAspectSupported()"
                 mat-icon-button
                 (click)="openAspectDialog()"
                 [attr.title]="'CORE.METADATA.ACTIONS.EDIT_ASPECTS' | translate"

--- a/lib/content-services/src/lib/content-metadata/components/content-metadata-card/content-metadata-card.component.spec.ts
+++ b/lib/content-services/src/lib/content-metadata/components/content-metadata-card/content-metadata-card.component.spec.ts
@@ -59,6 +59,7 @@ describe('ContentMetadataCardComponent', () => {
 
         component.node = node;
         component.preset = preset;
+        component.editAspectSupported = true;
         nodeAspectService = TestBed.inject(NodeAspectService);
         spyOn(contentMetadataService, 'getContentTypeProperty').and.returnValue(of([]));
         fixture.detectChanges();
@@ -220,6 +221,7 @@ describe('ContentMetadataCardComponent', () => {
         component.node.id = 'fake-node-id';
         component.node.allowableOperations = [AllowableOperationsEnum.UPDATE];
         spyOn(nodeAspectService, 'updateNodeAspects').and.stub();
+
         fixture.detectChanges();
 
         const button = fixture.debugElement.query(By.css('[data-automation-id="meta-data-card-edit-aspect"]'));
@@ -227,5 +229,18 @@ describe('ContentMetadataCardComponent', () => {
         fixture.detectChanges();
 
         expect(nodeAspectService.updateNodeAspects).toHaveBeenCalledWith('fake-node-id');
+    });
+
+    it('should not show the edit aspect button if ACS version is not supported', () => {
+        component.editable = true;
+        component.node.id = 'fake-node-id';
+        component.node.allowableOperations = [AllowableOperationsEnum.UPDATE];
+        spyOn(nodeAspectService, 'updateNodeAspects').and.stub();
+        component.editAspectSupported = false;
+        fixture.detectChanges();
+
+        const button = fixture.debugElement.query(By.css('[data-automation-id="meta-data-card-edit-aspect"]'));
+
+        expect(button).toBeNull();
     });
 });

--- a/lib/content-services/src/lib/content-metadata/components/content-metadata-card/content-metadata-card.component.ts
+++ b/lib/content-services/src/lib/content-metadata/components/content-metadata-card/content-metadata-card.component.ts
@@ -17,7 +17,7 @@
 
 import { Component, Input, OnChanges, SimpleChanges, ViewEncapsulation } from '@angular/core';
 import { Node } from '@alfresco/js-api';
-import { ContentService, AllowableOperationsEnum } from '@alfresco/adf-core';
+import { ContentService, AllowableOperationsEnum, VersionCompatibilityService } from '@alfresco/adf-core';
 import { NodeAspectService } from '../../../aspect-list/node-aspect.service';
 @Component({
     selector: 'adf-content-metadata-card',
@@ -81,7 +81,10 @@ export class ContentMetadataCardComponent implements OnChanges {
 
     expanded: boolean;
 
-    constructor(private contentService: ContentService, private nodeAspectService: NodeAspectService) {
+    editAspectSupported = false;
+
+    constructor(private contentService: ContentService, private nodeAspectService: NodeAspectService, private versionCompatibilityService: VersionCompatibilityService) {
+        this.editAspectSupported = this.versionCompatibilityService.isVersionSupported('7');
     }
 
     ngOnChanges(changes: SimpleChanges): void {
@@ -108,5 +111,9 @@ export class ContentMetadataCardComponent implements OnChanges {
 
     openAspectDialog() {
         this.nodeAspectService.updateNodeAspects(this.node.id);
+    }
+
+    isEditAspectSupported(): boolean {
+        return !this.readOnly && this.hasAllowableOperations() && this.editAspectSupported;
     }
 }


### PR DESCRIPTION
…ion below 7

**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Edit aspect is always enabled on metadata card


**What is the new behaviour?**
Edit aspect is available only for ACS versions from 7 and above


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
