### PR TITLE
[ACS-5135] Tree component emit pagination only when top-level entries…

### DIFF
--- a/lib/content-services/src/lib/tree/components/tree.component.spec.ts
+++ b/lib/content-services/src/lib/tree/components/tree.component.spec.ts
@@ -87,6 +87,18 @@ describe('TreeComponent', () => {
         expect(refreshSpy).toHaveBeenCalled();
     });
 
+    it('should emit pagination when tree is refreshed', (done) => {
+        spyOn(component.treeService, 'getSubNodes').and.returnValue(of({
+            pagination: {skipCount: 0, maxItems: userPreferenceService.paginationSize}, entries: []
+        }));
+        component.paginationChanged.subscribe((pagination) => {
+            expect(pagination.skipCount).toBe(0);
+            expect(pagination.maxItems).toBe(userPreferenceService.paginationSize);
+            done();
+        });
+        component.refreshTree();
+    });
+
     it('should show a header title showing displayName property value', () => {
         spyOn(component, 'isEmpty').and.returnValue(false);
         component.displayName = 'test';
@@ -145,16 +157,6 @@ describe('TreeComponent', () => {
         expect(nodeIcons[0].nativeElement.innerText).toContain('chevron_left');
     });
 
-    it('should emit pagination when nodes are loaded', (done) => {
-        component.treeService.treeNodes = Array.from(treeNodesMockExpanded);
-        component.paginationChanged.subscribe((pagination) => {
-            expect(pagination.skipCount).toBe(0);
-            expect(pagination.maxItems).toBe(userPreferenceService.paginationSize);
-            done();
-        });
-        component.expandCollapseNode(component.treeService.treeNodes[0]);
-    });
-
     it('when node has more items to load loadMore node should appear', () => {
         component.treeService.treeNodes = Array.from(treeNodesMockExpanded);
         fixture.detectChanges();
@@ -172,6 +174,7 @@ describe('TreeComponent', () => {
 
     it('should call correct server method on collapsing node', () => {
         component.refreshTree();
+        component.treeService.treeNodes[0].isLoading = false;
         fixture.detectChanges();
         const collapseSpy = spyOn(component.treeService, 'collapseNode');
         spyOn(component.treeService.treeControl, 'isExpanded').and.returnValue(true);

--- a/lib/content-services/src/lib/tree/components/tree.component.ts
+++ b/lib/content-services/src/lib/tree/components/tree.component.ts
@@ -208,7 +208,6 @@ export class TreeComponent<T extends TreeNode> implements OnInit, OnDestroy {
                 node.isLoading = true;
                 this.treeService.getSubNodes(node.id, 0, this.userPreferenceService.paginationSize).subscribe((response: TreeResponse<T>) => {
                     this.treeService.expandNode(node, response.entries);
-                    this.paginationChanged.emit(response.pagination);
                     node.isLoading = false;
                     if (this.treeNodesSelection.isSelected(node)) {
                         //timeout used to update nodeCheckboxes query list after new nodes are added so they can be selected
@@ -233,7 +232,6 @@ export class TreeComponent<T extends TreeNode> implements OnInit, OnDestroy {
         const loadedChildren: number = this.treeService.getChildren(parentNode).length;
         this.treeService.getSubNodes(parentNode.id, loadedChildren, this.userPreferenceService.paginationSize).subscribe((response: TreeResponse<T>) => {
             this.treeService.appendNodes(parentNode, response.entries);
-            this.paginationChanged.emit(response.pagination);
             node.isLoading = false;
             if (this.treeNodesSelection.isSelected(parentNode)) {
                 //timeout used to update nodeCheckboxes query list after new nodes are added so they can be selected


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

New pagination is emitted when tree fetches children. https://alfresco.atlassian.net/browse/ACS-5135

**What is the new behaviour?**

Pagination is emitted only when top-level nodes changes.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
