### PR TITLE
[ACS-5155] tags message about required field displayed after discarding changes

### DIFF
--- a/lib/content-services/src/lib/tag/tags-creator/tags-creator.component.spec.ts
+++ b/lib/content-services/src/lib/tag/tags-creator/tags-creator.component.spec.ts
@@ -313,8 +313,7 @@ describe('TagsCreatorComponent', () => {
                 typeTag('  ');
                 component.tags = ['new tag 1', 'new tag 2'];
                 fixture.detectChanges();
-                const error = getFirstError();
-                expect(error).toBe('TAG.TAGS_CREATOR.ERRORS.EMPTY_TAG');
+                expect(getFirstError()).toBe('TAG.TAGS_CREATOR.ERRORS.EMPTY_TAG');
             }));
 
             it('should show error for required', fakeAsync(() => {
@@ -327,8 +326,7 @@ describe('TagsCreatorComponent', () => {
                 typeTag('');
                 component.tags = ['new tag 1', 'new tag 2'];
                 fixture.detectChanges();
-                const error = getFirstError();
-                expect(error).toBeUndefined();
+                expect(getFirstError()).toBeUndefined();
             }));
 
             it('should show error when duplicated already added tag', fakeAsync(() => {
@@ -349,8 +347,7 @@ describe('TagsCreatorComponent', () => {
                 component.tags = ['Some tag'];
                 fixture.detectChanges();
 
-                const error = getFirstError();
-                expect(error).toBe('TAG.TAGS_CREATOR.ERRORS.ALREADY_ADDED_TAG');
+                expect(getFirstError()).toBe('TAG.TAGS_CREATOR.ERRORS.ALREADY_ADDED_TAG');
             }));
 
             it('should show error when duplicated already existing tag', fakeAsync(() => {

--- a/lib/content-services/src/lib/tag/tags-creator/tags-creator.component.spec.ts
+++ b/lib/content-services/src/lib/tag/tags-creator/tags-creator.component.spec.ts
@@ -300,11 +300,19 @@ describe('TagsCreatorComponent', () => {
         describe('Errors', () => {
             function getFirstError(): string {
                 const error = fixture.debugElement.query(By.directive(MatError));
-                return error.nativeElement.textContent;
+                return error?.nativeElement.textContent;
             }
 
             it('should show error for only spaces', fakeAsync(() => {
                 typeTag('  ');
+                const error = getFirstError();
+                expect(error).toBe('TAG.TAGS_CREATOR.ERRORS.EMPTY_TAG');
+            }));
+
+            it('should show error for only spaces if tags are changed', fakeAsync(() => {
+                typeTag('  ');
+                component.tags = ['new tag 1', 'new tag 2'];
+                fixture.detectChanges();
                 const error = getFirstError();
                 expect(error).toBe('TAG.TAGS_CREATOR.ERRORS.EMPTY_TAG');
             }));
@@ -315,11 +323,31 @@ describe('TagsCreatorComponent', () => {
                 expect(error).toBe('TAG.TAGS_CREATOR.ERRORS.REQUIRED');
             }));
 
+            it('should not show error for required if tags are changed', fakeAsync(() => {
+                typeTag('');
+                component.tags = ['new tag 1', 'new tag 2'];
+                fixture.detectChanges();
+                const error = getFirstError();
+                expect(error).toBeUndefined();
+            }));
+
             it('should show error when duplicated already added tag', fakeAsync(() => {
                 const tag = 'Some tag';
 
                 addTagToAddedList(tag);
                 typeTag(tag);
+
+                const error = getFirstError();
+                expect(error).toBe('TAG.TAGS_CREATOR.ERRORS.ALREADY_ADDED_TAG');
+            }));
+
+            it('should show error when duplicated already added tag if tags are changed', fakeAsync(() => {
+                const tag = 'Some tag';
+
+                addTagToAddedList(tag);
+                typeTag(tag);
+                component.tags = ['Some tag'];
+                fixture.detectChanges();
 
                 const error = getFirstError();
                 expect(error).toBe('TAG.TAGS_CREATOR.ERRORS.ALREADY_ADDED_TAG');

--- a/lib/content-services/src/lib/tag/tags-creator/tags-creator.component.ts
+++ b/lib/content-services/src/lib/tag/tags-creator/tags-creator.component.ts
@@ -84,6 +84,9 @@ export class TagsCreatorComponent implements OnInit, OnDestroy {
         this._existingTags = null;
         this.loadTags(this.tagNameControl.value);
         this.tagNameControl.updateValueAndValidity();
+        if (this.tagNameControl.errors?.required) {
+            this.tagNameControl.markAsUntouched();
+        }
     }
 
     get tags(): string[] {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ACS-5155


**What is the new behaviour?**
Required error message is not displayed when user reverts changes. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
