### PR TITLE
[ACS-3731] content reflow issue fixed to fit the viewport at 400% zoom sub task ACS-3889

### DIFF
--- a/lib/content-services/src/lib/dialogs/folder.dialog.html
+++ b/lib/content-services/src/lib/dialogs/folder.dialog.html
@@ -1,10 +1,10 @@
-<h2 mat-dialog-title id="title">
+<h2 mat-dialog-title class="title">
     {{ (editing ? editTitle : createTitle) | translate }}
 </h2>
 
 <mat-dialog-content>
     <form [formGroup]="form" (submit)="submit()">
-        <mat-form-field class="adf-full-width">
+        <mat-form-field class="adf-full-width adf-font-size-input">
             <input
                 id="adf-folder-name-input"
                 placeholder="{{ 'CORE.FOLDER_DIALOG.FOLDER_NAME.LABEL' | translate }}"

--- a/lib/content-services/src/lib/dialogs/folder.dialog.html
+++ b/lib/content-services/src/lib/dialogs/folder.dialog.html
@@ -1,4 +1,4 @@
-<h2 mat-dialog-title>
+<h2 mat-dialog-title id="title">
     {{ (editing ? editTitle : createTitle) | translate }}
 </h2>
 

--- a/lib/content-services/src/lib/dialogs/folder.dialog.html
+++ b/lib/content-services/src/lib/dialogs/folder.dialog.html
@@ -1,4 +1,4 @@
-<h2 mat-dialog-title class="title">
+<h2 mat-dialog-title>
     {{ (editing ? editTitle : createTitle) | translate }}
 </h2>
 
@@ -26,7 +26,7 @@
             </mat-hint>
         </mat-form-field>
 
-        <mat-form-field class="adf-full-width">
+        <mat-form-field class="adf-full-width adf-font-size-input">
             <input
                 id="adf-folder-title-input"
                 matInput
@@ -36,7 +36,7 @@
             />
         </mat-form-field>
 
-        <mat-form-field class="adf-full-width">
+        <mat-form-field class="adf-full-width adf-font-size-input">
             <textarea
                 id="adf-folder-description-input"
                 matInput

--- a/lib/content-services/src/lib/dialogs/folder.dialog.html
+++ b/lib/content-services/src/lib/dialogs/folder.dialog.html
@@ -4,7 +4,7 @@
 
 <mat-dialog-content>
     <form [formGroup]="form" (submit)="submit()">
-        <mat-form-field class="adf-full-width adf-font-size-input">
+        <mat-form-field class="adf-full-width">
             <input
                 id="adf-folder-name-input"
                 placeholder="{{ 'CORE.FOLDER_DIALOG.FOLDER_NAME.LABEL' | translate }}"
@@ -26,7 +26,7 @@
             </mat-hint>
         </mat-form-field>
 
-        <mat-form-field class="adf-full-width adf-font-size-input">
+        <mat-form-field class="adf-full-width">
             <input
                 id="adf-folder-title-input"
                 matInput
@@ -36,7 +36,7 @@
             />
         </mat-form-field>
 
-        <mat-form-field class="adf-full-width adf-font-size-input">
+        <mat-form-field class="adf-full-width">
             <textarea
                 id="adf-folder-description-input"
                 matInput

--- a/lib/content-services/src/lib/dialogs/folder.dialog.scss
+++ b/lib/content-services/src/lib/dialogs/folder.dialog.scss
@@ -37,10 +37,12 @@
     .mat-form-field {
         font-size: 6px;
     }
+
     .mat-dialog-title {
-        margin: 0 0 0px;
+        margin: 0;
     }
+
     .adf-dialog-buttons {
-        padding: 0px;
+        padding: 0;
     }
 }

--- a/lib/content-services/src/lib/dialogs/folder.dialog.scss
+++ b/lib/content-services/src/lib/dialogs/folder.dialog.scss
@@ -34,7 +34,7 @@
 }
 
 @media screen and (max-width: 380px) {
-    .adf-font-size-input {
+    .mat-form-field {
         font-size: 6px;
     }
     .mat-dialog-title {

--- a/lib/content-services/src/lib/dialogs/folder.dialog.scss
+++ b/lib/content-services/src/lib/dialogs/folder.dialog.scss
@@ -33,10 +33,10 @@
     color: var(--theme-text-color);
 }
 @media screen and (max-width: 380px){
-    .adf-full-width{
+    .adf-font-size-input{
         font-size: 6px;
     }
-    #title{
+    .title{
         margin: 0 0 0px;
     }
     .adf-dialog-buttons{

--- a/lib/content-services/src/lib/dialogs/folder.dialog.scss
+++ b/lib/content-services/src/lib/dialogs/folder.dialog.scss
@@ -32,3 +32,14 @@
 .adf-dialog-action-button:disabled > span {
     color: var(--theme-text-color);
 }
+@media screen and (max-width: 380px){
+    .adf-full-width{
+        font-size: 6px;
+    }
+    #title{
+        margin: 0 0 0px;
+    }
+    .adf-dialog-buttons{
+        padding: 0px;
+    }
+}

--- a/lib/content-services/src/lib/dialogs/folder.dialog.scss
+++ b/lib/content-services/src/lib/dialogs/folder.dialog.scss
@@ -32,14 +32,15 @@
 .adf-dialog-action-button:disabled > span {
     color: var(--theme-text-color);
 }
-@media screen and (max-width: 380px){
-    .adf-font-size-input{
+
+@media screen and (max-width: 380px) {
+    .adf-font-size-input {
         font-size: 6px;
     }
-    .title{
+    .mat-dialog-title {
         margin: 0 0 0px;
     }
-    .adf-dialog-buttons{
+    .adf-dialog-buttons {
         padding: 0px;
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
content doesn't reflow to fit the viewport at 400% zoom 


**What is the new behaviour?**
content reflow issue fixed to fit the viewport at 400% zoom 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
