### PR TITLE
[ACS-4300] Accessible name does not contain the visible label text, so added title in arrow_drop_down

### DIFF
--- a/lib/core/src/lib/pagination/pagination.component.html
+++ b/lib/core/src/lib/pagination/pagination.component.html
@@ -17,6 +17,7 @@
         <button
             mat-icon-button
             [attr.aria-label]="'CORE.PAGINATION.ARIA.ITEMS_PER_PAGE' | translate"
+            [attr.title]="'CORE.PAGINATION.ARIA.ITEMS_PER_PAGE' | translate"
             [matMenuTriggerFor]="pageSizeMenu">
             <mat-icon>arrow_drop_down</mat-icon>
         </button>


### PR DESCRIPTION
…le in arrow_drop_down

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Accessible name does not contain the visible label text,

**What is the new behaviour?**

Accessible name does not contain the visible label text, so added title in arrow_drop_down

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
