### PR TITLE
Dev wide landscape hxcs 1166

### DIFF
--- a/lib/core/src/lib/notifications/services/notification.service.spec.ts
+++ b/lib/core/src/lib/notifications/services/notification.service.spec.ts
@@ -17,7 +17,7 @@
 
 import { LiveAnnouncer } from '@angular/cdk/a11y';
 import { OverlayModule } from '@angular/cdk/overlay';
-import { Component } from '@angular/core';
+import { Component, TemplateRef, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { MatSnackBar, MatSnackBarConfig, MatSnackBarModule } from '@angular/material/snack-bar';
@@ -28,10 +28,15 @@ import { CoreTestingModule } from '../../testing/core.testing.module';
 import { TranslateModule } from '@ngx-translate/core';
 
 @Component({
-    template: '',
+    template: `<ng-template #customTemplate let-message>
+           <p class="custom-template-class">Custom content {{message}}</p>
+        </ng-template>`,
     providers: [NotificationService]
 })
 class ProvidesNotificationServiceComponent {
+
+    @ViewChild('customTemplate', { read: TemplateRef }) customTemplate: TemplateRef<any>;
+
     constructor(public notificationService: NotificationService) {
 
     }
@@ -68,6 +73,22 @@ class ProvidesNotificationServiceComponent {
         matSnackBarConfig.duration = 1000;
 
         return this.notificationService.openSnackMessageAction('Test notification', 'TestWarn', matSnackBarConfig);
+    }
+
+    sendMessageWithTemplateRef() {
+        const notificationConfig = new MatSnackBarConfig();
+        notificationConfig.duration = 1000;
+        notificationConfig.data = {templateRef: this.customTemplate};
+
+        return this.notificationService.openSnackMessage('with templateRef', notificationConfig);
+    }
+
+    sendMessageWithTemplateRefWithAction() {
+        const notificationConfig = new MatSnackBarConfig();
+        notificationConfig.duration = 1000;
+        notificationConfig.data = { templateRef: this.customTemplate };
+
+        return this.notificationService.openSnackMessageAction('with templateRef', 'TestWarn', notificationConfig);
     }
 
 }
@@ -197,4 +218,29 @@ describe('NotificationService', () => {
 
         expect(document.querySelector('snack-bar-container')).not.toBeNull();
     });
+
+    it('should open a message notification bar with a custom templateRef configuration', (done) => {
+        const promise = fixture.componentInstance.sendMessageWithTemplateRef();
+        promise.afterDismissed().subscribe(() => {
+            done();
+        });
+
+        fixture.detectChanges();
+
+        expect(document.querySelector('.custom-template-class')).not.toBeNull();
+        expect(document.querySelector('.custom-template-class').innerHTML).toEqual('Custom content with templateRef');
+    });
+
+    it('should open a message notification bar with action and custom templateRef configuration', (done) => {
+        const promise = fixture.componentInstance.sendMessageWithTemplateRefWithAction();
+        promise.afterDismissed().subscribe(() => {
+            done();
+        });
+
+        fixture.detectChanges();
+
+        expect(document.querySelector('.custom-template-class')).not.toBeNull();
+        expect(document.querySelector('.custom-template-class').innerHTML).toEqual('Custom content with templateRef');
+    });
+
 });

--- a/lib/core/src/lib/snackbar-content/snack-bar-data.ts
+++ b/lib/core/src/lib/snackbar-content/snack-bar-data.ts
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { TemplateRef } from '@angular/core';
+
 export interface SnackBarData {
     actionLabel?: string;
     actionIcon?: string;
@@ -22,4 +24,5 @@ export interface SnackBarData {
     message: string;
     showAction?: boolean;
     callActionOnIconClick?: boolean;
+    templateRef?: TemplateRef<any>;
 }

--- a/lib/core/src/lib/snackbar-content/snackbar-content.component.html
+++ b/lib/core/src/lib/snackbar-content/snackbar-content.component.html
@@ -1,4 +1,12 @@
-<p class="adf-snackbar-message-content" data-automation-id="adf-snackbar-message-content" aria-hidden="true">{{ data.message }}</p>
+<p class="adf-snackbar-message-content" data-automation-id="adf-snackbar-message-content" aria-hidden="true">
+<ng-container *ngIf="!data.templateRef else customTemplate">{{ data.message }}</ng-container>
+    <ng-template #customTemplate>
+        <ng-container
+            [ngTemplateOutlet]="data.templateRef"
+            [ngTemplateOutletContext]="{ $implicit: data.message}">
+        </ng-container>
+    </ng-template>
+</p>
 <div *ngIf="data.showAction" class="adf-snackbar-message-content-action" aria-hidden="true">
     <button mat-button (click)="snackBarRef.dismissWithAction()" *ngIf="data.actionLabel" class="adf-snackbar-message-content-action-button"
             data-automation-id="adf-snackbar-message-content-action-button">


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [X] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
ADF SnackBar can’t be customized to meet our mock up appearance, in particular there is no way to add a presentational icon in front of the text message

**What is the new behaviour?**
When the SnackBarContentComponent has a TemplateRef provided in the config param, then render the templateRef in place of the text message
The message should be passed to the TemplateRef to be displayed

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No, unless `templateRef` is used as data prop (unlikely but possible)


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
