### PR TITLE
[AAE-9190] - ATTACH FILE: view file content directly by clicking

### DIFF
--- a/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/file-properties-table-cloud.component.html
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/file-properties-table-cloud.component.html
@@ -19,10 +19,10 @@
             <th mat-header-cell *matHeaderCellDef>{{ 'FORM.FIELD.FILE_NAME' | translate }}</th>
             <td mat-cell *matCellDef="let element">
                 <span matLine id="{{'file-'+element?.id}}"
-                    role="button"
-                    tabindex="0"
-                    class="adf-file"
-                    (click)="onAttachFileClicked(element)"
+                      role="button"
+                      tabindex="0"
+                      class="adf-file"
+                      (click)="onAttachFileClicked(element)"
                 >{{element.name}}</span>
             </td>
         </ng-container>

--- a/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/file-properties-table-cloud.component.html
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/file-properties-table-cloud.component.html
@@ -18,8 +18,12 @@
         <ng-container matColumnDef="fileName">
             <th mat-header-cell *matHeaderCellDef>{{ 'FORM.FIELD.FILE_NAME' | translate }}</th>
             <td mat-cell *matCellDef="let element">
-                <span matLine id="{{'file-'+element?.id}}" role="button" tabindex="0" class="adf-file" 
-                (click)="onAttachFileClicked(element)">{{element.name}}</span>
+                <span matLine id="{{'file-'+element?.id}}"
+                    role="button"
+                    tabindex="0"
+                    class="adf-file"
+                    (click)="onAttachFileClicked(element)"
+                >{{element.name}}</span>
             </td>
         </ng-container>
 

--- a/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/file-properties-table-cloud.component.html
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/file-properties-table-cloud.component.html
@@ -18,8 +18,8 @@
         <ng-container matColumnDef="fileName">
             <th mat-header-cell *matHeaderCellDef>{{ 'FORM.FIELD.FILE_NAME' | translate }}</th>
             <td mat-cell *matCellDef="let element">
-                <span matLine id="{{'file-'+element?.id}}" role="button" tabindex="0" class="adf-file"
-                    (click)="onRowClicked(element)">{{element.name}}</span>
+                <span matLine id="{{'file-'+element?.id}}" role="button" tabindex="0" class="adf-file" 
+                (click)="onAttachFileClicked(element)">{{element.name}}</span>
             </td>
         </ng-container>
 
@@ -28,7 +28,7 @@
                 }}</th>
             <td mat-cell *matCellDef="let row">
                 <span matLine id="{{'fileProperty-'+row?.id+'-'+columnName?.name}}" role="button" tabindex="0"
-                    (click)="onRowClicked(row)">{{ getColumnValue(row, columnName) }}</span>
+                    (click)="onRowClicked(row)">{{ getColumnValue(row, columnName) }}</span>         
             </td>
         </ng-container>
 

--- a/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/file-properties-table-cloud.component.html
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/file-properties-table-cloud.component.html
@@ -32,7 +32,7 @@
                 }}</th>
             <td mat-cell *matCellDef="let row">
                 <span matLine id="{{'fileProperty-'+row?.id+'-'+columnName?.name}}" role="button" tabindex="0"
-                    (click)="onRowClicked(row)">{{ getColumnValue(row, columnName) }}</span>         
+                    (click)="onRowClicked(row)">{{ getColumnValue(row, columnName) }}</span>
             </td>
         </ng-container>
 

--- a/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/file-properties-table-cloud.component.scss
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/file-properties-table-cloud.component.scss
@@ -6,6 +6,7 @@
 
         .adf-file {
             cursor: pointer;
+
             &:hover {
                 text-decoration: underline;
             }

--- a/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/file-properties-table-cloud.component.scss
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/file-properties-table-cloud.component.scss
@@ -8,7 +8,6 @@
             cursor: pointer;
             &:hover {
                 text-decoration: underline;
-                // color: var(--theme-text-bold-color);
             }
         }
 

