### PR TITLE
[AAE-5392] - Make search text input more configurable & add an event …

### DIFF
--- a/docs/core/components/search-text-input.component.md
+++ b/docs/core/components/search-text-input.component.md
@@ -45,7 +45,7 @@ Displays a input text that supports autocompletion
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| reset | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<>` | Emitted when the search input is reset |
+| reset | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<boolean>` | Emitted when the search input is reset |
 | searchChange | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<string>` | Emitted when the search term is changed. The search term is provided in the 'value' property of the returned object.  If the term is less than three characters in length then it is truncated to an empty string. |
 | selectResult | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<any>` | Emitted when the result list is selected |
 | submit | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<any>` | Emitted when the search is submitted by pressing the ENTER key. The search term is provided as the value of the event. |

--- a/docs/core/components/search-text-input.component.md
+++ b/docs/core/components/search-text-input.component.md
@@ -37,7 +37,9 @@ Displays a input text that supports autocompletion
 | inputType | `string` | "text" | Type of the input field to render, e.g. "search" or "text" (default). |
 | liveSearchEnabled | `boolean` | true | Toggles "find-as-you-type" suggestions for possible matches. |
 | searchAutocomplete | `any` | false | Trigger autocomplete results on input change. |
-| searchTerm | `string` | "" | Search term preselected |
+| searchTerm | `string` | "" | Search term preselected. |
+| collapseOnBlur | `boolean` | "true" | Toggles whether to collapse the search on blur. |
+| showClearButton | `boolean` | "false" | Toggles whether to show a clear button that closes the search. |
 
 ### Events
 
@@ -47,3 +49,5 @@ Displays a input text that supports autocompletion
 | searchChange | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<string>` | Emitted when the search term is changed. The search term is provided in the 'value' property of the returned object.  If the term is less than three characters in length then it is truncated to an empty string. |
 | selectResult | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<any>` | Emitted when the result list is selected |
 | submit | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<any>` | Emitted when the search is submitted by pressing the ENTER key. The search term is provided as the value of the event. |
+| searchVisibility | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<boolean>` | Emitted when the search visibility changes. True when the search is active, false when it is inactive. |
+| clearButtonClicked | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<void>` | Emitted when the clear button is clicked. |

--- a/docs/core/components/search-text-input.component.md
+++ b/docs/core/components/search-text-input.component.md
@@ -50,4 +50,3 @@ Displays a input text that supports autocompletion
 | selectResult | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<any>` | Emitted when the result list is selected |
 | submit | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<any>` | Emitted when the search is submitted by pressing the ENTER key. The search term is provided as the value of the event. |
 | searchVisibility | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<boolean>` | Emitted when the search visibility changes. True when the search is active, false when it is inactive. |
-| clearButtonClicked | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<void>` | Emitted when the clear button is clicked. |

