### PR TITLE
[MNT-22613] Viewer wildcard extension

### DIFF
--- a/docs/extensions/components/preview-extension.component.md
+++ b/docs/extensions/components/preview-extension.component.md
@@ -96,6 +96,29 @@ You also need to provide a [viewer component](../../core/components/viewer.compo
 }
 ```
 
+You can also use `*` wildcard to register a single component that opens all files:
+
+```json
+{
+  "$version": "1.0.0",
+  "$name": "my viewer extension",
+  "$description": "my viewer  plugin",
+  "features": {
+    "viewer": {
+      "content": [
+        {
+          "id": "dev.tools.viewer.viewer",
+          "fileExtension": ["*"],
+          "component": "your-extension.main.component"
+        }
+      ]
+    }
+  }
+}
+```
+
+> It is recommended to use wildcard replacement only when introducing your own Viewer implementation.
+
 See the [App extensions](../../user-guide/app-extensions.md) page for
 further details of how to develop extensions.
 

--- a/lib/core/viewer/components/viewer.component.html
+++ b/lib/core/viewer/components/viewer.component.html
@@ -199,8 +199,17 @@
                  fxFlexOrder="1"
                  fxFlex="1 1 auto">
                 <div class="adf-viewer-layout-content adf-viewer__fullscreen-container">
-                    <div class="adf-viewer-content-container"
-                         [ngSwitch]="viewerType">
+                    <div class="adf-viewer-content-container" [ngSwitch]="viewerType">
+                        <ng-container *ngSwitchCase="'external'">
+                            <adf-preview-extension
+                                *ngIf="!!externalViewer"
+                                [id]="externalViewer.component"
+                                [node]="nodeEntry?.entry"
+                                [url]="urlFileContent"
+                                [extension]="externalViewer"
+                                [attr.data-automation-id]="externalViewer.component">
+                            </adf-preview-extension>
+                        </ng-container>
 
                         <ng-container *ngSwitchCase="'pdf'">
                             <adf-pdf-viewer (close)="onBackButtonClick()"

--- a/lib/core/viewer/components/viewer.component.html
+++ b/lib/core/viewer/components/viewer.component.html
@@ -206,7 +206,7 @@
                                 [id]="externalViewer.component"
                                 [node]="nodeEntry?.entry"
                                 [url]="urlFileContent"
-                                [extension]="externalViewer"
+                                [extension]="externalViewer.fileExtension"
                                 [attr.data-automation-id]="externalViewer.component">
                             </adf-preview-extension>
                         </ng-container>

--- a/lib/core/viewer/components/viewer.component.ts
+++ b/lib/core/viewer/components/viewer.component.ts
@@ -246,6 +246,15 @@ export class ViewerComponent implements OnChanges, OnInit, OnDestroy {
         return this.viewerExtensions.map(ext => ext.fileExtension);
     }
 
+    private _externalViewer: ViewerExtensionRef;
+    get externalViewer(): ViewerExtensionRef {
+        if (!this._externalViewer) {
+            this._externalViewer = this.viewerExtensions.find(ext => ext.fileExtension === '*');
+        }
+
+        return this._externalViewer;
+    }
+
     readOnly = true;
 
     private cacheBusterNumber: number;
@@ -433,7 +442,6 @@ export class ViewerComponent implements OnChanges, OnInit, OnDestroy {
         this.urlFileContent = this.urlFile;
         this.fileName = this.displayName;
         this.viewerType = this.urlFileViewer || this.getViewerType(this.extension, this.mimeType);
-
 
         this.extensionChange.emit(this.extension);
         this.scrollTop();
@@ -634,15 +642,6 @@ export class ViewerComponent implements OnChanges, OnInit, OnDestroy {
 
     private isExternalViewer(): boolean {
         return !!this.viewerExtensions.find(ext => ext.fileExtension === '*');
-    }
-
-    private _externalViewer: ViewerExtensionRef;
-    get externalViewer(): ViewerExtensionRef {
-        if (!this._externalViewer) {
-            this._externalViewer = this.viewerExtensions.find(ext => ext.fileExtension === '*');
-        }
-
-        return this._externalViewer;
     }
 
     isCustomViewerExtension(extension: string): boolean {

--- a/lib/core/viewer/components/viewer.component.ts
+++ b/lib/core/viewer/components/viewer.component.ts
@@ -225,17 +225,30 @@ export class ViewerComponent implements OnChanges, OnInit, OnDestroy {
     versionEntry: VersionEntry;
 
     extensionTemplates: { template: TemplateRef<any>, isVisible: boolean }[] = [];
-    externalExtensions: string[] = [];
     urlFileContent: string;
     otherMenu: any;
     extension: string;
     sidebarRightTemplateContext: { node: Node } = { node: null };
     sidebarLeftTemplateContext: { node: Node } = { node: null };
     fileTitle: string;
-    viewerExtensions: Array<ViewerExtensionRef> = [];
+
+    /**
+     * Returns a list of the active Viewer content extensions.
+     */
+    get viewerExtensions(): ViewerExtensionRef[] {
+        return this.extensionService.getViewerExtensions();
+    }
+
+    /**
+     * Provides a list of file extensions supported by external plugins.
+     */
+    get externalExtensions(): string[] {
+        return this.viewerExtensions.map(ext => ext.fileExtension);
+    }
+
     readOnly = true;
 
-    private cacheBusterNumber;
+    private cacheBusterNumber: number;
     cacheTypeForContent = '';
 
     // Extensions that are supported by the Viewer without conversion
@@ -316,16 +329,7 @@ export class ViewerComponent implements OnChanges, OnInit, OnDestroy {
         });
 
         this.closeOverlayManager();
-        this.loadExtensions();
         this.cacheTypeForContent = '';
-    }
-
-    private loadExtensions() {
-        this.viewerExtensions = this.extensionService.getViewerExtensions();
-        this.viewerExtensions
-            .forEach((extension: ViewerExtensionRef) => {
-                this.externalExtensions.push(extension.fileExtension);
-            });
     }
 
     private getNodeVersionProperty(node: Node): string {
@@ -427,13 +431,9 @@ export class ViewerComponent implements OnChanges, OnInit, OnDestroy {
         this.fileTitle = this.getDisplayName(filenameFromUrl);
         this.extension = this.getFileExtension(filenameFromUrl);
         this.urlFileContent = this.urlFile;
-
         this.fileName = this.displayName;
+        this.viewerType = this.urlFileViewer || this.getViewerType(this.extension, this.mimeType);
 
-        this.viewerType = this.urlFileViewer || this.getViewerTypeByExtension(this.extension);
-        if (this.viewerType === 'unknown') {
-            this.viewerType = this.getViewerTypeByMimeType(this.mimeType);
-        }
 
         this.extensionChange.emit(this.extension);
         this.scrollTop();
@@ -441,8 +441,6 @@ export class ViewerComponent implements OnChanges, OnInit, OnDestroy {
 
     private async setUpNodeFile(nodeData: Node, versionData?: Version) {
         this.readOnly = !this.contentService.hasAllowableOperations(nodeData, 'update');
-
-        let setupNode;
 
         if (versionData && versionData.content) {
             this.mimeType = versionData.content.mimeType;
@@ -461,13 +459,10 @@ export class ViewerComponent implements OnChanges, OnInit, OnDestroy {
             this.urlFileContent + '&' + currentFileVersion;
 
         this.extension = this.getFileExtension(versionData ? versionData.name : nodeData.name);
-
         this.fileName = versionData ? versionData.name : nodeData.name;
+        this.viewerType = this.getViewerType(this.extension, this.mimeType);
 
-        this.viewerType = this.getViewerTypeByExtension(this.extension);
-        if (this.viewerType === 'unknown') {
-            this.viewerType = this.getViewerTypeByMimeType(this.mimeType);
-        }
+        let setupNode: Promise<void>;
 
         if (this.viewerType === 'unknown') {
             if (versionData) {
@@ -485,18 +480,23 @@ export class ViewerComponent implements OnChanges, OnInit, OnDestroy {
         return setupNode;
     }
 
+    private getViewerType(extension: string, mimeType: string): string {
+        let viewerType = this.getViewerTypeByExtension(extension);
+
+        if (viewerType === 'unknown') {
+            viewerType = this.getViewerTypeByMimeType(mimeType);
+        }
+
+        return viewerType;
+    }
+
     private setUpSharedLinkFile(details: any) {
         this.mimeType = details.entry.content.mimeType;
         this.fileTitle = this.getDisplayName(details.entry.name);
         this.extension = this.getFileExtension(details.entry.name);
         this.fileName = details.entry.name;
-
         this.urlFileContent = this.contentApi.getSharedLinkContentUrl(this.sharedLinkId, false);
-
-        this.viewerType = this.getViewerTypeByMimeType(this.mimeType);
-        if (this.viewerType === 'unknown') {
-            this.viewerType = this.getViewerTypeByExtension(this.extension);
-        }
+        this.viewerType = this.getViewerType(this.extension, this.mimeType);
 
         if (this.viewerType === 'unknown') {
             this.displaySharedLinkRendition(this.sharedLinkId);
@@ -550,6 +550,10 @@ export class ViewerComponent implements OnChanges, OnInit, OnDestroy {
     getViewerTypeByExtension(extension: string) {
         if (extension) {
             extension = extension.toLowerCase();
+        }
+
+        if (this.isExternalViewer()) {
+            return 'external';
         }
 
         if (this.isCustomViewerExtension(extension)) {
@@ -628,8 +632,21 @@ export class ViewerComponent implements OnChanges, OnInit, OnDestroy {
         return null;
     }
 
+    private isExternalViewer(): boolean {
+        return !!this.viewerExtensions.find(ext => ext.fileExtension === '*');
+    }
+
+    private _externalViewer: ViewerExtensionRef;
+    get externalViewer(): ViewerExtensionRef {
+        if (!this._externalViewer) {
+            this._externalViewer = this.viewerExtensions.find(ext => ext.fileExtension === '*');
+        }
+
+        return this._externalViewer;
+    }
+
     isCustomViewerExtension(extension: string): boolean {
-        const extensions: any = this.externalExtensions || [];
+        const extensions = this.externalExtensions || [];
 
         if (extension && extensions.length > 0) {
             extension = extension.toLowerCase();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

provide support for `*` wildcards when extending Viewer, allows having one component that replaces all existing viewers

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://alfresco.atlassian.net/browse/MNT-22613