### PR TITLE
[ACA-4622] Remove additional close button, unify buttons style

### DIFF
--- a/lib/content-services/src/lib/i18n/en.json
+++ b/lib/content-services/src/lib/i18n/en.json
@@ -25,8 +25,7 @@
   },
   "ADF-NEW-VERSION-UPLOADER": {
     "DIALOG_LIST": {
-      "TITLE": "Manage Versions",
-      "CLOSE": "Close"
+      "TITLE": "Manage Versions"
     },
     "DIALOG_UPLOAD": {
       "TITLE": "Upload New Version",

--- a/lib/content-services/src/lib/new-version-uploader/new-version-uploader.dialog.html
+++ b/lib/content-services/src/lib/new-version-uploader/new-version-uploader.dialog.html
@@ -26,8 +26,5 @@
         ></adf-version-list>
       </div>
     </div>
-  </section>  
+  </section>
 </ng-container>
-<div mat-dialog-actions>
-    <button mat-button color="primary" [mat-dialog-close]="true">{{ 'ADF-NEW-VERSION-UPLOADER.DIALOG_LIST.CLOSE' | translate }}</button>
-</div>

--- a/lib/content-services/src/lib/upload/components/upload-button.component.html
+++ b/lib/content-services/src/lib/upload/components/upload-button.component.html
@@ -5,7 +5,7 @@
         <!--Single Files Upload-->
         <button *ngIf="!multipleFiles"
             [disabled]="isButtonDisabled()"
-            mat-button
+            mat-raised-button
             (click)="uploadSingleFile.click()">
             <mat-icon>file_upload</mat-icon>
             <span id="upload-single-file-label"
@@ -27,7 +27,7 @@
         <!--Multiple Files Upload-->
         <button *ngIf="multipleFiles"
             [disabled]="isButtonDisabled()"
-            mat-button
+            mat-raised-button
             (click)="uploadMultipleFiles.click()">
             <mat-icon>file_upload</mat-icon>
 
@@ -53,7 +53,7 @@
     <div *ngIf="uploadFolders">
         <button
             [disabled]="isButtonDisabled()"
-            mat-button
+            mat-raised-button
             (click)="uploadFolders.click()">
             <mat-icon>file_upload</mat-icon>
             <span id="uploadFolder-label"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

New version modal has additional close button https://alfresco.atlassian.net/browse/ACA-4622

**What is the new behaviour?**

Additional button has been removed, buttons on modal now has unified style.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
