### PR TITLE
[AAE-8565] multiple use viewer in form

### DIFF
--- a/lib/core/viewer/components/viewer.component.spec.ts
+++ b/lib/core/viewer/components/viewer.component.spec.ts
@@ -136,8 +136,8 @@ class ViewerWithCustomMoreActionsComponent {
 @Component({
     selector: 'adf-double-viewer',
     template: `
-        <adf-viewer #viewer1 ></adf-viewer>
-        <adf-viewer #viewer2 ></adf-viewer>
+        <adf-viewer #viewer1></adf-viewer>
+        <adf-viewer #viewer2></adf-viewer>
     `
 })
 class DoubleViewerComponent {
@@ -201,7 +201,7 @@ describe('ViewerComponent', () => {
     afterEach(() => {
         fixture.destroy();
     });
-    
+
     describe('Double viewer Test', () => {
 
         it('should not reload the content of all the viewer after type change', async () => {
@@ -231,7 +231,7 @@ describe('ViewerComponent', () => {
             expect(fixtureDouble.componentInstance.viewer2.viewerType).toBe('png');
         });
     });
-    
+
     describe('Extension Type Test', () => {
         it('should display pdf external viewer via wildcard notation', async () => {
             const extension: ViewerExtensionRef = {
@@ -1321,7 +1321,13 @@ describe('ViewerComponent', () => {
         describe('display name property override by nodeId', () => {
 
             const contentUrl = '/content/url/path';
-            const nodeDetails = new NodeEntry({ entry: { name: 'node-id-name', id: '12', content: { mimeType: 'txt' } } });
+            const nodeDetails = new NodeEntry({
+                entry: {
+                    name: 'node-id-name',
+                    id: '12',
+                    content: { mimeType: 'txt' }
+                }
+            });
 
             it('should use the node name if displayName is NOT set and nodeId is set', (done) => {
                 spyOn(component['nodesApi'], 'getNode').and.returnValue(Promise.resolve(nodeDetails));

--- a/lib/core/viewer/components/viewer.component.spec.ts
+++ b/lib/core/viewer/components/viewer.component.spec.ts
@@ -219,16 +219,16 @@ describe('ViewerComponent', () => {
             await fixtureDouble.detectChanges();
             await fixtureDouble.whenStable();
 
-            expect(fixtureDouble.componentInstance.viewer1.viewerType).toBe("pdf")
-            expect(fixtureDouble.componentInstance.viewer2.viewerType).toBe("unknown")
+            expect(fixtureDouble.componentInstance.viewer1.viewerType).toBe('pdf')
+            expect(fixtureDouble.componentInstance.viewer2.viewerType).toBe('unknown')
 
             fixtureDouble.componentInstance.viewer1.urlFile = 'fake-test-file.pdf';
             fixtureDouble.componentInstance.viewer2.urlFile = 'fake-test-file-two.png';
 
             (fixtureDouble.componentInstance.viewer2 as any).viewUtilService.viewerTypeChange.next('png');
 
-            expect(fixtureDouble.componentInstance.viewer1.viewerType).toBe("pdf")
-            expect(fixtureDouble.componentInstance.viewer2.viewerType).toBe("png")
+            expect(fixtureDouble.componentInstance.viewer1.viewerType).toBe('pdf')
+            expect(fixtureDouble.componentInstance.viewer2.viewerType).toBe('png')
         });
     });
     

--- a/lib/core/viewer/components/viewer.component.spec.ts
+++ b/lib/core/viewer/components/viewer.component.spec.ts
@@ -202,7 +202,7 @@ describe('ViewerComponent', () => {
         fixture.destroy();
     });
     
-     describe('Double viewer Test', () => {
+    describe('Double viewer Test', () => {
 
         it('should not reload the content of all the viewer after type change', async () => {
             const fixtureDouble = TestBed.createComponent(DoubleViewerComponent);
@@ -219,16 +219,16 @@ describe('ViewerComponent', () => {
             await fixtureDouble.detectChanges();
             await fixtureDouble.whenStable();
 
-            expect(fixtureDouble.componentInstance.viewer1.viewerType).toBe('pdf')
-            expect(fixtureDouble.componentInstance.viewer2.viewerType).toBe('unknown')
+            expect(fixtureDouble.componentInstance.viewer1.viewerType).toBe('pdf');
+            expect(fixtureDouble.componentInstance.viewer2.viewerType).toBe('unknown');
 
             fixtureDouble.componentInstance.viewer1.urlFile = 'fake-test-file.pdf';
             fixtureDouble.componentInstance.viewer2.urlFile = 'fake-test-file-two.png';
 
             (fixtureDouble.componentInstance.viewer2 as any).viewUtilService.viewerTypeChange.next('png');
 
-            expect(fixtureDouble.componentInstance.viewer1.viewerType).toBe('pdf')
-            expect(fixtureDouble.componentInstance.viewer2.viewerType).toBe('png')
+            expect(fixtureDouble.componentInstance.viewer1.viewerType).toBe('pdf');
+            expect(fixtureDouble.componentInstance.viewer2.viewerType).toBe('png');
         });
     });
     

--- a/lib/core/viewer/components/viewer.component.spec.ts
+++ b/lib/core/viewer/components/viewer.component.spec.ts
@@ -17,7 +17,7 @@
 
 import { Location } from '@angular/common';
 import { SpyLocation } from '@angular/common/testing';
-import { Component } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { AlfrescoApiService, RenditionsService } from '../../services';
 
@@ -132,6 +132,23 @@ class ViewerWithCustomOpenWithComponent {
 })
 class ViewerWithCustomMoreActionsComponent {
 }
+
+@Component({
+    selector: 'adf-double-viewer',
+    template: `
+        <adf-viewer #viewer1 ></adf-viewer>
+        <adf-viewer #viewer2 ></adf-viewer>
+    `
+})
+class DoubleViewerComponent {
+    @ViewChild('viewer1')
+    viewer1: ViewerComponent;
+
+    @ViewChild('viewer2')
+    viewer2: ViewerComponent;
+
+}
+
 describe('ViewerComponent', () => {
 
     let component: ViewerComponent;
@@ -151,6 +168,7 @@ describe('ViewerComponent', () => {
             MatIconModule
         ],
         declarations: [
+            DoubleViewerComponent,
             ViewerWithCustomToolbarComponent,
             ViewerWithCustomSidebarComponent,
             ViewerWithCustomOpenWithComponent,
@@ -183,7 +201,37 @@ describe('ViewerComponent', () => {
     afterEach(() => {
         fixture.destroy();
     });
+    
+     describe('Double viewer Test', () => {
 
+        it('should not reload the content of all the viewer after type change', async () => {
+            const fixtureDouble = TestBed.createComponent(DoubleViewerComponent);
+
+            await fixtureDouble.detectChanges();
+            await fixtureDouble.whenStable();
+
+            fixtureDouble.componentInstance.viewer1.urlFile = 'fake-test-file.pdf';
+            fixtureDouble.componentInstance.viewer2.urlFile = 'fake-test-file-two.xls';
+
+            fixtureDouble.componentInstance.viewer1.ngOnChanges();
+            fixtureDouble.componentInstance.viewer2.ngOnChanges();
+
+            await fixtureDouble.detectChanges();
+            await fixtureDouble.whenStable();
+
+            expect(fixtureDouble.componentInstance.viewer1.viewerType).toBe("pdf")
+            expect(fixtureDouble.componentInstance.viewer2.viewerType).toBe("unknown")
+
+            fixtureDouble.componentInstance.viewer1.urlFile = 'fake-test-file.pdf';
+            fixtureDouble.componentInstance.viewer2.urlFile = 'fake-test-file-two.png';
+
+            (fixtureDouble.componentInstance.viewer2 as any).viewUtilService.viewerTypeChange.next('png');
+
+            expect(fixtureDouble.componentInstance.viewer1.viewerType).toBe("pdf")
+            expect(fixtureDouble.componentInstance.viewer2.viewerType).toBe("png")
+        });
+    });
+    
     describe('Extension Type Test', () => {
         it('should display pdf external viewer via wildcard notation', async () => {
             const extension: ViewerExtensionRef = {

--- a/lib/core/viewer/components/viewer.component.ts
+++ b/lib/core/viewer/components/viewer.component.ts
@@ -50,7 +50,8 @@ import { FileModel } from '../../models';
     templateUrl: './viewer.component.html',
     styleUrls: ['./viewer.component.scss'],
     host: { class: 'adf-viewer' },
-    encapsulation: ViewEncapsulation.None
+    encapsulation: ViewEncapsulation.None,
+    providers: [ViewUtilService]
 })
 export class ViewerComponent implements OnChanges, OnInit, OnDestroy {
 


### PR DESCRIPTION
multiple use in the form of viewer needs multiple instance of ViewUtilService

**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
multiple use viewer in form display the same file when the rendition is involved due the subscribing service be a singleton


**What is the new behaviour?**
util service instance for each viewer


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
