### PR TITLE
[AAE-5715] support hint labels for search input

### DIFF
--- a/lib/core/search-text/search-text-input.component.html
+++ b/lib/core/search-text/search-text-input.component.html
@@ -10,7 +10,7 @@
                 (keyup.enter)="toggleSearchBar()">
             <mat-icon [attr.aria-label]="'SEARCH.BUTTON.ARIA-LABEL' | translate">search</mat-icon>
         </button>
-        <mat-form-field class="adf-input-form-field-divider">
+        <mat-form-field class="adf-input-form-field-divider" [hintLabel]="hintLabel">
             <input matInput
                    #searchInput
                    [attr.aria-label]="'SEARCH.INPUT.ARIA-LABEL' | translate"

--- a/lib/core/search-text/search-text-input.component.ts
+++ b/lib/core/search-text/search-text-input.component.ts
@@ -89,6 +89,10 @@ export class SearchTextInputComponent implements OnInit, OnDestroy {
     @Input()
     placeholder: string = '';
 
+    /** Hint label */
+    @Input()
+    hintLabel = '';
+
     /** Emitted when the search term is changed. The search term is provided
      * in the 'value' property of the returned object.  If the term is less
      * than three characters in length then it is truncated to an empty


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

update search input text to allow providing hint labels from external application
this is needed to allow admin app giving clues on minimal requirements 

![image](https://user-images.githubusercontent.com/503991/149151375-6de74c23-c1af-4e22-b36b-0244510ca892.png)


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://alfresco.atlassian.net/browse/AAE-5715