### PR TITLE
[AAE-5311] Add listGroupMemberships to people content service

### DIFF
--- a/docs/core/services/people-content.service.md
+++ b/docs/core/services/people-content.service.md
@@ -29,10 +29,15 @@ Gets information about a Content Services user.
 
     -   **Returns** [`Promise`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Using_promises)`<boolean>` - 
 
--   **listPeople**(requestQuery?: [`PeopleContentQueryRequestModel`](../../../lib/core/services/people-content.service.ts#32)): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`EcmUserModel`](../../core/models/ecm-user.model.md)`[]>`<br/>
+-   **listPeople**(requestQuery?: [`PeopleContentQueryRequestModel`](../../../lib/core/services/people-content.service.ts#32)): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`PeopleContentQueryResponse`](../../../lib/core/services/people-content.service.ts)`[]>`<br/>
     Gets a list of people.
     -   _requestQuery:_ [`PeopleContentQueryRequestModel`](../../../lib/core/services/people-content.service.ts)  - (Optional) maxItems and skipCount used for pagination
-    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`EcmUserModel`](../../core/models/ecm-user.model.md)`[]>` - Array of people
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`PeopleContentQueryResponse`](../../../lib/core/services/people-content.service.ts)`[]>` - Response containing pagination and list of entries
+-   **listGroupMemberships**(personId: `string`, opts?: `any`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`PeopleContentGroupsQueryResponse`](../../../lib/core/services/people-content.service.ts)`[]>`<br/>
+    Gets a list of groups a user is a member of.
+    -   _personId:_ `string`  - ID of the target user
+    -   _opts:_ `any`  - (Optional) Optional parameters
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`PeopleContentGroupsQueryResponse`](../../../lib/core/services/people-content.service.ts)`[]>` - Response containing pagination and list of entries
 
 ## Details
 

--- a/lib/core/mock/ecm-user.service.mock.ts
+++ b/lib/core/mock/ecm-user.service.mock.ts
@@ -16,7 +16,7 @@
  */
 
 import { EcmCompanyModel } from '../models/ecm-company.model';
-import { PersonEntry, Person, PersonPaging } from '@alfresco/js-api';
+import { PersonEntry, Person, PersonPaging, GroupPaging } from '@alfresco/js-api';
 import { EcmUserModel } from '../models';
 
 export const fakeEcmCompany: EcmCompanyModel = {
@@ -119,6 +119,34 @@ export const fakeEcmUserList = new PersonPaging({
             },
             {
                 entry: fakeEcmUser2
+            }
+        ]
+    }
+});
+
+export const fakeUserGroupsList = new GroupPaging({
+    list: {
+        pagination: {
+            count: 2,
+            hasMoreItems: false,
+            totalItems: 2,
+            skipCount: 0,
+            maxItems: 100
+        },
+        entries: [
+            {
+                entry: {
+                    id: 'fake-group-id-1',
+                    displayName: 'fake-group-1',
+                    isRoot: false
+                }
+            },
+            {
+                entry: {
+                    id: 'fake-group-id-2',
+                    displayName: 'fake-group-2',
+                    isRoot: false
+                }
             }
         ]
     }

--- a/lib/core/models/content-group.model.ts
+++ b/lib/core/models/content-group.model.ts
@@ -1,0 +1,32 @@
+/*!
+ * @license
+ * Copyright 2019 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export class ContentGroupModel {
+    id: string;
+    displayName: string;
+    isRoot?: boolean;
+    parentIds?: string[];
+    zones?: string[];
+
+    constructor(obj: any = {}) {
+        this.id = obj.id;
+        this.displayName = obj.displayName;
+        this.isRoot = obj.isRoot || false;
+        this.parentIds = obj.parentIds || [];
+        this.zones = obj.zones || [];
+    }
+}

--- a/lib/core/services/people-content.service.spec.ts
+++ b/lib/core/services/people-content.service.spec.ts
@@ -15,7 +15,13 @@
  * limitations under the License.
  */
 
-import { fakeEcmUser, fakeEcmUserList, createNewPersonMock, getFakeUserWithContentAdminCapability } from '../mock/ecm-user.service.mock';
+import {
+    fakeEcmUser,
+    fakeEcmUserList,
+    createNewPersonMock,
+    getFakeUserWithContentAdminCapability,
+    fakeUserGroupsList
+} from '../mock/ecm-user.service.mock';
 import { AlfrescoApiServiceMock } from '../mock/alfresco-api.service.mock';
 import { CoreTestingModule } from '../testing/core.testing.module';
 import { PeopleContentService, PeopleContentQueryResponse } from './people-content.service';
@@ -69,6 +75,22 @@ describe('PeopleContentService', () => {
             expect(getPersonSpy).toHaveBeenCalledWith('-me-');
             done();
         });
+    });
+
+    it('should be able to list the groups a user is a member of', async () => {
+        const spyObj = spyOn(service.groupsApi, 'listGroupMembershipsForPerson').and.returnValue(Promise.resolve(fakeUserGroupsList));
+        const { pagination, entries } = await service.listGroupMemberships('fake-user-id').toPromise();
+
+        expect(spyObj).toHaveBeenCalledWith('fake-user-id', undefined);
+        expect(pagination).toBeDefined();
+        expect(entries).toBeDefined();
+        expect(pagination.count).toEqual(2);
+        expect(pagination.totalItems).toEqual(2);
+        expect(pagination.hasMoreItems).toBeFalsy();
+        expect(pagination.skipCount).toEqual(0);
+        expect(pagination.maxItems).toEqual(100);
+        expect(entries[0].id).toEqual('fake-group-id-1');
+        expect(entries[1].id).toEqual('fake-group-id-2');
     });
 
     it('should be able to list people', (done) => {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://alfresco.atlassian.net/browse/AAE-5311 Adding to the people content service in adf so that it can be used from apps for this task.

**What is the new behaviour?**

Function which lists all of the groups that a user is a part of.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
