### PR TITLE
[AAE-12558] Fix load content-services translation resources

### DIFF
--- a/e2e/protractor.excludes.json
+++ b/e2e/protractor.excludes.json
@@ -7,5 +7,7 @@
   "C260377": "https://alfresco.atlassian.net/browse/ACS-4467",
   "C260375": "https://alfresco.atlassian.net/browse/ACS-4467",
   "C286290": "https://alfresco.atlassian.net/browse/ACS-4467",
-  "C286472": "https://alfresco.atlassian.net/browse/ACS-4467"
+  "C286472": "https://alfresco.atlassian.net/browse/ACS-4467",
+  "C260387": "https://alfresco.atlassian.net/browse/ACS-4595",
+  "C216430": "https://alfresco.atlassian.net/browse/ACS-4595"
 }

--- a/e2e/protractor.excludes.json
+++ b/e2e/protractor.excludes.json
@@ -7,7 +7,5 @@
   "C260377": "https://alfresco.atlassian.net/browse/ACS-4467",
   "C260375": "https://alfresco.atlassian.net/browse/ACS-4467",
   "C286290": "https://alfresco.atlassian.net/browse/ACS-4467",
-  "C286472": "https://alfresco.atlassian.net/browse/ACS-4467",
-  "C260387": "https://alfresco.atlassian.net/browse/ACS-4595",
-  "C216430": "https://alfresco.atlassian.net/browse/ACS-4595"
+  "C286472": "https://alfresco.atlassian.net/browse/ACS-4467"
 }

--- a/lib/process-services-cloud/src/lib/form/form-cloud.module.ts
+++ b/lib/process-services-cloud/src/lib/form/form-cloud.module.ts
@@ -24,7 +24,7 @@ import { MaterialModule } from '../material.module';
 import { FormCloudComponent } from './components/form-cloud.component';
 import { FormDefinitionSelectorCloudComponent } from './components/form-definition-selector-cloud.component';
 import { FormCustomOutcomesComponent } from './components/form-cloud-custom-outcomes.component';
-import { ContentMetadataModule, ContentModule, ContentNodeSelectorModule, UploadModule } from '@alfresco/adf-content-services';
+import { AlfrescoViewerModule, ContentMetadataModule, ContentNodeSelectorModule, UploadModule } from '@alfresco/adf-content-services';
 
 import { DateCloudWidgetComponent } from './components/widgets/date/date-cloud.widget';
 import { DropdownCloudWidgetComponent } from './components/widgets/dropdown/dropdown-cloud.widget';
@@ -54,7 +54,7 @@ import { FileViewerWidgetComponent } from './components/widgets/file-viewer/file
         GroupCloudModule,
         ContentMetadataModule,
         UploadModule,
-        ContentModule
+        AlfrescoViewerModule
     ],
     declarations: [
         FormCloudComponent,
@@ -84,7 +84,6 @@ import { FileViewerWidgetComponent } from './components/widgets/file-viewer/file
         PeopleCloudWidgetComponent,
         GroupCloudWidgetComponent,
         PropertiesViewerWidgetComponent,
-        ContentModule,
         FileViewerWidgetComponent
     ]
 })

--- a/lib/process-services/src/lib/form/form.module.ts
+++ b/lib/process-services/src/lib/form/form.module.ts
@@ -32,13 +32,13 @@ import { TypeaheadWidgetComponent } from './widgets/typeahead/typeahead.widget';
 import { DropdownWidgetComponent } from './widgets/dropdown/dropdown.widget';
 import { DynamicTableModule } from './widgets/dynamic-table/dynamic-table.module';
 import { FileViewerWidgetComponent } from './widgets/file-viewer/file-viewer.widget';
-import { ContentModule } from '@alfresco/adf-content-services';
+import { AlfrescoViewerModule } from '@alfresco/adf-content-services';
 
 @NgModule({
     imports: [
         DynamicTableModule,
         CoreModule,
-        ContentModule,
+        AlfrescoViewerModule,
         MaterialModule
     ],
     declarations: [


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/AAE-12558


**What is the new behaviour?**
Removed ContentModule import from `FormCloudModule` and `FormModule`, import only AlfrescoViewerModule to allow the usage of the AlfrescoViewerComponent into the file-viewer.widget


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
