### PR TITLE
[AAE-8764] Enable left labels in text, number and dropdown cloud widget

### DIFF
--- a/lib/core/form/components/form-renderer.component.scss
+++ b/lib/core/form/components/form-renderer.component.scss
@@ -121,6 +121,15 @@
         }
     }
 
+    &-compact-filter-select {
+        transform: none !important;
+        overflow-x: hidden !important;
+
+        mat-option:nth-child(2) {
+            margin-top: 15px;
+        }
+    }
+
     &-left-label {
         line-height: 48px;
         margin-right: 15px;

--- a/lib/core/form/components/form-renderer.component.scss
+++ b/lib/core/form/components/form-renderer.component.scss
@@ -106,6 +106,25 @@
             font-weight: bold;
         }
     }
+
+    &-compact-field-container {
+        display: flex;
+        font-size: 12px;
+        padding-bottom: 0;
+
+        div:nth-child(2) {
+            flex: 1;
+
+            mat-form-field {
+                font-size: 12px;
+            }
+        }
+    }
+
+    &-left-label {
+        line-height: 48px;
+        margin-right: 15px;
+    }
 }
 
 form-field {

--- a/lib/core/form/components/form-renderer.component.scss
+++ b/lib/core/form/components/form-renderer.component.scss
@@ -116,7 +116,7 @@
     }
 
     &-left-label {
-        line-height: calc(var(--theme-headline-line-height) * 2);
+        line-height: 64px;
         margin-right: 15px;
     }
 }

--- a/lib/core/form/components/form-renderer.component.scss
+++ b/lib/core/form/components/form-renderer.component.scss
@@ -107,31 +107,21 @@
         }
     }
 
-    &-compact-field-container {
+    &-left-label-input-container {
         display: flex;
-        font-size: 12px;
-        padding-bottom: 0;
 
         div:nth-child(2) {
             flex: 1;
-
-            mat-form-field {
-                font-size: 12px;
-            }
         }
     }
 
-    &-compact-filter-select {
+    &-left-label-filter-select {
         transform: none !important;
         overflow-x: hidden !important;
-
-        mat-option:nth-child(2) {
-            margin-top: 15px;
-        }
     }
 
     &-left-label {
-        line-height: 48px;
+        line-height: calc(var(--theme-headline-line-height) * 2);
         margin-right: 15px;
     }
 }

--- a/lib/core/form/components/form-renderer.component.scss
+++ b/lib/core/form/components/form-renderer.component.scss
@@ -115,11 +115,6 @@
         }
     }
 
