### PR TITLE
[ACS-4263] Add 'aria-pressed' attribute for reset button on content viewer page

### DIFF
--- a/lib/core/src/lib/viewer/components/pdf-viewer.component.html
+++ b/lib/core/src/lib/viewer/components/pdf-viewer.component.html
@@ -106,6 +106,7 @@
 
         <button
             id="viewer-scale-page-button"
+            role="button" aria-pressed="true"
             title="{{ 'ADF_VIEWER.ARIA.FIT_PAGE' | translate }}"
             attr.aria-label="{{ 'ADF_VIEWER.ARIA.FIT_PAGE' | translate }}"
             mat-icon-button


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ACS-4263


**What is the new behaviour?**
Now screen reader reads the specific button as pressed.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
