### PR TITLE
[AAE-5458] - Reset filters when the filter input is not defined (rollback code causing regression)

### DIFF
--- a/lib/process-services-cloud/src/lib/process/process-filters/components/process-filters-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/process/process-filters/components/process-filters-cloud.component.spec.ts
@@ -231,13 +231,10 @@ describe('ProcessFiltersCloudComponent', () => {
         expect(filterClickedSpy).toHaveBeenCalledWith(mockProcessFilters[0]);
     });
 
-    it('should reset the filter when the param is undefined', async () => {
+    it('should reset the filter when the param is undefined',  () => {
         const change = new SimpleChange(mockProcessFilters[0], undefined, false);
         component.currentFilter = mockProcessFilters[0];
         component.ngOnChanges({ 'filterParam': change });
-
-        fixture.detectChanges();
-        await fixture.whenStable();
 
         expect(component.currentFilter).toEqual(undefined);
     });

--- a/lib/process-services-cloud/src/lib/process/process-filters/components/process-filters-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/process/process-filters/components/process-filters-cloud.component.spec.ts
@@ -231,7 +231,7 @@ describe('ProcessFiltersCloudComponent', () => {
         expect(filterClickedSpy).toHaveBeenCalledWith(mockProcessFilters[0]);
     });
 
-    it('should reset the filter when the param is undefined',  () => {
+    it('should reset the filter when the param is undefined', () => {
         const change = new SimpleChange(mockProcessFilters[0], undefined, false);
         component.currentFilter = mockProcessFilters[0];
         component.ngOnChanges({ 'filterParam': change });

--- a/lib/process-services-cloud/src/lib/process/process-filters/components/process-filters-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/process/process-filters/components/process-filters-cloud.component.ts
@@ -95,10 +95,7 @@ export class ProcessFiltersCloudComponent implements OnInit, OnChanges, OnDestro
             (res: ProcessFilterCloudModel[]) => {
                 this.resetFilter();
                 this.filters = res || [];
-
-                if (this.filterParam) {
-                    this.selectFilterAndEmit(this.filterParam);
-                }
+                this.selectFilterAndEmit(this.filterParam);
                 this.success.emit(res);
             },
             (err: any) => {

--- a/lib/process-services-cloud/src/lib/task/task-filters/components/service-task-filters-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/task/task-filters/components/service-task-filters-cloud.component.spec.ts
@@ -231,7 +231,7 @@ describe('ServiceTaskFiltersCloudComponent', () => {
         expect(filterClickedSpy).not.toHaveBeenCalled();
     });
 
-    it('should reset the filter when the param is undefined',  () => {
+    it('should reset the filter when the param is undefined', () => {
         const change = new SimpleChange(null, undefined, false);
         component.currentFilter = fakeGlobalServiceFilters[0];
         component.ngOnChanges({ 'filterParam': change });

--- a/lib/process-services-cloud/src/lib/task/task-filters/components/service-task-filters-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/task/task-filters/components/service-task-filters-cloud.component.spec.ts
@@ -231,13 +231,10 @@ describe('ServiceTaskFiltersCloudComponent', () => {
         expect(filterClickedSpy).not.toHaveBeenCalled();
     });
 
-    it('should reset the filter when the param is undefined', async () => {
+    it('should reset the filter when the param is undefined',  () => {
         const change = new SimpleChange(null, undefined, false);
         component.currentFilter = fakeGlobalServiceFilters[0];
         component.ngOnChanges({ 'filterParam': change });
-
-        fixture.detectChanges();
-        await fixture.whenStable();
 
         expect(component.currentFilter).toBe(undefined);
     });

--- a/lib/process-services-cloud/src/lib/task/task-filters/components/service-task-filters-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-filters/components/service-task-filters-cloud.component.ts
@@ -70,10 +70,7 @@ export class ServiceTaskFiltersCloudComponent extends BaseTaskFiltersCloudCompon
             (res: ServiceTaskFilterCloudModel[]) => {
                 this.resetFilter();
                 this.filters = res || [];
-
-                if (this.filterParam) {
-                    this.selectFilterAndEmit(this.filterParam);
-                }
+                this.selectFilterAndEmit(this.filterParam);
                 this.success.emit(res);
             },
             (err: any) => {

--- a/lib/process-services-cloud/src/lib/task/task-filters/components/service-task-filters-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-filters/components/service-task-filters-cloud.component.ts
@@ -101,6 +101,8 @@ export class ServiceTaskFiltersCloudComponent extends BaseTaskFiltersCloudCompon
             if (this.currentFilter) {
                 this.filterSelected.emit(this.currentFilter);
             }
+        } else {
+            this.currentFilter = undefined;
         }
     }
 

--- a/lib/process-services-cloud/src/lib/task/task-filters/components/task-filters-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/task/task-filters/components/task-filters-cloud.component.spec.ts
@@ -248,7 +248,7 @@ describe('TaskFiltersCloudComponent', () => {
         expect(filterClickedSpy).not.toHaveBeenCalled();
     });
 
-    it('should reset the filter when the param is undefined', async () => {
+    it('should reset the filter when the param is undefined', () => {
         const change = new SimpleChange(fakeGlobalFilter[0], undefined, false);
         component.currentFilter = fakeGlobalFilter[0];
         component.ngOnChanges({ 'filterParam': change });

--- a/lib/process-services-cloud/src/lib/task/task-filters/components/task-filters-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/task/task-filters/components/task-filters-cloud.component.spec.ts
@@ -253,9 +253,6 @@ describe('TaskFiltersCloudComponent', () => {
         component.currentFilter = fakeGlobalFilter[0];
         component.ngOnChanges({ 'filterParam': change });
 
-        fixture.detectChanges();
-        await fixture.whenStable();
-
         expect(component.currentFilter).toEqual(undefined);
     });
 

--- a/lib/process-services-cloud/src/lib/task/task-filters/components/task-filters-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-filters/components/task-filters-cloud.component.ts
@@ -80,11 +80,7 @@ export class TaskFiltersCloudComponent extends BaseTaskFiltersCloudComponent imp
             (res: TaskFilterCloudModel[]) => {
                 this.resetFilter();
                 this.filters = res || [];
-
-                if (this.filterParam) {
-                    this.selectFilterAndEmit(this.filterParam);
-                }
-
+                this.selectFilterAndEmit(this.filterParam);
                 this.updateFilterCounters();
                 this.success.emit(res);
             },

--- a/lib/process-services-cloud/src/lib/task/task-filters/components/task-filters-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-filters/components/task-filters-cloud.component.ts
@@ -154,6 +154,8 @@ export class TaskFiltersCloudComponent extends BaseTaskFiltersCloudComponent imp
                 this.resetFilterCounter(this.currentFilter.key);
                 this.filterSelected.emit(this.currentFilter);
             }
+        } else {
+            this.currentFilter = undefined;
         }
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/AAE-5458


**What is the new behaviour?**
This PR rolls back changes that were made as part of https://github.com/Alfresco/alfresco-ng2-components/pull/7099 and are causing the regression


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
