### PR TITLE
[ACA-4410] Release button is no longer visible on the info drawer 

### DIFF
--- a/lib/process-services/src/lib/task-list/components/task-header.component.ts
+++ b/lib/process-services/src/lib/task-list/components/task-header.component.ts
@@ -46,7 +46,7 @@ export class TaskHeaderComponent implements OnChanges, OnInit {
 
     /** Toggles display of the claim/release button. */
     @Input()
-    showClaimRelease = true;
+    showClaimRelease = false;
 
     /** Emitted when the task is claimed. */
     @Output()


### PR DESCRIPTION


**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

If we open a info drawer after the task is claimed, there is a release button at the bottom of the page 

**What is the new behaviour?**

There is not any release button visible on info drawer on ADW app after task is claimed


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
