### PR TITLE
[AAE-5362] Add option to make actions button visible only on hover

### DIFF
--- a/docs/core/components/datatable.component.md
+++ b/docs/core/components/datatable.component.md
@@ -346,6 +346,7 @@ Learm more about styling your datatable: [Customizing the component's styles](#c
 | ---- | ---- | ------------- | ----------- |
 | actions | `boolean` | false | Toggles the data actions column. |
 | actionsPosition | `string` | "right" | Position of the actions dropdown menu. Can be "left" or "right". |
+| actionsVisibleOnHover | `boolean` | false | If set to true, the actions button will only be visible on row hover. |
 | allowFiltering | `boolean` | false | Flag that indicate if the datatable allow the use facet [widget](../../../lib/testing/src/lib/core/pages/form/widgets/widget.ts) search for filtering. |
 | columns | `any[]` | \[] | The columns that the datatable will show. |
 | contextMenu | `boolean` | false | Toggles custom context menu for the component. |

--- a/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.spec.ts
+++ b/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.spec.ts
@@ -407,7 +407,7 @@ describe('ContentMetadataComponent', () => {
             component.displayEmpty = true;
 
             fixture.detectChanges();
-            await fixture.whenStable()
+            await fixture.whenStable();
 
             let defaultProp = queryDom(fixture);
             let exifProp = queryDom(fixture, 'EXIF');
@@ -419,7 +419,7 @@ describe('ContentMetadataComponent', () => {
             component.displayAspect = 'CUSTOM';
 
             fixture.detectChanges();
-            await fixture.whenStable()
+            await fixture.whenStable();
 
             defaultProp = queryDom(fixture);
             exifProp = queryDom(fixture, 'EXIF');
@@ -431,7 +431,7 @@ describe('ContentMetadataComponent', () => {
             component.displayAspect = 'Properties';
 
             fixture.detectChanges();
-            await fixture.whenStable()
+            await fixture.whenStable();
 
             defaultProp = queryDom(fixture);
             exifProp = queryDom(fixture, 'EXIF');

--- a/lib/content-services/src/lib/site-dropdown/sites-dropdown.component.spec.ts
+++ b/lib/content-services/src/lib/site-dropdown/sites-dropdown.component.spec.ts
@@ -188,7 +188,7 @@ describe('DropdownSitesComponent', () => {
                 fixture.detectChanges();
                 await fixture.whenStable();
 
-                let options = debug.queryAll(By.css('mat-option'));
+                const options = debug.queryAll(By.css('mat-option'));
                 options[0].triggerEventHandler('click', null);
 
                 fixture.detectChanges();

--- a/lib/core/comments/comments.component.spec.ts
+++ b/lib/core/comments/comments.component.spec.ts
@@ -135,7 +135,7 @@ describe('CommentsComponent', () => {
         getProcessCommentsSpy.and.returnValue(of([]));
 
         fixture.detectChanges();
-        await fixture.whenStable()
+        await fixture.whenStable();
 
         expect(fixture.nativeElement.querySelector('#comment-container')).toBeNull();
     });
@@ -145,7 +145,7 @@ describe('CommentsComponent', () => {
         component.ngOnChanges({'taskId': change});
 
         fixture.detectChanges();
-        await fixture.whenStable()
+        await fixture.whenStable();
 
         expect(fixture.nativeElement.querySelector('#comment-input')).not.toBeNull();
     });
@@ -154,7 +154,7 @@ describe('CommentsComponent', () => {
         component.readOnly = true;
 
         fixture.detectChanges();
-        await fixture.whenStable()
+        await fixture.whenStable();
 
         expect(fixture.nativeElement.querySelector('#comment-input')).toBeNull();
     });

--- a/lib/core/datatable/components/datatable/datatable.component.html
+++ b/lib/core/datatable/components/datatable/datatable.component.html
@@ -72,7 +72,8 @@
                 [attr.data-automation-id]="'datatable-row-' + idx">
                 <!-- Actions (left) -->
                 <div *ngIf="actions && actionsPosition === 'left'" role="gridcell" class="adf-datatable-cell">
-                    <button mat-icon-button [matMenuTriggerFor]="menu"
+                    <button mat-icon-button [matMenuTriggerFor]="menu" #matMenuTrigger="matMenuTrigger"
+                            [ngClass]="{'adf-datatable-hide-actions-without-hover': actionsVisibleOnHover && !matMenuTrigger.menuOpen}"
                             [title]="'ADF-DATATABLE.CONTENT-ACTIONS.TOOLTIP' | translate"
                             [attr.id]="'action_menu_left_' + idx"
                             [attr.data-automation-id]="'action_menu_' + idx">
@@ -209,7 +210,8 @@
                 <div *ngIf="actions && actionsPosition === 'right'"
                      role="gridcell"
                      class="adf-datatable-cell adf-datatable__actions-cell adf-datatable-center-actions-column-ie">
-                    <button mat-icon-button [matMenuTriggerFor]="menu"
+                    <button mat-icon-button [matMenuTriggerFor]="menu" #matMenuTrigger="matMenuTrigger"
+                            [ngClass]="{'adf-datatable-hide-actions-without-hover': actionsVisibleOnHover && !matMenuTrigger.menuOpen}"
                             [attr.aria-label]="'ADF-DATATABLE.ACCESSIBILITY.ROW_OPTION_BUTTON' | translate"
                             [title]="'ADF-DATATABLE.CONTENT-ACTIONS.TOOLTIP' | translate"
                             [attr.id]="'action_menu_right_' + idx"

--- a/lib/core/datatable/components/datatable/datatable.component.html
+++ b/lib/core/datatable/components/datatable/datatable.component.html
@@ -72,8 +72,8 @@
                 [attr.data-automation-id]="'datatable-row-' + idx">
                 <!-- Actions (left) -->
                 <div *ngIf="actions && actionsPosition === 'left'" role="gridcell" class="adf-datatable-cell">
-                    <button mat-icon-button [matMenuTriggerFor]="menu" #matMenuTrigger="matMenuTrigger"
-                            [ngClass]="{'adf-datatable-hide-actions-without-hover': actionsVisibleOnHover && !matMenuTrigger.menuOpen}"
+                    <button mat-icon-button [matMenuTriggerFor]="menu" #actionsMenuTrigger="matMenuTrigger"
+                            [ngClass]="getHideActionsWithoutHoverClass(actionsMenuTrigger)"
                             [title]="'ADF-DATATABLE.CONTENT-ACTIONS.TOOLTIP' | translate"
                             [attr.id]="'action_menu_left_' + idx"
                             [attr.data-automation-id]="'action_menu_' + idx">
@@ -210,8 +210,8 @@
                 <div *ngIf="actions && actionsPosition === 'right'"
                      role="gridcell"
                      class="adf-datatable-cell adf-datatable__actions-cell adf-datatable-center-actions-column-ie">
-                    <button mat-icon-button [matMenuTriggerFor]="menu" #matMenuTrigger="matMenuTrigger"
-                            [ngClass]="{'adf-datatable-hide-actions-without-hover': actionsVisibleOnHover && !matMenuTrigger.menuOpen}"
+                    <button mat-icon-button [matMenuTriggerFor]="menu" #actionsMenuTrigger="matMenuTrigger"
+                            [ngClass]="getHideActionsWithoutHoverClass(actionsMenuTrigger)"
                             [attr.aria-label]="'ADF-DATATABLE.ACCESSIBILITY.ROW_OPTION_BUTTON' | translate"
                             [title]="'ADF-DATATABLE.CONTENT-ACTIONS.TOOLTIP' | translate"
                             [attr.id]="'action_menu_right_' + idx"

--- a/lib/core/datatable/components/datatable/datatable.component.scss
+++ b/lib/core/datatable/components/datatable/datatable.component.scss
@@ -149,6 +149,10 @@
                 top: 4px;
             }
 
+            .adf-datatable-row:not(:hover) .adf-datatable-hide-actions-without-hover {
+                display: none;
+            }
+
             .adf-image-table-cell {
                 margin: 8px;
                 padding: 4px;
@@ -437,6 +441,10 @@
         .adf-datatable__actions-cell, .adf-datatable-cell--image {
             max-width: $data-table-thumbnail-width;
             display: flex;
+        }
+
+        .adf-datatable-row:not(:hover) .adf-datatable-hide-actions-without-hover {
+            display: none;
         }
 
         .adf-datatable-cell--image {

--- a/lib/core/datatable/components/datatable/datatable.component.ts
+++ b/lib/core/datatable/components/datatable/datatable.component.ts
@@ -22,6 +22,7 @@ import {
 } from '@angular/core';
 import { FocusKeyManager } from '@angular/cdk/a11y';
 import { MatCheckboxChange } from '@angular/material/checkbox';
+import { MatMenuTrigger } from '@angular/material/menu';
 import { Subscription, Observable, Observer } from 'rxjs';
 import { DataColumnListComponent } from '../../../data-column/data-column-list.component';
 import { DataColumn } from '../../data/data-column.model';
@@ -678,6 +679,10 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck,
         } else {
             this.executeRowAction.emit(new DataRowActionEvent(row, action));
         }
+    }
+
+    getHideActionsWithoutHoverClass(actionsMenuTrigger: MatMenuTrigger) {
+        return { 'adf-datatable-hide-actions-without-hover': this.actionsVisibleOnHover && !actionsMenuTrigger.menuOpen };
     }
 
     rowAllowsDrop(row: DataRow): boolean {

--- a/lib/core/datatable/components/datatable/datatable.component.ts
+++ b/lib/core/datatable/components/datatable/datatable.component.ts
@@ -103,6 +103,10 @@ export class DataTableComponent implements AfterContentInit, OnChanges, DoCheck,
     @Input()
     actionsPosition: string = 'right'; // left|right
 
+    /** Toggles whether the actions dropdown should only be visible if the row is hovered over or the dropdown menu is open. */
+    @Input()
+    actionsVisibleOnHover: boolean = false;
+
     /** Fallback image for rows where the thumbnail is missing. */
     @Input()
     fallbackThumbnail: string;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://alfresco.atlassian.net/browse/AAE-5362

**What is the new behaviour?**

A new option "actionsVisibleOnHover" makes it so that the action button will only be visible on row hover, or while the menu button is open.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
