### PR TITLE
Retrieve jwt user info from id token

### DIFF
--- a/lib/core/services/identity-user.service.spec.ts
+++ b/lib/core/services/identity-user.service.spec.ts
@@ -25,7 +25,8 @@ import {
     mockIdentityUsers
 } from '../mock/identity-user.mock';
 import { mockJoinGroupRequest } from '../mock/identity-group.mock';
-import { IdentityUserService } from '../services/identity-user.service';
+import { IdentityUserService } from './identity-user.service';
+import { JwtHelperService } from './jwt-helper.service';
 import { setupTestBed } from '../testing/setup-test-bed';
 import { AlfrescoApiService } from './alfresco-api.service';
 import { mockToken } from '../mock/jwt-helper.service.spec';
@@ -83,8 +84,18 @@ describe('IdentityUserService', () => {
         });
     });
 
-    it('should fetch identity user info from Jwt token', () => {
-        localStorage.setItem('access_token', mockToken);
+    it('should fetch identity user info from Jwt id token', () => {
+        localStorage.setItem(JwtHelperService.USER_ID_TOKEN, mockToken);
+        const user = service.getCurrentUserInfo();
+        expect(user).toBeDefined();
+        expect(user.firstName).toEqual('John');
+        expect(user.lastName).toEqual('Doe');
+        expect(user.email).toEqual('johnDoe@gmail.com');
+        expect(user.username).toEqual('johnDoe1');
+    });
+
+    it('should fallback on Jwt access token for identity user info', () => {
+        localStorage.setItem(JwtHelperService.USER_ACCESS_TOKEN, mockToken);
         const user = service.getCurrentUserInfo();
         expect(user).toBeDefined();
         expect(user.firstName).toEqual('John');

--- a/lib/core/services/identity-user.service.ts
+++ b/lib/core/services/identity-user.service.ts
@@ -49,10 +49,10 @@ export class IdentityUserService implements IdentityUserServiceInterface {
      * @returns The user's details
      */
     getCurrentUserInfo(): IdentityUserModel {
-        const familyName = this.jwtHelperService.getValueFromLocalAccessToken<string>(JwtHelperService.FAMILY_NAME);
-        const givenName = this.jwtHelperService.getValueFromLocalAccessToken<string>(JwtHelperService.GIVEN_NAME);
-        const email = this.jwtHelperService.getValueFromLocalAccessToken<string>(JwtHelperService.USER_EMAIL);
-        const username = this.jwtHelperService.getValueFromLocalAccessToken<string>(JwtHelperService.USER_PREFERRED_USERNAME);
+        const familyName = this.jwtHelperService.getValueFromLocalToken<string>(JwtHelperService.FAMILY_NAME);
+        const givenName = this.jwtHelperService.getValueFromLocalToken<string>(JwtHelperService.GIVEN_NAME);
+        const email = this.jwtHelperService.getValueFromLocalToken<string>(JwtHelperService.USER_EMAIL);
+        const username = this.jwtHelperService.getValueFromLocalToken<string>(JwtHelperService.USER_PREFERRED_USERNAME);
         return { firstName: givenName, lastName: familyName, email: email, username: username };
     }
 

--- a/lib/core/services/jwt-helper.service.ts
+++ b/lib/core/services/jwt-helper.service.ts
@@ -28,6 +28,7 @@ export class JwtHelperService {
     static GIVEN_NAME = 'given_name';
     static USER_EMAIL = 'email';
     static USER_ACCESS_TOKEN = 'access_token';
+    static USER_ID_TOKEN = 'id_token';
     static REALM_ACCESS = 'realm_access';
     static RESOURCE_ACCESS = 'resource_access';
     static USER_PREFERRED_USERNAME = 'preferred_username';
@@ -77,6 +78,15 @@ export class JwtHelperService {
     }
 
     /**
+     * Gets a named value from the user access or id token.
+     * @param key Key name of the field to retrieve
+     * @returns Value from the token
+     */
+     getValueFromLocalToken<T>(key: string): T {
+        return this.getValueFromToken(this.getAccessToken(), key) || this.getValueFromToken(this.getIdToken(), key);
+    }
+
+    /**
      * Gets a named value from the user access token.
      * @param key Key name of the field to retrieve
      * @returns Value from the token
@@ -94,15 +104,32 @@ export class JwtHelperService {
     }
 
     /**
+     * Gets a named value from the user id token.
+     * @param key Key name of the field to retrieve
+     * @returns Value from the token
+     */
+     getValueFromLocalIdToken<T>(key: string): T {
+        return this.getValueFromToken(this.getIdToken(), key);
+    }
+
+    /**
+     * Gets id token
+     * @returns id token
+     */
+     getIdToken(): string {
+        return this.storageService.getItem(JwtHelperService.USER_ID_TOKEN);
+    }
+
+    /**
      * Gets a named value from the user access token.
      * @param accessToken your SSO access token where the value is encode
      * @param key Key name of the field to retrieve
      * @returns Value from the token
      */
-    getValueFromToken<T>(accessToken: string, key: string): T {
+    getValueFromToken<T>(token: string, key: string): T {
         let value;
-        if (accessToken) {
-            const tokenPayload = this.decodeToken(accessToken);
+        if (token) {
+            const tokenPayload = this.decodeToken(token);
             value = tokenPayload[key];
         }
         return <T> value;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Currently the Identity service retrieves user info from the access token.
However, since the OIDC spec does not require the access token to be a JWT (this token is meant to be used as a mere bearer token) the claims, which hold the user info, should  come in the ID token. 

**What is the new behaviour?**

Since Keycloak allows including the claims in either of the tokens this PR first tries to read them from the access token and falls back on the id token thus keeping compatibility.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No



