### PR TITLE
[AAE-10474] review why xit and console log is allowed to be committed

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -116,6 +116,31 @@
           }
         ],
         "no-bitwise": "off",
+        "no-console": [
+          "error",
+          {
+            "allow": [
+              "warn",
+              "dir",
+              "timeLog",
+              "assert",
+              "clear",
+              "count",
+              "countReset",
+              "group",
+              "groupEnd",
+              "table",
+              "dirxml",
+              "error",
+              "groupCollapsed",
+              "Console",
+              "profile",
+              "profileEnd",
+              "timeStamp",
+              "context"
+            ]
+          }
+        ],
         "no-duplicate-imports": "error",
         "no-multiple-empty-lines": "error",
         "no-redeclare": "error",

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx lint-staged
+npm run affected:lint

--- a/lib/cli/.eslintrc.json
+++ b/lib/cli/.eslintrc.json
@@ -34,7 +34,8 @@
         "no-duplicate-imports": "error",
         "no-multiple-empty-lines": "error",
         "no-redeclare": "error",
-        "no-return-await": "error"
+        "no-return-await": "error",
+        "no-console": "off"
       }
     },
     {

--- a/lib/core/src/lib/pagination/pagination.component.spec.ts
+++ b/lib/core/src/lib/pagination/pagination.component.spec.ts
@@ -386,7 +386,7 @@ describe('PaginationComponent', () => {
 
             const expectedPages = [1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
                 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 101];
-            console.log(component.pagination.totalItems, component.pagination.skipCount);
+
             expect(component.limitedPages).toEqual(expectedPages);
             expect(component.limitedPages).not.toEqual(component.pages);
         });

--- a/lib/core/src/lib/rich-text-editor/rich-text-editor.component.ts
+++ b/lib/core/src/lib/rich-text-editor/rich-text-editor.component.ts
@@ -74,7 +74,7 @@ export class RichTextEditorComponent implements OnInit, OnDestroy, AfterViewInit
         this.editorInstance.save().then((outputData) => {
             this._outputData.next(outputData);
         }).catch((error) => {
-            console.log('Saving failed: ', error);
+            console.error('Saving failed: ', error);
         });
     }
 

--- a/lib/testing/.eslintrc.json
+++ b/lib/testing/.eslintrc.json
@@ -53,6 +53,7 @@
           }
         ],
         "no-bitwise": "off",
+        "no-console": "off",
         "no-duplicate-imports": "error",
         "no-multiple-empty-lines": "error",
         "no-redeclare": "error",

--- a/package.json
+++ b/package.json
@@ -29,9 +29,7 @@
     "print-affected:lint": "nx print-affected --target=lint --select=tasks.target.project",
     "03": "echo -------------------------------------------- Lint  -----------------------------------------------",
     "03s": "",
-    "lint-demo": "tslint -p tsconfig.json -c tslint.json",
-    "lint-lib": "tslint -p ./lib/tsconfig.json -c ./lib/tslint.json",
-    "lint-e2e": "tsc -p tsconfig.e2e.json",
+    "affected:lint": "nx affected:lint",
     "validate-config": "ajv validate -s lib/core/src/lib/app-config/schema.json -d ./demo-shell/src/app.config.json --errors=text --verbose",
     "04": "echo -------------------------------------------- Demo Shell -----------------------------------------------",
     "04s": "",
@@ -233,16 +231,5 @@
     "node": ">=6.0.0"
   },
   "module": "./index.js",
-  "typings": "./index.d.ts",
-  "lint-staged": {
-    "**/demo-shell/src/**/*.ts": "npm run lint-demo -- --fix",
-    "**/lib/**/*.ts": "npm run lint-lib -- --fix",
-    "**/e2e/**/*.ts": "npm run lint-e2e -- --fix",
-    "*.scss": "npm run stylelint --  --fix"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  }
+  "typings": "./index.d.ts"
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [x] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/AAE-10474
The lint scripts were not being run because the pre-commit hook `lint-staged` was not being executed using the package.json configuration

**What is the new behaviour?**
A new pre-commit hook run the `nx affected:lint` script.
The old scripts that use `tslint` has been removed

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
