### PR TITLE
[AAE-8648] Fix deprecated copy to clipboard api

### DIFF
--- a/lib/core/clipboard/clipboard.service.spec.ts
+++ b/lib/core/clipboard/clipboard.service.spec.ts
@@ -54,7 +54,7 @@ describe('ClipboardService', () => {
     });
 
     it('should copy text to clipboard', () => {
-        spyOn(document, 'execCommand');
+        spyOn(navigator.clipboard, 'writeText');
         spyOn(inputElement, 'select');
         spyOn(inputElement, 'setSelectionRange');
 
@@ -65,7 +65,7 @@ describe('ClipboardService', () => {
         expect(inputElement.select).toHaveBeenCalledWith();
         expect(inputElement.setSelectionRange)
             .toHaveBeenCalledWith(0, inputElement.value.length);
-        expect(document.execCommand).toHaveBeenCalledWith('copy');
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith('some text');
     });
 
     it('should notify copy to clipboard with message', () => {
@@ -75,5 +75,15 @@ describe('ClipboardService', () => {
         clipboardService.copyToClipboard(inputElement, 'success');
 
         expect(notificationService.openSnackMessage).toHaveBeenCalledWith('success');
+    });
+
+    it('should copy content to clipboard', () => {
+        spyOn(navigator.clipboard, 'writeText');
+        spyOn(notificationService, 'openSnackMessage');
+
+        clipboardService.copyContentToClipboard('some text', 'some message');
+
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith('some text');
+        expect(notificationService.openSnackMessage).toHaveBeenCalledWith('some message');
     });
 });

--- a/lib/core/clipboard/clipboard.service.ts
+++ b/lib/core/clipboard/clipboard.service.ts
@@ -26,7 +26,7 @@ export class ClipboardService {
     constructor(
         @Inject(DOCUMENT) private document: any,
         private logService: LogService,
-        private notificationService: NotificationService) {}
+        private notificationService: NotificationService) { }
 
     /**
      * Checks if the target element can have its text copied.
@@ -52,7 +52,11 @@ export class ClipboardService {
             try {
                 target.select();
                 target.setSelectionRange(0, target.value.length);
-                this.document.execCommand('copy');
+                if (navigator.clipboard) {
+                    navigator.clipboard.writeText(target.value);
+                } else {
+                    this.document.execCommand('copy');
+                }
                 this.notify(message);
             } catch (error) {
                 this.logService.error(error);
@@ -68,12 +72,16 @@ export class ClipboardService {
      */
     copyContentToClipboard(content: string, message: string) {
         try {
-            document.addEventListener('copy', (e: ClipboardEvent) => {
-                e.clipboardData.setData('text/plain', (content));
-                e.preventDefault();
-                document.removeEventListener('copy', null);
-              });
-            document.execCommand('copy');
+            if (navigator.clipboard) {
+                navigator.clipboard.writeText(content);
+            } else {
+                document.addEventListener('copy', (e: ClipboardEvent) => {
+                    e.clipboardData.setData('text/plain', (content));
+                    e.preventDefault();
+                    document.removeEventListener('copy', null);
+                });
+                document.execCommand('copy');
+            }
             this.notify(message);
         } catch (error) {
             this.logService.error(error);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
The copy to clipboard functionality is using a deprecated method, that leads the copy/paste shortcuts not working correctly as the copy command is not retrieving the current selected content.


**What is the new behaviour?**
Use navigator clipboard API (it is not supported in IE so we still maintain old way as fallback)


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://alfresco.atlassian.net/browse/AAE-8648
