### PR TITLE
[ACS-4326] Content was overlapping with other contents and some elements were missing when we zoom at 400% or 320px equivalent which is fixed

### DIFF
--- a/lib/content-services/src/lib/upload/components/file-uploading-dialog.component.scss
+++ b/lib/content-services/src/lib/upload/components/file-uploading-dialog.component.scss
@@ -83,7 +83,6 @@
 [adfUploadDialogRight] .adf-upload-dialog { right: 25px; }
 
 @media screen and (min-width: 380px) and (max-width: 600px) {
-
     .adf-upload-dialog {
         width: 60%;
     }
@@ -94,7 +93,6 @@
 }
 
 @media screen and (max-width: 380px) {
-
     .adf-upload-dialog {
         width: 85%;
     }

--- a/lib/content-services/src/lib/upload/components/file-uploading-dialog.component.scss
+++ b/lib/content-services/src/lib/upload/components/file-uploading-dialog.component.scss
@@ -81,3 +81,25 @@
 
 [adfUploadDialogLeft] .adf-upload-dialog { left: 25px; }
 [adfUploadDialogRight] .adf-upload-dialog { right: 25px; }
+
+@media screen and (min-width: 380px) and (max-width: 600px) {
+
+    .adf-upload-dialog {
+        width: 60%;
+    }
+
+    .adf-file-uploading-row .adf-file-uploading-row__group {
+        min-width: 0px;
+    }
+}
+
+@media screen and (max-width: 380px) {
+
+    .adf-upload-dialog {
+        width: 85%;
+    }
+
+    .adf-file-uploading-row .adf-file-uploading-row__group {
+        min-width: 0px;
+    }
+}

--- a/lib/content-services/src/lib/upload/components/file-uploading-dialog.component.scss
+++ b/lib/content-services/src/lib/upload/components/file-uploading-dialog.component.scss
@@ -88,7 +88,7 @@
     }
 
     .adf-file-uploading-row .adf-file-uploading-row__group {
-        min-width: 0px;
+        min-width: 0;
     }
 }
 
@@ -98,6 +98,6 @@
     }
 
     .adf-file-uploading-row .adf-file-uploading-row__group {
-        min-width: 0px;
+        min-width: 0;
     }
 }

--- a/lib/content-services/src/lib/upload/components/file-uploading-dialog.component.scss
+++ b/lib/content-services/src/lib/upload/components/file-uploading-dialog.component.scss
@@ -82,7 +82,7 @@
 [adfUploadDialogLeft] .adf-upload-dialog { left: 25px; }
 [adfUploadDialogRight] .adf-upload-dialog { right: 25px; }
 
-@media screen and (min-width: 380px) and (max-width: 600px) {
+@media screen and (min-width: 380px) and (max-width: 768px) {
     .adf-upload-dialog {
         width: 60%;
     }


### PR DESCRIPTION
… 400% or 320px equivalent which is fixed now

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Content was overlapping with other contents and some elements were missing when we zoom at 400% or 320px equivalent.


**What is the new behaviour?**
Expand/Collapse Button, Uploaded 1/1" text, "Screenshot Name" Text were earlier missing when we zoom at 400% or 320px equivalent which is now fixed and we have all the elements at 400% zoom.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