-    &-left-label-filter-select {
-        transform: none !important;
-        overflow-x: hidden !important;
-    }
-
     &-left-label {
         line-height: calc(var(--theme-headline-line-height) * 2);
         margin-right: 15px;

--- a/lib/core/form/components/widgets/core/form-field.model.ts
+++ b/lib/core/form/components/widgets/core/form-field.model.ts
@@ -76,7 +76,7 @@ export class FormFieldModel extends FormWidgetModel {
     rule?: FormFieldRule;
     selectLoggedUser: boolean;
     groupsRestriction: string[];
-    compactForm: boolean = false;
+    leftLabels: boolean = false;
 
     // container model members
     numberOfColumns: number = 1;
@@ -221,7 +221,7 @@ export class FormFieldModel extends FormWidgetModel {
         }
 
         if (form.json) {
-            this.compactForm = form.json.compactForm || false;
+            this.leftLabels = form.json.leftLabels || false;
         }
         
         const emptyOption = Array.isArray(this.options) ? this.options.find(({ id }) => id === 'empty') : undefined;

--- a/lib/core/form/components/widgets/core/form-field.model.ts
+++ b/lib/core/form/components/widgets/core/form-field.model.ts
@@ -76,6 +76,7 @@ export class FormFieldModel extends FormWidgetModel {
     rule?: FormFieldRule;
     selectLoggedUser: boolean;
     groupsRestriction: string[];
+    compactFields: boolean = false;
 
     // container model members
     numberOfColumns: number = 1;
@@ -219,6 +220,10 @@ export class FormFieldModel extends FormWidgetModel {
             }
         }
 
+        if (form.json) {
+            this.compactFields = form.json.compactFields || false;
+        }
+        
         const emptyOption = Array.isArray(this.options) ? this.options.find(({ id }) => id === 'empty') : undefined;
         if (this.hasEmptyValue === undefined) {
             this.hasEmptyValue = json?.hasEmptyValue ?? !!emptyOption;

--- a/lib/core/form/components/widgets/core/form-field.model.ts
+++ b/lib/core/form/components/widgets/core/form-field.model.ts
@@ -220,7 +220,7 @@ export class FormFieldModel extends FormWidgetModel {
             }
         }
 
-        if (form.json) {
+        if (form?.json) {
             this.leftLabels = form.json.leftLabels || false;
         }
 

--- a/lib/core/form/components/widgets/core/form-field.model.ts
+++ b/lib/core/form/components/widgets/core/form-field.model.ts
@@ -76,7 +76,7 @@ export class FormFieldModel extends FormWidgetModel {
     rule?: FormFieldRule;
     selectLoggedUser: boolean;
     groupsRestriction: string[];
-    compactFields: boolean = false;
+    compactForm: boolean = false;
 
     // container model members
     numberOfColumns: number = 1;
@@ -221,7 +221,7 @@ export class FormFieldModel extends FormWidgetModel {
         }
 
         if (form.json) {
-            this.compactFields = form.json.compactFields || false;
+            this.compactForm = form.json.compactForm || false;
         }
         
         const emptyOption = Array.isArray(this.options) ? this.options.find(({ id }) => id === 'empty') : undefined;

--- a/lib/core/form/components/widgets/core/form-field.model.ts
+++ b/lib/core/form/components/widgets/core/form-field.model.ts
@@ -223,7 +223,7 @@ export class FormFieldModel extends FormWidgetModel {
         if (form.json) {
             this.leftLabels = form.json.leftLabels || false;
         }
-        
+
         const emptyOption = Array.isArray(this.options) ? this.options.find(({ id }) => id === 'empty') : undefined;
         if (this.hasEmptyValue === undefined) {
             this.hasEmptyValue = json?.hasEmptyValue ?? !!emptyOption;

--- a/lib/core/form/components/widgets/form.theme.scss
+++ b/lib/core/form/components/widgets/form.theme.scss
@@ -64,7 +64,7 @@ ul > li > form-field > .adf-focus {
             border-color: var(--theme-warn-color);
         }
     }
-    
+
     &-left-label {
         color: var(--theme-secondary-text-color);
     }

--- a/lib/core/form/components/widgets/form.theme.scss
+++ b/lib/core/form/components/widgets/form.theme.scss
@@ -64,6 +64,10 @@ ul > li > form-field > .adf-focus {
             border-color: var(--theme-warn-color);
         }
     }
+    
+    &-left-label {
+        color: var(--theme-secondary-text-color);
+    }
 }
 
 /* query for Microsoft IE 11 */

--- a/lib/core/form/components/widgets/number/number.widget.html
+++ b/lib/core/form/components/widgets/number/number.widget.html
@@ -1,7 +1,7 @@
 <div class="adf-textfield adf-number-widget {{field.className}}"
      [class.adf-invalid]="!field.isValid && isTouched()" [class.adf-readonly]="field.readOnly" [class.adf-left-label-input-container]="field.leftLabels">
     <div *ngIf="field.leftLabels">
-        <label class="adf-left-label" [attr.for]="field.id">{{field.name | translate }}<span class="adf-asterisk" *ngIf="isRequired()">*</span></label>
+        <label class="adf-label adf-left-label" [attr.for]="field.id">{{field.name | translate }}<span class="adf-asterisk" *ngIf="isRequired()">*</span></label>
     </div>
     <div>
         <mat-form-field [hideRequiredMarker]="true">

--- a/lib/core/form/components/widgets/number/number.widget.html
+++ b/lib/core/form/components/widgets/number/number.widget.html
@@ -1,11 +1,11 @@
 <div class="adf-textfield adf-number-widget {{field.className}}"
-     [class.adf-invalid]="!field.isValid && isTouched()" [class.adf-readonly]="field.readOnly" [class.adf-compact-field-container]="field.compactForm">
-    <div *ngIf="field.compactForm">
+     [class.adf-invalid]="!field.isValid && isTouched()" [class.adf-readonly]="field.readOnly" [class.adf-left-label-input-container]="field.leftLabels">
+    <div *ngIf="field.leftLabels">
         <label class="adf-left-label" [attr.for]="field.id">{{field.name | translate }}<span class="adf-asterisk" *ngIf="isRequired()">*</span></label>
     </div>
     <div>
         <mat-form-field [hideRequiredMarker]="true">
-            <label class="adf-label" *ngIf="!field.compactForm" [attr.for]="field.id">{{field.name | translate }}<span class="adf-asterisk" *ngIf="isRequired()">*</span></label>
+            <label class="adf-label" *ngIf="!field.leftLabels" [attr.for]="field.id">{{field.name | translate }}<span class="adf-asterisk" *ngIf="isRequired()">*</span></label>
             <input matInput
                 class="adf-input"
                 type="text"

--- a/lib/core/form/components/widgets/number/number.widget.html
+++ b/lib/core/form/components/widgets/number/number.widget.html
@@ -1,23 +1,28 @@
 <div class="adf-textfield adf-number-widget {{field.className}}"
-     [class.adf-invalid]="!field.isValid && isTouched()" [class.adf-readonly]="field.readOnly">
-    <mat-form-field [hideRequiredMarker]="true">
-        <label class="adf-label" [attr.for]="field.id">{{field.name | translate }}<span class="adf-asterisk" *ngIf="isRequired()">*</span></label>
-        <input matInput
-               class="adf-input"
-               type="text"
-               pattern="-?[0-9]*(\.[0-9]+)?"
-               [id]="field.id"
-               [required]="isRequired()"
-               [value]="displayValue"
-               [(ngModel)]="field.value"
-               (ngModelChange)="onFieldChanged(field)"
-               [disabled]="field.readOnly"
-               [placeholder]="field.placeholder"
-               [matTooltip]="field.tooltip"
-               (blur)="markAsTouched()"
-               matTooltipPosition="above"
-               matTooltipShowDelay="1000">
-    </mat-form-field>
-    <error-widget [error]="field.validationSummary" ></error-widget>
-    <error-widget *ngIf="isInvalidFieldRequired() && isTouched()" required="{{ 'FORM.FIELD.REQUIRED' | translate }}"></error-widget>
+     [class.adf-invalid]="!field.isValid && isTouched()" [class.adf-readonly]="field.readOnly" [class.adf-compact-field-container]="field.compactForm">
+    <div *ngIf="field.compactForm">
+        <label class="adf-left-label" [attr.for]="field.id">{{field.name | translate }}<span class="adf-asterisk" *ngIf="isRequired()">*</span></label>
+    </div>
+    <div>
+        <mat-form-field [hideRequiredMarker]="true">
+            <label class="adf-label" *ngIf="!field.compactForm" [attr.for]="field.id">{{field.name | translate }}<span class="adf-asterisk" *ngIf="isRequired()">*</span></label>
+            <input matInput
+                class="adf-input"
+                type="text"
+                pattern="-?[0-9]*(\.[0-9]+)?"
+                [id]="field.id"
+                [required]="isRequired()"
+                [value]="displayValue"
+                [(ngModel)]="field.value"
+                (ngModelChange)="onFieldChanged(field)"
+                [disabled]="field.readOnly"
+                [placeholder]="field.placeholder"
+                [matTooltip]="field.tooltip"
+                (blur)="markAsTouched()"
+                matTooltipPosition="above"
+                matTooltipShowDelay="1000">
+        </mat-form-field>
+        <error-widget [error]="field.validationSummary" ></error-widget>
+        <error-widget *ngIf="isInvalidFieldRequired() && isTouched()" required="{{ 'FORM.FIELD.REQUIRED' | translate }}"></error-widget>
+    </div>
 </div>

--- a/lib/core/form/components/widgets/number/number.widget.spec.ts
+++ b/lib/core/form/components/widgets/number/number.widget.spec.ts
@@ -65,11 +65,11 @@ describe('NumberWidgetComponent', () => {
             fixture.detectChanges();
             await fixture.whenStable();
 
-            const textWidgetContainer = element.querySelector('.adf-left-label-input-container')
-            expect(textWidgetContainer).not.toBeNull();
+            const widgetContainer = element.querySelector('.adf-left-label-input-container');
+            expect(widgetContainer).not.toBeNull();
 
-            const adfLeftLabel = element.querySelector('.adf-left-label')
-            expect(adfLeftLabel).not.toBeNull(); 
+            const adfLeftLabel = element.querySelector('.adf-left-label');
+            expect(adfLeftLabel).not.toBeNull();
         });
 
         it('should not have left labels classes on leftLabels false', async () => {
@@ -85,15 +85,15 @@ describe('NumberWidgetComponent', () => {
             fixture.detectChanges();
             await fixture.whenStable();
 
-            const textWidgetContainer = element.querySelector('.adf-left-label-input-container')
-            expect(textWidgetContainer).toBeNull();
+            const widgetContainer = element.querySelector('.adf-left-label-input-container');
+            expect(widgetContainer).toBeNull();
 
-            const adfLeftLabel = element.querySelector('.adf-left-label')
-            expect(adfLeftLabel).toBeNull(); 
+            const adfLeftLabel = element.querySelector('.adf-left-label');
+            expect(adfLeftLabel).toBeNull();
         });
 
         it('should not have left labels classes on leftLabels not present', async () => {
-            widget.field = new FormFieldModel(new FormModel({ taskId: 'fake-task-id'}), {
+            widget.field = new FormFieldModel(new FormModel({ taskId: 'fake-task-id' }), {
                 id: 'number-id',
                 name: 'number-name',
                 value: '',
@@ -105,11 +105,11 @@ describe('NumberWidgetComponent', () => {
             fixture.detectChanges();
             await fixture.whenStable();
 
-            const textWidgetContainer = element.querySelector('.adf-left-label-input-container')
-            expect(textWidgetContainer).toBeNull();
+            const widgetContainer = element.querySelector('.adf-left-label-input-container');
+            expect(widgetContainer).toBeNull();
 
-            const adfLeftLabel = element.querySelector('.adf-left-label')
-            expect(adfLeftLabel).toBeNull(); 
+            const adfLeftLabel = element.querySelector('.adf-left-label');
+            expect(adfLeftLabel).toBeNull();
         });
     });
 });

--- a/lib/core/form/components/widgets/number/number.widget.spec.ts
+++ b/lib/core/form/components/widgets/number/number.widget.spec.ts
@@ -15,17 +15,101 @@
  * limitations under the License.
  */
 
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { TranslateModule } from '@ngx-translate/core';
+import { CoreTestingModule, setupTestBed } from 'core/testing';
+import { FormFieldModel, FormFieldTypes, FormModel } from '../core';
 import { NumberWidgetComponent } from './number.widget';
 
 describe('NumberWidgetComponent', () => {
 
     let widget: NumberWidgetComponent;
+    let fixture: ComponentFixture<NumberWidgetComponent>;
+    let element: HTMLElement;
+
+    setupTestBed({
+        imports: [
+            TranslateModule.forRoot(),
+            CoreTestingModule,
+            MatInputModule,
+            FormsModule,
+            MatIconModule
+        ]
+    });
 
     beforeEach(() => {
-        widget = new NumberWidgetComponent(null, null);
+        fixture = TestBed.createComponent(NumberWidgetComponent);
+        widget = fixture.componentInstance;
+        element = fixture.nativeElement;
     });
 
     it('should exist', () => {
         expect(widget).toBeDefined();
+    });
+
+    describe('when form model has left labels', () => {
+
+        it('should have left labels classes on leftLabels true', async () => {
+            widget.field = new FormFieldModel(new FormModel({ taskId: 'fake-task-id', leftLabels: true }), {
+                id: 'number-id',
+                name: 'number-name',
+                value: '',
+                type: FormFieldTypes.NUMBER,
+                readOnly: false,
+                required: true
+            });
+
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            const textWidgetContainer = element.querySelector('.adf-left-label-input-container')
+            expect(textWidgetContainer).not.toBeNull();
+
+            const adfLeftLabel = element.querySelector('.adf-left-label')
+            expect(adfLeftLabel).not.toBeNull(); 
+        });
+
+        it('should not have left labels classes on leftLabels false', async () => {
+            widget.field = new FormFieldModel(new FormModel({ taskId: 'fake-task-id', leftLabels: false }), {
+                id: 'number-id',
+                name: 'number-name',
+                value: '',
+                type: FormFieldTypes.NUMBER,
+                readOnly: false,
+                required: true
+            });
+
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            const textWidgetContainer = element.querySelector('.adf-left-label-input-container')
+            expect(textWidgetContainer).toBeNull();
+
+            const adfLeftLabel = element.querySelector('.adf-left-label')
+            expect(adfLeftLabel).toBeNull(); 
+        });
+
+        it('should not have left labels classes on leftLabels not present', async () => {
+            widget.field = new FormFieldModel(new FormModel({ taskId: 'fake-task-id'}), {
+                id: 'number-id',
+                name: 'number-name',
+                value: '',
+                type: FormFieldTypes.NUMBER,
+                readOnly: false,
+                required: true
+            });
+
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            const textWidgetContainer = element.querySelector('.adf-left-label-input-container')
+            expect(textWidgetContainer).toBeNull();
+
+            const adfLeftLabel = element.querySelector('.adf-left-label')
+            expect(adfLeftLabel).toBeNull(); 
+        });
     });
 });

--- a/lib/core/form/components/widgets/text/text.widget.html
+++ b/lib/core/form/components/widgets/text/text.widget.html
@@ -1,23 +1,28 @@
 <div class="adf-textfield adf-text-widget {{field.className}}"
-     [class.adf-invalid]="!field.isValid && isTouched()" [class.adf-readonly]="field.readOnly">
-    <mat-form-field [hideRequiredMarker]="true">
-        <label class="adf-label" [attr.for]="field.id">{{field.name | translate }}<span class="adf-asterisk" *ngIf="isRequired()">*</span></label>
-        <input matInput
-               class="adf-input"
-               type="text"
-               [id]="field.id"
-               [required]="isRequired()"
-               [value]="field.value"
-               [(ngModel)]="field.value"
-               (ngModelChange)="onFieldChanged(field)"
-               [disabled]="field.readOnly || readOnly"
-               [textMask]="{mask: mask, isReversed: isMaskReversed}"
-               [placeholder]="placeholder"
-               [matTooltip]="field.tooltip"
-               (blur)="markAsTouched()"
-                matTooltipPosition="above"
-                matTooltipShowDelay="1000">
-    </mat-form-field>
-    <error-widget [error]="field.validationSummary"></error-widget>
-    <error-widget *ngIf="isInvalidFieldRequired() && isTouched()" required="{{ 'FORM.FIELD.REQUIRED' | translate }}"></error-widget>
-</div>
+     [class.adf-invalid]="!field.isValid && isTouched()" [class.adf-readonly]="field.readOnly" [class.adf-compact-field-container]="field.compactFields">
+     <div *ngIf="field.compactFields">
+        <label class="adf-left-label" [attr.for]="field.id">{{field.name | translate }}<span class="adf-asterisk" *ngIf="isRequired()">*</span></label>
+     </div>
+     <div>
+         <mat-form-field [hideRequiredMarker]="true">
+             <label class="adf-label" *ngIf="!field.compactFields" [attr.for]="field.id">{{field.name | translate }}<span class="adf-asterisk" *ngIf="isRequired()">*</span></label>
+             <input matInput
+                    class="adf-input"
+                    type="text"
+                    [id]="field.id"
+                    [required]="isRequired()"
+                    [value]="field.value"
+                    [(ngModel)]="field.value"
+                    (ngModelChange)="onFieldChanged(field)"
+                    [disabled]="field.readOnly || readOnly"
+                    [textMask]="{mask: mask, isReversed: isMaskReversed}"
+                    [placeholder]="placeholder"
+                    [matTooltip]="field.tooltip"
+                    (blur)="markAsTouched()"
+                     matTooltipPosition="above"
+                     matTooltipShowDelay="1000">
+         </mat-form-field>
+         <error-widget [error]="field.validationSummary"></error-widget>
+         <error-widget *ngIf="isInvalidFieldRequired() && isTouched()" required="{{ 'FORM.FIELD.REQUIRED' | translate }}"></error-widget>
+     </div>
+ </div>

--- a/lib/core/form/components/widgets/text/text.widget.html
+++ b/lib/core/form/components/widgets/text/text.widget.html
@@ -1,11 +1,11 @@
 <div class="adf-textfield adf-text-widget {{field.className}}"
-     [class.adf-invalid]="!field.isValid && isTouched()" [class.adf-readonly]="field.readOnly" [class.adf-compact-field-container]="field.compactForm">
-     <div *ngIf="field.compactForm">
+     [class.adf-invalid]="!field.isValid && isTouched()" [class.adf-readonly]="field.readOnly" [class.adf-left-label-input-container]="field.leftLabels">
+     <div *ngIf="field.leftLabels">
         <label class="adf-left-label" [attr.for]="field.id">{{field.name | translate }}<span class="adf-asterisk" *ngIf="isRequired()">*</span></label>
      </div>
      <div>
          <mat-form-field [hideRequiredMarker]="true">
-             <label class="adf-label" *ngIf="!field.compactForm" [attr.for]="field.id">{{field.name | translate }}<span class="adf-asterisk" *ngIf="isRequired()">*</span></label>
+             <label class="adf-label" *ngIf="!field.leftLabels" [attr.for]="field.id">{{field.name | translate }}<span class="adf-asterisk" *ngIf="isRequired()">*</span></label>
              <input matInput
                     class="adf-input"
                     type="text"

--- a/lib/core/form/components/widgets/text/text.widget.html
+++ b/lib/core/form/components/widgets/text/text.widget.html
@@ -1,11 +1,11 @@
 <div class="adf-textfield adf-text-widget {{field.className}}"
-     [class.adf-invalid]="!field.isValid && isTouched()" [class.adf-readonly]="field.readOnly" [class.adf-compact-field-container]="field.compactFields">
-     <div *ngIf="field.compactFields">
+     [class.adf-invalid]="!field.isValid && isTouched()" [class.adf-readonly]="field.readOnly" [class.adf-compact-field-container]="field.compactForm">
+     <div *ngIf="field.compactForm">
         <label class="adf-left-label" [attr.for]="field.id">{{field.name | translate }}<span class="adf-asterisk" *ngIf="isRequired()">*</span></label>
      </div>
      <div>
          <mat-form-field [hideRequiredMarker]="true">
-             <label class="adf-label" *ngIf="!field.compactFields" [attr.for]="field.id">{{field.name | translate }}<span class="adf-asterisk" *ngIf="isRequired()">*</span></label>
+             <label class="adf-label" *ngIf="!field.compactForm" [attr.for]="field.id">{{field.name | translate }}<span class="adf-asterisk" *ngIf="isRequired()">*</span></label>
              <input matInput
                     class="adf-input"
                     type="text"

--- a/lib/core/form/components/widgets/text/text.widget.html
+++ b/lib/core/form/components/widgets/text/text.widget.html
@@ -1,7 +1,7 @@
 <div class="adf-textfield adf-text-widget {{field.className}}"
      [class.adf-invalid]="!field.isValid && isTouched()" [class.adf-readonly]="field.readOnly" [class.adf-left-label-input-container]="field.leftLabels">
      <div *ngIf="field.leftLabels">
-        <label class="adf-left-label" [attr.for]="field.id">{{field.name | translate }}<span class="adf-asterisk" *ngIf="isRequired()">*</span></label>
+        <label class="adf-label adf-left-label" [attr.for]="field.id">{{field.name | translate }}<span class="adf-asterisk" *ngIf="isRequired()">*</span></label>
      </div>
      <div>
          <mat-form-field [hideRequiredMarker]="true">

--- a/lib/core/form/components/widgets/text/text.widget.spec.ts
+++ b/lib/core/form/components/widgets/text/text.widget.spec.ts
@@ -442,5 +442,68 @@ describe('TextWidgetComponent', () => {
                 expect(label.innerText).toBe('Phone : (__) ___-___');
             });
         });
+
+        describe('when form model has left labels', () => {
+
+            it('should have left labels classes on leftLabels true', async () => {
+                widget.field = new FormFieldModel(new FormModel({ taskId: 'fake-task-id', leftLabels: true }), {
+                    id: 'text-id',
+                    name: 'text-name',
+                    value: '',
+                    type: FormFieldTypes.TEXT,
+                    readOnly: false,
+                    required: true
+                });
+
+                fixture.detectChanges();
+                await fixture.whenStable();
+
+                const textWidgetContainer = element.querySelector('.adf-left-label-input-container')
+                expect(textWidgetContainer).not.toBeNull();
+
+                const adfLeftLabel = element.querySelector('.adf-left-label')
+                expect(adfLeftLabel).not.toBeNull(); 
+            });
+
+            it('should not have left labels classes on leftLabels false', async () => {
+                widget.field = new FormFieldModel(new FormModel({ taskId: 'fake-task-id', leftLabels: false }), {
+                    id: 'text-id',
+                    name: 'text-name',
+                    value: '',
+                    type: FormFieldTypes.TEXT,
+                    readOnly: false,
+                    required: true
+                });
+
+                fixture.detectChanges();
+                await fixture.whenStable();
+
+                const textWidgetContainer = element.querySelector('.adf-left-label-input-container')
+                expect(textWidgetContainer).toBeNull();
+
+                const adfLeftLabel = element.querySelector('.adf-left-label')
+                expect(adfLeftLabel).toBeNull(); 
+            });
+
+            it('should not have left labels classes on leftLabels not present', async () => {
+                widget.field = new FormFieldModel(new FormModel({ taskId: 'fake-task-id'}), {
+                    id: 'text-id',
+                    name: 'text-name',
+                    value: '',
+                    type: FormFieldTypes.TEXT,
+                    readOnly: false,
+                    required: true
+                });
+
+                fixture.detectChanges();
+                await fixture.whenStable();
+
+                const textWidgetContainer = element.querySelector('.adf-left-label-input-container')
+                expect(textWidgetContainer).toBeNull();
+
+                const adfLeftLabel = element.querySelector('.adf-left-label')
+                expect(adfLeftLabel).toBeNull(); 
+            });
+        });
     });
 });

--- a/lib/core/form/components/widgets/text/text.widget.spec.ts
+++ b/lib/core/form/components/widgets/text/text.widget.spec.ts
@@ -458,11 +458,11 @@ describe('TextWidgetComponent', () => {
                 fixture.detectChanges();
                 await fixture.whenStable();
 
-                const textWidgetContainer = element.querySelector('.adf-left-label-input-container')
-                expect(textWidgetContainer).not.toBeNull();
+                const widgetContainer = element.querySelector('.adf-left-label-input-container');
+                expect(widgetContainer).not.toBeNull();
 
-                const adfLeftLabel = element.querySelector('.adf-left-label')
-                expect(adfLeftLabel).not.toBeNull(); 
+                const adfLeftLabel = element.querySelector('.adf-left-label');
+                expect(adfLeftLabel).not.toBeNull();
             });
 
             it('should not have left labels classes on leftLabels false', async () => {
@@ -478,15 +478,15 @@ describe('TextWidgetComponent', () => {
                 fixture.detectChanges();
                 await fixture.whenStable();
 
-                const textWidgetContainer = element.querySelector('.adf-left-label-input-container')
-                expect(textWidgetContainer).toBeNull();
+                const widgetContainer = element.querySelector('.adf-left-label-input-container');
+                expect(widgetContainer).toBeNull();
 
-                const adfLeftLabel = element.querySelector('.adf-left-label')
-                expect(adfLeftLabel).toBeNull(); 
+                const adfLeftLabel = element.querySelector('.adf-left-label');
+                expect(adfLeftLabel).toBeNull();
             });
 
             it('should not have left labels classes on leftLabels not present', async () => {
-                widget.field = new FormFieldModel(new FormModel({ taskId: 'fake-task-id'}), {
+                widget.field = new FormFieldModel(new FormModel({ taskId: 'fake-task-id' }), {
                     id: 'text-id',
                     name: 'text-name',
                     value: '',
@@ -498,11 +498,11 @@ describe('TextWidgetComponent', () => {
                 fixture.detectChanges();
                 await fixture.whenStable();
 
-                const textWidgetContainer = element.querySelector('.adf-left-label-input-container')
-                expect(textWidgetContainer).toBeNull();
+                const widgetContainer = element.querySelector('.adf-left-label-input-container');
+                expect(widgetContainer).toBeNull();
 
-                const adfLeftLabel = element.querySelector('.adf-left-label')
-                expect(adfLeftLabel).toBeNull(); 
+                const adfLeftLabel = element.querySelector('.adf-left-label');
+                expect(adfLeftLabel).toBeNull();
             });
         });
     });

--- a/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.html
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.html
@@ -1,36 +1,39 @@
 <div class="adf-dropdown-widget {{field.className}}"
-     [class.adf-invalid]="(!field.isValid && isTouched()) || isRestApiFailed" [class.adf-readonly]="field.readOnly">
+     [class.adf-invalid]="(!field.isValid && isTouched()) || isRestApiFailed" [class.adf-readonly]="field.readOnly" [class.adf-compact-field-container]="field.compactForm">
     <div class="adf-dropdown-widget-top-labels">
-        <label class="adf-label" [attr.for]="field.id">{{field.name | translate }}<span class="adf-asterisk"
+        <label class="adf-label" [attr.for]="field.id" [class.adf-left-label]="field.compactForm">{{field.name | translate }}<span class="adf-asterisk"
             *ngIf="isRequired()">*</span>
         </label>
     </div>
-    <mat-form-field>
-        <mat-select class="adf-select"
-                    [id]="field.id"
-                    [(ngModel)]="field.value"
-                    [disabled]="field.readOnly"
-                    [compareWith]="compareDropdownValues"
-                    (ngModelChange)="selectionChangedForField(field)"
-                    [matTooltip]="field.tooltip"
-                    [required]="isRequired()"
-                    panelClass="adf-select-filter"
-                    (blur)="markAsTouched()"
-                    matTooltipPosition="above"
-                    matTooltipShowDelay="1000"
-                    [multiple]="field.hasMultipleValues">
-            <adf-select-filter-input *ngIf="showInputFilter" (change)="filter$.next($event)"></adf-select-filter-input>
-
-            <mat-option *ngFor="let opt of list$ | async"
-                        [value]="getOptionValue(opt, field.value)"
-                        [id]="opt.id">{{opt.name}}
-            </mat-option>
-            <mat-option id="readonlyOption" *ngIf="isReadOnlyType()" [value]="field.value">{{field.value}}</mat-option>
-        </mat-select>
-    </mat-form-field>
-    <error-widget [error]="field.validationSummary"></error-widget>
-    <error-widget class="adf-dropdown-required-message" *ngIf="showRequiredMessage()"
-                  required="{{ 'FORM.FIELD.REQUIRED' | translate }}"></error-widget>
-    <error-widget class="adf-dropdown-failed-message" *ngIf="isRestApiFailed"
-                  required="{{ 'FORM.FIELD.REST_API_FAILED' | translate: { hostname: restApiHostName } }}"></error-widget>
+    <div>
+        <mat-form-field>
+            <mat-select class="adf-select"
+                        [id]="field.id"
+                        [(ngModel)]="field.value"
+                        [disabled]="field.readOnly"
+                        [compareWith]="compareDropdownValues"
+                        (ngModelChange)="selectionChangedForField(field)"
+                        [matTooltip]="field.tooltip"
+                        [required]="isRequired()"
+                        panelClass="adf-select-filter"
+                        (blur)="markAsTouched()"
+                        matTooltipPosition="above"
+                        matTooltipShowDelay="1000"
+                        [multiple]="field.hasMultipleValues"
+                        [panelClass]="field.compactForm && showInputFilter ? 'adf-compact-filter-select' : ''">
+                <adf-select-filter-input *ngIf="showInputFilter" (change)="filter$.next($event)"></adf-select-filter-input>
+    
+                <mat-option *ngFor="let opt of list$ | async"
+                            [value]="getOptionValue(opt, field.value)"
+                            [id]="opt.id">{{opt.name}}
+                </mat-option>
+                <mat-option id="readonlyOption" *ngIf="isReadOnlyType()" [value]="field.value">{{field.value}}</mat-option>
+            </mat-select>
+        </mat-form-field>
+        <error-widget [error]="field.validationSummary"></error-widget>
+        <error-widget class="adf-dropdown-required-message" *ngIf="showRequiredMessage()"
+                      required="{{ 'FORM.FIELD.REQUIRED' | translate }}"></error-widget>
+        <error-widget class="adf-dropdown-failed-message" *ngIf="isRestApiFailed"
+                      required="{{ 'FORM.FIELD.REST_API_FAILED' | translate: { hostname: restApiHostName } }}"></error-widget>
+    </div>
 </div>

--- a/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.html
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.html
@@ -1,7 +1,7 @@
 <div class="adf-dropdown-widget {{field.className}}"
-     [class.adf-invalid]="(!field.isValid && isTouched()) || isRestApiFailed" [class.adf-readonly]="field.readOnly" [class.adf-compact-field-container]="field.compactForm">
+     [class.adf-invalid]="(!field.isValid && isTouched()) || isRestApiFailed" [class.adf-readonly]="field.readOnly" [class.adf-left-label-input-container]="field.leftLabels">
     <div class="adf-dropdown-widget-top-labels">
-        <label class="adf-label" [attr.for]="field.id" [class.adf-left-label]="field.compactForm">{{field.name | translate }}<span class="adf-asterisk"
+        <label class="adf-label" [attr.for]="field.id" [class.adf-left-label]="field.leftLabels">{{field.name | translate }}<span class="adf-asterisk"
             *ngIf="isRequired()">*</span>
         </label>
     </div>
@@ -20,7 +20,7 @@
                         matTooltipPosition="above"
                         matTooltipShowDelay="1000"
                         [multiple]="field.hasMultipleValues"
-                        [panelClass]="field.compactForm && showInputFilter ? 'adf-compact-filter-select' : ''">
+                        [panelClass]="field.leftLabels && showInputFilter ? 'adf-left-label-filter-select' : ''">
                 <adf-select-filter-input *ngIf="showInputFilter" (change)="filter$.next($event)"></adf-select-filter-input>
     
                 <mat-option *ngFor="let opt of list$ | async"

--- a/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.html
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.html
@@ -19,8 +19,7 @@
                         (blur)="markAsTouched()"
                         matTooltipPosition="above"
                         matTooltipShowDelay="1000"
-                        [multiple]="field.hasMultipleValues"
-                        [panelClass]="field.leftLabels && showInputFilter ? 'adf-left-label-filter-select' : ''">
+                        [multiple]="field.hasMultipleValues">
                 <adf-select-filter-input *ngIf="showInputFilter" (change)="filter$.next($event)"></adf-select-filter-input>
     
                 <mat-option *ngFor="let opt of list$ | async"

--- a/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.spec.ts
@@ -628,5 +628,65 @@ describe('DropdownCloudWidgetComponent', () => {
                 expect(widget.field.options).toEqual(mockRestDropdownOptions);
             });
         });
+
+        describe('when form model has left labels', () => {
+
+            it('should have left labels classes on leftLabels true', async () => {
+                widget.field = new FormFieldModel(new FormModel({ taskId: 'fake-task-id', leftLabels: true }), {
+                    id: 'dropdown-id',
+                    name: 'option list',
+                    type: FormFieldTypes.DROPDOWN,
+                    readOnly: false,
+                    options: filterOptionList
+                });
+
+                fixture.detectChanges();
+                await fixture.whenStable();
+
+                const textWidgetContainer = element.querySelector('.adf-left-label-input-container')
+                expect(textWidgetContainer).not.toBeNull();
+
+                const adfLeftLabel = element.querySelector('.adf-left-label')
+                expect(adfLeftLabel).not.toBeNull(); 
+            });
+
+            it('should not have left labels classes on leftLabels false', async () => {
+                widget.field = new FormFieldModel(new FormModel({ taskId: 'fake-task-id', leftLabels: false }), {
+                    id: 'dropdown-id',
+                    name: 'option list',
+                    type: FormFieldTypes.DROPDOWN,
+                    readOnly: false,
+                    options: filterOptionList
+                });
+
+                fixture.detectChanges();
+                await fixture.whenStable();
+
+                const textWidgetContainer = element.querySelector('.adf-left-label-input-container')
+                expect(textWidgetContainer).toBeNull();
+
+                const adfLeftLabel = element.querySelector('.adf-left-label')
+                expect(adfLeftLabel).toBeNull(); 
+            });
+
+            it('should not have left labels classes on leftLabels not present', async () => {
+                widget.field = new FormFieldModel(new FormModel({ taskId: 'fake-task-id'}), {
+                    id: 'dropdown-id',
+                    name: 'option list',
+                    type: FormFieldTypes.DROPDOWN,
+                    readOnly: false,
+                    options: filterOptionList
+                });
+
+                fixture.detectChanges();
+                await fixture.whenStable();
+
+                const textWidgetContainer = element.querySelector('.adf-left-label-input-container')
+                expect(textWidgetContainer).toBeNull();
+
+                const adfLeftLabel = element.querySelector('.adf-left-label')
+                expect(adfLeftLabel).toBeNull(); 
+            });
+        });
     });
 });

