### PR TITLE
[ADF-5272] fe files upload form width is increasing if we upload file name too long

### DIFF
--- a/lib/process-services/src/lib/content-widget/attach-file-widget.component.html
+++ b/lib/process-services/src/lib/content-widget/attach-file-widget.component.html
@@ -69,7 +69,7 @@
                  (keyup.enter)="onAttachFileClicked(file)"
                  role="button"
                  tabindex="0"/>
-            <span matLine id="{{'file-'+file.id}}" (click)="onAttachFileClicked(file)" (keyup.enter)="onAttachFileClicked(file)"
+            <span matLine id="{{'file-'+file.id}}" (click)="onAttachFileClicked(file)" [matTooltip]="file.name" (keyup.enter)="onAttachFileClicked(file)"
                   role="button" tabindex="0" class="adf-file">{{file.name}}</span>
             <button id="{{'file-'+file.id+'-option-menu'}}" mat-icon-button [matMenuTriggerFor]="fileActionMenu">
                 <mat-icon>more_vert</mat-icon>

--- a/lib/process-services/src/lib/content-widget/attach-file-widget.component.scss
+++ b/lib/process-services/src/lib/content-widget/attach-file-widget.component.scss
@@ -67,5 +67,15 @@
         .mat-line {
             margin-bottom: 0;
         }
+
+        .mat-list-text {
+            max-width: 200px;
+        }
+
+        @media screen and (max-width: 959px) {
+            .mat-list-text {
+                max-width: 150px;
+            }
+        }
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ADF-5272


**What is the new behaviour?**
![ADF-5272](https://user-images.githubusercontent.com/23027333/172567869-04f1f847-9e00-40cb-adde-c9c649546906.gif)



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
