### PR TITLE
[ACS-5364] Page refresh breaks icon styles

### DIFF
--- a/lib/content-services/src/lib/document-list/components/document-list.component.scss
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.scss
@@ -4,13 +4,6 @@
     background-color: var(--theme-background-color);
 }
 
-.mat-icon.adf-datatable-selected {
-    height: 100%;
-    width: 100%;
-    margin-left: -2px;
-    margin-top: 2px;
-}
-
 .adf-sticky-document-list {
     height: 310px;
     overflow-y: auto;

--- a/lib/content-services/src/lib/permission-manager/components/user-icon-column/user-icon-column.component.scss
+++ b/lib/content-services/src/lib/permission-manager/components/user-icon-column/user-icon-column.component.scss
@@ -33,4 +33,11 @@
             height: 40px;
         }
     }
+
+    &-datatable-selected.mat-icon {
+        height: 100%;
+        width: 100%;
+        margin-left: -2px;
+        margin-top: 2px;
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

If you go directly from personal files to libraries and open managing of members for that library then after clicking at any member the selection icon will be aligned properly but if you refresh page then it is not aligned. 

https://alfresco.atlassian.net/browse/ACS-5364

**What is the new behaviour?**

Bug fixed.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
