### PR TITLE
[MNT-22641] Upload versioning improvements

### DIFF
--- a/docs/core/services/upload.service.md
+++ b/docs/core/services/upload.service.md
@@ -112,16 +112,9 @@ From version `3.8.0` it is also possible to filter out the folders:
 In this way all the files present in the .git folder won't be uploaded.
 > Please note that the filtering options available for the folders is the same as the one for the files.
 
-### Enabling Versioning
-
-You can toggle auto-versioning for the uploaded nodes by setting the `upload.versioningEnabled` property:
-
-```json
-{
-    "upload": {
-        "versioningEnabled": true
-    }
-}
-```
+### Toggling Versioning Support
 
 It is also possible to provide the `versioningEnabled` value as part of the `FileUploadOptions` when using upload service from the code.
+
+> Note: When creating a new node using multipart/form-data by default versioning is enabled and set to MAJOR Version.
+> Since Alfresco 6.2.3 versioningEnabled flag was introduced offering better control over the new node Versioning.

--- a/lib/core/models/file.model.ts
+++ b/lib/core/models/file.model.ts
@@ -29,17 +29,44 @@ export class FileUploadOptions {
      * Setting this parameter also enables versioning of this node, if it is not already versioned.
      */
     comment?: string;
+    /**
+     * Overwrite the content of the node with a new version.
+     */
     newVersion?: boolean;
     /**
      * If true, then created node will be version 1.0 MAJOR. If false, then created node will be version 0.1 MINOR.
      */
     majorVersion?: boolean;
+    /**
+     * Root folder id.
+     */
     parentId?: string;
+    /**
+     * Defines the **relativePath** value.
+     * The relativePath specifies the folder structure to create relative to the node nodeId.
+     * Folders in the relativePath that do not exist are created before the node is created.
+     */
     path?: string;
+    /**
+     * You can use the nodeType field to create a specific type. The default is **cm:content**.
+     */
     nodeType?: string;
+    /**
+     * You can set multi-value properties when you create a new node which supports properties of type multiple.
+     */
     properties?: any;
+    /**
+     * If the content model allows then it is also possible to create primary children with a different assoc type.
+     */
     association?: any;
+    /**
+     * You can optionally specify an array of **secondaryChildren** to create one or more secondary child associations,
+     * such that the newly created node acts as a parent node.
+     */
     secondaryChildren?: AssocChildBody[];
+    /**
+     * You can optionally specify an array of **targets** to create one or more peer associations such that the newly created node acts as a source node.
+     */
     targets?: AssociationBody[];
     /**
      * If true, then created node will be versioned. If false, then created node will be unversioned and auto-versioning disabled.

--- a/lib/core/services/upload.service.spec.ts
+++ b/lib/core/services/upload.service.spec.ts
@@ -394,37 +394,7 @@ describe('UploadService', () => {
             );
         });
 
-        it('should upload with "versioningEnabled" parameter taken from app config', () => {
-            appConfigService.config.upload = { versioningEnabled: true };
-
-            const model = new FileModel(
-                <File> { name: 'file-name', size: 10 },
-                <FileUploadOptions> {}
-            );
-
-            service.addToQueue(model);
-            service.uploadFilesInTheQueue();
-
-            expect(uploadFileSpy).toHaveBeenCalledWith(
-                {
-                    name: 'file-name',
-                    size: 10
-                },
-                undefined,
-                undefined,
-                { newVersion: false },
-                {
-                    include: [ 'allowableOperations' ],
-                    renditions: 'doclib',
-                    versioningEnabled: true,
-                    autoRename: true
-                }
-            );
-        });
-
         it('should not use "versioningEnabled" if not explicitly provided', () => {
-            appConfigService.config.upload = {};
-
             const model = new FileModel(
                 <File> { name: 'file-name', size: 10 },
                 <FileUploadOptions> {}

--- a/lib/core/services/upload.service.ts
+++ b/lib/core/services/upload.service.ts
@@ -248,12 +248,6 @@ export class UploadService {
 
         if (file.options && file.options.versioningEnabled !== undefined) {
             opts.versioningEnabled = file.options.versioningEnabled;
-        } else {
-            const appConfigFlag = this.appConfigService.get('upload.versioningEnabled');
-
-            if (appConfigFlag !== undefined) {
-                opts.versioningEnabled = appConfigFlag;
-            }
         }
 
         if (file.options.newVersion === true) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

provide support for the `versioningEnabled` flag when uploading files (global configuration and api levels)

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://alfresco.atlassian.net/browse/MNT-22641