### PR TITLE
[ACS-3546] Add missing labels to folder dialog

### DIFF
--- a/lib/content-services/src/lib/dialogs/folder.dialog.html
+++ b/lib/content-services/src/lib/dialogs/folder.dialog.html
@@ -8,6 +8,7 @@
             <input
                 id="adf-folder-name-input"
                 placeholder="{{ 'CORE.FOLDER_DIALOG.FOLDER_NAME.LABEL' | translate }}"
+                [attr.aria-label]="'CORE.FOLDER_DIALOG.FOLDER_NAME.LABEL' | translate"
                 matInput
                 required
                 [formControlName]="'name'"
@@ -29,6 +30,7 @@
                 id="adf-folder-title-input"
                 matInput
                 placeholder="{{ 'CORE.FOLDER_DIALOG.FOLDER_TITLE.LABEL' | translate }}"
+                [attr.aria-label]="'CORE.FOLDER_DIALOG.FOLDER_TITLE.LABEL' | translate"
                 [formControlName]="'title'"
             />
         </mat-form-field>
@@ -38,6 +40,7 @@
                 id="adf-folder-description-input"
                 matInput
                 placeholder="{{ 'CORE.FOLDER_DIALOG.FOLDER_DESCRIPTION.LABEL' | translate }}"
+                [attr.aria-label]="'CORE.FOLDER_DIALOG.FOLDER_DESCRIPTION.LABEL' | translate"
                 rows="4"
                 [formControlName]="'description'">
             </textarea>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

New folder dialog form fields lacks labels.

**What is the new behaviour?**

Correct labels has been added.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
