### PR TITLE
[AAE-11274] remove unnecessary var export

### DIFF
--- a/scripts/test-e2e-lib.sh
+++ b/scripts/test-e2e-lib.sh
@@ -2,7 +2,7 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 cd "$DIR/../"
-export BROWSER_RUN=false
+BROWSER_RUN=false
 DEVELOPMENT=false
 LITESERVER=false
 EXEC_VERSION_JSAPI=false


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe: clean-up running e2e script


**What is the current behaviour?** (You can also link to an open issue here)
I think I added that export to the var before and it is unnecessary.
I tested it without export as I was reviewing confluence page about running tests.
Tests are running correctly headless and in browser mode without that export there with both `test-e2e-lib.sh` script and by `./node_modules/protractor/bin/protractor <path to protractor.conf.js> --specs=<path to spec file>`


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
