### PR TITLE
[AAE-10214] Storybook ErrorContent Component

### DIFF
--- a/lib/core/templates/error-content/error-content.component.stories.ts
+++ b/lib/core/templates/error-content/error-content.component.stories.ts
@@ -25,7 +25,7 @@ import { of } from 'rxjs';
 
 export default {
     component: ErrorContentComponent,
-    title: 'Core/Components/Error Content',
+    title: 'Core/Template/Error Content',
     decorators: [
         moduleMetadata({
             imports: [CoreStoryModule, TemplateModule, MatButtonModule],
@@ -95,6 +95,7 @@ errorKnownParamStory.decorators = [
         ]
     })
 ];
+errorKnownParamStory.storyName = 'Error Param with Known ID';
 
 export const errorUnknownParamStory = template.bind({});
 errorUnknownParamStory.args = {
@@ -113,3 +114,4 @@ errorUnknownParamStory.decorators = [
         ]
     })
 ];
+errorUnknownParamStory.storyName = 'Error Param with Unknown ID';

--- a/lib/core/templates/error-content/error-content.component.stories.ts
+++ b/lib/core/templates/error-content/error-content.component.stories.ts
@@ -20,7 +20,6 @@ import { ErrorContentComponent } from './error-content.component';
 import { CoreStoryModule } from '../../testing/core.story.module';
 import { TemplateModule } from '../template.module';
 import { ActivatedRoute } from '@angular/router';
