### PR TITLE
[AAE-10377] Fix the rich text editor widget is not opening

### DIFF
--- a/lib/core/src/lib/form/components/widgets/display-rich-text/display-rich-text.widget.ts
+++ b/lib/core/src/lib/form/components/widgets/display-rich-text/display-rich-text.widget.ts
@@ -21,7 +21,7 @@ import { Component, OnInit, ViewEncapsulation } from '@angular/core';
 import { FormService } from '../../../services/form.service';
 import { WidgetComponent } from '../widget.component';
 /* cspell:disable-next-line */
-import * as edjsHTML from 'editorjs-html';
+import edjsHTML from 'editorjs-html';
 @Component({
     selector: 'display-rich-text',
     templateUrl: './display-rich-text.widget.html',

--- a/lib/core/src/lib/rich-text-editor/editorjs-config.ts
+++ b/lib/core/src/lib/rich-text-editor/editorjs-config.ts
@@ -22,8 +22,8 @@ import InlineCode from '@editorjs/inline-code';
 import List from '@editorjs/list';
 import Marker from '@editorjs/marker';
 import Underline from '@editorjs/underline';
-import * as ChangeFontSize from '@quanzo/change-font-size';
-import * as ColorPlugin from 'editorjs-text-color-plugin';
+import ChangeFontSize from '@quanzo/change-font-size';
+import ColorPlugin from 'editorjs-text-color-plugin';
 
 export const editorJsConfig = {
     autofocus: true,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/AAE-10377


**What is the new behaviour?**
Changing the import from namespace import to default import the issues are fixed 

https://user-images.githubusercontent.com/23027333/187979161-42ed46a4-bf96-4584-93c2-660822dc3ee7.mp4



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
