### PR TITLE
[ACA-4310] - Show the breadcrumb even for invalid selections in searc…

### DIFF
--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.spec.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.spec.ts
@@ -269,13 +269,28 @@ describe('ContentNodeSelectorPanelComponent', () => {
 
             });
 
-            it('should show the breadcrumb for the selected node when search results are displayed', async () => {
+            it('should show the breadcrumb in search results for a valid node selection', async () => {
                 searchQueryBuilderService.userQuery = 'mock-search-term';
                 searchQueryBuilderService.update();
                 triggerSearchResults(fakeResultSetPaging);
 
                 const chosenNode = new Node({ path: { elements: ['one'] } });
                 component.onCurrentSelection([ { entry: chosenNode } ]);
+                fixture.detectChanges();
+
+                const breadcrumb = fixture.debugElement.query(By.directive(DropdownBreadcrumbComponent));
+                expect(breadcrumb).not.toBeNull();
+                expect(breadcrumb.componentInstance.folderNode.path).toBe(chosenNode.path);
+            });
+
+            it('should show the breadcrumb in search results even for an invalid node selection', async () => {
+                component.isSelectionValid = (node: Node) => node.isFile;
+                searchQueryBuilderService.userQuery = 'mock-search-term';
+                searchQueryBuilderService.update();
+                triggerSearchResults(fakeResultSetPaging);
+
+                const chosenNode = new Node({ path: { elements: ['fake-path'] }, isFile: false, isFolder: true });
+                component.onCurrentSelection([{ entry: chosenNode }]);
                 fixture.detectChanges();
 
                 const breadcrumb = fixture.debugElement.query(By.directive(DropdownBreadcrumbComponent));

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.ts
@@ -248,7 +248,8 @@ export class ContentNodeSelectorPanelComponent implements OnInit, OnDestroy {
     showingSearchResults: boolean = false;
     loadingSearchResults: boolean = false;
     inDialog: boolean = false;
-    _chosenNode: Node [] = null;
+    _chosenNode: Node[] = null;
+    selectionWithoutValidation: Node[] = null;
     folderIdToShow: string | null = null;
     breadcrumbFolderTitle: string | null = null;
     startSiteGuid: string | null = null;
@@ -454,8 +455,8 @@ export class ContentNodeSelectorPanelComponent implements OnInit, OnDestroy {
     get breadcrumbFolderNode(): Node | null {
         let folderNode: Node;
 
-        if (this.showingSearchResults && this.chosenNode) {
-            folderNode = this.chosenNode[0];
+        if (this.showingSearchResults && this.selectionWithoutValidation?.length) {
+            folderNode = this.selectionWithoutValidation[0];
         } else {
             folderNode = this.documentList.folderNode;
         }
@@ -629,6 +630,7 @@ export class ContentNodeSelectorPanelComponent implements OnInit, OnDestroy {
     onCurrentSelection(nodesEntries: NodeEntry[]): void {
         const validNodesEntity = nodesEntries.filter((node) => this.isSelectionValid(node.entry));
         this.chosenNode = validNodesEntity.map((node) => node.entry);
+        this.selectionWithoutValidation = nodesEntries.map(node => node.entry);
     }
 
     setTitleIfCustomSite(site: SiteEntry) {


### PR DESCRIPTION
…h results

**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ACA-4310


**What is the new behaviour?**
The breadcrumb is shown for any node selection


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
