### PR TITLE
[ACS-4254] Delete permissions button is now keyboard interact-able

### DIFF
--- a/lib/content-services/src/lib/permission-manager/components/permission-container/permission-container.component.html
+++ b/lib/content-services/src/lib/permission-manager/components/permission-container/permission-container.component.html
@@ -61,6 +61,7 @@
                 <button mat-icon-button
                         [disabled]="entry.row.obj.readonly"
                         (click)="removePermission($event, entry.row.obj)"
+                        (keydown.enter)="removePermission($event, entry.row.obj)"
                         [attr.data-automation-id]="'adf-delete-permission-button-' + entry.row.obj.authorityId"
                         [attr.aria-label]="'PERMISSION_MANAGER.ACTION.DELETE' | translate">
                     <mat-icon>delete_outline</mat-icon>

--- a/lib/content-services/src/lib/permission-manager/components/permission-container/permission-container.component.ts
+++ b/lib/content-services/src/lib/permission-manager/components/permission-container/permission-container.component.ts
@@ -75,7 +75,7 @@ export class PermissionContainerComponent implements OnChanges {
         this.updateAll.emit(role);
     }
 
-    removePermission(event: MouseEvent, permissionRow: PermissionDisplayModel) {
+    removePermission(event: Event, permissionRow: PermissionDisplayModel) {
         event.stopPropagation();
         this.delete.emit(permissionRow);
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
The button for remove permissions for a folder for a particular user was not working when enter key was pressed (spacebar was working fine)


**What is the new behaviour?**
The button can now be interacted with using the enter key


**Does this PR introduce a breaking change?** (check one with "x")

> - [x] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
