### PR TITLE
[AAE-5727] Add 'today' and 'now' as default values for date and datetime widgets

### DIFF
--- a/lib/core/form/components/widgets/core/form-field.model.spec.ts
+++ b/lib/core/form/components/widgets/core/form-field.model.spec.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import moment from 'moment';
 import { FormFieldTypes } from './form-field-types';
 import { FormFieldModel } from './form-field.model';
 import { FormModel } from './form.model';
@@ -247,6 +248,68 @@ describe('FormFieldModel', () => {
             dateDisplayFormat: 'DD-MM-YYYY'
         });
         expect(field.value).toBe('28-04-2017');
+    });
+
+    it('should set the value to today\'s date when the value is today', () => {
+        const form = new FormModel();
+        const field = new FormFieldModel(form, {
+            fieldType: 'FormFieldRepresentation',
+            id: 'ddmmyyy',
+            name: 'DD-MM-YYYY',
+            type: 'date',
+            value: 'today',
+            required: false,
+            readOnly: false,
+            params: {
+                field: {
+                    id: 'ddmmyyy',
+                    name: 'DD-MM-YYYY',
+                    type: 'date',
+                    value: 'today',
+                    required: false,
+                    readOnly: false
+                }
+            },
+            dateDisplayFormat: 'DD-MM-YYYY'
+        });
+
+        const currentDate = moment(new Date());
+        const expectedDate = moment(currentDate).format('DD-MM-YYYY');
+        const expectedDateFormat = `${currentDate.format('YYYY-MM-DD')}T00:00:00.000Z`;
+
+        expect(field.value).toBe(expectedDate);
+        expect(form.values['ddmmyyy']).toEqual(expectedDateFormat);
+    });
+
+    it('should set the value to now date time when the value is now', () => {
+        const form = new FormModel();
+        const field = new FormFieldModel(form, {
+            fieldType: 'FormFieldRepresentation',
+            id: 'datetime',
+            name: 'date and time',
+            type: 'datetime',
+            value: 'now',
+            required: false,
+            readOnly: false,
+            params: {
+                field: {
+                    id: 'datetime',
+                    name: 'date and time',
+                    type: 'datetime',
+                    value: 'now',
+                    required: false,
+                    readOnly: false
+                }
+            },
+            dateDisplayFormat: 'YYYY-MM-DD HH:mm'
+        });
+
+        const currentDateTime = moment(new Date());
+        const expectedDateTime = moment(currentDateTime).format('YYYY-MM-DD HH:mm');
+        const expectedDateTimeFormat = `${currentDateTime.utc().format('YYYY-MM-DDTHH:mm:00')}.000Z`;
+
+        expect(field.value).toBe(expectedDateTime);
+        expect(form.values['datetime']).toEqual(expectedDateTimeFormat);
     });
 
     it('should parse the checkbox set to "true" when it is readonly', () => {

--- a/lib/core/form/components/widgets/core/form-field.model.ts
+++ b/lib/core/form/components/widgets/core/form-field.model.ts
@@ -380,6 +380,10 @@ export class FormFieldModel extends FormWidgetModel {
                 }
                 break;
             case FormFieldTypes.DATE:
+                if (typeof this.value === 'string' && this.value === 'today') {
+                    this.value = moment(new Date()).format(this.dateDisplayFormat);
+                }
+
                 const dateValue = moment(this.value, this.dateDisplayFormat, true);
                 if (dateValue && dateValue.isValid()) {
                     this.form.values[this.id] = `${dateValue.format('YYYY-MM-DD')}T00:00:00.000Z`;
@@ -389,6 +393,10 @@ export class FormFieldModel extends FormWidgetModel {
                 }
                 break;
             case FormFieldTypes.DATETIME:
+                if (typeof this.value === 'string' && this.value === 'now') {
+                    this.value = moment(new Date()).format(this.dateDisplayFormat);
+                }
+
                 const dateTimeValue = moment(this.value, this.dateDisplayFormat, true).utc();
                 if (dateTimeValue && dateTimeValue.isValid()) {
                     /* cspell:disable-next-line */


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [X] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/AAE-5727


**What is the new behaviour?**
https://alfresco.atlassian.net/browse/AAE-5727


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
