### PR TITLE
[AAE-12065] Add isDefault flag to dropdown

### DIFF
--- a/lib/core/src/lib/form/components/widgets/core/form-field-option.ts
+++ b/lib/core/src/lib/form/components/widgets/core/form-field-option.ts
@@ -20,4 +20,5 @@
 export interface FormFieldOption {
     id: string;
     name: string;
+    isDefault?: boolean;
 }

--- a/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.spec.ts
@@ -18,6 +18,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { of, throwError } from 'rxjs';
+import { DropdownCloudWidgetComponent } from './dropdown-cloud.widget';
 import {
     FormFieldModel,
     FormModel,
@@ -26,7 +27,6 @@ import {
     FormFieldTypes,
     LogService
 } from '@alfresco/adf-core';
-import { DropdownCloudWidgetComponent, DropdownFormFieldOption } from './dropdown-cloud.widget';
 import { FormCloudService } from '../../../services/form-cloud.service';
 import { ProcessServiceCloudTestingModule } from '../../../../testing/process-service-cloud.testing.module';
 import { TranslateModule } from '@ngx-translate/core';
@@ -91,7 +91,7 @@ describe('DropdownCloudWidgetComponent', () => {
                 readOnly: false,
                 restUrl: 'https://fake-rest-url'
             });
-            widget.field.emptyOption = { id: 'empty', name: 'Choose one...', isDefault: true } as DropdownFormFieldOption;
+            widget.field.emptyOption = { id: 'empty', name: 'Choose one...' };
             widget.field.isVisible = true;
             fixture.detectChanges();
         });
