### PR TITLE
[AAE-8929] Get start event form static inputs

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -843,5 +843,8 @@
       }
     }
   },
-  "defaultProject": "demoshell"
+  "defaultProject": "demoshell",
+  "cli": {
+    "analytics": false
+  }
 }

--- a/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.html
+++ b/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.html
@@ -64,7 +64,7 @@
                 <adf-cloud-form
                     [appName]="appName"
                     [appVersion]="processDefinitionCurrent.appVersion"
-                    [data]="values"
+                    [data]="resolvedValues"
                     [formId]="processDefinitionCurrent.formKey"
                     [showSaveButton]="false"
                     [showCompleteButton]="false"

--- a/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.ts
@@ -109,6 +109,8 @@ export class StartProcessCloudComponent implements OnChanges, OnInit, OnDestroy 
     formCloud: FormModel;
     currentCreatedProcess: ProcessInstanceCloud;
     disableStartButton: boolean = true;
+    staticMappings: TaskVariableCloud[] = [];
+    resolvedValues: TaskVariableCloud[];
 
     protected onDestroy$ = new Subject<boolean>();
     processDefinitionLoaded = false;
@@ -152,6 +154,10 @@ export class StartProcessCloudComponent implements OnChanges, OnInit, OnDestroy 
             if (this.appName || this.appName === '') {
                 this.loadProcessDefinitions();
             }
+        }
+
+        if (changes['values'] && changes['values'].currentValue !== changes['values'].previousValue) {
+            this.resolvedValues = this.staticMappings.concat(this.values || []);
         }
     }
 
