### PR TITLE
[AAE-12784] elements get typography from theme

### DIFF
--- a/demo-shell/src/app/components/logout/logout.component.html
+++ b/demo-shell/src/app/components/logout/logout.component.html
@@ -1,8 +1,8 @@
 <header class="app-logout-background">
     <div class="app-logout-section" data-automation-id="adf-logout-section">
         <div class="app-logout-headline">
-            <h1>{{ 'APP.LOGOUT.TITLE' | translate}}</h1>
-            <h2>{{ 'APP.LOGOUT.SUB_TITLE' | translate}}</h2>
+            <h1 class="mat-h1">{{ 'APP.LOGOUT.TITLE' | translate}}</h1>
+            <h2 class="mat-h2">{{ 'APP.LOGOUT.SUB_TITLE' | translate}}</h2>
         </div>
 
         <div class="app-logout-login">

--- a/demo-shell/src/app/components/logout/logout.component.scss
+++ b/demo-shell/src/app/components/logout/logout.component.scss
@@ -15,16 +15,10 @@
 
 .app-logout-headline {
     h1 {
-        font-size: 56px;
-        font-weight: 300;
-        line-height: 56px;
         margin: 15px 5px;
     }
 
     h2 {
-        font-size: 18px;
-        font-weight: 300;
-        line-height: 28px;
         margin: 15px 0 25px;
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/AAE-12874


**What is the new behaviour?**
H1 and H2 elements gets typography from loaded theme. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
