### PR TITLE
[ACS-3731] move/copy dialog and content overlaps other than 320px issue fixed

### DIFF
--- a/lib/content-services/src/lib/content-node-selector/content-node-selector.component.scss
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector.component.scss
@@ -102,4 +102,9 @@ adf-content-node-selector {
             }
         }
     }
+    @media screen and (max-width: 768px){
+        .mat-dialog-container{
+            height: 100vh;
+        }
+    }
 }

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector.component.scss
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector.component.scss
@@ -102,8 +102,9 @@ adf-content-node-selector {
             }
         }
     }
-    @media screen and (max-width: 768px){
-        .mat-dialog-container{
+
+    @media screen and (max-width: 768px) {
+        .mat-dialog-container {
             height: 100vh;
         }
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Content is lost, clipped, or obscured when the page is zoomed to 200%, Content overlaps other content at 320px width equivalent

**What is the new behaviour?**
move/copy dialog and content overlaps other than 320px issue fixed


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
