### PR TITLE
[ADF-5514] Fix red dot still present after filter being cleared

### DIFF
--- a/lib/content-services/src/lib/search/components/search-filter-container/search-filter-container.component.spec.ts
+++ b/lib/content-services/src/lib/search/components/search-filter-container/search-filter-container.component.spec.ts
@@ -74,6 +74,7 @@ describe('SearchFilterContainerComponent', () => {
     });
 
     afterEach(() => {
+        queryBuilder.removeActiveFilter(mockCategory.columnKey);
         fixture.destroy();
     });
 

--- a/lib/content-services/src/lib/search/components/search-filter-container/search-filter-container.component.spec.ts
+++ b/lib/content-services/src/lib/search/components/search-filter-container/search-filter-container.component.spec.ts
@@ -150,6 +150,32 @@ describe('SearchFilterContainerComponent', () => {
         expect(eventRaised).toBe(true);
     });
 
+    it('should hide the red dot after the filter is cleared', async () => {
+        const badge: HTMLElement = fixture.nativeElement.querySelector(`[data-automation-id="filter-menu-button"] .mat-badge-content`);
+        expect(window.getComputedStyle(badge).display).toBe('none');
+
+        const menuButton: HTMLButtonElement = fixture.nativeElement.querySelector('[data-automation-id="filter-menu-button"]');
+        menuButton.click();
+        fixture.detectChanges();
+        await fixture.whenStable();
+        component.widgetContainer.componentRef.instance.value = 'searchText';
+        const widgetContainer = fixture.debugElement.query(By.css('adf-search-widget-container'));
+        widgetContainer.triggerEventHandler('keypress', {key: 'Enter'});
+        fixture.detectChanges();
+        await fixture.whenStable();
+        expect(window.getComputedStyle(badge).display).not.toBe('none');
+
+        menuButton.click();
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const fakeEvent = jasmine.createSpyObj('event', ['stopPropagation']);
+        const clearButton = fixture.debugElement.query(By.css('#clear-filter-button'));
+        clearButton.triggerEventHandler('click', fakeEvent);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        expect(window.getComputedStyle(badge).display).toBe('none');
+    });
+
     describe('Accessibility', () => {
 
         it('should set up a focus trap on the filter when the menu is opened', async () => {

--- a/lib/content-services/src/lib/search/components/search-filter-container/search-filter-container.component.ts
+++ b/lib/content-services/src/lib/search/components/search-filter-container/search-filter-container.component.ts
@@ -35,6 +35,7 @@ import { SearchCategory } from '../../models/search-category.interface';
 import { SEARCH_QUERY_SERVICE_TOKEN } from '../../search-query-service.token';
 import { Subject } from 'rxjs';
 import { MatMenuTrigger } from '@angular/material/menu';
+import { FilterSearch } from '../../models/filter-search.interface';
 
 @Component({
     selector: 'adf-search-filter-container',
@@ -119,7 +120,7 @@ export class SearchFilterContainerComponent implements OnInit, OnDestroy {
     }
 
     isActive(): boolean {
-        return this.widgetContainer && this.widgetContainer.componentRef && this.widgetContainer.componentRef.instance.isActive;
+        return this.searchFilterQueryBuilder.getActiveFilters().findIndex((f: FilterSearch) => f.key === this.category.columnKey) > -1;
     }
 
     onMenuOpen() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://alfresco.atlassian.net/browse/ADF-5514

**What is the new behaviour?**

The active state of the filter is calculated in a different way fixing the issue of it not changing on clear.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
