### PR TITLE
[AAE-7856] Show process variables in table

### DIFF
--- a/docs/core/components/data-column.component.md
+++ b/docs/core/components/data-column.component.md
@@ -21,6 +21,7 @@ Defines column properties for DataTable, Tasklist, Document List and other compo
     -   [Column Template](#column-template)
     -   [Styling Techniques](#styling-techniques)
     -   [Using the copyContent option](#using-the-copycontent-option)
+    -   [Exapmple of column customData](#example-of-column-customData)
 -   [See also](#see-also)
 
 ## Basic Usage
@@ -52,6 +53,7 @@ Defines column properties for DataTable, Tasklist, Document List and other compo
 | formatTooltip | `Function` |  | Custom tooltip formatter function. |
 | key | `string` |  | Data source key. Can be either a column/property key like `title`  or a property path like `createdBy.name`. |
 | sortable | `boolean` | true | Toggles ability to sort by this column, for example by clicking the column header. |
+| customData | `Generic` | any | Any feature specific data |
 | draggable | `boolean` | false | Toggles drag and drop for header column. |
 | isHidden | `boolean` | false | Hides columns |
 | sortingKey | `string` |  | When using server side sorting the column used by the api call where the sorting will be performed |
@@ -349,6 +351,35 @@ HTML `<data-column>` element example:
         ...
     </data-columns>
 </adf-tasklist>
+```
+
+### Example of column customData
+
+If you would like to pass any custom data related to your specific feature, you can use customData
+
+HTML `<data-column>` element example:
+
+```html
+<data-column [customData]="MyCustomData" key="id" title="Id"></data-column>
+```
+
+You can use generic type for `DataColumn` in order to get intellisense working e.g.
+
+```ts
+const dataColumn: DataColumn<{ shouldPerformActionIfDisplayed: boolean }> = {
+    ...
+    customData: { shouldPerformActionIfDisplayed: true }
+}
+
+// We should get proper types
+consol.log(dataColumn.customData.shouldPerformActionIfDisplayed);
+
+// Now we can use this data in our feature e.g.
+const shouldPerformAction = this.columns
+    .filter(column => column.isHidden)
+    .some(column => column.customData?.shouldPerformActionIfDisplayed === true);
+
+if (shouldPerformAction) { /* action */}
 ```
 
 ## See also

--- a/e2e/protractor.excludes.json
+++ b/e2e/protractor.excludes.json
@@ -2,5 +2,11 @@
   "C269081": "https://alfresco.atlassian.net/browse/ADF-5385",
   "C272819": "https://alfresco.atlassian.net/browse/ADF-5385",
   "C362241": "https://alfresco.atlassian.net/browse/ADF-5385",
-  "C593997": "https://alfresco.atlassian.net/browse/ADF-5479"
+  "C593997": "https://alfresco.atlassian.net/browse/ADF-5479",
+  "C246534": "https://alfresco.atlassian.net/browse/ADF-5485",
+  "C268151": "https://alfresco.atlassian.net/browse/ADF-5488",
+  "C260377": "https://alfresco.atlassian.net/browse/ADF-5488",
+  "C260375": "https://alfresco.atlassian.net/browse/ADF-5488",
+  "C286290": "https://alfresco.atlassian.net/browse/ADF-5488",
+  "C286472": "https://alfresco.atlassian.net/browse/ADF-5487"
 }

--- a/e2e/protractor.excludes.json
+++ b/e2e/protractor.excludes.json
@@ -2,11 +2,5 @@
   "C269081": "https://alfresco.atlassian.net/browse/ADF-5385",
   "C272819": "https://alfresco.atlassian.net/browse/ADF-5385",
   "C362241": "https://alfresco.atlassian.net/browse/ADF-5385",
-  "C593997": "https://alfresco.atlassian.net/browse/ADF-5479",
-  "C246534": "https://alfresco.atlassian.net/browse/ADF-5485",
-  "C268151": "https://alfresco.atlassian.net/browse/ADF-5488",
-  "C260377": "https://alfresco.atlassian.net/browse/ADF-5488",
-  "C260375": "https://alfresco.atlassian.net/browse/ADF-5488",
-  "C286290": "https://alfresco.atlassian.net/browse/ADF-5488",
-  "C286472": "https://alfresco.atlassian.net/browse/ADF-5487"
+  "C593997": "https://alfresco.atlassian.net/browse/ADF-5479"
 }

--- a/lib/content-services/src/lib/document-list/data/share-datatable-adapter.ts
+++ b/lib/content-services/src/lib/document-list/data/share-datatable-adapter.ts
@@ -70,6 +70,10 @@ export class ShareDataTableAdapter implements DataTableAdapter {
         this.allowDropFiles = allowDropFiles;
     }
 
+    getColumnType(_row: DataRow, col: DataColumn): string {
+        return col.type;
+    }
+
     getRows(): Array<DataRow> {
         return this.rows;
     }

--- a/lib/core/data-column/data-column.component.ts
+++ b/lib/core/data-column/data-column.component.ts
@@ -34,6 +34,10 @@ export class DataColumnComponent implements OnInit {
     @Input()
     key: string;
 
+    /** You can specify any custom data which can be used by any specific feature */
+    @Input()
+    customData: any;
+
     /** Value type for the column. Possible settings are 'text', 'image',
      * 'date', 'fileSize', 'location', and 'json'.
      */
@@ -51,6 +55,10 @@ export class DataColumnComponent implements OnInit {
     /* Enable drag and drop for header column */
     @Input()
     draggable: boolean = false;
+
+    /* Hide column */
+    @Input()
+    isHidden: boolean = false;
 
     /** Display title of the column, typically used for column headers. You can use the
      * i18n resource key to get it translated automatically.

--- a/lib/core/datatable/components/columns-selector/columns-selector.component.html
+++ b/lib/core/datatable/components/columns-selector/columns-selector.component.html
@@ -24,20 +24,22 @@
             [placeholder]='"ADF-DATATABLE.COLUMNS_SELECTOR.SEARCH" | translate'>
     </div>
 
-    <ng-container *ngFor="let column of columnItems">
-        <div
-            *ngIf="(column.title | translate | filterString:searchQuery) as translatedTitle"
-            class="adf-columns-selector-list-item-container">
-            <mat-checkbox
-                color="primary"
-                class="adf-columns-selector-column-checkbox"
-                [attr.data-automation-id]="'adf-columns-selector-column-checkbox-' + column.title"
-                [checked]="!column.isHidden"
-                (change)="changeColumnVisibility(column)">
-                <div class="adf-columns-selector-list-content">{{translatedTitle}}</div>
-            </mat-checkbox>
-        </div>
-    </ng-container>
+    <div class="adf-columns-selector-list-container">
+        <ng-container *ngFor="let column of columnItems">
+            <div
+                *ngIf="(column.title | translate | filterString:searchQuery) as translatedTitle"
+                class="adf-columns-selector-list-item">
+                <mat-checkbox
+                    color="primary"
+                    class="adf-columns-selector-column-checkbox"
+                    [attr.data-automation-id]="'adf-columns-selector-column-checkbox-' + column.title"
+                    [checked]="!column.isHidden"
+                    (change)="changeColumnVisibility(column)">
+                    <div class="adf-columns-selector-list-content">{{translatedTitle}}</div>
+                </mat-checkbox>
+            </div>
+        </ng-container>
+    </div>
 
     <mat-divider class="adf-columns-selector-divider"></mat-divider>
 

--- a/lib/core/datatable/components/columns-selector/columns-selector.component.scss
+++ b/lib/core/datatable/components/columns-selector/columns-selector.component.scss
@@ -25,7 +25,13 @@ $adf-columns-selector-space: 12px;
         font-size: var(--theme-body-1-font-size);
     }
 
-    &-list-item-container {
+    &-list-container {
+        max-height: 350px;
+        overflow-x: hidden;
+        overflow-y: auto;
+    }
+
+    &-list-item {
         margin-top: 10px;
 
         &:hover {

--- a/lib/core/datatable/components/datatable/datatable.component.html
+++ b/lib/core/datatable/components/datatable/datatable.component.html
@@ -194,7 +194,7 @@
                      [adf-context-menu-enabled]="contextMenu"
                      adf-drop-zone dropTarget="cell" [dropColumn]="col" [dropRow]="row">
                     <div *ngIf="!col.template" class="adf-datatable-cell-container">
-                        <ng-container [ngSwitch]="col.type">
+                        <ng-container [ngSwitch]="data.getColumnType(row, col)">
                             <div *ngSwitchCase="'image'" class="adf-cell-value">
                                 <mat-icon *ngIf="isIconValue(row, col); else no_iconvalue">{{ asIconValue(row, col) }}
                                 </mat-icon>
@@ -204,12 +204,12 @@
                                     </mat-icon>
                                     <ng-template #no_selected_row>
                                         <img class="adf-datatable-center-img-ie"
-                                            [attr.aria-label]=" (data.getValue(row, col) | fileType) === 'disable' ?
+                                            [attr.aria-label]="(data.getValue(row, col) | fileType) === 'disable' ?
                                                 ('ADF-DATATABLE.ACCESSIBILITY.ICON_DISABLED' | translate) :
                                                 'ADF-DATATABLE.ACCESSIBILITY.ICON_TEXT' | translate:{
                                                     type: 'ADF-DATATABLE.FILE_TYPE.' + (data.getValue(row, col) | fileType | uppercase) | translate
                                                 }"
-                                            [attr.alt]=" (data.getValue(row, col) | fileType) === 'disable' ?
+                                            [attr.alt]="(data.getValue(row, col) | fileType) === 'disable' ?
                                                 ('ADF-DATATABLE.ACCESSIBILITY.ICON_DISABLED' | translate) :
                                                 'ADF-DATATABLE.ACCESSIBILITY.ICON_TEXT' | translate:{
                                                         type: 'ADF-DATATABLE.FILE_TYPE.' + (data.getValue(row, col) | fileType | uppercase) | translate

--- a/lib/core/datatable/data/data-column.model.ts
+++ b/lib/core/datatable/data/data-column.model.ts
@@ -29,7 +29,7 @@ export interface DataColumnTypes {
 
 export type DataColumnType = keyof DataColumnTypes;
 
-export interface DataColumn {
+export interface DataColumn<T = unknown> {
     id?: string;
     key: string;
     type: DataColumnType;
@@ -47,4 +47,5 @@ export interface DataColumn {
     header?: TemplateRef<any>;
     draggable?: boolean;
     isHidden?: boolean;
+    customData?: T;
 }

--- a/lib/core/datatable/data/data-table.schema.ts
+++ b/lib/core/datatable/data/data-table.schema.ts
@@ -24,7 +24,7 @@ import { ObjectDataColumn } from './object-datacolumn.model';
 
 @Directive()
 // eslint-disable-next-line @angular-eslint/directive-class-suffix
-export abstract class DataTableSchema {
+export abstract class DataTableSchema<T = unknown> {
 
     @ContentChild(DataColumnListComponent)
     columnList: DataColumnListComponent;
@@ -33,7 +33,7 @@ export abstract class DataTableSchema {
     @Input()
     presetColumn: string;
 
-    columns: any;
+    columns: DataColumn<T>[];
 
     protected columnsOrder: string[] | undefined;
     protected columnsOrderedByKey: string = 'id';
@@ -91,7 +91,7 @@ export abstract class DataTableSchema {
         return customSchemaColumns;
     }
 
-    public getSchemaFromHtml(columnList: DataColumnListComponent): any {
+    public getSchemaFromHtml(columnList: DataColumnListComponent): DataColumn[] {
         let schema = [];
         if (columnList && columnList.columns && columnList.columns.length > 0) {
             schema = columnList.columns.map((c) => c as DataColumn);

--- a/lib/core/datatable/data/datatable-adapter.ts
+++ b/lib/core/datatable/data/datatable-adapter.ts
@@ -29,6 +29,7 @@ export interface DataTableAdapter {
     getColumns(): Array<DataColumn>;
     setColumns(columns: Array<DataColumn>): void;
     getValue(row: DataRow, col: DataColumn, resolverFn?: (_row: DataRow, _col: DataColumn) => any): any;
+    getColumnType(row: DataRow, col: DataColumn): string;
     getSorting(): DataSorting;
     setSorting(sorting: DataSorting): void;
     sort(key?: string, direction?: string): void;

--- a/lib/core/datatable/data/object-datacolumn.model.ts
+++ b/lib/core/datatable/data/object-datacolumn.model.ts
@@ -19,7 +19,7 @@ import { TemplateRef } from '@angular/core';
 import { DataColumn, DataColumnType } from './data-column.model';
 
 // Simple implementation of the DataColumn interface.
-export class ObjectDataColumn implements DataColumn {
+export class ObjectDataColumn<T = unknown> implements DataColumn<T> {
     id?: string;
     key: string;
     type: DataColumnType;
@@ -35,6 +35,7 @@ export class ObjectDataColumn implements DataColumn {
     header?: TemplateRef<any>;
     draggable: boolean;
     isHidden: boolean;
+    customData?: T;
 
     constructor(input: any) {
         this.id = input.id ?? '';
@@ -52,5 +53,6 @@ export class ObjectDataColumn implements DataColumn {
         this.header = input.header;
         this.draggable = input.draggable ?? false;
         this.isHidden = input.isHidden ?? false;
+        this.customData = input.customData;
     }
 }

--- a/lib/core/datatable/data/object-datatable-adapter.ts
+++ b/lib/core/datatable/data/object-datatable-adapter.ts
@@ -77,6 +77,10 @@ export class ObjectDataTableAdapter implements DataTableAdapter {
         this.rowsChanged = new Subject<Array<DataRow>>();
     }
 
+    getColumnType(_row: DataRow, col: DataColumn): string {
+        return col.type;
+    }
+
     getRows(): Array<DataRow> {
         return this._rows;
     }

--- a/lib/core/mock/data-column.mock.ts
+++ b/lib/core/mock/data-column.mock.ts
@@ -1,0 +1,22 @@
+import { DataColumn } from '../datatable/data/data-column.model';
+
+export const getDataColumnMock = <T = unknown>(column: Partial<DataColumn<T>> = {}): DataColumn<T> => ({
+    id: 'columnId',
+    key: 'key',
+    type: 'text',
+    format: 'format',
+    sortable: false,
+    title: 'title',
+    srTitle: 'srTitle',
+    cssClass: 'cssClass',
+    template: undefined,
+    copyContent: false,
+    editable: false,
+    focus: false,
+    sortingKey: 'sortingKey',
+    header: undefined,
+    draggable: false,
+    isHidden: false,
+    customData: undefined,
+    ...column
+});

--- a/lib/core/mock/public-api.ts
+++ b/lib/core/mock/public-api.ts
@@ -41,3 +41,4 @@ export * from './identity-group.mock';
 export * from './identity-user.mock';
 export * from './identity-group.service.mock';
 export * from './identity-user.service.mock';
+export * from './data-column.mock';

--- a/lib/process-services-cloud/src/lib/models/column-data-type.model.ts
+++ b/lib/process-services-cloud/src/lib/models/column-data-type.model.ts
@@ -1,0 +1,4 @@
+// eslint-disable-next-line no-shadow
+export enum ColumnDataType {
+    processVariableColumn = 'process-variable-column'
+}

--- a/lib/process-services-cloud/src/lib/models/process-definition-cloud.model.ts
+++ b/lib/process-services-cloud/src/lib/models/process-definition-cloud.model.ts
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { ProcessVariableDefinition } from './variable-definition';
+
 export class ProcessDefinitionCloud {
     id: string;
     appName: string;
@@ -25,6 +27,7 @@ export class ProcessDefinitionCloud {
     name: string;
     category: string;
     description: string;
+    variableDefinitions?: ProcessVariableDefinition[];
 
     constructor(obj?: any) {
         this.id = obj && obj.id || null;
@@ -36,5 +39,6 @@ export class ProcessDefinitionCloud {
         this.appVersion = obj && obj.appVersion || 0;
         this.category = obj && obj?.category || '';
         this.description = obj && obj?.description || '';
+        this.variableDefinitions = obj?.variableDefinitions ?? [];
     }
 }

--- a/lib/process-services-cloud/src/lib/models/process-instance-variable.model.ts
+++ b/lib/process-services-cloud/src/lib/models/process-instance-variable.model.ts
@@ -15,19 +15,19 @@
  * limitations under the License.
  */
 
-import { ProcessInstanceVariable } from '../../../models/process-instance-variable.model';
-export interface ProcessInstanceCloud {
-    appName?: string;
-    id?: string;
-    name?: string;
-    startDate?: Date;
-    initiator?: string;
-    status?: string;
-    businessKey?: string;
-    lastModified?: Date;
-    parentId?: string;
-    processDefinitionId?: string;
-    processDefinitionKey?: string;
-    processDefinitionName?: string;
-    variables?: ProcessInstanceVariable[];
+export interface ProcessInstanceVariable  {
+    id: number;
+    variableDefinitionId: string;
+    value: string;
+    appName: string;
+    createTime: string;
+    lastUpdatedTime: string;
+    markedAsDeleted: boolean;
+    name: string;
+    processInstanceId: string;
+    serviceFullName: string;
+    serviceName: string;
+    serviceVersion: string;
+    taskVariable: boolean;
+    type: string;
 }

--- a/lib/process-services-cloud/src/lib/models/variable-definition.ts
+++ b/lib/process-services-cloud/src/lib/models/variable-definition.ts
@@ -15,19 +15,11 @@
  * limitations under the License.
  */
 
-import { ProcessInstanceVariable } from '../../../models/process-instance-variable.model';
-export interface ProcessInstanceCloud {
-    appName?: string;
-    id?: string;
-    name?: string;
-    startDate?: Date;
-    initiator?: string;
-    status?: string;
-    businessKey?: string;
-    lastModified?: Date;
-    parentId?: string;
-    processDefinitionId?: string;
-    processDefinitionKey?: string;
-    processDefinitionName?: string;
-    variables?: ProcessInstanceVariable[];
+export interface ProcessVariableDefinition {
+    id: string;
+    name: string;
+    type: string;
+    required: boolean;
+    display: boolean;
+    displayName?: string;
 }

--- a/lib/process-services-cloud/src/lib/process/process-list/components/process-list-cloud.component.html
+++ b/lib/process-services-cloud/src/lib/process/process-list/components/process-list-cloud.component.html
@@ -1,6 +1,7 @@
 <adf-datatable #dataTable
         [rows]="rows"
         [columns]="columns"
+        [data]="dataAdapter"
         [stickyHeader]="stickyHeader"
         [loading]="isLoading"
         [sorting]="formattedSorting"

--- a/lib/process-services-cloud/src/lib/process/process-list/datatable/process-list-datatable-adapter.spec.ts
+++ b/lib/process-services-cloud/src/lib/process/process-list/datatable/process-list-datatable-adapter.spec.ts
@@ -1,0 +1,53 @@
+/*!
+ * @license
+ * Copyright 2019 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DataColumn, DataRow, getDataColumnMock } from '@alfresco/adf-core';
+import { ColumnDataType } from '../../../models/column-data-type.model';
+import { getProcessInstanceVariableMock } from '../mock/process-instance-variable.mock';
+import { ProcessListDataColumnCustomData } from '../models/data-column-custom-data';
+import { ProcessInstanceCloudListViewModel } from '../models/perocess-instance-cloud-view.model';
+import { ProcessListDatatableAdapter } from './process-list-datatable-adapter';
+
+describe('ProcessListDatatableAdapter', () => {
+    it('should get proepr type for column', () => {
+        const viewModel: ProcessInstanceCloudListViewModel = {
+            id: '1',
+            variablesMap: {
+                columnDisplayName1: getProcessInstanceVariableMock({ type: 'number' })
+            }
+        };
+
+        const row: DataRow = {
+            getValue: () => {},
+            hasValue: () => true,
+            isSelected: false,
+            obj: viewModel
+        };
+
+        const column: DataColumn<ProcessListDataColumnCustomData> = getDataColumnMock({
+            title: 'columnDisplayName1',
+            customData: {
+                assignedVariableDefinitionIds: ['1'],
+                columnType: ColumnDataType.processVariableColumn
+            }
+        });
+
+        const adapter = new ProcessListDatatableAdapter([], []);
+
+        expect(adapter.getColumnType(row, column)).toBe('number');
+    });
+});

--- a/lib/process-services-cloud/src/lib/process/process-list/datatable/process-list-datatable-adapter.ts
+++ b/lib/process-services-cloud/src/lib/process/process-list/datatable/process-list-datatable-adapter.ts
@@ -1,0 +1,23 @@
+import { DataColumn, DataRow, ObjectDataTableAdapter } from '@alfresco/adf-core';
+import { ProcessListDataColumnCustomData } from '../models/data-column-custom-data';
+import { ColumnDataType } from '../../../models/column-data-type.model';
+import { ProcessInstanceCloudListViewModel } from '../models/perocess-instance-cloud-view.model';
+
+export class ProcessListDatatableAdapter extends ObjectDataTableAdapter {
+    constructor(
+        data: ProcessInstanceCloudListViewModel[],
+        schema: DataColumn<ProcessListDataColumnCustomData>[]
+    ) {
+        super(data, schema);
+    }
+
+    getColumnType(row: DataRow, col: DataColumn<ProcessListDataColumnCustomData>): string {
+        if (col.customData?.columnType === ColumnDataType.processVariableColumn) {
+            const variableDisplayName = col.title;
+            const columnType = row.obj.variablesMap?.[variableDisplayName]?.type;
+            return columnType ?? 'text';
+        }
+
+        return super.getColumnType(row, col);
+    }
+}

--- a/lib/process-services-cloud/src/lib/process/process-list/mock/process-instance-variable.mock.ts
+++ b/lib/process-services-cloud/src/lib/process/process-list/mock/process-instance-variable.mock.ts
@@ -1,0 +1,19 @@
+import { ProcessInstanceVariable } from '../../../models/process-instance-variable.model';
+
+export const getProcessInstanceVariableMock = (variable: Partial<ProcessInstanceVariable> = {}): ProcessInstanceVariable => ({
+    id: 1,
+    variableDefinitionId: 'variableDefinitionId',
+    value: 'value',
+    appName: 'appName',
+    createTime: 'createTime',
+    lastUpdatedTime: 'lastUpdatedTime',
+    markedAsDeleted: false,
+    name: 'name',
+    processInstanceId: 'processInstanceId',
+    serviceFullName: 'serviceFullName',
+    serviceName: 'serviceName',
+    serviceVersion: 'serviceVersion',
+    taskVariable: false,
+    type: 'text',
+    ...variable
+});

--- a/lib/process-services-cloud/src/lib/process/process-list/mock/process-list-service.mock.ts
+++ b/lib/process-services-cloud/src/lib/process/process-list/mock/process-list-service.mock.ts
@@ -16,6 +16,7 @@
  */
 
 import { ObjectDataColumn } from '@alfresco/adf-core';
+import { ProcessListDataColumnCustomData } from '../models/data-column-custom-data';
 
 export const fakeProcessCloudList = {
     list: {
@@ -34,7 +35,8 @@ export const fakeProcessCloudList = {
                     status: 'RUNNING',
                     lastModified: 1540381146276,
                     lastModifiedTo: null,
-                    lastModifiedFrom: null
+                    lastModifiedFrom: null,
+                    variables: [{ id: 'variableId', value: 'variableValue'}]
                 }
             },
             {
@@ -84,13 +86,13 @@ export const fakeProcessCloudList = {
 
 export const fakeCustomSchema =
     [
-        new ObjectDataColumn({
+        new ObjectDataColumn<ProcessListDataColumnCustomData>({
             key: 'fakeName',
             type: 'text',
             title: 'ADF_CLOUD_TASK_LIST.PROPERTIES.FAKE',
             sortable: true
         }),
-        new ObjectDataColumn({
+        new ObjectDataColumn<ProcessListDataColumnCustomData>({
             key: 'fakeTaskName',
             type: 'text',
             title: 'ADF_CLOUD_TASK_LIST.PROPERTIES.TASK_FAKE',

--- a/lib/process-services-cloud/src/lib/process/process-list/models/data-column-custom-data.ts
+++ b/lib/process-services-cloud/src/lib/process/process-list/models/data-column-custom-data.ts
@@ -1,0 +1,4 @@
+export interface ProcessListDataColumnCustomData {
+    assignedVariableDefinitionIds: string[];
+    columnType: string;
+}

--- a/lib/process-services-cloud/src/lib/process/process-list/models/perocess-instance-cloud-view.model.ts
+++ b/lib/process-services-cloud/src/lib/process/process-list/models/perocess-instance-cloud-view.model.ts
@@ -16,18 +16,10 @@
  */
 
 import { ProcessInstanceVariable } from '../../../models/process-instance-variable.model';
-export interface ProcessInstanceCloud {
-    appName?: string;
-    id?: string;
-    name?: string;
-    startDate?: Date;
-    initiator?: string;
-    status?: string;
-    businessKey?: string;
-    lastModified?: Date;
-    parentId?: string;
-    processDefinitionId?: string;
-    processDefinitionKey?: string;
-    processDefinitionName?: string;
-    variables?: ProcessInstanceVariable[];
+import { ProcessInstanceCloud } from '../../start-process/models/process-instance-cloud.model';
+
+export interface ProcessInstanceCloudListViewModel extends ProcessInstanceCloud {
+    variablesMap?: {
+        [variableDisplayName: string]: ProcessInstanceVariable;
+    };
 }

--- a/lib/process-services-cloud/src/lib/process/process-list/models/process-cloud-query-request.model.ts
+++ b/lib/process-services-cloud/src/lib/process/process-list/models/process-cloud-query-request.model.ts
@@ -42,6 +42,8 @@ export class ProcessQueryCloudRequestModel {
    maxItems: number;
    skipCount: number;
    sorting?: ProcessListCloudSortingModel[];
+   variableDefinitions?: string[];
+
     constructor(obj?: any) {
        if (obj) {
            this.appName = obj.appName;
@@ -68,6 +70,7 @@ export class ProcessQueryCloudRequestModel {
            this.maxItems = obj.maxItems;
            this.skipCount = obj.skipCount;
            this.sorting = obj.sorting;
+           this.variableDefinitions = obj.variableDefinitions;
        }
    }
 }

--- a/lib/process-services-cloud/src/lib/process/process-list/services/process-list-cloud.service.spec.ts
+++ b/lib/process-services-cloud/src/lib/process/process-list/services/process-list-cloud.service.spec.ts
@@ -15,10 +15,16 @@
  * limitations under the License.
  */
 import { fakeAsync, TestBed } from '@angular/core/testing';
-import { setupTestBed, AlfrescoApiService } from '@alfresco/adf-core';
+import { setupTestBed, AlfrescoApiService, getDataColumnMock } from '@alfresco/adf-core';
 import { ProcessListCloudService } from './process-list-cloud.service';
 import { ProcessQueryCloudRequestModel } from '../models/process-cloud-query-request.model';
 import { ProcessServiceCloudTestingModule } from '../../../testing/process-service-cloud.testing.module';
+import { ProcessInstanceVariable } from '../../../models/process-instance-variable.model';
+import { ProcessInstanceCloudListViewModel } from '../models/perocess-instance-cloud-view.model';
+import { ProcessInstanceCloud } from '../../public-api';
+import { getProcessInstanceVariableMock } from '../mock/process-instance-variable.mock';
+import { ProcessListDataColumnCustomData } from '../models/data-column-custom-data';
+import { ColumnDataType } from '../../../models/column-data-type.model';
 
 describe('ProcessListCloudService', () => {
     let service: ProcessListCloudService;
@@ -97,5 +103,36 @@ describe('ProcessListCloudService', () => {
                 done();
             }
         );
+    });
+
+    it('should map to view model', () => {
+        const processInstanceVariable: ProcessInstanceVariable = getProcessInstanceVariableMock({
+            variableDefinitionId: '5c75b259-dc59-11ec-aa89-fed162b97957'
+        });
+
+        const columnTitle = 'columnTitle';
+        const column = getDataColumnMock<ProcessListDataColumnCustomData>({
+            title: columnTitle,
+            customData: {
+                assignedVariableDefinitionIds: ['5c75b259-dc59-11ec-aa89-fed162b97957'],
+                columnType: ColumnDataType.processVariableColumn
+            }
+        });
+
+        const processInstance: ProcessInstanceCloud = {
+            id: 'id',
+            variables: [processInstanceVariable]
+        };
+
+        const expectedViewModel: ProcessInstanceCloudListViewModel = {
+            ...processInstance,
+            variablesMap: {
+                [columnTitle]: processInstanceVariable
+            }
+        };
+
+        const viewModel = service.createRowsViewModel([processInstance], [column]);
+
+        expect(viewModel).toEqual([expectedViewModel]);
     });
 });

--- a/lib/process-services-cloud/src/lib/process/start-process/services/start-process-cloud.service.ts
+++ b/lib/process-services-cloud/src/lib/process/start-process/services/start-process-cloud.service.ts
@@ -42,11 +42,11 @@ export class StartProcessCloudService extends BaseCloudService {
      * @param appName Name of the target app
      * @returns Array of process definitions
      */
-    getProcessDefinitions(appName: string): Observable<ProcessDefinitionCloud[]> {
+    getProcessDefinitions(appName: string, queryParams?: { include: 'variables' }): Observable<ProcessDefinitionCloud[]> {
         if (appName || appName === '') {
             const url = `${this.getBasePath(appName)}/rb/v1/process-definitions`;
 
-            return this.get(url).pipe(
+            return this.get(url, queryParams).pipe(
                 map((res: any) => res.list.entries.map((processDefs) => new ProcessDefinitionCloud(processDefs.entry)))
             );
         } else {

--- a/lib/process-services-cloud/src/public-api.ts
+++ b/lib/process-services-cloud/src/public-api.ts
@@ -32,3 +32,5 @@ export * from './lib/models/application-version.model';
 export * from './lib/models/engine-event-cloud.model';
 export * from './lib/models/filter-cloud-model';
 export * from './lib/models/task-list-sorting.model';
+export * from './lib/models/column-data-type.model';
+export * from './lib/models/process-instance-variable.model';


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/AAE-7856


**What is the new behaviour?**
Allow to show process variables in datatable
<img width="700" alt="Screenshot 2022-05-22 at 14 05 31" src="https://user-images.githubusercontent.com/13885344/169694356-9bf884d0-d75a-4171-8fcd-29f72fb0bc02.png">

In order mark variable to be displayable in data-table, variable need to be marked in modelling app using specific flag:
<img width="270" alt="Screenshot 2022-05-22 at 14 10 21" src="https://user-images.githubusercontent.com/13885344/169694491-1d450d17-7662-4721-99eb-a7b642167098.png">

Processes are grouped by `display name` property, so if two processes have the same variable display name set in modelling app, these variables are going to be shown in the same column 

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
