### PR TITLE
<adf-context-menu-holder> removed from adf document list

### DIFF
--- a/docs/content-services/components/document-list.component.md
+++ b/docs/content-services/components/document-list.component.md
@@ -656,16 +656,26 @@ you can also define your own actions. See the
 [Content Action component](content-action.component.md)
 for more information and examples.
 
-You can also use the [Context Menu directive](../../core/directives/context-menu.directive.md) from the
-ADF Core library to show the
-actions you have defined in a context menu:
-
 ```ts
 @Component({
     selector: 'my-view',
     template: `
-        <adf-document-list [contextMenuActions]="true">...</adf-document-list>
-        <adf-context-menu-holder></context-menu-holder>
+        <adf-document-list [contextMenuActions]="true">
+            <content-actions>
+                <content-action
+                    title="Copy"
+                    permission="update"
+                    [disableWithNoPermission]="true"
+                    handler="copy">
+                </content-action>
+                <content-action
+                    title="Delete"
+                    permission="delete"
+                    disableWithNoPermission="true"
+                    handler="delete">
+                </content-action>
+            </content-actions>
+        </adf-document-list>
     `
 })
 export class MyView {


### PR DESCRIPTION
<adf-context-menu-holder> seems to be deprecated. The proposed solution seems to work.

**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
