### PR TITLE
[AAE-10202] Storybook EmptyContent component

### DIFF
--- a/lib/core/templates/empty-content/empty-content.component.stories.ts
+++ b/lib/core/templates/empty-content/empty-content.component.stories.ts
@@ -29,13 +29,54 @@ export default {
         })
     ],
     argTypes: {
+        icon: {
+            description: 'Angular Material icon',
+            table: {
+                category: 'Component Inputs',
+                type: {
+                    summary: 'string'
+                },
+                defaultValue: {
+                    summary: 'cake'
+                }
+            }
+        },
+        title: {
+            table: {
+                category: 'Component Inputs',
+                type: {
+                    summary: 'string'
+                },
+                defaultValue: {
+                    summary: ''
+                }
+            }
+        },
+        subtitle: {
+            table: {
+                category: 'Component Inputs',
+                type: {
+                    summary: 'string'
+                },
+                defaultValue: {
+                    summary: ''
+                }
+            }
+        },
         lines: {
             name: 'lines',
+            description: 'Content Projection Text',
             type: { name: 'object', required: false },
             defaultValue: [
                 'Items you removed are moved to the Trash',
                 'Empty Trash to permanently delete items'
-            ]
+            ],
+            table: {
+                category: 'Strories Inputs',
+                type: {
+                    summary: 'array'
+                }
+            }
         }
     }
 } as Meta;

--- a/lib/core/templates/empty-content/empty-content.component.stories.ts
+++ b/lib/core/templates/empty-content/empty-content.component.stories.ts
@@ -81,7 +81,9 @@ export default {
     }
 } as Meta;
 
-const template: Story = args => ({
+const template: Story<EmptyContentComponent> = (
+    args: EmptyContentComponent
+) => ({
     props: args
 });
 
@@ -98,7 +100,9 @@ defaultStory.args = {
 };
 defaultStory.storyName = 'Default';
 
-export const multipleLines: Story = args => ({
+export const multipleLines: Story<EmptyContentComponent> = (
+    args: EmptyContentComponent & { lines: string[] }
+) => ({
     props: {
         ...args
     },

--- a/lib/core/templates/empty-content/empty-content.component.stories.ts
+++ b/lib/core/templates/empty-content/empty-content.component.stories.ts
@@ -22,7 +22,7 @@ import { TemplateModule } from '../template.module';
 
 export default {
     component: EmptyContentComponent,
-    title: 'Core/Components/Empty Content',
+    title: 'Core/Template/Empty Content',
     decorators: [
         moduleMetadata({
             imports: [CoreStoryModule, TemplateModule]
@@ -72,7 +72,7 @@ export default {
                 'Empty Trash to permanently delete items'
             ],
             table: {
-                category: 'Strories Inputs',
+                category: 'Strories Controls',
                 type: {
                     summary: 'array'
                 }

--- a/lib/core/templates/empty-content/empty-content.component.stories.ts
+++ b/lib/core/templates/empty-content/empty-content.component.stories.ts
@@ -66,7 +66,7 @@ export default {
         lines: {
             name: 'lines',
             description: 'Content Projection Text',
-            type: { name: 'object', required: false },
+            control: {type: 'object'},
             defaultValue: [
                 'Items you removed are moved to the Trash',
                 'Empty Trash to permanently delete items'

--- a/lib/core/templates/empty-content/empty-content.component.stories.ts
+++ b/lib/core/templates/empty-content/empty-content.component.stories.ts
@@ -1,0 +1,72 @@
+/*!
+ * @license
+ * Copyright 2022 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meta, moduleMetadata, Story } from '@storybook/angular';
+import { EmptyContentComponent } from './empty-content.component';
+import { CoreStoryModule } from '../../testing/core.story.module';
+import { TemplateModule } from '../template.module';
+
+export default {
+    component: EmptyContentComponent,
+    title: 'Core/Components/Empty Content',
+    decorators: [
+        moduleMetadata({
+            imports: [CoreStoryModule, TemplateModule]
+        })
+    ],
+    argTypes: {
+        lines: {
+            name: 'lines',
+            type: { name: 'object', required: false },
+            defaultValue: [
+                'Items you removed are moved to the Trash',
+                'Empty Trash to permanently delete items'
+            ]
+        }
+    }
+} as Meta;
+
+const template: Story = args => ({
+    props: args
+});
+
+export const defaultStory = template.bind({});
+defaultStory.argTypes = {
+    lines: {
+        control: { disable: true }
+    }
+};
+defaultStory.args = {
+    icon: 'star_rate',
+    title: 'No favourite files or folders',
+    subtitle: 'Favourite items that you want to easily find later'
+};
+defaultStory.storyName = 'Default';
+
+export const multipleLines: Story = args => ({
+    props: {
+        ...args
+    },
+    template: `
+    <adf-empty-content icon="delete" title="Trash is empty">
+        <p class="adf-empty-content__text" *ngFor="let line of ${JSON.stringify(
+            args.lines
+        ).replace(/\"/g, '\'')}">
+            {{ line }}
+        </p>
+    </adf-empty-content>`
+});


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
[https://alfresco.atlassian.net/browse/AAE-10202](https://alfresco.atlassian.net/browse/AAE-10202)


**What is the new behaviour?**
Two new stories for Core EmptyContent component:

- **Default story**:
![image](https://user-images.githubusercontent.com/56632321/182842934-a11d6140-711f-4c9d-acfa-29a5356d1b5e.png)

- **Story with multiple message lines**:
![image](https://user-images.githubusercontent.com/56632321/182843024-37d193b5-8ca1-4fac-a649-eec825bb4425.png)

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
