### PR TITLE
[ACS-4260] Added aria-hidden=false to user informational icons on file uploading list row

### DIFF
--- a/lib/content-services/src/lib/upload/components/file-uploading-list-row.component.html
+++ b/lib/content-services/src/lib/upload/components/file-uploading-list-row.component.html
@@ -37,6 +37,7 @@
         </span>
 
         <mat-icon *ngIf="toggleIcon.isToggled"
+            aria-hidden="false"
             class="adf-file-uploading-row__action adf-file-uploading-row__action--cancel">
             clear
         </mat-icon>
@@ -51,6 +52,7 @@
         title="{{ 'ADF_FILE_UPLOAD.BUTTON.UPLOAD_SUCCESSFUL' | translate }}">
 
         <mat-icon
+            aria-hidden="false"
             class="adf-file-uploading-row__status adf-file-uploading-row__status--done">
             check_circle
         </mat-icon>
@@ -64,6 +66,7 @@
         >
         <mat-icon
             mat-list-icon
+            aria-hidden="false"
             class="adf-file-uploading-row__status--done">
             check_circle
         </mat-icon>
@@ -81,12 +84,14 @@
         [attr.aria-label]="'ADF_FILE_UPLOAD.ARIA-LABEL.STOP_FILE' | translate: { file: file.name }">
         <mat-icon
             *ngIf="!toggleIconCancel.isToggled"
+            aria-hidden="false"
             class="adf-file-uploading-row__status adf-file-uploading-row__status--pending">
             schedule
         </mat-icon>
 
         <mat-icon
             *ngIf="toggleIconCancel.isToggled"
+            aria-hidden="false"
             class="adf-file-uploading-row__action adf-file-uploading-row__action--remove">
             remove_circle
         </mat-icon>
@@ -98,6 +103,7 @@
         *ngIf="isUploadError()"
         class="adf-file-uploading-row__block adf-file-uploading-row__status--error">
         <mat-icon mat-list-icon
+            aria-hidden="false"
             [attr.aria-label]="'ADF_FILE_UPLOAD.ARIA-LABEL.UPLOAD_FILE_ERROR' | translate: { error: file.errorCode | adfFileUploadError }"
             [matTooltip]="file.errorCode | adfFileUploadError">
             report_problem


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Icons depicting upload status had aria-hidden flag set to true, hiding them from screen readers.


**What is the new behaviour?**
Set aria-hidden=false, so that screen readers can see the icons, and relay information appropriately


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
