### PR TITLE
[ACS-3550] a 11 y aca move copy dialog small correction

### DIFF
--- a/lib/content-services/src/lib/site-dropdown/sites-dropdown.component.html
+++ b/lib/content-services/src/lib/site-dropdown/sites-dropdown.component.html
@@ -8,11 +8,9 @@
             class="adf-site-dropdown-list-element"
             id="site-dropdown"
             placeholder="{{placeholder | translate}}"
-            [aria-label]="ariaLabel"
             floatPlaceholder="never"
             [(value)]="selected"
-            (selectionChange)="selectedSite($event)"
-            role="listbox">
+            (selectionChange)="selectedSite($event)">
             <mat-option *ngFor="let site of siteList?.list.entries;" [value]="site">
                 {{ site.entry.title | translate}}
             </mat-option>

--- a/lib/content-services/src/lib/site-dropdown/sites-dropdown.component.ts
+++ b/lib/content-services/src/lib/site-dropdown/sites-dropdown.component.ts
@@ -76,7 +76,6 @@ export class DropdownSitesComponent implements OnInit {
 
     private loading = true;
     private skipCount = 0;
-    private _ariaLabel = '';
 
     selected: SiteEntry = null;
     MY_FILES_VALUE = '-my-';
@@ -88,14 +87,9 @@ export class DropdownSitesComponent implements OnInit {
     }
 
     ngOnInit() {
-        this.updateAriaLabel(this.selected);
         if (!this.siteList) {
             this.loadSiteList();
         }
-    }
-
-    get ariaLabel(): string {
-        return this._ariaLabel;
     }
 
     loadAllOnScroll() {
@@ -106,7 +100,6 @@ export class DropdownSitesComponent implements OnInit {
     }
 
     selectedSite(event: MatSelectChange) {
-        this.updateAriaLabel(event.value);
         this.liveAnnouncer.announce(this.translateService.instant('ADF_DROPDOWN.SELECTION_ARIA_LABEL', {
             placeholder: this.translateService.instant(this.placeholder),
             selectedOption: this.translateService.instant(event.value.entry.title)
@@ -155,7 +148,6 @@ export class DropdownSitesComponent implements OnInit {
                 }
 
                 this.selected = this.siteList.list.entries.find((site: SiteEntry) => site.entry.id === this.value);
-                this.updateAriaLabel(this.selected);
 
                 if (this.value && !this.selected && this.siteListHasMoreItems()) {
                     this.loadSiteList();
@@ -189,9 +181,5 @@ export class DropdownSitesComponent implements OnInit {
     private isCurrentUserMember(site, loggedUserName): boolean {
         return site.entry.visibility === 'PUBLIC' ||
             !!site.relations.members.list.entries.find((member) => member.entry.id.toLowerCase() === loggedUserName.toLowerCase());
-    }
-
-    private updateAriaLabel(site: SiteEntry): void {
-        this._ariaLabel = `${this.translateService.instant(this.placeholder)} ${site ? this.translateService.instant(site.entry.title) : ''}`;
     }
 }

--- a/lib/core/src/lib/i18n/en.json
+++ b/lib/core/src/lib/i18n/en.json
@@ -582,6 +582,6 @@
   },
   "ADF_DROPDOWN": {
     "LOADING": "Loading...",
-    "SELECTION_ARIA_LABEL": "{{placeholder}} listbox {{selectedOption}}"
+    "SELECTION_ARIA_LABEL": "{{placeholder}} combobox {{selectedOption}}"
   }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
There were two redundant aria attributes - role because select component adds other role by default and label because it is already covered by LiveAnnouncer so these redundant attributes gave more accessibility issues like it was commented in that jira in last comment: https://alfresco.atlassian.net/browse/ACS-3550. 


**What is the new behaviour?**
Removed redundant attributes. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
