### PR TITLE
[ACS-5088] Added cast pipe to allow for typecasting in templates

### DIFF
--- a/demo-shell/src/app/components/files/files.component.html
+++ b/demo-shell/src/app/components/files/files.component.html
@@ -134,7 +134,7 @@
                             [adf-node-favorite]="documentList.selection"
                             matTooltip="{{ 'DOCUMENT_LIST.TOOLBAR.FAVORITES' | translate }}">
                         <mat-icon>
-                            {{ favorite.hasFavorites() ? 'star' :'star_border' }}
+                            {{ favorite.hasFavorites ? 'star' :'star_border' }}
                         </mat-icon>
                     </button>
                     <button mat-icon-button

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,3 @@
-
 ---
 Title: Component docs
 Github only: true
@@ -169,21 +168,21 @@ for more information about installing and using the source code.
 
 ### Pipes
 
-| Name                                                           | Description                                                                                                                                                                                                                   | Source link                                                               |
-|----------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------|
-| [App Config Pipe](core/pipes/app-config.pipe.md)               | Retrieves values from the application configuration file directly.                                                                                                                                                            | [Source](../lib/core/src/lib/app-config/app-config.pipe.ts)               |
-| [Decimal Number Pipe](core/pipes/decimal-number.pipe.md)       | Transforms a number to have a certain amount of digits in its integer part and also in its decimal part.                                                                                                                      | [Source](../lib/core/src/lib/pipes/decimal-number.pipe.ts)                |
-| [File Size pipe](core/pipes/file-size.pipe.md)                 | Converts a number of bytes to the equivalent in KB, MB, etc.                                                                                                                                                                  | [Source](../lib/core/src/lib/pipes/file-size.pipe.ts)                     |
-| [Format Space pipe](core/pipes/format-space.pipe.md)           | Replaces all the white space in a string with a supplied character.                                                                                                                                                           | [Source](../lib/core/src/lib/pipes/format-space.pipe.ts)                  |
-| [Full name pipe](core/pipes/full-name.pipe.md)                 | Joins the first and last name properties from a UserProcessModel object into a single string.                                                                                                                                 | [Source](../lib/core/src/lib/pipes/full-name.pipe.ts)                     |
-| [Localized Date pipe](core/pipes/localized-date.pipe.md)       | Converts a date to a given format and locale.                                                                                                                                                                                 | [Source](../lib/core/src/lib/pipes/localized-date.pipe.ts)                |
-| [Mime Type Icon pipe](core/pipes/mime-type-icon.pipe.md)       | Retrieves an icon to represent a MIME type.                                                                                                                                                                                   | [Source](../lib/core/src/lib/pipes/mime-type-icon.pipe.ts)                |
-| [Multi Value Pipe](core/pipes/multi-value.pipe.md)             | Takes an array of strings and turns it into one string where items are separated by a separator. The default separator applied to the list is the comma ,  however, you can set your own separator in the params of the pipe. | [Source](../lib/core/src/lib/pipes/multi-value.pipe.ts)                   |
-| [Node Name Tooltip pipe](core/pipes/node-name-tooltip.pipe.md) | Formats the tooltip for a Node.                                                                                                                                                                                               | [Source](../lib/content-services/src/lib/pipes/node-name-tooltip.pipe.ts) |
-| [Text Highlight pipe](core/pipes/text-highlight.pipe.md)       | Adds highlighting to words or sections of text that match a search string.                                                                                                                                                    | [Source](../lib/core/src/lib/pipes/text-highlight.pipe.ts)                |
-| [Time Ago pipe](core/pipes/time-ago.pipe.md)                   | Converts a recent past date into a number of days ago.                                                                                                                                                                        | [Source](../lib/core/src/lib/pipes/time-ago.pipe.ts)                      |
-| [User Initial pipe](core/pipes/user-initial.pipe.md)           | Takes the name fields of a UserProcessModel object and extracts and formats the initials.                                                                                                                                     | [Source](../lib/core/src/lib/pipes/user-initial.pipe.ts)                  |
-| [Type Cast pipe](core/pipes/user-initial.pipe.md)                 | Takes a reference to a constructor for a data type, and casts the provided object to that type                                                                                                                                | [Source](../lib/core/src/lib/pipes/type-cast.pipe.ts)                      |
+| Name | Description | Source link |
+| ---- | ----------- | ----------- |
+| [App Config Pipe](core/pipes/app-config.pipe.md) | Retrieves values from the application configuration file directly. | [Source](../lib/core/src/lib/app-config/app-config.pipe.ts) |
+| [Decimal Number Pipe](core/pipes/decimal-number.pipe.md) | Transforms a number to have a certain amount of digits in its integer part and also in its decimal part. | [Source](../lib/core/src/lib/pipes/decimal-number.pipe.ts) |
+| [File Size pipe](core/pipes/file-size.pipe.md) | Converts a number of bytes to the equivalent in KB, MB, etc. | [Source](../lib/core/src/lib/pipes/file-size.pipe.ts) |
+| [Format Space pipe](core/pipes/format-space.pipe.md) | Replaces all the white space in a string with a supplied character. | [Source](../lib/core/src/lib/pipes/format-space.pipe.ts) |
+| [Full name pipe](core/pipes/full-name.pipe.md) | Joins the first and last name properties from a UserProcessModel object into a single string. | [Source](../lib/core/src/lib/pipes/full-name.pipe.ts) |
+| [Localized Date pipe](core/pipes/localized-date.pipe.md) | Converts a date to a given format and locale. | [Source](../lib/core/src/lib/pipes/localized-date.pipe.ts) |
+| [Mime Type Icon pipe](core/pipes/mime-type-icon.pipe.md) | Retrieves an icon to represent a MIME type. | [Source](../lib/core/src/lib/pipes/mime-type-icon.pipe.ts) |
+| [Multi Value Pipe](core/pipes/multi-value.pipe.md) | Takes an array of strings and turns it into one string where items are separated by a separator. The default separator applied to the list is the comma ,  however, you can set your own separator in the params of the pipe. | [Source](../lib/core/src/lib/pipes/multi-value.pipe.ts) |
+| [Node Name Tooltip pipe](core/pipes/node-name-tooltip.pipe.md) | Formats the tooltip for a Node. | [Source](../lib/content-services/src/lib/pipes/node-name-tooltip.pipe.ts) |
+| [Text Highlight pipe](core/pipes/text-highlight.pipe.md) | Adds highlighting to words or sections of text that match a search string. | [Source](../lib/core/src/lib/pipes/text-highlight.pipe.ts) |
+| [Time Ago pipe](core/pipes/time-ago.pipe.md) | Converts a recent past date into a number of days ago. | [Source](../lib/core/src/lib/pipes/time-ago.pipe.ts) |
+| [User Initial pipe](core/pipes/user-initial.pipe.md) | Takes the name fields of a UserProcessModel object and extracts and formats the initials. | [Source](../lib/core/src/lib/pipes/user-initial.pipe.ts) |
+| [Type Cast pipe](core/pipes/user-initial.pipe.md) | Takes a reference to a constructor for a data type, and casts the provided object to that type | [Source](../lib/core/src/lib/pipes/type-cast.pipe.ts) |
 
 ### Services
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,4 @@
+
 ---
 Title: Component docs
 Github only: true
