### PR TITLE
[ACS-4270] [ACS-4301] Content or functionality was lost due to overlapping content when the page is adjusted to an equivalent width of 320px or 400% zoom 

### DIFF
--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.scss
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.scss
@@ -783,3 +783,9 @@ $data-table-cell-min-width-file-size: $data-table-cell-min-width !default;
         }
     }
 }
+
+@media screen and (max-width: 380px) {
+    .adf-datatable-header {
+        max-height: 50%;
+    }
+}


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Content or functionality is lost due to overlapping content when the page is adjusted to an equivalent width of 320px or 400% zoom 


**What is the new behaviour?**
adjusted the libraries section, content and pagination section at 400% zoom to fit in the view port.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

before -

![Screenshot from 2023-02-14 16-20-37](https://user-images.githubusercontent.com/105338943/218714383-e8303995-9c05-4122-802c-e4d7884f4cda.png)

after -

![Screenshot from 2023-02-14 16-06-12](https://user-images.githubusercontent.com/105338943/218714443-32eb4354-0e3a-4063-86d8-6c9d05c9a61d.png)


