### PR TITLE
AAE-12721 - when a PR is closed the part of the pipeline is still triggered

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ env:
 jobs:
   setup:
     timeout-minutes: 20
-    if: github.event.pull_request.merged || ${{ inputs.dry-run-release }}
+    if: github.event.pull_request.merged
     name: "Setup"
     runs-on: ubuntu-22.04
     steps:
@@ -91,7 +91,7 @@ jobs:
   release-demoshell:
     needs: [setup]
     timeout-minutes: 15
-    if: github.event.pull_request.merged || ${{ inputs.dry-run-release }}
+    if: github.event.pull_request.merged
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
@@ -117,7 +117,7 @@ jobs:
   release-storybook:
     needs: [setup]
     timeout-minutes: 15
-    if: github.event.pull_request.merged || ${{ inputs.dry-run-release }}
+    if: github.event.pull_request.merged
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
@@ -144,7 +144,7 @@ jobs:
   release-npm:
     needs: [setup]
     timeout-minutes: 15
-    if: github.event.pull_request.merged == true || ${{ inputs.dry-run-release }}
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
@@ -183,7 +183,7 @@ jobs:
   npm-check-bundle:
     needs: [release-npm]
     timeout-minutes: 15
-    if: github.event.pull_request.merged == true || ${{ inputs.dry-run-release }}
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
