### PR TITLE
[AAE-5208] Add pagination info to listPeople function in PeopleContentService

### DIFF
--- a/docs/core/services/people-content.service.md
+++ b/docs/core/services/people-content.service.md
@@ -29,9 +29,9 @@ Gets information about a Content Services user.
 
     -   **Returns** [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises)`<boolean>` - 
 
--   **listPeople**(options?: `any`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`EcmUserModel`](../../core/models/ecm-user.model.md)`[]>`<br/>
+-   **listPeople**(requestQuery?: [`PeopleContentQueryRequestModel`](../../../lib/core/services/people-content.service.ts#32)): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`EcmUserModel`](../../core/models/ecm-user.model.md)`[]>`<br/>
     Gets a list of people.
-    -   _options:_ `any`  - (Optional) Optional parameters supported by JS-API
+    -   _requestQuery:_ [`PeopleContentQueryRequestModel`](../../../lib/core/services/people-content.service.ts)  - (Optional) maxItems and skipCount used for pagination
     -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`EcmUserModel`](../../core/models/ecm-user.model.md)`[]>` - Array of people
 
 ## Details

--- a/lib/core/services/people-content.service.spec.ts
+++ b/lib/core/services/people-content.service.spec.ts
@@ -18,14 +18,13 @@
 import { fakeEcmUser, fakeEcmUserList, createNewPersonMock, getFakeUserWithContentAdminCapability } from '../mock/ecm-user.service.mock';
 import { AlfrescoApiServiceMock } from '../mock/alfresco-api.service.mock';
 import { CoreTestingModule } from '../testing/core.testing.module';
-import { PeopleContentService } from './people-content.service';
+import { PeopleContentService, PeopleContentQueryResponse } from './people-content.service';
 import { AlfrescoApiService } from './alfresco-api.service';
 import { setupTestBed } from '../testing/setup-test-bed';
 import { TranslateModule } from '@ngx-translate/core';
 import { TestBed } from '@angular/core/testing';
 import { LogService } from './log.service';
 import { of } from 'rxjs';
-import { EcmUserModel } from '../models/ecm-user.model';
 
 describe('PeopleContentService', () => {
 
@@ -74,11 +73,15 @@ describe('PeopleContentService', () => {
 
     it('should be able to list people', (done) => {
         spyOn(service.peopleApi, 'listPeople').and.returnValue(Promise.resolve(fakeEcmUserList));
-        service.listPeople().subscribe((people: EcmUserModel[]) => {
+        service.listPeople().subscribe((response: PeopleContentQueryResponse) => {
+            const people = response.entries, pagination = response.pagination;
             expect(people).toBeDefined();
-            expect(people.length).toEqual(2);
             expect(people[0].id).toEqual('fake-id');
             expect(people[1].id).toEqual('another-fake-id');
+            expect(pagination.count).toEqual(2);
+            expect(pagination.totalItems).toEqual(2);
+            expect(pagination.hasMoreItems).toBeFalsy();
+            expect(pagination.skipCount).toEqual(0);
             done();
         });
     });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://alfresco.atlassian.net/browse/AAE-5208

**What is the new behaviour?**

listPeople function returns pagination info as well as entries.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
