### PR TITLE
[ACS-3731]a11y zoom issues resolution

### DIFF
--- a/lib/content-services/src/lib/version-manager/version-list.component.scss
+++ b/lib/content-services/src/lib/version-manager/version-list.component.scss
@@ -14,4 +14,8 @@
     &-item-comment {
         opacity: 0.5;
     }
+
+    &-item-name, &-item-date {
+        white-space: normal !important;
+    }
 }

--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.scss
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.scss
@@ -100,7 +100,7 @@ $data-table-cell-min-width-file-size: $data-table-cell-min-width !default;
             text-align: left;
             flex: 0 1 24%;
             height: 136px !important;
-            white-space: nowrap;
+            white-space: normal;
             text-overflow: ellipsis;
             overflow: hidden;
             outline: none;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
when screen was zoomed, at places, texts were getting wrapped, which was being marked as a11y issue.


**What is the new behaviour?**
issue resolved wherever possible.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