--- a/docs/core/components/search-text-input.component.md
+++ b/docs/core/components/search-text-input.component.md
@@ -45,7 +45,7 @@ Displays a input text that supports autocompletion
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| reset | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<boolean>` | Emitted when the result list is reset |
+| reset | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<>` | Emitted when the search input is reset |
 | searchChange | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<string>` | Emitted when the search term is changed. The search term is provided in the 'value' property of the returned object.  If the term is less than three characters in length then it is truncated to an empty string. |
 | selectResult | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<any>` | Emitted when the result list is selected |
 | submit | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<any>` | Emitted when the search is submitted by pressing the ENTER key. The search term is provided as the value of the event. |

--- a/lib/content-services/src/lib/search/components/search-control.component.spec.ts
+++ b/lib/content-services/src/lib/search/components/search-control.component.spec.ts
@@ -321,17 +321,17 @@ describe('SearchControlComponent', () => {
             });
         });
 
-        it('should NOT display a autocomplete list control when configured not to', (done) => {
+        it('should NOT display a autocomplete list control when configured not to', async () => {
             searchServiceSpy.and.returnValue(of(JSON.parse(JSON.stringify(results))));
             component.liveSearchEnabled = false;
             fixture.detectChanges();
+            await fixture.whenStable();
 
             typeWordIntoSearchInput('TEST');
-            fixture.whenStable().then(() => {
-                fixture.detectChanges();
-                expect(element.querySelector('#autocomplete-search-result-list')).toBeNull();
-                done();
-            });
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            expect(element.querySelector('#autocomplete-search-result-list')).toBeNull();
         });
    });
 

--- a/lib/core/search-text/search-text-input.component.html
+++ b/lib/core/search-text/search-text-input.component.html
@@ -25,6 +25,13 @@
                    (ngModelChange)="inputChange($event)"
                    [searchAutocomplete]="searchAutocomplete ? searchAutocomplete : null"
                    (keyup.enter)="searchSubmit($event)">
+            <button mat-icon-button matSuffix
+                    data-automation-id="adf-clear-search-button"
+                    class="adf-clear-search-button"
+                    *ngIf="canShowClearSearch()"
+                    (mousedown)="onClearSearch()">
+                <mat-icon>clear</mat-icon>
+            </button>
         </mat-form-field>
     </div>
-</div> 
+</div>

--- a/lib/core/search-text/search-text-input.component.html
+++ b/lib/core/search-text/search-text-input.component.html
@@ -29,7 +29,7 @@
                     data-automation-id="adf-clear-search-button"
                     class="adf-clear-search-button"
                     *ngIf="canShowClearSearch()"
-                    (mousedown)="onClearSearch()">
+                    (mousedown)="resetSearch()">
                 <mat-icon>clear</mat-icon>
             </button>
         </mat-form-field>

--- a/lib/core/search-text/search-text-input.component.spec.ts
+++ b/lib/core/search-text/search-text-input.component.spec.ts
@@ -25,7 +25,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import { UserPreferencesService } from '../services/user-preferences.service';
 import { setupTestBed } from '../testing/setup-test-bed';
 
-describe('SearchTextInputComponent', () => {
+fdescribe('SearchTextInputComponent', () => {
 
     let fixture: ComponentFixture<SearchTextInputComponent>;
     let component: SearchTextInputComponent;
@@ -258,6 +258,107 @@ describe('SearchTextInputComponent', () => {
             await fixture.whenStable();
 
             expect(element.querySelector('#adf-control-input').getAttribute('autocomplete')).toBe('on');
+        });
+    });
+
+    describe('Search visibility', () => {
+        beforeEach(() => {
+            userPreferencesService.setWithoutStore('textOrientation', 'ltr');
+            fixture.detectChanges();
+        });
+
+        it('should emit an event when the search becomes active', fakeAsync(() => {
+            const searchVisibilityChangeSpy = spyOn(component.searchVisibility, 'emit');
+            component.toggleSearchBar();
+            tick(200);
+
+            expect(searchVisibilityChangeSpy).toHaveBeenCalledWith(true);
+        }));
+
+        it('should emit an event when the search becomes inactive', fakeAsync(() => {
+            component.toggleSearchBar();
+            tick(200);
+            expect(component.subscriptAnimationState.value).toEqual('active');
+
+            const searchVisibilityChangeSpy = spyOn(component.searchVisibility, 'emit');
+            component.toggleSearchBar();
+            tick(200);
+
+            expect(component.subscriptAnimationState.value).toEqual('inactive');
+            expect(searchVisibilityChangeSpy).toHaveBeenCalledWith(false);
+        }));
+
+        describe('Clear button', () => {
+            beforeEach(fakeAsync(() => {
+                fixture.detectChanges();
+                component.toggleSearchBar();
+                tick(200);
+            }));
+
+            it('should clear button be visible when showClearButton is set to true', async () => {
+                component.showClearButton = true;
+                fixture.detectChanges();
+                await fixture.whenStable();
+                const clearButton = fixture.debugElement.query(By.css('[data-automation-id="adf-clear-search-button"]'));
+
+                expect(clearButton).not.toBeNull();
+            });
+
+            it('should clear button not be visible when showClearButton is set to false', () => {
+                component.showClearButton = false;
+                fixture.detectChanges();
+                const clearButton = fixture.debugElement.query(By.css('[data-automation-id="adf-clear-search-button"]'));
+
+                expect(clearButton).toBeNull();
+            });
+
+            it('should reset the search when clicking the clear button', async () => {
+                const clearButtonEmitterSpy = spyOn(component.clearButtonClicked, 'emit');
+                const searchVisibilityChangeSpy = spyOn(component.searchVisibility, 'emit');
+                component.searchTerm = 'fake-search-term';
+                component.showClearButton = true;
+                fixture.detectChanges();
+                await fixture.whenStable();
+
+                const clearButton = fixture.debugElement.query(By.css('[data-automation-id="adf-clear-search-button"]'));
+                clearButton.nativeElement.dispatchEvent(new MouseEvent('mousedown'));
+
+                expect(clearButtonEmitterSpy).toHaveBeenCalled();
+                expect(searchVisibilityChangeSpy).toHaveBeenCalledWith(false);
+                expect(component.subscriptAnimationState.value).toEqual('inactive');
+                expect(component.searchTerm).toEqual('');
+            });
+
+        });
+
+        describe('Collapse on blur', () => {
+            beforeEach(fakeAsync(() => {
+                fixture.detectChanges();
+                component.toggleSearchBar();
+                tick(200);
+            }));
+
+            it('should collapse search on blur when the collapseOnBlur is set to true', () => {
+                const searchVisibilityChangeSpy = spyOn(component.searchVisibility, 'emit');
+                component.collapseOnBlur = true;
+                component.searchTerm = 'fake-search-term';
+                component.onBlur({ relatedTarget: null });
+
+                expect(searchVisibilityChangeSpy).toHaveBeenCalledWith(false);
+                expect(component.subscriptAnimationState.value).toEqual('inactive');
+                expect(component.searchTerm).toEqual('');
+            });
+
+            it('should not collapse search on blur when the collapseOnBlur is set to false', () => {
+                const searchVisibilityChangeSpy = spyOn(component.searchVisibility, 'emit');
+                component.searchTerm = 'fake-search-term';
+                component.collapseOnBlur = false;
+                component.onBlur({ relatedTarget: null });
+
+                expect(searchVisibilityChangeSpy).not.toHaveBeenCalled();
+                expect(component.subscriptAnimationState.value).toEqual('active');
+                expect(component.searchTerm).toEqual('fake-search-term');
+            });
         });
     });
 });

--- a/lib/core/search-text/search-text-input.component.spec.ts
+++ b/lib/core/search-text/search-text-input.component.spec.ts
@@ -288,6 +288,23 @@ describe('SearchTextInputComponent', () => {
             expect(searchVisibilityChangeSpy).toHaveBeenCalledWith(false);
         }));
 
+        it('should reset the search term when the search becomes inactive', fakeAsync(() => {
+            const searchTermEmitSpy = spyOn(component.searchChange, 'emit');
+            const resetSpy = spyOn(component.reset, 'emit');
+
+            component.toggleSearchBar();
+            tick(200);
+            expect(component.subscriptAnimationState.value).toEqual('active');
+            component.searchTerm = 'fake-search-term';
+
+            component.toggleSearchBar();
+            tick(200);
+
+            expect(resetSpy).toHaveBeenCalledWith(true);
+            expect(component.searchTerm).toEqual('');
+            expect(searchTermEmitSpy).toHaveBeenCalledWith('');
+        }));
+
         describe('Clear button', () => {
             beforeEach(fakeAsync(() => {
                 fixture.detectChanges();
@@ -315,6 +332,8 @@ describe('SearchTextInputComponent', () => {
             it('should reset the search when clicking the clear button', async () => {
                 const clearButtonEmitterSpy = spyOn(component.clearButtonClicked, 'emit');
                 const searchVisibilityChangeSpy = spyOn(component.searchVisibility, 'emit');
+                const searchTermEmitSpy = spyOn(component.searchChange, 'emit');
+
                 component.searchTerm = 'fake-search-term';
                 component.showClearButton = true;
                 fixture.detectChanges();
@@ -327,6 +346,7 @@ describe('SearchTextInputComponent', () => {
                 expect(searchVisibilityChangeSpy).toHaveBeenCalledWith(false);
                 expect(component.subscriptAnimationState.value).toEqual('inactive');
                 expect(component.searchTerm).toEqual('');
+                expect(searchTermEmitSpy).toHaveBeenCalledWith('');
             });
 
         });
@@ -340,6 +360,7 @@ describe('SearchTextInputComponent', () => {
 
             it('should collapse search on blur when the collapseOnBlur is set to true', () => {
                 const searchVisibilityChangeSpy = spyOn(component.searchVisibility, 'emit');
+                const searchTermEmitSpy = spyOn(component.searchChange, 'emit');
                 component.collapseOnBlur = true;
                 component.searchTerm = 'fake-search-term';
                 component.onBlur({ relatedTarget: null });
@@ -347,6 +368,7 @@ describe('SearchTextInputComponent', () => {
                 expect(searchVisibilityChangeSpy).toHaveBeenCalledWith(false);
                 expect(component.subscriptAnimationState.value).toEqual('inactive');
                 expect(component.searchTerm).toEqual('');
+                expect(searchTermEmitSpy).toHaveBeenCalledWith('');
             });
 
             it('should not collapse search on blur when the collapseOnBlur is set to false', () => {

--- a/lib/core/search-text/search-text-input.component.spec.ts
+++ b/lib/core/search-text/search-text-input.component.spec.ts
@@ -288,8 +288,7 @@ describe('SearchTextInputComponent', () => {
             expect(searchVisibilityChangeSpy).toHaveBeenCalledWith(false);
         }));
 
-        it('should reset the search term when the search becomes inactive', fakeAsync(() => {
-            const searchTermEmitSpy = spyOn(component.searchChange, 'emit');
+        it('should reset emit when the search becomes inactive', fakeAsync(() => {
             const resetSpy = spyOn(component.reset, 'emit');
 
             component.toggleSearchBar();
@@ -300,15 +299,15 @@ describe('SearchTextInputComponent', () => {
             component.toggleSearchBar();
             tick(200);
 
-            expect(resetSpy).toHaveBeenCalledWith(true);
+            expect(resetSpy).toHaveBeenCalled();
             expect(component.searchTerm).toEqual('');
-            expect(searchTermEmitSpy).toHaveBeenCalledWith('');
         }));
 
         describe('Clear button', () => {
             beforeEach(fakeAsync(() => {
                 fixture.detectChanges();
-                component.toggleSearchBar();
+                component.subscriptAnimationState.value = 'active';
+                fixture.detectChanges();
                 tick(200);
             }));
 
@@ -330,9 +329,8 @@ describe('SearchTextInputComponent', () => {
             });
 
             it('should reset the search when clicking the clear button', async () => {
-                const clearButtonEmitterSpy = spyOn(component.clearButtonClicked, 'emit');
+                const resetEmitSpy = spyOn(component.reset, 'emit');
                 const searchVisibilityChangeSpy = spyOn(component.searchVisibility, 'emit');
-                const searchTermEmitSpy = spyOn(component.searchChange, 'emit');
 
                 component.searchTerm = 'fake-search-term';
                 component.showClearButton = true;
@@ -341,12 +339,13 @@ describe('SearchTextInputComponent', () => {
 
                 const clearButton = fixture.debugElement.query(By.css('[data-automation-id="adf-clear-search-button"]'));
                 clearButton.nativeElement.dispatchEvent(new MouseEvent('mousedown'));
+                fixture.detectChanges();
+                await fixture.whenStable();
 
-                expect(clearButtonEmitterSpy).toHaveBeenCalled();
+                expect(resetEmitSpy).toHaveBeenCalled();
                 expect(searchVisibilityChangeSpy).toHaveBeenCalledWith(false);
                 expect(component.subscriptAnimationState.value).toEqual('inactive');
                 expect(component.searchTerm).toEqual('');
-                expect(searchTermEmitSpy).toHaveBeenCalledWith('');
             });
 
         });
@@ -358,18 +357,19 @@ describe('SearchTextInputComponent', () => {
                 tick(200);
             }));
 
-            it('should collapse search on blur when the collapseOnBlur is set to true', () => {
+            it('should collapse search on blur when the collapseOnBlur is set to true', fakeAsync (() => {
                 const searchVisibilityChangeSpy = spyOn(component.searchVisibility, 'emit');
-                const searchTermEmitSpy = spyOn(component.searchChange, 'emit');
+                const resetEmitSpy = spyOn(component.reset, 'emit');
                 component.collapseOnBlur = true;
                 component.searchTerm = 'fake-search-term';
                 component.onBlur({ relatedTarget: null });
+                tick(200);
 
                 expect(searchVisibilityChangeSpy).toHaveBeenCalledWith(false);
                 expect(component.subscriptAnimationState.value).toEqual('inactive');
                 expect(component.searchTerm).toEqual('');
-                expect(searchTermEmitSpy).toHaveBeenCalledWith('');
-            });
+                expect(resetEmitSpy).toHaveBeenCalled();
+            }));
 
             it('should not collapse search on blur when the collapseOnBlur is set to false', () => {
                 const searchVisibilityChangeSpy = spyOn(component.searchVisibility, 'emit');

--- a/lib/core/search-text/search-text-input.component.spec.ts
+++ b/lib/core/search-text/search-text-input.component.spec.ts
@@ -25,7 +25,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import { UserPreferencesService } from '../services/user-preferences.service';
 import { setupTestBed } from '../testing/setup-test-bed';
 
-fdescribe('SearchTextInputComponent', () => {
+describe('SearchTextInputComponent', () => {
 
     let fixture: ComponentFixture<SearchTextInputComponent>;
     let component: SearchTextInputComponent;

--- a/lib/core/search-text/search-text-input.component.ts
+++ b/lib/core/search-text/search-text-input.component.ts
@@ -104,7 +104,7 @@ export class SearchTextInputComponent implements OnInit, OnDestroy {
 
     /**  Emitted when the result list is reset */
     @Output()
-    reset: EventEmitter<void> = new EventEmitter();
+    reset: EventEmitter<boolean> = new EventEmitter();
 
     /** Emitted when the search visibility changes. True when the search is active, false when it is inactive */
     @Output()
@@ -145,7 +145,7 @@ export class SearchTextInputComponent implements OnInit, OnDestroy {
                     this.subscriptAnimationState = this.toggleAnimation();
                     if (this.subscriptAnimationState.value === 'inactive') {
                         this.searchTerm = '';
-                        this.reset.emit();
+                        this.reset.emit(true);
                         if (document.activeElement.id === this.searchInput.nativeElement.id) {
                             this.searchInput.nativeElement.blur();
                         }

--- a/lib/core/search-text/search-text-input.component.ts
+++ b/lib/core/search-text/search-text-input.component.ts
@@ -149,6 +149,7 @@ export class SearchTextInputComponent implements OnInit, OnDestroy {
                     this.subscriptAnimationState = this.toggleAnimation();
                     if (this.subscriptAnimationState.value === 'inactive') {
                         this.searchTerm = '';
+                        this.searchChange.emit('');
                         this.reset.emit(true);
                         if (document.activeElement.id === this.searchInput.nativeElement.id) {
                             this.searchInput.nativeElement.blur();

--- a/lib/core/search-text/search-text-input.component.ts
+++ b/lib/core/search-text/search-text-input.component.ts
@@ -306,6 +306,7 @@ export class SearchTextInputComponent implements OnInit, OnDestroy {
         if (this.defaultState === SearchTextStateEnum.collapsed) {
             this.searchTerm = '';
             this.subscriptAnimationState = this.animationStates[this.dir].inactive;
+            this.searchChange.emit('');
             this.clearButtonClicked.emit();
             this.searchVisibility.emit(false);
         }

--- a/lib/core/search-text/search-text-input.component.ts
+++ b/lib/core/search-text/search-text-input.component.ts
@@ -250,6 +250,7 @@ export class SearchTextInputComponent implements OnInit, OnDestroy {
     onBlur($event) {
         if (this.collapseOnBlur && !$event.relatedTarget && this.defaultState === SearchTextStateEnum.collapsed) {
             this.searchTerm = '';
+            this.searchChange.emit('');
             this.subscriptAnimationState = this.animationStates[this.dir].inactive;
             this.subscriptAnimationState.value === 'active' ? this.searchVisibility.emit(true) : this.searchVisibility.emit(false);
         }


### PR DESCRIPTION
…emitter to indicate the state of it (active-inactive)

**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [X] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [X] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/AAE-5392


**What is the new behaviour?**
<img width="299" alt="Screenshot 2021-07-23 at 12 22 07 am" src="https://user-images.githubusercontent.com/32884230/126720811-08fea348-a6c4-4168-afee-65f073ef4d26.png">

Added inputs:
- Toggle a clear (X) button
- Toggle whether the search should collapse on blur

Added event emitters:
- Emits when clearing the search by the clear (X) button
- Emits the state of the search (true for active- false for inactive)


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
