### PR TITLE
Fix git author when updating multiple projects

### DIFF
--- a/scripts/travis/update/update-project.sh
+++ b/scripts/travis/update/update-project.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-git config user.name "alfresco-build"
-git config user.email "alfresco-build@hyland.com"
+git config --global user.name "alfresco-build"
+git config --global user.email "alfresco-build@hyland.com"
 
 BUILD_PIPELINE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 REPO_DIR="$BUILD_PIPELINE_DIR/../.."


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Build related changes


**What is the current behaviour?** (You can also link to an open issue here)

[PR](https://github.com/Alfresco/alfresco-content-app/pull/2745) can't be merged because it's using the default travis user

**What is the new behaviour?**

Make sure that the correct git author is used in every repository the update-project script is handling

**Does this PR introduce a breaking change?** (check one with "x")

> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