@@ -168,20 +169,21 @@ for more information about installing and using the source code.
 
 ### Pipes
 
-| Name | Description | Source link |
-| ---- | ----------- | ----------- |
-| [App Config Pipe](core/pipes/app-config.pipe.md) | Retrieves values from the application configuration file directly. | [Source](../lib/core/src/lib/app-config/app-config.pipe.ts) |
-| [Decimal Number Pipe](core/pipes/decimal-number.pipe.md) | Transforms a number to have a certain amount of digits in its integer part and also in its decimal part. | [Source](../lib/core/src/lib/pipes/decimal-number.pipe.ts) |
-| [File Size pipe](core/pipes/file-size.pipe.md) | Converts a number of bytes to the equivalent in KB, MB, etc. | [Source](../lib/core/src/lib/pipes/file-size.pipe.ts) |
-| [Format Space pipe](core/pipes/format-space.pipe.md) | Replaces all the white space in a string with a supplied character. | [Source](../lib/core/src/lib/pipes/format-space.pipe.ts) |
-| [Full name pipe](core/pipes/full-name.pipe.md) | Joins the first and last name properties from a UserProcessModel object into a single string. | [Source](../lib/core/src/lib/pipes/full-name.pipe.ts) |
-| [Localized Date pipe](core/pipes/localized-date.pipe.md) | Converts a date to a given format and locale. | [Source](../lib/core/src/lib/pipes/localized-date.pipe.ts) |
-| [Mime Type Icon pipe](core/pipes/mime-type-icon.pipe.md) | Retrieves an icon to represent a MIME type. | [Source](../lib/core/src/lib/pipes/mime-type-icon.pipe.ts) |
-| [Multi Value Pipe](core/pipes/multi-value.pipe.md) | Takes an array of strings and turns it into one string where items are separated by a separator. The default separator applied to the list is the comma ,  however, you can set your own separator in the params of the pipe. | [Source](../lib/core/src/lib/pipes/multi-value.pipe.ts) |
-| [Node Name Tooltip pipe](core/pipes/node-name-tooltip.pipe.md) | Formats the tooltip for a Node. | [Source](../lib/content-services/src/lib/pipes/node-name-tooltip.pipe.ts) |
-| [Text Highlight pipe](core/pipes/text-highlight.pipe.md) | Adds highlighting to words or sections of text that match a search string. | [Source](../lib/core/src/lib/pipes/text-highlight.pipe.ts) |
-| [Time Ago pipe](core/pipes/time-ago.pipe.md) | Converts a recent past date into a number of days ago. | [Source](../lib/core/src/lib/pipes/time-ago.pipe.ts) |
-| [User Initial pipe](core/pipes/user-initial.pipe.md) | Takes the name fields of a UserProcessModel object and extracts and formats the initials. | [Source](../lib/core/src/lib/pipes/user-initial.pipe.ts) |
+| Name                                                           | Description                                                                                                                                                                                                                   | Source link                                                               |
+|----------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------|
+| [App Config Pipe](core/pipes/app-config.pipe.md)               | Retrieves values from the application configuration file directly.                                                                                                                                                            | [Source](../lib/core/src/lib/app-config/app-config.pipe.ts)               |
+| [Decimal Number Pipe](core/pipes/decimal-number.pipe.md)       | Transforms a number to have a certain amount of digits in its integer part and also in its decimal part.                                                                                                                      | [Source](../lib/core/src/lib/pipes/decimal-number.pipe.ts)                |
+| [File Size pipe](core/pipes/file-size.pipe.md)                 | Converts a number of bytes to the equivalent in KB, MB, etc.                                                                                                                                                                  | [Source](../lib/core/src/lib/pipes/file-size.pipe.ts)                     |
+| [Format Space pipe](core/pipes/format-space.pipe.md)           | Replaces all the white space in a string with a supplied character.                                                                                                                                                           | [Source](../lib/core/src/lib/pipes/format-space.pipe.ts)                  |
+| [Full name pipe](core/pipes/full-name.pipe.md)                 | Joins the first and last name properties from a UserProcessModel object into a single string.                                                                                                                                 | [Source](../lib/core/src/lib/pipes/full-name.pipe.ts)                     |
+| [Localized Date pipe](core/pipes/localized-date.pipe.md)       | Converts a date to a given format and locale.                                                                                                                                                                                 | [Source](../lib/core/src/lib/pipes/localized-date.pipe.ts)                |
+| [Mime Type Icon pipe](core/pipes/mime-type-icon.pipe.md)       | Retrieves an icon to represent a MIME type.                                                                                                                                                                                   | [Source](../lib/core/src/lib/pipes/mime-type-icon.pipe.ts)                |
+| [Multi Value Pipe](core/pipes/multi-value.pipe.md)             | Takes an array of strings and turns it into one string where items are separated by a separator. The default separator applied to the list is the comma ,  however, you can set your own separator in the params of the pipe. | [Source](../lib/core/src/lib/pipes/multi-value.pipe.ts)                   |
+| [Node Name Tooltip pipe](core/pipes/node-name-tooltip.pipe.md) | Formats the tooltip for a Node.                                                                                                                                                                                               | [Source](../lib/content-services/src/lib/pipes/node-name-tooltip.pipe.ts) |
+| [Text Highlight pipe](core/pipes/text-highlight.pipe.md)       | Adds highlighting to words or sections of text that match a search string.                                                                                                                                                    | [Source](../lib/core/src/lib/pipes/text-highlight.pipe.ts)                |
+| [Time Ago pipe](core/pipes/time-ago.pipe.md)                   | Converts a recent past date into a number of days ago.                                                                                                                                                                        | [Source](../lib/core/src/lib/pipes/time-ago.pipe.ts)                      |
+| [User Initial pipe](core/pipes/user-initial.pipe.md)           | Takes the name fields of a UserProcessModel object and extracts and formats the initials.                                                                                                                                     | [Source](../lib/core/src/lib/pipes/user-initial.pipe.ts)                  |
+| [Type Cast pipe](core/pipes/user-initial.pipe.md)                 | Takes a reference to a constructor for a data type, and casts the provided object to that type                                                                                                                                | [Source](../lib/core/src/lib/pipes/type-cast.pipe.ts)                      |
 
 ### Services
 

