### PR TITLE
fix: address peerDeps resolution issue by allowing newer beta's of @angular/flex-layout

### DIFF
--- a/lib/content-services/package.json
+++ b/lib/content-services/package.json
@@ -16,7 +16,7 @@
     "@angular/common": ">=14.0.5",
     "@angular/compiler": ">=14.0.5",
     "@angular/core": ">=14.0.5",
-    "@angular/flex-layout": ">=13.0.0-beta.38",
+    "@angular/flex-layout": ">=13.0.0-beta || >=14.0.0-beta",
     "@angular/forms": ">=14.0.5",
     "@angular/material": ">=13.3.9",
     "@angular/platform-browser": ">=14.0.5",

--- a/lib/core/package.json
+++ b/lib/core/package.json
@@ -34,7 +34,7 @@
     "@angular/cdk": ">=10.0.1",
     "@angular/common": ">=10.0.2",
     "@angular/core": ">=10.0.2",
-    "@angular/flex-layout": ">=10.0.0-beta.32",
+    "@angular/flex-layout": ">=10.0.0-beta || >=11.0.0-beta || >=12.0.0-beta || >=13.0.0-beta || >=14.0.0-beta",
     "@angular/forms": ">=10.0.2",
     "@angular/material": ">=10.0.1",
     "@angular/material-moment-adapter": ">=10.0.1",

--- a/lib/insights/package.json
+++ b/lib/insights/package.json
@@ -14,7 +14,7 @@
     "@angular/common": ">=14.0.5",
     "@angular/compiler": ">=14.0.5",
     "@angular/core": ">=14.0.5",
-    "@angular/flex-layout": ">=13.0.0-beta.38",
+    "@angular/flex-layout": ">=13.0.0-beta || >=14.0.0-beta",
     "@angular/forms": ">=14.0.5",
     "@angular/material": ">=13.3.9",
     "@alfresco/adf-core": "5.1.0",

--- a/lib/process-services-cloud/package.json
+++ b/lib/process-services-cloud/package.json
@@ -16,7 +16,7 @@
     "@angular/common": ">=14.0.5",
     "@angular/compiler": ">=14.0.5",
     "@angular/core": ">=14.0.5",
-    "@angular/flex-layout": ">=13.0.0-beta.38",
+    "@angular/flex-layout": ">=13.0.0-beta || >=14.0.0-beta",
     "@angular/forms": ">=14.0.5",
     "@angular/material": ">=13.3.9",
     "@angular/material-moment-adapter": ">=13.3.9",

--- a/lib/process-services/package.json
+++ b/lib/process-services/package.json
@@ -16,7 +16,7 @@
     "@angular/common": ">=14.0.5",
     "@angular/compiler": ">=14.0.5",
     "@angular/core": ">=14.0.5",
-    "@angular/flex-layout": ">=13.0.0-beta.38",
+    "@angular/flex-layout": ">=13.0.0-beta || >=14.0.0-beta",
     "@angular/forms": ">=14.0.5",
     "@angular/material": ">=13.3.9",
     "@angular/platform-browser": ">=14.0.5",


### PR DESCRIPTION
Since the version specified like that: `>=13.0.0-beta.38` in case of `@angular/flex-layout` it only allows updating

* to theoretically possible `-beta.39`
* to newer stable versions (which flex-layout doesn't have - only beta's)

then all beta versions must be combined via `||`.

To better understand this behavior go to https://semver.npmjs.com

![image](https://user-images.githubusercontent.com/1770529/200141675-be848e12-484b-4b58-9d4a-711150db7f10.png)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix


**What is the current behaviour?** (You can also link to an open issue here)
`@alfresco/adf-core` can't be installed in Angular project with the newest `@angular/flex-layout@14.0.0-beta.41` via npm@>7 because of upstream dependency conflict
```bash
npm verb node v18.9.1
npm verb npm  v8.19.3
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: adf-core-peer-deps-issue@1.0.0
npm ERR! Found: @angular/flex-layout@14.0.0-beta.41
npm ERR! node_modules/@angular/flex-layout
npm ERR!   @angular/flex-layout@"^14.0.0-beta.41" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer @angular/flex-layout@">=10.0.0-beta.32" from @alfresco/adf-core@5.1.0
npm ERR! node_modules/@alfresco/adf-core
npm ERR!   @alfresco/adf-core@"5.1.0" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```
Repro:
```bash
cd temp
npm init -y
npm i @angular/core @angular/common @angular/cdk @angular/flex-layout
npm i @alfresco/adf-core # will fail here because adf-core allows only newer beta's of @angular/flex-layout@10
```

**What is the new behaviour?**
`npm i @alfresco/adf-core` should work since `@angular/flex-layout@"^14.0.0-beta.41"` will be in the allowed range of versions.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No