### PR TITLE
[ACS-4051] Copy to clipboard button is now accessible through the keyboard enter earlier which was only accessible through mouse click

### DIFF
--- a/lib/core/src/lib/clipboard/clipboard.directive.spec.ts
+++ b/lib/core/src/lib/clipboard/clipboard.directive.spec.ts
@@ -64,6 +64,15 @@ describe('ClipboardDirective', () => {
 
         expect(clipboardService.copyToClipboard).toHaveBeenCalled();
     });
+
+    it('should notify copy target value on mouse enter event', () => {
+        spyOn(clipboardService, 'copyToClipboard');
+        fixture.nativeElement.querySelector('input').value = 'some value';
+        fixture.nativeElement.querySelector('button').dispatchEvent(new KeyboardEvent('keydown', {code: 'Enter', key: 'Enter'}));
+
+        expect(clipboardService.copyToClipboard).toHaveBeenCalled();
+    });
+
 });
 
 describe('CopyClipboardDirective', () => {
@@ -123,6 +132,16 @@ describe('CopyClipboardDirective', () => {
         fixture.detectChanges();
         spyOn(navigator.clipboard, 'writeText');
         spanHTMLElement.dispatchEvent(new Event('click'));
+        tick();
+        fixture.detectChanges();
+        expect(navigator.clipboard.writeText).toHaveBeenCalledWith('text to copy');
+    }));
+
+    it('should copy the content of element on mouse enter', fakeAsync(() => {
+        const spanHTMLElement = element.querySelector<HTMLInputElement>('span');
+        fixture.detectChanges();
+        spyOn(navigator.clipboard, 'writeText');
+        spanHTMLElement.dispatchEvent(new KeyboardEvent('keydown', {code: 'Enter', key: 'Enter'}));
         tick();
         fixture.detectChanges();
         expect(navigator.clipboard.writeText).toHaveBeenCalledWith('text to copy');

--- a/lib/core/src/lib/clipboard/clipboard.directive.spec.ts
+++ b/lib/core/src/lib/clipboard/clipboard.directive.spec.ts
@@ -65,7 +65,7 @@ describe('ClipboardDirective', () => {
         expect(clipboardService.copyToClipboard).toHaveBeenCalled();
     });
 
-    it('should notify copy target value on mouse enter event', () => {
+    it('should notify copy target value on keydown event', () => {
         spyOn(clipboardService, 'copyToClipboard');
         fixture.nativeElement.querySelector('input').value = 'some value';
         fixture.nativeElement.querySelector('button').dispatchEvent(new KeyboardEvent('keydown', {code: 'Enter', key: 'Enter'}));
@@ -137,7 +137,7 @@ describe('CopyClipboardDirective', () => {
         expect(navigator.clipboard.writeText).toHaveBeenCalledWith('text to copy');
     }));
 
-    it('should copy the content of element on mouse enter', fakeAsync(() => {
+    it('should copy the content of element on keydown event', fakeAsync(() => {
         const spanHTMLElement = element.querySelector<HTMLInputElement>('span');
         fixture.detectChanges();
         spyOn(navigator.clipboard, 'writeText');

--- a/lib/core/src/lib/clipboard/clipboard.directive.ts
+++ b/lib/core/src/lib/clipboard/clipboard.directive.ts
@@ -40,20 +40,6 @@ export class ClipboardDirective {
                 public viewContainerRef: ViewContainerRef,
                 private resolver: ComponentFactoryResolver) {}
 
-    @HostListener('click', ['$event'])
-    handleClickEvent(event: MouseEvent) {
-        event.preventDefault();
-        event.stopPropagation();
-        this.copyToClipboard();
-    }
-
-    @HostListener('keydown.enter', ['$event'])
-    handleKeyDown(event: KeyboardEvent){
-        event.preventDefault();
-        event.stopPropagation();
-        this.copyToClipboard();
-    }
-
     @HostListener('mouseenter')
     showTooltip() {
         if (this.placeholder) {
@@ -68,7 +54,12 @@ export class ClipboardDirective {
         this.viewContainerRef.remove();
     }
 
-    private copyToClipboard() {
+    @HostListener('click', ['$event'])
+    @HostListener('keydown.enter', ['$event'])
+    copyToClipboard(event: MouseEvent | KeyboardEvent) {
+        event.preventDefault();
+        event.stopPropagation();
+
         const isValidTarget = this.clipboardService.isTargetValid(this.target);
 
         if (isValidTarget) {

--- a/lib/core/src/lib/clipboard/clipboard.directive.ts
+++ b/lib/core/src/lib/clipboard/clipboard.directive.ts
@@ -47,6 +47,13 @@ export class ClipboardDirective {
         this.copyToClipboard();
     }
 
+    @HostListener('keydown.enter', ['$event'])
+    handleKeyDown(event: KeyboardEvent){
+        event.preventDefault();
+        event.stopPropagation();
+        this.copyToClipboard();
+    }
+
     @HostListener('mouseenter')
     showTooltip() {
         if (this.placeholder) {


### PR DESCRIPTION
… earlier which was only accessible through mouse click

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Copy to clipboard button was not accessible through the keyboard enter button


**What is the new behaviour?**
Copy to clipboard button is now accessible through the keyboard enter earlier which was only accessible through mouse click


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
