### PR TITLE
[ACS-5395] Fixed possibility to containing script by string

### DIFF
--- a/lib/core/src/lib/common/services/highlight-transform.service.ts
+++ b/lib/core/src/lib/common/services/highlight-transform.service.ts
@@ -44,7 +44,7 @@ export class HighlightTransformService {
             pattern = pattern.split(' ').filter((t) => t.length > 0).join('|');
 
             const regex = new RegExp(pattern, 'gi');
-            result = text.replace(/<[^>]+>/g, '').replace(regex, (match) => {
+            result = text.replace(/<[^>]*>*/g, '').replace(regex, (match) => {
                 isMatching = true;
                 return `<span class="${wrapperClass}">${match}</span>`;
             });

--- a/lib/core/src/lib/common/services/highlight-transform.service.ts
+++ b/lib/core/src/lib/common/services/highlight-transform.service.ts
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, SecurityContext } from '@angular/core';
+import { DomSanitizer } from '@angular/platform-browser';
 
 export interface HighlightTransformResult {
     text: string;
@@ -26,6 +27,8 @@ export interface HighlightTransformResult {
     providedIn: 'root'
 })
 export class HighlightTransformService {
+
+    constructor(private sanitizer: DomSanitizer) {}
 
     /**
      * Searches for `search` string(s) within `text` and highlights all occurrences.
@@ -44,7 +47,7 @@ export class HighlightTransformService {
             pattern = pattern.split(' ').filter((t) => t.length > 0).join('|');
 
             const regex = new RegExp(pattern, 'gi');
-            result = text.replace(/<[^>]*>*/g, '').replace(regex, (match) => {
+            result = this.sanitizer.sanitize(SecurityContext.HTML, text).replace(regex, (match) => {
                 isMatching = true;
                 return `<span class="${wrapperClass}">${match}</span>`;
             });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ACS-5395


**What is the new behaviour?**
<script is not allowed anymore inside string. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