--- a/docs/core/pipes/type-cast.pipe.md
+++ b/docs/core/pipes/type-cast.pipe.md
@@ -1,0 +1,36 @@
+---
+Title: Type cast pipe
+Added: v6.0.0
+Status: Active
+Last reviewed: 2023-05-23
+---
+
+# [Type Cast pipe](../../../lib/core/src/lib/pipes/type-cast.pipe.ts "Defined in user-initial.pipe.ts")
+
+Takes a reference to a constructor and then type casts the provided object to the type of that constructor. 
+
+## Basic Usage
+
+<!-- {% raw %} -->
+```TS
+    protected readonly MyCustomTypeConstructor = MyCustomTypeConstructor
+```
+```HTML
+<div>
+    <my-comp [inputProp]="someVar | cast : MyCustomTypeConstructor"></my-comp>
+</div>
+```
+
+<!-- {% endraw %} -->
+
+## Details
+
+The pipe takes a reference of a constructor to which the typecasting is to be done. 
+Preferably, this should be declared a readonly property in the .ts file for the component,
+and have the same name as the constructor, matching its casing. This is optional, 
+but would improve the readability of the code.
+
+Once the reference has been declared in the typescript file, the pipe can then be used in the template,
+by providing the constructor reference as shown above. In the example above, the input data property
+`inputProp` has a type of `MyCustomTypeConstructor`, and would expect data of that type only. 
+

