### PR TITLE
[ACS-4592] missing right click menu on row and left click is only allow on indicator rotate

### DIFF
--- a/docs/content-services/components/tree.component.md
+++ b/docs/content-services/components/tree.component.md
@@ -27,23 +27,25 @@ Shows the nodes in tree structure, each node containing children is collapsible/
 
 ### Properties
 
-| Name | Type | Default value | Description |
-| ---- | ---- | ------------- | ----------- |
-| emptyContentTemplate | `TemplateRef` |  | Template that will be rendered when no nodes are loaded. |
-| nodeActionsMenuTemplate | `TemplateRef` |  | Template that will be rendered when context menu for given node is opened. |
-| stickyHeader | `boolean` | false | If set to true header will be sticky. |
-| selectableNodes | `boolean` | false | If set to true nodes will be selectable. |
-| displayName | `string` | | Display name for tree title. |
-| loadMoreSuffix | `string` | | Suffix added to `Load more` string inside load more node. |
-| expandIcon | `string` | `chevron_right` | Icon shown when node is collapsed. |
-| collapseIcon | `string` | `expand_more` | Icon showed when node is expanded. |
+| Name | Type          | Default value | Description |
+| ---- |---------------| --------- | ----------- |
+| emptyContentTemplate | `TemplateRef` | | Template that will be rendered when no nodes are loaded. |
+| nodeActionsMenuTemplate | `TemplateRef` | | Template that will be rendered when context menu for given node is opened. |
+| stickyHeader | `boolean`     | false | If set to true header will be sticky. |
+| selectableNodes | `boolean`     | false | If set to true nodes will be selectable. |
+| displayName | `string`      | | Display name for tree title. |
+| loadMoreSuffix | `string`      | | Suffix added to `Load more` string inside load more node. |
+| expandIcon | `string`      | `chevron_right` | Icon shown when node is collapsed. |
+| collapseIcon | `string`      | `expand_more` | Icon showed when node is expanded. |
+| contextMenuOptions | `any[]`       | | Array of context menu options which should be displayed for each row. |
 
 
 ### Events
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| paginationChanged | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<PaginationModel>` | Emitted when during loading additional nodes pagination changes. |
+| Name | Type                                                                                   | Description                                                      |
+| ---- |----------------------------------------------------------------------------------------|------------------------------------------------------------------|
+| paginationChanged | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<PaginationModel>`          | Emitted when during loading additional nodes pagination changes. |
+| contextMenuOptionSelected | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<TreeContextMenuResult<T>>` | Emitted when any context menu option is selected.                |
 
 ## Details
 

--- a/lib/content-services/src/lib/tree/components/tree.component.html
+++ b/lib/content-services/src/lib/tree/components/tree.component.html
@@ -11,7 +11,7 @@
             class="adf-tree-body"
             [dataSource]="treeService"
             [treeControl]="treeService.treeControl">
-                <mat-tree-node
+            <mat-tree-node
                 class="adf-tree-load-more-row"
                 [attr.data-automation-id]="'loadMoreSubnodes_' + node.parentId"
                 *matTreeNodeDef="let node when isLoadMoreNode"

--- a/lib/content-services/src/lib/tree/components/tree.component.html
+++ b/lib/content-services/src/lib/tree/components/tree.component.html
@@ -33,7 +33,9 @@
                     </button>
                 </div>
                 <div class="adf-tree-cell">
-                    <span class="adf-tree-cell-value">
+                    <span
+                        class="adf-tree-cell-value"
+                        (click)="loadMoreSubnodes(node)">
                         {{ 'ADF-TREE.LOAD-MORE-BUTTON' | translate: { name: loadMoreSuffix } }}
                     </span>
                 </div>
@@ -47,7 +49,7 @@
                 [adf-context-menu-enabled]="!!contextMenuOptions"
                 (contextmenu)="contextMenuSource = node">
                 <div class="adf-tree-expand-collapse-container">
-                    <button *ngIf="node.hasChildren"x
+                    <button *ngIf="node.hasChildren"
                         class="adf-tree-expand-collapse-button"
                         mat-icon-button
                         matTreeNodeToggle>
@@ -83,7 +85,10 @@
                     </ng-template>
                 </ng-container>
                 <div class="adf-tree-cell">
-                    <span class="adf-tree-cell-value" (click)="expandCollapseNode(node)">
+                    <span
+                        class="adf-tree-cell-value"
+                        [class.adf-tree-clickable-cell-value]="node.hasChildren"
+                        (click)="expandCollapseNode(node)">
                         {{ node.nodeName }}
                     </span>
                 </div>

--- a/lib/content-services/src/lib/tree/components/tree.component.html
+++ b/lib/content-services/src/lib/tree/components/tree.component.html
@@ -11,7 +11,7 @@
             class="adf-tree-body"
             [dataSource]="treeService"
             [treeControl]="treeService.treeControl">
-            <mat-tree-node
+                <mat-tree-node
                 class="adf-tree-load-more-row"
                 [attr.data-automation-id]="'loadMoreSubnodes_' + node.parentId"
                 *matTreeNodeDef="let node when isLoadMoreNode"
@@ -42,9 +42,12 @@
                 class="adf-tree-row"
                 [attr.data-automation-id]="'node_' + node.id"
                 *matTreeNodeDef="let node"
-                matTreeNodePadding>
+                matTreeNodePadding
+                [adf-context-menu]="contextMenuOptions"
+                [adf-context-menu-enabled]="!!contextMenuOptions"
+                (contextmenu)="contextMenuSource = node">
                 <div class="adf-tree-expand-collapse-container">
-                    <button *ngIf="node.hasChildren"
+                    <button *ngIf="node.hasChildren"x
                         class="adf-tree-expand-collapse-button"
                         mat-icon-button
                         matTreeNodeToggle>
@@ -80,7 +83,7 @@
                     </ng-template>
                 </ng-container>
                 <div class="adf-tree-cell">
-                    <span class="adf-tree-cell-value">
+                    <span class="adf-tree-cell-value" (click)="expandCollapseNode(node)">
                         {{ node.nodeName }}
                     </span>
                 </div>

--- a/lib/content-services/src/lib/tree/components/tree.component.scss
+++ b/lib/content-services/src/lib/tree/components/tree.component.scss
@@ -61,7 +61,7 @@ $tree-header-font-size: 12px !default;
     }
 }
 
-.adf-tree-load-more-row, .adf-tree-row .adf-tree-cell-value {
+.adf-tree-load-more-row .adf-tree-cell-value, .adf-tree-clickable-cell-value {
     cursor: pointer;
 }
 

--- a/lib/content-services/src/lib/tree/components/tree.component.scss
+++ b/lib/content-services/src/lib/tree/components/tree.component.scss
@@ -11,6 +11,11 @@ $tree-header-font-size: 12px !default;
     }
 }
 
+.adf-tree-load-more-row .adf-tree-cell-value,
+.adf-tree-clickable-cell-value {
+    cursor: pointer;
+}
+
 .adf-tree-row,
 .adf-tree-load-more-row {
     transition: all 0.3s ease;
@@ -59,10 +64,6 @@ $tree-header-font-size: 12px !default;
             word-break: break-word;
         }
     }
-}
-
-.adf-tree-load-more-row .adf-tree-cell-value, .adf-tree-clickable-cell-value {
-    cursor: pointer;
 }
 
 .adf-tree-header {

--- a/lib/content-services/src/lib/tree/components/tree.component.scss
+++ b/lib/content-services/src/lib/tree/components/tree.component.scss
@@ -21,7 +21,6 @@ $tree-header-font-size: 12px !default;
     transition-property: background-color;
     border-bottom: 1px solid var(--theme-border-color);
     min-height: $tree-row-height;
-    cursor: pointer;
     user-select: none;
 
     .adf-tree-expand-collapse-container {
@@ -55,11 +54,15 @@ $tree-header-font-size: 12px !default;
         width: 100%;
 
         .adf-tree-cell-value {
-            display: block;
+            display: inline-block;
             padding: 10px;
             word-break: break-word;
         }
     }
+}
+
+.adf-tree-load-more-row, .adf-tree-row .adf-tree-cell-value {
+    cursor: pointer;
 }
 
 .adf-tree-header {

--- a/lib/content-services/src/lib/tree/components/tree.component.ts
+++ b/lib/content-services/src/lib/tree/components/tree.component.ts
@@ -84,6 +84,7 @@ export class TreeComponent<T extends TreeNode> implements OnInit, OnDestroy {
     @Output()
     public paginationChanged: EventEmitter<PaginationModel> = new EventEmitter();
 
+    /** Emitted when any context menu option is selected */
     @Output()
     public contextMenuOptionSelected = new EventEmitter<TreeContextMenuResult<T>>();
 
@@ -104,6 +105,7 @@ export class TreeComponent<T extends TreeNode> implements OnInit, OnDestroy {
         this._contextMenuSource = contextMenuSource;
     }
 
+    /** Array of context menu options which should be displayed for each row. */
     @Input()
     set contextMenuOptions(contextMenuOptions: any[]) {
         this.contextMenuOptionsChanged$.next();
@@ -112,7 +114,7 @@ export class TreeComponent<T extends TreeNode> implements OnInit, OnDestroy {
                 if (!option.subject) {
                     option = {
                         ...option,
-                        subject: new Subject(),
+                        subject: new Subject()
                     };
                 }
                 return option;

--- a/lib/content-services/src/lib/tree/components/tree.component.ts
+++ b/lib/content-services/src/lib/tree/components/tree.component.ts
@@ -109,7 +109,10 @@ export class TreeComponent<T extends TreeNode> implements OnInit, OnDestroy {
     set contextMenuOptions(contextMenuOptions: any[]) {
         merge(...contextMenuOptions.map((option) => {
             if (!option.subject) {
-                option.subject =  new Subject();
+                option = {
+                    ...option,
+                    subject: new Subject(),
+                };
             }
             return option.subject;
         })).pipe(takeUntil(this.onDestroy$)).subscribe((option) => {
@@ -191,21 +194,23 @@ export class TreeComponent<T extends TreeNode> implements OnInit, OnDestroy {
      * @param node node to be collapsed/expanded
      */
     public expandCollapseNode(node: T): void {
-        if (this.treeService.treeControl.isExpanded(node)) {
-            this.treeService.collapseNode(node);
-        } else {
-            node.isLoading = true;
-            this.treeService.getSubNodes(node.id, 0, this.userPreferenceService.paginationSize).subscribe((response: TreeResponse<T>) => {
-                this.treeService.expandNode(node, response.entries);
-                this.paginationChanged.emit(response.pagination);
-                node.isLoading = false;
-                if (this.treeNodesSelection.isSelected(node)) {
-                    //timeout used to update nodeCheckboxes query list after new nodes are added so they can be selected
-                    setTimeout(() => {
-                        this.treeNodesSelection.select(...response.entries);
-                    });
-                }
-            });
+        if (node.hasChildren) {
+            if (this.treeService.treeControl.isExpanded(node)) {
+                this.treeService.collapseNode(node);
+            } else {
+                node.isLoading = true;
+                this.treeService.getSubNodes(node.id, 0, this.userPreferenceService.paginationSize).subscribe((response: TreeResponse<T>) => {
+                    this.treeService.expandNode(node, response.entries);
+                    this.paginationChanged.emit(response.pagination);
+                    node.isLoading = false;
+                    if (this.treeNodesSelection.isSelected(node)) {
+                        //timeout used to update nodeCheckboxes query list after new nodes are added so they can be selected
+                        setTimeout(() => {
+                            this.treeNodesSelection.select(...response.entries);
+                        });
+                    }
+                });
+            }
         }
     }
 

--- a/lib/content-services/src/lib/tree/models/tree-context-menu-result.interface.ts
+++ b/lib/content-services/src/lib/tree/models/tree-context-menu-result.interface.ts
@@ -1,0 +1,4 @@
+export interface TreeContextMenuResult<T> {
+    row: T;
+    contextMenuOption: any;
+}

--- a/lib/content-services/src/lib/tree/models/tree-context-menu-result.interface.ts
+++ b/lib/content-services/src/lib/tree/models/tree-context-menu-result.interface.ts
@@ -1,3 +1,20 @@
+/*!
+ * @license
+ * Copyright 2019 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export interface TreeContextMenuResult<T> {
     row: T;
     contextMenuOption: any;

--- a/lib/content-services/src/lib/tree/public-api.ts
+++ b/lib/content-services/src/lib/tree/public-api.ts
@@ -18,5 +18,6 @@
 export * from './tree.module';
 export * from './models/tree-response.interface';
 export * from './models/tree-node.interface';
+export * from './models/tree-context-menu-result.interface';
 export * from './services/tree.service';
 export * from './components/tree.component';

--- a/lib/content-services/src/lib/tree/tree.module.ts
+++ b/lib/content-services/src/lib/tree/tree.module.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { CoreModule } from '@alfresco/adf-core';
+import { ContextMenuModule, CoreModule } from '@alfresco/adf-core';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
@@ -27,7 +27,8 @@ import { TreeComponent } from './components/tree.component';
         CommonModule,
         CoreModule,
         MaterialModule,
-        TranslateModule
+        TranslateModule,
+        ContextMenuModule
     ],
     declarations: [
         TreeComponent


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ACS-4592


**What is the new behaviour?**
Now we have possibility to use context menu for tree component by passing list of context menu options. Also removed click icon as mouse cursor during hovering a row as row is not clickable. Keep that icon only during hovering row's label or expand/collapse icon which are clickable. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
Alfresco Applications PR: https://github.com/Alfresco/alfresco-applications/pull/53