-import { MatButtonModule } from '@angular/material/button';
 import { of } from 'rxjs';
 
 export default {
@@ -28,7 +27,7 @@ export default {
     title: 'Core/Template/Error Content',
     decorators: [
         moduleMetadata({
-            imports: [CoreStoryModule, TemplateModule, MatButtonModule],
+            imports: [CoreStoryModule, TemplateModule],
             providers: [
                 {
                     provide: ActivatedRoute,
@@ -83,16 +82,6 @@ export default {
     }
 } as Meta;
 
-export const errorCodeStory: Story = args => ({
-    props: args,
-    template: `
-    <adf-error-content [errorCode]="${args.errorCode}">
-        <div adf-error-content-actions *ngIf="${args.isAdditionalContent}">
-        <button mat-raised-button type="button">MyAction</button>
-        </div>
-    </adf-error-content>`
-});
-
 const templateArgTypes = {
     errorCode: {
         control: {
@@ -101,7 +90,9 @@ const templateArgTypes = {
     }
 };
 
-const template: Story = args => ({
+const template: Story<ErrorContentComponent> = (
+    args: ErrorContentComponent & { isAdditionalContent: boolean }
+) => ({
     props: args,
     template: `
         <adf-error-content>
@@ -143,3 +134,15 @@ errorUnknownParamStory.decorators = [
     })
 ];
 errorUnknownParamStory.storyName = 'Error Param with Unknown ID';
+
+export const errorCodeStory: Story<ErrorContentComponent> = (
+    args: ErrorContentComponent & { isAdditionalContent: boolean }
+) => ({
+    props: args,
+    template: `
+    <adf-error-content [errorCode]="${args.errorCode}">
+        <div adf-error-content-actions *ngIf="${args.isAdditionalContent}">
+        <button mat-raised-button type="button">MyAction</button>
+        </div>
+    </adf-error-content>`
+});

--- a/lib/core/templates/error-content/error-content.component.stories.ts
+++ b/lib/core/templates/error-content/error-content.component.stories.ts
@@ -1,0 +1,115 @@
+/*!
+ * @license
+ * Copyright 2022 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Meta, moduleMetadata, Story } from '@storybook/angular';
+import { ErrorContentComponent } from './error-content.component';
+import { CoreStoryModule } from '../../testing/core.story.module';
+import { TemplateModule } from '../template.module';
+import { ActivatedRoute } from '@angular/router';
+import { MatButtonModule } from '@angular/material/button';
+import { of } from 'rxjs';
+
+export default {
+    component: ErrorContentComponent,
+    title: 'Core/Components/Error Content',
+    decorators: [
+        moduleMetadata({
+            imports: [CoreStoryModule, TemplateModule, MatButtonModule],
+            providers: [
+                {
+                    provide: ActivatedRoute,
+                    useValue: { params: of({}) }
+                }
+            ]
+        })
+    ],
+    argTypes: {
+        errorCode: {
+            type: 'string',
+            defaultValue: '404'
+        },
+        isAdditionalContent: {
+            type: 'boolean',
+            defaultValue: true
+        }
+    }
+} as Meta;
+
+export const errorCodeStory: Story = args => ({
+    props: args,
+    template: `
+    <adf-error-content [errorCode]="${args.errorCode}">
+        <div adf-error-content-actions *ngIf="${args.isAdditionalContent}">
+        <button mat-raised-button type="button">MyAction</button>
+        </div>
+    </adf-error-content>`
+});
+
+const templateArgTypes = {
+    errorCode: {
+        control: {
+            disable: true
+        }
+    }
+};
+
+const template: Story = args => ({
+    props: args,
+    template: `
+        <adf-error-content>
+            <div adf-error-content-actions *ngIf="${args.isAdditionalContent}">
+            <button mat-raised-button type="button">MyAction</button>
+            </div>
+        </adf-error-content>
+        `
+});
+
+export const errorKnownParamStory = template.bind({});
+errorKnownParamStory.args = {
+    isAdditionalContent: true
+};
+errorKnownParamStory.argTypes = templateArgTypes;
+errorKnownParamStory.decorators = [
+    moduleMetadata({
+        providers: [
+            {
+                provide: ActivatedRoute,
+                useValue: {
+                    params: of({ id: '500' })
+                }
+            }
+        ]
+    })
+];
+
+export const errorUnknownParamStory = template.bind({});
+errorUnknownParamStory.args = {
+    isAdditionalContent: true
+};
+errorUnknownParamStory.argTypes = templateArgTypes;
+errorUnknownParamStory.decorators = [
+    moduleMetadata({
+        providers: [
+            {
+                provide: ActivatedRoute,
+                useValue: {
+                    params: of({ id: '200' })
+                }
+            }
+        ]
+    })
+];

--- a/lib/core/templates/error-content/error-content.component.stories.ts
+++ b/lib/core/templates/error-content/error-content.component.stories.ts
@@ -40,11 +40,45 @@ export default {
     argTypes: {
         errorCode: {
             type: 'string',
+            description: 'Component level Error Code',
+            table: {
+                category: 'Component Inputs',
+                type: {
+                    summary: 'string'
+                },
+                defaultValue: {
+                    summary: 'UNKNOWN'
+                }
+            },
             defaultValue: '404'
+        },
+        errorCodeTranslated: {
+            type: 'string',
+            description:
+                'Code of translated Error - if translation doesn\'t exist then is UNKNOWN',
+            table: {
+                category: 'Component Variables',
+                type: {
+                    summary: 'string'
+                }
+            },
+            control: {
+                disable: true
+            }
         },
         isAdditionalContent: {
             type: 'boolean',
-            defaultValue: true
+            description: 'Enable Content Projection',
+            defaultValue: false,
+            table: {
+                category: 'Story Controls',
+                type: {
+                    summary: 'boolean'
+                },
+                defaultValue: {
+                    summary: false
+                }
+            }
         }
     }
 } as Meta;
@@ -79,9 +113,6 @@ const template: Story = args => ({
 });
 
 export const errorKnownParamStory = template.bind({});
-errorKnownParamStory.args = {
-    isAdditionalContent: true
-};
 errorKnownParamStory.argTypes = templateArgTypes;
 errorKnownParamStory.decorators = [
     moduleMetadata({
@@ -98,9 +129,6 @@ errorKnownParamStory.decorators = [
 errorKnownParamStory.storyName = 'Error Param with Known ID';
 
 export const errorUnknownParamStory = template.bind({});
-errorUnknownParamStory.args = {
-    isAdditionalContent: true
-};
 errorUnknownParamStory.argTypes = templateArgTypes;
 errorUnknownParamStory.decorators = [
     moduleMetadata({

--- a/lib/core/templates/template.module.ts
+++ b/lib/core/templates/template.module.ts
@@ -1,6 +1,6 @@
 /*!
  * @license
- * Copyright 2019 Alfresco Software, Ltd.
+ * Copyright 2022 Alfresco Software, Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,25 +18,14 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
-import { MaterialModule } from '../material.module';
 import { ErrorContentComponent } from './error-content/error-content.component';
 import { EmptyContentComponent } from './empty-content/empty-content.component';
 import { IconModule } from '../icon/icon.module';
+import { MatButtonModule } from '@angular/material/button';
 
 @NgModule({
-    imports: [
-        CommonModule,
-        MaterialModule,
-        TranslateModule,
-        IconModule
-    ],
-    declarations: [
-        ErrorContentComponent,
-        EmptyContentComponent
-    ],
-    exports: [
-        ErrorContentComponent,
-        EmptyContentComponent
-    ]
+    imports: [CommonModule, TranslateModule, IconModule],
+    declarations: [ErrorContentComponent, EmptyContentComponent],
+    exports: [ErrorContentComponent, EmptyContentComponent, MatButtonModule]
 })
 export class TemplateModule {}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**
Added three stories for ErrorContent Component:
- **Error Code Story**

Handle input codeError changes

![image](https://user-images.githubusercontent.com/56632321/183898626-4fcb8b89-ccf1-49e6-8818-5b41d8c851a3.png)

- **Error Param with Known ID**

Shows known error caused by Route (500 error)

![image](https://user-images.githubusercontent.com/56632321/183898996-5eee5bc0-84a7-41a1-80fe-4911beefa4f6.png)

- **Error Param with Unknown ID**

Shows unknown error caused by Route (200 error)

![image](https://user-images.githubusercontent.com/56632321/183899109-b2f97a0f-0d33-475e-a42d-e8b36de0b241.png)

Video:

https://user-images.githubusercontent.com/56632321/183901739-a4578f5c-98f5-476d-ad4d-7157cdb77514.mp4





**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
