### PR TITLE
Added missing top-level export for MainMenuDataTableTemplateDirective

### DIFF
--- a/lib/core/datatable/public-api.ts
+++ b/lib/core/datatable/public-api.ts
@@ -48,5 +48,6 @@ export * from './directives/header-filter-template.directive';
 export * from './directives/custom-empty-content-template.directive';
 export * from './directives/custom-loading-template.directive';
 export * from './directives/custom-no-permission-template.directive';
+export * from './directives/main-data-table-action-template.directive';
 
 export * from './datatable.module';


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
After running `scripts/build/build-core.sh` we got error:

`Unsupported private class MainMenuDataTableTemplateDirective. This class is visible to consumers via DataTableModule -> MainMenuDataTableTemplateDirective, but is not exported from the top-level library entrypoint.`


**What is the new behaviour?**
No error for `scripts/build/build-core.sh`


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
