### PR TITLE
[ADF-4918] Fix placeholder color in invalid and untouched state

### DIFF
--- a/lib/core/form/components/widgets/date-time/date-time.widget.html
+++ b/lib/core/form/components/widgets/date-time/date-time.widget.html
@@ -4,6 +4,7 @@
         <input matInput
                [id]="field.id"
                [value]="field.value"
+               [(ngModel)]="field.value"
                [required]="isRequired()"
                [disabled]="field.readOnly"
                (change)="onDateChanged($any($event).srcElement.value)"

--- a/lib/core/form/components/widgets/date/date.widget.html
+++ b/lib/core/form/components/widgets/date/date.widget.html
@@ -4,6 +4,7 @@
         <input matInput
                [id]="field.id"
                [value]="field.value"
+               [(ngModel)]="field.value"
                [required]="isRequired()"
                [disabled]="field.readOnly"
                (change)="onDateChanged($any($event).srcElement.value)"

--- a/lib/core/form/components/widgets/form.theme.scss
+++ b/lib/core/form/components/widgets/form.theme.scss
@@ -5,6 +5,7 @@ ul > li > form-field > .adf-focus {
 }
 
 .adf {
+
     &-error-text-container {
         height: 20px;
         margin-top: -12px;
@@ -30,6 +31,7 @@ ul > li > form-field > .adf-focus {
     }
 
     &-invalid {
+
         .mat-form-field-underline {
             background-color: #f44336 !important;
         }
@@ -42,6 +44,7 @@ ul > li > form-field > .adf-focus {
         }
 
         .mat-select {
+
             &-value {
                 color: var(--theme-warn-color);
             }
@@ -72,12 +75,9 @@ ul > li > form-field > .adf-focus {
 }
 
 /* query for Microsoft IE 11*/
-@media screen and (-ms-high-contrast: active),
-    screen and (-ms-high-contrast: none) {
+@media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none) {
     adf-form-field {
-        .mat-input-element,
-        .mat-select,
-        .mat-form-field {
+        .mat-input-element, .mat-select, .mat-form-field {
             display: block !important;
         }
     }

--- a/lib/core/form/components/widgets/form.theme.scss
+++ b/lib/core/form/components/widgets/form.theme.scss
@@ -5,7 +5,6 @@ ul > li > form-field > .adf-focus {
 }
 
 .adf {
-
     &-error-text-container {
         height: 20px;
         margin-top: -12px;
@@ -27,7 +26,7 @@ ul > li > form-field > .adf-focus {
     }
 
     &-label {
-        color: rgb(186, 186, 186);;
+        color: rgb(186, 186, 186);
     }
 
     &-invalid {
@@ -49,14 +48,12 @@ ul > li > form-field > .adf-focus {
         }
 
         .mat-select {
-
             &-value {
                 color: var(--theme-warn-color);
             }
             &-arrow {
                 color: var(--theme-warn-color);
             }
-
         }
 
         .adf-file {
@@ -80,11 +77,13 @@ ul > li > form-field > .adf-focus {
     }
 }
 
-
 /* query for Microsoft IE 11*/
-@media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none) {
+@media screen and (-ms-high-contrast: active),
+    screen and (-ms-high-contrast: none) {
     adf-form-field {
-        .mat-input-element, .mat-select, .mat-form-field {
+        .mat-input-element,
+        .mat-select,
+        .mat-form-field {
             display: block !important;
         }
     }

--- a/lib/core/form/components/widgets/form.theme.scss
+++ b/lib/core/form/components/widgets/form.theme.scss
@@ -30,12 +30,6 @@ ul > li > form-field > .adf-focus {
     }
 
     &-invalid {
-        .mat-form-field-label,
-        .mat-form-field-required-marker,
-        .mat-input-element ::placeholder {
-            color: #f44336 !important;
-        }
-
         .mat-form-field-underline {
             background-color: #f44336 !important;
         }

--- a/lib/core/form/components/widgets/form.theme.scss
+++ b/lib/core/form/components/widgets/form.theme.scss
@@ -31,6 +31,11 @@ ul > li > form-field > .adf-focus {
     }
 
     &-invalid {
+        .mat-form-field-label,
+        .mat-form-field-required-marker,
+        .mat-input-element ::placeholder {
+            color: #f44336 !important;
+        }
 
         .mat-form-field-underline {
             background-color: #f44336 !important;

--- a/lib/core/form/components/widgets/index.ts
+++ b/lib/core/form/components/widgets/index.ts
@@ -52,6 +52,7 @@ import { FileViewerWidgetComponent } from './file-viewer/file-viewer.widget';
 // core
 export * from './widget.component';
 export * from './core/index';
+export * from './invalid-error-state-matcher';
 
 // containers
 export * from './tabs/tabs.widget';
@@ -91,9 +92,6 @@ export * from './dynamic-table/editors/text/text.editor';
 export * from './dynamic-table/editors/datetime/datetime.editor';
 export * from './dynamic-table/editors/amount/amount.editor';
 export * from './text/text-mask.component';
-
-// matcher
-export * from './invalid-error-state-matcher';
 
 export const WIDGET_DIRECTIVES: any[] = [
     UnknownWidgetComponent,

--- a/lib/core/form/components/widgets/index.ts
+++ b/lib/core/form/components/widgets/index.ts
@@ -92,6 +92,9 @@ export * from './dynamic-table/editors/datetime/datetime.editor';
 export * from './dynamic-table/editors/amount/amount.editor';
 export * from './text/text-mask.component';
 
+// matcher
+export * from './invalid-error-state-matcher';
+
 export const WIDGET_DIRECTIVES: any[] = [
     UnknownWidgetComponent,
     TabsWidgetComponent,

--- a/lib/core/form/components/widgets/invalid-error-state-matcher.spec.ts
+++ b/lib/core/form/components/widgets/invalid-error-state-matcher.spec.ts
@@ -1,0 +1,38 @@
+/*!
+ * @license
+ * Copyright 2019 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { InvalidErrorStateMatcher } from './invalid-error-state-matcher';
+import { FormControl, Validators } from '@angular/forms';
+
+describe('InvalidErrorStateMatcher', () => {
+
+    const matcher = new InvalidErrorStateMatcher();
+
+    it('Should return false if the form is valid', () => {
+        const fakeFormControlValid = new FormControl('');
+        expect(matcher.isErrorState(fakeFormControlValid)).toBeFalsy();
+    });
+
+    it('Should return false if the form is null', () => {
+        expect(matcher.isErrorState(null)).toBeFalsy();
+    });
+
+    it('Should return true if form is invalid', () => {
+        const fakeFormControlInvalid = new FormControl('', Validators.required);
+        expect(matcher.isErrorState(fakeFormControlInvalid)).toBeTruthy();
+    });
+});

--- a/lib/core/form/components/widgets/invalid-error-state-matcher.ts
+++ b/lib/core/form/components/widgets/invalid-error-state-matcher.ts
@@ -1,0 +1,25 @@
+/*!
+ * @license
+ * Copyright 2019 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FormControl  } from '@angular/forms';
+import { ErrorStateMatcher } from '@angular/material/core';
+
+export class InvalidErrorStateMatcher implements ErrorStateMatcher {
+    isErrorState(control: FormControl | null): boolean {
+        return !!(control && control.invalid);
+    }
+}

--- a/lib/core/form/form-base.module.ts
+++ b/lib/core/form/form-base.module.ts
@@ -40,6 +40,8 @@ import { EditJsonDialogModule } from '../dialogs/edit-json/edit-json.dialog.modu
 import { A11yModule } from '@angular/cdk/a11y';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { ViewerModule } from '../viewer/viewer.module';
+import { ErrorStateMatcher } from '@angular/material/core';
+import { InvalidErrorStateMatcher } from './components/widgets/invalid-error-state-matcher';
 
 @NgModule({
     imports: [
@@ -76,6 +78,9 @@ import { ViewerModule } from '../viewer/viewer.module';
         FormRendererComponent,
         StartFormCustomButtonDirective,
         ...WIDGET_DIRECTIVES
+    ],
+    providers: [
+        { provide: ErrorStateMatcher, useClass: InvalidErrorStateMatcher }
     ]
 })
 export class FormBaseModule {

--- a/lib/process-services-cloud/src/lib/form/components/widgets/date/date-cloud.widget.html
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/date/date-cloud.widget.html
@@ -4,6 +4,7 @@
         <input matInput
                [id]="field.id"
                [value]="field.value"
+               [(ngModel)]="field.value"
                [required]="isRequired()"
                [disabled]="field.readOnly"
                (change)="onDateChanged($any($event).srcElement.value)"

--- a/lib/process-services-cloud/src/lib/form/form-cloud.module.ts
+++ b/lib/process-services-cloud/src/lib/form/form-cloud.module.ts
@@ -18,7 +18,8 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FlexLayoutModule } from '@angular/flex-layout';
-import { CoreModule } from '@alfresco/adf-core';
+import { ErrorStateMatcher } from '@angular/material/core';
+import { CoreModule, InvalidErrorStateMatcher } from '@alfresco/adf-core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MaterialModule } from '../material.module';
 import { FormCloudComponent } from './components/form-cloud.component';
@@ -80,6 +81,9 @@ import { FilePropertiesTableCloudComponent } from './components/widgets/attach-f
         PeopleCloudWidgetComponent,
         GroupCloudWidgetComponent,
         PropertiesViewerWidgetComponent
+    ],
+    providers: [
+        { provide: ErrorStateMatcher, useClass: InvalidErrorStateMatcher }
     ]
 })
 export class FormCloudModule {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Placeholder text is not red when form is loaded.
[ADF-4918](https://alfresco.atlassian.net/browse/ADF-4918)


**What is the new behaviour?**
Placeholder text is highlighted in red without user action.
Compatible with this [test case](https://alfresco.testrail.net/index.php?/tests/view/14675031&group_by=cases:section_id&group_id=32546&group_order=asc)



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
It's a regression issue