### PR TITLE
[ACS-4277] Changed whitespace to normal in order to make longer notifications messages visible

### DIFF
--- a/lib/core/src/lib/notifications/components/notification-history.component.scss
+++ b/lib/core/src/lib/notifications/components/notification-history.component.scss
@@ -69,3 +69,7 @@
         padding: 0;
     }
 }
+
+.mat-list-base .mat-list-item .mat-line {
+    white-space: normal;
+}

--- a/lib/core/src/lib/notifications/components/notification-history.component.scss
+++ b/lib/core/src/lib/notifications/components/notification-history.component.scss
@@ -70,6 +70,7 @@
     }
 }
 
-.mat-list-base .mat-list-item .mat-line {
+.mat-list-base .mat-list-item.adf-notification-history-menu-no-message .mat-line,
+.mat-list-base .mat-list-item .adf-notification-history-menu-message.mat-line {
     white-space: normal;
 }


### PR DESCRIPTION
…essage visible.

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Notification messages get truncated.


**What is the new behaviour?**
We don't want to limit the visibility of texts in order to make it convenient for accessibility reasons. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
