### PR TITLE
[ACS-4106] changed place of mat-error tag & style change

### DIFF
--- a/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.html
+++ b/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.html
@@ -52,14 +52,6 @@
         </mat-form-field>
     </div>
 
-    <mat-error [attr.data-automation-id]="'card-textitem-error-' + property.key"
-        class="adf-textitem-editable-error"
-        *ngIf="isEditable && hasErrors">
-        <ul>
-            <li *ngFor="let error of errors">{{ error.message | translate: error }}</li>
-        </ul>
-    </mat-error>
-
     <div *ngSwitchCase="'chipsTemplate'"
          class="adf-property-field adf-textitem-chip-list-container">
         <mat-chip-list #chipList
@@ -131,6 +123,14 @@
         <ng-container *ngTemplateOutlet="label"></ng-container>
         <span class="adf-textitem-default-value">{{ property.default | translate }}</span>
     </div>
+
+    <mat-error [attr.data-automation-id]="'card-textitem-error-' + property.key"
+               class="adf-textitem-editable-error"
+               *ngIf="isEditable && hasErrors">
+        <ul>
+            <li *ngFor="let error of errors">{{ error.message | translate: error }}</li>
+        </ul>
+    </mat-error>
 </div>
 
 <ng-template #label>

--- a/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.scss
+++ b/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.scss
@@ -80,7 +80,7 @@
 
         &-error {
             font-size: var(--theme-caption-font-size);
-            padding-top: 4px;
+            padding-top: 6px;
 
             ul {
                 margin: 0;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
If upload file is not selected, the 'create' buttons remains in enabled state.


**What is the new behaviour?**
'Create' button remains disabled until user doesn't select upload file


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
