### PR TITLE
[HXCS-1322] fix e2e NotificaionComponent demo

### DIFF
--- a/demo-shell/src/app/components/notifications/notifications.component.ts
+++ b/demo-shell/src/app/components/notifications/notifications.component.ts
@@ -29,7 +29,7 @@ import { takeUntil } from 'rxjs/operators';
 export class NotificationsComponent implements OnInit, OnDestroy {
 
     message = 'I ♥️ ADF';
-    decorativeIcon = 'folder';
+    decorativeIcon = '';
     withAction = false;
     actionOutput = '';
     snackBarConfigObject = '';

--- a/e2e/core/notifications-component.e2e.ts
+++ b/e2e/core/notifications-component.e2e.ts
@@ -53,6 +53,7 @@ describe('Notifications Component', () => {
     afterEach(async () => {
         await notificationPage.snackbarPage.waitForSnackBarToClose();
         await browser.executeScript(`document.querySelector('button[data-automation-id="notification-custom-dismiss-button"]').click();`);
+        await notificationPage.enterDecorativeIconField('');
     });
 
     it('[C279979] Should not show notification when the message is empty and button is clicked', async () => {

--- a/e2e/core/notifications-component.e2e.ts
+++ b/e2e/core/notifications-component.e2e.ts
@@ -53,7 +53,6 @@ describe('Notifications Component', () => {
     afterEach(async () => {
         await notificationPage.snackbarPage.waitForSnackBarToClose();
         await browser.executeScript(`document.querySelector('button[data-automation-id="notification-custom-dismiss-button"]').click();`);
-        await notificationPage.enterDecorativeIconField('');
     });
 
     it('[C279979] Should not show notification when the message is empty and button is clicked', async () => {
@@ -66,13 +65,6 @@ describe('Notifications Component', () => {
         await notificationPage.enterMessageField('test');
         await notificationPage.clickNotificationButton();
         await expect(await notificationPage.snackbarPage.getSnackBarMessage()).toEqual('test');
-    });
-
-    it('[C694098] Should show a decorative icon when the message and the icon fields are not empty and button is clicked', async () => {
-        await notificationPage.enterMessageField('test');
-        await notificationPage.enterDecorativeIconField('folder');
-        await notificationPage.clickNotificationButton();
-        await expect(await notificationPage.snackbarPage.getSnackBarDecorativeIcon()).toEqual('folder');
     });
 
     it('[C279978] Should show notification with action when the message is not empty and button is clicked', async () => {
@@ -102,6 +94,13 @@ describe('Notifications Component', () => {
         await notificationPage.clickActionButton();
         await notificationPage.checkActionEvent();
         await notificationPage.clickActionToggle();
+    });
+
+    it('[C694098] Should show a decorative icon when the message and the icon fields are not empty and button is clicked', async () => {
+        await notificationPage.enterMessageField('test');
+        await notificationPage.enterDecorativeIconField('folder');
+        await notificationPage.clickNotificationButton();
+        await expect(await notificationPage.snackbarPage.getSnackBarDecorativeIcon()).toEqual('folder');
     });
 
     it('[C279987] Should show custom notification during a limited time when a duration is added', async () => {

--- a/lib/core/src/lib/snackbar-content/snackbar-content.component.html
+++ b/lib/core/src/lib/snackbar-content/snackbar-content.component.html
@@ -1,6 +1,4 @@
-<p class="adf-snackbar-message-content" data-automation-id="adf-snackbar-message-content" aria-hidden="true">
-    <mat-icon *ngIf="data.decorativeIcon" data-automation-id="adf-snackbar-decorative-icon">{{ data.decorativeIcon }}</mat-icon>{{ data.message }}
-</p>
+<p class="adf-snackbar-message-content" data-automation-id="adf-snackbar-message-content" aria-hidden="true"><mat-icon *ngIf="data.decorativeIcon" data-automation-id="adf-snackbar-decorative-icon">{{ data.decorativeIcon }}</mat-icon>{{ data.message }}</p>
 <div *ngIf="data.showAction" class="adf-snackbar-message-content-action" aria-hidden="true">
     <button mat-button (click)="snackBarRef.dismissWithAction()" *ngIf="data.actionLabel" class="adf-snackbar-message-content-action-button"
             data-automation-id="adf-snackbar-message-content-action-button">


### PR DESCRIPTION
remove initial value to not break tests already present

**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
The issue is present in the NotificationsComponent used in the Demo. I added a new public property decorativeIcon with a default value 'folder'  binded to an <input> in the template. That breaks already present test. What do you prefer to solve the issue:


**What is the new behaviour?**
remove default value 'folder' from the NotificationsComponent and leave tests as they are


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
