### PR TITLE
[ACS-5093] Optimise Categories facet names load

### DIFF
--- a/docs/content-services/services/category.service.md
+++ b/docs/content-services/services/category.service.md
@@ -22,6 +22,9 @@ Manages categories in Content Services.
 -   **getCategory**(categoryId: `string`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`CategoryEntry`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/api/content-rest-api/docs/CategoryEntry.md)`>`<br/>
     Gets a specific category by categoryId.
     -   _categoryId:_ `string`  - The identifier of a category
+    -   _opts:_ `any`  - Optional parameters
+    -   _opts.fields_ `string[]` - A list of field names
+    -   _opts.include_ `string[]` - Returns additional information about the category. The following optional fields can be requested: count, path
     -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`CategoryEntry`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/api/content-rest-api/docs/CategoryEntry.md)`>` - CategoryEntry object (defined in JS-API) containing information about the category.
 -   **createSubcategories**(parentCategoryId: `string`, payload: [`CategoryBody[]`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/api/content-rest-api/docs/CategoryBody.md)): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`CategoryPaging`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/api/content-rest-api/docs/CategoryPaging.md) | [`CategoryEntry`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/api/content-rest-api/docs/CategoryEntry.md)`>`<br/>
     Creates subcategories under category with provided categoryId.

--- a/lib/content-services/src/lib/category/services/category.service.spec.ts
+++ b/lib/content-services/src/lib/category/services/category.service.spec.ts
@@ -63,8 +63,8 @@ describe('CategoryService', () => {
 
     it('should fetch the category with the provided categoryId', fakeAsync(() => {
         const getSpy = spyOn(categoryService.categoriesApi, 'getCategory').and.returnValue(Promise.resolve(fakeCategoryEntry));
-        categoryService.getCategory(fakeParentCategoryId).subscribe(() => {
-            expect(getSpy).toHaveBeenCalledOnceWith(fakeParentCategoryId);
+        categoryService.getCategory(fakeParentCategoryId, {include: ['path']}).subscribe(() =>  {
+            expect(getSpy).toHaveBeenCalledOnceWith(fakeParentCategoryId, {include: ['path']});
         });
     }));
 

--- a/lib/content-services/src/lib/category/services/category.service.ts
+++ b/lib/content-services/src/lib/category/services/category.service.ts
@@ -61,10 +61,15 @@ export class CategoryService {
      * Get a category by ID
      *
      * @param categoryId The identifier of a category.
+     * @param opts Optional parameters.
+     * @param opts.fields A list of field names.
+     * @param opts.include Returns additional information about the category. The following optional fields can be requested:
+     * count
+     * path
      * @return Observable<CategoryEntry>
      */
-    getCategory(categoryId: string): Observable<CategoryEntry> {
-        return from(this.categoriesApi.getCategory(categoryId));
+    getCategory(categoryId: string, opts?: any): Observable<CategoryEntry> {
+        return from(this.categoriesApi.getCategory(categoryId, opts));
     }
 
     /**

--- a/lib/content-services/src/lib/search/services/search-facet-filters.service.spec.ts
+++ b/lib/content-services/src/lib/search/services/search-facet-filters.service.spec.ts
@@ -34,8 +34,7 @@ describe('SearchFacetFiltersService', () => {
             providers: [{
                 provide: CategoryService,
                 useValue: {
-                    getCategory: () => EMPTY,
-                    searchCategories: () => EMPTY
+                    getCategory: () => EMPTY
                 }
             }]
         });
@@ -472,22 +471,9 @@ describe('SearchFacetFiltersService', () => {
     });
 
     it('should load category names for cm:categories facet', () => {
-        const entry = {id: 'test-id-test', name: 'name'};
+        const entry = {id: 'test-id-test', name: 'name', path: '/categories/General/Test Category/Subcategory'};
         searchFacetFiltersService.responseFacets = null;
         spyOn(categoryService, 'getCategory').and.returnValue(of({entry}));
-        spyOn(categoryService, 'searchCategories').and.returnValue(of({
-                    list: {
-                        entries: [{
-                            entry: {
-                                ...entry,
-                                nodeType: 'node-type',
-                                path: { name: '/categories/General/Test Category/Subcategory'},
-                                isFolder: false,
-                                isFile: false
-                            }
-                        }]
-                    }
-                }));
 
         queryBuilder.config = {
             categories: [],
@@ -521,8 +507,7 @@ describe('SearchFacetFiltersService', () => {
 
         searchFacetFiltersService.onDataLoaded(data);
 
-        expect(categoryService.getCategory).toHaveBeenCalledWith(entry.id);
-        expect(categoryService.searchCategories).toHaveBeenCalledWith(entry.name);
+        expect(categoryService.getCategory).toHaveBeenCalledWith(entry.id, { include: [ 'path' ]});
         expect(searchFacetFiltersService.responseFacets[1].buckets.items[0].display).toBe(`Test Category/Subcategory/${entry.name}`);
         expect(searchFacetFiltersService.responseFacets[1].buckets.length).toEqual(1);
         expect(searchFacetFiltersService.responseFacets.length).toEqual(2);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [X] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [X] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Currently in `search-facet-filters.service.ts` to load category name and path 2 API requests are being sent: `getCategory`  and `searchCategories`. 

**What is the new behaviour?**

Now, with updated API redundant request is removed, adding {include: ['path']} as option in getCategory

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://alfresco.atlassian.net/browse/ACS-5093