### PR TITLE
[ACS-4322] content overlap issue fixed at 400% zoom and close button which was earlier not visible at 400% zoom is visible now.

### DIFF
--- a/lib/content-services/src/lib/content-node-share/content-node-share.dialog.scss
+++ b/lib/content-services/src/lib/content-node-share/content-node-share.dialog.scss
@@ -68,14 +68,13 @@
     }
 
     @media screen and (max-width: 380px) {
+        .mat-dialog-container {
+            padding: 0 15px;
+        }
 
         .mat-dialog-actions {
             margin-bottom: 0px;
             padding: 2px 0;
-        }
-
-        .mat-dialog-content {
-            max-height: 52vh;
         }
 
         .mat-form-field-suffix {

--- a/lib/content-services/src/lib/content-node-share/content-node-share.dialog.scss
+++ b/lib/content-services/src/lib/content-node-share/content-node-share.dialog.scss
@@ -66,4 +66,20 @@
     .mat-form-field-flex {
         align-items: center;
     }
+
+    @media screen and (max-width: 380px) {
+
+        .mat-dialog-actions {
+            margin-bottom: 0px;
+            padding: 2px 0;
+        }
+
+        .mat-dialog-content {
+            max-height: 52vh;
+        }
+
+        .mat-form-field-suffix {
+            padding-left: 8px;
+        }
+    }
 }


### PR DESCRIPTION
…arlier not visible at 400% zoom fixed

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
 issue of overlapping at 400% zoom and close button not visible at 400% zoom.


**What is the new behaviour?**
I have corrected the issue of overlapping by adding gap between the copy icon and link to share which was earlier not present at 400% zoom and close button which was earlier not visible is visible now at 400% zoom. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