--- a/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.spec.ts
@@ -643,11 +643,11 @@ describe('DropdownCloudWidgetComponent', () => {
                 fixture.detectChanges();
                 await fixture.whenStable();
 
-                const textWidgetContainer = element.querySelector('.adf-left-label-input-container')
-                expect(textWidgetContainer).not.toBeNull();
+                const widgetContainer = element.querySelector('.adf-left-label-input-container');
+                expect(widgetContainer).not.toBeNull();
 
-                const adfLeftLabel = element.querySelector('.adf-left-label')
-                expect(adfLeftLabel).not.toBeNull(); 
+                const adfLeftLabel = element.querySelector('.adf-left-label');
+                expect(adfLeftLabel).not.toBeNull();
             });
 
             it('should not have left labels classes on leftLabels false', async () => {
@@ -662,15 +662,15 @@ describe('DropdownCloudWidgetComponent', () => {
                 fixture.detectChanges();
                 await fixture.whenStable();
 
-                const textWidgetContainer = element.querySelector('.adf-left-label-input-container')
-                expect(textWidgetContainer).toBeNull();
+                const widgetContainer = element.querySelector('.adf-left-label-input-container');
+                expect(widgetContainer).toBeNull();
 
-                const adfLeftLabel = element.querySelector('.adf-left-label')
-                expect(adfLeftLabel).toBeNull(); 
+                const adfLeftLabel = element.querySelector('.adf-left-label');
+                expect(adfLeftLabel).toBeNull();
             });
 
             it('should not have left labels classes on leftLabels not present', async () => {
-                widget.field = new FormFieldModel(new FormModel({ taskId: 'fake-task-id'}), {
+                widget.field = new FormFieldModel(new FormModel({ taskId: 'fake-task-id' }), {
                     id: 'dropdown-id',
                     name: 'option list',
                     type: FormFieldTypes.DROPDOWN,
@@ -681,11 +681,11 @@ describe('DropdownCloudWidgetComponent', () => {
                 fixture.detectChanges();
                 await fixture.whenStable();
 
-                const textWidgetContainer = element.querySelector('.adf-left-label-input-container')
-                expect(textWidgetContainer).toBeNull();
+                const widgetContainer = element.querySelector('.adf-left-label-input-container');
+                expect(widgetContainer).toBeNull();
 
-                const adfLeftLabel = element.querySelector('.adf-left-label')
-                expect(adfLeftLabel).toBeNull(); 
+                const adfLeftLabel = element.querySelector('.adf-left-label');
+                expect(adfLeftLabel).toBeNull();
             });
         });
     });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [X] Other... Please describe:
Refactor styles

**What is the current behaviour?** (You can also link to an open issue here)


**What is the new behaviour?**
Text, number and dropdown widget accept form compact mode showing their labels in the left side of the input



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
