### PR TITLE
[MNT-22030] ADW Previewer does not wrap long lines and there are no scroll-bars

### DIFF
--- a/lib/core/viewer/components/txt-viewer.component.scss
+++ b/lib/core/viewer/components/txt-viewer.component.scss
@@ -5,8 +5,7 @@
 
     .adf-txt-viewer {
         background-color: mat-color($background, background);
-        overflow: hidden;
-        overflow-y: scroll;
+        overflow: auto;
         height: 100%;
         width: 100%;
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Problems with overflow scroll in some cases

**What is the new behaviour?**

Fixed the issues stated in the ticket (added also a recording in JIRA)

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**: https://alfresco.atlassian.net/browse/MNT-22030
