### PR TITLE
AAE-12240: Managed to enable/disable form save button only when needed

### DIFF
--- a/docs/core/components/form-field.component.md
+++ b/docs/core/components/form-field.component.md
@@ -29,6 +29,12 @@ based on the field type or the metadata information.
 | ---- | ---- | ------------- | ----------- |
 | field | [`FormFieldModel`](../../core/models/form-field.model.md) | null | Contains all the necessary data needed to determine what UI Widget to use when rendering the field in the form. You would typically not create this data manually but instead create the form in APS and export it to get to all the [`FormFieldModel`](../../core/models/form-field.model.md) definitions. |
 
+### Events
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| valueChanged | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<boolean>` | Emitted when the form field value changes |
+
 ## Details
 
 You would typically not use this component directly but instead use the `<adf-form>` component, which under the hood

--- a/lib/core/src/lib/form/components/form-base.component.ts
+++ b/lib/core/src/lib/form/components/form-base.component.ts
@@ -169,6 +169,7 @@ export abstract class FormBaseComponent {
 
             if (outcome.isSystem) {
                 if (outcome.id === FormBaseComponent.SAVE_OUTCOME_ID) {
+                    this.disableSaveButton = true;
                     this.saveTaskForm();
                     return true;
                 }

--- a/lib/core/src/lib/form/components/form-field/form-field.component.ts
+++ b/lib/core/src/lib/form/components/form-field/form-field.component.ts
@@ -20,11 +20,13 @@ import {
     Component, ComponentFactory,
     ComponentFactoryResolver,
     ComponentRef,
+    EventEmitter,
     Input,
     ModuleWithComponentFactories,
     NgModule,
     OnDestroy,
     OnInit,
+    Output,
     ViewChild,
     ViewContainerRef,
     ViewEncapsulation
@@ -63,6 +65,10 @@ export class FormFieldComponent implements OnInit, OnDestroy {
     @Input()
     field: FormFieldModel = null;
 
+    /** Emitted when the form field value changes. */
+    @Output()
+    valueChanged: EventEmitter<boolean> = new EventEmitter<boolean>();
+
     componentRef: ComponentRef<any>;
 
     focus: boolean = false;
@@ -99,6 +105,7 @@ export class FormFieldComponent implements OnInit, OnDestroy {
                         if (field && this.field.form) {
                             this.visibilityService.refreshVisibility(field.form);
                             field.form.onFormFieldChanged(field);
+                            this.valueChanged.emit(true);
                         }
                     });
                 }

--- a/lib/core/src/lib/form/components/form-renderer.component.html
+++ b/lib/core/src/lib/form/components/form-renderer.component.html
@@ -41,7 +41,7 @@
                      *ngIf="currentRootElement?.isExpanded">
                     <div class="adf-grid-list-item" *ngFor="let field of getContainerFields(currentRootElement)"
                          [ngStyle]="{'grid-area': 'auto / auto / span '+(field?.rowspan || 1)+' / span '+(field?.colspan || 1)}">
-                        <adf-form-field *ngIf="field" [field]="field"></adf-form-field>
+                        <adf-form-field *ngIf="field" [field]="field" (valueChanged)="onValueChanged()"></adf-form-field>
                     </div>
                 </div>
             </div>
@@ -51,7 +51,7 @@
                     <div class="adf-grid-list-single-column" *ngFor="let column of currentRootElement?.columns"
                          [style.width.%]="getColumnWith(currentRootElement)">
                         <div class="adf-grid-list-column-view-item" *ngFor="let field of column?.fields">
-                            <adf-form-field *ngIf="field" [field]="field"></adf-form-field>
+                            <adf-form-field *ngIf="field" [field]="field" (valueChanged)="onValueChanged()"></adf-form-field>
                         </div>
                     </div>
                 </section>
@@ -59,7 +59,7 @@
 
         </div>
         <div *ngIf="currentRootElement.type === 'dynamic-table'" class="adf-container-widget" >
-           <adf-form-field [field]="currentRootElement"></adf-form-field>
+           <adf-form-field [field]="currentRootElement" (valueChanged)="onValueChanged()"></adf-form-field>
         </div>
     </div>
 </ng-template>

--- a/lib/core/src/lib/form/components/form-renderer.component.ts
+++ b/lib/core/src/lib/form/components/form-renderer.component.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Component, ViewEncapsulation, Input, OnDestroy, Injector, OnChanges } from '@angular/core';
+import { Component, ViewEncapsulation, Input, OnDestroy, Injector, OnChanges, Output, EventEmitter } from '@angular/core';
 import { FormRulesManager, formRulesManagerFactory } from '../models/form-rules.model';
 import { FormModel } from './widgets/core/form.model';
 import { ContainerModel, FormFieldModel, TabModel } from './widgets';
@@ -42,6 +42,10 @@ export class FormRendererComponent<T> implements OnChanges, OnDestroy {
 
     @Input()
     formDefinition: FormModel;
+
+    /** Emitted when the form field value changes. */
+    @Output()
+    valueChanged: EventEmitter<boolean> = new EventEmitter<boolean>();
 
     debugMode: boolean;
 
@@ -76,6 +80,10 @@ export class FormRendererComponent<T> implements OnChanges, OnDestroy {
         return (content.json?.numberOfColumns || 1) > (content.columns?.length || 1) ?
             (content.json?.numberOfColumns || 1) :
             (content.columns?.length || 1);
+    }
+
+    onValueChanged(): void {
+        this.valueChanged.emit(true);
     }
 
     /**

--- a/lib/process-services-cloud/src/lib/form/components/form-cloud.component.html
+++ b/lib/process-services-cloud/src/lib/form/components/form-cloud.component.html
@@ -31,7 +31,7 @@
             </mat-card-title>
         </mat-card-header>
         <mat-card-content>
-            <adf-form-renderer [formDefinition]="form">
+            <adf-form-renderer [formDefinition]="form" (valueChanged)="disableSaveButton=false">
             </adf-form-renderer>
         </mat-card-content>
         <mat-card-actions *ngIf="form.hasOutcomes()" class="adf-form-mat-card-actions">

--- a/lib/process-services-cloud/src/lib/form/components/form-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/form-cloud.component.spec.ts
@@ -1035,6 +1035,50 @@ describe('FormCloudComponent', () => {
         expect(formComponent.disableCompleteButton).toBeTrue();
     });
 
+    it('should disable save button on [save] outcome click', () => {
+        const formModel = new FormModel();
+        const outcome = new FormOutcomeModel(formModel, {
+            id: FormCloudComponent.SAVE_OUTCOME_ID,
+            name: 'SAVE',
+            isSystem: true
+        });
+        formComponent.form = formModel;
+
+        formComponent.onOutcomeClicked(outcome);
+
+        expect(formComponent.disableSaveButton).toBeTrue();
+        expect(formComponent.disableCompleteButton).toBeFalse();
+    });
+
+    it('should enable save button when form field value changes', () => {
+        spyOn(formCloudService, 'getForm').and.returnValue(of(fakeCloudForm));
+        const formModel = new FormModel(fakeCloudForm);
+        const formId = '123';
+        const appName = 'test-app';
+        const outcome = new FormOutcomeModel(formModel, {
+            id: FormCloudComponent.SAVE_OUTCOME_ID,
+            name: 'SAVE',
+            isSystem: true
+        });
+        formComponent.formId = formId;
+        formComponent.appVersion = 1;
+        formComponent.appName = appName;
+
+        formComponent.loadForm();
+        fixture.detectChanges();
+
+        formComponent.onOutcomeClicked(outcome);
+
+        expect(formComponent.disableSaveButton).toBeTrue();
+
+        const inputElement = fixture.debugElement.query(By.css('[id="field-firstName-container"] input')).nativeElement;
+        inputElement.value = 'Hyland';
+        inputElement.dispatchEvent(new Event('input'));
+        fixture.detectChanges();
+
+        expect(formComponent.disableSaveButton).toBeFalse();
+    });
+
     it('should ENABLE complete & save buttons when something goes wrong during completion process', (done) => {
         const errorMessage = 'Something went wrong.';
         spyOn(formCloudService, 'completeTaskForm').and.callFake(() => throwError(errorMessage));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [X] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [X] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
users are able to click on form save button multiple times leading to several api calls.


**What is the new behaviour?**
After the first click of user on the form save button, the button will be disabled until user changes any form field or something wrong happens during the save process. consequently, the number of api calls will be reduced to just one. 

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
