### PR TITLE
[AAE-5163] Landing page title tooltip is displayed correctly

### DIFF
--- a/lib/core/templates/empty-content/empty-content.component.html
+++ b/lib/core/templates/empty-content/empty-content.component.html
@@ -1,4 +1,4 @@
-<div class="adf-empty-content">
+<div class="adf-empty-content" [title]="title | translate">
     <adf-icon class="adf-empty-content__icon" [value]="icon"></adf-icon>
     <div class="adf-empty-content__title">{{ title | translate }}</div>
     <div class="adf-empty-content__subtitle">{{ subtitle | translate }}</div>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
When we login to Admin App, we see the landing page tooltip title as 'APP.LANDING_PAGE.TITLE'

**What is the new behaviour?**
Landing page tooltip title is  "Welcome to the Alfresco Admin App" 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
