### PR TITLE
[ACA-4677] Added download functionality on DownloadPromptDialog

### DIFF
--- a/docs/core/components/viewer.component.md
+++ b/docs/core/components/viewer.component.md
@@ -84,12 +84,13 @@ See the [Custom layout](#custom-layout) section for full details of all availabl
 
 ### Events
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| navigateBefore | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<KeyboardEvent \| MouseEvent>` | Emitted when user clicks 'Navigate Before' ("&lt;") button. |
-| navigateNext | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<KeyboardEvent \| MouseEvent>` | Emitted when user clicks 'Navigate Next' (">") button. |
-| showViewerChange | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<boolean>` | Emitted when the viewer close |
-| submitFile | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob)`>` | Emitted when the img is submitted in the img viewer. |
+| Name | Type                                                                                                                            | Description                                                               |
+| ---- |---------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------|
+| navigateBefore | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<KeyboardEvent \| MouseEvent>`                                       | Emitted when user clicks 'Navigate Before' ("&lt;") button.               |
+| navigateNext | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<KeyboardEvent \| MouseEvent>`                                       | Emitted when user clicks 'Navigate Next' (">") button.                    |
+| showViewerChange | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<boolean>`                                                           | Emitted when the viewer close                                             |
+| submitFile | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob)`>` | Emitted when the img is submitted in the img viewer.                      |
+| submitFile | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`void`](https://developer.mozilla.org/en-US/docs/Web/API/Blob)`>` | Emitted when download button is clicked on the downloadPrompt dialog. |
 
 ## Keyboard shortcuts
 

--- a/docs/core/components/viewer.component.md
+++ b/docs/core/components/viewer.component.md
@@ -84,13 +84,13 @@ See the [Custom layout](#custom-layout) section for full details of all availabl
 
 ### Events
 
-| Name | Type                                                                                                                            | Description                                                               |
-| ---- |---------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------|
-| navigateBefore | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<KeyboardEvent \| MouseEvent>`                                       | Emitted when user clicks 'Navigate Before' ("&lt;") button.               |
-| navigateNext | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<KeyboardEvent \| MouseEvent>`                                       | Emitted when user clicks 'Navigate Next' (">") button.                    |
-| showViewerChange | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<boolean>`                                                           | Emitted when the viewer close                                             |
-| submitFile | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob)`>` | Emitted when the img is submitted in the img viewer.                      |
-| submitFile | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`void`](https://developer.mozilla.org/en-US/docs/Web/API/Blob)`>` | Emitted when download button is clicked on the downloadPrompt dialog. |
+| Name             | Type                                                                                                                            | Description                                                                |
+|------------------|---------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------|
+| navigateBefore   | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<KeyboardEvent \| MouseEvent>`                                       | Emitted when user clicks 'Navigate Before' ("&lt;") button.                |
+| navigateNext     | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<KeyboardEvent \| MouseEvent>`                                       | Emitted when user clicks 'Navigate Next' (">") button.                     |
+| showViewerChange | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<boolean>`                                                           | Emitted when the viewer close                                              |
+| submitFile       | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob)`>` | Emitted when the img is submitted in the img viewer.                       |
+| downloadFile     | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<`[`void`](https://developer.mozilla.org/en-US/docs/Web/API/Blob)`>` | Emitted when download button is clicked on the Download File Prompt. |
 
 ## Keyboard shortcuts
 

--- a/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.html
+++ b/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.html
@@ -21,6 +21,7 @@
     [urlFile]="urlFileContent"
     [tracks]="tracks"
     [readOnly]="readOnly"
+    (downloadFile)="onDownloadFile()"
     (navigateBefore)="onNavigateBeforeClick($event)"
     (navigateNext)="onNavigateNextClick($event)"
     (showViewerChange)="onClose()"

--- a/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.spec.ts
+++ b/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.spec.ts
@@ -26,7 +26,7 @@ import { AppExtensionService, ViewerExtensionRef } from '@alfresco/adf-extension
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { NodeEntry, VersionEntry } from '@alfresco/js-api';
-import { AlfrescoViewerComponent, RenditionService } from '@alfresco/adf-content-services';
+import { AlfrescoViewerComponent, NodeActionsService, RenditionService } from '@alfresco/adf-content-services';
 import {
     CoreTestingModule,
     setupTestBed,
@@ -37,7 +37,7 @@ import { NodesApiService } from '../../common/services/nodes-api.service';
 import { UploadService } from '../../common/services/upload.service';
 import { FileModel } from '../../common/models/file.model';
 import { throwError } from 'rxjs';
-import { Component } from '@angular/core';
+import { Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ESCAPE } from '@angular/cdk/keycodes';
 
 @Component({
@@ -149,6 +149,7 @@ describe('AlfrescoViewerComponent', () => {
     let extensionService: AppExtensionService;
     let renditionService: RenditionService;
     let viewUtilService: ViewUtilService;
+    let nodeActionsService: NodeActionsService;
 
     setupTestBed({
         imports: [
@@ -174,7 +175,8 @@ describe('AlfrescoViewerComponent', () => {
             },
             {provide: Location, useClass: SpyLocation},
             MatDialog
-        ]
+        ],
+        schemas: [CUSTOM_ELEMENTS_SCHEMA]
     });
 
     beforeEach(() => {
@@ -188,6 +190,7 @@ describe('AlfrescoViewerComponent', () => {
         extensionService = TestBed.inject(AppExtensionService);
         renditionService = TestBed.inject(RenditionService);
         viewUtilService = TestBed.inject(ViewUtilService);
+        nodeActionsService = TestBed.inject(NodeActionsService);
     });
 
     afterEach(() => {
@@ -349,6 +352,12 @@ describe('AlfrescoViewerComponent', () => {
         expect(component.fileName).toBe('file3');
         expect(component.nodeId).toBe('id1');
     }));
+
+    it('should download file when downloadFile event is emitted', () => {
+        spyOn(nodeActionsService, 'downloadNode');
+        component.onDownloadFile();
+        expect(nodeActionsService.downloadNode).toHaveBeenCalled();
+    });
 
     describe('Viewer Example Component Rendering', () => {
 

--- a/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.spec.ts
+++ b/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.spec.ts
@@ -31,7 +31,7 @@ import {
     CoreTestingModule,
     setupTestBed,
     EventMock,
-    ViewUtilService
+    ViewUtilService, ViewerComponent
 } from '@alfresco/adf-core';
 import { NodesApiService } from '../../common/services/nodes-api.service';
 import { UploadService } from '../../common/services/upload.service';
@@ -39,6 +39,7 @@ import { FileModel } from '../../common/models/file.model';
 import { throwError } from 'rxjs';
 import { Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ESCAPE } from '@angular/cdk/keycodes';
+import { By } from '@angular/platform-browser';
 
 @Component({
     selector: 'adf-viewer-container-toolbar',
@@ -355,7 +356,10 @@ describe('AlfrescoViewerComponent', () => {
 
     it('should download file when downloadFile event is emitted', () => {
         spyOn(nodeActionsService, 'downloadNode');
-        component.onDownloadFile();
+        const viewerComponent = fixture.debugElement.query(By.directive(ViewerComponent));
+        viewerComponent.triggerEventHandler('downloadFile');
+
+        fixture.detectChanges();
         expect(nodeActionsService.downloadNode).toHaveBeenCalled();
     });
 

--- a/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.ts
+++ b/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.ts
@@ -60,6 +60,7 @@ import { ContentService } from '../../common/services/content.service';
 import { NodesApiService } from '../../common/services/nodes-api.service';
 import { UploadService } from '../../common/services/upload.service';
 import { FileModel } from '../../common/models/file.model';
+import { NodeActionsService } from '../../document-list';
 
 @Component({
     selector: 'adf-alfresco-viewer',
@@ -238,7 +239,8 @@ export class AlfrescoViewerComponent implements OnChanges, OnInit, OnDestroy {
                 private contentService: ContentService,
                 private uploadService: UploadService,
                 public dialog: MatDialog,
-                private cdr: ChangeDetectorRef) {
+                private cdr: ChangeDetectorRef,
+                private nodeActionsService: NodeActionsService) {
         renditionService.maxRetries = this.maxRetries;
 
     }
@@ -449,4 +451,7 @@ export class AlfrescoViewerComponent implements OnChanges, OnInit, OnDestroy {
         this.onDestroy$.complete();
     }
 
+    onDownloadFile() {
+        this.nodeActionsService.downloadNode(this.nodeEntry);
+    }
 }

--- a/lib/core/src/lib/viewer/components/viewer.component.spec.ts
+++ b/lib/core/src/lib/viewer/components/viewer.component.spec.ts
@@ -675,5 +675,15 @@ describe('ViewerComponent', () => {
             flush();
             discardPeriodicTasks();
         }));
+
+        it('should emit downloadFileEvent when DownloadPromptDialog return DownloadPromptActions.DOWNLOAD on close', fakeAsync( () => {
+            dialogOpenSpy.and.returnValue({ afterClosed: () => of(DownloadPromptActions.DOWNLOAD) } as any);
+            spyOn(component.downloadFile, 'emit');
+            fixture.detectChanges();
+            tick(3000);
+            fixture.detectChanges();
+
+            expect(component.downloadFile.emit).toHaveBeenCalled();
+        }));
     });
 });

--- a/lib/core/src/lib/viewer/components/viewer.component.ts
+++ b/lib/core/src/lib/viewer/components/viewer.component.ts
@@ -190,6 +190,12 @@ export class ViewerComponent<T> implements OnDestroy, OnInit, OnChanges {
      * */
     downloadPromptReminderDelay: number = 15;
 
+    /**
+     * Emitted when user clicks on download button on non responsive preview dialog.
+     * */
+    @Output()
+    downloadFile: EventEmitter<void> = new EventEmitter<void>();
+
     /** Emitted when user clicks 'Navigate Before' ("<") button. */
     @Output()
     navigateBefore = new EventEmitter<MouseEvent | KeyboardEvent>();
@@ -388,7 +394,10 @@ export class ViewerComponent<T> implements OnDestroy, OnInit, OnChanges {
             this.isDialogVisible = true;
             this.dialog.open(DownloadPromptDialogComponent, { disableClose: true }).afterClosed().pipe(first()).subscribe((result: DownloadPromptActions) => {
                 this.isDialogVisible = false;
-                if (result === DownloadPromptActions.WAIT) {
+                if (result === DownloadPromptActions.DOWNLOAD) {
+                    this.downloadFile.emit();
+                    this.onClose();
+                } else if (result === DownloadPromptActions.WAIT) {
                     if (this.enableDownloadPromptReminder) {
                         this.clearDownloadPromptTimeouts();
                         this.downloadPromptReminderTimer = window.setTimeout(() => {

--- a/lib/core/src/lib/viewer/components/viewer.component.ts
+++ b/lib/core/src/lib/viewer/components/viewer.component.ts
@@ -191,7 +191,7 @@ export class ViewerComponent<T> implements OnDestroy, OnInit, OnChanges {
     downloadPromptReminderDelay: number = 15;
 
     /**
-     * Emitted when user clicks on download button on non responsive preview dialog.
+     * Emitted when user clicks on download button on download prompt dialog.
      * */
     @Output()
     downloadFile: EventEmitter<void> = new EventEmitter<void>();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
DownloadPrompt for viewer component was implemented in ACA-4675. However, the 'Download' button in that prompt was not functional.


**What is the new behaviour?**
This PR adds the 'Download' button functionality to the DownloadPrompt


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
More information on this can be found on the following JIRAs - 
- [ACA-4675 (EPIC)](https://alfresco.atlassian.net/browse/ACA-4675)
- [ACA-4677 (STORY)](https://alfresco.atlassian.net/browse/ACA-4677)