### PR TITLE
Revert "[ACS-4051] Copy to clipboard button is now accessible through the keyboard enter earlier which was only accessible through mouse click"

### DIFF
--- a/lib/core/src/lib/clipboard/clipboard.directive.spec.ts
+++ b/lib/core/src/lib/clipboard/clipboard.directive.spec.ts
@@ -64,15 +64,6 @@ describe('ClipboardDirective', () => {
 
         expect(clipboardService.copyToClipboard).toHaveBeenCalled();
     });
-
-    it('should notify copy target value on keydown event', () => {
-        spyOn(clipboardService, 'copyToClipboard');
-        fixture.nativeElement.querySelector('input').value = 'some value';
-        fixture.nativeElement.querySelector('button').dispatchEvent(new KeyboardEvent('keydown', {code: 'Enter', key: 'Enter'}));
-
-        expect(clipboardService.copyToClipboard).toHaveBeenCalled();
-    });
-
 });
 
 describe('CopyClipboardDirective', () => {
@@ -132,16 +123,6 @@ describe('CopyClipboardDirective', () => {
         fixture.detectChanges();
         spyOn(navigator.clipboard, 'writeText');
         spanHTMLElement.dispatchEvent(new Event('click'));
-        tick();
-        fixture.detectChanges();
-        expect(navigator.clipboard.writeText).toHaveBeenCalledWith('text to copy');
-    }));
-
-    it('should copy the content of element on keydown event', fakeAsync(() => {
-        const spanHTMLElement = element.querySelector<HTMLInputElement>('span');
-        fixture.detectChanges();
-        spyOn(navigator.clipboard, 'writeText');
-        spanHTMLElement.dispatchEvent(new KeyboardEvent('keydown', {code: 'Enter', key: 'Enter'}));
         tick();
         fixture.detectChanges();
         expect(navigator.clipboard.writeText).toHaveBeenCalledWith('text to copy');

--- a/lib/core/src/lib/clipboard/clipboard.directive.ts
+++ b/lib/core/src/lib/clipboard/clipboard.directive.ts
@@ -40,6 +40,13 @@ export class ClipboardDirective {
                 public viewContainerRef: ViewContainerRef,
                 private resolver: ComponentFactoryResolver) {}
 
+    @HostListener('click', ['$event'])
+    handleClickEvent(event: MouseEvent) {
+        event.preventDefault();
+        event.stopPropagation();
+        this.copyToClipboard();
+    }
+
     @HostListener('mouseenter')
     showTooltip() {
         if (this.placeholder) {
@@ -54,12 +61,7 @@ export class ClipboardDirective {
         this.viewContainerRef.remove();
     }
 
-    @HostListener('click', ['$event'])
-    @HostListener('keydown.enter', ['$event'])
-    copyToClipboard(event: MouseEvent | KeyboardEvent) {
-        event.preventDefault();
-        event.stopPropagation();
-
+    private copyToClipboard() {
         const isValidTarget = this.clipboardService.isTargetValid(this.target);
 
         if (isValidTarget) {


### PR DESCRIPTION
Reverts Alfresco/alfresco-ng2-components#8165