### PR TITLE
[#7604] Allow cache content-actions clearing of DocumentListComponent

### DIFF
--- a/docs/content-services/components/content-action.component.md
+++ b/docs/content-services/components/content-action.component.md
@@ -430,6 +430,10 @@ funcName = (parameters): boolean => {
 }
 ```
 
+#### Clearing actions cache
+
+The actions visibility and disabled states are evaluated once for each node and then cached by [Document List component](document-list.component.md) for futurs uses. If your actions states might have changed since the first evaluation of the node, you should call `clearActionsCache()`.
+
 ### Customizing built-in actions
 
 The built-in actions are defined in the [Document Actions service](../services/document-actions.service.md) and

--- a/docs/content-services/components/document-list.component.md
+++ b/docs/content-services/components/document-list.component.md
@@ -691,6 +691,8 @@ export class MyView {
 
 This single extra line in the template enables context menu items for documents and folders.
 
+The actions visibility and disabled states are evaluated once for each node and then cached by [Document List component](document-list.component.md) for futurs uses. If your actions states might have changed since the first evaluation of the node, you should call `clearActionsCache()`.
+
 ### Navigation mode
 
 By default, the [Document List component](document-list.component.md) uses 'double-click' mode for navigation.

--- a/lib/content-services/src/lib/document-list/components/document-list.component.spec.ts
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.spec.ts
@@ -531,6 +531,56 @@ describe('DocumentList', () => {
         expect(actions[1].disabled).toBe(false);
     });
 
+    it('should revaluate conditional disabled state for content action after cache clearing', () => {
+        documentList.actions = [
+            new ContentActionModel({
+                target: 'document',
+                title: 'Action1',
+                disabled: (node): boolean => node.entry.name === 'custom'
+            })
+        ];
+
+        let actions = documentList.getNodeActions({ entry: { id: 1, isFile: true, name: 'xyz' } });
+
+        expect(actions.length).toBe(1);
+        expect(actions[0].disabled).toBe(false);
+
+        actions = documentList.getNodeActions({ entry: { id: 1, isFile: true, name: 'custom' } });
+
+        expect(actions.length).toBe(1);
+        expect(actions[0].disabled).toBe(false);
+
+        documentList.clearActionsCache();
+
+        actions = documentList.getNodeActions({ entry: { id: 1, isFile: true, name: 'custom' } });
+        expect(actions.length).toBe(1);
+        expect(actions[0].disabled).toBe(true);
+    });
+
+    it('should revaluate conditional visibility state for content action after cache clearing', () => {
+        documentList.actions = [
+            new ContentActionModel({
+                target: 'document',
+                title: 'Action1',
+                visible: (node): boolean => node.entry.name === 'custom'
+            })
+        ];
+
+        let actions = documentList.getNodeActions({ entry: { id: 1, isFile: true, name: 'xyz' } });
+
+        expect(actions.length).toBe(0);
+
+        actions = documentList.getNodeActions({ entry: { id: 1, isFile: true, name: 'custom' } });
+
+        expect(actions.length).toBe(0);
+
+        documentList.clearActionsCache();
+
+        actions = documentList.getNodeActions({ entry: { id: 1, isFile: true, name: 'custom' } });
+        expect(actions.length).toBe(1);
+        expect(actions[0].visible).toBe(true);
+    });
+
     it('should not disable the action if there is copy permission', () => {
         const documentMenu = new ContentActionModel({
             disableWithNoPermission: true,

--- a/lib/content-services/src/lib/document-list/components/document-list.component.ts
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.ts
@@ -610,6 +610,13 @@ export class DocumentListComponent extends DataTableSchema implements OnInit, On
         return [];
     }
 
+    /**
+     * Clear the actions cache. This should be called before .reload() when the actions available on the nodes might have changed.
+     */
+    clearActionsCache(): void {
+        this.rowMenuCache = {};
+    }
+
     private refreshAction(action: ContentActionModel, node: NodeEntry) {
         action.disabled = this.isActionDisabled(action, node);
         action.visible = this.isActionVisible(action, node);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

unable to clear the actions cache for document list
https://github.com/Alfresco/alfresco-ng2-components/issues/7604

**What is the new behaviour?**

clearActionsCache() method on document list

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
