### PR TITLE
[AAE-10767] Make CardView Reusable

### DIFF
--- a/docs/content-services/interfaces/base-card-view-content-update.interface.md
+++ b/docs/content-services/interfaces/base-card-view-content-update.interface.md
@@ -1,0 +1,51 @@
+---
+Title: Base Card View Content Update interface
+Added: v6.0.0
+Status: Active
+Last reviewed: 2022-11-25
+---
+
+# [Base Card View Content Update interface](../../../lib/content-services/src/lib/interfaces/base-card-view-content-update.interface.ts "Defined in base-card-view-content-update.interface.ts")
+
+Specifies required properties and methods for [Card View Content Update service](../../../lib/content-services/src/lib/services/card-view-content-update.service.ts).
+Extends from [`BaseCardViewUpdate`](../../../lib/core/src/lib/card-view/interfaces/base-card-view-update.interface.ts).
+
+## Basic usage
+
+```ts
+export interface BaseCardViewContentUpdate {
+    itemUpdated$: Subject<UpdateNotification>;
+    updatedAspect$: Subject<MinimalNode>;
+
+    update(property: CardViewBaseItemModel, newValue: any);
+    updateElement(notification: CardViewBaseItemModel);
+    updateNodeAspect(node: MinimalNode);
+}
+```
+
+### Properties
+
+| Name | Type | Default value | Description |
+| ---- | ---- | ------------- | ----------- |
+| itemUpdated$ | [`Subject`](http://reactivex.io/documentation/subject.html)`<`[`UpdateNotification`](../../../lib/core/src/lib/card-view/interfaces/update-notification.interface.ts)`>` |  | The current updated item. |
+| updatedAspect$ | [`Subject`](http://reactivex.io/documentation/subject.html)`<`[`MinimalNode`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/NodeMinimalEntry.md)`>`(@alfresco/js-api) |  | [Subject](http://reactivex.io/documentation/subject.html) holding the current node |
+
+### Methods
+
+-   **update**(property: [`CardViewBaseItemModel`](../../../lib/core/src/lib/card-view/models/card-view-baseitem.model.ts), newValue: `any`)<br/>
+    Update itemUpdated$ property.
+
+    -   property:\_ [`CardViewBaseItemModel`](../../../lib/core/src/lib/card-view/models/card-view-baseitem.model.ts)  - The property.
+    -   newValue:\_ `any`  - new value.
+
+-   **updateElement**(notification: [`CardViewBaseItemModel`](../../../lib/core/src/lib/card-view/models/card-view-baseitem.model.ts))<br/>
+    Update updateItem$ observable.
+    -   notification:\_ [`CardViewBaseItemModel`](../../../lib/core/src/lib/card-view/models/card-view-baseitem.model.ts)  - The notification.
+
+-   **updateNodeAspect**(node: [`MinimalNode`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/NodeMinimalEntry.md))<br/>
+    Update node aspect observable.
+    -   node:\_ [`MinimalNode`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/NodeMinimalEntry.md)  - The node.
+
+## See also
+
+-   [CardViewContentUpdate service](../services/card-view-content-update.service.md)

--- a/docs/content-services/services/card-view-content-update.service.md
+++ b/docs/content-services/services/card-view-content-update.service.md
@@ -1,0 +1,35 @@
+---
+Title: Card View Content Update Service
+Added: v6.0.0
+Status: Active
+Last reviewed: 2022-11-25
+---
+
+# [Card View Content Update Service](../../../lib/content-services/src/lib/services/card-view-content-update.service.ts "Defined in card-view-content-update.service.ts")
+
+Manages Card View properties in the content services environment. 
+Implements [`BaseCardViewContentUpdate`](../../../lib/content-services/src/lib/interfaces/base-card-view-content-update.interface.ts).
+
+## Class members
+
+### Methods
+
+-   **update**(property: [`CardViewBaseItemModel`](../../../lib/core/src/lib/card-view/models/card-view-baseitem.model.ts), newValue: `any`)<br/>
+
+    -   _property:_ [`CardViewBaseItemModel`](../../../lib/core/src/lib/card-view/models/card-view-baseitem.model.ts)
+    -   _newValue:_ `any`
+
+-   **updateElement**(notification: [`CardViewBaseItemModel`](../../../lib/core/src/lib/card-view/models/card-view-baseitem.model.ts))<br/>
+    Updates the cardview items property
+    -   _notification:_ [`CardViewBaseItemModel`](../../../lib/core/src/lib/card-view/models/card-view-baseitem.model.ts)
+
+-   **updateNodeAspect**(node: [`MinimalNode`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/NodeMinimalEntry.md))<br/>
+    Update node aspect observable.
+    -   _node:_ [`MinimalNode`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/NodeMinimalEntry.md)
+
+## Properties
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| itemUpdated$ | [`Subject`](http://reactivex.io/documentation/subject.html)`<`[`UpdateNotification`](../../../lib/core/src/lib/card-view/interfaces/update-notification.interface.ts)`>` | The current updated item. |
+| updateAspect$ | [`Subject`](http://reactivex.io/documentation/subject.html)`<`[`MinimalNode`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/NodeMinimalEntry.md)`>`(@alfresco/js-api) | The current Node. |

--- a/docs/core/interfaces/base-card-view-update.interface.md
+++ b/docs/core/interfaces/base-card-view-update.interface.md
@@ -1,0 +1,53 @@
+---
+Title: Base Card View Update Interface
+Added: v6.0.0
+Status: Active
+Last reviewed: 2022-11-25
+---
+
+# [Base Card View Update interface](../../../lib/core/src/lib/card-view/interfaces/base-card-view-update.interface.ts "Defined in base-card-view-update.interface.ts")
+
+Specifies required properties and methods for [Card View Update service](../../../lib/core/src/lib/card-view/services/card-view-update.service.ts).
+
+## Basic usage
+
+```ts
+export interface BaseCardViewUpdate {
+    itemUpdated$: Subject<UpdateNotification>;
+    itemClicked$: Subject<ClickNotification>;
+    updateItem$: Subject<CardViewBaseItemModel>;
+
+    update(property: CardViewBaseItemModel, newValue: any);
+    clicked(property: CardViewBaseItemModel);
+    updateElement(notification: CardViewBaseItemModel);
+}
+```
+
+## Properties
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| itemUpdated$ | [`Subject`](http://reactivex.io/documentation/subject.html)`<`[`UpdateNotification`](../../../lib/core/src/lib/card-view/interfaces/update-notification.interface.ts)`>` | The current updated item. |
+| itemClicked$ | [`Subject`](http://reactivex.io/documentation/subject.html)`<`[`ClickNotification`](../../../lib/core/src/lib/card-view/interfaces/click-notification.interface.ts)`>` | The current clicked item. |
+| updateItem$ | [`Subject`](http://reactivex.io/documentation/subject.html)`<`[`CardViewBaseItemModel`](../../../lib/core/src/lib/card-view/models/card-view-baseitem.model.ts)`>` | The current model for the update item. |
+
+### Methods
+
+-   **update**(property: [`CardViewBaseItemModel`](../../../lib/core/src/lib/card-view/models/card-view-baseitem.model.ts), newValue: `any`)<br/>
+    Update itemUpdated$ property.
+
+    -   property:\_ [`CardViewBaseItemModel`](../../../lib/core/src/lib/card-view/models/card-view-baseitem.model.ts)  - The property.
+    -   newValue:\_ `any`  - new value.
+
+-   **clicked**(property: [`CardViewBaseItemModel`](../../../lib/core/src/lib/card-view/models/card-view-baseitem.model.ts))<br/>
+    Update itemClicked$ property.
+
+    -   property:\_ [`CardViewBaseItemModel`](../../../lib/core/src/lib/card-view/models/card-view-baseitem.model.ts)  - The property.
+
+-   **updateElement**(notification: [`CardViewBaseItemModel`](../../../lib/core/src/lib/card-view/models/card-view-baseitem.model.ts))<br/>
+    Update updateItem$ observable.
+    -   notification:\_ [`CardViewBaseItemModel`](../../../lib/core/src/lib/card-view/models/card-view-baseitem.model.ts)  - The notification.
+
+## See also
+
+-   [CardViewUpdate service](../services/card-view-update.service.md)

--- a/docs/core/interfaces/click-notification.interface.md
+++ b/docs/core/interfaces/click-notification.interface.md
@@ -1,0 +1,26 @@
+---
+Title: Click Notification Interface
+Added: v6.0.0
+Status: Active
+Last reviewed: 2022-11-25
+---
+
+# [Click Notification Interface](../../../lib/core/src/lib/card-view/interfaces/click-notification.interface.ts "Defined in click-notification.interface.ts")
+
+## Basic usage
+
+```ts
+export interface ClickNotification {
+    target: any;
+}
+```
+
+## Properties
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| target | `any` | The target for the click notification. |
+
+## See also
+
+-   [BaseCardViewUpdate interface](../interfaces/base-card-view-update.interface.md)

--- a/docs/core/interfaces/update-notification.interface.md
+++ b/docs/core/interfaces/update-notification.interface.md
@@ -1,0 +1,28 @@
+---
+Title: Update Notification Interface
+Added: v6.0.0
+Status: Active
+Last reviewed: 2022-11-25
+---
+
+# [Update Notification Interface](../../../lib/core/src/lib/card-view/interfaces/update-notification.interface.ts "Defined in update-notification.interface.ts")
+
+## Basic usage
+
+```ts
+export interface UpdateNotification {
+     target: CardViewBaseItemModel;
+     changed: any;
+ }
+```
+
+## Properties
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| target | [`CardViewBaseItemModel`](../../../lib/core/src/lib/card-view/models/card-view-baseitem.model.ts) | The target for the update notification. |
+| changed | `any` | The changed value on the update notification. |
+
+## See also
+
+-   [BaseCardViewUpdate interface](../interfaces/base-card-view-update.interface.md)

--- a/docs/core/services/card-view-update.service.md
+++ b/docs/core/services/card-view-update.service.md
@@ -2,12 +2,13 @@
 Title: Card View Update service
 Added: v2.0.0
 Status: Active
-Last reviewed: 2018-11-14
+Last reviewed: 2022-11-25
 ---
 
-# [Card View Update service](lib/core/src/lib/card-view/services/card-view-update.service.ts "Defined in card-view-update.service.ts")
+# [Card View Update service](../../../lib/core/src/lib/card-view/services/card-view-update.service.ts "Defined in card-view-update.service.ts")
 
 Reports edits and clicks within fields of a [Card View component](../components/card-view.component.md).
+Implements [`BaseCardViewUpdate`](../../../lib/core/src/lib/card-view/interfaces/base-card-view-update.interface.ts).
 
 ## Details
 
@@ -55,7 +56,7 @@ constructor(private cardViewUpdateService: CardViewUpdateService) {
 }
 ```
 
-The constructor here also sets the [`CardViewTextItemModel`](lib/core/src/lib/card-view/models/card-view-textitem.model.ts) instances that define the layout of the
+The constructor here also sets the [`CardViewTextItemModel`](../../../lib/core/src/lib/card-view/models/card-view-textitem.model.ts) instances that define the layout of the
 card view (see the [Card View component](../components/card-view.component.md) for further information
 about this). The model objects and the `key` property are used to identify which item has been clicked
 or updated when an event occurs. 
@@ -77,7 +78,7 @@ called after updates and clicks, respectively.
 
 ### Responding to updates
 
-The update function is passed a parameter of type [`UpdateNotification`](lib/core/src/lib/card-view/services/card-view-update.service.ts):
+The update function is passed a parameter of type [`UpdateNotification`](../../../lib/core/src/lib/card-view/interfaces/update-notification.interface.ts):
 
 ```ts
 export interface UpdateNotification {
@@ -86,8 +87,8 @@ export interface UpdateNotification {
 }
 ```
 
-Here, `target` contains the [`CardViewTextItemModel`](lib/core/src/lib/card-view/models/card-view-textitem.model.ts) that was used to initialize
-the field in question (in practice, this might be a [`CardViewDateItemModel`](lib/core/src/lib/card-view/models/card-view-dateitem.model.ts) or [`CardViewMapItemModel`](lib/core/src/lib/card-view/models/card-view-mapitem.model.ts) if
+Here, `target` contains the [`CardViewTextItemModel`](../../../lib/core/src/lib/card-view/models/card-view-textitem.model.ts) that was used to initialize
+the field in question (in practice, this might be a [`CardViewDateItemModel`](../../../lib/core/src/lib/card-view/models/card-view-dateitem.model.ts) or [`CardViewMapItemModel`](../../../lib/core/src/lib/card-view/models/card-view-mapitem.model.ts) if
 the card layout includes these objects). The `changed` property contains an object with a single property:
 
 ```ts
@@ -115,7 +116,7 @@ on the [Card View component](../components/card-view.component.md) itself.
 
 ### Responding to clicks
 
-The click function is passed a [`ClickNotification`](lib/core/src/lib/card-view/services/card-view-update.service.ts) object, which is similar to [`UpdateNotification`](lib/core/src/lib/card-view/services/card-view-update.service.ts) described above,
+The click function is passed a [`ClickNotification`](../../../lib/core/src/lib/card-view/interfaces/click-notification.interface.ts) object, which is similar to [`UpdateNotification`](../../../lib/core/src/lib/card-view/interfaces/update-notification.interface.ts) described above,
 but without the `changed` property. Use the `target` property to identify the item that was clicked:
 
 ```ts
@@ -128,7 +129,7 @@ Note that this function will only be called if the `clickable` property of the m
 
 ## Update cardview update item
 
-[`updateElement`](lib/core/src/lib/card-view/services/card-view-update.service.ts)  function helps to update the card view item. It takes the [`CardViewBaseItemModel`](lib/core/src/lib/card-view/models/card-view-baseitem.model.ts)  type object as parameter.
+[`updateElement`](../../../lib/core/src/lib/card-view/services/card-view-update.service.ts)  function helps to update the card view item. It takes the [`CardViewBaseItemModel`](../../../lib/core/src/lib/card-view/models/card-view-baseitem.model.ts)  type object as parameter.
 
 Example
 
@@ -139,3 +140,5 @@ Example
 ## See also
 
 -   [Card view component](../components/card-view.component.md)
+-   [UpdateNotification interface](../interfaces/update-notification.interface.md)
+-   [ClickNotification interface](../interfaces/click-notification.interface.md)

--- a/docs/upgrade-guide/upgrade50-60.md
+++ b/docs/upgrade-guide/upgrade50-60.md
@@ -81,6 +81,17 @@ How to fix it:
 
 Following classes have been relocated:
 - `VersionCompatibilityService` and `VersionCompatibilityDirective` relocated from `@alfresco/adf-core` to `@alfresco/adf-content-services`
+The following directives have been moved from the Core library to the Content Services
+library. You should modify your code to import these classes from
+`@alfresco/adf-content-services`.
+
+-   [`CheckAllowableOperationDirective`](lib/content-services/src/lib/directives/check-allowable-operation.directive.ts)
+-   [`LibraryFavoriteDirective`](lib/content-services/src/lib/directives/library-favorite.directive.ts)
+-   [`LibraryMembershipDirective`](lib/content-services/src/lib/directives/library-membership.directive.ts)
+-   [`NodeDeleteDirective`](lib/content-services/src/lib/directives/node-delete.directive.ts)
+-   [`NodeFavoriteDirective`](lib/content-services/src/lib/directives/node-favorite.directive.ts)
+-   [`NodeRestoreDirective`](lib/content-services/src/lib/directives/node-restore.directive.ts)
+
 
 ## Renamed items
 

--- a/lib/content-services/src/lib/aspect-list/services/node-aspect.service.spec.ts
+++ b/lib/content-services/src/lib/aspect-list/services/node-aspect.service.spec.ts
@@ -18,11 +18,12 @@
 import { MinimalNode } from '@alfresco/js-api';
 import { TestBed } from '@angular/core/testing';
 import { TranslateModule } from '@ngx-translate/core';
-import { AlfrescoApiService, CardViewUpdateService, NodesApiService, setupTestBed } from '@alfresco/adf-core';
+import { AlfrescoApiService, NodesApiService, setupTestBed } from '@alfresco/adf-core';
 import { EMPTY, of } from 'rxjs';
 import { ContentTestingModule } from '../../testing/content.testing.module';
 import { NodeAspectService } from './node-aspect.service';
 import { DialogAspectListService } from './dialog-aspect-list.service';
+import { CardViewContentUpdateService } from '../../services/card-view-content-update.service';
 
 describe('NodeAspectService', () => {
 
@@ -30,7 +31,7 @@ describe('NodeAspectService', () => {
     let nodeAspectService: NodeAspectService;
     let nodeApiService: NodesApiService;
     let alfrescoApiService: AlfrescoApiService;
-    let cardViewUpdateService: CardViewUpdateService;
+    let cardViewContentUpdateService: CardViewContentUpdateService;
 
     setupTestBed({
         imports: [
@@ -44,7 +45,7 @@ describe('NodeAspectService', () => {
         nodeAspectService = TestBed.inject(NodeAspectService);
         nodeApiService = TestBed.inject(NodesApiService);
         alfrescoApiService = TestBed.inject(AlfrescoApiService);
-        cardViewUpdateService = TestBed.inject(CardViewUpdateService);
+        cardViewContentUpdateService = TestBed.inject(CardViewContentUpdateService);
     });
 
     it('should call openAspectListDialog with correct parameters when selectorAutoFocusedOnClose is passed', () => {
@@ -89,7 +90,7 @@ describe('NodeAspectService', () => {
     });
 
     it('should send and update node aspect once the node has been updated', async () => {
-        await cardViewUpdateService.updatedAspect$.subscribe((nodeUpdated) => {
+        await cardViewContentUpdateService.updatedAspect$.subscribe((nodeUpdated) => {
             expect(nodeUpdated.id).toBe('fake-node-id');
             expect(nodeUpdated.aspectNames).toEqual(['a', 'b', 'c']);
         });

--- a/lib/content-services/src/lib/aspect-list/services/node-aspect.service.ts
+++ b/lib/content-services/src/lib/aspect-list/services/node-aspect.service.ts
@@ -16,8 +16,9 @@
  */
 
 import { Injectable } from '@angular/core';
-import { AlfrescoApiService, CardViewUpdateService, NodesApiService } from '@alfresco/adf-core';
+import { AlfrescoApiService, NodesApiService } from '@alfresco/adf-core';
 import { DialogAspectListService } from './dialog-aspect-list.service';
+import { CardViewContentUpdateService } from '../../services/card-view-content-update.service';
 
 @Injectable({
     providedIn: 'root'
@@ -27,14 +28,14 @@ export class NodeAspectService {
     constructor(private alfrescoApiService: AlfrescoApiService,
                 private nodesApiService: NodesApiService,
                 private dialogAspectListService: DialogAspectListService,
-                private cardViewUpdateService: CardViewUpdateService) {
+                private cardViewContentUpdateService: CardViewContentUpdateService) {
     }
 
     updateNodeAspects(nodeId: string, selectorAutoFocusedOnClose?: string) {
         this.dialogAspectListService.openAspectListDialog(nodeId, selectorAutoFocusedOnClose).subscribe((aspectList) => {
             this.nodesApiService.updateNode(nodeId, { aspectNames: [...aspectList] }).subscribe((updatedNode) => {
                 this.alfrescoApiService.nodeUpdated.next(updatedNode);
-                this.cardViewUpdateService.updateNodeAspect(updatedNode);
+                this.cardViewContentUpdateService.updateNodeAspect(updatedNode);
             });
         });
     }

--- a/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.spec.ts
+++ b/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.spec.ts
@@ -22,19 +22,20 @@ import { MinimalNode, Node } from '@alfresco/js-api';
 import { ContentMetadataComponent } from './content-metadata.component';
 import { ContentMetadataService } from '../../services/content-metadata.service';
 import {
-    CardViewBaseItemModel, CardViewComponent, CardViewUpdateService, NodesApiService,
+    CardViewBaseItemModel, CardViewComponent, NodesApiService,
     LogService, setupTestBed
 } from '@alfresco/adf-core';
 import { throwError, of } from 'rxjs';
 import { ContentTestingModule } from '../../../testing/content.testing.module';
 import { mockGroupProperties } from './mock-data';
 import { TranslateModule } from '@ngx-translate/core';
+import { CardViewContentUpdateService } from '../../../services/card-view-content-update.service';
 
 describe('ContentMetadataComponent', () => {
     let component: ContentMetadataComponent;
     let fixture: ComponentFixture<ContentMetadataComponent>;
     let contentMetadataService: ContentMetadataService;
-    let updateService: CardViewUpdateService;
+    let updateService: CardViewContentUpdateService;
     let nodesApiService: NodesApiService;
     let node: Node;
     let folderNode: Node;
@@ -52,7 +53,7 @@ describe('ContentMetadataComponent', () => {
         fixture = TestBed.createComponent(ContentMetadataComponent);
         component = fixture.componentInstance;
         contentMetadataService = TestBed.inject(ContentMetadataService);
-        updateService = TestBed.inject(CardViewUpdateService);
+        updateService = TestBed.inject(CardViewContentUpdateService);
         nodesApiService = TestBed.inject(NodesApiService);
 
         node = {

--- a/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.ts
+++ b/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.ts
@@ -22,7 +22,6 @@ import {
     CardViewItem,
     NodesApiService,
     LogService,
-    CardViewUpdateService,
     AlfrescoApiService,
     TranslationService,
     AppConfigService,
@@ -32,6 +31,7 @@ import {
 import { ContentMetadataService } from '../../services/content-metadata.service';
 import { CardViewGroup, PresetConfig } from '../../interfaces/content-metadata.interfaces';
 import { takeUntil, debounceTime, catchError, map } from 'rxjs/operators';
+import { CardViewContentUpdateService } from '../../../services/card-view-content-update.service';
 
 const DEFAULT_SEPARATOR = ', ';
 
@@ -97,7 +97,7 @@ export class ContentMetadataComponent implements OnChanges, OnInit, OnDestroy {
 
     constructor(
         private contentMetadataService: ContentMetadataService,
-        private cardViewUpdateService: CardViewUpdateService,
+        private cardViewContentUpdateService: CardViewContentUpdateService,
         private nodesApiService: NodesApiService,
         private logService: LogService,
         private alfrescoApiService: AlfrescoApiService,
@@ -110,7 +110,7 @@ export class ContentMetadataComponent implements OnChanges, OnInit, OnDestroy {
     }
 
     ngOnInit() {
-        this.cardViewUpdateService.itemUpdated$
+        this.cardViewContentUpdateService.itemUpdated$
             .pipe(
                 debounceTime(500),
                 takeUntil(this.onDestroy$))
@@ -122,7 +122,7 @@ export class ContentMetadataComponent implements OnChanges, OnInit, OnDestroy {
                 }
             );
 
-        this.cardViewUpdateService.updatedAspect$.pipe(
+        this.cardViewContentUpdateService.updatedAspect$.pipe(
             debounceTime(500),
             takeUntil(this.onDestroy$))
             .subscribe((node) => this.loadProperties(node));
@@ -201,14 +201,14 @@ export class ContentMetadataComponent implements OnChanges, OnInit, OnDestroy {
     private updateNode() {
         this.nodesApiService.updateNode(this.node.id, this.changedProperties).pipe(
             catchError((err) => {
-                this.cardViewUpdateService.updateElement(this.targetProperty);
+                this.cardViewContentUpdateService.updateElement(this.targetProperty);
                 this.handleUpdateError(err);
                 return of(null);
             }))
             .subscribe((updatedNode) => {
                 if (updatedNode) {
                     if (this.hasContentTypeChanged(this.changedProperties)) {
-                        this.cardViewUpdateService.updateNodeAspect(this.node);
+                        this.cardViewContentUpdateService.updateNodeAspect(this.node);
                     }
                     this.revertChanges();
                     Object.assign(this.node, updatedNode);

--- a/lib/content-services/src/lib/interfaces/base-card-view-content-update.interface.ts
+++ b/lib/content-services/src/lib/interfaces/base-card-view-content-update.interface.ts
@@ -15,10 +15,15 @@
  * limitations under the License.
  */
 
-export * from './node-allowable-operation-subject.interface';
-export * from './library-entity.interface';
-export * from './restore-message-model.interface';
-export * from './library-membership-error-event.interface';
-export * from './library-membership-toggle-event.interface';
-export * from './base-card-view-content-update.interface';
+import { CardViewBaseItemModel, UpdateNotification } from '@alfresco/adf-core';
+import { MinimalNode } from '@alfresco/js-api';
+import { Subject } from 'rxjs';
 
+export interface BaseCardViewContentUpdate {
+    itemUpdated$: Subject<UpdateNotification>;
+    updatedAspect$: Subject<MinimalNode>;
+
+    update(property: CardViewBaseItemModel, newValue: any);
+    updateElement(notification: CardViewBaseItemModel);
+    updateNodeAspect(node: MinimalNode);
+}

--- a/lib/content-services/src/lib/services/card-view-content-update.service.spec.ts
+++ b/lib/content-services/src/lib/services/card-view-content-update.service.spec.ts
@@ -1,0 +1,38 @@
+/*!
+ * @license
+ * Copyright 2019 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MinimalNode } from '@alfresco/js-api';
+import { fakeAsync, TestBed } from '@angular/core/testing';
+import { CardViewContentUpdateService } from './card-view-content-update.service';
+
+describe('CardViewContentUpdateService', () => {
+
+  let cardViewContentUpdateService: CardViewContentUpdateService;
+
+        beforeEach(() => {
+          cardViewContentUpdateService = TestBed.inject(CardViewContentUpdateService);
+        });
+
+        it('should send updated node when aspect changed', fakeAsync(() => {
+            const fakeNode: MinimalNode = { id: 'Bigfoot'} as MinimalNode;
+            cardViewContentUpdateService.updatedAspect$.subscribe((node: MinimalNode) => {
+                expect(node.id).toBe('Bigfoot');
+            });
+
+            cardViewContentUpdateService.updateNodeAspect(fakeNode);
+        }));
+});

--- a/lib/content-services/src/lib/services/card-view-content-update.service.ts
+++ b/lib/content-services/src/lib/services/card-view-content-update.service.ts
@@ -1,0 +1,58 @@
+/*!
+ * @license
+ * Copyright 2019 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { UpdateNotification, CardViewBaseItemModel, CardViewUpdateService } from '@alfresco/adf-core';
+import { MinimalNode } from '@alfresco/js-api';
+import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs';
+import { BaseCardViewContentUpdate } from '../interfaces/base-card-view-content-update.interface';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CardViewContentUpdateService implements BaseCardViewContentUpdate {
+
+  itemUpdated$ = new Subject<UpdateNotification>();
+
+  updatedAspect$ = new Subject<MinimalNode>();
+
+  constructor(private cardViewUpdateService: CardViewUpdateService) {
+    this.linkVariables();
+  }
+
+  update(property: CardViewBaseItemModel, newValue: any) {
+    this.cardViewUpdateService.update(property, newValue);
+  }
+
+  updateElement(notification: CardViewBaseItemModel) {
+    this.cardViewUpdateService.updateElement(notification);
+  }
+
+  updateNodeAspect(node: MinimalNode) {
+    this.updatedAspect$.next(node);
+  }
+
+  private linkVariables() {
+    this.linkItemUpdated();
+  }
+
+  private linkItemUpdated() {
+    this.cardViewUpdateService.itemUpdated$.subscribe(res => {
+      this.itemUpdated$.next(res);
+    });
+  }
+}

--- a/lib/content-services/src/lib/services/index.ts
+++ b/lib/content-services/src/lib/services/index.ts
@@ -15,10 +15,4 @@
  * limitations under the License.
  */
 
-export * from './node-allowable-operation-subject.interface';
-export * from './library-entity.interface';
-export * from './restore-message-model.interface';
-export * from './library-membership-error-event.interface';
-export * from './library-membership-toggle-event.interface';
-export * from './base-card-view-content-update.interface';
-
+export * from './public-api';

--- a/lib/content-services/src/lib/services/public-api.ts
+++ b/lib/content-services/src/lib/services/public-api.ts
@@ -15,10 +15,4 @@
  * limitations under the License.
  */
 
-export * from './node-allowable-operation-subject.interface';
-export * from './library-entity.interface';
-export * from './restore-message-model.interface';
-export * from './library-membership-error-event.interface';
-export * from './library-membership-toggle-event.interface';
-export * from './base-card-view-content-update.interface';
-
+export * from './card-view-content-update.service';

--- a/lib/content-services/src/public-api.ts
+++ b/lib/content-services/src/public-api.ts
@@ -38,5 +38,6 @@ export * from './lib/content-type/index';
 export * from './lib/new-version-uploader';
 export * from './lib/interfaces/index';
 export * from './lib/version-compatibility/index';
+export * from './lib/services/index';
 
 export * from './lib/content.module';

--- a/lib/core/src/lib/breaking-changes.md
+++ b/lib/core/src/lib/breaking-changes.md
@@ -1,9 +1,0 @@
-6.0.0-beta.1
-- CheckAllowableOperationDirective: Moved from ADF Core to ADF content services
-- LibraryFavoriteDirective: Moved from ADF Core to ADF content services
-- LibraryMembershipDirective: Moved from ADF Core to ADF content services
-- NodeDeleteDirective: Moved from ADF Core to ADF content services
-- NodeFavoriteDirective: Moved from ADF Core to ADF content services
-- NodeRestoreDirective: Moved from ADF Core to ADF content services
-
-

--- a/lib/core/src/lib/card-view/components/card-view-item-dispatcher/card-view-item-dispatcher.component.ts
+++ b/lib/core/src/lib/card-view/components/card-view-item-dispatcher/card-view-item-dispatcher.component.ts
@@ -17,7 +17,6 @@
 
 import {
     Component,
-    ComponentFactoryResolver,
     Input,
     OnChanges,
     SimpleChange,
@@ -67,8 +66,7 @@ export class CardViewItemDispatcherComponent implements OnChanges {
     public ngOnInit;
     public ngDoCheck;
 
-    constructor(private cardItemTypeService: CardItemTypeService,
-                private resolver: ComponentFactoryResolver) {
+    constructor(private cardItemTypeService: CardItemTypeService) {
         const dynamicLifeCycleMethods = [
             'ngOnInit',
             'ngDoCheck',
@@ -102,8 +100,7 @@ export class CardViewItemDispatcherComponent implements OnChanges {
     private loadComponent() {
         const factoryClass = this.cardItemTypeService.resolveComponentType(this.property);
 
-        const factory = this.resolver.resolveComponentFactory(factoryClass);
-        this.componentReference = this.content.viewContainerRef.createComponent(factory);
+        this.componentReference = this.content.viewContainerRef.createComponent(factoryClass);
 
         this.componentReference.instance.editable = this.editable;
         this.componentReference.instance.property = this.property;

--- a/lib/core/src/lib/card-view/interfaces/base-card-view-update.interface.ts
+++ b/lib/core/src/lib/card-view/interfaces/base-card-view-update.interface.ts
@@ -15,10 +15,17 @@
  * limitations under the License.
  */
 
-export * from './node-allowable-operation-subject.interface';
-export * from './library-entity.interface';
-export * from './restore-message-model.interface';
-export * from './library-membership-error-event.interface';
-export * from './library-membership-toggle-event.interface';
-export * from './base-card-view-content-update.interface';
+import { Subject } from 'rxjs';
+import { CardViewBaseItemModel } from '../models/card-view-baseitem.model';
+import { UpdateNotification } from './update-notification.interface';
+import { ClickNotification } from './click-notification.interface';
 
+export interface BaseCardViewUpdate {
+    itemUpdated$: Subject<UpdateNotification>;
+    itemClicked$: Subject<ClickNotification>;
+    updateItem$: Subject<CardViewBaseItemModel>;
+
+    update(property: CardViewBaseItemModel, newValue: any);
+    clicked(property: CardViewBaseItemModel);
+    updateElement(notification: CardViewBaseItemModel);
+}

--- a/lib/core/src/lib/card-view/interfaces/card-view-item-properties.interface.ts
+++ b/lib/core/src/lib/card-view/interfaces/card-view-item-properties.interface.ts
@@ -16,7 +16,6 @@
  */
 
 import { CardViewItemValidator } from './card-view-item-validator.interface';
-import { Constraint } from '@alfresco/js-api';
 
 export interface CardViewItemProperties {
     label: string;
@@ -29,6 +28,12 @@ export interface CardViewItemProperties {
     hint?: string;
     validators?: CardViewItemValidator[];
     data?: any;
-    constraints?: Constraint[];
+    constraints?: Array<{
+        id: string;
+        type?: string;
+        title?: string;
+        description?: string;
+        parameters?: { [key: string]: any };
+    }>;
     multivalued?: boolean;
 }

--- a/lib/core/src/lib/card-view/interfaces/card-view.interfaces.ts
+++ b/lib/core/src/lib/card-view/interfaces/card-view.interfaces.ts
@@ -24,3 +24,6 @@ export * from './card-view-boolitem-properties.interface';
 export * from './card-view-textitem-pipe-property.interface';
 export * from './card-view-keyvaluepairsitem-properties.interface';
 export * from './card-view-selectitem-properties.interface';
+export * from './base-card-view-update.interface';
+export * from './click-notification.interface';
+export * from './update-notification.interface';

--- a/lib/core/src/lib/card-view/interfaces/click-notification.interface.ts
+++ b/lib/core/src/lib/card-view/interfaces/click-notification.interface.ts
@@ -15,10 +15,6 @@
  * limitations under the License.
  */
 
-export * from './node-allowable-operation-subject.interface';
-export * from './library-entity.interface';
-export * from './restore-message-model.interface';
-export * from './library-membership-error-event.interface';
-export * from './library-membership-toggle-event.interface';
-export * from './base-card-view-content-update.interface';
-
+export interface ClickNotification {
+    target: any;
+}

--- a/lib/core/src/lib/card-view/interfaces/update-notification.interface.ts
+++ b/lib/core/src/lib/card-view/interfaces/update-notification.interface.ts
@@ -15,10 +15,9 @@
  * limitations under the License.
  */
 
-export * from './node-allowable-operation-subject.interface';
-export * from './library-entity.interface';
-export * from './restore-message-model.interface';
-export * from './library-membership-error-event.interface';
-export * from './library-membership-toggle-event.interface';
-export * from './base-card-view-content-update.interface';
+import { CardViewBaseItemModel } from '../models/card-view-baseitem.model';
 
+export interface UpdateNotification {
+    target: CardViewBaseItemModel;
+    changed: any;
+}

--- a/lib/core/src/lib/card-view/services/card-view-update.service.spec.ts
+++ b/lib/core/src/lib/card-view/services/card-view-update.service.spec.ts
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import { MinimalNode } from '@alfresco/js-api';
 import { fakeAsync, TestBed } from '@angular/core/testing';
 import { CardViewBaseItemModel } from '../models/card-view-baseitem.model';
 import { CardViewUpdateService, transformKeyToObject } from './card-view-update.service';
@@ -82,14 +81,6 @@ describe('CardViewUpdateService', () => {
                 }
             );
             cardViewUpdateService.clicked(property);
-        }));
-
-        it('should send updated node when aspect changed', fakeAsync(() => {
-            const fakeNode: MinimalNode = { id: 'Bigfoot'} as MinimalNode;
-            cardViewUpdateService.updatedAspect$.subscribe((node: MinimalNode) => {
-                expect(node.id).toBe('Bigfoot');
-            });
-            cardViewUpdateService.updateNodeAspect(fakeNode);
         }));
     });
 });

--- a/lib/core/src/lib/card-view/services/card-view-update.service.ts
+++ b/lib/core/src/lib/card-view/services/card-view-update.service.ts
@@ -15,19 +15,12 @@
  * limitations under the License.
  */
 
-import { MinimalNode } from '@alfresco/js-api';
 import { Injectable } from '@angular/core';
 import { Subject } from 'rxjs';
+import { BaseCardViewUpdate } from '../interfaces/base-card-view-update.interface';
+import { ClickNotification } from '../interfaces/click-notification.interface';
+import { UpdateNotification } from '../interfaces/update-notification.interface';
 import { CardViewBaseItemModel } from '../models/card-view-baseitem.model';
-
-export interface UpdateNotification {
-    target: CardViewBaseItemModel;
-    changed: any;
-}
-
-export interface ClickNotification {
-    target: any;
-}
 
 export const transformKeyToObject = (key: string, value): any => {
     const objectLevels: string[] = key.split('.').reverse();
@@ -38,12 +31,11 @@ export const transformKeyToObject = (key: string, value): any => {
 @Injectable({
     providedIn: 'root'
 })
-export class CardViewUpdateService {
+export class CardViewUpdateService implements BaseCardViewUpdate {
 
     itemUpdated$ = new Subject<UpdateNotification>();
     itemClicked$ = new Subject<ClickNotification>();
     updateItem$ = new Subject<CardViewBaseItemModel>();
-    updatedAspect$ = new Subject<MinimalNode>();
 
     update(property: CardViewBaseItemModel, newValue: any) {
         this.itemUpdated$.next({
@@ -65,10 +57,6 @@ export class CardViewUpdateService {
      */
     updateElement(notification: CardViewBaseItemModel) {
         this.updateItem$.next(notification);
-    }
-
-    updateNodeAspect(node: MinimalNode) {
-        this.updatedAspect$.next(node);
     }
 
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Core `CardViewUpdateService` is coupled with content-services logic.
https://alfresco.atlassian.net/browse/AAE-10767

breaking-changes.md present.



**What is the new behaviour?**
Core `CardViewUpdateService` is no longer coupled with content-services logic. Instead a service was created in content-services to reflect this logic.

breaking-changes.md was removed and logic was moved to upgrade50-60.md.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
