### PR TITLE
[AAE-7313] User can claim a task only if he is an candidate and relea…

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -843,8 +843,5 @@
       }
     }
   },
-  "defaultProject": "demoshell",
-  "cli": {
-    "analytics": false
-  }
+  "defaultProject": "demoshell"
 }

--- a/angular.json
+++ b/angular.json
@@ -843,5 +843,8 @@
       }
     }
   },
-  "defaultProject": "demoshell"
+  "defaultProject": "demoshell",
+  "cli": {
+    "analytics": false
+  }
 }

--- a/e2e/protractor.excludes.json
+++ b/e2e/protractor.excludes.json
@@ -1,5 +1,6 @@
 {
   "C269081": "https://alfresco.atlassian.net/browse/ADF-5385",
   "C272819": "https://alfresco.atlassian.net/browse/ADF-5385",
-  "C362241": "https://alfresco.atlassian.net/browse/ADF-5385"
+  "C362241": "https://alfresco.atlassian.net/browse/ADF-5385",
+  "C593997": "https://alfresco.atlassian.net/browse/ADF-5479"
 }

--- a/lib/process-services-cloud/src/lib/form/services/form-cloud.service.ts
+++ b/lib/process-services-cloud/src/lib/form/services/form-cloud.service.ts
@@ -182,9 +182,7 @@ export class FormCloudService extends BaseCloudService implements FormCloudServi
                     skipCount
                 }) : EMPTY;
             }),
-            map((res: any) => {
-                return res.list.entries.map((variable) => new TaskVariableCloud(variable.entry));
-            }),
+            map((res: any) => res.list.entries.map((variable) => new TaskVariableCloud(variable.entry))),
             reduce((acc, res) => acc.concat(res), [])
         );
     }

--- a/lib/process-services-cloud/src/lib/task/models/task.model.ts
+++ b/lib/process-services-cloud/src/lib/task/models/task.model.ts
@@ -32,11 +32,3 @@ export const DEFAULT_TASK_PRIORITIES: TaskPriorityOption[] = [
     { label: 'ADF_CLOUD_TASK_LIST.PROPERTIES.PRIORITY_VALUES.NORMAL', value: '2', key: '2' },
     { label: 'ADF_CLOUD_TASK_LIST.PROPERTIES.PRIORITY_VALUES.HIGH', value: '3', key: '3' }
 ];
-
-export const TASK_ASSIGNED_STATE = 'ASSIGNED';
-
-export const TASK_CREATED_STATE = 'CREATED';
-
-export const TASK_CLAIM_PERMISSION = 'CLAIM';
-export const TASK_RELEASE_PERMISSION = 'RELEASE';
-export const TASK_VIEW_PERMISSION = 'VIEW';

