### PR TITLE
[AAE-11708] Use perl regexp instead of reverse grep in changelog

### DIFF
--- a/lib/cli/scripts/changelog.ts
+++ b/lib/cli/scripts/changelog.ts
@@ -92,8 +92,8 @@ function getCommits(options: DiffOptions): Array<Commit> {
         options.range,
         `--no-merges`,
         `--first-parent`,
-        `--invert-grep`,
-        `--author="${authorFilter}"`,
+        `--perl-regexp`,
+        `--author="^((?!${authorFilter}).*)$"`,
         // this format is needed to allow parsing all characters in the commit message and safely convert to JSON
         `--format="{ ^@^hash^@^: ^@^%h^@^, ^@^author^@^: ^@^%an^@^, ^@^author_email^@^: ^@^%ae^@^, ^@^date^@^: ^@^%ad^@^, ^@^subject^@^: ^@^%s^@^ }"`
     ];


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [X] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
The git log command does not work anymore with invert grep and we can’t generate the changelog automatically when doing releases.


**What is the new behaviour?**
An alternative solution we can apply is filter the authors by a regexp with perl-regexp


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
