### PR TITLE
[ACA-4654] Sign in button isn't centred as expected

### DIFF
--- a/lib/core/src/lib/login/components/login.component.scss
+++ b/lib/core/src/lib/login/components/login.component.scss
@@ -116,8 +116,12 @@
     .adf-login-button {
         width: 100%;
         height: 36px;
-        line-height: 38px;
+        line-height: normal;
         box-shadow: none;
+    }
+
+    .adf-login-button .mat-button-wrapper {
+        display: inline-flex;
     }
 
     .adf-login-button-label {
@@ -144,6 +148,7 @@
     .adf-interactive-login-label {
         display: flex;
         flex-direction: row;
+        line-height: 38px;
         justify-content: center;
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [X] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

'Sign in' text is not aligned properly in login button
<img width="455" alt="Screenshot 2023-03-30 at 15 54 32" src="https://user-images.githubusercontent.com/84377976/228859167-c50492b3-10fe-4ac5-ac34-600f28055739.png">


**What is the new behaviour?**

'Sign in' text is aligned properly in login button
<img width="457" alt="Screenshot 2023-03-30 at 15 54 58" src="https://user-images.githubusercontent.com/84377976/228859105-1e4b81c1-6fc9-486e-b827-1cc0892870a6.png">


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://alfresco.atlassian.net/browse/ACA-4654