--- a/lib/content-services/src/lib/directives/node-favorite.directive.spec.ts
+++ b/lib/content-services/src/lib/directives/node-favorite.directive.spec.ts
@@ -80,13 +80,13 @@ describe('NodeFavoriteDirective', () => {
             directive.ngOnChanges({selection: change});
             tick();
 
-            expect(directive.hasFavorites()).toBe(true);
+            expect(directive.hasFavorites).toBe(true);
 
             change = new SimpleChange(null, [], true);
             directive.ngOnChanges({selection: change});
             tick();
 
-            expect(directive.hasFavorites()).toBe(false);
+            expect(directive.hasFavorites).toBe(false);
         }));
     });
 
@@ -304,7 +304,7 @@ describe('NodeFavoriteDirective', () => {
             directive.toggleFavorite();
             tick();
 
-            expect(directive.hasFavorites()).toBe(false);
+            expect(directive.hasFavorites).toBe(false);
         }));
 
         it('should set isFavorites items to true', fakeAsync(() => {
@@ -317,7 +317,7 @@ describe('NodeFavoriteDirective', () => {
             directive.toggleFavorite();
             tick();
 
-            expect(directive.hasFavorites()).toBe(true);
+            expect(directive.hasFavorites).toBe(true);
         }));
     });
 
@@ -371,7 +371,7 @@ describe('NodeFavoriteDirective', () => {
         it('should return false when favorites collection is empty', () => {
             directive.favorites = [];
 
-            const hasFavorites = directive.hasFavorites();
+            const hasFavorites = directive.hasFavorites;
 
             expect(hasFavorites).toBe(false);
         });
@@ -382,7 +382,7 @@ describe('NodeFavoriteDirective', () => {
                 { entry: { id: '2', name: 'name2', isFavorite: false } }
             ];
 
-            const hasFavorites = directive.hasFavorites();
+            const hasFavorites = directive.hasFavorites;
 
             expect(hasFavorites).toBe(false);
         });
@@ -393,7 +393,7 @@ describe('NodeFavoriteDirective', () => {
                 { entry: { id: '2', name: 'name2', isFavorite: true } }
             ];
 
-            const hasFavorites = directive.hasFavorites();
+            const hasFavorites = directive.hasFavorites;
 
             expect(hasFavorites).toBe(true);
         });

--- a/lib/content-services/src/lib/directives/node-favorite.directive.ts
+++ b/lib/content-services/src/lib/directives/node-favorite.directive.ts
@@ -36,6 +36,8 @@ export class NodeFavoriteDirective implements OnChanges {
         return this._favoritesApi;
     }
 
+    hasFavorites = false;
+
     /** Array of nodes to toggle as favorites. */
     @Input('adf-node-favorite')
     selection: NodeEntry[] = [];
