### PR TITLE
[ACS-4441] Destination folder ids are now properly visible on View Rule Screen in Folder Rules

### DIFF
--- a/lib/core/src/lib/card-view/components/card-view/card-view.component.scss
+++ b/lib/core/src/lib/card-view/components/card-view/card-view.component.scss
@@ -19,6 +19,7 @@
 
             .mat-form-field-infix {
                 border-top-width: 0;
+                width: 280px;
             }
 
             .mat-form-field-label {


### PR DESCRIPTION
…n Folder Rules

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Destination Folder ids are truncated on View Rule screen in Folder Rules


**What is the new behaviour?**
Destination folder ids are now properly visible on View Rule Screen in Folder Rules


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Before - 

![Screenshot from 2023-03-10 13-39-08](https://user-images.githubusercontent.com/105338943/224263041-7d9b0539-5bec-499f-bb11-30c6fa2b59bc.png)

After - 

![Screenshot from 2023-03-10 13-38-27](https://user-images.githubusercontent.com/105338943/224263091-14c2be69-1afe-4ead-8c9f-3db0bbea6074.png)




