### PR TITLE
Add eslint ban rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,9 +22,20 @@
       ],
       "plugins": [
         "eslint-plugin-unicorn",
-        "eslint-plugin-rxjs"
+        "eslint-plugin-rxjs",
+        "ban"
       ],
       "rules": {
+        "ban/ban": [
+          "error",
+          { "name": "eval", "message": "Calls to eval is not allowed." },
+          { "name": "fdescribe", "message": "Calls to fdescribe is not allowed" },
+          { "name": "fit", "message": "Calls to fit is not allowed" },
+          { "name": "xit", "message": "Calls to xit is not allowed" },
+          { "name": "xdescribe", "message": "Calls to xdescribe is not allowed" },
+          { "name": ["test", "only"], "message": "Calls to test.only is not allowed" },
+          { "name": ["describe", "only"], "message": "Calls to describe.only is not allowed" }
+        ],
         "@angular-eslint/component-selector": [
           "error",
           {

--- a/lib/core/form/components/widgets/widget.component.spec.ts
+++ b/lib/core/form/components/widgets/widget.component.spec.ts
@@ -24,7 +24,7 @@ import { CoreTestingModule } from '../../../testing';
 import { TranslateModule } from '@ngx-translate/core';
 import { filter } from 'rxjs/operators';
 
-fdescribe('WidgetComponent', () => {
+describe('WidgetComponent', () => {
 
     let widget: WidgetComponent;
     let fixture: ComponentFixture<WidgetComponent>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -31469,6 +31469,15 @@
         }
       }
     },
+    "eslint-plugin-ban": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-ban/-/eslint-plugin-ban-1.6.0.tgz",
+      "integrity": "sha512-gZptoV+SFHOHO57/5lmPvizMvSXrjFatP9qlVQf3meL/WHo9TxSoERygrMlESl19CPh95U86asTxohT8OprwDw==",
+      "dev": true,
+      "requires": {
+        "requireindex": "~1.2.0"
+      }
+    },
     "eslint-plugin-import": {
       "version": "2.25.4",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.25.4.tgz",

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "css-loader": "^5.2.6",
     "dotenv": "^8.2.0",
     "eslint": "^7.6.0",
+    "eslint-plugin-ban": "^1.6.0",
     "eslint-plugin-import": "2.25.4",
     "eslint-plugin-jsdoc": "30.7.6",
     "eslint-plugin-prefer-arrow": "1.2.2",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [X] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
We have been able to merge a PR containing `fdescribe` without receiving an error in the pipeline


**What is the new behaviour?**
Ban non desired words such as `fdescribe`, `fit`, `xit`, 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