--- a/lib/process-services-cloud/src/lib/task/models/task.model.ts
+++ b/lib/process-services-cloud/src/lib/task/models/task.model.ts
@@ -36,3 +36,7 @@ export const DEFAULT_TASK_PRIORITIES: TaskPriorityOption[] = [
 export const TASK_ASSIGNED_STATE = 'ASSIGNED';
 
 export const TASK_CREATED_STATE = 'CREATED';
+
+export const TASK_CLAIM_PERMISSION = 'CLAIM';
+export const TASK_RELEASE_PERMISSION = 'RELEASE';
+export const TASK_VIEW_PERMISSION = 'VIEW';

--- a/lib/process-services-cloud/src/lib/task/services/task-cloud.service.ts
+++ b/lib/process-services-cloud/src/lib/task/services/task-cloud.service.ts
@@ -23,7 +23,14 @@ import { TaskDetailsCloudModel, StartTaskCloudResponseModel } from '../start-tas
 import { BaseCloudService } from '../../services/base-cloud.service';
 import { StartTaskCloudRequestModel } from '../start-task/models/start-task-cloud-request.model';
 import { ProcessDefinitionCloud } from '../../models/process-definition-cloud.model';
-import { DEFAULT_TASK_PRIORITIES, TaskPriorityOption, TASK_ASSIGNED_STATE, TASK_CREATED_STATE } from '../models/task.model';
+import {
+    DEFAULT_TASK_PRIORITIES,
+    TaskPriorityOption,
+    TASK_ASSIGNED_STATE,
+    TASK_CLAIM_PERMISSION,
+    TASK_CREATED_STATE,
+    TASK_RELEASE_PERMISSION
+} from '../models/task.model';
 import { TaskCloudServiceInterface } from './task-cloud.service.interface';
 
 @Injectable({
@@ -98,7 +105,9 @@ export class TaskCloudService extends BaseCloudService implements TaskCloudServi
      * @returns Boolean value if the task can be completed
      */
     canClaimTask(taskDetails: TaskDetailsCloudModel): boolean {
-        return taskDetails && taskDetails.status === TASK_CREATED_STATE;
+        return taskDetails &&
+               taskDetails.status === TASK_CREATED_STATE &&
+               taskDetails.permissions.includes(TASK_CLAIM_PERMISSION);
     }
 
     /**
@@ -109,7 +118,10 @@ export class TaskCloudService extends BaseCloudService implements TaskCloudServi
      */
     canUnclaimTask(taskDetails: TaskDetailsCloudModel): boolean {
         const currentUser = this.identityUserService.getCurrentUserInfo().username;
-        return taskDetails && taskDetails.status === TASK_ASSIGNED_STATE && taskDetails.assignee === currentUser;
+        return taskDetails &&
+               taskDetails.status === TASK_ASSIGNED_STATE &&
+               taskDetails.assignee === currentUser &&
+               taskDetails.permissions.includes(TASK_RELEASE_PERMISSION);
     }
 
     /**

--- a/lib/process-services-cloud/src/lib/task/services/task-cloud.service.ts
+++ b/lib/process-services-cloud/src/lib/task/services/task-cloud.service.ts
@@ -19,17 +19,20 @@ import { Injectable } from '@angular/core';
 import { AlfrescoApiService, LogService, AppConfigService, IdentityUserService, CardViewArrayItem, TranslationService } from '@alfresco/adf-core';
 import { throwError, Observable, of, Subject } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { TaskDetailsCloudModel, StartTaskCloudResponseModel } from '../start-task/models/task-details-cloud.model';
+import {
+    TaskDetailsCloudModel,
+    StartTaskCloudResponseModel,
+    TASK_ASSIGNED_STATE,
+    TASK_CLAIM_PERMISSION,
+    TASK_CREATED_STATE,
+    TASK_RELEASE_PERMISSION
+} from '../start-task/models/task-details-cloud.model';
 import { BaseCloudService } from '../../services/base-cloud.service';
 import { StartTaskCloudRequestModel } from '../start-task/models/start-task-cloud-request.model';
 import { ProcessDefinitionCloud } from '../../models/process-definition-cloud.model';
 import {
     DEFAULT_TASK_PRIORITIES,
-    TaskPriorityOption,
-    TASK_ASSIGNED_STATE,
-    TASK_CLAIM_PERMISSION,
-    TASK_CREATED_STATE,
-    TASK_RELEASE_PERMISSION
+    TaskPriorityOption
 } from '../models/task.model';
 import { TaskCloudServiceInterface } from './task-cloud.service.interface';
 
@@ -105,9 +108,8 @@ export class TaskCloudService extends BaseCloudService implements TaskCloudServi
      * @returns Boolean value if the task can be completed
      */
     canClaimTask(taskDetails: TaskDetailsCloudModel): boolean {
-        return taskDetails &&
-               taskDetails.status === TASK_CREATED_STATE &&
-               taskDetails.permissions.includes(TASK_CLAIM_PERMISSION);
+        return taskDetails?.status === TASK_CREATED_STATE &&
+               taskDetails?.permissions.includes(TASK_CLAIM_PERMISSION);
     }
 
     /**
@@ -118,10 +120,10 @@ export class TaskCloudService extends BaseCloudService implements TaskCloudServi
      */
     canUnclaimTask(taskDetails: TaskDetailsCloudModel): boolean {
         const currentUser = this.identityUserService.getCurrentUserInfo().username;
-        return taskDetails &&
-               taskDetails.status === TASK_ASSIGNED_STATE &&
-               taskDetails.assignee === currentUser &&
-               taskDetails.permissions.includes(TASK_RELEASE_PERMISSION);
+        return taskDetails?.status === TASK_ASSIGNED_STATE &&
+               taskDetails?.assignee === currentUser &&
+               taskDetails?.permissions.includes(TASK_RELEASE_PERMISSION) &&
+               !taskDetails?.standalone;
     }
 
     /**

--- a/lib/process-services-cloud/src/lib/task/start-task/models/task-details-cloud.model.ts
+++ b/lib/process-services-cloud/src/lib/task/start-task/models/task-details-cloud.model.ts
@@ -51,15 +51,26 @@ export interface StartTaskCloudResponseModel {
     entry: TaskDetailsCloudModel;
 }
 
-export type TaskStatus = |
+export type TaskStatus =
     'COMPLETED' |
     'CREATED' |
     'ASSIGNED' |
     'SUSPENDED' |
     'CANCELLED';
 
-export type TaskPermissions = |
+export const TASK_COMPLETED_STATE: TaskStatus = 'COMPLETED';
+export const TASK_CREATED_STATE: TaskStatus = 'CREATED';
+export const TASK_ASSIGNED_STATE: TaskStatus = 'ASSIGNED';
+export const TASK_SUSPENDED_STATE: TaskStatus = 'SUSPENDED';
+export const TASK_CANCELLED_STATE: TaskStatus = 'CANCELLED';
+
+export type TaskPermissions =
     'VIEW' |
     'CLAIM' |
     'RELEASE' |
     'UPDATE';
+
+export const TASK_CLAIM_PERMISSION: TaskPermissions = 'CLAIM';
+export const TASK_RELEASE_PERMISSION: TaskPermissions = 'RELEASE';
+export const TASK_VIEW_PERMISSION: TaskPermissions = 'VIEW';
+export const TASK_UPDATE_PERMISSION: TaskPermissions = 'UPDATE';

--- a/lib/process-services-cloud/src/lib/task/start-task/models/task-details-cloud.model.ts
+++ b/lib/process-services-cloud/src/lib/task/start-task/models/task-details-cloud.model.ts
@@ -33,6 +33,7 @@ export interface TaskDetailsCloudModel {
     lastModifiedFrom?: Date;
     owner?: any;
     parentTaskId?: string;
+    permissions?: TaskPermissions[];
     priority?: number;
     processDefinitionId?: string;
     processInstanceId?: string;
@@ -56,3 +57,9 @@ export type TaskStatus = |
     'ASSIGNED' |
     'SUSPENDED' |
     'CANCELLED';
+
+export type TaskPermissions = |
+    'VIEW' |
+    'CLAIM' |
+    'RELEASE' |
+    'UPDATE';

--- a/lib/process-services-cloud/src/lib/task/task-form/components/task-form-cloud.component.html
+++ b/lib/process-services-cloud/src/lib/task/task-form/components/task-form-cloud.component.html
@@ -57,7 +57,7 @@
                 (success)="onClaimTask()" (error)="onError($event)">
             {{'ADF_CLOUD_TASK_FORM.EMPTY_FORM.BUTTONS.CLAIM' | translate}}
         </button>
-        <button mat-button *ngIf="hasCandidateUsersOrGroups() && canUnclaimTask()" adf-cloud-unclaim-task [appName]="appName" [taskId]="taskId"
+        <button mat-button *ngIf="canUnclaimTask()" adf-cloud-unclaim-task [appName]="appName" [taskId]="taskId"
                 (success)="onUnclaimTask()" (error)="onError($event)">
             {{'ADF_CLOUD_TASK_FORM.EMPTY_FORM.BUTTONS.UNCLAIM' | translate}}
         </button>

--- a/lib/process-services-cloud/src/lib/task/task-form/components/task-form-cloud.component.html
+++ b/lib/process-services-cloud/src/lib/task/task-form/components/task-form-cloud.component.html
@@ -57,7 +57,7 @@
                 (success)="onClaimTask()" (error)="onError($event)">
             {{'ADF_CLOUD_TASK_FORM.EMPTY_FORM.BUTTONS.CLAIM' | translate}}
         </button>
-        <button mat-button *ngIf="hasCandidateUsersOrGroups()" adf-cloud-unclaim-task [appName]="appName" [taskId]="taskId"
+        <button mat-button *ngIf="hasCandidateUsersOrGroups() && canUnclaimTask()" adf-cloud-unclaim-task [appName]="appName" [taskId]="taskId"
                 (success)="onUnclaimTask()" (error)="onError($event)">
             {{'ADF_CLOUD_TASK_FORM.EMPTY_FORM.BUTTONS.UNCLAIM' | translate}}
         </button>

--- a/lib/process-services-cloud/src/lib/task/task-form/components/task-form-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/task/task-form/components/task-form-cloud.component.spec.ts
@@ -22,7 +22,14 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { IdentityUserService, setupTestBed } from '@alfresco/adf-core';
 import { ProcessServiceCloudTestingModule } from '../../../testing/process-service-cloud.testing.module';
 import { TaskFormCloudComponent } from './task-form-cloud.component';
-import { TaskDetailsCloudModel, TASK_ASSIGNED_STATE, TASK_CLAIM_PERMISSION, TASK_CREATED_STATE, TASK_RELEASE_PERMISSION, TASK_VIEW_PERMISSION } from '../../start-task/models/task-details-cloud.model';
+import {
+    TaskDetailsCloudModel,
+    TASK_ASSIGNED_STATE,
+    TASK_CLAIM_PERMISSION,
+    TASK_CREATED_STATE,
+    TASK_RELEASE_PERMISSION,
+    TASK_VIEW_PERMISSION
+} from '../../start-task/models/task-details-cloud.model';
 import { TaskCloudService } from '../../services/task-cloud.service';
 import { TranslateModule } from '@ngx-translate/core';
 
@@ -41,7 +48,7 @@ const taskDetails: TaskDetailsCloudModel = {
     permissions: [TASK_VIEW_PERMISSION]
 };
 
-fdescribe('TaskFormCloudComponent', () => {
+describe('TaskFormCloudComponent', () => {
 
     let taskCloudService: TaskCloudService;
     let identityUserService: IdentityUserService;

--- a/lib/process-services-cloud/src/lib/task/task-form/components/task-form-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-form/components/task-form-cloud.component.ts
@@ -133,7 +133,7 @@ export class TaskFormCloudComponent implements OnInit, OnChanges {
         }
     }
 
-    loadTask() {
+    private loadTask() {
         this.loading = true;
 
         this.taskCloudService
@@ -161,7 +161,7 @@ export class TaskFormCloudComponent implements OnInit, OnChanges {
     }
 
     canClaimTask(): boolean {
-        return !this.readOnly && this.taskCloudService.canClaimTask(this.taskDetails);
+        return !this.readOnly && this.taskCloudService.canClaimTask(this.taskDetails) && this.hasCandidateUsersOrGroups();
     }
 
     hasCandidateUsers(): boolean {
@@ -173,16 +173,11 @@ export class TaskFormCloudComponent implements OnInit, OnChanges {
     }
 
     hasCandidateUsersOrGroups(): boolean {
-        let hasCandidateUsersOrGroups = false;
-
-        if (this.taskDetails?.status === 'ASSIGNED') {
-            hasCandidateUsersOrGroups = this.hasCandidateUsers() || this.hasCandidateGroups();
-        }
-        return hasCandidateUsersOrGroups;
+        return this.hasCandidateUsers() || this.hasCandidateGroups();
     }
 
     canUnclaimTask(): boolean {
-        return !this.readOnly && this.taskCloudService.canUnclaimTask(this.taskDetails);
+        return !this.readOnly && this.taskCloudService.canUnclaimTask(this.taskDetails) && this.hasCandidateUsersOrGroups();
     }
 
     isReadOnly(): boolean {


### PR DESCRIPTION
…se if he is assigned

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
User can claim and release is he is an initiator and not candidate.


**What is the new behaviour?**
User can claim a task only if he is an candidate and release task if he is assigned


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
