### PR TITLE
[AAE-11275] - e2e protractor - remove sleep step

### DIFF
--- a/lib/testing/src/lib/protractor/process-services/pages/start-process.page.ts
+++ b/lib/testing/src/lib/protractor/process-services/pages/start-process.page.ts
@@ -70,13 +70,18 @@ export class StartProcessPage {
         try {
             await this.clickProcessDropdownArrow();
             await this.selectProcessOption(name);
-            await browser.sleep(500);
         } catch (error) {
             if (retry < 3) {
                 retry++;
                 await this.selectFromProcessDropdown(name, retry);
             }
         }
+        try {
+            await BrowserVisibility.waitUntilElementIsVisible($('.mat-card-content'), 2000);
+        } catch (error) {
+            Logger.log(`No start form on process`);
+        }
+
     }
 
     async selectFromApplicationDropdown(name): Promise<void> {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
A hardcoded sleep was introduced to overcome a waiting issue.


**What is the new behaviour?**
The sleep was replaces with Expected Condition to wait for a start from. I couldn't find any other way to wait. There was no additional request that I could wait for and the page in general seemed loaded. It looks like that form is the last thing that loads after picking dropdown option. If it is not there the catch will happen. The solution is not ideal, but works and is slightly better than sleep.

If the solution is not good enough, we can stay with the sleep.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