@@ -105,8 +107,8 @@ export class NodeFavoriteDirective implements OnChanges {
 
     markFavoritesNodes(selection: NodeEntry[]) {
         if (selection.length <= this.favorites.length) {
-            const newFavorites = this.reduce(this.favorites, selection);
-            this.favorites = newFavorites;
+            this.favorites = this.reduce(this.favorites, selection);
+            this.hasFavorites = this.evaluateHasFavorites();
         }
 
         const result = this.diff(selection, this.favorites);
@@ -114,10 +116,11 @@ export class NodeFavoriteDirective implements OnChanges {
 
         forkJoin(batch).subscribe((data) => {
             this.favorites.push(...data);
+            this.hasFavorites = this.evaluateHasFavorites();
         });
     }
 
-    hasFavorites(): boolean {
+    evaluateHasFavorites(): boolean {
         if (this.favorites && !this.favorites.length) {
             return false;
         }

--- a/lib/core/src/lib/pipes/pipe.module.ts
+++ b/lib/core/src/lib/pipes/pipe.module.ts
@@ -35,6 +35,7 @@ import { MomentDatePipe } from './moment-date.pipe';
 import { MomentDateTimePipe } from './moment-datetime.pipe';
 import { FilterStringPipe } from './filter-string.pipe';
 import { FilterOutArrayObjectsByPropPipe } from './filter-out-every-object-by-prop.pipe';
+import { TypeCastPipe } from './type-cast.pipe';
 
 @NgModule({
     imports: [
@@ -57,7 +58,8 @@ import { FilterOutArrayObjectsByPropPipe } from './filter-out-every-object-by-pr
         MomentDatePipe,
         MomentDateTimePipe,
         FilterStringPipe,
-        FilterOutArrayObjectsByPropPipe
+        FilterOutArrayObjectsByPropPipe,
+        TypeCastPipe
     ],
     providers: [
         FileSizePipe,
@@ -74,7 +76,8 @@ import { FilterOutArrayObjectsByPropPipe } from './filter-out-every-object-by-pr
         MomentDatePipe,
         MomentDateTimePipe,
         FilterStringPipe,
-        FilterOutArrayObjectsByPropPipe
+        FilterOutArrayObjectsByPropPipe,
+        TypeCastPipe
     ],
     exports: [
         FileSizePipe,
@@ -92,7 +95,8 @@ import { FilterOutArrayObjectsByPropPipe } from './filter-out-every-object-by-pr
         MomentDatePipe,
         MomentDateTimePipe,
         FilterStringPipe,
-        FilterOutArrayObjectsByPropPipe
+        FilterOutArrayObjectsByPropPipe,
+        TypeCastPipe
     ]
 })
 export class PipeModule {

--- a/lib/core/src/lib/pipes/public-api.ts
+++ b/lib/core/src/lib/pipes/public-api.ts
@@ -32,3 +32,4 @@ export * from './moment-date.pipe';
 export * from './moment-datetime.pipe';
 export * from './filter-string.pipe';
 export * from './filter-out-every-object-by-prop.pipe';
+export * from './type-cast.pipe';

--- a/lib/core/src/lib/pipes/type-cast.pipe.ts
+++ b/lib/core/src/lib/pipes/type-cast.pipe.ts
@@ -1,0 +1,30 @@
+/*!
+ * @license
+ * Copyright © 2005-2023 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+    name: 'cast',
+    pure: true
+})
+export class TypeCastPipe implements PipeTransform {
+
+    transform<T>(value: any, _type: (new (...args: any[]) => T) | T): T {
+        return value as T;
+    }
+
+}

--- a/lib/core/src/lib/pipes/type-cast.pipe.ts
+++ b/lib/core/src/lib/pipes/type-cast.pipe.ts
@@ -18,8 +18,7 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({
-    name: 'cast',
-    pure: true
+    name: 'cast'
 })
 export class TypeCastPipe implements PipeTransform {
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
There is no pipe to allow casting variables on templates


**What is the new behaviour?**
Added a new pipe, to allow casting a variable to a different type on html


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
Added a 'type-cast.pipe.ts' that allows casting of variables from one type to another. This is useful if an input data property is of different type than what is available in the component.

Usage notes - In order to use it, create a reference (preferably readonly) of the constructor for the data type to which to cast to, in the component.ts file.

`protected readonly NodeEntity = NodeEntity`

You should then be able to use this reference in the template to cast a variable to this type. 

`<my-comp [inputProp]="someVariable | cast : NodeEntity"></my-comp>`