### PR TITLE
[AAE-9314] Fix preselected user display in completed task

### DIFF
--- a/lib/process-services-cloud/src/lib/form/components/widgets/group/group-cloud.widget.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/group/group-cloud.widget.spec.ts
@@ -15,13 +15,12 @@
  * limitations under the License.
  */
 
-import { FormFieldModel, FormFieldTypes, FormModel, setupTestBed } from '@alfresco/adf-core';
+import { FormFieldModel, FormFieldTypes, FormModel, IdentityGroupModel, setupTestBed } from '@alfresco/adf-core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { GroupCloudWidgetComponent } from './group-cloud.widget';
 import { ProcessServiceCloudTestingModule } from '../../../../testing/process-service-cloud.testing.module';
 import { TranslateModule } from '@ngx-translate/core';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-// import { By } from '@angular/platform-browser';
 
 describe('GroupCloudWidgetComponent', () => {
     let fixture: ComponentFixture<GroupCloudWidgetComponent>;
@@ -66,7 +65,7 @@ describe('GroupCloudWidgetComponent', () => {
             expect(asterisk.textContent).toEqual('*');
         });
 
-        it('should be invalid if no default option after interaction', async () => {
+        it('should be invalid if no option is selected after interaction', async () => {
             fixture.detectChanges();
             await fixture.whenStable();
 
@@ -82,27 +81,57 @@ describe('GroupCloudWidgetComponent', () => {
         });
     });
 
-    // fdescribe('when is readOnly', () => {
+    describe('when is readOnly', () => {
 
-    //     it('should chip be disabled', async () => {
-    //         widget.field = new FormFieldModel( new FormModel({ taskId: '<id>' }, null, true), {
-    //             type: FormFieldTypes.GROUP,
-    //             value: {
-    //                 id: 'fake-group-id',
-    //                 name: 'fake-group'
-    //             },
-    //             readOnly: true
-    //         });
+        it('should single chip be disabled', async () => {
+            const mockSpaghetti: IdentityGroupModel[] = [{
+                id: 'bolognese',
+                name: 'Bolognese'
+            }];
 
-    //         fixture.detectChanges();
-    //         await fixture.whenStable();
+            widget.field = new FormFieldModel( new FormModel({ taskId: '<id>'}, null, true), {
+                type: FormFieldTypes.GROUP,
+                value: mockSpaghetti
+            });
 
-    //         const disabledFormField: HTMLElement = element.querySelector('.mat-form-field-disabled');
-    //         const disabledChip = fixture.debugElement.query(By.css(`adf-cloud-group-chip-fake-group`));
-    //         expect(disabledFormField).toBeTruthy();
-    //         expect(disabledChip).toBeTruthy();
-    //     });
-    // });
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            const disabledFormField: HTMLElement = element.querySelector('.mat-form-field-disabled');
+            expect(disabledFormField).toBeTruthy();
+
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            const disabledGroupChip: HTMLElement = element.querySelector('.mat-chip-disabled');
+            expect(disabledGroupChip).toBeTruthy();
+        });
+
+        it('should multi chips be disabled', async () => {
+            const mockSpaghetti: IdentityGroupModel[] = [
+                { id: 'bolognese', name: 'Bolognese' },
+                { id: 'carbonara', name: 'Carbonara' }
+            ];
+
+            widget.field = new FormFieldModel( new FormModel({ taskId: '<id>'}, null, true), {
+                type: FormFieldTypes.GROUP,
+                value: mockSpaghetti
+            });
+
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            const disabledFormField: HTMLElement = element.querySelector('.mat-form-field-disabled');
+            expect(disabledFormField).toBeTruthy();
+
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            const disabledGroupChips = element.querySelectorAll('.mat-chip-disabled');
+            expect(disabledGroupChips.item(0)).toBeTruthy();
+            expect(disabledGroupChips.item(1)).toBeTruthy();
+        });
+    });
 
     describe('when form model has left labels', () => {
 

--- a/lib/process-services-cloud/src/lib/form/components/widgets/group/group-cloud.widget.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/group/group-cloud.widget.spec.ts
@@ -21,6 +21,7 @@ import { GroupCloudWidgetComponent } from './group-cloud.widget';
 import { ProcessServiceCloudTestingModule } from '../../../../testing/process-service-cloud.testing.module';
 import { TranslateModule } from '@ngx-translate/core';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+// import { By } from '@angular/platform-browser';
 
 describe('GroupCloudWidgetComponent', () => {
     let fixture: ComponentFixture<GroupCloudWidgetComponent>;
@@ -80,6 +81,28 @@ describe('GroupCloudWidgetComponent', () => {
             expect(element.querySelector('.adf-invalid')).toBeTruthy();
         });
     });
+
+    // fdescribe('when is readOnly', () => {
+
+    //     it('should chip be disabled', async () => {
+    //         widget.field = new FormFieldModel( new FormModel({ taskId: '<id>' }, null, true), {
+    //             type: FormFieldTypes.GROUP,
+    //             value: {
+    //                 id: 'fake-group-id',
+    //                 name: 'fake-group'
+    //             },
+    //             readOnly: true
+    //         });
+
+    //         fixture.detectChanges();
+    //         await fixture.whenStable();
+
+    //         const disabledFormField: HTMLElement = element.querySelector('.mat-form-field-disabled');
+    //         const disabledChip = fixture.debugElement.query(By.css(`adf-cloud-group-chip-fake-group`));
+    //         expect(disabledFormField).toBeTruthy();
+    //         expect(disabledChip).toBeTruthy();
+    //     });
+    // });
 
     describe('when form model has left labels', () => {
 

--- a/lib/process-services-cloud/src/lib/form/components/widgets/people/people-cloud.widget.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/people/people-cloud.widget.spec.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { FormFieldModel, FormFieldTypes, FormModel, IdentityUserService, setupTestBed } from '@alfresco/adf-core';
+import { FormFieldModel, FormFieldTypes, FormModel, IdentityUserModel, IdentityUserService, setupTestBed } from '@alfresco/adf-core';
 import { TranslateModule } from '@ngx-translate/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { PeopleCloudWidgetComponent } from './people-cloud.widget';
@@ -84,7 +84,7 @@ describe('PeopleCloudWidgetComponent', () => {
             expect(asterisk.textContent).toEqual('*');
         });
 
-        it('should be invalid if no default option after interaction', async () => {
+        it('should be invalid if no option is selected after interaction', async () => {
             fixture.detectChanges();
             await fixture.whenStable();
 
@@ -97,6 +97,59 @@ describe('PeopleCloudWidgetComponent', () => {
             await fixture.whenStable();
 
             expect(element.querySelector('.adf-invalid')).toBeTruthy();
+        });
+    });
+
+    describe('when is readOnly', () => {
+
+        it('should single chip be disabled', async () => {
+            const mockSpaghetti: IdentityUserModel[] = [{
+                id: 'bolognese',
+                username: 'Bolognese',
+                email: 'bolognese@example.com'
+            }];
+
+            widget.field = new FormFieldModel( new FormModel({ taskId: '<id>'}, null, true), {
+                type: FormFieldTypes.GROUP,
+                value: mockSpaghetti
+            });
+
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            const disabledFormField: HTMLElement = element.querySelector('.mat-form-field-disabled');
+            expect(disabledFormField).toBeTruthy();
+
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            const disabledGroupChip: HTMLElement = element.querySelector('.mat-chip-disabled');
+            expect(disabledGroupChip).toBeTruthy();
+        });
+
+        it('should multi chips be disabled', async () => {
+            const mockSpaghetti: IdentityUserModel[] = [
+                { id: 'bolognese', username: 'Bolognese', email: 'bolognese@example.com' },
+                { id: 'carbonara', username: 'Carbonara', email: 'carbonara@example.com' }
+            ];
+
+            widget.field = new FormFieldModel( new FormModel({ taskId: '<id>'}, null, true), {
+                type: FormFieldTypes.GROUP,
+                value: mockSpaghetti
+            });
+
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            const disabledFormField: HTMLElement = element.querySelector('.mat-form-field-disabled');
+            expect(disabledFormField).toBeTruthy();
+
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            const disabledGroupChips = element.querySelectorAll('.mat-chip-disabled');
+            expect(disabledGroupChips.item(0)).toBeTruthy();
+            expect(disabledGroupChips.item(1)).toBeTruthy();
         });
     });
 

--- a/lib/process-services-cloud/src/lib/group/components/group-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/group/components/group-cloud.component.ts
@@ -27,7 +27,6 @@ import {
     SimpleChanges,
     OnChanges,
     OnDestroy,
-    ChangeDetectionStrategy,
     SimpleChange
 } from '@angular/core';
 import { FormControl } from '@angular/forms';
@@ -50,7 +49,6 @@ import { ComponentSelectionMode } from '../../types';
             ])
         ])
     ],
-    changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None
 })
 export class GroupCloudComponent implements OnInit, OnChanges, OnDestroy {

--- a/lib/process-services-cloud/src/lib/people/components/people-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/people/components/people-cloud.component.ts
@@ -26,7 +26,6 @@ import {
     SimpleChanges,
     OnChanges,
     OnDestroy,
-    ChangeDetectionStrategy,
     ViewChild, ElementRef, SimpleChange
 } from '@angular/core';
 import { Observable, of, BehaviorSubject, Subject } from 'rxjs';
@@ -54,7 +53,6 @@ import { ComponentSelectionMode } from '../../types';
         ])
     ],
     providers: [FullNamePipe],
-    changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None
 })
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/AAE-9314


**What is the new behaviour?**
Once user complete task with form that includes people/group widgets, these widgets are in readOnly state (disabled)


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
