### PR TITLE
[ACS-5226] Make Categories & Tags View Details Edit consistent

### DIFF
--- a/lib/content-services/src/lib/category/categories-management/categories-management.component.spec.ts
+++ b/lib/content-services/src/lib/category/categories-management/categories-management.component.spec.ts
@@ -187,7 +187,8 @@ describe('CategoriesManagementComponent', () => {
                 expect(categoryControlLabel.textContent.trim()).toBe('CATEGORIES_MANAGEMENT.NAME');
             });
 
-            it('should hide category control and existing categories panel on clicking hide button', () => {
+            it('should hide and clear category control and existing categories panel on clicking hide button', fakeAsync(() => {
+                typeCategory('test');
                 const categoryControlHideBtn: HTMLButtonElement = fixture.debugElement.query(By.css('.adf-category-name-field button')).nativeElement;
                 const controlVisibilityChangeSpy = spyOn(component.categoryNameControlVisibleChange, 'emit').and.callThrough();
                 categoryControlHideBtn.click();
@@ -198,7 +199,12 @@ describe('CategoriesManagementComponent', () => {
                 expect(component.categoryNameControlVisible).toBeFalse();
                 expect(component.existingCategoriesPanelVisible).toBeFalse();
                 expect(controlVisibilityChangeSpy).toHaveBeenCalledOnceWith(false);
-            });
+
+                component.categoryNameControlVisible = true;
+                fixture.detectChanges();
+                tick(100);
+                expect(getCategoryControlInput().value).toBe('');
+            }));
         });
 
         describe('Spinner', () => {

--- a/lib/content-services/src/lib/category/categories-management/categories-management.component.ts
+++ b/lib/content-services/src/lib/category/categories-management/categories-management.component.ts
@@ -89,6 +89,7 @@ export class CategoriesManagementComponent implements OnInit, OnDestroy {
              this._existingCategoriesPanelVisible = true;
          } else {
             this._existingCategoriesPanelVisible = false;
+            this.clearCategoryNameInput();
          }
      }
 
@@ -211,6 +212,7 @@ export class CategoriesManagementComponent implements OnInit, OnDestroy {
         this.categoryNameControlVisible = false;
         this.categoryNameControlVisibleChange.emit(false);
         this._existingCategoriesPanelVisible = false;
+        this.clearCategoryNameInput();
     }
 
     /**
@@ -222,8 +224,7 @@ export class CategoriesManagementComponent implements OnInit, OnDestroy {
             const newCat = new Category({ id: newCatName, name: newCatName });
             this.categories.push(newCat);
             this.hideNameInput();
-            this.categoryNameControl.setValue('');
-            this.categoryNameControl.markAsUntouched();
+            this.clearCategoryNameInput();
             this._existingCategories = null;
             this.categoriesChange.emit(this.categories);
         }
@@ -335,5 +336,10 @@ export class CategoriesManagementComponent implements OnInit, OnDestroy {
 
     private sortCategoriesList(categoriesList: Category[]) {
         categoriesList.sort((category1, category2) => category1.name.localeCompare(category2.name));
+    }
+
+    private clearCategoryNameInput() {
+        this.categoryNameControl.setValue('');
+        this.categoryNameControl.markAsUntouched();
     }
 }

--- a/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.spec.ts
+++ b/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.spec.ts
@@ -388,9 +388,11 @@ describe('ContentMetadataComponent', () => {
     });
 
     describe('Reseting', () => {
-        it('should reset changedProperties on reset click', async () => {
+        it('should reset properties on reset click', async () => {
             component.changedProperties = { properties: { 'property-key': 'updated-value' } };
             component.hasMetadataChanged = true;
+            component.tagNameControlVisible = true;
+            component.categoryControlVisible = true;
             component.editable = true;
             const expectedNode = Object.assign({}, node, { name: 'some-modified-value' });
             spyOn(nodesApiService, 'updateNode').and.returnValue(of(expectedNode));
@@ -403,6 +405,9 @@ describe('ContentMetadataComponent', () => {
             fixture.detectChanges();
             expect(component.changedProperties).toEqual({});
             expect(nodesApiService.updateNode).not.toHaveBeenCalled();
+            expect(component.hasMetadataChanged).toBeFalse();
+            expect(component.tagNameControlVisible).toBeFalse();
+            expect(component.categoryControlVisible).toBeFalse();
         });
     });
 

--- a/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.ts
+++ b/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.ts
@@ -267,6 +267,8 @@ export class ContentMetadataComponent implements OnChanges, OnInit, OnDestroy {
     revertChanges() {
         this.changedProperties = {};
         this.hasMetadataChanged = false;
+        this.tagNameControlVisible = false;
+        this.categoryControlVisible = false;
     }
 
     cancelChanges() {

--- a/lib/content-services/src/lib/tag/tags-creator/tags-creator.component.spec.ts
+++ b/lib/content-services/src/lib/tag/tags-creator/tags-creator.component.spec.ts
@@ -211,7 +211,6 @@ describe('TagsCreatorComponent', () => {
             expect(getAddedTags().length).toBe(0);
         }));
 
-
         it('should remove specific tag after clicking at remove icon', fakeAsync(() => {
             const tag1 = 'Tag 1';
             const tag2 = 'Tag 2';
@@ -266,8 +265,9 @@ describe('TagsCreatorComponent', () => {
             expect(tagNameField.query(By.directive(MatFormField))).toBeTruthy();
         });
 
-        it('should be hidden after clicking button for hiding input', fakeAsync(() => {
+        it('should be hidden and cleared after clicking button for hiding input', fakeAsync(() => {
             component.tagNameControlVisible = true;
+            typeTag('test');
             fixture.detectChanges();
             tick(100);
 
@@ -275,6 +275,12 @@ describe('TagsCreatorComponent', () => {
 
             const tagNameField = fixture.debugElement.query(By.css(tagNameFieldSelector));
             expect(tagNameField).toBeFalsy();
+
+            component.tagNameControlVisible = true;
+            fixture.detectChanges();
+            tick(100);
+
+            expect(getNameInput().value).toBe('');
         }));
 
         it('should input be autofocused', fakeAsync(() => {
@@ -295,6 +301,25 @@ describe('TagsCreatorComponent', () => {
             tick(100);
 
             expect(getNameInput()).toBe(document.activeElement as HTMLInputElement);
+        }));
+
+        it('should be hidden and cleared on discard changes', fakeAsync(() => {
+            component.tagNameControlVisible = true;
+            component.tags = ['Passed tag 1', 'Passed tag 2'];
+            typeTag('test');
+            fixture.detectChanges();
+            tick(100);
+            expect(getNameInput().value).toBe('test');
+
+            component.tagNameControlVisible = false;
+            fixture.detectChanges();
+            tick(100);
+            expect(getNameInput()).toBeFalsy();
+
+            component.tagNameControlVisible = true;
+            fixture.detectChanges();
+            tick(100);
+            expect(getNameInput().value).toBe('');
         }));
 
         describe('Errors', () => {

--- a/lib/content-services/src/lib/tag/tags-creator/tags-creator.component.ts
+++ b/lib/content-services/src/lib/tag/tags-creator/tags-creator.component.ts
@@ -108,6 +108,7 @@ export class TagsCreatorComponent implements OnInit, OnDestroy {
             });
         } else {
             this._existingTagsPanelVisible = false;
+            this.clearTagNameInput();
         }
         this.existingTagsPanelVisibilityChange.emit(this.existingTagsPanelVisible);
     }
@@ -250,6 +251,7 @@ export class TagsCreatorComponent implements OnInit, OnDestroy {
         this._existingTagsPanelVisible = false;
         this.existingTagsPanelVisibilityChange.emit(this.existingTagsPanelVisible);
         this.tagNameControlVisibleChange.emit(this.tagNameControlVisible);
+        this.clearTagNameInput();
     }
 
     /**
@@ -260,9 +262,8 @@ export class TagsCreatorComponent implements OnInit, OnDestroy {
         if (!this._typing && !this.tagNameControl.invalid) {
             this.tags.push(this.tagNameControl.value.trim());
             this.hideNameInput();
-            this.tagNameControl.setValue('');
+            this.clearTagNameInput();
             this.checkScrollbarVisibility();
-            this.tagNameControl.markAsUntouched();
             this.tagsChange.emit(this.tags);
         }
     }
@@ -424,5 +425,10 @@ export class TagsCreatorComponent implements OnInit, OnDestroy {
 
     private excludeAlreadyAddedTags(tags: TagEntry[]) {
         this._existingTags = tags.filter((tag) => !this.tags.includes(tag.entry.tag));
+    }
+
+    private clearTagNameInput() {
+        this.tagNameControl.setValue('');
+        this.tagNameControl.markAsUntouched();
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Clicking on the 'Discard changes' hides categories input while tags input remains visible and input is not cleared. Also, hiding the the filed by clicking on the 'Hide input' button did not clear the input so when it is being reopened second time it contains old value.

**What is the new behaviour?**

- All active inputs should are hidden after pressing the “Discard” button, the same for Tags and Categories.
- The search field input is being cleared by the discard action. 
- The input also being cleared by pressing on the ‘Hide input’ button.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://alfresco.atlassian.net/browse/ACS-5226
