### PR TITLE
[AAE-12662] Get rid of multiplicity of "more than one element found for locator" warnings in tests caused by redundant click 

### DIFF
--- a/lib/testing/src/lib/protractor/core/pages/material/date-picker.page.ts
+++ b/lib/testing/src/lib/protractor/core/pages/material/date-picker.page.ts
@@ -34,7 +34,6 @@ export class DatePickerPage {
     }
 
     async setTodayDateValue(): Promise<void> {
-        await this.clickDatePicker();
         await this.dateTime.selectTodayDate();
     }
 


### PR DESCRIPTION
**Please check if the PR fulfils these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/AAE-12662


**What is the new behaviour?**
There's no additional click before inputting date in calendar


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
