### PR TITLE
MNT-23143 allow discoveryService withCredentials

### DIFF
--- a/lib/core/src/lib/services/discovery-api.service.ts
+++ b/lib/core/src/lib/services/discovery-api.service.ts
@@ -42,7 +42,9 @@ export class DiscoveryApiService {
     ) {
         this.authenticationService.onLogin
             .pipe(
-                filter(() => this.apiService.getInstance()?.isEcmLoggedIn() || this.authenticationService.isKerberosEnabled()),
+                filter(() => this.apiService.getInstance()?.isEcmLoggedIn() || 
+                       ((this.authenticationService.isECMProvider() || this.authenticationService.isALLProvider()) && 
+                        this.authenticationService.isKerberosEnabled()),
                 take(1),
                 switchMap(() => this.getEcmProductInfo())
             )

--- a/lib/core/src/lib/services/discovery-api.service.ts
+++ b/lib/core/src/lib/services/discovery-api.service.ts
@@ -42,7 +42,7 @@ export class DiscoveryApiService {
     ) {
         this.authenticationService.onLogin
             .pipe(
-                filter(() => this.apiService.getInstance()?.isEcmLoggedIn()),
+                filter(() => this.apiService.getInstance()?.isEcmLoggedIn() || this.authenticationService.isKerberosEnabled()),
                 take(1),
                 switchMap(() => this.getEcmProductInfo())
             )


### PR DESCRIPTION
If withCredentials=true in app.config.json, the contentAuth is not used. Therefore, the filter isEcmLoggedIn() will be false. Adding a dedicated check for Kerberos (i.e. withCredentials=true)