### PR TITLE
[ACS-3758] Focus modal first focusable element after opening

### DIFF
--- a/lib/content-services/src/lib/dialogs/dialog.module.ts
+++ b/lib/content-services/src/lib/dialogs/dialog.module.ts
@@ -27,6 +27,7 @@ import { ConfirmDialogComponent } from './confirm.dialog';
 import { MatDatetimepickerModule } from '@mat-datetimepicker/core';
 import { MatMomentDatetimeModule } from '@mat-datetimepicker/moment';
 import { LibraryDialogComponent } from './library/library.dialog';
+import { ContentDirectiveModule } from '../directives';
 
 @NgModule({
     imports: [
@@ -36,7 +37,8 @@ import { LibraryDialogComponent } from './library/library.dialog';
         FormsModule,
         ReactiveFormsModule,
         MatMomentDatetimeModule,
-        MatDatetimepickerModule
+        MatDatetimepickerModule,
+        ContentDirectiveModule
     ],
     declarations: [
         FolderDialogComponent,

--- a/lib/content-services/src/lib/dialogs/folder.dialog.html
+++ b/lib/content-services/src/lib/dialogs/folder.dialog.html
@@ -12,6 +12,7 @@
                 matInput
                 required
                 [formControlName]="'name'"
+                adf-auto-focus
             />
 
             <mat-hint *ngIf="form.controls['name'].dirty">

--- a/lib/content-services/src/lib/dialogs/library/library.dialog.html
+++ b/lib/content-services/src/lib/dialogs/library/library.dialog.html
@@ -9,6 +9,7 @@
         matInput
         formControlName="title"
         autocomplete="off"
+        adf-auto-focus
       />
 
       <mat-hint *ngIf="libraryTitleExists">{{


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
There is no focused element after opening modal for library or folder creation. 


**What is the new behaviour?**
After opening library or folder creation dialog - first focusable element is auto focused. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
APPS PR: https://github.com/Alfresco/alfresco-apps/pull/4570
ACA PR: https://github.com/Alfresco/alfresco-apps/pull/4570