### PR TITLE
[ACS-4634] Add ADF and JS API upstream to applications repo

### DIFF
--- a/scripts/travis/update/update-project.sh
+++ b/scripts/travis/update/update-project.sh
@@ -17,7 +17,7 @@ show_help() {
     echo ""
     echo "-t or --token: Github ouath token"
     echo "-p or --pr: Originating jsapi PR number"
-    echo "-v or --version version to update"    
+    echo "-v or --version version to update"
     echo "-d or --dry-run: The script won't execute critical operation, just simulate them"
 }
 
@@ -146,8 +146,9 @@ if [ "$isSameADFSha" = 'true' ]; then
             update "generator-alfresco-adf-app"
             update "alfresco-content-app"
             update "alfresco-apps"
+            update "alfresco-applications"
         else
-            echo "[dry-run] it would have update repos: 'generator-alfresco-adf-app', 'alfresco-content-app' and 'alfresco-apps'"
+            echo "[dry-run] it would have update repos: 'generator-alfresco-adf-app', 'alfresco-content-app', 'alfresco-apps' and 'alfresco-applications'"
         fi
 fi
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

There is no upstream for ADF and JS API for applications repo. https://alfresco.atlassian.net/browse/ACS-4634

**What is the new behaviour?**

Upstream has been added.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
