### PR TITLE
[AAE-6050] Avoid to distort logo when show in application

### DIFF
--- a/lib/core/layout/components/header/header.component.scss
+++ b/lib/core/layout/components/header/header.component.scss
@@ -17,7 +17,6 @@ adf-layout-header .mat-toolbar-single-row {
     .adf-app-logo {
         position: relative;
         height: 28px;
-        width: 28px;
         vertical-align: middle;
         margin-top: -3px;
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Logo image has fixed dimensions 28x28px, after using images with different dimensions, image ratio can be distorted
https://alfresco.atlassian.net/browse/AAE-6050

**What is the new behaviour?**
Height is still fixed, but width is calculated preserving correct ratio


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