@@ -202,6 +208,15 @@ export class StartProcessCloudComponent implements OnChanges, OnInit, OnDestroy 
     setProcessDefinitionOnForm(selectedProcessDefinitionName: string) {
         this.processDefinitionCurrent = this.filteredProcesses.find((process: ProcessDefinitionCloud) =>
             process.name === selectedProcessDefinitionName || process.key === selectedProcessDefinitionName);
+
+        this.startProcessCloudService.getStartEventFormStaticValuesMapping(this.appName, this.processDefinitionCurrent.id)
+            .subscribe(
+                staticMappings => {
+                    this.staticMappings = staticMappings;
+                    this.resolvedValues = this.staticMappings.concat(this.values || []);
+                },
+                () => this.resolvedValues = this.values
+            );
 
         this.isFormCloudLoaded = false;
         this.processPayloadCloud.processDefinitionKey = this.processDefinitionCurrent.key;

--- a/lib/process-services-cloud/src/lib/process/start-process/services/start-process-cloud.service.spec.ts
+++ b/lib/process-services-cloud/src/lib/process/start-process/services/start-process-cloud.service.spec.ts
@@ -162,12 +162,21 @@ describe('StartProcessCloudService', () => {
         const processDefinitionId = 'processDefinitionId';
         const oauth2Auth = jasmine.createSpyObj('oauth2Auth', ['callCustomApi']);
         oauth2Auth.callCustomApi.and.returnValue(Promise.resolve({ static1: 'value', static2: 0, static3: true }));
+        spyOn(alfrescoApiService, 'getInstance').and.returnValue({
+            oauth2Auth
+        });
 
         service.getStartEventFormStaticValuesMapping(appName, processDefinitionId).subscribe((result) => {
             expect(result.length).toEqual(3);
-            expect(result[0]).toEqual({ id: 'static1', name: 'static1', value: 'value' });
-            expect(result[0]).toEqual({ id: 'static2', name: 'static2', value: 0 });
-            expect(result[0]).toEqual({ id: 'static3', name: 'static3', value: true });
+            expect(result[0].name).toEqual('static1');
+            expect(result[0].id).toEqual('static1');
+            expect(result[0].value).toEqual('value');
+            expect(result[1].name).toEqual('static2');
+            expect(result[1].id).toEqual('static2');
+            expect(result[1].value).toEqual(0);
+            expect(result[2].name).toEqual('static3');
+            expect(result[2].id).toEqual('static3');
+            expect(result[2].value).toEqual(true);
             expect(oauth2Auth.callCustomApi.calls.mostRecent().args[0].endsWith(`${appName}/rb/v1/process-definitions/${processDefinitionId}/static-values`)).toBeTruthy();
             expect(oauth2Auth.callCustomApi.calls.mostRecent().args[1]).toBe('GET');
             done();

--- a/lib/process-services-cloud/src/lib/process/start-process/services/start-process-cloud.service.spec.ts
+++ b/lib/process-services-cloud/src/lib/process/start-process/services/start-process-cloud.service.spec.ts
@@ -156,4 +156,21 @@ describe('StartProcessCloudService', () => {
                 }
             );
     });
+
+    it('should transform the response into task variables', (done) => {
+        const appName = 'test-app';
+        const processDefinitionId = 'processDefinitionId';
+        const oauth2Auth = jasmine.createSpyObj('oauth2Auth', ['callCustomApi']);
+        oauth2Auth.callCustomApi.and.returnValue(Promise.resolve({ static1: 'value', static2: 0, static3: true }));
+
+        service.getStartEventFormStaticValuesMapping(appName, processDefinitionId).subscribe((result) => {
+            expect(result.length).toEqual(3);
+            expect(result[0]).toEqual({ id: 'static1', name: 'static1', value: 'value' });
+            expect(result[0]).toEqual({ id: 'static2', name: 'static2', value: 0 });
+            expect(result[0]).toEqual({ id: 'static3', name: 'static3', value: true });
+            expect(oauth2Auth.callCustomApi.calls.mostRecent().args[0].endsWith(`${appName}/rb/v1/process-definitions/${processDefinitionId}/static-values`)).toBeTruthy();
+            expect(oauth2Auth.callCustomApi.calls.mostRecent().args[1]).toBe('GET');
+            done();
+        });
+    });
 });

--- a/lib/process-services-cloud/src/lib/process/start-process/services/start-process-cloud.service.ts
+++ b/lib/process-services-cloud/src/lib/process/start-process/services/start-process-cloud.service.ts
@@ -23,6 +23,7 @@ import { ProcessInstanceCloud } from '../models/process-instance-cloud.model';
 import { ProcessPayloadCloud } from '../models/process-payload-cloud.model';
 import { ProcessDefinitionCloud } from '../../../models/process-definition-cloud.model';
 import { BaseCloudService } from '../../../services/base-cloud.service';
+import { TaskVariableCloud } from '../../../form/models/task-variable-cloud.model';
 
 @Injectable({
     providedIn: 'root'
@@ -125,5 +126,25 @@ export class StartProcessCloudService extends BaseCloudService {
         const url = `${this.getBasePath(appName)}/rb/v1/process-instances/${processInstanceId}`;
 
         return this.delete(url);
+    }
+
+    /**
+     * Gets the static values mapped to the start form of a process definition.
+     *
+     * @param appName Name of the app
+     * @param processDefinitionId ID of the target process definition
+     * @returns Static mappings for the start event
+     */
+     getStartEventFormStaticValuesMapping(appName: string, processDefinitionId: string): Observable<TaskVariableCloud[]> {
+        const apiUrl = `${this.getBasePath(appName)}/rb/v1/process-definitions/${processDefinitionId}/static-values`;
+        return this.get(apiUrl).pipe(
+            map((res: { [key: string]: any }) => {
+                const result = [];
+                if (res) {
+                    Object.keys(res).forEach(mapping => result.push(new TaskVariableCloud({ name: mapping, value: res[mapping] })));
+                }
+                return result;
+            })
+        );
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [X] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
There is no way of retrieving the static inputs for a start event form


**What is the new behaviour?**
Use the new rest endpoint in Activit Cloud RB to retrieve the static inputs for a start event form and use those inputs as values for the form to populate the corresponding inputs


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
