### PR TITLE
[ACS-4128] Undo functionality added for input in Perform Actions after selecting an action and it works after destnation folder change in Create/Edit a rule in Manage Rules

### DIFF
--- a/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.html
+++ b/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.html
@@ -19,7 +19,7 @@
                     [matTooltip]="'CORE.METADATA.ACTIONS.COPY_TO_CLIPBOARD' | translate"
                     [matTooltipDisabled]="isEditable"
                     [attr.data-automation-id]="'card-textitem-value-' + property.key"
-                    (keydown)="checkKeyboardEvent($event)">
+                    (keydown)="undoText($event)">
                 <textarea matInput
                     *ngIf="property.multiline"
                     title="{{property.label | translate }}"

--- a/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.html
+++ b/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.html
@@ -18,7 +18,8 @@
                     matTooltipShowDelay="1000"
                     [matTooltip]="'CORE.METADATA.ACTIONS.COPY_TO_CLIPBOARD' | translate"
                     [matTooltipDisabled]="isEditable"
-                    [attr.data-automation-id]="'card-textitem-value-' + property.key">
+                    [attr.data-automation-id]="'card-textitem-value-' + property.key"
+                    (keydown)="checkKeyboardEvent($event)">
                 <textarea matInput
                     *ngIf="property.multiline"
                     title="{{property.label | translate }}"

--- a/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
@@ -73,6 +73,30 @@ describe('CardViewTextItemComponent', () => {
         }
     };
 
