### PR TITLE
[AAE-7819] Change column order - load and save column order preferences for TASKS, moved preference service to components services - [3/3]

### DIFF
--- a/lib/core/datatable/data/data-table.schema.ts
+++ b/lib/core/datatable/data/data-table.schema.ts
@@ -16,6 +16,8 @@
  */
 
 import { ContentChild, Input, Directive } from '@angular/core';
+import { Subject } from 'rxjs';
+import { shareReplay } from 'rxjs/operators';
 import { AppConfigService } from '../../app-config/app-config.service';
 import { DataColumnListComponent } from '../../data-column/data-column-list.component';
 import { DataColumn } from './data-column.model';
@@ -39,14 +41,23 @@ export abstract class DataTableSchema {
 
     private layoutPresets = {};
 
+    private columnsSchemaSubject$ = new Subject<boolean>();
+    protected isColumnSchemaCreated$ = this.columnsSchemaSubject$.asObservable().pipe(
+        shareReplay(1)
+    );
+
     constructor(private appConfigService: AppConfigService,
                 protected presetKey: string,
                 protected presetsModel: any) { }
 
     public createDatatableSchema(): void {
         this.loadLayoutPresets();
+
         if (!this.columns || this.columns.length === 0) {
             this.createColumns();
+            this.columnsSchemaSubject$.next(true);
+        } else {
+            this.columnsSchemaSubject$.next(false);
         }
     }
 

--- a/lib/process-services-cloud/src/lib/process-services-cloud.module.ts
+++ b/lib/process-services-cloud/src/lib/process-services-cloud.module.ts
@@ -27,7 +27,9 @@ import {
     LocalPreferenceCloudService,
     PreferenceCloudServiceInterface,
     PROCESS_FILTERS_SERVICE_TOKEN,
-    TASK_FILTERS_SERVICE_TOKEN
+    TASK_FILTERS_SERVICE_TOKEN,
+    PROCESS_LISTS_PREFERENCES_SERVICE_TOKEN,
+    TASK_LIST_PREFERENCES_TOKEN
 } from './services/public-api';
 import { PeopleCloudModule } from './people/people-cloud.module';
 import { CloudFormRenderingService } from './form/components/cloud-form-rendering.service';
@@ -67,7 +69,10 @@ import { ProcessServicesCloudPipeModule } from './pipes/process-services-cloud-p
     ]
 })
 export class ProcessServicesCloudModule {
-    static forRoot(preferenceServiceInstance?: PreferenceCloudServiceInterface): ModuleWithProviders<ProcessServicesCloudModule> {
+    static forRoot(
+        filterPreferenceServiceInstance?: PreferenceCloudServiceInterface,
+        listPreferenceServiceInstance?: PreferenceCloudServiceInterface
+    ): ModuleWithProviders<ProcessServicesCloudModule> {
         return {
             ngModule: ProcessServicesCloudModule,
             providers: [
@@ -79,20 +84,19 @@ export class ProcessServicesCloudModule {
                         source: 'assets/adf-process-services-cloud'
                     }
                 },
-                { provide: PROCESS_FILTERS_SERVICE_TOKEN, useExisting: preferenceServiceInstance ?? LocalPreferenceCloudService },
-                { provide: TASK_FILTERS_SERVICE_TOKEN, useExisting: preferenceServiceInstance ?? LocalPreferenceCloudService },
+                { provide: PROCESS_FILTERS_SERVICE_TOKEN, useExisting: filterPreferenceServiceInstance ?? LocalPreferenceCloudService },
+                { provide: TASK_FILTERS_SERVICE_TOKEN, useExisting: filterPreferenceServiceInstance ?? LocalPreferenceCloudService },
+                { provide: PROCESS_LISTS_PREFERENCES_SERVICE_TOKEN, useExisting: listPreferenceServiceInstance ?? LocalPreferenceCloudService },
+                { provide: TASK_LIST_PREFERENCES_TOKEN, useExisting: listPreferenceServiceInstance ?? LocalPreferenceCloudService },
                 FormRenderingService,
                 { provide: FormRenderingService, useClass: CloudFormRenderingService }
             ]
         };
     }
 
-    static forChild(preferenceServiceInstance?: PreferenceCloudServiceInterface): ModuleWithProviders<ProcessServicesCloudModule> {
+    static forChild(): ModuleWithProviders<ProcessServicesCloudModule> {
         return {
-            ngModule: ProcessServicesCloudModule,
-            providers: [
-                { provide: PROCESS_FILTERS_SERVICE_TOKEN, useExisting: preferenceServiceInstance ?? LocalPreferenceCloudService }
-            ]
+            ngModule: ProcessServicesCloudModule
         };
     }
 }

--- a/lib/process-services-cloud/src/lib/process/process-list/components/process-list-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/process/process-list/components/process-list-cloud.component.spec.ts
@@ -120,7 +120,7 @@ describe('ProcessListCloudComponent', () => {
         spyOn(processListCloudService, 'getProcessByRequest').and.returnValue(of(emptyList));
 
         fixture.detectChanges();
-        expect(component.isLoadingProcesses).toBe(true);
+        expect(component.isLoading).toBe(true);
         let loadingContent = fixture.debugElement.query(By.css('mat-progress-spinner'));
         expect(loadingContent.nativeElement).toBeDefined();
 
@@ -140,14 +140,14 @@ describe('ProcessListCloudComponent', () => {
         const appName = new SimpleChange(null, 'FAKE-APP-NAME', true);
 
         fixture.detectChanges();
-        expect(component.isLoadingProcesses).toBe(true);
+        expect(component.isLoading).toBe(true);
         let loadingContent = fixture.debugElement.query(By.css('mat-progress-spinner'));
         expect(loadingContent.nativeElement).toBeDefined();
 
         component.ngOnChanges({ appName });
         fixture.detectChanges();
 
-        expect(component.isLoadingProcesses).toBe(false);
+        expect(component.isLoading).toBe(false);
         loadingContent = fixture.debugElement.query(By.css('mat-progress-spinner'));
         expect(loadingContent).toBeFalsy();
 

--- a/lib/process-services-cloud/src/lib/process/process-list/components/process-list-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/process/process-list/components/process-list-cloud.component.ts
@@ -21,14 +21,14 @@ import { DataTableSchema, PaginatedComponent,
          UserPreferencesService, PaginationModel,
          UserPreferenceValues, DataRowEvent, CustomLoadingContentTemplateDirective, DataCellEvent, DataRowActionEvent, DataTableComponent, DataColumn } from '@alfresco/adf-core';
 import { ProcessListCloudService } from '../services/process-list-cloud.service';
-import { BehaviorSubject, Observable } from 'rxjs';
+import { BehaviorSubject, combineLatest } from 'rxjs';
 import { processCloudPresetsDefaultModel } from '../models/process-cloud-preset.model';
 import { ProcessQueryCloudRequestModel } from '../models/process-cloud-query-request.model';
 import { ProcessListCloudSortingModel } from '../models/process-list-sorting.model';
-import { ProcessListCloudPreferences } from '../models/process-cloud-preferences';
+import { map, take } from 'rxjs/operators';
 import { PreferenceCloudServiceInterface } from '../../../services/preference-cloud.interface';
-import { PROCESS_FILTERS_SERVICE_TOKEN } from '../../../services/cloud-token.service';
-import { take } from 'rxjs/operators';
+import { PROCESS_LISTS_PREFERENCES_SERVICE_TOKEN } from '../../../services/cloud-token.service';
+import { ProcessListCloudPreferences } from '../models/process-cloud-preferences';
 
 const PRESET_KEY = 'adf-cloud-process-list.presets';
 
@@ -192,12 +192,7 @@ export class ProcessListCloudComponent extends DataTableSchema implements OnChan
     skipCount: number = 0;
     currentInstanceId: string;
     selectedInstances: any[];
-    isLoadingProcesses = true;
-    isLoadingColumnsOrder = true;
-
-    get isLoading(): boolean {
-        return this.isLoadingProcesses || this.isLoadingColumnsOrder;
-    }
+    isLoading = false;
 
     rows: any[] = [];
     formattedSorting: any[];
@@ -208,7 +203,7 @@ export class ProcessListCloudComponent extends DataTableSchema implements OnChan
     constructor(private processListCloudService: ProcessListCloudService,
                 appConfigService: AppConfigService,
                 private userPreferences: UserPreferencesService,
-                @Inject(PROCESS_FILTERS_SERVICE_TOKEN) private cloudPreferenceService: PreferenceCloudServiceInterface) {
+                @Inject(PROCESS_LISTS_PREFERENCES_SERVICE_TOKEN) private cloudPreferenceService: PreferenceCloudServiceInterface) {
         super(appConfigService, PRESET_KEY, processCloudPresetsDefaultModel);
         this.size = userPreferences.paginationSize;
         this.userPreferences.select(UserPreferenceValues.PaginationSize).subscribe((pageSize) => {
@@ -222,16 +217,22 @@ export class ProcessListCloudComponent extends DataTableSchema implements OnChan
     }
 
     ngAfterContentInit() {
-        this.isLoadingColumnsOrder = true;
-        this.loadColumnsOrderPreferences()
-            .pipe(take(1))
-            .subscribe((columnsOrder) => {
-                this.isLoadingColumnsOrder = false;
+        this.cloudPreferenceService.getPreferences(this.appName)
+            .pipe(
+                take(1),
+                map((preferences => {
+                    const preferencesList = preferences?.list?.entries ?? [];
+                    const columnsOrder = preferencesList.find(preference => preference.entry.key === ProcessListCloudPreferences.columnOrder);
+
+                    return {
+                        columnsOrder: columnsOrder ? JSON.parse(columnsOrder.entry.value) : undefined
+                    };
+                }))
+            )
+            .subscribe(({ columnsOrder }) => {
                 this.columnsOrder = columnsOrder;
 
                 this.createDatatableSchema();
-            }, () => {
-                this.isLoadingColumnsOrder = false;
             });
     }
 
@@ -258,18 +259,22 @@ export class ProcessListCloudComponent extends DataTableSchema implements OnChan
     }
 
     private load(requestNode: ProcessQueryCloudRequestModel) {
-        this.isLoadingProcesses = true;
+        this.isLoading = true;
 
-        this.processListCloudService.getProcessByRequest(requestNode).pipe(take(1)).subscribe(
-            (processes) => {
-                this.rows = processes.list.entries;
-                this.success.emit(processes);
-                this.isLoadingProcesses = false;
-                this.pagination.next(processes.list.pagination);
-            }, (error) => {
-                this.error.emit(error);
-                this.isLoadingProcesses = false;
-            });
+        combineLatest([
+            this.processListCloudService.getProcessByRequest(requestNode),
+            this.isColumnSchemaCreated$
+        ]).pipe(
+            take(1)
+        ).subscribe(([processes]) => {
+            this.rows = processes.list.entries;
+            this.success.emit(processes);
+            this.isLoading = false;
+            this.pagination.next(processes.list.pagination);
+        }, (error) => {
+            this.error.emit(error);
+            this.isLoading = false;
+        });
     }
 
     private isAnyPropertyChanged(changes: SimpleChanges): boolean {
@@ -321,13 +326,12 @@ export class ProcessListCloudComponent extends DataTableSchema implements OnChan
     }
 
     onColumnOrderChanged(columnsWithNewOrder: DataColumn[]): void {
-        this.columnsOrder = columnsWithNewOrder.map(column => column.id);
-
         if (this.appName) {
+            const newColumnsOrder = columnsWithNewOrder.map(column => column.id);
             this.cloudPreferenceService.updatePreference(
                 this.appName,
                 ProcessListCloudPreferences.columnOrder,
-                this.columnsOrder
+                newColumnsOrder
             );
         }
     }
@@ -416,12 +420,5 @@ export class ProcessListCloudComponent extends DataTableSchema implements OnChan
 
     isValidSorting(sorting: ProcessListCloudSortingModel[]) {
         return sorting.length && sorting[0].orderBy && sorting[0].direction;
-    }
-
-    private loadColumnsOrderPreferences(): Observable<string[]> {
-        return this.cloudPreferenceService.getPreferences(
-            this.appName,
-            ProcessListCloudPreferences.columnOrder
-        );
     }
 }

--- a/lib/process-services-cloud/src/lib/services/cloud-token.service.ts
+++ b/lib/process-services-cloud/src/lib/services/cloud-token.service.ts
@@ -19,6 +19,10 @@ import { InjectionToken } from '@angular/core';
 import { PreferenceCloudServiceInterface } from './preference-cloud.interface';
 import { TaskListCloudServiceInterface } from './task-list-cloud.service.interface';
 
+export const PROCESS_LISTS_PREFERENCES_SERVICE_TOKEN = new InjectionToken<PreferenceCloudServiceInterface>('proccess-lists-preferences-cloud');
+
+export const TASK_LIST_PREFERENCES_TOKEN = new InjectionToken<PreferenceCloudServiceInterface>('proccess-lists-preferences-cloud');
+
 export const PROCESS_FILTERS_SERVICE_TOKEN = new InjectionToken<PreferenceCloudServiceInterface>('proccess-filters-cloud');
 
 export const TASK_FILTERS_SERVICE_TOKEN = new InjectionToken<PreferenceCloudServiceInterface>('task-filters-cloud');

--- a/lib/process-services-cloud/src/lib/services/preference-cloud.interface.ts
+++ b/lib/process-services-cloud/src/lib/services/preference-cloud.interface.ts
@@ -18,11 +18,9 @@
 import { Observable } from 'rxjs';
 
 export interface PreferenceCloudServiceInterface {
-
     getPreferences(appName: string, key?: string): Observable<any>;
     getPreferenceByKey(appName: string, key: string): Observable<any>;
     createPreference(appName: string, key: string, newPreference: any): Observable<any>;
     updatePreference(appName: string, key: string, updatedPreference: any): Observable<any>;
-    deletePreference(appName: string, key: any): Observable<any>;
-
+    deletePreference(appName: string, key: string): Observable<any>;
 }

--- a/lib/process-services-cloud/src/lib/services/user-preference-cloud.service.ts
+++ b/lib/process-services-cloud/src/lib/services/user-preference-cloud.service.ts
@@ -20,7 +20,6 @@ import { PreferenceCloudServiceInterface } from './preference-cloud.interface';
 import { AlfrescoApiService, AppConfigService, LogService } from '@alfresco/adf-core';
 import { throwError, Observable } from 'rxjs';
 import { BaseCloudService } from './base-cloud.service';
-import { map } from 'rxjs/operators';
 
 @Injectable({ providedIn: 'root' })
 export class UserPreferenceCloudService extends BaseCloudService implements PreferenceCloudServiceInterface {
@@ -38,19 +37,10 @@ export class UserPreferenceCloudService extends BaseCloudService implements Pref
    * @param appName Name of the target app
    * @returns List of user preferences
    */
-  getPreferences(appName: string, key?: string): Observable<any> {
+  getPreferences(appName: string): Observable<any> {
     if (appName) {
       const url = `${this.getBasePath(appName)}/preference/v1/preferences`;
-
-      return this.get(url).pipe(map((preferences: any) => {
-        if (key) {
-          const preferencesList = preferences?.list?.entries ?? [];
-          const searchedPreferences = preferencesList.find(preference => preference.entry.key === key);
-          return searchedPreferences ? JSON.parse(searchedPreferences.entry.value) : null;
-        }
-
-        return preferences;
-      }));
+      return this.get(url);
     } else {
       this.logService.error('Appname is mandatory for querying preferences');
       return throwError('Appname not configured');

--- a/lib/process-services-cloud/src/lib/task/task-list/components/base-task-list-cloud.component.html
+++ b/lib/process-services-cloud/src/lib/task/task-list/components/base-task-list-cloud.component.html
@@ -19,7 +19,8 @@
             (row-unselect)="onRowUnselect($any($event))"
             (rowClick)="onRowClick($any($event))"
             (row-keyup)="onRowKeyUp($any($event))"
-            (sorting-changed)="onSortingChanged($any($event))">
+            (sorting-changed)="onSortingChanged($any($event))"
+            (columnOrderChanged)="onColumnOrderChanged($event)">
             <adf-loading-content-template>
                 <ng-template>
                     <!-- Add your custom loading template here -->

--- a/lib/process-services-cloud/src/lib/task/task-list/components/base-task-list-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-list/components/base-task-list-cloud.component.ts
@@ -26,8 +26,10 @@ import { taskPresetsCloudDefaultModel } from '../models/task-preset-cloud.model'
 import { TaskQueryCloudRequestModel } from '../../../models/filter-cloud-model';
 import { BehaviorSubject, Subject } from 'rxjs';
 import { TaskListCloudSortingModel } from '../../../models/task-list-sorting.model';
-import { takeUntil } from 'rxjs/operators';
+import { map, take, takeUntil } from 'rxjs/operators';
 import { TaskCloudService } from '../../services/task-cloud.service';
+import { PreferenceCloudServiceInterface } from '../../../services/preference-cloud.interface';
+import { TasksListCloudPreferences } from '../models/tasks-cloud-preferences';
 
 @Directive()
 // eslint-disable-next-line @angular-eslint/directive-class-suffix
@@ -109,7 +111,7 @@ export abstract class BaseTaskListCloudComponent extends DataTableSchema impleme
     size: number;
     skipCount: number = 0;
     currentInstanceId: any;
-    isLoading = true;
+    isLoading = false;
     selectedInstances: any[];
     formattedSorting: any[];
     private defaultSorting = { key: 'startDate', direction: 'desc' };
@@ -120,7 +122,8 @@ export abstract class BaseTaskListCloudComponent extends DataTableSchema impleme
     constructor(appConfigService: AppConfigService,
                 private taskCloudService: TaskCloudService,
                 private userPreferences: UserPreferencesService,
-                presetKey: string) {
+                presetKey: string,
+                private cloudPreferenceService: PreferenceCloudServiceInterface) {
         super(appConfigService, presetKey, taskPresetsCloudDefaultModel);
         this.size = userPreferences.paginationSize;
 
@@ -153,7 +156,18 @@ export abstract class BaseTaskListCloudComponent extends DataTableSchema impleme
     }
 
     ngAfterContentInit() {
-        this.createDatatableSchema();
+        this.cloudPreferenceService.getPreferences(this.appName).pipe(
+            take(1),
+            map((preferences => {
+                const preferencesList = preferences?.list?.entries ?? [];
+                const searchedPreferences = preferencesList.find(preference => preference.entry.key === TasksListCloudPreferences.columnOrder);
+                return searchedPreferences ? JSON.parse(searchedPreferences.entry.value) : null;
+            }))
+        ).subscribe(columnsOrder => {
+                this.columnsOrder = columnsOrder;
+                this.createDatatableSchema();
+            }
+        );
     }
 
     reload() {
@@ -233,6 +247,18 @@ export abstract class BaseTaskListCloudComponent extends DataTableSchema impleme
 
     onExecuteRowAction(row: DataRowActionEvent) {
         this.executeRowAction.emit(row);
+    }
+
+    onColumnOrderChanged(columnsWithNewOrder: DataColumn[]): void {
+        this.columnsOrder = columnsWithNewOrder.map(column => column.id);
+
+        if (this.appName) {
+                this.cloudPreferenceService.updatePreference(
+                this.appName,
+                TasksListCloudPreferences.columnOrder,
+                this.columnsOrder
+            );
+        }
     }
 
     setSorting(sortDetail) {

--- a/lib/process-services-cloud/src/lib/task/task-list/components/service-task-list-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-list/components/service-task-list-cloud.component.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Component, ViewEncapsulation, Input } from '@angular/core';
+import { Component, ViewEncapsulation, Input, Inject } from '@angular/core';
 import {
     AppConfigService, UserPreferencesService
 } from '@alfresco/adf-core';
@@ -23,6 +23,9 @@ import { ServiceTaskQueryCloudRequestModel } from '../models/service-task-cloud.
 import { BaseTaskListCloudComponent } from './base-task-list-cloud.component';
 import { ServiceTaskListCloudService } from '../services/service-task-list-cloud.service';
 import { TaskCloudService } from '../../services/task-cloud.service';
+import { combineLatest } from 'rxjs';
+import { PreferenceCloudServiceInterface, TASK_LIST_PREFERENCES_TOKEN } from '../../../services/public-api';
+import { take } from 'rxjs/operators';
 
 const PRESET_KEY = 'adf-cloud-service-task-list.presets';
 
@@ -39,14 +42,21 @@ export class ServiceTaskListCloudComponent extends BaseTaskListCloudComponent {
     constructor(private serviceTaskListCloudService: ServiceTaskListCloudService,
                 appConfigService: AppConfigService,
                 taskCloudService: TaskCloudService,
-                userPreferences: UserPreferencesService) {
-        super(appConfigService, taskCloudService, userPreferences, PRESET_KEY);
+                userPreferences: UserPreferencesService,
+                @Inject(TASK_LIST_PREFERENCES_TOKEN) cloudPreferenceService: PreferenceCloudServiceInterface) {
+        super(appConfigService, taskCloudService, userPreferences, PRESET_KEY, cloudPreferenceService);
     }
 
     load(requestNode: ServiceTaskQueryCloudRequestModel) {
         this.isLoading = true;
-        this.serviceTaskListCloudService.getServiceTaskByRequest(requestNode).subscribe(
-            (tasks) => {
+
+        combineLatest([
+            this.serviceTaskListCloudService.getServiceTaskByRequest(requestNode),
+            this.isColumnSchemaCreated$
+        ]).pipe(
+            take(1)
+        ).subscribe(
+            ([tasks]) => {
                 this.rows = tasks.list.entries;
                 this.success.emit(tasks);
                 this.isLoading = false;

--- a/lib/process-services-cloud/src/lib/task/task-list/models/tasks-cloud-preferences.ts
+++ b/lib/process-services-cloud/src/lib/task/task-list/models/tasks-cloud-preferences.ts
@@ -1,0 +1,4 @@
+// eslint-disable-next-line no-shadow
+export enum TasksListCloudPreferences {
+    columnOrder = 'tasks-list-cloud-columns-order'
+}

--- a/lib/process-services-cloud/src/lib/task/task-list/public-api.ts
+++ b/lib/process-services-cloud/src/lib/task/task-list/public-api.ts
@@ -20,6 +20,7 @@ export * from './components/service-task-list-cloud.component';
 
 export * from './models/service-task-cloud.model';
 export * from './models/task-preset-cloud.model';
+export * from './models/tasks-cloud-preferences';
 
 export * from './services/task-list-cloud.service';
 export * from './services/service-task-list-cloud.service';

--- a/lib/process-services-cloud/src/lib/task/task-list/task-list-cloud.module.ts
+++ b/lib/process-services-cloud/src/lib/task/task-list/task-list-cloud.module.ts
@@ -22,7 +22,7 @@ import { TaskListCloudComponent } from './components/task-list-cloud.component';
 import { ServiceTaskListCloudComponent } from './components/service-task-list-cloud.component';
 import { CoreModule } from '@alfresco/adf-core';
 import { TASK_LIST_CLOUD_TOKEN } from '../../services/cloud-token.service';
-import { TaskListCloudService } from './public-api';
+import { TaskListCloudService } from './services/task-list-cloud.service';
 
 @NgModule({
     imports: [


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/AAE-7819


**What is the new behaviour?**
This is the third part for [AAE-7819](https://alfresco.atlassian.net/browse/AAE-7819) (Allowing to change column order for processes and task table)

In this PR I am saving and loading columns order using preferences service for tasks.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
Other PRs:
https://github.com/Alfresco/alfresco-ng2-components/pull/7567 [1/3] - Enable drag&drop for data-table
https://github.com/Alfresco/alfresco-ng2-components/pull/7568 [2/3] - saving/loading preferences for processes
https://github.com/Alfresco/alfresco-ng2-components/pull/7569 [3/3]  - saving/loading preferences for tasks