### PR TITLE
[ACS-4242] Visible label/form field are not associated

### DIFF
--- a/lib/core/src/lib/viewer/components/pdf-viewer.component.html
+++ b/lib/core/src/lib/viewer/components/pdf-viewer.component.html
@@ -71,8 +71,9 @@
         </button>
 
         <div class="adf-pdf-viewer__toolbar-page-selector">
-            <span>{{ 'ADF_VIEWER.PAGE_LABEL.SHOWING' | translate }}</span>
+            <label for="page-selector">{{ 'ADF_VIEWER.PAGE_LABEL.SHOWING' | translate }}</label>
             <input #page
+                   id="page-selector"
                    type="text"
                    data-automation-id="adf-page-selector"
                    pattern="-?[0-9]*(\.[0-9]+)?"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Clicking on showing which is located in pagination of toolbar of pdf, the visible label are not associated.


**What is the new behaviour?**
The visible label are associated.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