--- a/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/file-properties-table-cloud.component.scss
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/file-properties-table-cloud.component.scss
@@ -4,6 +4,14 @@
         border: 1px solid var(--theme-border-color);
         box-shadow: none;
 
+        .adf-file {
+            cursor: pointer;
+            &:hover {
+                text-decoration: underline;
+                // color: var(--theme-text-bold-color);
+            }
+        }
+
         .adf-datatable-selected {
             padding: 6px;
         }

--- a/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/file-properties-table-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/file-properties-table-cloud.component.spec.ts
@@ -21,9 +21,10 @@ import { ProcessServiceCloudTestingModule } from '../../../../testing/process-se
 import { TranslateModule } from '@ngx-translate/core';
 import { FilePropertiesTableCloudComponent } from './file-properties-table-cloud.component';
 import { By } from '@angular/platform-browser';
-import { MaterialModule } from 'core';
+import { MatTableModule } from '@angular/material/table';
+import { MatIconModule } from '@angular/material/icon';
 
-describe('FilePropertiesTableCloudComponent', () => {
+fdescribe('FilePropertiesTableCloudComponent', () => {
     let widget: FilePropertiesTableCloudComponent;
     let fixture: ComponentFixture<FilePropertiesTableCloudComponent>;
 
@@ -32,7 +33,8 @@ describe('FilePropertiesTableCloudComponent', () => {
             imports: [
                 TranslateModule.forRoot(),
                 ProcessServiceCloudTestingModule,
-                MaterialModule
+                MatTableModule,
+                MatIconModule
             ],
             declarations: [FilePropertiesTableCloudComponent]
         }).compileComponents();

--- a/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/file-properties-table-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/file-properties-table-cloud.component.spec.ts
@@ -24,7 +24,7 @@ import { By } from '@angular/platform-browser';
 import { MatTableModule } from '@angular/material/table';
 import { MatIconModule } from '@angular/material/icon';
 
-fdescribe('FilePropertiesTableCloudComponent', () => {
+describe('FilePropertiesTableCloudComponent', () => {
     let widget: FilePropertiesTableCloudComponent;
     let fixture: ComponentFixture<FilePropertiesTableCloudComponent>;
 

--- a/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/file-properties-table-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/file-properties-table-cloud.component.spec.ts
@@ -16,80 +16,17 @@
  */
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import {
-    FormFieldModel,
-    FormFieldTypes,
-    FormModel,
-    FormService
-    // setupTestBed
-    // FormFieldModel,
-    // FormModel,
-    // FormFieldTypes
-} from '@alfresco/adf-core';
 
 import { ProcessServiceCloudTestingModule } from '../../../../testing/process-service-cloud.testing.module';
-// import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ContentModule } from '@alfresco/adf-content-services';
 import { FormCloudModule } from '../../../form-cloud.module';
 import { TranslateModule } from '@ngx-translate/core';
 import { FilePropertiesTableCloudComponent } from './file-properties-table-cloud.component';
-import { allSourceParams, fakeMinimalNode, fakeNodeWithProperties } from '../../../mocks/attach-file-cloud-widget.mock';
-import { ProcessCloudContentService } from '../../../public-api';
-import { of } from 'rxjs';
 import { By } from '@angular/platform-browser';
 
-
-fdescribe('FilePropertiesTableCloudComponent', () => {
+describe('FilePropertiesTableCloudComponent', () => {
     let widget: FilePropertiesTableCloudComponent;
     let fixture: ComponentFixture<FilePropertiesTableCloudComponent>;
-    let processCloudContentService: ProcessCloudContentService;
-    let formService: FormService;
-
-    // let dataSource: CdkTableDataSourceInput<any>;
-
-
-    let element: HTMLInputElement;
-
-    const createUploadWidgetField = (form: FormModel, fieldId: string, value?: any, params?: any, multiple?: boolean, name?: string, readOnly?: boolean) => {
-        widget.field = new FormFieldModel(form, {
-            type: FormFieldTypes.UPLOAD,
-            value,
-            id: fieldId,
-            readOnly,
-            name,
-            tooltip: 'attach file widget',
-            params: { ...params, multiple }
-        });
-    };
-    // const fakePngUpload: any = {
-    //     id: 1166,
-    //     name: 'fake-png.png',
-    //     created: '2017-07-25T17:17:37.099Z',
-    //     createdBy: { id: 1001, firstName: 'Admin', lastName: 'admin', email: 'admin' },
-    //     relatedContent: false,
-    //     contentAvailable: true,
-    //     link: false,
-    //     isExternal: false,
-    //     mimeType: 'image/png',
-    //     simpleType: 'image',
-    //     previewStatus: 'queued',
-    //     thumbnailStatus: 'queued'
-    // };
-    // const clickOnAttachFileWidget = (id: string) => {
-    //     const attachButton: HTMLButtonElement = element.querySelector(`#${id}`);
-    //     attachButton.click();
-    // };
-
-    // setupTestBed({
-    //     imports: [
-    //         TranslateModule.forRoot(),
-    //         ProcessServiceCloudTestingModule,
-    //         FormCloudModule,
-    //         ContentModule.forRoot()
-    //     ],
-    //     declarations: [FilePropertiesTableCloudComponent]
-    //     // schemas: [CUSTOM_ELEMENTS_SCHEMA]
-    // });
 
     beforeEach(async () => {
         TestBed.configureTestingModule({
@@ -106,11 +43,36 @@ fdescribe('FilePropertiesTableCloudComponent', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(FilePropertiesTableCloudComponent);
         widget = fixture.componentInstance;
-        element = fixture.nativeElement;
-        processCloudContentService = TestBed.inject(ProcessCloudContentService);
-        formService = TestBed.inject(FormService);
 
-        widget.uploadedFiles = [{id: 'id'}];
+        widget.uploadedFiles = [{
+            id: 'id',
+            name: 'download.png',
+            mimeType: 'image/png',
+            isExternal: true,
+            isFile: true,
+            isFolder: false,
+            content: {
+                mimeType: 'image/png'
+            }
+        }, {
+            id: 'id2',
+            name: 'download2.png',
+            mimeType: 'image/png',
+            isExternal: true,
+            isFile: true,
+            isFolder: false,
+            content: {
+                mimeType: 'image/png'
+            }
+        }];
+
+        widget.hasFile = true;
+
+        widget.displayedColumns = [
+            'icon',
+            'fileName'
+        ];
+
         fixture.detectChanges();
     });
 
@@ -118,65 +80,16 @@ fdescribe('FilePropertiesTableCloudComponent', () => {
         fixture.destroy();
     });
 
-    // it('should select row on click', () => {
-    //     const row = {selected: false} as any;
-    //     widget.onAttachFileClicked(row);
+    fit('should emit attachFileClick', async (done) => {
+        widget.attachFileClick.subscribe((fileClicked) => {
+            expect(fileClicked.id).toBe('id');
+            expect(fileClicked.mimeType).toBe('image/png');
+            expect(fileClicked.name).toBe('download.png');
+            done();
+        });
 
-    //     expect(row.selected).toBeTruthy();
-    //     // expect(component.field.selected).toBe(row);
-    // });
-
-    // it('should preview file when file is clicked', (done) => {
-    //     spyOn(processCloudContentService, 'getRawContentNode').and.returnValue(of(new Blob()));
-    //     formService.formContentClicked.subscribe(
-    //         (fileClicked: any) => {
-    //             expect(fileClicked.nodeId).toBe('fake-properties');
-    //             done();
-    //         }
-    //     );
-
-    //     fixture.detectChanges();
-
-    //     const menuButton = fixture.debugElement.query(By.css('#file-fake-properties')).nativeElement as HTMLButtonElement;
-    //     menuButton.click();
-    //     fixture.detectChanges();
-
-    // });
-
-    // fit('should throw a nodeClicked event when a node is clicked', (done) => {
-    //     widget.attachFileClick.subscribe((nodeClicked) => {
-    //         expect(nodeClicked).toBeDefined();
-    //         expect(nodeClicked).not.toBeNull();
-    //         expect(nodeClicked.entry.name).toBe('fake-node-name');
-    //         expect(nodeClicked.entry.id).toBe('fake-node-id');
-    //         done();
-    //     });
-    //     const button = fixture.debugElement.query(By.css('#file-fake-properties'));
-    //     button.nativeElement.click();
-    // });
-
-
-    it('should emit attachFileClick', async () => {
-        debugger;
-
-        // createUploadWidgetField(new FormModel(), 'attach-file-alfresco', [], allSourceParams);
-        // fixture.detectChanges();
-        // await fixture.whenStable();
-        // expect(element.querySelector('#attach-file-alfresco')).not.toBeNull();
-
-  
-    //     const attachedFileName = fixture.debugElement.query(By.css('.adf-file'));
-
-    //     expect(attachedFileName.nativeElement.innerText).toEqual('fake-name');
-
-        // component.onAttachFileClicked(fakeNodeWithProperties);
-        // const showOption = fixture.debugElement.query(By.css('#file-fake-properties-show-file')).nativeElement as HTMLButtonElement;
-        // const test = fixture.debugElement.query(By.css('#file-id'));
-//         const test = fixture.nativeElement.querySelector('#file-id');
-
-        // const showOption = fixture.debugElement.query(By.css('.adf-file'));
-        // showOption.nativeElement.click();
-        // expect(nodeContentLoadedSpy).toHaveBeenCalledWith(fakeNodeWithProperties);
+        const attachedFile = fixture.debugElement.query(By.css('#file-id')).nativeElement as HTMLButtonElement;
+        attachedFile.click();
+        fixture.detectChanges();
     });
-
 });

--- a/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/file-properties-table-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/file-properties-table-cloud.component.spec.ts
@@ -18,13 +18,12 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ProcessServiceCloudTestingModule } from '../../../../testing/process-service-cloud.testing.module';
-import { ContentModule } from '@alfresco/adf-content-services';
-import { FormCloudModule } from '../../../form-cloud.module';
 import { TranslateModule } from '@ngx-translate/core';
 import { FilePropertiesTableCloudComponent } from './file-properties-table-cloud.component';
 import { By } from '@angular/platform-browser';
+import { MaterialModule } from 'core';
 
-describe('FilePropertiesTableCloudComponent', () => {
+fdescribe('FilePropertiesTableCloudComponent', () => {
     let widget: FilePropertiesTableCloudComponent;
     let fixture: ComponentFixture<FilePropertiesTableCloudComponent>;
 
@@ -33,8 +32,7 @@ describe('FilePropertiesTableCloudComponent', () => {
             imports: [
                 TranslateModule.forRoot(),
                 ProcessServiceCloudTestingModule,
-                FormCloudModule,
-                ContentModule.forRoot()
+                MaterialModule
             ],
             declarations: [FilePropertiesTableCloudComponent]
         }).compileComponents();
@@ -80,16 +78,13 @@ describe('FilePropertiesTableCloudComponent', () => {
         fixture.destroy();
     });
 
-    it('should emit attachFileClick', async (done) => {
-        widget.attachFileClick.subscribe((fileClicked) => {
-            expect(fileClicked.id).toBe('id');
-            expect(fileClicked.mimeType).toBe('image/png');
-            expect(fileClicked.name).toBe('download.png');
-            done();
-        });
+    it('should emit attachFileClick', () => {
+        const attachFileClickSpy = spyOn(widget.attachFileClick, 'emit').and.callThrough();
 
         const attachedFile = fixture.debugElement.query(By.css('#file-id')).nativeElement as HTMLButtonElement;
         attachedFile.click();
         fixture.detectChanges();
+
+        expect(attachFileClickSpy).toHaveBeenCalledWith(widget.uploadedFiles[0]);
     });
 });

--- a/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/file-properties-table-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/file-properties-table-cloud.component.spec.ts
@@ -80,7 +80,7 @@ describe('FilePropertiesTableCloudComponent', () => {
         fixture.destroy();
     });
 
-    fit('should emit attachFileClick', async (done) => {
+    it('should emit attachFileClick', async (done) => {
         widget.attachFileClick.subscribe((fileClicked) => {
             expect(fileClicked.id).toBe('id');
             expect(fileClicked.mimeType).toBe('image/png');

--- a/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/file-properties-table-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/file-properties-table-cloud.component.spec.ts
@@ -23,7 +23,7 @@ import { FilePropertiesTableCloudComponent } from './file-properties-table-cloud
 import { By } from '@angular/platform-browser';
 import { MaterialModule } from 'core';
 
-fdescribe('FilePropertiesTableCloudComponent', () => {
+describe('FilePropertiesTableCloudComponent', () => {
     let widget: FilePropertiesTableCloudComponent;
     let fixture: ComponentFixture<FilePropertiesTableCloudComponent>;
 

--- a/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/file-properties-table-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/file-properties-table-cloud.component.spec.ts
@@ -1,0 +1,182 @@
+/*!
+ * @license
+ * Copyright 2019 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+    FormFieldModel,
+    FormFieldTypes,
+    FormModel,
+    FormService
+    // setupTestBed
+    // FormFieldModel,
+    // FormModel,
+    // FormFieldTypes
+} from '@alfresco/adf-core';
+
+import { ProcessServiceCloudTestingModule } from '../../../../testing/process-service-cloud.testing.module';
+// import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { ContentModule } from '@alfresco/adf-content-services';
+import { FormCloudModule } from '../../../form-cloud.module';
+import { TranslateModule } from '@ngx-translate/core';
+import { FilePropertiesTableCloudComponent } from './file-properties-table-cloud.component';
+import { allSourceParams, fakeMinimalNode, fakeNodeWithProperties } from '../../../mocks/attach-file-cloud-widget.mock';
+import { ProcessCloudContentService } from '../../../public-api';
+import { of } from 'rxjs';
+import { By } from '@angular/platform-browser';
+
+
+fdescribe('FilePropertiesTableCloudComponent', () => {
+    let widget: FilePropertiesTableCloudComponent;
+    let fixture: ComponentFixture<FilePropertiesTableCloudComponent>;
+    let processCloudContentService: ProcessCloudContentService;
+    let formService: FormService;
+
+    // let dataSource: CdkTableDataSourceInput<any>;
+
+
+    let element: HTMLInputElement;
+
+    const createUploadWidgetField = (form: FormModel, fieldId: string, value?: any, params?: any, multiple?: boolean, name?: string, readOnly?: boolean) => {
+        widget.field = new FormFieldModel(form, {
+            type: FormFieldTypes.UPLOAD,
+            value,
+            id: fieldId,
+            readOnly,
+            name,
+            tooltip: 'attach file widget',
+            params: { ...params, multiple }
+        });
+    };
+    // const fakePngUpload: any = {
+    //     id: 1166,
+    //     name: 'fake-png.png',
+    //     created: '2017-07-25T17:17:37.099Z',
+    //     createdBy: { id: 1001, firstName: 'Admin', lastName: 'admin', email: 'admin' },
+    //     relatedContent: false,
+    //     contentAvailable: true,
+    //     link: false,
+    //     isExternal: false,
+    //     mimeType: 'image/png',
+    //     simpleType: 'image',
+    //     previewStatus: 'queued',
+    //     thumbnailStatus: 'queued'
+    // };
+    // const clickOnAttachFileWidget = (id: string) => {
+    //     const attachButton: HTMLButtonElement = element.querySelector(`#${id}`);
+    //     attachButton.click();
+    // };
+
+    // setupTestBed({
+    //     imports: [
+    //         TranslateModule.forRoot(),
+    //         ProcessServiceCloudTestingModule,
+    //         FormCloudModule,
+    //         ContentModule.forRoot()
+    //     ],
+    //     declarations: [FilePropertiesTableCloudComponent]
+    //     // schemas: [CUSTOM_ELEMENTS_SCHEMA]
+    // });
+
+    beforeEach(async () => {
+        TestBed.configureTestingModule({
+            imports: [
+                TranslateModule.forRoot(),
+                ProcessServiceCloudTestingModule,
+                FormCloudModule,
+                ContentModule.forRoot()
+            ],
+            declarations: [FilePropertiesTableCloudComponent]
+        }).compileComponents();
+    });
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(FilePropertiesTableCloudComponent);
+        widget = fixture.componentInstance;
+        element = fixture.nativeElement;
+        processCloudContentService = TestBed.inject(ProcessCloudContentService);
+        formService = TestBed.inject(FormService);
+
+        widget.uploadedFiles = [{id: 'id'}];
+        fixture.detectChanges();
+    });
+
+    afterEach(() => {
+        fixture.destroy();
+    });
+
+    // it('should select row on click', () => {
+    //     const row = {selected: false} as any;
+    //     widget.onAttachFileClicked(row);
+
+    //     expect(row.selected).toBeTruthy();
+    //     // expect(component.field.selected).toBe(row);
+    // });
+
+    // it('should preview file when file is clicked', (done) => {
+    //     spyOn(processCloudContentService, 'getRawContentNode').and.returnValue(of(new Blob()));
+    //     formService.formContentClicked.subscribe(
+    //         (fileClicked: any) => {
+    //             expect(fileClicked.nodeId).toBe('fake-properties');
+    //             done();
+    //         }
+    //     );
+
+    //     fixture.detectChanges();
+
+    //     const menuButton = fixture.debugElement.query(By.css('#file-fake-properties')).nativeElement as HTMLButtonElement;
+    //     menuButton.click();
+    //     fixture.detectChanges();
+
+    // });
+
+    // fit('should throw a nodeClicked event when a node is clicked', (done) => {
+    //     widget.attachFileClick.subscribe((nodeClicked) => {
+    //         expect(nodeClicked).toBeDefined();
+    //         expect(nodeClicked).not.toBeNull();
+    //         expect(nodeClicked.entry.name).toBe('fake-node-name');
+    //         expect(nodeClicked.entry.id).toBe('fake-node-id');
+    //         done();
+    //     });
+    //     const button = fixture.debugElement.query(By.css('#file-fake-properties'));
+    //     button.nativeElement.click();
+    // });
+
+
+    it('should emit attachFileClick', async () => {
+        debugger;
+
+        // createUploadWidgetField(new FormModel(), 'attach-file-alfresco', [], allSourceParams);
+        // fixture.detectChanges();
+        // await fixture.whenStable();
+        // expect(element.querySelector('#attach-file-alfresco')).not.toBeNull();
+
+  
+    //     const attachedFileName = fixture.debugElement.query(By.css('.adf-file'));
+
+    //     expect(attachedFileName.nativeElement.innerText).toEqual('fake-name');
+
+        // component.onAttachFileClicked(fakeNodeWithProperties);
+        // const showOption = fixture.debugElement.query(By.css('#file-fake-properties-show-file')).nativeElement as HTMLButtonElement;
+        // const test = fixture.debugElement.query(By.css('#file-id'));
+//         const test = fixture.nativeElement.querySelector('#file-id');
+
+        // const showOption = fixture.debugElement.query(By.css('.adf-file'));
+        // showOption.nativeElement.click();
+        // expect(nodeContentLoadedSpy).toHaveBeenCalledWith(fakeNodeWithProperties);
+    });
+
+});


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [X] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Currently when listing files in a form using the ATTACH FILE widget, when a user needs to view the file content he needs to select the file and then open the contextual menu and then select the view option.

**What is the new behaviour?**

When the file is attached, users can click on a file in order to preview it inline.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
