### PR TITLE
AAE-2824: Managed to trigger executeOutcome when clicking on custom outcome buttons

### DIFF
--- a/lib/core/src/lib/form/components/form-base.component.ts
+++ b/lib/core/src/lib/form/components/form-base.component.ts
@@ -191,7 +191,6 @@ export abstract class FormBaseComponent {
             } else {
                 // Note: Activiti is using NAME field rather than ID for outcomes
                 if (outcome.name) {
-                    this.onTaskSaved(this.form);
                     this.completeTaskForm(outcome.name);
                     return true;
                 }

--- a/lib/process-services-cloud/src/lib/form/components/form-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/form-cloud.component.spec.ts
@@ -480,7 +480,7 @@ describe('FormCloudComponent', () => {
 
         const result = formComponent.onOutcomeClicked(outcome);
         expect(result).toBeTruthy();
-        expect(saved).toBeTruthy();
+        expect(saved).toBeFalse();
         expect(formComponent.completeTaskForm).toHaveBeenCalledWith(outcomeName);
     });
 

--- a/lib/process-services-cloud/src/lib/task/task-form/components/task-form-cloud.component.html
+++ b/lib/process-services-cloud/src/lib/task/task-form/components/task-form-cloud.component.html
@@ -14,7 +14,8 @@
                     (formCompleted)="onFormCompleted($event)"
                     (formError)="onError($event)"
                     (error)="onError($event)"
-                    (formContentClicked)="onFormContentClicked($event)">
+                    (formContentClicked)="onFormContentClicked($event)"
+                    (executeOutcome)="onFormExecuteOutcome($event)">
         <adf-cloud-form-custom-outcomes>
             <ng-template [ngTemplateOutlet]="taskFormCloudButtons">
             </ng-template>

--- a/lib/process-services-cloud/src/lib/task/task-form/components/task-form-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/task/task-form/components/task-form-cloud.component.spec.ts
@@ -19,7 +19,7 @@ import { DebugElement, SimpleChange } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { of } from 'rxjs';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { setupTestBed } from '@alfresco/adf-core';
+import { FormModel, FormOutcomeEvent, FormOutcomeModel, setupTestBed } from '@alfresco/adf-core';
 import { ProcessServiceCloudTestingModule } from '../../../testing/process-service-cloud.testing.module';
 import { TaskFormCloudComponent } from './task-form-cloud.component';
 import {
@@ -399,6 +399,14 @@ describe('TaskFormCloudComponent', () => {
             const loadingTemplate = debugElement.query(By.css('mat-progress-spinner'));
 
             expect(loadingTemplate).toBeNull();
+        });
+
+        it('should emit an executeOutcome event when form outcome executed', () => {
+            const executeOutcomeSpy: jasmine.Spy = spyOn(component.executeOutcome, 'emit');
+
+            component.onFormExecuteOutcome(new FormOutcomeEvent(new FormOutcomeModel(new FormModel())));
+
+            expect(executeOutcomeSpy).toHaveBeenCalled();
         });
     });
 

--- a/lib/process-services-cloud/src/lib/task/task-form/components/task-form-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-form/components/task-form-cloud.component.ts
@@ -21,7 +21,7 @@ import {
 } from '@angular/core';
 import { TaskDetailsCloudModel } from '../../start-task/models/task-details-cloud.model';
 import { TaskCloudService } from '../../services/task-cloud.service';
-import { FormRenderingService, FormModel, ContentLinkModel } from '@alfresco/adf-core';
+import { FormRenderingService, FormModel, ContentLinkModel, FormOutcomeEvent } from '@alfresco/adf-core';
 import { AttachFileCloudWidgetComponent } from '../../../form/components/widgets/attach-file/attach-file-cloud-widget.component';
 import { DropdownCloudWidgetComponent } from '../../../form/components/widgets/dropdown/dropdown-cloud.widget';
 import { DateCloudWidgetComponent } from '../../../form/components/widgets/date/date-cloud.widget';
@@ -97,6 +97,12 @@ export class TaskFormCloudComponent implements OnInit, OnChanges {
     /** Emitted when form content is clicked. */
     @Output()
     formContentClicked: EventEmitter<ContentLinkModel> = new EventEmitter();
+
+    /** Emitted when any outcome is executed. Default behaviour can be prevented
+     * via `event.preventDefault()`.
+     */
+    @Output()
+    executeOutcome = new EventEmitter<FormOutcomeEvent>();
 
     taskDetails: TaskDetailsCloudModel;
 
@@ -218,5 +224,9 @@ export class TaskFormCloudComponent implements OnInit, OnChanges {
 
     onFormContentClicked(content: ContentLinkModel) {
         this.formContentClicked.emit(content);
+    }
+
+    onFormExecuteOutcome(outcome: FormOutcomeEvent) {
+        this.executeOutcome.emit(outcome);
     }
 }

--- a/lib/process-services/src/lib/form/form.component.spec.ts
+++ b/lib/process-services/src/lib/form/form.component.spec.ts
@@ -378,7 +378,7 @@ describe('FormComponent', () => {
 
         const result = formComponent.onOutcomeClicked(outcome);
         expect(result).toBeTruthy();
-        expect(saved).toBeTruthy();
+        expect(saved).toBeFalse();
         expect(formComponent.completeTaskForm).toHaveBeenCalledWith(outcomeName);
     });
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Currently, when the user clicks on a custom outcome button (like 'Approves', 'Rejected', etc), we display a generic notification as **"The form saved successfully"**.


**What is the new behaviour?**

After this change, when the user clicks on a custom outcome button (like 'Approves', 'Rejected', etc), we will display a customized message based on the custom outcome button user clicked. for example, clicking on 'Approved' button the notification will be 'Action Approved'.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
