### PR TITLE
[AAE-11221] - gh action to parse github.event_name into correct TRAVIS_EVENT_TYPE

### DIFF
--- a/.github/actions/travis-event-type-load/action.yml
+++ b/.github/actions/travis-event-type-load/action.yml
@@ -1,0 +1,28 @@
+# TRAVIS_EVENT_TYPE= Indicates how the build was triggered. One of push, pull_request, api, cron
+name: "travis-event-type-env-var"
+description: "Mimic loading of a TRAVIS_EVENT_TYPE env var"
+
+inputs:
+  event_name:
+    description: "override github.event_name"
+    required: false
+    default: ${{ github.event_name }}
+runs:
+  using: "composite"
+  steps:
+    - name: Parse env global
+      run: |
+        EVENT_TYPE=""
+        REGEX="(repository|workflow)_dispatch"
+        if [[ "${{ inputs.event_name }}" == "schedule"  ]]; then 
+            EVENT_TYPE="cron"; 
+        elif [[ "${{ inputs.event_name }}" == "pull_request"  ]]; then
+            EVENT_TYPE="pull_request"; 
+        elif [[ "${{ inputs.event_name }}" == "push"  ]]; then
+            EVENT_TYPE="push";
+        elif [[ "${{ inputs.event_name }}" =~ $REGEX ]]; then
+            EVENT_TYPE="api";
+        fi
+        echo "TRAVIS_EVENT_TYPE=${EVENT_TYPE}" >> $GITHUB_ENV
+        echo "exporting TRAVIS_EVENT_TYPE=${EVENT_TYPE}"
+      shell: bash


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

TRAVIS_EVENT_TYPE env var (used by TRAVIS CI) doesn't have a corresponding item in Github CI.

**What is the new behaviour?**

This commit adds a layer of compatibility between Travis CI and GH CI, parsing github.event_name into TRAVIS_EVENT_TYPE.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
