### PR TITLE
[ACA-4589] Remove requirement for update permission on node to open manage versions dialog

### DIFF
--- a/lib/content-services/src/lib/new-version-uploader/new-version-uploader.service.spec.ts
+++ b/lib/content-services/src/lib/new-version-uploader/new-version-uploader.service.spec.ts
@@ -20,7 +20,6 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { TranslateModule } from '@ngx-translate/core';
 import { BehaviorSubject, of, Subject } from 'rxjs';
-import { ContentService } from '../common/services/content.service';
 import { mockFile, mockNewVersionUploaderData, mockNode } from '../mock';
 import { ContentTestingModule } from '../testing/content.testing.module';
 import {
@@ -51,7 +50,6 @@ class TestDialogComponent {
 describe('NewVersionUploaderService', () => {
     let fixture: ComponentFixture<TestDialogComponent>;
     let service: NewVersionUploaderService;
-    let contentService: ContentService;
     let dialog: MatDialog;
     let spyOnDialogOpen: jasmine.Spy;
     let dialogRefSpyObj;
@@ -68,7 +66,6 @@ describe('NewVersionUploaderService', () => {
 
     beforeEach(() => {
         service = TestBed.inject(NewVersionUploaderService);
-        contentService = TestBed.inject(ContentService);
         dialog = TestBed.inject(MatDialog);
         fixture = TestBed.createComponent(TestDialogComponent);
 
@@ -83,29 +80,9 @@ describe('NewVersionUploaderService', () => {
     });
 
     describe('openUploadNewVersionDialog', () => {
-        it('Should not open dialog if update operation is not allowed', () => {
-            spyOn(contentService, 'hasAllowableOperations').and.returnValue(false);
-            expect(spyOnDialogOpen).not.toHaveBeenCalled();
-        });
-
-        it('Should return error if update operation is not allowed', async () => {
-            spyOn(contentService, 'hasAllowableOperations').and.returnValue(false);
-            const mockNewVersionUploaderDialogData: NewVersionUploaderDialogData = {
-                node: mockNode,
-                file: mockFile
-            };
-            try {
-                await service.openUploadNewVersionDialog(mockNewVersionUploaderDialogData).toPromise();
-                fail('An error should have been thrown');
-            } catch (error) {
-                expect(error).toEqual({ value: 'OPERATION.ERROR.PERMISSION' });
-            }
-        });
-
         describe('Mat Dialog configuration', () => {
             let mockNewVersionUploaderDialogData: NewVersionUploaderDialogData;
             beforeEach(() => {
-                spyOn(contentService, 'hasAllowableOperations').and.returnValue(true);
                 spyOn(service.versionsApi, 'listVersionHistory').and.returnValue(Promise.resolve({
                     list: { entries: [{ entry: '2' }] }
                 } as any));
@@ -220,7 +197,6 @@ describe('NewVersionUploaderService', () => {
             let mockNewVersionUploaderDialogData: NewVersionUploaderDialogData;
 
             beforeEach(() => {
-                spyOn(contentService, 'hasAllowableOperations').and.returnValue(true);
                 spyOn(service.versionsApi, 'listVersionHistory').and.returnValue(Promise.resolve({
                     list: { entries: [{ entry: '2' }] }
                 }) as any);

--- a/lib/content-services/src/lib/new-version-uploader/new-version-uploader.service.ts
+++ b/lib/content-services/src/lib/new-version-uploader/new-version-uploader.service.ts
@@ -18,7 +18,6 @@
 import { Injectable } from '@angular/core';
 import { MatDialog, MatDialogConfig } from '@angular/material/dialog';
 import { AlfrescoApiService } from '@alfresco/adf-core';
-import { ContentService } from  '../common/services/content.service';
 
 import { NewVersionUploaderDialogComponent } from './new-version-uploader.dialog';
 import { VersionPaging, VersionsApi } from '@alfresco/js-api';
@@ -38,7 +37,6 @@ export class NewVersionUploaderService {
     }
 
     constructor(
-        private contentService: ContentService,
         private apiService: AlfrescoApiService,
         private dialog: MatDialog,
         private overlayContainer: OverlayContainer
@@ -61,30 +59,26 @@ export class NewVersionUploaderService {
         const allowDownload = true;
 
         return new Observable((observer) => {
-            if (this.contentService.hasAllowableOperations(node, 'update')) {
-                this.versionsApi.listVersionHistory(node.id).then((versionPaging: VersionPaging) => {
-                    const dialogRef = this.dialog.open(NewVersionUploaderDialogComponent, {
-                        data: { file, node, currentVersion: versionPaging.list.entries[0].entry, showComments, allowDownload, showVersionsOnly },
-                        panelClass: this.composePanelClass(showVersionsOnly),
-                        width: '630px',
-                        ...(config && Object.keys(config).length > 0 && config)
-                    });
-                    dialogRef.componentInstance.dialogAction.asObservable()
-                        .subscribe((newVersionUploaderData: NewVersionUploaderData) => {
-                            observer.next(newVersionUploaderData);
-                        });
-                    dialogRef.componentInstance.uploadError.asObservable().subscribe(error => {
-                        observer.error(error);
-                    });
-                    dialogRef.afterClosed().subscribe(() => {
-                        this.overlayContainer.getContainerElement().setAttribute('role', 'region');
-                        NewVersionUploaderService.focusOnClose(selectorAutoFocusedOnClose);
-                    });
-                    this.overlayContainer.getContainerElement().setAttribute('role', 'main');
+            this.versionsApi.listVersionHistory(node.id).then((versionPaging: VersionPaging) => {
+                const dialogRef = this.dialog.open(NewVersionUploaderDialogComponent, {
+                    data: { file, node, currentVersion: versionPaging.list.entries[0].entry, showComments, allowDownload, showVersionsOnly },
+                    panelClass: this.composePanelClass(showVersionsOnly),
+                    width: '630px',
+                    ...(config && Object.keys(config).length > 0 && config)
                 });
-            } else {
-                observer.error({ value: 'OPERATION.ERROR.PERMISSION' });
-            }
+                dialogRef.componentInstance.dialogAction.asObservable()
+                    .subscribe((newVersionUploaderData: NewVersionUploaderData) => {
+                        observer.next(newVersionUploaderData);
+                    });
+                dialogRef.componentInstance.uploadError.asObservable().subscribe(error => {
+                    observer.error(error);
+                });
+                dialogRef.afterClosed().subscribe(() => {
+                    this.overlayContainer.getContainerElement().setAttribute('role', 'region');
+                    NewVersionUploaderService.focusOnClose(selectorAutoFocusedOnClose);
+                });
+                this.overlayContainer.getContainerElement().setAttribute('role', 'main');
+            });
         });
 
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://alfresco.atlassian.net/browse/ACA-4589

**What is the new behaviour?**

Previously, the "update" permission was required on a node to open the manage versions dialog. Since we would like to allow consumers and contributors to also view and download the versions of a file, this restrictions should be removed. It's worth noting that access to this dialog does not give access to consumers and contributors to the "delete" and "restore" functions, as they remain greyed out:

<img width="597" alt="image" src="https://user-images.githubusercontent.com/26234396/232503268-8f65444d-9a3d-405d-8fe2-f4ac4ce74502.png">

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
