### PR TITLE
[ACS-3770] Stop select event propagation to restore keyboard function…

### DIFF
--- a/lib/content-services/src/lib/permission-manager/components/user-role-column/user-role-column.component.ts
+++ b/lib/content-services/src/lib/permission-manager/components/user-role-column/user-role-column.component.ts
@@ -26,7 +26,9 @@ import { RoleModel } from '../../models/role.model';
                 (click)="$event.stopPropagation()"
                 [placeholder]="placeholder | translate"
                 [value]="value"
-                (selectionChange)="onRoleChanged($event.value)">
+                (selectionChange)="onRoleChanged($event.value)"
+                (keyup.arrowdown)="$event.stopPropagation()"
+                (keyup.arrowup)="$event.stopPropagation()">
                 <mat-option *ngFor="let role of roles" [value]="role.role">
                     {{ role.label | adfLocalizedRole }}
                 </mat-option>


### PR DESCRIPTION
…ality

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://alfresco.atlassian.net/browse/ACS-3770 Keyboard interaction with mat-select doesn't work. Event is propagated and catched by underlying table cell.

**What is the new behaviour?**

Event propagation is stopped so that up&down arrows allow user to select other options.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
