### PR TITLE
[AAE-11992] pass only the processInstanceId as Input instead of the e…

### DIFF
--- a/lib/process-services-cloud/src/lib/task/task-filters/components/edit-task-filters/base-edit-task-filter-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-filters/components/edit-task-filters/base-edit-task-filter-cloud.component.ts
@@ -67,6 +67,10 @@ export abstract class BaseEditTaskFilterCloudComponent<T> implements OnInit, OnC
     @Input()
     id: string;
 
+    /** processInstanceId of the task filter. */
+    @Input()
+    processInstanceId: string;
+
     /** Toggles the title. */
     @Input()
     showTitle = true;
@@ -147,12 +151,8 @@ export abstract class BaseEditTaskFilterCloudComponent<T> implements OnInit, OnC
     }
 
     ngOnChanges(changes: SimpleChanges) {
-        const { id, taskFilter } = changes;
-        if(taskFilter && taskFilter.currentValue?.processInstanceId !== taskFilter.previousValue?.processInstanceId){
-            this.taskFilterProperties = this.createAndFilterProperties();
-            this.taskFilterActions = this.createAndFilterActions();
-            this.buildForm(this.taskFilterProperties);
-        } else if (id && id.currentValue !== id.previousValue) {
+        const { id } = changes;
+        if (id && id.currentValue !== id.previousValue) {
             this.retrieveTaskFilterAndBuildForm();
         }
     }

--- a/lib/process-services-cloud/src/lib/task/task-filters/components/edit-task-filters/edit-task-filter-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/task/task-filters/components/edit-task-filters/edit-task-filter-cloud.component.spec.ts
@@ -49,11 +49,8 @@ import {
     mockDefaultTaskFilter,
     mockDueDateFilter,
     mockTaskFilterIdChange,
-    mockTaskFilterProcessInstanceIdChange,
-    mockTaskFilterProcessInstanceIdChangeToNull,
-    mockTaskFilterProcessInstanceIdNotChanged,
-    mockTaskFilterWithProcessInstanceId2,
-    mockTaskFilterWithProcessInstanceIdNull
+    mockTaskFilterResponse,
+    mockTaskFilterResponseWithProcessInstanceIdNull
 } from '../../mock/edit-task-filter-cloud.mock';
 import { mockFoodUsers } from '../../../../people/mock/people-cloud.mock';
 import { mockFoodGroups } from '../../../../group/mock/group-cloud.mock';
@@ -135,47 +132,66 @@ describe('EditTaskFilterCloudComponent', () => {
             return fixture.debugElement.query(By.css(cssSelector.processInstanceIdInput)).nativeElement;
         }
 
-        it('should set processInstanceId filter when processInstanceId changes', () => {
-            component.taskFilter = mockTaskFilterWithProcessInstanceId2;
-            component.filterProperties = [ 'appName', 'processInstanceId', 'sort', 'order'];
-            fixture.detectChanges();
-            component.ngOnChanges({ taskFilter: mockTaskFilterProcessInstanceIdChange});
-            fixture.detectChanges();
-            expandFilterPanel();
-            expect(getTaskFilterSpy).not.toHaveBeenCalled();
-            expect(getProcessInstanceIdInputElement().value).toEqual('fakeProcessInstance-2');
-        });
-
-        it('should processInstanceId filter be empty string if taskFilter processInstanceId change to null', () => {
-            component.taskFilter = mockTaskFilterWithProcessInstanceIdNull;
-            component.filterProperties = [ 'appName', 'processInstanceId', 'sort', 'order'];
-            fixture.detectChanges();
-            component.ngOnChanges({ taskFilter: mockTaskFilterProcessInstanceIdChangeToNull});
-            fixture.detectChanges();
-            expandFilterPanel();
-            expect(getTaskFilterSpy).not.toHaveBeenCalled();
-            expect(getProcessInstanceIdInputElement().value).toEqual('');
-        });
-
-        it('should processInstanceId filter be empty string if id of the task filter is changed', () => {
+        it('should set processInstanceId filter when id changes', async () => {
+            getTaskFilterSpy.and.returnValue(of(mockTaskFilterResponse));
+            component.processInstanceId = 'fakeProcessInstanceId';
             component.filterProperties = [ 'appName', 'processInstanceId', 'sort', 'order'];
             fixture.detectChanges();
             component.ngOnChanges({ id: mockTaskFilterIdChange });
             fixture.detectChanges();
+            await fixture.whenStable();
             expandFilterPanel();
-            expect(getTaskFilterSpy).toHaveBeenCalled();
+            expect(getProcessInstanceIdInputElement().value).toEqual('fakeProcessInstanceId');
+        });
+
+        it('should processInstanceId filter be empty string if processInstanceId is null', async () => {
+            getTaskFilterSpy.and.returnValue(of(mockTaskFilterResponseWithProcessInstanceIdNull));
+            component.processInstanceId = null;
+            component.filterProperties = [ 'appName', 'processInstanceId', 'sort', 'order'];
+            fixture.detectChanges();
+            component.ngOnChanges({ id: mockTaskFilterIdChange });
+            fixture.detectChanges();
+            await fixture.whenStable();
+            expandFilterPanel();
             expect(getProcessInstanceIdInputElement().value).toEqual('');
         });
 
-        it('should processInstanceId filter be empty string if id of the task filter is changed', () => {
+        it('should processInstanceId filter be empty string if processInstanceId is undefined', async () => {
+            getTaskFilterSpy.and.returnValue(of(mockTaskFilterResponseWithProcessInstanceIdNull));
+            component.processInstanceId = undefined;
             component.filterProperties = [ 'appName', 'processInstanceId', 'sort', 'order'];
             fixture.detectChanges();
-            component.ngOnChanges({ id: mockTaskFilterIdChange, taskFilter: mockTaskFilterProcessInstanceIdNotChanged });
+            component.ngOnChanges({ id: mockTaskFilterIdChange });
             fixture.detectChanges();
+            await fixture.whenStable();
             expandFilterPanel();
-            expect(getTaskFilterSpy).toHaveBeenCalled();
             expect(getProcessInstanceIdInputElement().value).toEqual('');
         });
+
+        it('should processInstanceId filter be set with the processInstanceId from response if processInstanceId input is null', async () => {
+            getTaskFilterSpy.and.returnValue(of(mockTaskFilterResponse));
+            component.processInstanceId = null;
+            component.filterProperties = [ 'appName', 'processInstanceId', 'sort', 'order'];
+            fixture.detectChanges();
+            component.ngOnChanges({ id: mockTaskFilterIdChange });
+            fixture.detectChanges();
+            await fixture.whenStable();
+            expandFilterPanel();
+            expect(getProcessInstanceIdInputElement().value).toEqual('fakeProcessInstanceIdFromResponse');
+        });
+
+        it('should processInstanceId filter be set with the processInstanceId from response if processInstanceId input is undefined', async () => {
+            getTaskFilterSpy.and.returnValue(of(mockTaskFilterResponse));
+            component.processInstanceId = undefined;
+            component.filterProperties = [ 'appName', 'processInstanceId', 'sort', 'order'];
+            fixture.detectChanges();
+            component.ngOnChanges({ id: mockTaskFilterIdChange });
+            fixture.detectChanges();
+            await fixture.whenStable();
+            expandFilterPanel();
+            expect(getProcessInstanceIdInputElement().value).toEqual('fakeProcessInstanceIdFromResponse');
+        });
+
 
     });
 

--- a/lib/process-services-cloud/src/lib/task/task-filters/components/edit-task-filters/edit-task-filter-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-filters/components/edit-task-filters/edit-task-filter-cloud.component.ts
@@ -192,7 +192,7 @@ export class EditTaskFilterCloudComponent extends BaseEditTaskFilterCloudCompone
                 label: 'ADF_CLOUD_EDIT_TASK_FILTER.LABEL.PROCESS_INSTANCE_ID',
                 type: 'text',
                 key: 'processInstanceId',
-                value: this.taskFilter.processInstanceId || ''
+                value: this.processInstanceId || this.taskFilter.processInstanceId || ''
             },
             {
                 label: 'ADF_CLOUD_EDIT_TASK_FILTER.LABEL.PROCESS_DEF_ID',

--- a/lib/process-services-cloud/src/lib/task/task-filters/mock/edit-task-filter-cloud.mock.ts
+++ b/lib/process-services-cloud/src/lib/task/task-filters/mock/edit-task-filter-cloud.mock.ts
@@ -29,27 +29,29 @@ export const mockAlfrescoApi: any = {
 
 export const mockTaskFilterIdChange = new SimpleChange(undefined, 'mock-task-filter-id', true);
 
-export const mockTaskFilterWithProcessInstanceId1: any = { id: 'fakeId-1', processInstanceId: 'fakeProcessInstance-1', appName: 'fakeAppName', sort: 'startDate', order: 'DESC' };
-export const mockTaskFilterWithProcessInstanceId2: any = { ...mockTaskFilterWithProcessInstanceId1, processInstanceId: 'fakeProcessInstance-2' };
-export const mockTaskFilterWithProcessInstanceIdNull: any = { ...mockTaskFilterWithProcessInstanceId1, processInstanceId: null };
+export const mockTaskFilterResponse = {
+    name: 'FakeInvolvedTasks',
+    icon: 'adjust',
+    id: 'mock-task-filter-id',
+    appName: 'mock-app-name',
+    processDefinitionId: 'process-def-id',
+    assignee: 'fake-involved',
+    order: 'ASC',
+    sort: 'id',
+    processInstanceId: 'fakeProcessInstanceIdFromResponse'
+};
 
-export const mockTaskFilterProcessInstanceIdChange = new SimpleChange(
-    mockTaskFilterWithProcessInstanceId1,
-    mockTaskFilterWithProcessInstanceId2,
-    true
-);
-
-export const mockTaskFilterProcessInstanceIdNotChanged = new SimpleChange(
-    mockTaskFilterWithProcessInstanceId1,
-    mockTaskFilterWithProcessInstanceId1,
-    false
-);
-
-export const mockTaskFilterProcessInstanceIdChangeToNull = new SimpleChange(
-    mockTaskFilterWithProcessInstanceId1,
-    mockTaskFilterWithProcessInstanceIdNull,
-    false
-);
+export const mockTaskFilterResponseWithProcessInstanceIdNull = {
+    name: 'FakeInvolvedTasks',
+    icon: 'adjust',
+    id: 'mock-task-filter-id',
+    appName: 'mock-app-name',
+    processDefinitionId: 'process-def-id',
+    assignee: 'fake-involved',
+    order: 'ASC',
+    sort: 'id',
+    processInstanceId: null
+};
 
 export const mockDefaultTaskFilter = {
     name: 'ADF_CLOUD_TASK_FILTERS.MY_TASKS',


### PR DESCRIPTION
…ntire taskFilter object

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/AAE-11992


**What is the new behaviour?**
Improvement of this previous PR https://github.com/Alfresco/alfresco-ng2-components/pull/8128 
Instead of passing the  whole `taskFilter` it's better to pass only the single `processInstanceId` property

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
