### PR TITLE
[ACA-4503] Fix closing dialogs behind when closing the content selector dialog

### DIFF
--- a/lib/content-services/src/lib/content-node-selector/content-node-dialog.service.spec.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-dialog.service.spec.ts
@@ -33,7 +33,7 @@ const fakeNodeEntry: NodeEntry = <NodeEntry> {
     }
 };
 
-const fakeNode: Node = <Node>  {
+const fakeNode: Node = <Node> {
     id: 'fake',
     name: 'fake-name'
 };
@@ -87,6 +87,7 @@ describe('ContentNodeDialogService', () => {
         spyOnDialogOpen = spyOn(materialDialog, 'open').and.returnValue({
             afterOpen: () => afterOpenObservable,
             afterClosed: () => of({}),
+            close: () => { },
             componentInstance: {
                 error: new Subject<any>()
             }
@@ -112,7 +113,7 @@ describe('ContentNodeDialogService', () => {
 
     it('should NOT be able to open the dialog when node has NOT permission', () => {
         service.openCopyMoveDialog(NodeAction.CHOOSE, fakeNode, 'noperm').subscribe(
-            () => {},
+            () => { },
             (error) => {
                 expect(spyOnDialogOpen).not.toHaveBeenCalled();
                 expect(JSON.parse(error.message).error.statusCode).toBe(403);
@@ -121,7 +122,7 @@ describe('ContentNodeDialogService', () => {
 
     it('should be able to open the dialog using a folder id', fakeAsync(() => {
         spyOn(documentListService, 'getFolderNode').and.returnValue(of(fakeNodeEntry));
-        service.openFileBrowseDialogByFolderId('fake-folder-id').subscribe(() => {});
+        service.openFileBrowseDialogByFolderId('fake-folder-id').subscribe(() => { });
         tick();
         expect(spyOnDialogOpen).toHaveBeenCalled();
     }));
@@ -129,7 +130,7 @@ describe('ContentNodeDialogService', () => {
     it('should be able to open the dialog for files using the first user site', fakeAsync(() => {
         spyOn(sitesService, 'getSites').and.returnValue(of(fakeSiteList));
         spyOn(documentListService, 'getFolderNode').and.returnValue(of(fakeNodeEntry));
-        service.openFileBrowseDialogBySite().subscribe(() => {});
+        service.openFileBrowseDialogBySite().subscribe(() => { });
         tick();
         expect(spyOnDialogOpen).toHaveBeenCalled();
     }));
@@ -137,16 +138,24 @@ describe('ContentNodeDialogService', () => {
     it('should be able to open the dialog for folder using the first user site', fakeAsync(() => {
         spyOn(sitesService, 'getSites').and.returnValue(of(fakeSiteList));
         spyOn(documentListService, 'getFolderNode').and.returnValue(of(fakeNodeEntry));
-        service.openFolderBrowseDialogBySite().subscribe(() => {});
+        service.openFolderBrowseDialogBySite().subscribe(() => { });
         tick();
         expect(spyOnDialogOpen).toHaveBeenCalled();
     }));
 
-    it('should be able to close the material dialog', () => {
-        spyOn(materialDialog, 'closeAll');
-        service.close();
-        expect(materialDialog.closeAll).toHaveBeenCalled();
-    });
+    it('should be able to close the material dialog', fakeAsync(() => {
+        const openContentNodeDialogSpy = spyOn<any>(service, 'openContentNodeDialog');
+        const mockDialogRef = {
+            close: () => { }
+        };
+        const mockDialogRefCloseSpy = spyOn(mockDialogRef, 'close');
+        openContentNodeDialogSpy.and.returnValue(mockDialogRef);
+
+        const select = service.openUploadFolderDialog(NodeAction.CHOOSE, fakeNodeEntry.entry);
+        (select as Subject<Node[]>).complete();
+        tick();
+        expect(mockDialogRefCloseSpy).toHaveBeenCalled();
+    }));
 
     describe('for the copy/move dialog', () => {
         const siteNode: Node = <Node> {
@@ -201,7 +210,7 @@ describe('ContentNodeDialogService', () => {
         beforeEach(() => {
             spyOnDialogOpen.and.callFake((_: any, config: any) => {
                 testContentNodeSelectorComponentData = config.data;
-                return { componentInstance: {} };
+                return { componentInstance: {}, close: () => {} };
             });
             service.openCopyMoveDialog(NodeAction.CHOOSE, fakeNode, '!update');
         });

--- a/lib/content-services/src/lib/content-node-selector/content-node-dialog.service.spec.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-dialog.service.spec.ts
@@ -33,7 +33,7 @@ const fakeNodeEntry: NodeEntry = <NodeEntry> {
     }
 };
 
-const fakeNode: Node = <Node> {
+const fakeNode: Node = <Node>  {
     id: 'fake',
     name: 'fake-name'
 };
@@ -87,7 +87,6 @@ describe('ContentNodeDialogService', () => {
         spyOnDialogOpen = spyOn(materialDialog, 'open').and.returnValue({
             afterOpen: () => afterOpenObservable,
             afterClosed: () => of({}),
-            close: () => { },
             componentInstance: {
                 error: new Subject<any>()
             }
@@ -113,7 +112,7 @@ describe('ContentNodeDialogService', () => {
 
     it('should NOT be able to open the dialog when node has NOT permission', () => {
         service.openCopyMoveDialog(NodeAction.CHOOSE, fakeNode, 'noperm').subscribe(
-            () => { },
+            () => {},
             (error) => {
                 expect(spyOnDialogOpen).not.toHaveBeenCalled();
                 expect(JSON.parse(error.message).error.statusCode).toBe(403);
@@ -122,7 +121,7 @@ describe('ContentNodeDialogService', () => {
 
     it('should be able to open the dialog using a folder id', fakeAsync(() => {
         spyOn(documentListService, 'getFolderNode').and.returnValue(of(fakeNodeEntry));
-        service.openFileBrowseDialogByFolderId('fake-folder-id').subscribe(() => { });
+        service.openFileBrowseDialogByFolderId('fake-folder-id').subscribe(() => {});
         tick();
         expect(spyOnDialogOpen).toHaveBeenCalled();
     }));
@@ -130,7 +129,7 @@ describe('ContentNodeDialogService', () => {
     it('should be able to open the dialog for files using the first user site', fakeAsync(() => {
         spyOn(sitesService, 'getSites').and.returnValue(of(fakeSiteList));
         spyOn(documentListService, 'getFolderNode').and.returnValue(of(fakeNodeEntry));
-        service.openFileBrowseDialogBySite().subscribe(() => { });
+        service.openFileBrowseDialogBySite().subscribe(() => {});
         tick();
         expect(spyOnDialogOpen).toHaveBeenCalled();
     }));
@@ -138,23 +137,9 @@ describe('ContentNodeDialogService', () => {
     it('should be able to open the dialog for folder using the first user site', fakeAsync(() => {
         spyOn(sitesService, 'getSites').and.returnValue(of(fakeSiteList));
         spyOn(documentListService, 'getFolderNode').and.returnValue(of(fakeNodeEntry));
-        service.openFolderBrowseDialogBySite().subscribe(() => { });
+        service.openFolderBrowseDialogBySite().subscribe(() => {});
         tick();
         expect(spyOnDialogOpen).toHaveBeenCalled();
-    }));
-
-    it('should be able to close the material dialog', fakeAsync(() => {
-        const openContentNodeDialogSpy = spyOn<any>(service, 'openContentNodeDialog');
-        const mockDialogRef = {
-            close: () => { }
-        };
-        const mockDialogRefCloseSpy = spyOn(mockDialogRef, 'close');
-        openContentNodeDialogSpy.and.returnValue(mockDialogRef);
-
-        const select = service.openUploadFolderDialog(NodeAction.CHOOSE, fakeNodeEntry.entry);
-        (select as Subject<Node[]>).complete();
-        tick();
-        expect(mockDialogRefCloseSpy).toHaveBeenCalled();
     }));
 
     describe('for the copy/move dialog', () => {
@@ -210,7 +195,7 @@ describe('ContentNodeDialogService', () => {
         beforeEach(() => {
             spyOnDialogOpen.and.callFake((_: any, config: any) => {
                 testContentNodeSelectorComponentData = config.data;
-                return { componentInstance: {}, close: () => {} };
+                return { componentInstance: {} };
             });
             service.openCopyMoveDialog(NodeAction.CHOOSE, fakeNode, '!update');
         });

--- a/lib/content-services/src/lib/content-node-selector/content-node-dialog.service.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-dialog.service.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { MatDialog } from '@angular/material/dialog';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { EventEmitter, Injectable, Output } from '@angular/core';
 import { ContentService, ThumbnailService, SitesService, TranslationService, AllowableOperationsEnum } from '@alfresco/adf-core';
 import { Subject, Observable, throwError } from 'rxjs';
@@ -143,9 +143,6 @@ export class ContentNodeDialogService {
         if (this.contentService.hasAllowableOperations(contentEntry, permission)) {
 
             const select = new Subject<Node[]>();
-            select.subscribe({
-                complete: this.close.bind(this)
-            });
 
             const data: ContentNodeSelectorComponentData = {
                 title: this.getTitleTranslation(action, contentEntry.name),
@@ -159,7 +156,11 @@ export class ContentNodeDialogService {
                 select: select
             };
 
-            this.openContentNodeDialog(data, 'adf-content-node-selector-dialog', '630px');
+            const dialogRef = this.openContentNodeDialog(data, 'adf-content-node-selector-dialog', '630px');
+
+            select.subscribe({
+                complete: dialogRef.close.bind(this)
+            });
 
             return select;
         } else {
@@ -186,9 +187,6 @@ export class ContentNodeDialogService {
      */
     openUploadFolderDialog(action: NodeAction, contentEntry: Node): Observable<Node[]> {
         const select = new Subject<Node[]>();
-        select.subscribe({
-            complete: this.close.bind(this)
-        });
 
         const data: ContentNodeSelectorComponentData = {
             title: this.getTitleTranslation(action, this.translation.instant('DROPDOWN.MY_FILES_OPTION')),
@@ -201,7 +199,12 @@ export class ContentNodeDialogService {
             select: select
         };
 
-        this.openContentNodeDialog(data, 'adf-content-node-selector-dialog', '630px');
+        const dialogRef = this.openContentNodeDialog(data, 'adf-content-node-selector-dialog', '630px');
+
+        select.subscribe({
+            complete: dialogRef.close.bind(this)
+        });
+
         return select;
     }
 
@@ -214,9 +217,6 @@ export class ContentNodeDialogService {
      */
     openUploadFileDialog(action: NodeAction, contentEntry: Node, showFilesInResult = false): Observable<Node[]> {
         const select = new Subject<Node[]>();
-        select.subscribe({
-            complete: this.close.bind(this)
-        });
 
         const data: ContentNodeSelectorComponentData = {
             title: this.getTitleTranslation(action, this.translation.instant('DROPDOWN.MY_FILES_OPTION')),
@@ -229,12 +229,17 @@ export class ContentNodeDialogService {
             showFilesInResult
         };
 
-        this.openContentNodeDialog(data, 'adf-content-node-selector-dialog', '630px');
+        const dialogRef = this.openContentNodeDialog(data, 'adf-content-node-selector-dialog', '630px');
+
+        select.subscribe({
+            complete: dialogRef.close.bind(this)
+        });
+
         return select;
     }
 
-    private openContentNodeDialog(data: ContentNodeSelectorComponentData, panelClass: string, width: string) {
-        this.dialog.open(ContentNodeSelectorComponent, {
+    private openContentNodeDialog(data: ContentNodeSelectorComponentData, panelClass: string, width: string): MatDialogRef<ContentNodeSelectorComponent> {
+        return this.dialog.open(ContentNodeSelectorComponent, {
             data,
             panelClass,
             width,
@@ -271,11 +276,6 @@ export class ContentNodeDialogService {
 
     private isSite(entry) {
         return !!entry.guid || entry.nodeType === 'st:site' || entry.nodeType === 'st:sites';
-    }
-
-    /** Closes the currently open dialog. */
-    close() {
-        this.dialog.closeAll();
     }
 
 }

--- a/lib/content-services/src/lib/content-node-selector/content-node-dialog.service.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-dialog.service.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { MatDialog } from '@angular/material/dialog';
 import { EventEmitter, Injectable, Output } from '@angular/core';
 import { ContentService, ThumbnailService, SitesService, TranslationService, AllowableOperationsEnum } from '@alfresco/adf-core';
 import { Subject, Observable, throwError } from 'rxjs';
@@ -156,11 +156,7 @@ export class ContentNodeDialogService {
                 select: select
             };
 
-            const dialogRef = this.openContentNodeDialog(data, 'adf-content-node-selector-dialog', '630px');
-
-            select.subscribe({
-                complete: dialogRef.close.bind(this)
-            });
+            this.openContentNodeDialog(data, 'adf-content-node-selector-dialog', '630px');
 
             return select;
         } else {
@@ -199,12 +195,7 @@ export class ContentNodeDialogService {
             select: select
         };
 
-        const dialogRef = this.openContentNodeDialog(data, 'adf-content-node-selector-dialog', '630px');
-
-        select.subscribe({
-            complete: dialogRef.close.bind(this)
-        });
-
+        this.openContentNodeDialog(data, 'adf-content-node-selector-dialog', '630px');
         return select;
     }
 
@@ -229,17 +220,12 @@ export class ContentNodeDialogService {
             showFilesInResult
         };
 
-        const dialogRef = this.openContentNodeDialog(data, 'adf-content-node-selector-dialog', '630px');
-
-        select.subscribe({
-            complete: dialogRef.close.bind(this)
-        });
-
+        this.openContentNodeDialog(data, 'adf-content-node-selector-dialog', '630px');
         return select;
     }
 
-    private openContentNodeDialog(data: ContentNodeSelectorComponentData, panelClass: string, width: string): MatDialogRef<ContentNodeSelectorComponent> {
-        return this.dialog.open(ContentNodeSelectorComponent, {
+    private openContentNodeDialog(data: ContentNodeSelectorComponentData, panelClass: string, width: string) {
+        this.dialog.open(ContentNodeSelectorComponent, {
             data,
             panelClass,
             width,

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector.component.spec.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector.component.spec.ts
@@ -37,6 +37,7 @@ describe('ContentNodeSelectorComponent', () => {
     let fixture: ComponentFixture<ContentNodeSelectorComponent>;
     let data: any;
     let uploadService: UploadService;
+    let dialog: MatDialogRef<ContentNodeSelectorComponent>;
 
     beforeEach(() => {
         data = {
@@ -73,6 +74,7 @@ describe('ContentNodeSelectorComponent', () => {
 
         const documentListService = TestBed.inject(DocumentListService);
         const sitesService: SitesService = TestBed.inject(SitesService);
+        dialog = TestBed.inject(MatDialogRef);
         uploadService = TestBed.inject(UploadService);
 
         spyOn(documentListService, 'getFolder').and.callThrough();
@@ -193,6 +195,23 @@ describe('ContentNodeSelectorComponent', () => {
             const closeButton = fixture.debugElement.query(By.css('[content-node-selector-actions-cancel]'));
             expect(closeButton).toBeNull();
         });
+
+        it('should close the dialog', () => {
+            let cancelButton;
+            data.select.subscribe(
+                () => {
+                },
+                () => {
+                },
+                () => {
+                    cancelButton = fixture.debugElement.query(By.css('[data-automation-id="content-node-selector-actions-cancel"]'));
+                    expect(cancelButton).not.toBeNull();
+                });
+
+            cancelButton = fixture.debugElement.query(By.css('[data-automation-id="content-node-selector-actions-cancel"]'));
+            cancelButton.triggerEventHandler('click', {});
+            expect(dialog.close).toHaveBeenCalled();
+        });
     });
 
     describe('Action button for the chosen node', () => {
@@ -226,6 +245,16 @@ describe('ContentNodeSelectorComponent', () => {
             const actionButtonWithoutNodeSelected = fixture.debugElement.query(By.css('[data-automation-id="content-node-selector-actions-choose"]'));
 
             expect(actionButtonWithoutNodeSelected.nativeElement.disabled).toBe(true);
+        });
+
+        it('should close the dialog when action button is clicked', async () => {
+            component.onSelect([new Node({ id: 'fake' })]);
+            fixture.detectChanges();
+
+            const actionButton = fixture.debugElement.query(By.css('[data-automation-id="content-node-selector-actions-choose"]'));
+            await actionButton.nativeElement.click();
+
+            expect(dialog.close).toHaveBeenCalled();
         });
     });
 

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector.component.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector.component.ts
@@ -77,6 +77,7 @@ export class ContentNodeSelectorComponent implements OnInit {
 
     close() {
         this.data.select.complete();
+        this.dialog.close();
     }
 
     onSelect(nodeList: Node[]) {
@@ -94,7 +95,7 @@ export class ContentNodeSelectorComponent implements OnInit {
 
     onClick(): void {
         this.data.select.next(this.chosenNode);
-        this.data.select.complete();
+        this.close();
     }
 
     updateTitle(siteTitle: string) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ACA-4503


**What is the new behaviour?**
https://alfresco.atlassian.net/browse/ACA-4503


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
