### PR TITLE
[MNT-22418] - disabling action for physical records

### DIFF
--- a/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.html
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.html
@@ -26,21 +26,21 @@
                     [src]="file.content ? getIcon(file.content.mimeType) : getIcon(file.mimeType)" [alt]="mimeTypeIcon"
                     role="button" tabindex="0" />
             <span matLine id="{{'file-'+file?.id}}" role="button" tabindex="0" class="adf-file" (click)="onRowClicked(file)">{{file.name}}</span>
-            <button id="{{'file-'+file?.id+'-option-menu'}}" mat-icon-button [matMenuTriggerFor]="fileActionMenu">
+            <button id="{{'file-'+file?.id+'-option-menu'}}" mat-icon-button [matMenuTriggerFor]="fileActionMenu" *ngIf="!!file.content?.mimeType">
                 <mat-icon>more_vert</mat-icon>
             </button>
             <mat-menu #fileActionMenu="matMenu" xPosition="before">
-                <button *ngIf="displayMenuOption('show')" id="{{'file-'+file?.id+'-show-file'}}"
+                <button *ngIf="displayMenuOption('show') && !!file.content?.mimeType" id="{{'file-'+file?.id+'-show-file'}}"
                         mat-menu-item (click)="onAttachFileClicked(file)">
                     <mat-icon>visibility</mat-icon>
                     <span>{{ 'FORM.FIELD.VIEW_FILE' | translate }}</span>
                 </button>
-                <button *ngIf="displayMenuOption('download')" id="{{'file-'+file?.id+'-download-file'}}"
+                <button *ngIf="displayMenuOption('download') && !!file.content?.mimeType" id="{{'file-'+file?.id+'-download-file'}}"
                         mat-menu-item (click)="downloadContent(file)">
                     <mat-icon>file_download</mat-icon>
                     <span>{{ 'FORM.FIELD.DOWNLOAD_FILE' | translate }}</span>
                 </button>
-                <button *ngIf="displayMenuOption('retrieveMetadata')" id="{{'file-'+file?.id+'-retrieve-file-metadata'}}"
+                <button *ngIf="displayMenuOption('retrieveMetadata') && !!file.content?.mimeType" id="{{'file-'+file?.id+'-retrieve-file-metadata'}}"
                         mat-menu-item (click)="contentModelFormFileHandler(file)">
                     <mat-icon class="mat-24">low_priority</mat-icon>
                     <span>{{ 'ADF_CLOUD_FORM_COMPONENT.RETRIEVE_METADATA' | translate }}</span>

--- a/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.spec.ts
@@ -59,7 +59,8 @@ import {
     processVariables,
     mockAllFileSourceWithRenamedFolderVariablePathType,
     allSourceParamsWithWrongRelativePath,
-    allSourceParamsWithRelativePath
+    allSourceParamsWithRelativePath,
+    fakeLocalPhysicalRecordResponse
 } from '../../../mocks/attach-file-cloud-widget.mock';
 import { ProcessServiceCloudTestingModule } from '../../../../testing/process-service-cloud.testing.module';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
@@ -509,6 +510,14 @@ describe('AttachFileCloudWidgetComponent', () => {
             fixture.detectChanges();
 
             expect(fixture.debugElement.query(By.css('#file-1155-remove'))).toBeNull();
+        }));
+
+        it('should not show any action when the attached file is a physical record', async(() => {
+            createUploadWidgetField(new FormModel(), 'fill-test', [fakeLocalPhysicalRecordResponse], onlyLocalParams, null, null, true);
+            fixture.detectChanges();
+            const menuButton = fixture.debugElement.query(By.css('#file-1155-option-menu'));
+
+            expect(menuButton).toBeNull();
         }));
     });
 

--- a/lib/process-services-cloud/src/lib/form/mocks/attach-file-cloud-widget.mock.ts
+++ b/lib/process-services-cloud/src/lib/form/mocks/attach-file-cloud-widget.mock.ts
@@ -33,6 +33,33 @@ export const fakeLocalPngResponse = {
     contentAvailable: true,
     link: false,
     mimeType: 'image/png',
+    content: {
+        mimeType: 'image/png'
+    },
+    simpleType: 'image',
+    previewStatus: 'queued',
+    thumbnailStatus: 'queued',
+    properties: {
+        'pfx:property_one': 'testValue',
+        'pfx:property_two': true
+    }
+};
+
+export const fakeLocalPhysicalRecordResponse = {
+    id: 1155,
+    nodeId: 1155,
+    name: 'a_png_file.png',
+    created: '2017-07-25T17:17:37.099Z',
+    createdBy: {
+        id: 1001,
+        firstName: 'Admin',
+        lastName: 'admin',
+        email: 'admin'
+    },
+    relatedContent: false,
+    contentAvailable: true,
+    link: false,
+    mimeType: null,
     simpleType: 'image',
     previewStatus: 'queued',
     thumbnailStatus: 'queued',

--- a/lib/process-services/src/lib/content-widget/attach-file-widget.component.html
+++ b/lib/process-services/src/lib/content-widget/attach-file-widget.component.html
@@ -76,13 +76,13 @@
             </button>
             <mat-menu #fileActionMenu="matMenu" xPosition="before">
                 <button id="{{'file-'+file.id+'-show-file'}}"
-                    [disabled]="file.isExternal || !file.contentAvailable"
+                    [disabled]="file.isExternal || !file.contentAvailable || !file.mimeType"
                     mat-menu-item (click)="onAttachFileClicked(file)">
                     <mat-icon>visibility</mat-icon>
                     <span>{{ 'FORM.FIELD.VIEW_FILE' | translate }}</span>
                 </button>
                 <button id="{{'file-'+file.id+'-download-file'}}"
-                    [disabled]="file.isExternal"
+                    [disabled]="file.isExternal || !file.mimeType"
                     mat-menu-item (click)="downloadContent(file)">
                     <mat-icon>file_download</mat-icon>
                     <span>{{ 'FORM.FIELD.DOWNLOAD_FILE' | translate }}</span>

--- a/lib/process-services/src/lib/content-widget/attach-file-widget.component.ts
+++ b/lib/process-services/src/lib/content-widget/attach-file-widget.component.ts
@@ -256,7 +256,7 @@ export class AttachFileWidgetComponent extends UploadWidgetComponent implements 
         from(fileNodeList).pipe(
             mergeMap((node) =>
                 zip(
-                    of(node.content.mimeType),
+                    of(node?.content?.mimeType),
                     this.activitiContentService.applyAlfrescoNode(node, siteId, accountId),
                     of(node.isExternal)
                 )


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Physical record wrongly show actions that can be performed whilst they are just link for physical documents.


**What is the new behaviour?**
No action is displayed for physical records, that can be attached to the attach file


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
