### PR TITLE
[ACS-5145] Align header row with data rows.

### DIFF
--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.html
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.html
@@ -65,7 +65,7 @@
                     [ngClass]="{ 'adf-datatable-cell-header-content--hovered':
                         hoveredHeaderColumnIndex === columnIndex &&
                         !isDraggingHeaderColumn &&
-                        !isResizing }"
+                        !isResizing && col.sortable}"
                 >
                     <span
                         *ngIf="hoveredHeaderColumnIndex === columnIndex && col.draggable && !isResizing"

--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.scss
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.scss
@@ -229,7 +229,7 @@ $data-table-cell-min-width-file-size: $data-table-cell-min-width !default;
         box-sizing: border-box;
 
         .adf-datatable-row {
-            padding-right: 30px;
+            padding-right: 15px;
 
             &:hover,
             &:focus {

--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.scss
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.scss
@@ -229,6 +229,8 @@ $data-table-cell-min-width-file-size: $data-table-cell-min-width !default;
         box-sizing: border-box;
 
         .adf-datatable-row {
+            padding-right: 30px;
+
             &:hover,
             &:focus {
                 background-color: inherit;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

The header row of adf-datatable, shifts a little towards right. https://alfresco.atlassian.net/browse/ACS-5145

**What is the new behaviour?**

The header aligns with the data rows and form a column.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
