### PR TITLE
Change email domain for users created by e2e to example.com

### DIFF
--- a/e2e/test.config.js
+++ b/e2e/test.config.js
@@ -74,7 +74,7 @@ if (LOG) {
 module.exports = {
 
     projectName: 'adf',
-    emailDomain: 'example.net',
+    emailDomain: 'example.com',
 
     appConfig: appConfig,
 

--- a/lib/testing/src/lib/protractor/core/models/user.model.ts
+++ b/lib/testing/src/lib/protractor/core/models/user.model.ts
@@ -33,7 +33,7 @@ export class UserModel {
     id: number;
 
     constructor(details: any = {}) {
-        const EMAIL_DOMAIN = browser.params?.testConfig?.emailDomain ? browser.params.testConfig.emailDomain : 'example.net';
+        const EMAIL_DOMAIN = browser.params?.testConfig?.emailDomain ? browser.params.testConfig.emailDomain : 'example.com';
         this.firstName = details.firstName ? details.firstName : this.firstName;
         this.lastName = details.lastName ? details.lastName : this.lastName;
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
We have changed the email domain of the users created by the e2e tests from adf.com to example.com because adf.com creates a problem with AWS as it triggers an email bounce through the AWS Simple email service. example.com seems to be a domain that will allows us to overcome this problem.


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
