### PR TITLE
[dependabot issue] Use one bucket variable

### DIFF
--- a/.github/actions/e2e/action.yml
+++ b/.github/actions/e2e/action.yml
@@ -60,9 +60,9 @@ runs:
       run: |
         set -u;
         mkdir -p "${SMART_RUNNER_PATH}"
-        if [[ $(aws s3 ls "${S3_BUILD_BUCKET}/adf/${REMOTE_PATH}" > /dev/null; echo $?) -eq 0 ]]; then
+        if [[ $(aws s3 ls "s3://${S3_BUILD_BUCKET_SHORT_NAME}/adf/${REMOTE_PATH}" > /dev/null; echo $?) -eq 0 ]]; then
           echo "downloading test files"
-          aws s3 cp "${S3_BUILD_BUCKET}/adf/${REMOTE_PATH}" .;
+          aws s3 cp "s3://${S3_BUILD_BUCKET_SHORT_NAME}/adf/${REMOTE_PATH}" .;
           tar xzf ${{ inputs.e2e-tar-name }};
         else
           echo "nothing to download";
@@ -161,7 +161,7 @@ runs:
         name: e2e-artifact-output
         path: /home/runner/work/alfresco-ng2-components/alfresco-ng2-components/e2e-output-*
 
-    - name: upload smartrunner tests results on s3 to cache tests
+    - name: upload smart-runner tests results on s3 to cache tests
       shell: bash
       if: always()
       env:
@@ -169,4 +169,4 @@ runs:
       # description: always upload newer results
       run: |
         tar czf "${{ inputs.e2e-tar-name }}" "${SMART_RUNNER_PATH}"
-        aws s3 cp "${{ inputs.e2e-tar-name }}" "${S3_BUILD_BUCKET}/adf/$REMOTE_PATH"
+        aws s3 cp "${{ inputs.e2e-tar-name }}" "s3://${S3_BUILD_BUCKET_SHORT_NAME}/adf/${REMOTE_PATH}"

--- a/.github/actions/upload-cache-and-artifacts/action.yml
+++ b/.github/actions/upload-cache-and-artifacts/action.yml
@@ -7,13 +7,13 @@ runs:
     - name: tar and upload artifacts
       shell: bash
       env:
-        REMOTE_PATH: "alfresco-ng2-components/build-cache/${{ github.run_id }}"      
+        REMOTE_PATH: "alfresco-ng2-components/build-cache/${{ github.run_id }}"
       run: |
         packages=( dist nxcache node_modules )
         for i in "${packages[@]}"; do
           time tar czf $i.tar.gz $i
           du -h $i.tar.gz
-          time aws s3 cp --no-progress $i.tar.gz s3://${S3_BUILD_BUCKET_SHORT_NAME}/${REMOTE_PATH}/$i.tar.gz
+          time aws s3 cp --no-progress $i.tar.gz "s3://${S3_BUILD_BUCKET_SHORT_NAME}/${REMOTE_PATH}/$i.tar.gz"
         done
 
 

--- a/.github/workflows/git-tag.yml
+++ b/.github/workflows/git-tag.yml
@@ -52,7 +52,6 @@ env:
   HR_USER_PASSWORD: ${{ secrets.HR_USER_PASSWORD }}
   SMART_RUNNER_PATH: ".protractor-smartrunner"
   S3_DBP_PATH:  ${{ secrets.S3_DBP_PATH }}
-  S3_BUILD_BUCKET: ${{ secrets.S3_BUILD_BUCKET }}
   S3_BUILD_BUCKET_SHORT_NAME: ${{ secrets.S3_BUILD_BUCKET_SHORT_NAME }}
   NODE_OPTIONS: "--max-old-space-size=5120"
   DOCKER_REPOSITORY_DOMAIN: ${{ secrets.DOCKER_REPOSITORY_DOMAIN }}
@@ -84,8 +83,8 @@ jobs:
         uses: actions/checkout@v3
       - id: set-dryrun
         uses: ./.github/actions/enable-dryrun
-        with: 
-          dry-run-flag: ${{ inputs.dry-run-release }}    
+        with:
+          dry-run-flag: ${{ inputs.dry-run-release }}
       - name: install NPM
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -60,7 +60,6 @@ env:
   HR_USER_PASSWORD: ${{ secrets.HR_USER_PASSWORD }}
   SMART_RUNNER_PATH: ".protractor-smartrunner"
   S3_DBP_PATH:  ${{ secrets.S3_DBP_PATH }}
-  S3_BUILD_BUCKET: ${{ secrets.S3_BUILD_BUCKET }}
   S3_BUILD_BUCKET_SHORT_NAME: ${{ secrets.S3_BUILD_BUCKET_SHORT_NAME }}
   NODE_OPTIONS: "--max-old-space-size=5120"
   DOCKER_REPOSITORY_DOMAIN: ${{ secrets.DOCKER_REPOSITORY_DOMAIN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,6 @@ env:
   HR_USER_PASSWORD: ${{ secrets.HR_USER_PASSWORD }}
   SMART_RUNNER_PATH: ".protractor-smartrunner"
   S3_DBP_PATH:  ${{ secrets.S3_DBP_PATH }}
-  S3_BUILD_BUCKET: ${{ secrets.S3_BUILD_BUCKET }}
   S3_BUILD_BUCKET_SHORT_NAME: ${{ secrets.S3_BUILD_BUCKET_SHORT_NAME }}
   NODE_OPTIONS: "--max-old-space-size=5120"
   DOCKER_REPOSITORY_DOMAIN: ${{ secrets.DOCKER_REPOSITORY_DOMAIN }}


### PR DESCRIPTION
Can be miss configured with different buckets
We need to maintain two variables:
They seems to be used in different ways because one contain s3:// the other not

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
use one bucket variable


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
