### PR TITLE
[#7902] Fix to enable cmaps with pdfjs

### DIFF
--- a/lib/core/src/lib/viewer/components/pdf-viewer.component.ts
+++ b/lib/core/src/lib/viewer/components/pdf-viewer.component.ts
@@ -109,7 +109,9 @@ export class PdfViewerComponent implements OnChanges, OnDestroy {
     private eventBus = new pdfjsViewer.EventBus();
     private pdfjsDefaultOptions = {
         disableAutoFetch: true,
-        disableStream: true
+        disableStream: true,
+        cMapUrl: './cmaps/',
+        cMapPacked: true
     };
     private pdfjsWorkerDestroy$ = new Subject<boolean>();
     private onDestroy$ = new Subject<boolean>();


### PR DESCRIPTION
pdfjs works fine with Japanese characters with this options.

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

What is the current behaviour? (You can also link to an open issue here)
Browser does not load cmaps files correctly with pdfjs.

What is the new behaviour?
Browser loads cmaps files with pdfjs.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
