### PR TITLE
[ADF-5508] Fix half hidden checkmark icon

### DIFF
--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.scss
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.scss
@@ -395,7 +395,7 @@ $data-table-cell-min-width-file-size: $data-table-cell-min-width !default;
         min-height: inherit;
         align-items: center;
         word-break: break-all;
-        width: 100%
+        width: 100%;
     }
 
     .adf-datatable__actions-cell,

--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.scss
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.scss
@@ -395,7 +395,6 @@ $data-table-cell-min-width-file-size: $data-table-cell-min-width !default;
         min-height: inherit;
         align-items: center;
         word-break: break-all;
-        width: 100%;
     }
 
     .adf-datatable__actions-cell,

--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.scss
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.scss
@@ -395,12 +395,17 @@ $data-table-cell-min-width-file-size: $data-table-cell-min-width !default;
         min-height: inherit;
         align-items: center;
         word-break: break-all;
+        width: 100%
     }
 
     .adf-datatable__actions-cell,
     .adf-datatable-cell--image {
         max-width: $data-table-thumbnail-width;
         display: flex;
+
+        .adf-cell-value {
+            width: unset;
+        }
     }
 
     .adf-datatable-row:not(:hover) .adf-datatable-hide-actions-without-hover {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://alfresco.atlassian.net/browse/ADF-5508

**What is the new behaviour?**

The checkmark is fully visible.
Note that I would like any feedback on whether this change could cause other issues if merged. In the demoshell it seems to work completely as intended but I fear elsewhere it could not.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
