### PR TITLE
[ACS-4788] Add support for the Categories facet

### DIFF
--- a/docs/content-services/services/category.service.md
+++ b/docs/content-services/services/category.service.md
@@ -13,32 +13,36 @@ Manages categories in Content Services.
 
 ### Methods
 
--   **createSubcategories**(parentCategoryId: `string`, payload: `CategoryBody[]`): [`Observable`](http://reactivex.io/documentation/observable.html)`<CategoryPaging|CategoryEntry>`<br/>
-    Creates subcategories under category with provided categoryId
-    -   _parentCategoryId:_ `string`  - The identifier of a parent category.
-    -   _payload:_ `CategoryBody[]`  - List of categories to be created.
-    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<CategoryPaging|CategoryEntry>` - [`Observable`](http://reactivex.io/documentation/observable.html)&lt;CategoryPaging | CategoryEntry>
+-   **getSubcategories**(parentCategoryId: `string`, skipCount?: `number`, maxItems?: `number`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`CategoryPaging`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/api/content-rest-api/docs/CategoryPaging.md)`>`<br/>
+    Gets subcategories of a given parent category.
+    -   _parentCategoryId:_ `string`  - Identifier of a parent category
+    -   _skipCount:_ `number`  - Number of top categories to skip
+    -   _maxItems:_ `number`  - Maximum number of subcategories returned from Observable
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`CategoryPaging`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/api/content-rest-api/docs/CategoryPaging.md)`>` - CategoryPaging object (defined in JS-API) with category paging list
+-   **getCategory**(categoryId: `string`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`CategoryEntry`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/api/content-rest-api/docs/CategoryEntry.md)`>`<br/>
+    Gets a specific category by categoryId.
+    -   _categoryId:_ `string`  - The identifier of a category
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`CategoryEntry`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/api/content-rest-api/docs/CategoryEntry.md)`>` - CategoryEntry object (defined in JS-API) containing information about the category.
+-   **createSubcategories**(parentCategoryId: `string`, payload: [`CategoryBody[]`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/api/content-rest-api/docs/CategoryBody.md)): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`CategoryPaging`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/api/content-rest-api/docs/CategoryPaging.md) | [`CategoryEntry`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/api/content-rest-api/docs/CategoryEntry.md)`>`<br/>
+    Creates subcategories under category with provided categoryId.
+    -   _parentCategoryId:_ `string`  - Identifier of a parent category
+    -   _payload:_ [`CategoryBody[]`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/api/content-rest-api/docs/CategoryBody.md)  - List of categories to be created
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`CategoryPaging`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/api/content-rest-api/docs/CategoryPaging.md) | [`CategoryEntry`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/api/content-rest-api/docs/CategoryEntry.md)`>` - CategoryEntry object (defined in JS-API) containing the category
+-   **updateCategory**(categoryId: `string`, payload: [`CategoryBody`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/api/content-rest-api/docs/CategoryBody.md)): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`CategoryEntry`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/api/content-rest-api/docs/CategoryEntry.md)`>`<br/>
+    Updates category.
+    -   _categoryId:_ `string`  - Identifier of a category
+    -   _payload:_ [`CategoryBody`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/api/content-rest-api/docs/CategoryBody.md)  - Created category body
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`CategoryEntry`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/api/content-rest-api/docs/CategoryEntry.md)`>` - CategoryEntry object (defined in JS-API) containing the category
 -   **deleteCategory**(categoryId: `string`): [`Observable`](http://reactivex.io/documentation/observable.html)`<void>`<br/>
     Deletes category
     -   _categoryId:_ `string`  - The identifier of a category.
     -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<void>` - [`Observable`](http://reactivex.io/documentation/observable.html)&lt;void>
--   **getSubcategories**(parentCategoryId: `string`, skipCount?: `number`, maxItems?: `number`): [`Observable`](http://reactivex.io/documentation/observable.html)`<CategoryPaging>`<br/>
-    Get subcategories of a given parent category
-    -   _parentCategoryId:_ `string`  - The identifier of a parent category.
-    -   _skipCount:_ `number`  - (Optional) Number of top categories to skip.
-    -   _maxItems:_ `number`  - (Optional) Maximum number of subcategories returned from [Observable](http://reactivex.io/documentation/observable.html).
-    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<CategoryPaging>` - [`Observable`](http://reactivex.io/documentation/observable.html)&lt;CategoryPaging>
 -   **searchCategories**(name: `string`, skipCount: `number` = `0`, maxItems?: `number`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`ResultSetPaging`](https://github.com/Alfresco/alfresco-js-api/blob/develop/src/api/search-rest-api/docs/ResultSetPaging.md)`>`<br/>
     Searches categories by their name.
     -   _name:_ `string`  - Value for name which should be used during searching categories.
     -   _skipCount:_ `number`  - Specify how many first results should be skipped. Default 0.
     -   _maxItems:_ `number`  - (Optional) Specify max number of returned categories. Default is specified by [UserPreferencesService](../../core/services/user-preferences.service.md).
     -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`ResultSetPaging`](https://github.com/Alfresco/alfresco-js-api/blob/develop/src/api/search-rest-api/docs/ResultSetPaging.md)`>` - [`Observable`](http://reactivex.io/documentation/observable.html)&lt;ResultSetPaging> Found categories which name contains searched name.
--   **updateCategory**(categoryId: `string`, payload: `CategoryBody`): [`Observable`](http://reactivex.io/documentation/observable.html)`<CategoryEntry>`<br/>
-    Updates category
-    -   _categoryId:_ `string`  - The identifier of a category.
-    -   _payload:_ `CategoryBody`  - Updated category body
-    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<CategoryEntry>` - [`Observable`](http://reactivex.io/documentation/observable.html)&lt;CategoryEntry>
 
 ## Details
 

--- a/lib/content-services/src/lib/category/services/category.service.spec.ts
+++ b/lib/content-services/src/lib/category/services/category.service.spec.ts
@@ -61,6 +61,13 @@ describe('CategoryService', () => {
         });
     }));
 
+    it('should fetch the category with the provided categoryId', fakeAsync(() => {
+        const getSpy = spyOn(categoryService.categoriesApi, 'getCategory').and.returnValue(Promise.resolve(fakeCategoryEntry));
+        categoryService.getCategory(fakeParentCategoryId).subscribe(() => {
+            expect(getSpy).toHaveBeenCalledOnceWith(fakeParentCategoryId);
+        });
+    }));
+
     it('should create subcategory', fakeAsync(() => {
         const createSpy = spyOn(categoryService.categoriesApi, 'createSubcategories').and.returnValue(Promise.resolve(fakeCategoryEntry));
         categoryService.createSubcategories(fakeParentCategoryId, [fakeCategoryEntry.entry]).subscribe(() => {

--- a/lib/content-services/src/lib/category/services/category.service.ts
+++ b/lib/content-services/src/lib/category/services/category.service.ts
@@ -58,6 +58,16 @@ export class CategoryService {
     }
 
     /**
+     * Get a category by ID
+     *
+     * @param categoryId The identifier of a category.
+     * @return Observable<CategoryEntry>
+     */
+    getCategory(categoryId: string): Observable<CategoryEntry> {
+        return from(this.categoriesApi.getCategory(categoryId));
+    }
+
+    /**
      * Creates subcategories under category with provided categoryId
      *
      * @param parentCategoryId The identifier of a parent category.

--- a/lib/content-services/src/lib/search/services/search-facet-filters.service.spec.ts
+++ b/lib/content-services/src/lib/search/services/search-facet-filters.service.spec.ts
@@ -30,7 +30,7 @@ describe('SearchFacetFiltersService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-          imports: [ContentTestingModule],
+            imports: [ContentTestingModule],
             providers: [{
                 provide: CategoryService,
                 useValue: {

--- a/lib/content-services/src/lib/search/services/search-facet-filters.service.spec.ts
+++ b/lib/content-services/src/lib/search/services/search-facet-filters.service.spec.ts
@@ -472,14 +472,14 @@ describe('SearchFacetFiltersService', () => {
     });
 
     it('should load category names for cm:categories facet', () => {
+        const entry = {id: 'test-id-test', name: 'name'};
         searchFacetFiltersService.responseFacets = null;
-        spyOn(categoryService, 'getCategory').and.returnValue(of({entry: {id: 'test-id-test', name: 'name'}}));
+        spyOn(categoryService, 'getCategory').and.returnValue(of({entry}));
         spyOn(categoryService, 'searchCategories').and.returnValue(of({
                     list: {
                         entries: [{
                             entry: {
-                                id: 'test-id-test',
-                                name: 'name',
+                                ...entry,
                                 nodeType: 'node-type',
                                 path: { name: '/categories/General/Test Category/Subcategory'},
                                 isFolder: false,
@@ -506,8 +506,8 @@ describe('SearchFacetFiltersService', () => {
             {type: 'field', label: 'f1', buckets: [{label: 'a1'}, {label: 'a2'}]},
             {
                 type: 'field', label: 'categories', buckets: [{
-                    label: 'workspace://SpacesStore/test-id-test',
-                    filterQuery: 'cm:categories:"workspace://SpacesStore/test-id-test"',
+                    label: `workspace://SpacesStore/${entry.id}`,
+                    filterQuery: `cm:categories:"workspace://SpacesStore/${entry.id}"`,
                 }]
             }
         ];
@@ -521,9 +521,9 @@ describe('SearchFacetFiltersService', () => {
 
         searchFacetFiltersService.onDataLoaded(data);
 
-        expect(categoryService.getCategory).toHaveBeenCalledWith('test-id-test');
-        expect(categoryService.searchCategories).toHaveBeenCalledWith('name');
-        expect(searchFacetFiltersService.responseFacets[1].buckets.items[0].display).toBe('Test Category/Subcategory/name');
+        expect(categoryService.getCategory).toHaveBeenCalledWith(entry.id);
+        expect(categoryService.searchCategories).toHaveBeenCalledWith(entry.name);
+        expect(searchFacetFiltersService.responseFacets[1].buckets.items[0].display).toBe(`Test Category/Subcategory/${entry.name}`);
         expect(searchFacetFiltersService.responseFacets[1].buckets.length).toEqual(1);
         expect(searchFacetFiltersService.responseFacets.length).toEqual(2);
     });

--- a/lib/content-services/src/lib/search/services/search-facet-filters.service.spec.ts
+++ b/lib/content-services/src/lib/search/services/search-facet-filters.service.spec.ts
@@ -20,16 +20,27 @@ import { TestBed } from '@angular/core/testing';
 import { SearchFacetFiltersService } from './search-facet-filters.service';
 import { ContentTestingModule } from '../../testing/content.testing.module';
 import { SearchQueryBuilderService } from './search-query-builder.service';
-import { FacetBucketSortBy, FacetBucketSortDirection } from '@alfresco/adf-content-services';
+import { CategoryService, FacetBucketSortBy, FacetBucketSortDirection } from '@alfresco/adf-content-services';
+import { EMPTY, of } from 'rxjs';
 
 describe('SearchFacetFiltersService', () => {
     let searchFacetFiltersService: SearchFacetFiltersService;
     let queryBuilder: SearchQueryBuilderService;
+    let categoryService: CategoryService;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-          imports: [ContentTestingModule]
+          imports: [ContentTestingModule],
+            providers: [{
+                provide: CategoryService,
+                useValue: {
+                    getCategory: () => EMPTY,
+                    searchCategories: () => EMPTY
+                }
+            }],
         });
+
+        categoryService = TestBed.inject(CategoryService);
         searchFacetFiltersService = TestBed.inject(SearchFacetFiltersService);
         queryBuilder = TestBed.inject(SearchQueryBuilderService);
     });
@@ -458,6 +469,63 @@ describe('SearchFacetFiltersService', () => {
 
         searchFacetFiltersService.onDataLoaded(data);
         expect(searchFacetFiltersService.responseFacets.map(f => f.field)).toEqual(['field4', 'field1', 'Query 1', 'field2', 'field3']);
+    });
+
+    it('should load category names for cm:categories facet', () => {
+        searchFacetFiltersService.responseFacets = null;
+        spyOn(categoryService, 'getCategory').and.returnValue(of({entry: {id: 'test-id-test', name: 'name'}}));
+        spyOn(categoryService, 'searchCategories').and.returnValue(of({
+                    list: {
+                        entries: [{
+                            entry: {
+                                id: 'test-id-test',
+                                name: 'name',
+                                nodeType: 'node-type',
+                                path: { name: '/categories/General/Test Category/Subcategory'},
+                                isFolder: false,
+                                isFile: false
+                            }
+                        }]
+                    }
+                }));
+
+        queryBuilder.config = {
+            categories: [],
+            facetFields: {
+                fields: [
+                    {label: 'f1', field: 'f1', mincount: 0},
+                    {label: 'categories', field: 'cm:categories', mincount: 0}
+                ]
+            },
+            facetQueries: {
+                queries: []
+            }
+        };
+
+        const fields: any = [
+            {type: 'field', label: 'f1', buckets: [{label: 'a1'}, {label: 'a2'}]},
+            {
+                type: 'field', label: 'categories', buckets: [{
+                    label: 'workspace://SpacesStore/test-id-test',
+                    filterQuery: 'cm:categories:"workspace://SpacesStore/test-id-test"',
+                }]
+            }
+        ];
+        let data = {
+            list: {
+                context: {
+                    facets: fields
+                }
+            }
+        };
+
+        searchFacetFiltersService.onDataLoaded(data);
+
+        expect(categoryService.getCategory).toHaveBeenCalledWith('test-id-test');
+        expect(categoryService.searchCategories).toHaveBeenCalledWith('name');
+        expect(searchFacetFiltersService.responseFacets[1].buckets.items[0].display).toBe('Test Category/Subcategory/name');
+        expect(searchFacetFiltersService.responseFacets[1].buckets.length).toEqual(1);
+        expect(searchFacetFiltersService.responseFacets.length).toEqual(2);
     });
 
     describe('Bucket sorting', () => {

--- a/lib/content-services/src/lib/search/services/search-facet-filters.service.spec.ts
+++ b/lib/content-services/src/lib/search/services/search-facet-filters.service.spec.ts
@@ -37,7 +37,7 @@ describe('SearchFacetFiltersService', () => {
                     getCategory: () => EMPTY,
                     searchCategories: () => EMPTY
                 }
-            }],
+            }]
         });
 
         categoryService = TestBed.inject(CategoryService);
@@ -507,7 +507,7 @@ describe('SearchFacetFiltersService', () => {
             {
                 type: 'field', label: 'categories', buckets: [{
                     label: `workspace://SpacesStore/${entry.id}`,
-                    filterQuery: `cm:categories:"workspace://SpacesStore/${entry.id}"`,
+                    filterQuery: `cm:categories:"workspace://SpacesStore/${entry.id}"`
                 }]
             }
         ];

--- a/lib/content-services/src/lib/search/services/search-facet-filters.service.ts
+++ b/lib/content-services/src/lib/search/services/search-facet-filters.service.ts
@@ -350,7 +350,7 @@ export class SearchFacetFiltersService implements OnDestroy {
                     concatMap((categoryEntry) => this.categoryService.searchCategories(categoryEntry.entry.name)),
                     catchError(error => {
                         return throwError(error);
-            }),
+                    }),
                 )
                 .subscribe(
                     result => {

--- a/lib/content-services/src/lib/search/services/search-facet-filters.service.ts
+++ b/lib/content-services/src/lib/search/services/search-facet-filters.service.ts
@@ -343,7 +343,7 @@ export class SearchFacetFiltersService implements OnDestroy {
     }
 
     private loadCategoryNames(bucketList: FacetFieldBucket[]) {
-        bucketList.map((item) => {
+        bucketList.forEach((item) => {
             const categoryId = item.label.split('/').pop();
             this.categoryService.getCategory(categoryId)
                 .subscribe(categoryEntry => {

--- a/lib/content-services/src/lib/search/services/search-facet-filters.service.ts
+++ b/lib/content-services/src/lib/search/services/search-facet-filters.service.ts
@@ -300,7 +300,6 @@ export class SearchFacetFiltersService implements OnDestroy {
 
     private updateExistingBuckets(responseField, responseBuckets, alreadyExistingField, alreadyExistingBuckets) {
         const bucketsToDelete = [];
-
         alreadyExistingBuckets
             .map((bucket) => {
                 const responseBucket = ((responseField && responseField.buckets) || []).find((respBucket) => respBucket.label === bucket.label);
@@ -341,7 +340,7 @@ export class SearchFacetFiltersService implements OnDestroy {
         };
     }
 
-    private loadCategoryNames(bucketList) {
+    private loadCategoryNames(bucketList: FacetFieldBucket[]) {
         bucketList.map((item) => {
             const categoryId = item.label.split('/').pop();
             this.categoryService.getCategory(categoryId)
@@ -353,7 +352,7 @@ export class SearchFacetFiltersService implements OnDestroy {
                             const currentCat = res.list.entries.filter(entry => entry.entry.id === categoryId)[0];
                             const path = currentCat.entry.path.name.split(pathSeparator).slice(nextAfterGeneralPathPartIndex).join('/');
 
-                            path ? item.label = `${path}/${currentCat.entry.name}` : item.label = currentCat.entry.name;
+                            path ? item.display = `${path}/${currentCat.entry.name}` : item.display = currentCat.entry.name;
                         }
                     );
                 });

--- a/lib/content-services/src/lib/search/services/search-facet-filters.service.ts
+++ b/lib/content-services/src/lib/search/services/search-facet-filters.service.ts
@@ -348,9 +348,7 @@ export class SearchFacetFiltersService implements OnDestroy {
             this.categoryService.getCategory(categoryId)
                 .pipe(
                     concatMap((categoryEntry) => this.categoryService.searchCategories(categoryEntry.entry.name)),
-                    catchError(error => {
-                        return throwError(error);
-                    }),
+                    catchError(error => throwError(error))
                 )
                 .subscribe(
                     result => {
@@ -360,8 +358,7 @@ export class SearchFacetFiltersService implements OnDestroy {
                         const path = currentCat.entry.path.name.split(pathSeparator).slice(nextAfterGeneralPathPartIndex).join('/');
 
                         item.display = path ? `${path}/${currentCat.entry.name}` : currentCat.entry.name;
-                    },
-                    error => console.log(`Error: ${error}`)
+                    }
                 );
         });
     }

--- a/lib/content-services/src/lib/search/services/search-facet-filters.service.ts
+++ b/lib/content-services/src/lib/search/services/search-facet-filters.service.ts
@@ -21,11 +21,12 @@ import { Subject } from 'rxjs';
 import { SEARCH_QUERY_SERVICE_TOKEN } from '../search-query-service.token';
 import { SearchQueryBuilderService } from './search-query-builder.service';
 import { TranslationService } from '@alfresco/adf-core';
-import { SearchService } from '../services/search.service';
+import { SearchService } from './search.service';
 import { takeUntil } from 'rxjs/operators';
 import { GenericBucket, GenericFacetResponse, ResultSetContext, ResultSetPaging } from '@alfresco/js-api';
 import { SearchFilterList } from '../models/search-filter-list.model';
 import { FacetFieldBucket } from '../models/facet-field-bucket.interface';
+import { CategoryService } from '../../category';
 
 export interface SelectedBucket {
     field: FacetField;
@@ -53,7 +54,9 @@ export class SearchFacetFiltersService implements OnDestroy {
 
     constructor(@Inject(SEARCH_QUERY_SERVICE_TOKEN) public queryBuilder: SearchQueryBuilderService,
                 private searchService: SearchService,
-                private translationService: TranslationService) {
+                private translationService: TranslationService,
+                private categoryService: CategoryService
+    ) {
         if (queryBuilder.config && queryBuilder.config.facetQueries) {
             this.facetQueriesPageSize = queryBuilder.config.facetQueries.pageSize || DEFAULT_PAGE_SIZE;
         }
@@ -79,7 +82,6 @@ export class SearchFacetFiltersService implements OnDestroy {
 
     onDataLoaded(data: any) {
         const context = data.list.context;
-
         if (context) {
             this.parseFacets(context);
         } else {
@@ -101,6 +103,10 @@ export class SearchFacetFiltersService implements OnDestroy {
                 .filter(this.getFilterByMinCount(field.mincount));
             this.sortFacetBuckets(responseBuckets, field.settings?.bucketSortBy, field.settings?.bucketSortDirection ?? FacetBucketSortDirection.ASCENDING);
             const alreadyExistingField = this.findResponseFacet(itemType, field.label);
+
+            if (field.field === 'cm:categories'){
+                this.loadCategoryNames(responseBuckets);
+            }
 
             if (alreadyExistingField) {
                 const alreadyExistingBuckets = alreadyExistingField.buckets && alreadyExistingField.buckets.items || [];
@@ -333,6 +339,25 @@ export class SearchFacetFiltersService implements OnDestroy {
             }
             return true;
         };
+    }
+
+    private loadCategoryNames(bucketList) {
+        bucketList.map((item) => {
+            const categoryId = item.label.split('/').pop();
+            this.categoryService.getCategory(categoryId)
+                .subscribe(res => {
+                    this.categoryService.searchCategories(res.entry.name).subscribe(
+                        res => {
+                            const nextAfterGeneralPathPartIndex = 3;
+                            const pathSeparator = '/';
+                            const currentCat = res.list.entries.filter(entry => entry.entry.id === categoryId)[0];
+                            const path = currentCat.entry.path.name.split(pathSeparator).slice(nextAfterGeneralPathPartIndex).join('/');
+
+                            path ? item.label = `${path}/${currentCat.entry.name}` : item.label = currentCat.entry.name;
+                        }
+                    );
+                });
+        });
     }
 
     unselectFacetBucket(field: FacetField, bucket: FacetFieldBucket) {

--- a/lib/content-services/src/lib/search/services/search-facet-filters.service.ts
+++ b/lib/content-services/src/lib/search/services/search-facet-filters.service.ts
@@ -82,6 +82,7 @@ export class SearchFacetFiltersService implements OnDestroy {
 
     onDataLoaded(data: any) {
         const context = data.list.context;
+
         if (context) {
             this.parseFacets(context);
         } else {
@@ -300,6 +301,7 @@ export class SearchFacetFiltersService implements OnDestroy {
 
     private updateExistingBuckets(responseField, responseBuckets, alreadyExistingField, alreadyExistingBuckets) {
         const bucketsToDelete = [];
+
         alreadyExistingBuckets
             .map((bucket) => {
                 const responseBucket = ((responseField && responseField.buckets) || []).find((respBucket) => respBucket.label === bucket.label);

--- a/lib/content-services/src/lib/search/services/search-facet-filters.service.ts
+++ b/lib/content-services/src/lib/search/services/search-facet-filters.service.ts
@@ -346,12 +346,12 @@ export class SearchFacetFiltersService implements OnDestroy {
         bucketList.map((item) => {
             const categoryId = item.label.split('/').pop();
             this.categoryService.getCategory(categoryId)
-                .subscribe(res => {
-                    this.categoryService.searchCategories(res.entry.name).subscribe(
-                        res => {
+                .subscribe(categoryEntry => {
+                    this.categoryService.searchCategories(categoryEntry.entry.name).subscribe(
+                        result => {
                             const nextAfterGeneralPathPartIndex = 3;
                             const pathSeparator = '/';
-                            const currentCat = res.list.entries.filter(entry => entry.entry.id === categoryId)[0];
+                            const currentCat = result.list.entries.filter(entry => entry.entry.id === categoryId)[0];
                             const path = currentCat.entry.path.name.split(pathSeparator).slice(nextAfterGeneralPathPartIndex).join('/');
 
                             path ? item.display = `${path}/${currentCat.entry.name}` : item.display = currentCat.entry.name;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [X] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [X] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://alfresco.atlassian.net/browse/ACS-4788

**What is the new behaviour?**

The category names and path are loaded for the category facet instead of the default result of the type: `workspace://SpacesStore/category-id`

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
