### PR TITLE
[ACA-4436] remove None option from the nodeType dropdown

### DIFF
--- a/lib/content-services/src/lib/content-metadata/services/content-type-property.service.ts
+++ b/lib/content-services/src/lib/content-metadata/services/content-type-property.service.ts
@@ -85,6 +85,7 @@ export class ContentTypePropertiesService {
             value: currentValue,
             key: 'nodeType',
             editable: true,
+            displayNoneOption: false,
             options$: options$
         });
 

--- a/lib/core/card-view/components/card-view-selectitem/card-view-selectitem.component.html
+++ b/lib/core/card-view/components/card-view-selectitem/card-view-selectitem.component.html
@@ -15,7 +15,7 @@
 
                     <adf-select-filter-input *ngIf="showInputFilter" (change)="onFilterInputChange($event)"></adf-select-filter-input>
 
-                    <mat-option *ngIf="showNoneOption() && property.key !== 'nodeType'">{{ 'CORE.CARDVIEW.NONE' | translate }}</mat-option>
+                    <mat-option *ngIf="showNoneOption()">{{ 'CORE.CARDVIEW.NONE' | translate }}</mat-option>
                     <mat-option *ngFor="let option of list$ | async"
                                 [value]="option.key">
                         {{ option.label | translate }}

--- a/lib/core/card-view/components/card-view-selectitem/card-view-selectitem.component.html
+++ b/lib/core/card-view/components/card-view-selectitem/card-view-selectitem.component.html
@@ -15,7 +15,7 @@
 
                     <adf-select-filter-input *ngIf="showInputFilter" (change)="onFilterInputChange($event)"></adf-select-filter-input>
 
-                    <mat-option *ngIf="showNoneOption()">{{ 'CORE.CARDVIEW.NONE' | translate }}</mat-option>
+                    <mat-option *ngIf="showNoneOption() && property.key !== 'nodeType'">{{ 'CORE.CARDVIEW.NONE' | translate }}</mat-option>
                     <mat-option *ngFor="let option of list$ | async"
                                 [value]="option.key">
                         {{ option.label | translate }}

--- a/lib/core/card-view/components/card-view-selectitem/card-view-selectitem.component.spec.ts
+++ b/lib/core/card-view/components/card-view-selectitem/card-view-selectitem.component.spec.ts
@@ -47,6 +47,14 @@ describe('CardViewSelectItemComponent', () => {
         key: 'key',
         editable: true
     };
+    const mockNodeTypes = [{ key: 'type1', label: 'Type 1' }, { key: 'type2', label: 'Type 2' }];
+    const mockNodeTypeProps = {
+        label: 'Select node type',
+        value: 'node type',
+        options$: of(mockNodeTypes),
+        key: 'nodeType',
+        editable: true
+    }
 
     setupTestBed({
         imports: [
@@ -158,6 +166,24 @@ describe('CardViewSelectItemComponent', () => {
             const noneElement: HTMLElement = overlayContainer.getContainerElement().querySelector('mat-option');
             expect(noneElement).toBeDefined();
             expect(noneElement.innerText).toEqual('CORE.CARDVIEW.NONE');
+        });
+
+        it('should not display None option in the nodeType select', () => {
+            component.property = new CardViewSelectItemModel({
+                ...mockNodeTypeProps,
+                editable: true
+            });
+            component.editable = true;
+            component.displayNoneOption = true;
+            component.ngOnChanges();
+            fixture.detectChanges();
+
+            const selectBox = fixture.debugElement.query(By.css('.mat-select-trigger'));
+            selectBox.triggerEventHandler('click', {});
+
+            fixture.detectChanges();
+            const optionsElement = Array.from(overlayContainer.getContainerElement().querySelectorAll('mat-option'));
+            expect(optionsElement.length).toEqual(2);
         });
 
         it('should render select box if editable property is TRUE', () => {

--- a/lib/core/card-view/components/card-view-selectitem/card-view-selectitem.component.spec.ts
+++ b/lib/core/card-view/components/card-view-selectitem/card-view-selectitem.component.spec.ts
@@ -171,10 +171,12 @@ describe('CardViewSelectItemComponent', () => {
         it('should not display None option in the nodeType select', () => {
             component.property = new CardViewSelectItemModel({
                 ...mockNodeTypeProps,
-                editable: true
+                editable: true,
+                displayNoneOption: false
             });
             component.editable = true;
             component.displayNoneOption = true;
+
             component.ngOnChanges();
             fixture.detectChanges();
 

--- a/lib/core/card-view/components/card-view-selectitem/card-view-selectitem.component.ts
+++ b/lib/core/card-view/components/card-view-selectitem/card-view-selectitem.component.ts
@@ -98,7 +98,7 @@ export class CardViewSelectItemComponent extends BaseCardView<CardViewSelectItem
     }
 
     showNoneOption() {
-        return this.displayNoneOption && this.property.key !== 'nodeType';
+        return this.displayNoneOption && this.property.displayNoneOption;
     }
 
     get showProperty(): boolean {

--- a/lib/core/card-view/components/card-view-selectitem/card-view-selectitem.component.ts
+++ b/lib/core/card-view/components/card-view-selectitem/card-view-selectitem.component.ts
@@ -98,7 +98,7 @@ export class CardViewSelectItemComponent extends BaseCardView<CardViewSelectItem
     }
 
     showNoneOption() {
-        return this.displayNoneOption;
+        return this.displayNoneOption && this.property.key !== 'nodeType';
     }
 
     get showProperty(): boolean {

--- a/lib/core/card-view/interfaces/card-view-selectitem-properties.interface.ts
+++ b/lib/core/card-view/interfaces/card-view-selectitem-properties.interface.ts
@@ -26,4 +26,5 @@ export interface CardViewSelectItemOption<T> {
 export interface CardViewSelectItemProperties<T> extends CardViewItemProperties {
     value: string | number;
     options$: Observable<CardViewSelectItemOption<T>[]>;
+    displayNoneOption?: boolean;
 }

--- a/lib/core/card-view/models/card-view-selectitem.model.ts
+++ b/lib/core/card-view/models/card-view-selectitem.model.ts
@@ -24,6 +24,9 @@ import { switchMap } from 'rxjs/operators';
 
 export class CardViewSelectItemModel<T> extends CardViewBaseItemModel implements CardViewItem, DynamicComponentModel {
     type: string = 'select';
+
+    displayNoneOption: boolean;
+
     options$: Observable<CardViewSelectItemOption<T>[]>;
 
     valueFetch$: Observable<string> = null;
@@ -38,6 +41,8 @@ export class CardViewSelectItemModel<T> extends CardViewBaseItemModel implements
                 const option = options.find((o) => o.key === this.value?.toString());
                 return of(option ? option.label : '');
         }));
+
+        this.displayNoneOption = cardViewSelectItemProperties.displayNoneOption ?? true;
     }
 
     get displayValue() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

None option is available and selectable in the nodeType dropdown, which causes ACA-4436

**What is the new behaviour?**

remove the None option from the nodeType select

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other Information**:
