### PR TITLE
Dev alepore 12511 fix bc wrong auth url

### DIFF
--- a/lib/core/src/lib/api-factories/alfresco-api-v2-loader.service.ts
+++ b/lib/core/src/lib/api-factories/alfresco-api-v2-loader.service.ts
@@ -36,7 +36,7 @@ export class AlfrescoApiLoaderService {
         return this.initAngularAlfrescoApi();
     }
 
-    private initAngularAlfrescoApi() {
+    private async initAngularAlfrescoApi() {
         const oauth: OauthConfigModel = Object.assign({}, this.appConfig.get<OauthConfigModel>(AppConfigValues.OAUTHCONFIG, null));
 
         if (oauth) {
@@ -57,6 +57,6 @@ export class AlfrescoApiLoaderService {
             oauth2: oauth
         });
 
-        this.apiService.load(config);
+        await this.apiService.load(config);
     }
 }

--- a/lib/core/src/lib/services/alfresco-api.service.ts
+++ b/lib/core/src/lib/services/alfresco-api.service.ts
@@ -49,7 +49,7 @@ export class AlfrescoApiService {
         this.currentAppConfig = config;
 
         if (config.authType === 'OAUTH') {
-                this.mapAlfrescoApiOpenIdConfig();
+                await this.mapAlfrescoApiOpenIdConfig();
         }
 
         this.initAlfrescoApiWithConfig();
@@ -59,7 +59,7 @@ export class AlfrescoApiService {
     async reset() {
         this.getCurrentAppConfig();
         if (this.currentAppConfig.authType === 'OAUTH') {
-            this.mapAlfrescoApiOpenIdConfig();
+            await this.mapAlfrescoApiOpenIdConfig();
         }
         this.initAlfrescoApiWithConfig();
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Impossible to reach the login page of the studio-hxp app because the app tries to connect using the Keycloak url ( https://hxpmockcache-hxp-iam.envalfresco.com/idp/protocol/openid-connect/auth) instead of the HXP IDP (https://hxpmockcache-hxp-iam.envalfresco.com/idp/connect/authorize)


**What is the new behaviour?**
The app wait for the idp config to be set properly with the openid-configuration response


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
