### PR TITLE
[ACS-3889] content reflow issue fixed to fit the viewport at 400% zoom

### DIFF
--- a/lib/content-services/src/lib/dialogs/folder.dialog.html
+++ b/lib/content-services/src/lib/dialogs/folder.dialog.html
@@ -1,4 +1,4 @@
-<h2 mat-dialog-title>
+<h2 mat-dialog-title id="title">
     {{ (editing ? editTitle : createTitle) | translate }}
 </h2>
 

--- a/lib/content-services/src/lib/dialogs/folder.dialog.scss
+++ b/lib/content-services/src/lib/dialogs/folder.dialog.scss
@@ -32,3 +32,14 @@
 .adf-dialog-action-button:disabled > span {
     color: var(--theme-text-color);
 }
+@media screen and (max-width: 380px){
+    .mat-form-field{
+        font-size: 6px;
+    }
+    .mat-dialog-title{
+        margin: 0 0 0px;
+    }
+    .adf-dialog-buttons{
+        padding: 0px;
+    }
+}

--- a/lib/content-services/src/lib/dialogs/folder.dialog.scss
+++ b/lib/content-services/src/lib/dialogs/folder.dialog.scss
@@ -33,10 +33,10 @@
     color: var(--theme-text-color);
 }
 @media screen and (max-width: 380px){
-    .mat-form-field{
+    .adf-full-width{
         font-size: 6px;
     }
-    .mat-dialog-title{
+    #title{
         margin: 0 0 0px;
     }
     .adf-dialog-buttons{


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Content doesn't reflow to fit the viewport when we zoom to 400% and cancel and create buttons are not visible


**What is the new behaviour?**
Content now reflow's to fit the viewport when zoom at 400% and cancel and create buttons are visible.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
