### PR TITLE
[ACS-5147] Fixed typo

### DIFF
--- a/lib/content-services/src/lib/i18n/en.json
+++ b/lib/content-services/src/lib/i18n/en.json
@@ -173,7 +173,7 @@
     "UNASSIGN_CATEGORY": "Unassign Category",
     "DELETE_CATEGORY": "Delete Category",
     "EXISTING_CATEGORIES": "Existing Categories:",
-    "SELECT_EXISTING_CATEGORY": "Select a existing Category:",
+    "SELECT_EXISTING_CATEGORY": "Select an existing Category:",
     "NO_EXISTING_CATEGORIES": "No existing Categories",
     "GENERIC_CREATE": "Create: {{name}}",
     "NAME": "Category name",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ACS-5147


**What is the new behaviour?**
"a" is changed to "an" in "Select a Existing Category:" text. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
