### PR TITLE
[ACS-4746] Returning focus to trigger element after restore option is…

### DIFF
--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.ts
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.ts
@@ -224,6 +224,7 @@ export class DataTableComponent implements OnInit, AfterContentInit, OnChanges, 
     isSelectAllIndeterminate: boolean = false;
     isSelectAllChecked: boolean = false;
     selection = new Array<DataRow>();
+    selectedRowId: string = '';
 
     isDraggingHeaderColumn = false;
     hoveredHeaderColumnIndex = -1;
@@ -285,6 +286,7 @@ export class DataTableComponent implements OnInit, AfterContentInit, OnChanges, 
 
     ngOnChanges(changes: SimpleChanges) {
         this.initAndSubscribeClickStream();
+        this.setRowAsContextSource();
 
         const dataChanges = changes['data'];
         const rowChanges = changes['rows'];
@@ -780,8 +782,13 @@ export class DataTableComponent implements OnInit, AfterContentInit, OnChanges, 
     }
 
     markRowAsContextMenuSource(selectedRow: DataRow): void {
+        this.selectedRowId = selectedRow.id ? selectedRow.id : '';
         this.data.getRows().forEach((row) => row.isContextMenuSource = false);
         selectedRow.isContextMenuSource = true;
+    }
+
+    setRowAsContextSource(): void {
+        this.data.getRows().forEach((row) => row.isContextMenuSource = this.selectedRowId === row.id ? true : false);
     }
 
     getSortingKey(): string | null {


### PR DESCRIPTION
… selected and manage version modal is closed

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Once the manage version modal is opened and restore option is selected. After the restore option is performed, when you close the dialog, the focus does not return to the trigger element.


**What is the new behaviour?**
Once the manage version modal is opened and restore option is selected. After the restore option is performed, when you close the dialog, the focus returns to the trigger element.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
