### PR TITLE
[MNT-22334] ADW - User information not displayed when Kerberos is in use

### DIFF
--- a/demo-shell/src/app.config.json
+++ b/demo-shell/src/app.config.json
@@ -10,7 +10,7 @@
   "locale": "en",
   "notificationDefaultDuration": 2000,
   "auth": {
-    "withCredentials": true
+    "withCredentials": false
   },
   "oauth2": {
     "host": "{protocol}//{hostname}{:port}/auth/realms/alfresco",

--- a/demo-shell/src/app.config.json
+++ b/demo-shell/src/app.config.json
@@ -10,7 +10,7 @@
   "locale": "en",
   "notificationDefaultDuration": 2000,
   "auth": {
-    "withCredentials": false
+    "withCredentials": true
   },
   "oauth2": {
     "host": "{protocol}//{hostname}{:port}/auth/realms/alfresco",

--- a/lib/core/services/authentication.service.spec.ts
+++ b/lib/core/services/authentication.service.spec.ts
@@ -65,6 +65,7 @@ describe('AuthenticationService', () => {
 
         beforeEach(() => {
             appConfigService.config.providers = 'ECM';
+            appConfigService.config.auth = { withCredentials: false };
             appConfigService.load();
             apiService.reset();
         });
@@ -186,12 +187,20 @@ describe('AuthenticationService', () => {
         it('[ECM] should return isBpmLoggedIn false', () => {
             expect(authService.isBpmLoggedIn()).toBe(false);
         });
+
+        it('[ECM] should return true if kerberos configured', () => {
+            appConfigService.config.auth.withCredentials = true ;
+
+            expect(authService.isLoggedInWith('ECM')).toBe(true);
+            expect(authService.isLoggedIn()).toBe(true);
+        });
     });
 
     describe('when the setting is BPM', () => {
 
         beforeEach(() => {
             appConfigService.config.providers = 'BPM';
+            appConfigService.config.auth = { withCredentials: false };
             appConfigService.load();
             apiService.reset();
         });
@@ -321,6 +330,7 @@ describe('AuthenticationService', () => {
 
         beforeEach(() => {
             appConfigService.config.providers = 'ECM';
+            appConfigService.config.auth = { withCredentials: false };
             appConfigService.load();
             apiService.reset();
         });
@@ -385,6 +395,7 @@ describe('AuthenticationService', () => {
 
         beforeEach(() => {
             appConfigService.config.providers = 'ALL';
+            appConfigService.config.auth = { withCredentials: false };
             appConfigService.load();
             apiService.reset();
         });

--- a/lib/core/services/authentication.service.ts
+++ b/lib/core/services/authentication.service.ts
@@ -64,6 +64,10 @@ export class AuthenticationService {
      * @returns True if logged in, false otherwise
      */
     isLoggedIn(): boolean {
+        if (this.isKerberosConfigured()) {
+            return true;
+        }
+
         if (!this.isOauth() && this.cookie.isEnabled() && !this.isRememberMeSet()) {
             return false;
         }
@@ -224,6 +228,10 @@ export class AuthenticationService {
      * @returns True if logged in, false otherwise
      */
     isEcmLoggedIn(): boolean {
+        if (this.isKerberosConfigured()) {
+            return true;
+        }
+
         if (this.isECMProvider() || this.isALLProvider()) {
             if (!this.isOauth() && this.cookie.isEnabled() && !this.isRememberMeSet()) {
                 return false;
@@ -245,6 +253,10 @@ export class AuthenticationService {
             return this.alfrescoApi.getInstance().isBpmLoggedIn();
         }
         return false;
+    }
+
+    isKerberosConfigured(): boolean {
+        return this.appConfig.get<boolean>(AppConfigValues.AUTH_WITH_CREDENTIALS, false);
     }
 
     /**


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://alfresco.atlassian.net/browse/MNT-22334

**What is the new behaviour?**


![image](https://user-images.githubusercontent.com/14145706/126275369-9d8d8815-466e-4fbc-9f91-57fe3cde2d66.png)


fixed

I have tested using this repo -> https://github.com/dhrn/alfresco-kerberos

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
