### PR TITLE
[ACS-4662] Allow to see category children after search

### DIFF
--- a/lib/content-services/src/lib/category/mock/category-mock.service.ts
+++ b/lib/content-services/src/lib/category/mock/category-mock.service.ts
@@ -32,6 +32,16 @@ export class CategoryServiceMock {
         return parentNodeId ? of(this.getChildrenLevelResponse(skipCount, maxItems)) : of(this.getRootLevelResponse(skipCount, maxItems));
     }
 
+    public getCategory(): Observable<CategoryEntry> {
+        return of({
+            entry: {
+                name: 'some name',
+                id: 'some id',
+                hasChildren: true
+            }
+        });
+    }
+
     public searchCategories(): Observable<ResultSetPaging> {
         const result = new ResultSetPaging();
         result.list = new ResultSetPagingList();

--- a/lib/content-services/src/lib/category/services/category-tree-datasource.service.spec.ts
+++ b/lib/content-services/src/lib/category/services/category-tree-datasource.service.spec.ts
@@ -21,7 +21,7 @@ import { CategoryService } from '../services/category.service';
 import { CategoryNode, CategoryTreeDatasourceService } from '@alfresco/adf-content-services';
 import { CategoryServiceMock } from '../mock/category-mock.service';
 import { TreeNodeType, TreeResponse } from '../../tree';
-import { EMPTY } from 'rxjs';
+import { EMPTY, of } from 'rxjs';
 import { Pagination } from '@alfresco/js-api';
 
 describe('CategoryTreeDatasourceService', () => {
@@ -83,7 +83,45 @@ describe('CategoryTreeDatasourceService', () => {
         expect(categoryService.searchCategories).toHaveBeenCalledWith(name, skipCount, maxItems);
     });
 
+    it('should call getCategory for every instance if value of name parameter is defined', (done) => {
+        spyOn(categoryService, 'getCategory').and.returnValues(of({
+                entry: {
+                    name: 'name',
+                    id: 'some id 1',
+                    hasChildren: true
+                }
+            }),
+            of({
+                entry: {
+                    name: 'Language/some other name',
+                    id: 'some id 2',
+                    hasChildren: false
+                }
+            }));
+        categoryTreeDatasourceService.getSubNodes('id', undefined, undefined, 'name')
+            .subscribe(() => {
+
+                expect(categoryService.getCategory).toHaveBeenCalledWith('some id 1');
+                expect(categoryService.getCategory).toHaveBeenCalledWith('some id 2');
+                done();
+            });
+    });
+
     it('should return observable which emits correct categories', (done) => {
+        spyOn(categoryService, 'getCategory').and.returnValues(of({
+                entry: {
+                    name: 'some name',
+                    id: 'some id 1',
+                    hasChildren: true
+                }
+            }),
+            of({
+                entry: {
+                    name: 'Language/some other name',
+                    id: 'some id 2',
+                    hasChildren: false
+                }
+            }));
         categoryTreeDatasourceService.getSubNodes('id', undefined, undefined, 'name')
             .subscribe((response) => {
                 const pagination = new Pagination();
@@ -104,7 +142,7 @@ describe('CategoryTreeDatasourceService', () => {
                         parentId: 'parent id 2',
                         level: 0,
                         nodeType: TreeNodeType.RegularNode,
-                        hasChildren: true,
+                        hasChildren: false,
                         isLoading: false
                     }]
                 });

--- a/lib/content-services/src/lib/category/services/category-tree-datasource.service.spec.ts
+++ b/lib/content-services/src/lib/category/services/category-tree-datasource.service.spec.ts
@@ -96,7 +96,7 @@ describe('CategoryTreeDatasourceService', () => {
                         parentId: 'parent id 1',
                         level: 0,
                         nodeType: TreeNodeType.RegularNode,
-                        hasChildren: false,
+                        hasChildren: true,
                         isLoading: false
                     }, {
                         id: 'some id 2',
@@ -104,7 +104,7 @@ describe('CategoryTreeDatasourceService', () => {
                         parentId: 'parent id 2',
                         level: 0,
                         nodeType: TreeNodeType.RegularNode,
-                        hasChildren: false,
+                        hasChildren: true,
                         isLoading: false
                     }]
                 });

--- a/lib/content-services/src/lib/category/services/category-tree-datasource.service.ts
+++ b/lib/content-services/src/lib/category/services/category-tree-datasource.service.ts
@@ -21,7 +21,7 @@ import { CategoryNode } from '../models/category-node.interface';
 import { CategoryService } from './category.service';
 import { CategoryEntry, CategoryPaging } from '@alfresco/js-api';
 import { from, Observable } from 'rxjs';
-import { map, mergeMap, tap, toArray } from 'rxjs/operators';
+import { map, mergeMap, toArray } from 'rxjs/operators';
 
 @Injectable({ providedIn: 'root' })
 export class CategoryTreeDatasourceService extends TreeService<CategoryNode>  {
@@ -30,7 +30,7 @@ export class CategoryTreeDatasourceService extends TreeService<CategoryNode>  {
         super();
     }
 
-    public getSubNodes(parentNodeId: string, skipCount?: number, maxItems?: number, name?: string): Observable<any> {
+    public getSubNodes(parentNodeId: string, skipCount?: number, maxItems?: number, name?: string): Observable<TreeResponse<CategoryNode>> {
         return !name ? this.categoryService.getSubcategories(parentNodeId, skipCount, maxItems).pipe(map((response: CategoryPaging) => {
             const parentNode: CategoryNode = this.getParentNode(parentNodeId);
             const nodesList: CategoryNode[] = response.list.entries.map((entry: CategoryEntry) => ({
@@ -77,19 +77,8 @@ export class CategoryTreeDatasourceService extends TreeService<CategoryNode>  {
                     })
                 );
             }),
-                toArray());
-            // const treeResponse: TreeResponse<CategoryNode>;
-            // entries.subscribe(res => {
-            //    treeResponse = {entries: res, pagination: pagingResult.list.pagination}
-            // })
-            //
-            // const treeResponse: TreeResponse<CategoryNode> = {entries, pagination: pagingResult.list.pagination}
-            // return treeResponse;
-        })).pipe(
-            tap(res => {
-
-                console.log(res)
-            })
-        );
+                toArray(),
+                map(res =>  ({entries: res, pagination: pagingResult.list.pagination})));
+        }))
     }
 }

--- a/lib/content-services/src/lib/category/services/category-tree-datasource.service.ts
+++ b/lib/content-services/src/lib/category/services/category-tree-datasource.service.ts
@@ -79,6 +79,6 @@ export class CategoryTreeDatasourceService extends TreeService<CategoryNode>  {
             }),
                 toArray(),
                 map(res =>  ({entries: res, pagination: pagingResult.list.pagination})));
-        }))
+        }));
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://alfresco.atlassian.net/browse/ACS-4662

**What is the new behaviour?**

If the searched categories have children, then a chevron will be shown for them, after clicking on it, all child elements for a particular category will be loaded.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
