### PR TITLE
[AAE-6346] ADW Header is not aligned to right

### DIFF
--- a/lib/core/layout/components/header/header.component.scss
+++ b/lib/core/layout/components/header/header.component.scss
@@ -28,6 +28,10 @@ adf-layout-header .mat-toolbar-single-row {
         font-weight: 100;
     }
 
+    .adf-toolbar--spacer {
+        flex: 1 1 auto;
+    }
+
     .adf-toolbar-divider {
         margin: 0 5px;
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/AAE-6346


**What is the new behaviour?**
'adf-toolbar--spacer' class is available in header component even with not `adf-toolbar` element


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
