### PR TITLE
[ADF-5472] Missing placeholder for inplace input

### DIFF
--- a/lib/core/form/components/inplace-form-input/inplace-form-input.component.html
+++ b/lib/core/form/components/inplace-form-input/inplace-form-input.component.html
@@ -1,6 +1,6 @@
 <div
     class="adf-inplace-input-container"
-    [ngClass]="{'adf-inplace-input-container-error': control.invalid}"
+    [ngClass]="{'adf-inplace-input-container-error': control.invalid && control.touched}"
 >
     <mat-form-field class="adf-inplace-input-mat-form-field">
         <input
@@ -10,8 +10,12 @@
             data-automation-id="adf-inplace-input"
         >
 
+        <mat-label data-automation-id="adf-inplace-input-label">
+            <ng-content select="[label]"></ng-content>
+        </mat-label>
+
         <mat-error data-automation-id="adf-inplace-input-error">
-            <ng-content></ng-content>
+            <ng-content select="[error]"></ng-content>
         </mat-error>
     </mat-form-field>
 </div>

--- a/lib/core/form/components/inplace-form-input/inplace-form-input.component.scss
+++ b/lib/core/form/components/inplace-form-input/inplace-form-input.component.scss
@@ -1,3 +1,5 @@
+$adf-inplace-input-padding: 7px;
+
 .adf-inplace-input-container {
     .mat-form-field-underline {
         display: none;
@@ -8,8 +10,12 @@
         border-top: 0;
     }
 
+    .mat-form-field-label {
+        padding: $adf-inplace-input-padding;
+    }
+
     &-error {
-        input {
+        .adf-inplace-input {
             border: 1px solid var(--theme-warn-color) !important;
         }
     }
@@ -19,7 +25,7 @@
     }
 
     .adf-inplace-input {
-        padding: 7px;
+        padding: $adf-inplace-input-padding;
         border: 1px solid transparent;
         border-radius: 4px;
 

--- a/lib/core/form/components/inplace-form-input/inplace-form-input.component.spec.ts
+++ b/lib/core/form/components/inplace-form-input/inplace-form-input.component.spec.ts
@@ -69,4 +69,16 @@ describe('InplaceFormInputComponent', () => {
 
         expect(error).toBeTruthy();
     });
+
+    it('should show label', () => {
+        formControl.setValue('');
+
+        fixture.detectChanges();
+
+        const error = fixture.nativeElement.querySelector(
+            '[data-automation-id="adf-inplace-input-label"]'
+        );
+
+        expect(error).toBeTruthy();
+    });
 });

--- a/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.html
+++ b/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.html
@@ -42,15 +42,21 @@
                 </mat-form-field>
 
                 <adf-inplace-form-input [control]="processInstanceName">
-                    <span *ngIf="processInstanceName.hasError('required')">
-                        {{ 'ADF_CLOUD_PROCESS_LIST.ADF_CLOUD_START_PROCESS.ERROR.PROCESS_NAME_REQUIRED' | translate }}
-                    </span>
-                    <span id="adf-start-process-maxlength-error" *ngIf="processInstanceName.hasError('maxlength')">
-                        {{ 'ADF_CLOUD_PROCESS_LIST.ADF_CLOUD_START_PROCESS.ERROR.MAXIMUM_LENGTH' | translate : { characters : maxNameLength } }}
-                    </span>
-                    <span *ngIf="processInstanceName.hasError('pattern')">
-                        {{ 'ADF_CLOUD_PROCESS_LIST.ADF_CLOUD_START_PROCESS.ERROR.SPACE_VALIDATOR' | translate }}
-                    </span>
+                    <ng-container label>
+                        {{'ADF_CLOUD_PROCESS_LIST.ADF_CLOUD_START_PROCESS.FORM.LABEL.NAME' | translate}}
+                    </ng-container>
+
+                    <ng-container error>
+                        <span *ngIf="processInstanceName.hasError('required')">
+                            {{ 'ADF_CLOUD_PROCESS_LIST.ADF_CLOUD_START_PROCESS.ERROR.PROCESS_NAME_REQUIRED' | translate }}
+                        </span>
+                        <span id="adf-start-process-maxlength-error" *ngIf="processInstanceName.hasError('maxlength')">
+                            {{ 'ADF_CLOUD_PROCESS_LIST.ADF_CLOUD_START_PROCESS.ERROR.MAXIMUM_LENGTH' | translate : { characters : maxNameLength } }}
+                        </span>
+                        <span *ngIf="processInstanceName.hasError('pattern')">
+                            {{ 'ADF_CLOUD_PROCESS_LIST.ADF_CLOUD_START_PROCESS.ERROR.SPACE_VALIDATOR' | translate }}
+                        </span>
+                    </ng-container>
                 </adf-inplace-form-input>
             </form>
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ADF-5472


**What is the new behaviour?**
1. Adding placeholder to `inplace-input`,
2. Showing red border in the same time when `mat-error` is shown 

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
In `adf` demo app we have situation that process name does not have initial value, which results with showing input with only red border. Without placeholder user would not know what data in to this input need to be entered

After adding placeholder:
<img width="722" alt="Screenshot 2022-03-07 at 12 29 16" src="https://user-images.githubusercontent.com/13885344/157028953-8943278b-3172-43fb-b86a-01c96777a675.png">