+    const renderChipsForMultiValuedProperties = async (labelValue: string, itemValue: Array<any>, keyValue: string,
+        editableValue: boolean, multivaluedValue: boolean, flag: boolean,
+        length: number, param1: string, param2: string, param3: string, defaultValue?: Array<any>) => {
+        component.property = new CardViewTextItemModel({
+            label: labelValue,
+            value: itemValue,
+            key: keyValue,
+            default: defaultValue? defaultValue: [],
+            editable: editableValue,
+            multivalued: multivaluedValue
+        });
+        component.useChipsForMultiValueProperty = flag;
+        component.ngOnChanges({ property: new SimpleChange(null, null, true) });
+
+        fixture.detectChanges();
+        await fixture.whenStable();
+        const valueChips = fixture.debugElement.queryAll(By.css(`mat-chip`));
+        expect(valueChips).not.toBeNull();
+        expect(valueChips.length).toBe(length);
+        expect(valueChips[0].nativeElement.innerText.trim()).toBe(param1);
+        expect(valueChips[1].nativeElement.innerText.trim()).toBe(param2);
+        expect(valueChips[2].nativeElement.innerText.trim()).toBe(param3);
+    };
+
     setupTestBed({
         imports: [
             TranslateModule.forRoot(),
@@ -201,67 +225,21 @@ describe('CardViewTextItemComponent', () => {
         });
 
         it('should render chips for multivalue properties when chips are enabled', async () => {
-            component.property = new CardViewTextItemModel({
-                label: 'Text label',
-                value: ['item1', 'item2', 'item3'],
-                key: 'textkey',
-                default: ['FAKE-DEFAULT-KEY'],
-                editable: true,
-                multivalued: true
-            });
-            component.useChipsForMultiValueProperty = true;
-            component.ngOnChanges({ property: new SimpleChange(null, null, true) });
+            renderChipsForMultiValuedProperties('Text label', ['item1', 'item2', 'item3'], 'textkey', true, true,
+            true, 3, 'item1', 'item2', 'item3', ['FAKE-DEFAULT-KEY']);
 
-            fixture.detectChanges();
-            await fixture.whenStable();
-            const valueChips = fixture.debugElement.queryAll(By.css(`mat-chip`));
-            expect(valueChips).not.toBeNull();
-            expect(valueChips.length).toBe(3);
-            expect(valueChips[0].nativeElement.innerText.trim()).toBe('item1');
-            expect(valueChips[1].nativeElement.innerText.trim()).toBe('item2');
-            expect(valueChips[2].nativeElement.innerText.trim()).toBe('item3');
         });
 
         it('should render chips for multivalue integers when chips are enabled', async () => {
-            component.property = new CardViewIntItemModel({
-                label: 'Text label',
-                value: [1, 2, 3],
-                key: 'textkey',
-                editable: true,
-                multivalued: true
-            });
-            component.useChipsForMultiValueProperty = true;
-            component.ngOnChanges({ property: new SimpleChange(null, null, true) });
+            renderChipsForMultiValuedProperties('Text label', [1, 2, 3], 'textkey', true, true,
+            true, 3, '1', '2', '3');
 
-            fixture.detectChanges();
-            await fixture.whenStable();
-            const valueChips = fixture.debugElement.queryAll(By.css(`mat-chip`));
-            expect(valueChips).not.toBeNull();
-            expect(valueChips.length).toBe(3);
-            expect(valueChips[0].nativeElement.innerText.trim()).toBe('1');
-            expect(valueChips[1].nativeElement.innerText.trim()).toBe('2');
-            expect(valueChips[2].nativeElement.innerText.trim()).toBe('3');
         });
 
         it('should render chips for multivalue decimal numbers when chips are enabled', async () => {
-            component.property = new CardViewFloatItemModel({
-                label: 'Text label',
-                value: [1.1, 2.2, 3.3],
-                key: 'textkey',
-                editable: true,
-                multivalued: true
-            });
-            component.useChipsForMultiValueProperty = true;
-            component.ngOnChanges({ property: new SimpleChange(null, null, true) });
+            renderChipsForMultiValuedProperties('Text label', [1.1, 2.2, 3.3], 'textkey', true, true,
+            true, 3, '1.1', '2.2', '3.3');
 
-            fixture.detectChanges();
-            await fixture.whenStable();
-            const valueChips = fixture.debugElement.queryAll(By.css(`mat-chip`));
-            expect(valueChips).not.toBeNull();
-            expect(valueChips.length).toBe(3);
-            expect(valueChips[0].nativeElement.innerText.trim()).toBe('1.1');
-            expect(valueChips[1].nativeElement.innerText.trim()).toBe('2.2');
-            expect(valueChips[2].nativeElement.innerText.trim()).toBe('3.3');
         });
 
         it('should render string for multivalue properties when chips are disabled', async () => {

--- a/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
@@ -557,6 +557,13 @@ describe('CardViewTextItemComponent', () => {
             expect(component.property.value).toEqual(component.editedValue);
         });
 
+        it('should perform undo action by clearing the text that we enter in the text field using undo keyboard shortcut', async () => {
+            component.textInput.setValue('UNDO TEST');
+            component.checkKeyboardEvent({ctrlKey: true, code: 'KeyZ'});
+
+            expect(component.textInput.value).toBe('');
+        });
+
         it('should trigger an update event on the CardViewUpdateService [integration]', async () => {
             const cardViewUpdateService = TestBed.inject(CardViewUpdateService);
             const itemUpdatedSpy = spyOn(cardViewUpdateService.itemUpdated$, 'next');

--- a/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
@@ -58,6 +58,21 @@ describe('CardViewTextItemComponent', () => {
         return textItemInputError.nativeElement.innerText;
     };
 
+    const checkCtrlZActions = (ctrlKeyValue: boolean, codeValue: string, metaKeyValue: boolean, mockTestValue: string, flag: boolean) => {
+        component.textInput.setValue(mockTestValue);
+        const event = new KeyboardEvent('keydown', {
+            ctrlKey: ctrlKeyValue,
+            code: codeValue,
+            metaKey: metaKeyValue
+        } as KeyboardEventInit );
+        component.undoText(event);
+        if (flag) {
+            expect(component.textInput.value).toBe('');
+        } else {
+            expect(component.textInput.value).not.toBe('');
+        }
+    };
+
     setupTestBed({
         imports: [
             TranslateModule.forRoot(),
@@ -822,52 +837,24 @@ describe('CardViewTextItemComponent', () => {
     describe('events', () => {
 
         it('should perform undo action by clearing the text that we enter in the text field using undo keyboard shortcut', async () => {
-            component.textInput.setValue('UNDO TEST');
-            const event = new KeyboardEvent('keydown', {
-                ctrlKey: true,
-                code: 'KeyZ',
-                metaKey: false
-            } as KeyboardEventInit );
-            component.undoText(event);
+            checkCtrlZActions(true, 'KeyZ', false, 'UNDO TEST', true);
 
-            expect(component.textInput.value).toBe('');
         });
 
 
         it('should not perform undo action when we hit any other shortcut instead of using undo keyboard shortcut', async () => {
-            component.textInput.setValue('DO NOT DO UNDO');
-            const event = new KeyboardEvent('keydown', {
-                ctrlKey: true,
-                code: 'KeyH',
-                metaKey: false
-            } as KeyboardEventInit );
-            component.undoText(event);
+            checkCtrlZActions(true, 'KeyH', false, 'DO NOT DO UNDO', false);
 
-            expect(component.textInput.value).not.toBe('');
         });
 
         it('should not perform undo action when control key is not pressed even if the keycode is correct', async () => {
-            component.textInput.setValue('DO NOT PERFORM UNDO');
-            const event = new KeyboardEvent('keydown', {
-                ctrlKey: false,
-                code: 'KeyZ',
-                metaKey: false
-            } as KeyboardEventInit );
-            component.undoText(event);
+            checkCtrlZActions(false, 'KeyZ', false, 'DO NOT DO UNDO', false);
 
-            expect(component.textInput.value).not.toBe('');
         });
 
         it('should perform undo action in MacOS by clearing the text that we enter in the text field using undo keyboard shortcut', async () => {
-            component.textInput.setValue('UNDO TEST FOR MACOS');
-            const event = new KeyboardEvent('keydown', {
-                ctrlKey: false,
-                code: 'KeyZ',
-                metaKey: true
-            } as KeyboardEventInit );
-            component.undoText(event);
+            checkCtrlZActions(false, 'KeyZ', true, 'UNDO TEST FOR MACOS', true);
 
-            expect(component.textInput.value).toBe('');
         });
     });
 });

--- a/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
@@ -73,17 +73,9 @@ describe('CardViewTextItemComponent', () => {
         }
     };
 
-    const renderChipsForMultiValuedProperties = async (labelValue: string, itemValue: Array<any>, keyValue: string,
-        editableValue: boolean, multivaluedValue: boolean, flag: boolean,
-        length: number, param1: string, param2: string, param3: string, defaultValue?: Array<any>) => {
-        component.property = new CardViewTextItemModel({
-            label: labelValue,
-            value: itemValue,
-            key: keyValue,
-            default: defaultValue? defaultValue: [],
-            editable: editableValue,
-            multivalued: multivaluedValue
-        });
+    const renderChipsForMultiValuedProperties = async (cardViewTextItemObject, flag: boolean, length: number,
+        param1: string, param2: string, param3: string) => {
+        component.property = new CardViewTextItemModel(cardViewTextItemObject);
         component.useChipsForMultiValueProperty = flag;
         component.ngOnChanges({ property: new SimpleChange(null, null, true) });
 
@@ -225,20 +217,39 @@ describe('CardViewTextItemComponent', () => {
         });
 
         it('should render chips for multivalue properties when chips are enabled', async () => {
-            renderChipsForMultiValuedProperties('Text label', ['item1', 'item2', 'item3'], 'textkey', true, true,
-            true, 3, 'item1', 'item2', 'item3', ['FAKE-DEFAULT-KEY']);
+            const cardViewTextItemObject = {
+                label: 'Text label 1',
+                value: ['item1', 'item2', 'item3'],
+                key: 'textkey',
+                default: ['FAKE-DEFAULT-KEY'],
+                editable: true,
+                multivalued: true
+            };
+            renderChipsForMultiValuedProperties(cardViewTextItemObject, true, 3, 'item1', 'item2', 'item3');
 
         });
 
         it('should render chips for multivalue integers when chips are enabled', async () => {
-            renderChipsForMultiValuedProperties('Text label', [1, 2, 3], 'textkey', true, true,
-            true, 3, '1', '2', '3');
+            const cardViewTextItemObject = {
+                label: 'Text label 2',
+                value: [1, 2, 3],
+                key: 'textkey',
+                editable: true,
+                multivalued: true
+            };
+            renderChipsForMultiValuedProperties(cardViewTextItemObject, true, 3, '1', '2', '3');
 
         });
 
         it('should render chips for multivalue decimal numbers when chips are enabled', async () => {
-            renderChipsForMultiValuedProperties('Text label', [1.1, 2.2, 3.3], 'textkey', true, true,
-            true, 3, '1.1', '2.2', '3.3');
+            const cardViewTextItemObject = {
+                label: 'Text label 3',
+                value: [1.1, 2.2, 3.3],
+                key: 'textkey',
+                editable: true,
+                multivalued: true
+            };
+            renderChipsForMultiValuedProperties(cardViewTextItemObject, true, 3, '1.1', '2.2', '3.3');
 
         });
 

--- a/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
@@ -847,7 +847,7 @@ describe('CardViewTextItemComponent', () => {
         });
 
         it('should not perform undo action when control key is not pressed even if the keycode is correct', async () => {
-            component.textInput.setValue('DO NOT DO UNDO');
+            component.textInput.setValue('DO NOT PERFORM UNDO');
             const event = new KeyboardEvent('keydown', {
                 ctrlKey: false,
                 code: 'KeyZ',

--- a/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
@@ -557,51 +557,6 @@ describe('CardViewTextItemComponent', () => {
             expect(component.property.value).toEqual(component.editedValue);
         });
 
-        it('should perform undo action by clearing the text that we enter in the text field using undo keyboard shortcut', async () => {
-            component.textInput.setValue('UNDO TEST');
-            component.undoText({
-                ctrlKey: true,
-                code: 'KeyZ',
-                metaKey: false
-            });
-
-            expect(component.textInput.value).toBe('');
-        });
-
-
-        it('should not perform undo action when we hit any other shortcut instead of using undo keyboard shortcut', async () => {
-            component.textInput.setValue('DO NOT DO UNDO');
-            component.undoText({
-                ctrlKey: true,
-                code: 'KeyH',
-                metaKey: false
-            });
-
-            expect(component.textInput.value).not.toBe('');
-        });
-
-        it('should not perform undo action when control key is not pressed even if the keycode is correct', async () => {
-            component.textInput.setValue('DO NOT DO UNDO');
-            component.undoText({
-                ctrlKey: false,
-                code: 'KeyZ',
-                metaKey: false
-            });
-
-            expect(component.textInput.value).not.toBe('');
-        });
-
-        it('should perform undo action in MacOS by clearing the text that we enter in the text field using undo keyboard shortcut', async () => {
-            component.textInput.setValue('UNDO TEST FOR MACOS');
-            component.undoText({
-                ctrlKey: false,
-                code: 'KeyZ',
-                metaKey: true
-            });
-
-            expect(component.textInput.value).toBe('');
-        });
-
         it('should trigger an update event on the CardViewUpdateService [integration]', async () => {
             const cardViewUpdateService = TestBed.inject(CardViewUpdateService);
             const itemUpdatedSpy = spyOn(cardViewUpdateService.itemUpdated$, 'next');
@@ -861,6 +816,58 @@ describe('CardViewTextItemComponent', () => {
             expect(error).toBeFalsy();
             expect(getTextFieldValue(component.property.key)).toEqual(expectedNumber.toString());
             expect(component.property.value).toBe(expectedNumber.toString());
+        });
+    });
+
+    describe('events', () => {
+
+        it('should perform undo action by clearing the text that we enter in the text field using undo keyboard shortcut', async () => {
+            component.textInput.setValue('UNDO TEST');
+            const event = new KeyboardEvent('keydown', {
+                ctrlKey: true,
+                code: 'KeyZ',
+                metaKey: false
+            } as KeyboardEventInit );
+            component.undoText(event);
+
+            expect(component.textInput.value).toBe('');
+        });
+
+
+        it('should not perform undo action when we hit any other shortcut instead of using undo keyboard shortcut', async () => {
+            component.textInput.setValue('DO NOT DO UNDO');
+            const event = new KeyboardEvent('keydown', {
+                ctrlKey: true,
+                code: 'KeyH',
+                metaKey: false
+            } as KeyboardEventInit );
+            component.undoText(event);
+
+            expect(component.textInput.value).not.toBe('');
+        });
+
+        it('should not perform undo action when control key is not pressed even if the keycode is correct', async () => {
+            component.textInput.setValue('DO NOT DO UNDO');
+            const event = new KeyboardEvent('keydown', {
+                ctrlKey: false,
+                code: 'KeyZ',
+                metaKey: false
+            } as KeyboardEventInit );
+            component.undoText(event);
+
+            expect(component.textInput.value).not.toBe('');
+        });
+
+        it('should perform undo action in MacOS by clearing the text that we enter in the text field using undo keyboard shortcut', async () => {
+            component.textInput.setValue('UNDO TEST FOR MACOS');
+            const event = new KeyboardEvent('keydown', {
+                ctrlKey: false,
+                code: 'KeyZ',
+                metaKey: true
+            } as KeyboardEventInit );
+            component.undoText(event);
+
+            expect(component.textInput.value).toBe('');
         });
     });
 });

--- a/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
@@ -559,7 +559,45 @@ describe('CardViewTextItemComponent', () => {
 
         it('should perform undo action by clearing the text that we enter in the text field using undo keyboard shortcut', async () => {
             component.textInput.setValue('UNDO TEST');
-            component.checkKeyboardEvent({ctrlKey: true, code: 'KeyZ'});
+            component.undoText({
+                ctrlKey: true,
+                code: 'KeyZ',
+                metaKey: false
+            });
+
+            expect(component.textInput.value).toBe('');
+        });
+
+
+        it('should not perform undo action when we hit any other shortcut instead of using undo keyboard shortcut', async () => {
+            component.textInput.setValue('DO NOT DO UNDO');
+            component.undoText({
+                ctrlKey: true,
+                code: 'KeyH',
+                metaKey: false
+            });
+
+            expect(component.textInput.value).not.toBe('');
+        });
+
+        it('should not perform undo action when control key is not pressed even if the keycode is correct', async () => {
+            component.textInput.setValue('DO NOT DO UNDO');
+            component.undoText({
+                ctrlKey: false,
+                code: 'KeyZ',
+                metaKey: false
+            });
+
+            expect(component.textInput.value).not.toBe('');
+        });
+
+        it('should perform undo action in MacOS by clearing the text that we enter in the text field using undo keyboard shortcut', async () => {
+            component.textInput.setValue('UNDO TEST FOR MACOS');
+            component.undoText({
+                ctrlKey: false,
+                code: 'KeyZ',
+                metaKey: true
+            });
 
             expect(component.textInput.value).toBe('');
         });

--- a/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.ts
+++ b/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.ts
@@ -36,12 +36,6 @@ const templateTypes = {
     defaultTemplate: 'defaultTemplate'
 };
 
-interface KeyboardEvents {
-    ctrlKey: boolean;
-    metaKey: boolean;
-    code: string;
-}
-
 @Component({
     selector: 'adf-card-view-textitem',
     templateUrl: './card-view-textitem.component.html',
@@ -198,11 +192,9 @@ export class CardViewTextItemComponent extends BaseCardView<CardViewTextItemMode
         }
     }
 
-    undoText(event: KeyboardEvents) {
-        if ((event.ctrlKey || event.metaKey) && event.code === 'KeyZ') {
-            if (this.textInput.value) {
+    undoText(event: KeyboardEvent) {
+        if ((event.ctrlKey || event.metaKey) && event.code === 'KeyZ' && this.textInput.value) {
                 this.textInput.setValue('');
-            }
         }
     }
 

--- a/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.ts
+++ b/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.ts
@@ -192,6 +192,14 @@ export class CardViewTextItemComponent extends BaseCardView<CardViewTextItemMode
         }
     }
 
+    checkKeyboardEvent(event: any) {
+        if ((event.ctrlKey || event.metaKey) && event.code === 'KeyZ') {
+            if (this.textInput.value) {
+                this.textInput.setValue('');
+            }
+        }
+    }
+
     ngOnDestroy() {
         this.onDestroy$.next(true);
         this.onDestroy$.complete();

--- a/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.ts
+++ b/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.ts
@@ -36,6 +36,12 @@ const templateTypes = {
     defaultTemplate: 'defaultTemplate'
 };
 
+interface KeyboardEvents {
+    ctrlKey: boolean;
+    metaKey: boolean;
+    code: string;
+}
+
 @Component({
     selector: 'adf-card-view-textitem',
     templateUrl: './card-view-textitem.component.html',
@@ -192,7 +198,7 @@ export class CardViewTextItemComponent extends BaseCardView<CardViewTextItemMode
         }
     }
 
-    checkKeyboardEvent(event: any) {
+    undoText(event: KeyboardEvents) {
         if ((event.ctrlKey || event.metaKey) && event.code === 'KeyZ') {
             if (this.textInput.value) {
                 this.textInput.setValue('');


### PR DESCRIPTION
… for Create and Edit a rule

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Undo functionality (ctrl+Z) was not working for input in Perform Actions after selecting an action after destnation folder change in Create/Edit a rule in Manage Rules


**What is the new behaviour?**
Undo functionality (ctrl+Z) is now working for input in Perform Actions after selecting an action after destnation folder change in Create/Edit a rule in Manage Rules


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
