### PR TITLE
Change email domain for users created by e2e

### DIFF
--- a/e2e/test.config.js
+++ b/e2e/test.config.js
@@ -74,6 +74,7 @@ if (LOG) {
 module.exports = {
 
     projectName: 'adf',
+    emailDomain: 'example.net',
 
     appConfig: appConfig,
 

--- a/lib/testing/src/lib/protractor/core/models/user.model.ts
+++ b/lib/testing/src/lib/protractor/core/models/user.model.ts
@@ -33,7 +33,7 @@ export class UserModel {
     id: number;
 
     constructor(details: any = {}) {
-        const EMAIL_DOMAIN = browser.params?.testConfig?.emailDomain ? browser.params.testConfig.emailDomain : 'alfresco.com';
+        const EMAIL_DOMAIN = browser.params?.testConfig?.emailDomain ? browser.params.testConfig.emailDomain : 'example.net';
         this.firstName = details.firstName ? details.firstName : this.firstName;
         this.lastName = details.lastName ? details.lastName : this.lastName;
 

--- a/lib/testing/src/lib/protractor/core/models/user.model.ts
+++ b/lib/testing/src/lib/protractor/core/models/user.model.ts
@@ -33,14 +33,14 @@ export class UserModel {
     id: number;
 
     constructor(details: any = {}) {
-        const EMAIL_DOMAIN = browser.params?.testConfig?.projectName ? browser.params.testConfig.projectName : 'alfresco';
+        const EMAIL_DOMAIN = browser.params?.testConfig?.emailDomain ? browser.params.testConfig.emailDomain : 'alfresco';
         this.firstName = details.firstName ? details.firstName : this.firstName;
         this.lastName = details.lastName ? details.lastName : this.lastName;
 
         const USER_IDENTIFY = `${this.firstName}${this.lastName}.${StringUtil.generateRandomLowercaseString(5)}`;
 
         this.password = details.password ? details.password : this.password;
-        this.email = details.email ? details.email : `${USER_IDENTIFY}@${EMAIL_DOMAIN}.com`;
+        this.email = details.email ? details.email : `${USER_IDENTIFY}@${EMAIL_DOMAIN}`;
         this.username = details.username ? details.username : USER_IDENTIFY;
         this.idIdentityService = details.idIdentityService ? details.idIdentityService : this.idIdentityService;
         this.type = details.type ? details.type : this.type;

--- a/lib/testing/src/lib/protractor/core/models/user.model.ts
+++ b/lib/testing/src/lib/protractor/core/models/user.model.ts
@@ -33,7 +33,7 @@ export class UserModel {
     id: number;
 
     constructor(details: any = {}) {
-        const EMAIL_DOMAIN = browser.params?.testConfig?.emailDomain ? browser.params.testConfig.emailDomain : 'alfresco';
+        const EMAIL_DOMAIN = browser.params?.testConfig?.emailDomain ? browser.params.testConfig.emailDomain : 'alfresco.com';
         this.firstName = details.firstName ? details.firstName : this.firstName;
         this.lastName = details.lastName ? details.lastName : this.lastName;
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [X] Other... Please describe:
Env issues

**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**
We have changed the email domain of the users created by the e2e tests from adf.com to example.net because adf.com creates a problem with AWS as it triggers an email bounce through the AWS Simple email service. example.net seems to be a domain that will allows us to overcome this problem.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
