### PR TITLE
[AAE-11437] Remove snackbar duplications

### DIFF
--- a/e2e/content-services/components/permissions-component.e2e.ts
+++ b/e2e/content-services/components/permissions-component.e2e.ts
@@ -88,7 +88,11 @@ describe('Permissions Component', () => {
     const roleContributorFolderModel = new FolderModel({ name: 'roleContributor' + StringUtil.generateRandomString() });
     const roleEditorFolderModel = new FolderModel({ name: 'roleEditor' + StringUtil.generateRandomString() });
 
-    let roleConsumerFolder, roleCoordinatorFolder, roleContributorFolder, roleCollaboratorFolder, roleEditorFolder;
+    let roleConsumerFolder;
+    let roleCoordinatorFolder;
+    let roleContributorFolder;
+    let roleCollaboratorFolder;
+    let roleEditorFolder;
 
     beforeAll(async () => {
         try {
@@ -173,7 +177,7 @@ describe('Permissions Component', () => {
             await permissionsPage.addPermissionsDialog.selectRole(groupBody.displayName, 'Consumer');
             await expect(await permissionsPage.addPermissionsDialog.addButtonIsEnabled()).toBe(true, 'button should be enabled');
             await permissionsPage.addPermissionsDialog.clickAddButton();
-            await expect(await notificationPage.getSnackBarMessage()).toEqual('Added 0 user(s) 1 group(s)');
+            await expect(await notificationPage.snackbarPage.getSnackBarMessage()).toEqual('Added 0 user(s) 1 group(s)');
             await permissionsPage.checkUserIsAdded(groupBody.id);
         });
 
@@ -194,8 +198,8 @@ describe('Permissions Component', () => {
             await permissionsPage.checkPermissionListDisplayed();
             await expect(await permissionsPage.isInherited()).toBe(true, 'Inherited permission should be on');
             await permissionsPage.toggleInheritPermission();
-            await expect(await notificationPage.getSnackBarMessage()).toContain('Disabled inherited permission', 'Disabled notification not shown');
-            await notificationPage.waitForSnackBarToClose();
+            await expect(await notificationPage.snackbarPage.getSnackBarMessage()).toContain('Disabled inherited permission', 'Disabled notification not shown');
+            await notificationPage.snackbarPage.waitForSnackBarToClose();
             await expect(await permissionsPage.isInherited()).toBe(false, 'Inherited permission should be off');
         });
     });
@@ -222,8 +226,8 @@ describe('Permissions Component', () => {
             await permissionsPage.addPermissionsDialog.selectRole(filePermissionUser.fullName, 'Contributor');
             await expect(await permissionsPage.addPermissionsDialog.addButtonIsEnabled()).toBe(true, 'button should be enabled');
             await permissionsPage.addPermissionsDialog.clickAddButton();
-            await expect(await notificationPage.getSnackBarMessage()).toEqual('Added 1 user(s) 0 group(s)');
-            await notificationPage.waitForSnackBarToClose();
+            await expect(await notificationPage.snackbarPage.getSnackBarMessage()).toEqual('Added 1 user(s) 0 group(s)');
+            await notificationPage.snackbarPage.waitForSnackBarToClose();
             await permissionsPage.checkUserIsAdded(filePermissionUser.username);
         });
 
@@ -246,19 +250,19 @@ describe('Permissions Component', () => {
 
             await BrowserActions.closeMenuAndDialogs();
             await permissionsPage.changePermission(filePermissionUser.username, 'Collaborator');
-            await notificationPage.waitForSnackBarToClose();
+            await notificationPage.snackbarPage.waitForSnackBarToClose();
             await expect(await permissionsPage.getRoleCellValue(filePermissionUser.username)).toEqual('Collaborator');
 
             await permissionsPage.changePermission(filePermissionUser.username, 'Coordinator');
-            await notificationPage.waitForSnackBarToClose();
+            await notificationPage.snackbarPage.waitForSnackBarToClose();
             await expect(await permissionsPage.getRoleCellValue(filePermissionUser.username)).toEqual('Coordinator');
 
             await permissionsPage.changePermission(filePermissionUser.username, 'Editor');
-            await notificationPage.waitForSnackBarToClose();
+            await notificationPage.snackbarPage.waitForSnackBarToClose();
             await expect(await permissionsPage.getRoleCellValue(filePermissionUser.username)).toEqual('Editor');
 
             await permissionsPage.changePermission(filePermissionUser.username, 'Consumer');
-            await notificationPage.waitForSnackBarToClose();
+            await notificationPage.snackbarPage.waitForSnackBarToClose();
             await expect(await permissionsPage.getRoleCellValue(filePermissionUser.username)).toEqual('Consumer');
         });
 
@@ -277,7 +281,7 @@ describe('Permissions Component', () => {
             await expect(await permissionsPage.getRoleCellValue(filePermissionUser.username)).toEqual('Contributor');
             await permissionsPage.clickDeletePermissionButton(filePermissionUser.username);
             await permissionsPage.checkUserIsDeleted(filePermissionUser.username);
-            await expect(await notificationPage.getSnackBarMessage()).toEqual('User/Group deleted');
+            await expect(await notificationPage.snackbarPage.getSnackBarMessage()).toEqual('User/Group deleted');
         });
     });
 
@@ -299,11 +303,11 @@ describe('Permissions Component', () => {
             await BrowserActions.closeMenuAndDialogs();
             await contentList.checkActionMenuIsNotDisplayed();
             await contentServicesPage.metadataContent('RoleConsumer' + fileModel.name);
-            await expect(await notificationPage.getSnackBarMessage()).toEqual('You don\'t have access to do this.');
+            await expect(await notificationPage.snackbarPage.getSnackBarMessage()).toEqual('You don\'t have access to do this.');
             await notificationHistoryPage.checkNotifyContains('You don\'t have access to do this.');
             await browser.sleep(3000);
             await contentServicesPage.uploadFile(fileLocation);
-            await expect(await notificationPage.getSnackBarMessage()).toEqual('You don\'t have the create permission to upload the content');
+            await expect(await notificationPage.snackbarPage.getSnackBarMessage()).toEqual('You don\'t have the create permission to upload the content');
             await notificationHistoryPage.checkNotifyContains('You don\'t have the create permission to upload the content');
         });
 

--- a/e2e/content-services/components/site-permissions.e2e.ts
+++ b/e2e/content-services/components/site-permissions.e2e.ts
@@ -57,7 +57,9 @@ describe('Permissions Component', () => {
 
     const contentList = contentServicesPage.getDocumentList();
 
-    let publicSite, privateSite, folderName;
+    let publicSite;
+    let privateSite;
+    let folderName;
 
     const fileModel = new FileModel({
         name: browser.params.resources.Files.ADF_DOCUMENTS.TXT_0B.file_name,
@@ -79,7 +81,8 @@ describe('Permissions Component', () => {
         location: browser.params.resources.Files.ADF_DOCUMENTS.PNG_B.file_location
     });
 
-    let siteFolder, privateSiteFile;
+    let siteFolder;
+    let privateSiteFile;
 
     const folderOwnerUser = new UserModel();
     const consumerUser: UserModel = new UserModel();
@@ -210,8 +213,8 @@ describe('Permissions Component', () => {
             await expect(await permissionsPage.addPermissionsDialog.getRoleCellValue(consumerUser.fullName)).toEqual('Site Collaborator');
             await expect(await permissionsPage.addPermissionsDialog.addButtonIsEnabled()).toBe(true, 'Add button should be enabled');
             await permissionsPage.addPermissionsDialog.clickAddButton();
-            await expect(await notificationPage.getSnackBarMessage()).toEqual('Added 1 user(s) 0 group(s)');
-            await notificationPage.waitForSnackBarToClose();
+            await expect(await notificationPage.snackbarPage.getSnackBarMessage()).toEqual('Added 1 user(s) 0 group(s)');
+            await notificationPage.snackbarPage.waitForSnackBarToClose();
 
             await permissionsPage.checkUserIsAdded(consumerUser.username);
 

--- a/e2e/core/notifications-component.e2e.ts
+++ b/e2e/core/notifications-component.e2e.ts
@@ -51,27 +51,27 @@ describe('Notifications Component', () => {
     });
 
     afterEach(async () => {
-        await notificationPage.waitForSnackBarToClose();
+        await notificationPage.snackbarPage.waitForSnackBarToClose();
         await browser.executeScript(`document.querySelector('button[data-automation-id="notification-custom-dismiss-button"]').click();`);
     });
 
     it('[C279979] Should not show notification when the message is empty and button is clicked', async () => {
         await notificationPage.clearMessage();
         await notificationPage.clickNotificationButton();
-        await expect(await notificationPage.isNotificationSnackBarDisplayed()).toEqual(false);
+        await expect(await notificationPage.snackbarPage.isNotificationSnackBarDisplayed()).toEqual(false);
     });
 
     it('[C279977] Should show notification when the message is not empty and button is clicked', async () => {
         await notificationPage.enterMessageField('test');
         await notificationPage.clickNotificationButton();
-        await expect(await notificationPage.getSnackBarMessage()).toEqual('test');
+        await expect(await notificationPage.snackbarPage.getSnackBarMessage()).toEqual('test');
     });
 
     it('[C279978] Should show notification with action when the message is not empty and button is clicked', async () => {
         await notificationPage.enterMessageField('test');
         await notificationPage.clickActionToggle();
         await notificationPage.clickNotificationButton();
-        await expect(await notificationPage.getSnackBarMessage()).toEqual('test');
+        await expect(await notificationPage.snackbarPage.getSnackBarMessage()).toEqual('test');
         await notificationPage.clickActionButton();
         await notificationPage.checkActionEvent();
         await notificationPage.clickActionToggle();
@@ -80,16 +80,16 @@ describe('Notifications Component', () => {
     it('[C279981] Should show notification with action when the message is not empty and custom configuration button is clicked', async () => {
         await notificationPage.enterMessageField('test');
         await notificationPage.clickNotificationButton();
-        await expect(await notificationPage.isNotificationSnackBarDisplayed()).toEqual(true);
+        await expect(await notificationPage.snackbarPage.isNotificationSnackBarDisplayed()).toEqual(true);
     });
 
     it('[C280000] Should show notification with action when the message is not empty and custom button is clicked', async () => {
         await notificationPage.enterMessageField('test');
         await notificationPage.clickActionToggle();
         await notificationPage.clickNotificationButton();
-        await expect(await notificationPage.isNotificationSnackBarDisplayed()).toEqual(true);
-        await expect(await notificationPage.getSnackBarMessage()).toEqual('test');
-        await notificationPage.waitForSnackBarToClose();
+        await expect(await notificationPage.snackbarPage.isNotificationSnackBarDisplayed()).toEqual(true);
+        await expect(await notificationPage.snackbarPage.getSnackBarMessage()).toEqual('test');
+        await notificationPage.snackbarPage.waitForSnackBarToClose();
         await notificationPage.clickNotificationButton();
         await notificationPage.clickActionButton();
         await notificationPage.checkActionEvent();
@@ -100,9 +100,9 @@ describe('Notifications Component', () => {
         await notificationPage.enterMessageField('test');
         await notificationPage.enterDurationField(1000);
         await notificationPage.clickNotificationButton();
-        await expect(await notificationPage.isNotificationSnackBarDisplayed()).toEqual(true);
+        await expect(await notificationPage.snackbarPage.isNotificationSnackBarDisplayed()).toEqual(true);
         await browser.sleep(2000);
-        await expect(await notificationPage.isNotificationSnackBarDisplayed()).toEqual(false);
+        await expect(await notificationPage.snackbarPage.isNotificationSnackBarDisplayed()).toEqual(false);
     });
 
     it('[C280001] Should meet configuration when a custom notification is set', async () => {

--- a/e2e/core/pages/notification.page.ts
+++ b/e2e/core/pages/notification.page.ts
@@ -46,18 +46,6 @@ export class NotificationDemoPage {
         return BrowserActions.getText(this.notificationConfig);
     }
 
-    async isNotificationSnackBarDisplayed(): Promise<boolean> {
-        return this.snackbarPage.isNotificationSnackBarDisplayed();
-    }
-
-    async getSnackBarMessage(): Promise<string> {
-        return this.snackbarPage.getSnackBarMessage();
-    }
-
-    async waitForSnackBarToClose(): Promise<void> {
-        await this.snackbarPage.waitForSnackBarToClose(15000);
-    }
-
     async enterMessageField(text: string): Promise<void> {
         await BrowserActions.clearSendKeys(this.messageField, text);
     }

--- a/lib/testing/src/lib/protractor/core/pages/snackbar.page.ts
+++ b/lib/testing/src/lib/protractor/core/pages/snackbar.page.ts
@@ -31,7 +31,7 @@ export class SnackbarPage {
         );
     }
 
-    async waitForSnackBarToClose(timeout = 10000) {
+    async waitForSnackBarToClose(timeout = 15000) {
         return BrowserVisibility.waitUntilElementIsNotVisible(this.snackBarContainerCss.first(), timeout);
     }
 

--- a/lib/testing/src/lib/protractor/core/pages/snackbar.page.ts
+++ b/lib/testing/src/lib/protractor/core/pages/snackbar.page.ts
@@ -31,7 +31,7 @@ export class SnackbarPage {
         );
     }
 
-    async waitForSnackBarToClose(timeout = 5000) {
+    async waitForSnackBarToClose(timeout = 10000) {
         return BrowserVisibility.waitUntilElementIsNotVisible(this.snackBarContainerCss.first(), timeout);
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**
The PR is just removing methods that we wrapped in methods with the same name. As the snackbar already had these methods there was no need to duplicate them.

The timeout was extended so we won't need to defined it again in alfresco-apps

The let splitting to separate lines was hinted by linter.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
