### PR TITLE
Revert "[ACS-4051] Copy to clipboard button is now accessible through the keyboard enter earlier which was only accessible through mouse click"

### DIFF
--- a/lib/core/src/lib/clipboard/clipboard.directive.spec.ts
+++ b/lib/core/src/lib/clipboard/clipboard.directive.spec.ts
@@ -64,14 +64,6 @@ describe('ClipboardDirective', () => {
 
         expect(clipboardService.copyToClipboard).toHaveBeenCalled();
     });
-
-    it('should notify copy target value on mouse enter event', () => {
-        spyOn(clipboardService, 'copyToClipboard');
-        fixture.nativeElement.querySelector('input').value = 'some value';
-        window.dispatchEvent(new KeyboardEvent('keydown', {code: 'Enter', key: 'Enter'}));
-
-        expect(clipboardService.copyToClipboard).toHaveBeenCalled();
-    });
 });
 
 describe('CopyClipboardDirective', () => {
@@ -131,15 +123,6 @@ describe('CopyClipboardDirective', () => {
         fixture.detectChanges();
         spyOn(navigator.clipboard, 'writeText');
         spanHTMLElement.dispatchEvent(new Event('click'));
-        tick();
-        fixture.detectChanges();
-        expect(navigator.clipboard.writeText).toHaveBeenCalledWith('text to copy');
-    }));
-
-    it('should copy the content of element on mouse enter', fakeAsync(() => {
-        fixture.detectChanges();
-        spyOn(navigator.clipboard, 'writeText');
-        window.dispatchEvent(new KeyboardEvent('keydown', {code: 'Enter', key: 'Enter'}));
         tick();
         fixture.detectChanges();
         expect(navigator.clipboard.writeText).toHaveBeenCalledWith('text to copy');

--- a/lib/core/src/lib/clipboard/clipboard.directive.ts
+++ b/lib/core/src/lib/clipboard/clipboard.directive.ts
@@ -46,12 +46,6 @@ export class ClipboardDirective {
         event.stopPropagation();
         this.copyToClipboard();
     }
-    @HostListener('window:keydown.enter', ['$event'])
-    handleKeyDown(event: KeyboardEvent){
-        event.preventDefault();
-        event.stopPropagation();
-        this.copyToClipboard();
-    }
 
     @HostListener('mouseenter')
     showTooltip() {


### PR DESCRIPTION
Reverts Alfresco/alfresco-ng2-components#8119