### PR TITLE
[AAE-11707] Fix wrong paths in adf-core

### DIFF
--- a/lib/core/src/lib/datatable/data-column/data-column.module.ts
+++ b/lib/core/src/lib/datatable/data-column/data-column.module.ts
@@ -32,7 +32,9 @@ import { DateColumnHeaderComponent } from './data-column-header.component';
         DateColumnHeaderComponent
     ],
     exports: [
-
+        DataColumnComponent,
+        DataColumnListComponent,
+        DateColumnHeaderComponent
     ]
 })
 export class DataColumnModule {}

--- a/lib/core/src/lib/datatable/datatable.module.ts
+++ b/lib/core/src/lib/datatable/datatable.module.ts
@@ -52,6 +52,7 @@ import { IconModule } from '../icon/icon.module';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { DataColumnComponent, DataColumnListComponent, DateColumnHeaderComponent } from './data-column';
 import { ResizableModule } from './directives/resizable/resizable.module';
+import { DataColumnModule } from './data-column/data-column.module';
 
 @NgModule({
     imports: [
@@ -67,7 +68,8 @@ import { ResizableModule } from './directives/resizable/resizable.module';
         IconModule,
         FormsModule,
         ReactiveFormsModule,
-        ResizableModule
+        ResizableModule,
+        DataColumnModule
     ],
     declarations: [
         DataTableComponent,
@@ -90,10 +92,7 @@ import { ResizableModule } from './directives/resizable/resizable.module';
         CustomLoadingContentTemplateDirective,
         CustomNoPermissionTemplateDirective,
         MainMenuDataTableTemplateDirective,
-        DropZoneDirective,
-        DataColumnComponent,
-        DataColumnListComponent,
-        DateColumnHeaderComponent
+        DropZoneDirective
     ],
     exports: [
         DataTableComponent,

--- a/lib/core/tsconfig.lib.json
+++ b/lib/core/tsconfig.lib.json
@@ -5,7 +5,11 @@
     "declarationMap": true,
     "paths": {
       "@alfresco/adf-extensions": ["../../../dist/libs/extensions"],
-      "@alfresco/adf-extensions/*": ["../../../dist/libs/extensions/*"]
+      "@alfresco/adf-extensions/*": ["../../../dist/libs/extensions/*"],
+      "@alfresco/adf-core/auth": ["../auth/src/index.ts"],
+      "@alfresco/adf-core/shell": ["../shell/src/index.ts"],
+      "@alfresco/adf-core/api": ["../api/src/index.ts"],
+
     }
   },
   "exclude": ["src/test.ts", "**/*.spec.ts", "**/*.test.ts"],


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [X] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/AAE-11707
When opening the VS Code, if I open the file `lib/core/src/lib/core.module.ts` I get errors on imports
```typescript
import { AlfrescoJsClientsModule } from '@alfresco/adf-core/api';
import { AuthenticationInterceptor, Authentication } from '@alfresco/adf-core/auth';
```
This is because in the `tsconfig.lib.json` file for the core library we are overriding the paths in the base tsconfig file. So we are not including there the paths for `@alfresco/adf-core/api` and `@alfresco/adf-core/auth`
https://github.com/Alfresco/alfresco-ng2-components/blob/2590e7d0a906fccc2374f286502a30a8a9588490/lib/core/tsconfig.lib.json#L6-L9

In addition to that, once that I fixed I got the compiler complaining because there were some components that were declared in two different modules, concretely: `DataColumnComponent`, `DataColumnListComponent` and `DateColumnHeaderComponent` where defined both in `DataColumnModule` and `DataTableModule`.


**What is the new behaviour?**
Fix the wrong imports and duplication of the declaration of the components.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
