### PR TITLE
[ACS-5197] Disable empty facets

### DIFF
--- a/lib/content-services/src/lib/search/components/search-filter-chips/search-facet-chip/search-facet-chip.component.html
+++ b/lib/content-services/src/lib/search/components/search-filter-chips/search-facet-chip/search-facet-chip.component.html
@@ -2,6 +2,7 @@
           disableRipple
           class="adf-search-filter-chip"
           [class.adf-search-toggle-chip]="(facetField.displayValue$ | async) || menuTrigger.menuOpen"
+          [disabled]="!isPopulated()"
           tabIndex="0"
           [matMenuTriggerFor]="menu"
           (onMenuOpen)="onMenuOpen()"
@@ -18,7 +19,10 @@
         &nbsp; {{ displayValue | translate }}
     </span>
     <ng-template #showAny><span class="adf-search-filter-ellipsis adf-filter-value">&nbsp;{{ 'SEARCH.FILTER.ANY' | translate }}</span></ng-template>
-    <mat-icon>keyboard_arrow_down</mat-icon>
+    <mat-icon *ngIf="isPopulated(); else disabledIcon">keyboard_arrow_down</mat-icon>
+    <ng-template #disabledIcon>
+        <mat-icon>remove</mat-icon>
+    </ng-template>
 </mat-chip>
 
 <mat-menu #menu="matMenu" backdropClass="adf-search-filter-chip-menu" (closed)="onClosed()">

--- a/lib/content-services/src/lib/search/components/search-filter-chips/search-facet-chip/search-facet-chip.component.scss
+++ b/lib/content-services/src/lib/search/components/search-filter-chips/search-facet-chip/search-facet-chip.component.scss
@@ -1,0 +1,5 @@
+.adf-search-filter-chip {
+    &[disabled] {
+        pointer-events: none;
+    }
+}

--- a/lib/content-services/src/lib/search/components/search-filter-chips/search-facet-chip/search-facet-chip.component.spec.ts
+++ b/lib/content-services/src/lib/search/components/search-filter-chips/search-facet-chip/search-facet-chip.component.spec.ts
@@ -63,4 +63,27 @@ describe('SearchFacetChipComponent', () => {
         applyButton.triggerEventHandler('click', {});
         expect(queryBuilder.update).toHaveBeenCalled();
     });
+
+    it('should display arrow down icon and not disable the chip when items are loaded',  () => {
+        component.field.buckets.items = [{ count: 1, label: 'test', filterQuery: '' }];
+        fixture.detectChanges();
+        const chip = fixture.debugElement.query(By.css('mat-chip'));
+        const icon = fixture.debugElement.query(By.css('mat-chip mat-icon')).nativeElement.innerText;
+        expect(chip.classes['mat-chip-disabled']).toBeUndefined();
+        expect(icon).toEqual('keyboard_arrow_down');
+    });
+
+    it('should display remove icon and disable facet when no items are loaded',  () => {
+        const chip = fixture.debugElement.query(By.css('mat-chip'));
+        const icon = fixture.debugElement.query(By.css('mat-chip mat-icon')).nativeElement.innerText;
+        expect(chip.classes['mat-chip-disabled']).toBeTrue();
+        expect(icon).toEqual('remove');
+    });
+
+    it('should not open context menu when no items are loaded',  () => {
+        spyOn(component.menuTrigger, 'openMenu');
+        const chip = fixture.debugElement.query(By.css('mat-chip')).nativeElement;
+        chip.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter' }));
+        expect(component.menuTrigger.openMenu).not.toHaveBeenCalled();
+    });
 });

--- a/lib/content-services/src/lib/search/components/search-filter-chips/search-facet-chip/search-facet-chip.component.ts
+++ b/lib/content-services/src/lib/search/components/search-filter-chips/search-facet-chip/search-facet-chip.component.ts
@@ -24,6 +24,7 @@ import { SearchFacetFieldComponent } from '../../search-facet-field/search-facet
 @Component({
   selector: 'adf-search-facet-chip',
   templateUrl: './search-facet-chip.component.html',
+  styleUrls: ['./search-facet-chip.component.scss'],
   encapsulation: ViewEncapsulation.None
 })
 export class SearchFacetChipComponent {
@@ -65,10 +66,12 @@ export class SearchFacetChipComponent {
     }
 
     onEnterKeydown(): void {
-        if (!this.menuTrigger.menuOpen) {
-            this.menuTrigger.openMenu();
-        } else {
-            this.menuTrigger.closeMenu();
+        if (this.isPopulated()) {
+            if (!this.menuTrigger.menuOpen) {
+                this.menuTrigger.openMenu();
+            } else {
+                this.menuTrigger.closeMenu();
+            }
         }
     }
 
@@ -76,5 +79,9 @@ export class SearchFacetChipComponent {
         if (this.menuTrigger.menuOpen) {
             this.menuTrigger.closeMenu();
         }
+    }
+
+    isPopulated(): boolean {
+        return this.field.buckets && this.field.buckets.items.length > 0;
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

If facet is empty it looks like other ones and is empty upon opening. https://alfresco.atlassian.net/browse/ACS-5197

**What is the new behaviour?**

If facet is empty and has none item selected previously it will be disabled and cannot be opened.
<img width="326" alt="Zrzut ekranu 2023-06-12 o 14 32 27" src="https://github.com/Alfresco/alfresco-ng2-components/assets/113341662/1528aad2-cc09-4819-8952-1840f378cc7c">

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
