### PR TITLE
[ACS-4252] Resolved accessibility issues around inherited permissions popover

### DIFF
--- a/lib/content-services/src/lib/permission-manager/components/permission-list/permission-list.component.html
+++ b/lib/content-services/src/lib/permission-manager/components/permission-list/permission-list.component.html
@@ -44,7 +44,6 @@
                 data-automation-id="permission-info-button"
                 [adf-pop-over]="inheritedPermission"
                 [target]="target"
-                [autofocusedElementSelector]="'.adf-sortable'"
                 #popOver="adfPopOver"
                 *ngIf="model.node.permissions.isInheritanceEnabled">
                 {{ (popOver.open ? 'PERMISSION_MANAGER.LABELS.HIDE' : 'PERMISSION_MANAGER.LABELS.SHOW') | translate }}

--- a/lib/content-services/src/lib/permission-manager/components/pop-over.directive.spec.ts
+++ b/lib/content-services/src/lib/permission-manager/components/pop-over.directive.spec.ts
@@ -23,7 +23,7 @@ import { OverlayModule } from '@angular/cdk/overlay';
 
 @Component({
     template: `
-        <div [adf-pop-over]="popOver" [autofocusedElementSelector]="'#test'" [target]="target" #target tabindex="0">
+        <div [adf-pop-over]="popOver" [autofocusedElementSelector]="'#test'" [target]="target" #target tabindex="0" [panelClass]="'adf-popover-test'">
         </div>
         <ng-template #popOver>
             <div id="test" tabindex="0"></div>
@@ -79,5 +79,29 @@ describe('PopOverDirective', () => {
             key: 'Escape'
         }));
         expect(popOverTrigger).not.toEqual(document.activeElement);
+    });
+
+    it('should open pop over on enter key press if pop over is not open', () => {
+        const popOverTrigger = fixture.debugElement.query(By.directive(PopOverDirective)).nativeElement;
+        fixture.detectChanges();
+        popOverTrigger.dispatchEvent(new KeyboardEvent('keyup', {
+            key: 'Enter'
+        }));
+        fixture.detectChanges();
+        const popOverPanel = document.querySelector('.adf-popover-test');
+        expect(popOverPanel).toBeDefined();
+    });
+
+    it('should close pop over on enter key press if pop over is open', () => {
+        const popOverTrigger = fixture.debugElement.query(By.directive(PopOverDirective)).nativeElement;
+        fixture.detectChanges();
+        popOverTrigger.click();
+        fixture.detectChanges();
+        popOverTrigger.dispatchEvent(new KeyboardEvent('keyup', {
+            key: 'Enter'
+        }));
+        fixture.detectChanges();
+        const popOverPanel = document.querySelector('.adf-popover-test');
+        expect(popOverPanel).toBeNull();
     });
 });

--- a/lib/content-services/src/lib/permission-manager/components/pop-over.directive.ts
+++ b/lib/content-services/src/lib/permission-manager/components/pop-over.directive.ts
@@ -108,7 +108,6 @@ export class PopOverDirective implements OnInit, OnDestroy, AfterViewInit {
         if (!this.overlayRef.hasAttached()) {
             this.attachOverlay();
         } else {
-            console.log('inside detach condition')
             this.detachOverlay();
         }
     }


### PR DESCRIPTION
Inherited permissions popover can now be opened and closed by enter key press. Additionally, added configurableFocusTrap to popover when it is opened and resolved focus jumping issue.

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

1. The pop-over for inherited permissions could only be opened via keyboard, not closed. 
2. Once the popover was opened, focus was automatically getting set to the column header.
3. After opening the pop-over, focus was getting lost behind background elements, before eventually coming to the popover.


**What is the new behaviour?**

1. Popover can now be opened and closed via enter key press
2. Focus is retained on the open/close button when the popup is opened/closed.
3. Once the popover is opened, focus is retained on the popover itself.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
