### PR TITLE
[ACS-4051] Copy to clipboard button is now accessible through the keyboard enter earlier which was only accessible through mouse click

### DIFF
--- a/lib/core/src/lib/clipboard/clipboard.directive.spec.ts
+++ b/lib/core/src/lib/clipboard/clipboard.directive.spec.ts
@@ -64,6 +64,14 @@ describe('ClipboardDirective', () => {
 
         expect(clipboardService.copyToClipboard).toHaveBeenCalled();
     });
+
+    it('should notify copy target value on mouse enter event', () => {
+        spyOn(clipboardService, 'copyToClipboard');
+        fixture.nativeElement.querySelector('input').value = 'some value';
+        window.dispatchEvent(new KeyboardEvent('keydown', {code: 'Enter', key: 'Enter'}));
+
+        expect(clipboardService.copyToClipboard).toHaveBeenCalled();
+    });
 });
 
 describe('CopyClipboardDirective', () => {
@@ -123,6 +131,15 @@ describe('CopyClipboardDirective', () => {
         fixture.detectChanges();
         spyOn(navigator.clipboard, 'writeText');
         spanHTMLElement.dispatchEvent(new Event('click'));
+        tick();
+        fixture.detectChanges();
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith('text to copy');
+    }));
+
+    it('should copy the content of element on mouse enter', fakeAsync(() => {
+        fixture.detectChanges();
+        spyOn(navigator.clipboard, 'writeText');
+        window.dispatchEvent(new KeyboardEvent('keydown', {code: 'Enter', key: 'Enter'}));
         tick();
         fixture.detectChanges();
         expect(navigator.clipboard.writeText).toHaveBeenCalledWith('text to copy');

--- a/lib/core/src/lib/clipboard/clipboard.directive.ts
+++ b/lib/core/src/lib/clipboard/clipboard.directive.ts
@@ -46,6 +46,12 @@ export class ClipboardDirective {
         event.stopPropagation();
         this.copyToClipboard();
     }
+    @HostListener('window:keydown.enter', ['$event'])
+    handleKeyDown(event: KeyboardEvent){
+        event.preventDefault();
+        event.stopPropagation();
+        this.copyToClipboard();
+    }
 
     @HostListener('mouseenter')
     showTooltip() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

There was no way to perform the function using only the keyboard on the same screen or on a qualifying conforming alternate version.

**What is the new behaviour?**

using the keyboard we can copy the link to clipboard that was earlier not able to perform.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
