### PR TITLE
[ACS-3701] Add auto focus directive

### DIFF
--- a/docs/content-services/directives/auto-focus.directive.md
+++ b/docs/content-services/directives/auto-focus.directive.md
@@ -1,0 +1,20 @@
+---
+Title: Auto Focus directive
+Added: v5.1.0
+Status: Active
+Last reviewed: 2022-10-25
+---
+
+# [Auto Focus directive](../../../lib/content-services/src/lib/directives/auto-focus.directive.ts "Defined in auto-focus.directive.ts")
+
+Automatically focuses HTML element after content is initialized.
+
+## Basic Usage
+
+```html
+<button adf-auto-focus>...</button>
+```
+
+## Class members
+
+### Properties

--- a/lib/content-services/src/lib/aspect-list/aspect-list-dialog.component.html
+++ b/lib/content-services/src/lib/aspect-list/aspect-list-dialog.component.html
@@ -26,7 +26,7 @@
         </button>
     </div>
     <div>
-        <button mat-button cdkFocusInitial (click)="onCancel()" id="aspect-list-dialog-actions-cancel"
+        <button mat-button adf-auto-focus (click)="onCancel()" id="aspect-list-dialog-actions-cancel"
             data-automation-id="aspect-list-dialog-actions-cancel">{{
             'ADF-ASPECT-LIST.DIALOG.CANCEL' | translate }}
         </button>

--- a/lib/content-services/src/lib/aspect-list/aspect-list.module.ts
+++ b/lib/content-services/src/lib/aspect-list/aspect-list.module.ts
@@ -28,6 +28,7 @@ import { AspectListDialogComponent } from './aspect-list-dialog.component';
 import { MatButtonModule } from '@angular/material/button';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { ContentDirectiveModule } from '../directives/content-directive.module';
 
 @NgModule({
     imports: [
@@ -40,7 +41,8 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
         MatDialogModule,
         MatButtonModule,
         MatTooltipModule,
-        MatProgressSpinnerModule
+        MatProgressSpinnerModule,
+        ContentDirectiveModule
     ],
     exports: [
         AspectListComponent,

--- a/lib/content-services/src/lib/directives/auto-focus.directive.spec.ts
+++ b/lib/content-services/src/lib/directives/auto-focus.directive.spec.ts
@@ -1,0 +1,52 @@
+/*!
+ * @license
+ * Copyright 2019 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Component } from '@angular/core';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { AutoFocusDirective } from './auto-focus.directive';
+import { By } from '@angular/platform-browser';
+import { TranslateModule } from '@ngx-translate/core';
+
+@Component({
+    template: `<div tabindex="0" adf-auto-focus> Test</div>`
+})
+class AutoFoucsTestComponent {}
+
+describe('AutoFocusDirective', () => {
+    let fixture: ComponentFixture<AutoFoucsTestComponent>;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [
+                TranslateModule.forRoot()
+            ],
+            declarations: [
+                AutoFocusDirective,
+                AutoFoucsTestComponent
+            ]
+        });
+        fixture = TestBed.createComponent(AutoFoucsTestComponent);
+    });
+
+    it('should focus the element after content is initialized', fakeAsync(() => {
+        const autoFocusElement = fixture.debugElement.query(By.directive(AutoFocusDirective)).nativeElement;
+        spyOn(autoFocusElement, 'focus');
+        fixture.detectChanges();
+        tick(200);
+        expect(autoFocusElement.focus).toHaveBeenCalled();
+    }));
+});

--- a/lib/content-services/src/lib/directives/auto-focus.directive.ts
+++ b/lib/content-services/src/lib/directives/auto-focus.directive.ts
@@ -15,7 +15,17 @@
  * limitations under the License.
  */
 
-export * from './content-directive.module';
-export * from './node-lock.directive';
-export * from './node-counter.directive';
-export * from './auto-focus.directive';
+import { AfterContentInit, Directive, ElementRef } from "@angular/core";
+
+@Directive({
+  selector: "[adf-auto-focus]"
+})
+export class AutoFocusDirective implements AfterContentInit {
+  public constructor(private el: ElementRef) {}
+
+  public ngAfterContentInit() {
+    setTimeout(() => {
+      this.el.nativeElement.focus();
+    }, 100);
+  }
+}

--- a/lib/content-services/src/lib/directives/auto-focus.directive.ts
+++ b/lib/content-services/src/lib/directives/auto-focus.directive.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { AfterContentInit, Directive, ElementRef } from "@angular/core";
+import { AfterContentInit, Directive, ElementRef } from '@angular/core';
 
 @Directive({
   selector: '[adf-auto-focus]'

--- a/lib/content-services/src/lib/directives/auto-focus.directive.ts
+++ b/lib/content-services/src/lib/directives/auto-focus.directive.ts
@@ -18,7 +18,7 @@
 import { AfterContentInit, Directive, ElementRef } from "@angular/core";
 
 @Directive({
-  selector: "[adf-auto-focus]"
+  selector: '[adf-auto-focus]'
 })
 export class AutoFocusDirective implements AfterContentInit {
   public constructor(private el: ElementRef) {}

--- a/lib/content-services/src/lib/directives/content-directive.module.ts
+++ b/lib/content-services/src/lib/directives/content-directive.module.ts
@@ -22,6 +22,7 @@ import { TranslateModule } from '@ngx-translate/core';
 
 import { NodeLockDirective } from './node-lock.directive';
 import { NodeCounterComponent, NodeCounterDirective } from './node-counter.directive';
+import { AutoFocusDirective } from './auto-focus.directive';
 
 @NgModule({
     imports: [
@@ -32,11 +33,13 @@ import { NodeCounterComponent, NodeCounterDirective } from './node-counter.direc
     declarations: [
         NodeLockDirective,
         NodeCounterDirective,
-        NodeCounterComponent
+        NodeCounterComponent,
+        AutoFocusDirective
     ],
     exports: [
         NodeLockDirective,
-        NodeCounterDirective
+        NodeCounterDirective,
+        AutoFocusDirective
     ]
 })
 export class ContentDirectiveModule {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Edit aspects dialog has incorrect initial focus.

**What is the new behaviour?**

Auto focus directive was created and applied to correct button in the dialog. CdkFocusInitial didn't work for all cases due to the fact that viewer and dialog itself both have focus trap so initial focus on the dialog was not applied.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