@@ -184,20 +184,17 @@ describe('DropdownCloudWidgetComponent', () => {
             widget.field.optionType = 'rest';
             widget.field.value = {
                 id: 'opt1',
-                name: 'default1_value',
-                isDefault: false
+                name: 'default1_value'
             };
 
             spyOn(formCloudService, 'getRestWidgetData').and.returnValue(of([
                 {
                     id: 'opt1',
-                    name: 'default1_value',
-                    isDefault: false
+                    name: 'default1_value'
                 },
                 {
                     id: 2,
-                    name: 'default2_value',
-                    isDefault: false
+                    name: 'default2_value'
                 }
             ] as any));
 
@@ -218,13 +215,11 @@ describe('DropdownCloudWidgetComponent', () => {
             spyOn(formCloudService, 'getRestWidgetData').and.returnValue(of([
                 {
                     id: 'opt1',
-                    name: 'default1_value',
-                    isDefault: false
+                    name: 'default1_value'
                 },
                 {
                     id: 2,
-                    name: 'default2_value',
-                    isDefault: false
+                    name: 'default2_value'
                 }
             ] as any));
 
@@ -234,12 +229,12 @@ describe('DropdownCloudWidgetComponent', () => {
             await openSelect();
             const options = fixture.debugElement.queryAll(By.css('.mat-option-text'));
             expect(options[0].nativeElement.innerText).toBe('default1_value');
-            expect(widget.field.form.values['dropdown-id']).toEqual({ id: 'opt1', name: 'default1_value', isDefault: false });
+            expect(widget.field.form.values['dropdown-id']).toEqual({ id: 'opt1', name: 'default1_value' });
         });
 
         it('should not display required error for a non required dropdown when selecting the none option', async () => {
             widget.field.options = [
-                { id: 'empty', name: 'Choose empty', isDefault: true },
+                { id: 'empty', name: 'Choose empty' },
                 ...fakeOptionList
             ];
 
@@ -259,7 +254,7 @@ describe('DropdownCloudWidgetComponent', () => {
         it('should not display required error when selecting a valid option for a required dropdown', async () => {
             widget.field.required = true;
             widget.field.options = [
-                { id: 'empty', name: 'Choose empty', isDefault: true },
+                { id: 'empty', name: 'Choose empty' },
                 ...fakeOptionList
             ];
 
@@ -278,7 +273,7 @@ describe('DropdownCloudWidgetComponent', () => {
 
         it('should not have a value when switching from an available option to the None option', async () => {
             widget.field.options = [
-                { id: 'empty', name: 'This is a mock none option', isDefault: true },
+                { id: 'empty', name: 'This is a mock none option' },
                 ...fakeOptionList
             ];
 
@@ -444,8 +439,8 @@ describe('DropdownCloudWidgetComponent', () => {
                 options: fakeOptionList,
                 selectionType: 'multiple',
                 value: [
-                    { id: 'opt_1', name: 'option_1', isDefault: false },
-                    { id: 'opt_2', name: 'option_2', isDefault: false }
+                    { id: 'opt_1', name: 'option_1' },
+                    { id: 'opt_2', name: 'option_2' }
                 ]
             });
             fixture.detectChanges();
@@ -479,8 +474,8 @@ describe('DropdownCloudWidgetComponent', () => {
             optionOne.triggerEventHandler('click', null);
             optionTwo.triggerEventHandler('click', null);
             expect(widget.field.value).toEqual([
-                { id: 'opt_1', name: 'option_1', isDefault: false },
-                { id: 'opt_2', name: 'option_2', isDefault: false }
+                { id: 'opt_1', name: 'option_1' },
+                { id: 'opt_2', name: 'option_2' }
             ]);
         });
 
@@ -494,30 +489,26 @@ describe('DropdownCloudWidgetComponent', () => {
                 optionType : 'rest',
                 selectionType: 'multiple',
                 value: [
-                    { id: 'opt_3', name: 'option_3', isDefault: false },
-                    { id: 'opt_4', name: 'option_4', isDefault: false }
+                    { id: 'opt_3', name: 'option_3' },
+                    { id: 'opt_4', name: 'option_4' }
                 ]
             });
             spyOn(formCloudService, 'getRestWidgetData').and.returnValue(of([
                 {
                     id: 'opt_1',
-                    name: 'option_1',
-                    isDefault: false
+                    name: 'option_1'
                 },
                 {
                     id: 'opt_2',
-                    name: 'option_2',
-                    isDefault: false
+                    name: 'option_2'
                 },
                 {
                     id: 'opt_3',
-                    name: 'option_3',
-                    isDefault: false
+                    name: 'option_3'
                 },
                 {
                     id: 'opt_4',
-                    name: 'option_4',
-                    isDefault: false
+                    name: 'option_4'
                 }
             ] as any));
 
@@ -549,23 +540,19 @@ describe('DropdownCloudWidgetComponent', () => {
             spyOn(formCloudService, 'getRestWidgetData').and.returnValue(of([
                 {
                     id: 'opt_1',
-                    name: 'option_1',
-                    isDefault: false
+                    name: 'option_1'
                 },
                 {
                     id: 'opt_2',
-                    name: 'option_2',
-                    isDefault: false
+                    name: 'option_2'
                 },
                 {
                     id: 'opt_3',
-                    name: 'option_3',
-                    isDefault: false
+                    name: 'option_3'
                 },
                 {
                     id: 'opt_4',
-                    name: 'option_4',
-                    isDefault: false
+                    name: 'option_4'
                 }
             ] as any));
 
@@ -577,8 +564,8 @@ describe('DropdownCloudWidgetComponent', () => {
             optionOne.triggerEventHandler('click', null);
             optionTwo.triggerEventHandler('click', null);
             expect(widget.field.value).toEqual([
-                { id: 'opt_2', name: 'option_2', isDefault: false },
-                { id: 'opt_4', name: 'option_4', isDefault: false }
+                { id: 'opt_2', name: 'option_2' },
+                { id: 'opt_4', name: 'option_4' }
             ]);
         });
     });

--- a/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.spec.ts
@@ -786,22 +786,28 @@ describe('DropdownCloudWidgetComponent', () => {
                 expect(call).toEqual(undefined);
             });
 
-            it('should get default option from list of options which have any id matching the DEFAULT_OPTION id, while not having an isDefault flag set to true', () => {
+            it('should get default option from list of options which has an id matching the DEFAULT_OPTION id, while not having an isDefault flag on that option', () => {
                 const call = widget.getDefaultOption(fakeFormOptionEntries[1]);
 
                 expect(call).toEqual(fakeFormOptionEntries[1][0]);
             });
 
-            it('should get default option from list of options which have any id matching the DEFAULT_OPTION id while also having an isDefault flag set to true', () => {
+            it('should get default option from list of options which has an id matching the DEFAULT_OPTION id while also having an isDefault flag set to true on that option', () => {
                 const call = widget.getDefaultOption(fakeFormOptionEntries[2]);
 
                 expect(call).toEqual(fakeFormOptionEntries[2][0]);
             });
 
-            it('should get default option from list of options which has an isDefault flag set to true, despite the option id', () => {
+            it('should get default option from list of options which has an isDefault flag set to true, despite the option id not matching the DEFAULT_OPTION id', () => {
                 const call = widget.getDefaultOption(fakeFormOptionEntries[3]);
 
                 expect(call).toEqual(fakeFormOptionEntries[3][0]);
+            });
+
+            it('should not get default option from list of options which has an id matching the DEFAULT_OPTION id, while having an isDefault flag set to false on that option', () => {
+                const call = widget.getDefaultOption(fakeFormOptionEntries[4]);
+
+                expect(call).toEqual(undefined);
             });
         });
 

--- a/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.spec.ts
@@ -18,7 +18,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { of, throwError } from 'rxjs';
-import { DropdownCloudWidgetComponent } from './dropdown-cloud.widget';
 import {
     FormFieldModel,
     FormModel,
@@ -27,6 +26,7 @@ import {
     FormFieldTypes,
     LogService
 } from '@alfresco/adf-core';
+import { DropdownCloudWidgetComponent, DropdownFormFieldOption } from './dropdown-cloud.widget';
 import { FormCloudService } from '../../../services/form-cloud.service';
 import { ProcessServiceCloudTestingModule } from '../../../../testing/process-service-cloud.testing.module';
 import { TranslateModule } from '@ngx-translate/core';
@@ -91,7 +91,7 @@ describe('DropdownCloudWidgetComponent', () => {
                 readOnly: false,
                 restUrl: 'https://fake-rest-url'
             });
-            widget.field.emptyOption = { id: 'empty', name: 'Choose one...' };
+            widget.field.emptyOption = { id: 'empty', name: 'Choose one...', isDefault: true } as DropdownFormFieldOption;
             widget.field.isVisible = true;
             fixture.detectChanges();
         });
@@ -184,17 +184,20 @@ describe('DropdownCloudWidgetComponent', () => {
             widget.field.optionType = 'rest';
             widget.field.value = {
                 id: 'opt1',
-                name: 'default1_value'
+                name: 'default1_value',
+                isDefault: false
             };
 
             spyOn(formCloudService, 'getRestWidgetData').and.returnValue(of([
                 {
                     id: 'opt1',
-                    name: 'default1_value'
+                    name: 'default1_value',
+                    isDefault: false
                 },
                 {
                     id: 2,
-                    name: 'default2_value'
+                    name: 'default2_value',
+                    isDefault: false
                 }
             ] as any));
 
@@ -215,11 +218,13 @@ describe('DropdownCloudWidgetComponent', () => {
             spyOn(formCloudService, 'getRestWidgetData').and.returnValue(of([
                 {
                     id: 'opt1',
-                    name: 'default1_value'
+                    name: 'default1_value',
+                    isDefault: false
                 },
                 {
                     id: 2,
-                    name: 'default2_value'
+                    name: 'default2_value',
+                    isDefault: false
                 }
             ] as any));
 
@@ -229,12 +234,12 @@ describe('DropdownCloudWidgetComponent', () => {
             await openSelect();
             const options = fixture.debugElement.queryAll(By.css('.mat-option-text'));
             expect(options[0].nativeElement.innerText).toBe('default1_value');
-            expect(widget.field.form.values['dropdown-id']).toEqual({ id: 'opt1', name: 'default1_value' });
+            expect(widget.field.form.values['dropdown-id']).toEqual({ id: 'opt1', name: 'default1_value', isDefault: false });
         });
 
         it('should not display required error for a non required dropdown when selecting the none option', async () => {
             widget.field.options = [
-                { id: 'empty', name: 'Choose empty' },
+                { id: 'empty', name: 'Choose empty', isDefault: true },
                 ...fakeOptionList
             ];
 
@@ -254,7 +259,7 @@ describe('DropdownCloudWidgetComponent', () => {
         it('should not display required error when selecting a valid option for a required dropdown', async () => {
             widget.field.required = true;
             widget.field.options = [
-                { id: 'empty', name: 'Choose empty' },
+                { id: 'empty', name: 'Choose empty', isDefault: true },
                 ...fakeOptionList
             ];
 
@@ -273,7 +278,7 @@ describe('DropdownCloudWidgetComponent', () => {
 
         it('should not have a value when switching from an available option to the None option', async () => {
             widget.field.options = [
-                { id: 'empty', name: 'This is a mock none option' },
+                { id: 'empty', name: 'This is a mock none option', isDefault: true },
                 ...fakeOptionList
             ];
 
@@ -439,8 +444,8 @@ describe('DropdownCloudWidgetComponent', () => {
                 options: fakeOptionList,
                 selectionType: 'multiple',
                 value: [
-                    { id: 'opt_1', name: 'option_1' },
-                    { id: 'opt_2', name: 'option_2' }
+                    { id: 'opt_1', name: 'option_1', isDefault: false },
+                    { id: 'opt_2', name: 'option_2', isDefault: false }
                 ]
             });
             fixture.detectChanges();
@@ -474,8 +479,8 @@ describe('DropdownCloudWidgetComponent', () => {
             optionOne.triggerEventHandler('click', null);
             optionTwo.triggerEventHandler('click', null);
             expect(widget.field.value).toEqual([
-                { id: 'opt_1', name: 'option_1' },
-                { id: 'opt_2', name: 'option_2' }
+                { id: 'opt_1', name: 'option_1', isDefault: false },
+                { id: 'opt_2', name: 'option_2', isDefault: false }
             ]);
         });
 
@@ -489,26 +494,30 @@ describe('DropdownCloudWidgetComponent', () => {
                 optionType : 'rest',
                 selectionType: 'multiple',
                 value: [
-                    { id: 'opt_3', name: 'option_3' },
-                    { id: 'opt_4', name: 'option_4' }
+                    { id: 'opt_3', name: 'option_3', isDefault: false },
+                    { id: 'opt_4', name: 'option_4', isDefault: false }
                 ]
             });
             spyOn(formCloudService, 'getRestWidgetData').and.returnValue(of([
                 {
                     id: 'opt_1',
-                    name: 'option_1'
+                    name: 'option_1',
+                    isDefault: false
                 },
                 {
                     id: 'opt_2',
-                    name: 'option_2'
+                    name: 'option_2',
+                    isDefault: false
                 },
                 {
                     id: 'opt_3',
-                    name: 'option_3'
+                    name: 'option_3',
+                    isDefault: false
                 },
                 {
                     id: 'opt_4',
-                    name: 'option_4'
+                    name: 'option_4',
+                    isDefault: false
                 }
             ] as any));
 
@@ -540,19 +549,23 @@ describe('DropdownCloudWidgetComponent', () => {
             spyOn(formCloudService, 'getRestWidgetData').and.returnValue(of([
                 {
                     id: 'opt_1',
-                    name: 'option_1'
+                    name: 'option_1',
+                    isDefault: false
                 },
                 {
                     id: 'opt_2',
-                    name: 'option_2'
+                    name: 'option_2',
+                    isDefault: false
                 },
                 {
                     id: 'opt_3',
-                    name: 'option_3'
+                    name: 'option_3',
+                    isDefault: false
                 },
                 {
                     id: 'opt_4',
-                    name: 'option_4'
+                    name: 'option_4',
+                    isDefault: false
                 }
             ] as any));
 
@@ -564,8 +577,8 @@ describe('DropdownCloudWidgetComponent', () => {
             optionOne.triggerEventHandler('click', null);
             optionTwo.triggerEventHandler('click', null);
             expect(widget.field.value).toEqual([
-                { id: 'opt_2', name: 'option_2' },
-                { id: 'opt_4', name: 'option_4' }
+                { id: 'opt_2', name: 'option_2', isDefault: false },
+                { id: 'opt_4', name: 'option_4', isDefault: false }
             ]);
         });
     });

--- a/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.spec.ts
@@ -39,7 +39,8 @@ import {
     mockRestDropdownOptions,
     mockSecondRestDropdownOptions,
     mockVariablesWithDefaultJson,
-    mockProcessVariablesWithJson
+    mockProcessVariablesWithJson,
+    fakeFormOptionEntries
 } from '../../../mocks/dropdown.mock';
 import { OverlayContainer } from '@angular/cdk/overlay';
 import { TaskVariableCloud } from '../../../models/task-variable-cloud.model';
@@ -775,6 +776,32 @@ describe('DropdownCloudWidgetComponent', () => {
 
                     expect(formFieldValueChangedSpy).toHaveBeenCalledWith(formFieldValueChangedEvent);
                 });
+            });
+        });
+
+        describe('Default option', () => {
+            it('should not get default option from list of options which do not have any id matching the DEFAULT_OPTION id', () => {
+                const call = widget.getDefaultOption(fakeFormOptionEntries[0]);
+
+                expect(call).toEqual(undefined);
+            });
+
+            it('should get default option from list of options which have any id matching the DEFAULT_OPTION id, while not having an isDefault flag set to true', () => {
+                const call = widget.getDefaultOption(fakeFormOptionEntries[1]);
+
+                expect(call).toEqual(fakeFormOptionEntries[1][0]);
+            });
+
+            it('should get default option from list of options which have any id matching the DEFAULT_OPTION id while also having an isDefault flag set to true', () => {
+                const call = widget.getDefaultOption(fakeFormOptionEntries[2]);
+
+                expect(call).toEqual(fakeFormOptionEntries[2][0]);
+            });
+
+            it('should get default option from list of options which has an isDefault flag set to true, despite the option id', () => {
+                const call = widget.getDefaultOption(fakeFormOptionEntries[3]);
+
+                expect(call).toEqual(fakeFormOptionEntries[3][0]);
             });
         });
 

--- a/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.ts
@@ -38,10 +38,6 @@ export const DEFAULT_OPTION = {
 };
 export const HIDE_FILTER_LIMIT = 5;
 
-export interface DropdownFormFieldOption extends FormFieldOption {
-    isDefault: boolean;
-}
-
 /* eslint-disable @angular-eslint/component-selector */
 
 @Component({
@@ -68,7 +64,7 @@ export class DropdownCloudWidgetComponent extends WidgetComponent implements OnI
     variableOptionsFailed = false;
     previewState = false;
     restApiHostName: string;
-    list$: Observable<DropdownFormFieldOption[]>;
+    list$: Observable<FormFieldOption[]>;
     filter$ = new BehaviorSubject<string>('');
 
     private readonly defaultVariableOptionId = 'id';
@@ -199,7 +195,7 @@ export class DropdownCloudWidgetComponent extends WidgetComponent implements OnI
             const bodyParam = this.buildBodyParam();
             this.formCloudService.getRestWidgetData(this.field.form.id, this.field.id, bodyParam)
                 .pipe(takeUntil(this.onDestroy$))
-                .subscribe((result: DropdownFormFieldOption[]) => {
+                .subscribe((result: FormFieldOption[]) => {
                     this.resetRestApiErrorMessage();
                     this.field.options = result;
                     this.updateOptions();
@@ -338,7 +334,7 @@ export class DropdownCloudWidgetComponent extends WidgetComponent implements OnI
         return this.field?.rule?.ruleOn;
     }
 
-    compareDropdownValues(opt1: DropdownFormFieldOption | string, opt2: DropdownFormFieldOption | string): boolean {
+    compareDropdownValues(opt1: FormFieldOption | string, opt2: FormFieldOption | string): boolean {
         if (!opt1 || !opt2) {
             return false;
         }
@@ -358,7 +354,7 @@ export class DropdownCloudWidgetComponent extends WidgetComponent implements OnI
         return opt1 === opt2;
     }
 
-    getOptionValue(option: DropdownFormFieldOption, fieldValue: string): string | DropdownFormFieldOption {
+    getOptionValue(option: FormFieldOption, fieldValue: string): string | FormFieldOption {
         if (this.field.hasMultipleValues) {
             return option;
         }
@@ -399,7 +395,7 @@ export class DropdownCloudWidgetComponent extends WidgetComponent implements OnI
 
     updateOptions(): void {
         this.showInputFilter = this.field.options.length > this.appConfig.get<number>('form.dropDownFilterLimit', HIDE_FILTER_LIMIT);
-        this.list$ = combineLatest([of(this.field.options as DropdownFormFieldOption[]), this.filter$])
+        this.list$ = combineLatest([of(this.field.options), this.filter$])
             .pipe(
                 map(([items, search]) => {
                     if (!search) {
@@ -438,7 +434,7 @@ export class DropdownCloudWidgetComponent extends WidgetComponent implements OnI
             !this.variableOptionsFailed;
     }
 
-    getDefaultOption(options: DropdownFormFieldOption[]): DropdownFormFieldOption {
-        return options.find((option: DropdownFormFieldOption) => option.isDefault);
+    getDefaultOption(options: FormFieldOption[]): FormFieldOption {
+        return options.find((option: FormFieldOption) => option.isDefault === undefined ? option.id === DEFAULT_OPTION.id : option.isDefault);
     }
 }

--- a/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.ts
@@ -435,6 +435,6 @@ export class DropdownCloudWidgetComponent extends WidgetComponent implements OnI
     }
 
     getDefaultOption(options: FormFieldOption[]): FormFieldOption {
-        return options.find((option: FormFieldOption) => option.isDefault === undefined ? option.id === DEFAULT_OPTION.id : option.isDefault);
+        return options.find((option: FormFieldOption) => option.isDefault ?? option.id === DEFAULT_OPTION.id);
     }
 }

--- a/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.ts
@@ -38,6 +38,10 @@ export const DEFAULT_OPTION = {
 };
 export const HIDE_FILTER_LIMIT = 5;
 
+export interface DropdownFormFieldOption extends FormFieldOption {
+    isDefault: boolean;
+}
+
 /* eslint-disable @angular-eslint/component-selector */
 
 @Component({
@@ -64,7 +68,7 @@ export class DropdownCloudWidgetComponent extends WidgetComponent implements OnI
     variableOptionsFailed = false;
     previewState = false;
     restApiHostName: string;
-    list$: Observable<FormFieldOption[]>;
+    list$: Observable<DropdownFormFieldOption[]>;
     filter$ = new BehaviorSubject<string>('');
 
     private readonly defaultVariableOptionId = 'id';
@@ -195,7 +199,7 @@ export class DropdownCloudWidgetComponent extends WidgetComponent implements OnI
             const bodyParam = this.buildBodyParam();
             this.formCloudService.getRestWidgetData(this.field.form.id, this.field.id, bodyParam)
                 .pipe(takeUntil(this.onDestroy$))
-                .subscribe((result: FormFieldOption[]) => {
+                .subscribe((result: DropdownFormFieldOption[]) => {
                     this.resetRestApiErrorMessage();
                     this.field.options = result;
                     this.updateOptions();
@@ -334,7 +338,7 @@ export class DropdownCloudWidgetComponent extends WidgetComponent implements OnI
         return this.field?.rule?.ruleOn;
     }
 
-    compareDropdownValues(opt1: FormFieldOption | string, opt2: FormFieldOption | string): boolean {
+    compareDropdownValues(opt1: DropdownFormFieldOption | string, opt2: DropdownFormFieldOption | string): boolean {
         if (!opt1 || !opt2) {
             return false;
         }
@@ -354,7 +358,7 @@ export class DropdownCloudWidgetComponent extends WidgetComponent implements OnI
         return opt1 === opt2;
     }
 
-    getOptionValue(option: FormFieldOption, fieldValue: string): string | FormFieldOption {
+    getOptionValue(option: DropdownFormFieldOption, fieldValue: string): string | DropdownFormFieldOption {
         if (this.field.hasMultipleValues) {
             return option;
         }
@@ -395,7 +399,7 @@ export class DropdownCloudWidgetComponent extends WidgetComponent implements OnI
 
     updateOptions(): void {
         this.showInputFilter = this.field.options.length > this.appConfig.get<number>('form.dropDownFilterLimit', HIDE_FILTER_LIMIT);
-        this.list$ = combineLatest([of(this.field.options), this.filter$])
+        this.list$ = combineLatest([of(this.field.options as DropdownFormFieldOption[]), this.filter$])
             .pipe(
                 map(([items, search]) => {
                     if (!search) {
@@ -434,7 +438,7 @@ export class DropdownCloudWidgetComponent extends WidgetComponent implements OnI
             !this.variableOptionsFailed;
     }
 
-    getDefaultOption(options: FormFieldOption[]): FormFieldOption {
-        return options.find((option: FormFieldOption) => option.id === DEFAULT_OPTION.id);
+    getDefaultOption(options: DropdownFormFieldOption[]): DropdownFormFieldOption {
+        return options.find((option: DropdownFormFieldOption) => option.isDefault);
     }
 }

--- a/lib/process-services-cloud/src/lib/form/mocks/dropdown.mock.ts
+++ b/lib/process-services-cloud/src/lib/form/mocks/dropdown.mock.ts
@@ -168,6 +168,71 @@ export const mockCountriesResponse = {
     ]
 };
 
+export const fakeFormOptionEntries = [
+    [
+        {
+            id: 'id_1',
+            name: 'name_1'
+        },
+        {
+            id: 'id_1',
+            name: 'name_2'
+        },
+        {
+            id: 'id_3',
+            name: 'name_3'
+        }
+    ],
+    [
+        {
+            id: 'empty',
+            name: 'name_1'
+        },
+        {
+            id: 'id_1',
+            name: 'name_2'
+        },
+        {
+            id: 'id_3',
+            name: 'name_3'
+        }
+    ],
+    [
+        {
+            id: 'empty',
+            name: 'name_1',
+            isDefault: true
+        },
+        {
+            id: 'id_1',
+            name: 'name_2',
+            isDefault: false
+        },
+        {
+            id: 'id_3',
+            name: 'name_3',
+            isDefault: false
+        }
+    ],
+    [
+        {
+            id: 'id_1',
+            name: 'name_1',
+            isDefault: true
+        },
+        {
+            id: 'id_1',
+            name: 'name_2',
+            isDefault: false
+        },
+        {
+            id: 'id_3',
+            name: 'name_3',
+            isDefault: false
+        }
+    ]
+];
+
 export const mockFormVariableWithJson = [
     new TaskVariableCloud({ name: 'json-form-variable', value: mockCountriesResponse, type: 'json', id: 'fake-id-1' })
 ];

--- a/lib/process-services-cloud/src/lib/form/mocks/dropdown.mock.ts
+++ b/lib/process-services-cloud/src/lib/form/mocks/dropdown.mock.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { FormFieldOption } from '@alfresco/adf-core';
+import { DropdownFormFieldOption } from '../components/widgets/dropdown/dropdown-cloud.widget';
 import { TaskVariableCloud } from '../models/task-variable-cloud.model';
 
 export const mockConditionalEntries = [
@@ -24,15 +24,18 @@ export const mockConditionalEntries = [
         options: [
             {
                 id: 'empty',
-                name: 'Choose one...'
+                name: 'Choose one...',
+                isDefault: true
             },
             {
                 id: 'ATH',
-                name: 'Athens'
+                name: 'Athens',
+                isDefault: false
             },
             {
                 id: 'SKG',
-                name: 'Thessaloniki'
+                name: 'Thessaloniki',
+                isDefault: false
             }
         ]
     },
@@ -41,15 +44,18 @@ export const mockConditionalEntries = [
         options: [
             {
                 id: 'empty',
-                name: 'Choose one...'
+                name: 'Choose one...',
+                isDefault: true
             },
             {
                 id: 'MI',
-                name: 'MILAN'
+                name: 'MILAN',
+                isDefault: false
             },
             {
                 id: 'RM',
-                name: 'ROME'
+                name: 'ROME',
+                isDefault: false
             }
         ]
     },
@@ -58,51 +64,56 @@ export const mockConditionalEntries = [
         options: [
             {
                 id: 'empty',
-                name: 'Choose one...'
+                name: 'Choose one...',
+                isDefault: true
             },
             {
                 id: 'LDN',
-                name: 'London'
+                name: 'London',
+                isDefault: false
             },
             {
                 id: 'MAN',
-                name: 'Manchester'
+                name: 'Manchester',
+                isDefault: false
             },
             {
                 id: 'SHE',
-                name: 'Sheffield'
+                name: 'Sheffield',
+                isDefault: false
             },
             {
                 id: 'LEE',
-                name: 'Leeds'
+                name: 'Leeds',
+                isDefault: false
             }
         ]
     }
 ];
 
-export const mockRestDropdownOptions: FormFieldOption[] = [
-    { id: 'LO', name: 'LONDON' },
-    { id: 'MA', name: 'MANCHESTER' }
+export const mockRestDropdownOptions: DropdownFormFieldOption[] = [
+    { id: 'LO', name: 'LONDON', isDefault: false },
+    { id: 'MA', name: 'MANCHESTER', isDefault: false }
 ];
 
-export const mockSecondRestDropdownOptions: FormFieldOption[] = [
-    { id: 'MI', name: 'MILAN' },
-    { id: 'RM', name: 'ROME' }
+export const mockSecondRestDropdownOptions: DropdownFormFieldOption[] = [
+    { id: 'MI', name: 'MILAN', isDefault: false },
+    { id: 'RM', name: 'ROME', isDefault: false }
 ];
 
-export const fakeOptionList: FormFieldOption[] = [
-    { id: 'opt_1', name: 'option_1' },
-    { id: 'opt_2', name: 'option_2' },
-    { id: 'opt_3', name: 'option_3' }
+export const fakeOptionList: DropdownFormFieldOption[] = [
+    { id: 'opt_1', name: 'option_1', isDefault: false },
+    { id: 'opt_2', name: 'option_2', isDefault: false },
+    { id: 'opt_3', name: 'option_3', isDefault: false }
 ];
 
-export const filterOptionList = [
-    { id: 'opt_1', name: 'option_1' },
-    { id: 'opt_2', name: 'option_2' },
-    { id: 'opt_3', name: 'option_3' },
-    { id: 'opt_4', name: 'option_4' },
-    { id: 'opt_5', name: 'option_5' },
-    { id: 'opt_6', name: 'option_6' }
+export const filterOptionList: DropdownFormFieldOption[] = [
+    { id: 'opt_1', name: 'option_1', isDefault: false },
+    { id: 'opt_2', name: 'option_2', isDefault: false },
+    { id: 'opt_3', name: 'option_3', isDefault: false },
+    { id: 'opt_4', name: 'option_4', isDefault: false },
+    { id: 'opt_5', name: 'option_5', isDefault: false },
+    { id: 'opt_6', name: 'option_6', isDefault: false }
 ];
 
 export const mockPlayersResponse = {
@@ -138,15 +149,18 @@ export const mockDefaultResponse = {
     [
         {
             id: 'default-pet-1',
-            name: 'Dog'
+            name: 'Dog',
+            isDefault: false
         },
         {
             id: 'default-pet-2',
-            name: 'Cat'
+            name: 'Cat',
+            isDefault: false
         },
         {
             id: 'default-pet-3',
-            name: 'Parrot'
+            name: 'Parrot',
+            isDefault: false
         }
     ]
 };
@@ -155,15 +169,18 @@ export const mockCountriesResponse = {
     countries: [
         {
             id: 'PL',
-            name: 'Poland'
+            name: 'Poland',
+            isDefault: false
         },
         {
             id: 'UK',
-            name: 'United Kingdom'
+            name: 'United Kingdom',
+            isDefault: false
         },
         {
             id: 'GR',
-            name: 'Greece'
+            name: 'Greece',
+            isDefault: false
         }
     ]
 };

--- a/lib/process-services-cloud/src/lib/form/mocks/dropdown.mock.ts
+++ b/lib/process-services-cloud/src/lib/form/mocks/dropdown.mock.ts
@@ -230,6 +230,23 @@ export const fakeFormOptionEntries = [
             name: 'name_3',
             isDefault: false
         }
+    ],
+    [
+        {
+            id: 'empty',
+            name: 'name_1',
+            isDefault: false
+        },
+        {
+            id: 'id_1',
+            name: 'name_2',
+            isDefault: false
+        },
+        {
+            id: 'id_3',
+            name: 'name_3',
+            isDefault: false
+        }
     ]
 ];
 

--- a/lib/process-services-cloud/src/lib/form/mocks/dropdown.mock.ts
+++ b/lib/process-services-cloud/src/lib/form/mocks/dropdown.mock.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { DropdownFormFieldOption } from '../components/widgets/dropdown/dropdown-cloud.widget';
+import { FormFieldOption } from '@alfresco/adf-core';
 import { TaskVariableCloud } from '../models/task-variable-cloud.model';
 
 export const mockConditionalEntries = [
@@ -24,18 +24,15 @@ export const mockConditionalEntries = [
         options: [
             {
                 id: 'empty',
-                name: 'Choose one...',
-                isDefault: true
+                name: 'Choose one...'
             },
             {
                 id: 'ATH',
-                name: 'Athens',
-                isDefault: false
+                name: 'Athens'
             },
             {
                 id: 'SKG',
-                name: 'Thessaloniki',
-                isDefault: false
+                name: 'Thessaloniki'
             }
         ]
     },
@@ -44,18 +41,15 @@ export const mockConditionalEntries = [
         options: [
             {
                 id: 'empty',
-                name: 'Choose one...',
-                isDefault: true
+                name: 'Choose one...'
             },
             {
                 id: 'MI',
-                name: 'MILAN',
-                isDefault: false
+                name: 'MILAN'
             },
             {
                 id: 'RM',
-                name: 'ROME',
-                isDefault: false
+                name: 'ROME'
             }
         ]
     },
@@ -64,56 +58,51 @@ export const mockConditionalEntries = [
         options: [
             {
                 id: 'empty',
-                name: 'Choose one...',
-                isDefault: true
+                name: 'Choose one...'
             },
             {
                 id: 'LDN',
-                name: 'London',
-                isDefault: false
+                name: 'London'
             },
             {
                 id: 'MAN',
-                name: 'Manchester',
-                isDefault: false
+                name: 'Manchester'
             },
             {
                 id: 'SHE',
-                name: 'Sheffield',
-                isDefault: false
+                name: 'Sheffield'
             },
             {
                 id: 'LEE',
-                name: 'Leeds',
-                isDefault: false
+                name: 'Leeds'
             }
         ]
     }
 ];
 
-export const mockRestDropdownOptions: DropdownFormFieldOption[] = [
-    { id: 'LO', name: 'LONDON', isDefault: false },
-    { id: 'MA', name: 'MANCHESTER', isDefault: false }
+export const mockRestDropdownOptions: FormFieldOption[] = [
+    { id: 'LO', name: 'LONDON' },
+    { id: 'MA', name: 'MANCHESTER' }
 ];
 
-export const mockSecondRestDropdownOptions: DropdownFormFieldOption[] = [
-    { id: 'MI', name: 'MILAN', isDefault: false },
-    { id: 'RM', name: 'ROME', isDefault: false }
+export const mockSecondRestDropdownOptions: FormFieldOption[] = [
+    { id: 'MI', name: 'MILAN' },
+    { id: 'RM', name: 'ROME' }
 ];
 
-export const fakeOptionList: DropdownFormFieldOption[] = [
-    { id: 'opt_1', name: 'option_1', isDefault: false },
-    { id: 'opt_2', name: 'option_2', isDefault: false },
-    { id: 'opt_3', name: 'option_3', isDefault: false }
+export const fakeOptionList: FormFieldOption[] = [
+    { id: 'opt_1', name: 'option_1' },
+    { id: 'opt_2', name: 'option_2' },
+    { id: 'opt_3', name: 'option_3' }
 ];
 
-export const filterOptionList: DropdownFormFieldOption[] = [
-    { id: 'opt_1', name: 'option_1', isDefault: false },
-    { id: 'opt_2', name: 'option_2', isDefault: false },
-    { id: 'opt_3', name: 'option_3', isDefault: false },
-    { id: 'opt_4', name: 'option_4', isDefault: false },
-    { id: 'opt_5', name: 'option_5', isDefault: false },
-    { id: 'opt_6', name: 'option_6', isDefault: false }
+export const filterOptionList = [
+    { id: 'opt_1', name: 'option_1' },
+    { id: 'opt_2', name: 'option_2' },
+    { id: 'opt_3', name: 'option_3' },
+    { id: 'opt_4', name: 'option_4' },
+    { id: 'opt_5', name: 'option_5' },
+    { id: 'opt_6', name: 'option_6' }
 ];
 
 export const mockPlayersResponse = {
@@ -149,18 +138,15 @@ export const mockDefaultResponse = {
     [
         {
             id: 'default-pet-1',
-            name: 'Dog',
-            isDefault: false
+            name: 'Dog'
         },
         {
             id: 'default-pet-2',
-            name: 'Cat',
-            isDefault: false
+            name: 'Cat'
         },
         {
             id: 'default-pet-3',
-            name: 'Parrot',
-            isDefault: false
+            name: 'Parrot'
         }
     ]
 };
@@ -169,18 +155,15 @@ export const mockCountriesResponse = {
     countries: [
         {
             id: 'PL',
-            name: 'Poland',
-            isDefault: false
+            name: 'Poland'
         },
         {
             id: 'UK',
-            name: 'United Kingdom',
-            isDefault: false
+            name: 'United Kingdom'
         },
         {
             id: 'GR',
-            name: 'Greece',
-            isDefault: false
+            name: 'Greece'
         }
     ]
 };


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
If dropdown field had the same id as the `DEFAULT_OPTION.id`, it would be taken as the default option

https://alfresco.atlassian.net/browse/AAE-12065
https://github.com/Alfresco/alfresco-apps/pull/5894


**What is the new behaviour?**
Add `isDefault` flag to allow users to use the `DEFAULT_OPTION.id` as an id, without making such an option the default option
Is compatible with JSON forms previously created


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
