### PR TITLE
[ADF-5173] - delayed destroying of pdfjs worker to prevent error on c…

### DIFF
--- a/lib/core/viewer/components/pdf-viewer.component.ts
+++ b/lib/core/viewer/components/pdf-viewer.component.ts
@@ -237,11 +237,12 @@ export class PdfViewerComponent implements OnChanges, OnDestroy {
 
         if (this.loadingTask) {
             try {
-                this.loadingTask.destroy();
+                setTimeout(() => {
+                    this.loadingTask.destroy();
+                    this.loadingTask = null;
+                }, 700);
             } catch {
             }
-
-            this.loadingTask = null;
         }
     }
 

--- a/lib/core/viewer/components/pdf-viewer.component.ts
+++ b/lib/core/viewer/components/pdf-viewer.component.ts
@@ -237,7 +237,7 @@ export class PdfViewerComponent implements OnChanges, OnDestroy {
         }
 
         if (this.loadingTask) {
-            timer(700).subscribe(() => this.destroyPdJsWorker())
+            timer(700).subscribe(() => this.destroyPdJsWorker());
         }
     }
 

--- a/lib/core/viewer/components/pdf-viewer.component.ts
+++ b/lib/core/viewer/components/pdf-viewer.component.ts
@@ -33,6 +33,7 @@ import { RenderingQueueServices } from '../services/rendering-queue.services';
 import { PdfPasswordDialogComponent } from './pdf-viewer-password-dialog';
 import { AppConfigService } from './../../app-config/app-config.service';
 import { PDFDocumentProxy, PDFSource } from 'pdfjs-dist';
+import { timer } from 'rxjs';
 
 declare const pdfjsLib: any;
 declare const pdfjsViewer: any;
@@ -236,14 +237,13 @@ export class PdfViewerComponent implements OnChanges, OnDestroy {
         }
 
         if (this.loadingTask) {
-            try {
-                setTimeout(() => {
-                    this.loadingTask.destroy();
-                    this.loadingTask = null;
-                }, 700);
-            } catch {
-            }
+            timer(700).subscribe(() => this.destroyPdJsWorker())
         }
+    }
+
+    private destroyPdJsWorker() {
+        this.loadingTask.destroy();
+        this.loadingTask = null;
     }
 
     toggleThumbnails() {


### PR DESCRIPTION
…losing while loading

**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Pdfjs will throw an error while trying to destroy the worker if the user close immediately the viewer after opening it


**What is the new behaviour?**
Delaying the destroying of the worker helps pdfjs to close everything without errors


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
