### PR TITLE
[ADF-5369] HTTP 500 response in adf-upload-button is emitted as a success event

### DIFF
--- a/demo-shell/src/app/components/files/files.component.ts
+++ b/demo-shell/src/app/components/files/files.component.ts
@@ -404,8 +404,8 @@ export class FilesComponent implements OnInit, OnChanges, OnDestroy {
         });
     }
 
-    openSnackMessageError(message: string) {
-        this.notificationService.showError(message);
+    openSnackMessageError(error: any) {
+        this.notificationService.showError(error.value || error);
     }
 
     openSnackMessageInfo(message: string) {

--- a/lib/content-services/src/lib/mock/upload.service.mock.ts
+++ b/lib/content-services/src/lib/mock/upload.service.mock.ts
@@ -1,0 +1,58 @@
+/*!
+ * @license
+ * Copyright 2019 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const mockUploadSuccessPromise = {
+    on: function (event, callback) {
+        if (event === 'success') {
+            callback();
+        }
+        return this;
+    },
+    catch: function (callback) {
+        callback();
+        return this;
+    },
+    then: function (callback) {
+        callback();
+        return this;
+    },
+    next: function (callback) {
+        callback();
+        return this;
+    }
+};
+
+export const mockUploadErrorPromise = {
+    on: function (event, callback) {
+        if (event === 'error') {
+            callback();
+        }
+        return this;
+    },
+    catch: function (callback) {
+        callback();
+        return this;
+    },
+    then: function (callback) {
+        callback();
+        return this;
+    },
+    next: function (callback) {
+        callback();
+        return this;
+    }
+};

--- a/lib/content-services/src/lib/upload/components/base-upload/upload-base.ts
+++ b/lib/content-services/src/lib/upload/components/base-upload/upload-base.ts
@@ -126,14 +126,15 @@ export abstract class UploadBase implements OnInit, OnDestroy {
             const event = new UploadFilesEvent(
                 [...filteredFiles],
                 this.uploadService,
-                this.success
+                this.success,
+                this.error
             );
             this.beginUpload.emit(event);
 
             if (!event.defaultPrevented) {
                 if (filteredFiles.length > 0) {
                     this.uploadService.addToQueue(...filteredFiles);
-                    this.uploadService.uploadFilesInTheQueue(this.success);
+                    this.uploadService.uploadFilesInTheQueue(this.success, this.error);
                 }
             }
         });

--- a/lib/content-services/src/lib/upload/components/upload-files.event.ts
+++ b/lib/content-services/src/lib/upload/components/upload-files.event.ts
@@ -32,7 +32,8 @@ export class UploadFilesEvent {
     constructor(
         public files: Array<FileModel>,
         private uploadService: UploadService,
-        private callback: EventEmitter<any>
+        private successEmitter: EventEmitter<any>,
+        private errorEmitter: EventEmitter<any>
     ) {}
 
     pauseUpload() {
@@ -42,7 +43,7 @@ export class UploadFilesEvent {
     resumeUpload() {
         if (this.files && this.files.length > 0) {
             this.uploadService.addToQueue(...this.files);
-            this.uploadService.uploadFilesInTheQueue(this.callback);
+            this.uploadService.uploadFilesInTheQueue(this.successEmitter, this.errorEmitter);
         }
     }
 }

--- a/lib/core/services/upload.service.spec.ts
+++ b/lib/core/services/upload.service.spec.ts
@@ -195,7 +195,7 @@ describe('UploadService', () => {
             <FileUploadOptions> { parentId: '-root-' }
         );
         service.addToQueue(fileFake);
-        service.uploadFilesInTheQueue(emitter);
+        service.uploadFilesInTheQueue(null, emitter);
         expect(jasmine.Ajax.requests.mostRecent().url)
             .toBe('http://localhost:9876/ecm/alfresco/api/-default-/public/alfresco/versions/1/nodes/-root-/children?autoRename=true&include=allowableOperations');
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://alfresco.atlassian.net/browse/ADF-5369

**What is the new behaviour?**

fixed https://github.com/Alfresco/alfresco-ng2-components/issues/6352

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
