### PR TITLE
[ADF-5546] Don't run forbidden labels job when cron runs e2es

### DIFF
--- a/.github/workflows/cron-e2e.yml
+++ b/.github/workflows/cron-e2e.yml
@@ -70,4 +70,6 @@ jobs:
   run-e2e:
     name: run e2e
     uses: ./.github/workflows/pull-request.yml
+    with:
+      cron-run: true
     secrets: inherit

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,6 +13,11 @@ on:
         required: false
         type: string
         default: false
+      cron-run:
+        description: 'disables jobs which shouldn't run when cron runs e2es'
+        required: false
+        type: boolean
+        default: false
   pull_request:
     types: [opened, synchronize, reopened]
     branches:
@@ -450,6 +455,7 @@ jobs:
           deps: ${{ matrix.e2e-test.deps }}
 
   PR-forbidden-labels:
+    if: ${{ github.event.inputs.cron-run == 'false' }}
     runs-on: ubuntu-latest
     steps:
       - id: checkoutRepo

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,7 +14,7 @@ on:
         type: string
         default: false
       cron-run:
-        description: 'disables jobs which shouldn't run when cron runs e2es'
+        description: 'disables jobs which should not run when cron runs e2es'
         required: false
         type: boolean
         default: false

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -455,7 +455,7 @@ jobs:
           deps: ${{ matrix.e2e-test.deps }}
 
   PR-forbidden-labels:
-    if: ${{ github.event.inputs.cron-run == 'false' }}
+    if: ${{ github.event.inputs.cron-run == '' || github.event.inputs.cron-run == 'false' }}
     runs-on: ubuntu-latest
     steps:
       - id: checkoutRepo


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Cron E2E runs forbidden-labels step which fails outside of PR runs. https://alfresco.atlassian.net/browse/ADF-5547

**What is the new behaviour?**

New input to pr workflow has been added disabling failing job for cron runs.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
