### PR TITLE
[AAE-11654] Fix default option being selectable when parent dropdown …

### DIFF
--- a/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.spec.ts
@@ -501,10 +501,7 @@ describe('DropdownCloudWidgetComponent', () => {
                 fixture.detectChanges();
                 await openSelect('child-dropdown-id');
 
-                const defaultOption: any = fixture.debugElement.query(By.css('[id="empty"]'));
-                expect(widget.field.options).toEqual([{ id: 'empty', name: 'Choose one...' }]);
-                expect(defaultOption.context.value).toBe(undefined);
-                expect(defaultOption.context.viewValue).toBe('Choose one...');
+                expect(widget.field.options).toEqual([]);
             });
 
             it('should fetch the options from a rest url for a linked dropdown', async () => {
@@ -631,10 +628,7 @@ describe('DropdownCloudWidgetComponent', () => {
                 fixture.detectChanges();
                 await openSelect('child-dropdown-id');
 
-                const defaultOption: any = fixture.debugElement.query(By.css('[id="empty"]'));
-                expect(widget.field.options).toEqual([{ id: 'empty', name: 'Choose one...' }]);
-                expect(defaultOption.context.value).toBe(undefined);
-                expect(defaultOption.context.viewValue).toBe('Choose one...');
+                expect(widget.field.options).toEqual([]);
             });
 
             describe('Manual - On parent value changes (chain)', () => {

--- a/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.ts
@@ -288,10 +288,6 @@ export class DropdownCloudWidgetComponent extends WidgetComponent implements OnI
                 }),
                 takeUntil(this.onDestroy$)
             );
-
-        // this.list$.subscribe(res => {
-        //     console.log(res);
-        // });
     }
 
     resetRestApiErrorMessage() {

--- a/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.ts
@@ -138,7 +138,7 @@ export class DropdownCloudWidgetComponent extends WidgetComponent implements OnI
             this.isValidRestType() ? this.persistFieldOptionsFromRestApi() : this.persistFieldOptionsFromManualList(value);
         } else if (this.isNoneValueSelected(value)) {
             this.resetRestApiErrorMessage();
-            this.addDefaultOption();
+            this.resetOptions();
             this.resetInvalidValue();
         } else {
             this.field.options = [];
@@ -196,8 +196,8 @@ export class DropdownCloudWidgetComponent extends WidgetComponent implements OnI
         return !!this.field.rule.entries.length;
     }
 
-    private addDefaultOption() {
-        this.field.options = [DEFAULT_OPTION];
+    private resetOptions() {
+        this.field.options = [];
         this.updateOptions();
     }
 
@@ -288,6 +288,10 @@ export class DropdownCloudWidgetComponent extends WidgetComponent implements OnI
                 }),
                 takeUntil(this.onDestroy$)
             );
+
+        // this.list$.subscribe(res => {
+        //     console.log(res);
+        // });
     }
 
     resetRestApiErrorMessage() {


### PR DESCRIPTION
…has no option selected

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
There is a "Choose one" left in child dropdown while no option is selected in parent
https://alfresco.atlassian.net/browse/AAE-11654


**What is the new behaviour?**
Child dropdown has no options when parent has no option selected


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
