### PR TITLE
[ACA-4557] Upload Dialog fixes and refactoring

### DIFF
--- a/e2e/content-services/upload/upload-dialog.e2e.ts
+++ b/e2e/content-services/upload/upload-dialog.e2e.ts
@@ -118,17 +118,6 @@ describe('Upload component', () => {
         await uploadDialog.dialogIsNotDisplayed();
     });
 
-    it('[C260168] Should be possible to cancel upload using dialog icon', async () => {
-        await contentServicesPage.uploadFile(pdfFileModel.location);
-        await contentServicesPage.checkContentIsDisplayed(pdfFileModel.name);
-        await uploadDialog.removeUploadedFile(pdfFileModel.name);
-        await uploadDialog.fileIsCancelled(pdfFileModel.name);
-        await expect(await uploadDialog.getTitleText()).toEqual('Upload canceled');
-        await uploadDialog.clickOnCloseButton();
-        await uploadDialog.dialogIsNotDisplayed();
-        await contentServicesPage.checkContentIsNotDisplayed(pdfFileModel.name);
-    });
-
     it('[C260176] Should remove files from upload dialog box when closed', async () => {
         await contentServicesPage.uploadFile(pngFileModelTwo.location);
         await contentServicesPage.checkContentIsDisplayed(pngFileModelTwo.name);

--- a/e2e/content-services/upload/uploader-component.e2e.ts
+++ b/e2e/content-services/upload/uploader-component.e2e.ts
@@ -249,12 +249,6 @@ describe('Upload component', () => {
         await uploadToggles.enableExtensionFilter();
         await browser.sleep(1000);
         await uploadToggles.addExtension('.docx');
-        await contentServicesPage.uploadFile(docxFileModel.location);
-        await contentServicesPage.checkContentIsDisplayed(docxFileModel.name);
-        await uploadDialog.removeUploadedFile(docxFileModel.name);
-        await uploadDialog.fileIsCancelled(docxFileModel.name);
-        await uploadDialog.clickOnCloseButton();
-        await uploadDialog.dialogIsNotDisplayed();
         await contentServicesPage.uploadFile(pngFileModel.location);
         await contentServicesPage.checkContentIsNotDisplayed(pngFileModel.name);
         await uploadDialog.dialogIsNotDisplayed();
@@ -267,14 +261,6 @@ describe('Upload component', () => {
         await uploadToggles.addExtension('.docx');
 
         const dragAndDropArea = element.all(by.css('adf-upload-drag-area div')).first();
-
-        await DropActions.dropFile(dragAndDropArea, docxFileModel.location);
-        await contentServicesPage.checkContentIsDisplayed(docxFileModel.name);
-
-        await uploadDialog.removeUploadedFile(docxFileModel.name);
-        await uploadDialog.fileIsCancelled(docxFileModel.name);
-        await uploadDialog.clickOnCloseButton();
-        await uploadDialog.dialogIsNotDisplayed();
 
         await DropActions.dropFile(dragAndDropArea, pngFileModel.location);
         await contentServicesPage.checkContentIsNotDisplayed(pngFileModel.name);

--- a/lib/content-services/src/lib/upload/components/file-uploading-dialog.component.html
+++ b/lib/content-services/src/lib/upload/components/file-uploading-dialog.component.html
@@ -61,7 +61,6 @@
                 <ng-template let-file="$implicit">
                      <adf-file-uploading-list-row
                         [file]="file"
-                        (remove)="uploadList.removeFile(file)"
                         (cancel)="uploadList.cancelFile(file)">
                     </adf-file-uploading-list-row>
                 </ng-template>

--- a/lib/content-services/src/lib/upload/components/file-uploading-list-row.component.html
+++ b/lib/content-services/src/lib/upload/components/file-uploading-list-row.component.html
@@ -27,7 +27,7 @@
         (keyup.enter)="onCancel(file)"
         (click)="onCancel(file)"
         data-automation-id="cancel-upload-progress"
-        *ngIf="file.status === FileUploadStatus.Progress || file.status === FileUploadStatus.Starting"
+        *ngIf="isUploading()"
         [attr.aria-label]="'ADF_FILE_UPLOAD.ARIA-LABEL.CANCEL_FILE_UPLOAD' | translate: { file: file.name }"
         class="adf-file-uploading-row__group adf-file-uploading-row__group--toggle"
         title="{{ 'ADF_FILE_UPLOAD.BUTTON.CANCEL_FILE' | translate }}">
@@ -42,28 +42,8 @@
         </mat-icon>
     </div>
 
-    <button mat-icon-button
-        adf-toggle-icon
-        #toggleIcon="toggleIcon"
-        *ngIf="file.status === FileUploadStatus.Complete && !isUploadVersion()"
-        (click)="onRemove(file)"
-        class="adf-file-uploading-row__group"
-        [attr.aria-label]="'ADF_FILE_UPLOAD.ARIA-LABEL.REMOVE_FILE' | translate: { file: file.name }"
-        title="{{ 'ADF_FILE_UPLOAD.BUTTON.REMOVE_FILE' | translate }}">
-
-        <mat-icon *ngIf="!toggleIcon.isToggled"
-            class="adf-file-uploading-row__status adf-file-uploading-row__status--done">
-            check_circle
-        </mat-icon>
-
-        <mat-icon *ngIf="toggleIcon.isToggled"
-            class="adf-file-uploading-row__action adf-file-uploading-row__action--remove">
-            remove_circle
-        </mat-icon>
-    </button>
-
     <div
-        *ngIf="file.status === FileUploadStatus.Complete && isUploadVersion()"
+        *ngIf="isUploadVersionComplete()"
         class="adf-file-uploading-row__file-version"
         [attr.aria-label]="'ADF_FILE_UPLOAD.STATUS.FILE_DONE_STATUS' | translate"
         role="status"
@@ -79,7 +59,7 @@
         adf-toggle-icon
         #toggleIconCancel="toggleIcon"
         mat-icon-button
-        *ngIf="file.status === FileUploadStatus.Pending"
+        *ngIf="canCancelUpload()"
         (click)="onCancel(file)"
         data-automation-id="cancel-upload-queue"
         class="adf-file-uploading-row__group"
@@ -101,7 +81,7 @@
     <div
         tabindex="0"
         role="status"
-        *ngIf="file.status === FileUploadStatus.Error"
+        *ngIf="isUploadError()"
         class="adf-file-uploading-row__block adf-file-uploading-row__status--error">
         <mat-icon mat-list-icon
             [attr.aria-label]="'ADF_FILE_UPLOAD.ARIA-LABEL.UPLOAD_FILE_ERROR' | translate: { error: file.errorCode | adfFileUploadError }"

--- a/lib/content-services/src/lib/upload/components/file-uploading-list-row.component.html
+++ b/lib/content-services/src/lib/upload/components/file-uploading-list-row.component.html
@@ -42,6 +42,20 @@
         </mat-icon>
     </div>
 
+    <button mat-icon-button
+        adf-toggle-icon
+        #toggleIcon="toggleIcon"
+        *ngIf="isUploadComplete()"
+        class="adf-file-uploading-row__group"
+        [attr.aria-label]="'ADF_FILE_UPLOAD.ARIA-LABEL.REMOVE_FILE' | translate: { file: file.name }"
+        title="{{ 'ADF_FILE_UPLOAD.BUTTON.REMOVE_FILE' | translate }}">
+
+        <mat-icon
+            class="adf-file-uploading-row__status adf-file-uploading-row__status--done">
+            check_circle
+        </mat-icon>
+    </button>
+
     <div
         *ngIf="isUploadVersionComplete()"
         class="adf-file-uploading-row__file-version"

--- a/lib/content-services/src/lib/upload/components/file-uploading-list-row.component.spec.ts
+++ b/lib/content-services/src/lib/upload/components/file-uploading-list-row.component.spec.ts
@@ -50,13 +50,6 @@ describe('FileUploadingListRowComponent', () => {
 
             expect(component.cancel.emit).toHaveBeenCalledWith(file);
         });
-
-        it('should emit remove event', () => {
-            spyOn(component.remove, 'emit');
-            component.onRemove(component.file);
-
-            expect(component.remove.emit).toHaveBeenCalledWith(file);
-        });
     });
 
     it('should render node version when upload a version file', () => {
@@ -69,20 +62,6 @@ describe('FileUploadingListRowComponent', () => {
         expect(fixture.nativeElement.querySelector(
             '.adf-file-uploading-row__version'
         ).textContent).toContain('1');
-    });
-
-    it('should not emit remove event on a version file', () => {
-        spyOn(component.remove, 'emit');
-        component.file = new FileModel({ name: 'fake-name' } as File);
-        component.file.options = { newVersion: true };
-        component.file.data = { entry: { properties: { 'cm:versionLabel': '1' } } };
-        component.file.status = FileUploadStatus.Complete;
-
-        fixture.detectChanges();
-        const uploadCompleteIcon = document.querySelector('.adf-file-uploading-row__file-version .adf-file-uploading-row__status--done');
-        uploadCompleteIcon.dispatchEvent(new MouseEvent('click'));
-
-        expect(component.remove.emit).not.toHaveBeenCalled();
     });
 
     it('should show cancel button when upload is in progress', async () => {

--- a/lib/content-services/src/lib/upload/components/file-uploading-list-row.component.ts
+++ b/lib/content-services/src/lib/upload/components/file-uploading-list-row.component.ts
@@ -29,20 +29,10 @@ export class FileUploadingListRowComponent {
     file: FileModel;
 
     @Output()
-    cancel: EventEmitter<FileModel> = new EventEmitter<FileModel>();
-
-    @Output()
-    remove: EventEmitter<FileModel> = new EventEmitter<FileModel>();
-
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    FileUploadStatus = FileUploadStatus;
+    cancel = new EventEmitter<FileModel>();
 
     onCancel(file: FileModel): void {
         this.cancel.emit(file);
-    }
-
-    onRemove(file: FileModel): void {
-        this.remove.emit(file);
     }
 
     showCancelledStatus(): boolean {
@@ -71,5 +61,21 @@ export class FileUploadingListRowComponent {
             this.file.data.entry.properties &&
             this.file.data.entry.properties['cm:versionLabel']
         );
+    }
+
+    canCancelUpload(): boolean {
+        return this.file && this.file.status === FileUploadStatus.Pending;
+    }
+
+    isUploadError(): boolean {
+        return this.file && this.file.status === FileUploadStatus.Error;
+    }
+
+    isUploading(): boolean {
+        return this.file && (this.file.status === FileUploadStatus.Progress || this.file.status === FileUploadStatus.Starting);
+    }
+
+    isUploadVersionComplete(): boolean {
+        return this.file && (this.file.status === FileUploadStatus.Complete && this.isUploadVersion());
     }
 }

--- a/lib/content-services/src/lib/upload/components/file-uploading-list-row.component.ts
+++ b/lib/content-services/src/lib/upload/components/file-uploading-list-row.component.ts
@@ -75,6 +75,10 @@ export class FileUploadingListRowComponent {
         return this.file && (this.file.status === FileUploadStatus.Progress || this.file.status === FileUploadStatus.Starting);
     }
 
+    isUploadComplete(): boolean {
+        return this.file.status === FileUploadStatus.Complete && !this.isUploadVersion();
+    }
+
     isUploadVersionComplete(): boolean {
         return this.file && (this.file.status === FileUploadStatus.Complete && this.isUploadVersion());
     }

--- a/lib/content-services/src/lib/upload/components/file-uploading-list.component.spec.ts
+++ b/lib/content-services/src/lib/upload/components/file-uploading-list.component.spec.ts
@@ -16,7 +16,7 @@
  */
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { TranslationService, FileUploadStatus, NodesApiService, UploadService, setupTestBed } from '@alfresco/adf-core';
+import { TranslationService, FileUploadStatus, NodesApiService, UploadService, setupTestBed, FileModel } from '@alfresco/adf-core';
 import { of } from 'rxjs';
 import { FileUploadingListComponent } from './file-uploading-list.component';
 import { ContentTestingModule } from '../../testing/content.testing.module';

--- a/lib/content-services/src/lib/upload/components/file-uploading-list.component.spec.ts
+++ b/lib/content-services/src/lib/upload/components/file-uploading-list.component.spec.ts
@@ -16,8 +16,8 @@
  */
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { TranslationService, FileUploadStatus, NodesApiService, UploadService, setupTestBed, FileModel } from '@alfresco/adf-core';
-import { of, throwError } from 'rxjs';
+import { TranslationService, FileUploadStatus, NodesApiService, UploadService, setupTestBed } from '@alfresco/adf-core';
+import { of } from 'rxjs';
 import { FileUploadingListComponent } from './file-uploading-list.component';
 import { ContentTestingModule } from '../../testing/content.testing.module';
 import { TranslateModule } from '@ngx-translate/core';
@@ -77,91 +77,6 @@ describe('FileUploadingListComponent', () => {
         });
     });
 
-    describe('removeFile()', () => {
-        it('should change file status when api returns success', () => {
-            spyOn(nodesApiService, 'deleteNode').and.returnValue(of(file));
-
-            component.removeFile(file);
-            fixture.detectChanges();
-
-            expect(file.status).toBe(FileUploadStatus.Deleted);
-        });
-
-        it('should change file status when api returns error', () => {
-            spyOn(nodesApiService, 'deleteNode').and.returnValue(throwError(file));
-
-            component.removeFile(file);
-            fixture.detectChanges();
-
-            expect(file.status).toBe(FileUploadStatus.Error);
-        });
-
-        it('should call uploadService on error', () => {
-            spyOn(nodesApiService, 'deleteNode').and.returnValue(throwError(file));
-
-            component.removeFile(file);
-            fixture.detectChanges();
-
-            expect(uploadService.cancelUpload).toHaveBeenCalled();
-        });
-
-        it('should call uploadService on success', () => {
-            spyOn(nodesApiService, 'deleteNode').and.returnValue(of(file));
-
-            component.removeFile(file);
-            fixture.detectChanges();
-
-            expect(uploadService.cancelUpload).toHaveBeenCalled();
-        });
-
-        it('should set `Deleted` status on file version instances when original is removed', () => {
-            component.files = [
-                {
-                    data: {
-                        entry: { id: 'nodeId' }
-                    },
-                    name: 'file',
-                    status: FileUploadStatus.Complete,
-                    options: {
-                        newVersion: false
-                    }
-                } as FileModel,
-                {
-                    data: {
-                        entry: { id: 'nodeId' }
-                    },
-                    name: 'file_v1',
-                    status: FileUploadStatus.Complete,
-                    options: {
-                        newVersion: true
-                    }
-                } as FileModel
-            ];
-
-            spyOn(nodesApiService, 'deleteNode').and.returnValue(of(component.files[0]));
-
-            component.removeFile(component.files[0]);
-            fixture.detectChanges();
-
-            expect(nodesApiService.deleteNode).toHaveBeenCalledTimes(1);
-            expect(component.files[0].status).toBe(FileUploadStatus.Deleted);
-            expect(component.files[1].status).toBe(FileUploadStatus.Deleted);
-        });
-
-        describe('Events', () => {
-
-            it('should throw an error event if delete file goes wrong', (done) => {
-                spyOn(nodesApiService, 'deleteNode').and.returnValue(throwError(file));
-
-                component.error.subscribe(() => {
-                    done();
-                });
-
-                component.removeFile(file);
-            });
-        });
-    });
-
     describe('cancelAllFiles()', () => {
         beforeEach(() => {
             component.files = [
@@ -192,15 +107,6 @@ describe('FileUploadingListComponent', () => {
             component.cancelAllFiles();
 
             expect(uploadService.cancelUpload).not.toHaveBeenCalled();
-        });
-
-        it('should call deleteNode when there are completed uploads', () => {
-            spyOn(nodesApiService, 'deleteNode').and.returnValue(of({}));
-
-            component.files[0].status = FileUploadStatus.Complete;
-            component.cancelAllFiles();
-
-            expect(nodesApiService.deleteNode).toHaveBeenCalled();
         });
 
         it('should call uploadService when there are uploading files', () => {

--- a/lib/core/datatable/components/datatable-cell/datatable-cell.component.ts
+++ b/lib/core/datatable/components/datatable-cell/datatable-cell.component.ts
@@ -90,7 +90,7 @@ export class DataTableCellComponent implements OnInit, OnDestroy {
         this.alfrescoApiService.nodeUpdated
             .pipe(takeUntil(this.onDestroy$))
             .subscribe(node => {
-                if (this.row) {
+                if (this.row && node && node.id) {
                     if (this.row['node'].entry.id === node.id) {
                         this.row['node'].entry = node;
                         this.row['cache'][this.column.key] = this.column.key.split('.').reduce((source, key) => source ? source[key] : '', node);

--- a/lib/core/services/upload.service.ts
+++ b/lib/core/services/upload.service.ts
@@ -186,7 +186,10 @@ export class UploadService {
                 promise.next();
             } else {
                 const performAction = this.getAction(file);
-                performAction();
+
+                if (performAction) {
+                    performAction();
+                }
             }
         });
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

- user successfully uploads 1000 files and then cancels 1 more file -> all 1001 file gets deleted
- user uploads a file and then a new version of the file, cancelling new version deletes original file
- cancelling upload deletes all the files from the Upload Dialog list, even if those were uploaded during previous drag and drop operations

**What is the new behaviour?**

- remove the automatic removal of nodes upon cancel (users should decide what to do with the already uploaded content themselves)
- remove the "delete" button from the upload dialog (users should operate with content outside the upload dialog)
- cancelling upload stops uploading of the current file and all pending uploads, no existing content is affected or deleted

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://alfresco.atlassian.net/browse/ACA-4557