### PR TITLE
Be able to provide the email domain for test users from an env var

### DIFF
--- a/e2e/test.config.js
+++ b/e2e/test.config.js
@@ -37,6 +37,8 @@ const REDIRECT_URI_LOGOUT = process.env.REDIRECT_URI_LOGOUT || "#/logout";
 const EXTERNAL_ACS_HOST = process.env.EXTERNAL_ACS_HOST;
 const E2E_LOG_LEVEL = process.env.E2E_LOG_LEVEL || 'ERROR';
 
+const E2E_EMAIL_DOMAIN = process.env.E2E_EMAIL_DOMAIN || "default.com";
+
 const appConfig = {
     "log": E2E_LOG_LEVEL,
     "ecmHost": HOST_ECM,
@@ -74,7 +76,7 @@ if (LOG) {
 module.exports = {
 
     projectName: 'adf',
-    emailDomain: 'example.com',
+    emailDomain: E2E_EMAIL_DOMAIN,
 
     appConfig: appConfig,
 

--- a/e2e/test.config.js
+++ b/e2e/test.config.js
@@ -37,7 +37,7 @@ const REDIRECT_URI_LOGOUT = process.env.REDIRECT_URI_LOGOUT || "#/logout";
 const EXTERNAL_ACS_HOST = process.env.EXTERNAL_ACS_HOST;
 const E2E_LOG_LEVEL = process.env.E2E_LOG_LEVEL || 'ERROR';
 
-const E2E_EMAIL_DOMAIN = process.env.E2E_EMAIL_DOMAIN || "default.com";
+const E2E_EMAIL_DOMAIN = process.env.E2E_EMAIL_DOMAIN || "example.com";
 
 const appConfig = {
     "log": E2E_LOG_LEVEL,

--- a/lib/testing/src/lib/protractor/core/models/user.model.ts
+++ b/lib/testing/src/lib/protractor/core/models/user.model.ts
@@ -33,7 +33,7 @@ export class UserModel {
     id: number;
 
     constructor(details: any = {}) {
-        const EMAIL_DOMAIN = browser.params?.testConfig?.emailDomain ? browser.params.testConfig.emailDomain : 'default.com';
+        const EMAIL_DOMAIN = browser.params?.testConfig?.emailDomain ? browser.params.testConfig.emailDomain : 'example.com';
         this.firstName = details.firstName ? details.firstName : this.firstName;
         this.lastName = details.lastName ? details.lastName : this.lastName;
 

--- a/lib/testing/src/lib/protractor/core/models/user.model.ts
+++ b/lib/testing/src/lib/protractor/core/models/user.model.ts
@@ -33,7 +33,7 @@ export class UserModel {
     id: number;
 
     constructor(details: any = {}) {
-        const EMAIL_DOMAIN = browser.params?.testConfig?.emailDomain ? browser.params.testConfig.emailDomain : 'example.com';
+        const EMAIL_DOMAIN = browser.params?.testConfig?.emailDomain ? browser.params.testConfig.emailDomain : 'default.com';
         this.firstName = details.firstName ? details.firstName : this.firstName;
         this.lastName = details.lastName ? details.lastName : this.lastName;
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [X] Other... Please describe:
change configuration for e2e

**What is the current behaviour?** (You can also link to an open issue here)
We need to change the email that is used to generate users for e2e, it should come from an env variable


**What is the new behaviour?**
The email for e2e users is now configurable via an env var


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
