### PR TITLE
[AAE-7077] Reset people content service cache on logout

### DIFF
--- a/lib/core/services/people-content.service.spec.ts
+++ b/lib/core/services/people-content.service.spec.ts
@@ -49,7 +49,7 @@ describe('PeopleContentService', () => {
     });
 
     it('should be able to fetch person details based on id', (done) => {
-        spyOn(peopleContentService['peopleApi'], 'getPerson').and.returnValue(Promise.resolve(new PersonEntry({ entry: fakeEcmUser })));
+        spyOn(peopleContentService.peopleApi, 'getPerson').and.returnValue(Promise.resolve(new PersonEntry({ entry: fakeEcmUser })));
         peopleContentService.getPerson('fake-id').subscribe((person) => {
             expect(person.entry.id).toEqual('fake-id');
             expect(person.entry.email).toEqual('fakeEcm@ecmUser.com');
@@ -58,7 +58,7 @@ describe('PeopleContentService', () => {
     });
 
     it('calls getPerson api method by an id', (done) => {
-        const getPersonSpy = spyOn(peopleContentService['peopleApi'], 'getPerson').and.returnValue(Promise.resolve(null));
+        const getPersonSpy = spyOn(peopleContentService.peopleApi, 'getPerson').and.returnValue(Promise.resolve(null));
         peopleContentService.getPerson('fake-id').subscribe(() => {
             expect(getPersonSpy).toHaveBeenCalledWith('fake-id');
             done();
@@ -66,7 +66,7 @@ describe('PeopleContentService', () => {
     });
 
     it('calls getPerson api method with "-me-"', (done) => {
-        const getPersonSpy = spyOn(peopleContentService['peopleApi'], 'getPerson').and.returnValue(Promise.resolve(null));
+        const getPersonSpy = spyOn(peopleContentService.peopleApi, 'getPerson').and.returnValue(Promise.resolve(null));
         peopleContentService.getPerson('-me-').subscribe(() => {
             expect(getPersonSpy).toHaveBeenCalledWith('-me-');
             done();
@@ -74,7 +74,7 @@ describe('PeopleContentService', () => {
     });
 
     it('should be able to list people', (done) => {
-        spyOn(peopleContentService['peopleApi'], 'listPeople').and.returnValue(Promise.resolve(fakeEcmUserList));
+        spyOn(peopleContentService.peopleApi, 'listPeople').and.returnValue(Promise.resolve(fakeEcmUserList));
         peopleContentService.listPeople().subscribe((response: PeopleContentQueryResponse) => {
             const people = response.entries;
             const pagination = response.pagination;
@@ -91,7 +91,7 @@ describe('PeopleContentService', () => {
     });
 
     it('should call listPeople api method', (done) => {
-        const listPeopleSpy = spyOn(peopleContentService['peopleApi'], 'listPeople').and.returnValue(Promise.resolve(fakeEcmUserList));
+        const listPeopleSpy = spyOn(peopleContentService.peopleApi, 'listPeople').and.returnValue(Promise.resolve(fakeEcmUserList));
         peopleContentService.listPeople().subscribe(() => {
             expect(listPeopleSpy).toHaveBeenCalled();
             done();
@@ -99,7 +99,7 @@ describe('PeopleContentService', () => {
     });
 
     it('should call listPeople api with requested sorting params', async () => {
-        const listPeopleSpy = spyOn(peopleContentService['peopleApi'], 'listPeople').and.returnValue(Promise.resolve(fakeEcmUserList));
+        const listPeopleSpy = spyOn(peopleContentService.peopleApi, 'listPeople').and.returnValue(Promise.resolve(fakeEcmUserList));
         const requestQueryParams: PeopleContentQueryRequestModel = { skipCount: 10, maxItems: 20, sorting: { orderBy: 'firstName', direction: 'asc' } };
         const expectedValue = { skipCount: 10, maxItems: 20, orderBy: ['firstName ASC'] };
 
@@ -109,7 +109,7 @@ describe('PeopleContentService', () => {
     });
 
     it('should not call listPeople api with sorting params if sorting is not defined', async () => {
-        const listPeopleSpy = spyOn(peopleContentService['peopleApi'], 'listPeople').and.returnValue(Promise.resolve(fakeEcmUserList));
+        const listPeopleSpy = spyOn(peopleContentService.peopleApi, 'listPeople').and.returnValue(Promise.resolve(fakeEcmUserList));
         const requestQueryParams: PeopleContentQueryRequestModel = { skipCount: 10, maxItems: 20, sorting: undefined };
         const expectedValue = { skipCount: 10, maxItems: 20 };
 
@@ -119,7 +119,7 @@ describe('PeopleContentService', () => {
     });
 
     it('should be able to create new person', (done) => {
-        spyOn(peopleContentService['peopleApi'], 'createPerson').and.returnValue(Promise.resolve(new PersonEntry({ entry: fakeEcmUser })));
+        spyOn(peopleContentService.peopleApi, 'createPerson').and.returnValue(Promise.resolve(new PersonEntry({ entry: fakeEcmUser })));
         peopleContentService.createPerson(createNewPersonMock).subscribe((person) => {
             expect(person.id).toEqual('fake-id');
             expect(person.email).toEqual('fakeEcm@ecmUser.com');
@@ -128,7 +128,7 @@ describe('PeopleContentService', () => {
     });
 
     it('should be able to call createPerson api with new person details', (done) => {
-        const createPersonSpy = spyOn(peopleContentService['peopleApi'], 'createPerson').and.returnValue(Promise.resolve(new PersonEntry({ entry: fakeEcmUser })));
+        const createPersonSpy = spyOn(peopleContentService.peopleApi, 'createPerson').and.returnValue(Promise.resolve(new PersonEntry({ entry: fakeEcmUser })));
         peopleContentService.createPerson(createNewPersonMock).subscribe((person) => {
             expect(person.id).toEqual('fake-id');
             expect(person.email).toEqual('fakeEcm@ecmUser.com');
@@ -138,7 +138,7 @@ describe('PeopleContentService', () => {
     });
 
     it('should be able to throw an error if createPerson api failed', (done) => {
-        const createPersonSpy = spyOn(peopleContentService['peopleApi'], 'createPerson').and.returnValue(Promise.reject({ message: 'failed to create new person' }));
+        const createPersonSpy = spyOn(peopleContentService.peopleApi, 'createPerson').and.returnValue(Promise.reject({ message: 'failed to create new person' }));
         const logErrorSpy = spyOn(logService, 'error');
         peopleContentService.createPerson(createNewPersonMock).subscribe(
         () => {},
@@ -151,7 +151,7 @@ describe('PeopleContentService', () => {
     });
 
     it('Should make the api call to check if the user is a content admin only once', async () => {
-        const getCurrentPersonSpy = spyOn(peopleContentService['peopleApi'], 'getPerson').and.returnValue(Promise.resolve(getFakeUserWithContentAdminCapability()));
+        const getCurrentPersonSpy = spyOn(peopleContentService.peopleApi, 'getPerson').and.returnValue(Promise.resolve(getFakeUserWithContentAdminCapability()));
 
         expect(await peopleContentService.isContentAdmin()).toBe(true);
         expect(getCurrentPersonSpy.calls.count()).toEqual(1);
@@ -163,7 +163,7 @@ describe('PeopleContentService', () => {
     });
 
     it('should reset the admin cache upon logout', async () => {
-        const getCurrentPersonSpy = spyOn(peopleContentService['peopleApi'], 'getPerson').and.returnValue(Promise.resolve(getFakeUserWithContentAdminCapability()));
+        const getCurrentPersonSpy = spyOn(peopleContentService.peopleApi, 'getPerson').and.returnValue(Promise.resolve(getFakeUserWithContentAdminCapability()));
 
         expect(await peopleContentService.isContentAdmin()).toBeTruthy();
         expect(peopleContentService.hasCheckedIsContentAdmin).toBeTruthy();

--- a/lib/core/services/people-content.service.spec.ts
+++ b/lib/core/services/people-content.service.spec.ts
@@ -20,35 +20,37 @@ import { AlfrescoApiServiceMock } from '../mock/alfresco-api.service.mock';
 import { CoreTestingModule } from '../testing/core.testing.module';
 import { PeopleContentService, PeopleContentQueryResponse, PeopleContentQueryRequestModel } from './people-content.service';
 import { AlfrescoApiService } from './alfresco-api.service';
-import { setupTestBed } from '../testing/setup-test-bed';
 import { TranslateModule } from '@ngx-translate/core';
 import { TestBed } from '@angular/core/testing';
 import { LogService } from './log.service';
 import { PersonEntry } from '@alfresco/js-api';
+import { AuthenticationService } from './authentication.service';
 
 describe('PeopleContentService', () => {
 
-    let service: PeopleContentService;
+    let peopleContentService: PeopleContentService;
     let logService: LogService;
-
-    setupTestBed({
-        imports: [
-            TranslateModule.forRoot(),
-            CoreTestingModule
-        ],
-        providers: [
-            { provide: AlfrescoApiService, useClass: AlfrescoApiServiceMock }
-        ]
-    });
+    let authenticationService: AuthenticationService;
 
     beforeEach(() => {
-        service = TestBed.inject(PeopleContentService);
+        TestBed.configureTestingModule({
+            imports: [
+                TranslateModule.forRoot(),
+                CoreTestingModule
+            ],
+            providers: [
+                { provide: AlfrescoApiService, useClass: AlfrescoApiServiceMock }
+            ]
+        });
+
+        authenticationService = TestBed.inject(AuthenticationService);
+        peopleContentService = TestBed.inject(PeopleContentService);
         logService = TestBed.inject(LogService);
     });
 
     it('should be able to fetch person details based on id', (done) => {
-        spyOn(service['peopleApi'], 'getPerson').and.returnValue(Promise.resolve(new PersonEntry({ entry: fakeEcmUser })));
-        service.getPerson('fake-id').subscribe((person) => {
+        spyOn(peopleContentService['peopleApi'], 'getPerson').and.returnValue(Promise.resolve(new PersonEntry({ entry: fakeEcmUser })));
+        peopleContentService.getPerson('fake-id').subscribe((person) => {
             expect(person.entry.id).toEqual('fake-id');
             expect(person.entry.email).toEqual('fakeEcm@ecmUser.com');
             done();
@@ -56,24 +58,24 @@ describe('PeopleContentService', () => {
     });
 
     it('calls getPerson api method by an id', (done) => {
-        const getPersonSpy = spyOn(service['peopleApi'], 'getPerson').and.returnValue(Promise.resolve(null));
-        service.getPerson('fake-id').subscribe(() => {
+        const getPersonSpy = spyOn(peopleContentService['peopleApi'], 'getPerson').and.returnValue(Promise.resolve(null));
+        peopleContentService.getPerson('fake-id').subscribe(() => {
             expect(getPersonSpy).toHaveBeenCalledWith('fake-id');
             done();
         });
     });
 
     it('calls getPerson api method with "-me-"', (done) => {
-        const getPersonSpy = spyOn(service['peopleApi'], 'getPerson').and.returnValue(Promise.resolve(null));
-        service.getPerson('-me-').subscribe(() => {
+        const getPersonSpy = spyOn(peopleContentService['peopleApi'], 'getPerson').and.returnValue(Promise.resolve(null));
+        peopleContentService.getPerson('-me-').subscribe(() => {
             expect(getPersonSpy).toHaveBeenCalledWith('-me-');
             done();
         });
     });
 
     it('should be able to list people', (done) => {
-        spyOn(service['peopleApi'], 'listPeople').and.returnValue(Promise.resolve(fakeEcmUserList));
-        service.listPeople().subscribe((response: PeopleContentQueryResponse) => {
+        spyOn(peopleContentService['peopleApi'], 'listPeople').and.returnValue(Promise.resolve(fakeEcmUserList));
+        peopleContentService.listPeople().subscribe((response: PeopleContentQueryResponse) => {
             const people = response.entries;
             const pagination = response.pagination;
 
@@ -89,36 +91,36 @@ describe('PeopleContentService', () => {
     });
 
     it('should call listPeople api method', (done) => {
-        const listPeopleSpy = spyOn(service['peopleApi'], 'listPeople').and.returnValue(Promise.resolve(fakeEcmUserList));
-        service.listPeople().subscribe(() => {
+        const listPeopleSpy = spyOn(peopleContentService['peopleApi'], 'listPeople').and.returnValue(Promise.resolve(fakeEcmUserList));
+        peopleContentService.listPeople().subscribe(() => {
             expect(listPeopleSpy).toHaveBeenCalled();
             done();
         });
     });
 
     it('should call listPeople api with requested sorting params', async () => {
-        const listPeopleSpy = spyOn(service['peopleApi'], 'listPeople').and.returnValue(Promise.resolve(fakeEcmUserList));
+        const listPeopleSpy = spyOn(peopleContentService['peopleApi'], 'listPeople').and.returnValue(Promise.resolve(fakeEcmUserList));
         const requestQueryParams: PeopleContentQueryRequestModel = { skipCount: 10, maxItems: 20, sorting: { orderBy: 'firstName', direction: 'asc' } };
         const expectedValue = { skipCount: 10, maxItems: 20, orderBy: ['firstName ASC'] };
 
-        await service.listPeople(requestQueryParams).toPromise();
+        await peopleContentService.listPeople(requestQueryParams).toPromise();
 
         expect(listPeopleSpy).toHaveBeenCalledWith(expectedValue);
     });
 
     it('should not call listPeople api with sorting params if sorting is not defined', async () => {
-        const listPeopleSpy = spyOn(service['peopleApi'], 'listPeople').and.returnValue(Promise.resolve(fakeEcmUserList));
+        const listPeopleSpy = spyOn(peopleContentService['peopleApi'], 'listPeople').and.returnValue(Promise.resolve(fakeEcmUserList));
         const requestQueryParams: PeopleContentQueryRequestModel = { skipCount: 10, maxItems: 20, sorting: undefined };
         const expectedValue = { skipCount: 10, maxItems: 20 };
 
-        await service.listPeople(requestQueryParams).toPromise();
+        await peopleContentService.listPeople(requestQueryParams).toPromise();
 
         expect(listPeopleSpy).toHaveBeenCalledWith(expectedValue);
     });
 
     it('should be able to create new person', (done) => {
-        spyOn(service['peopleApi'], 'createPerson').and.returnValue(Promise.resolve(new PersonEntry({ entry: fakeEcmUser })));
-        service.createPerson(createNewPersonMock).subscribe((person) => {
+        spyOn(peopleContentService['peopleApi'], 'createPerson').and.returnValue(Promise.resolve(new PersonEntry({ entry: fakeEcmUser })));
+        peopleContentService.createPerson(createNewPersonMock).subscribe((person) => {
             expect(person.id).toEqual('fake-id');
             expect(person.email).toEqual('fakeEcm@ecmUser.com');
             done();
@@ -126,8 +128,8 @@ describe('PeopleContentService', () => {
     });
 
     it('should be able to call createPerson api with new person details', (done) => {
-        const createPersonSpy = spyOn(service['peopleApi'], 'createPerson').and.returnValue(Promise.resolve(new PersonEntry({ entry: fakeEcmUser })));
-        service.createPerson(createNewPersonMock).subscribe((person) => {
+        const createPersonSpy = spyOn(peopleContentService['peopleApi'], 'createPerson').and.returnValue(Promise.resolve(new PersonEntry({ entry: fakeEcmUser })));
+        peopleContentService.createPerson(createNewPersonMock).subscribe((person) => {
             expect(person.id).toEqual('fake-id');
             expect(person.email).toEqual('fakeEcm@ecmUser.com');
             expect(createPersonSpy).toHaveBeenCalledWith(createNewPersonMock, undefined);
@@ -136,9 +138,9 @@ describe('PeopleContentService', () => {
     });
 
     it('should be able to throw an error if createPerson api failed', (done) => {
-        const createPersonSpy = spyOn(service['peopleApi'], 'createPerson').and.returnValue(Promise.reject({ message: 'failed to create new person' }));
+        const createPersonSpy = spyOn(peopleContentService['peopleApi'], 'createPerson').and.returnValue(Promise.reject({ message: 'failed to create new person' }));
         const logErrorSpy = spyOn(logService, 'error');
-        service.createPerson(createNewPersonMock).subscribe(
+        peopleContentService.createPerson(createNewPersonMock).subscribe(
         () => {},
         (error) => {
             expect(error).toEqual({ message: 'failed to create new person' });
@@ -149,14 +151,27 @@ describe('PeopleContentService', () => {
     });
 
     it('Should make the api call to check if the user is a content admin only once', async () => {
-        const getCurrentPersonSpy = spyOn(service['peopleApi'], 'getPerson').and.returnValue(Promise.resolve(getFakeUserWithContentAdminCapability()));
+        const getCurrentPersonSpy = spyOn(peopleContentService['peopleApi'], 'getPerson').and.returnValue(Promise.resolve(getFakeUserWithContentAdminCapability()));
 
-        expect(await service.isContentAdmin()).toBe(true);
+        expect(await peopleContentService.isContentAdmin()).toBe(true);
         expect(getCurrentPersonSpy.calls.count()).toEqual(1);
 
-        await service.isContentAdmin();
+        await peopleContentService.isContentAdmin();
 
-        expect(await service.isContentAdmin()).toBe(true);
+        expect(await peopleContentService.isContentAdmin()).toBe(true);
         expect(getCurrentPersonSpy.calls.count()).toEqual(1);
+    });
+
+    it('should reset the admin cache upon logout', async () => {
+        const getCurrentPersonSpy = spyOn(peopleContentService['peopleApi'], 'getPerson').and.returnValue(Promise.resolve(getFakeUserWithContentAdminCapability()));
+
+        expect(await peopleContentService.isContentAdmin()).toBeTruthy();
+        expect(peopleContentService.hasCheckedIsContentAdmin).toBeTruthy();
+
+        authenticationService.onLogout.next(true);
+        expect(peopleContentService.hasCheckedIsContentAdmin).toBeFalsy();
+
+        expect(await peopleContentService.isContentAdmin()).toBe(true);
+        expect(getCurrentPersonSpy.calls.count()).toEqual(2);
     });
 });

--- a/lib/core/services/people-content.service.ts
+++ b/lib/core/services/people-content.service.ts
@@ -22,6 +22,7 @@ import { catchError, map } from 'rxjs/operators';
 import { PersonEntry, PeopleApi, PersonBodyCreate, Pagination, PersonBodyUpdate } from '@alfresco/js-api';
 import { EcmUserModel } from '../models/ecm-user.model';
 import { LogService } from './log.service';
+import { AuthenticationService } from './authentication.service';
 
 // eslint-disable-next-line no-shadow
 export enum ContentGroups {
@@ -57,7 +58,15 @@ export class PeopleContentService {
         return this._peopleApi;
     }
 
-    constructor(private apiService: AlfrescoApiService, private logService: LogService) {
+    constructor(
+        private apiService: AlfrescoApiService,
+        authenticationService: AuthenticationService,
+        private logService: LogService
+    ) {
+        authenticationService.onLogout.subscribe(() => {
+            this.hasCheckedIsContentAdmin = false;
+            this.hasContentAdminRole = false;
+        });
     }
 
     /**


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

reset the service flags upon logout to force re-caching of the state

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://alfresco.atlassian.net/browse/AAE-7077