### PR TITLE
[AAE-12318] Adjustments for HxP Attach-File widget

### DIFF
--- a/lib/core/src/lib/form/components/widgets/core/form.model.ts
+++ b/lib/core/src/lib/form/components/widgets/core/form.model.ts
@@ -91,7 +91,13 @@ export class FormModel implements ProcessFormModel {
     processVariables: ProcessVariableModel[] = [];
     variables: FormVariableModel[] = [];
 
-    constructor(json?: any, formValues?: FormValues, readOnly: boolean = false, protected formService?: FormValidationService, enableFixedSpace?: boolean) {
+    constructor(
+        json?: any,
+        formValues?: FormValues,
+        readOnly: boolean = false,
+        protected formService?: FormValidationService,
+        enableFixedSpace?: boolean
+    ) {
         this.readOnly = readOnly;
         this.json = json;
 
@@ -415,8 +421,10 @@ export class FormModel implements ProcessFormModel {
     }
 
     setNodeIdValueForViewersLinkedToUploadWidget(linkedUploadWidgetContentSelected: UploadWidgetContentLinkModel) {
+        const linkedWidgetType = linkedUploadWidgetContentSelected?.options?.linkedWidgetType ?? 'uploadWidget';
+
         const subscribedViewers = this.fieldsCache.filter(field =>
-            linkedUploadWidgetContentSelected.uploadWidgetId === field.params['uploadWidget']
+            linkedUploadWidgetContentSelected.uploadWidgetId === field.params[linkedWidgetType]
         );
 
         subscribedViewers.forEach(viewer => {

--- a/lib/core/src/lib/form/components/widgets/core/upload-widget-content-link.model.ts
+++ b/lib/core/src/lib/form/components/widgets/core/upload-widget-content-link.model.ts
@@ -16,11 +16,13 @@
  */
 
 import { ContentLinkModel } from './content-link.model';
-
+export class UploadWidgetContentLinkModelOptions {
+    linkedWidgetType: string;
+}
 export class UploadWidgetContentLinkModel extends ContentLinkModel {
     uploadWidgetId: string;
 
-    constructor(obj?: any, uploadWidgetId?: string) {
+    constructor(obj?: any, uploadWidgetId?: string, public options?: UploadWidgetContentLinkModelOptions) {
         super(obj);
         this.uploadWidgetId = uploadWidgetId;
     }

--- a/lib/process-services-cloud/src/lib/form/components/form-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/form/components/form-cloud.component.ts
@@ -33,7 +33,8 @@ import {
     FormValues,
     FormModel,
     ContentLinkModel,
-    UploadWidgetContentLinkModel
+    UploadWidgetContentLinkModel,
+    FormEvent
 } from '@alfresco/adf-core';
 import { FormCloudService } from '../services/form-cloud.service';
 import { TaskVariableCloud } from '../models/task-variable-cloud.model';
@@ -119,6 +120,7 @@ export class FormCloudComponent extends FormBaseComponent implements OnChanges, 
                 if (content instanceof UploadWidgetContentLinkModel) {
                     this.form.setNodeIdValueForViewersLinkedToUploadWidget(content);
                     this.onFormDataRefreshed(this.form);
+                    this.formService.formDataRefreshed.next(new FormEvent(this.form));
                 } else {
                     this.formContentClicked.emit(content);
                 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

'uploadWidget' string present in `FormModel` class in adf doesn't allow for extensions in hxp

**What is the new behaviour?**

- added `public options?: UploadWidgetContentLinkModelOptions` as optional parameter in `UploadWidgetContentLinkModel` constructor,
- added `formDataRefreshed.next(new FormEvent(this.form))` in `formContentClicked` subscription in `FormCloudComponent` constructor.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
