### PR TITLE
[ACS-5797] Disable restore action for the latest version of file

### DIFF
--- a/e2e/content-services/upload/version-actions.e2e.ts
+++ b/e2e/content-services/upload/version-actions.e2e.ts
@@ -91,9 +91,8 @@ describe('Version component actions', () => {
 
     it('[C280004] Should not be possible restore the version if there is only one version', async () => {
         await versionManagePage.clickActionButton('1.0');
-        await expect(await element(by.css(`[id="adf-version-list-action-restore-1.0"]`)).isEnabled()).toBe(false);
+        await expect(await element(by.css(`[id="adf-version-list-action-restore-1.0"]`)).isPresent()).toBe(false);
         await versionManagePage.closeActionsMenu();
-        await BrowserVisibility.waitUntilElementIsNotVisible(element(by.css(`[id="adf-version-list-action-restore-1.0"]`)));
     });
 
     it('[C280005] Should be showed all the default action when you have more then one version', async () => {

--- a/e2e/content-services/upload/version-actions.e2e.ts
+++ b/e2e/content-services/upload/version-actions.e2e.ts
@@ -91,8 +91,9 @@ describe('Version component actions', () => {
 
     it('[C280004] Should not be possible restore the version if there is only one version', async () => {
         await versionManagePage.clickActionButton('1.0');
-        await expect(await element(by.css(`[id="adf-version-list-action-restore-1.0"]`)).isPresent()).toBe(false);
+        await expect(await element(by.css(`[id="adf-version-list-action-restore-1.0"]`)).isEnabled()).toBe(false);
         await versionManagePage.closeActionsMenu();
+        await BrowserVisibility.waitUntilElementIsNotVisible(element(by.css(`[id="adf-version-list-action-restore-1.0"]`)));
     });
 
     it('[C280005] Should be showed all the default action when you have more then one version', async () => {

--- a/lib/content-services/src/lib/version-manager/version-list.component.html
+++ b/lib/content-services/src/lib/version-manager/version-list.component.html
@@ -22,8 +22,7 @@
                 </ng-container>
                 <button
                     [id]="'adf-version-list-action-restore-'+version.entry.id"
-                    [disabled]="!canUpdate()"
-                    *ngIf="!latestVersion"
+                    [disabled]="!canUpdate() || latestVersion"
                     mat-menu-item
                     (click)="restore(version.entry.id)">
                     {{ 'ADF_VERSION_LIST.ACTIONS.RESTORE' | translate }}

--- a/lib/content-services/src/lib/version-manager/version-list.component.html
+++ b/lib/content-services/src/lib/version-manager/version-list.component.html
@@ -1,5 +1,5 @@
 <mat-list class="adf-version-list" *ngIf="!isLoading; else loading_template">
-    <mat-list-item *ngFor="let version of versions; let idx = index">
+    <mat-list-item *ngFor="let version of versions; let idx = index; let latestVersion = first">
         <mat-icon mat-list-icon>insert_drive_file</mat-icon>
         <p mat-line class="adf-version-list-item-name" [id]="'adf-version-list-item-name-' + version.entry.id" >{{version.entry.name}}</p>
         <p mat-line>
@@ -23,6 +23,7 @@
                 <button
                     [id]="'adf-version-list-action-restore-'+version.entry.id"
                     [disabled]="!canUpdate()"
+                    *ngIf="!latestVersion"
                     mat-menu-item
                     (click)="restore(version.entry.id)">
                     {{ 'ADF_VERSION_LIST.ACTIONS.RESTORE' | translate }}

--- a/lib/content-services/src/lib/version-manager/version-list.component.spec.ts
+++ b/lib/content-services/src/lib/version-manager/version-list.component.spec.ts
@@ -327,23 +327,25 @@ describe('VersionListComponent', () => {
             return fixture.debugElement.query(By.css(`[id="adf-version-list-action-restore-${version}"]`))?.nativeElement;
         };
 
+        beforeEach(() => {
+            fixture.detectChanges();
+            spyOn(component.versionsApi, 'listVersionHistory').and.callFake(() => Promise.resolve(new VersionPaging({
+                list: {
+                    entries: [
+                        {
+                            entry: { name: 'test-file-two', id: '1.1', versionComment: 'test-version-comment' }
+                        },
+                        {
+                            entry: { name: 'test-file-name', id: '1.0', versionComment: 'test-version-comment' }
+                        }
+                    ]
+                }
+            })));
+        });
+
         describe('showActions', () => {
             beforeEach(() => {
-                fixture.detectChanges();
                 component.node = new Node({ id: nodeId });
-                spyOn(component.versionsApi, 'listVersionHistory').and.callFake(() => Promise.resolve(new VersionPaging({
-                    list: {
-                        entries: [
-                            {
-                                entry: { name: 'test-file-name', id: '1.1', versionComment: 'test-version-comment' }
-                            },
-                            {
-                                entry: { name: 'test-file-name', id: '1.0', versionComment: 'test-version-comment' }
-                            }
-                        ]
-                    }
-                })));
-
                 component.ngOnChanges();
             });
 
@@ -387,21 +389,7 @@ describe('VersionListComponent', () => {
         describe('disabled', () => {
 
             beforeEach(() => {
-                fixture.detectChanges();
                 component.node = { id: nodeId } as Node;
-                spyOn(component.versionsApi, 'listVersionHistory').and.callFake(() => Promise.resolve(new VersionPaging({
-                    list: {
-                        entries: [
-                            {
-                                entry: { name: 'test-file-two', id: '1.1', versionComment: 'test-version-comment' }
-                            },
-                            {
-                                entry: { name: 'test-file-name', id: '1.0', versionComment: 'test-version-comment' }
-                            }
-                        ]
-                    }
-                })));
-
                 component.ngOnChanges();
             });
 
@@ -427,21 +415,7 @@ describe('VersionListComponent', () => {
         describe('enabled', () => {
 
             beforeEach(() => {
-                fixture.detectChanges();
                 component.node = { id: nodeId, allowableOperations: ['update', 'delete'] } as Node;
-                spyOn(component.versionsApi, 'listVersionHistory').and.callFake(() => Promise.resolve(new VersionPaging({
-                    list: {
-                        entries: [
-                            {
-                                entry: { name: 'test-file-name', id: '1.1', versionComment: 'test-version-comment' }
-                            },
-                            {
-                                entry: { name: 'test-file-name', id: '1.0', versionComment: 'test-version-comment' }
-                            }
-                        ]
-                    }
-                })));
-
                 component.ngOnChanges();
             });
 

--- a/lib/content-services/src/lib/version-manager/version-list.component.spec.ts
+++ b/lib/content-services/src/lib/version-manager/version-list.component.spec.ts
@@ -370,20 +370,6 @@ describe('VersionListComponent', () => {
                     done();
                 });
             });
-
-            it('should show restore action for old version', (done) => {
-                fixture.whenStable().then(() => {
-                    expect(getRestoreButton()).toBeDefined();
-                    done();
-                });
-            });
-
-            it('should show restore action for the latest version', (done) => {
-                fixture.whenStable().then(() => {
-                    expect(getRestoreButton('1.1')).toBeUndefined();
-                    done();
-                });
-            });
         });
 
         describe('disabled', () => {
@@ -406,7 +392,14 @@ describe('VersionListComponent', () => {
 
             it('should disable restore action if is not allowed', (done) => {
                 fixture.whenStable().then(() => {
-                    expect(getRestoreButton().disabled).toBe(true);
+                    expect(getRestoreButton().disabled).toBeTrue();
+                    done();
+                });
+            });
+
+            it('should disable restore action for the latest version', (done) => {
+                fixture.whenStable().then(() => {
+                    expect(getRestoreButton('1.1').disabled).toBeTrue();
                     done();
                 });
             });
@@ -432,7 +425,7 @@ describe('VersionListComponent', () => {
 
             it('should enable restore action if is allowed', (done) => {
                 fixture.whenStable().then(() => {
-                    expect(getRestoreButton().disabled).toBe(false);
+                    expect(getRestoreButton().disabled).toBeFalse();
                     done();
                 });
             });

--- a/lib/content-services/src/lib/version-manager/version-list.component.spec.ts
+++ b/lib/content-services/src/lib/version-manager/version-list.component.spec.ts
@@ -317,15 +317,26 @@ describe('VersionListComponent', () => {
     });
 
     describe('Actions buttons', () => {
+        const getActionMenuButton = (version = '1.0'): HTMLButtonElement => {
+            fixture.detectChanges();
+            return fixture.debugElement.query(By.css(`[id="adf-version-list-action-menu-button-${version}"]`))?.nativeElement;
+        };
+
+        const getRestoreButton = (version = '1.0'): HTMLButtonElement => {
+            getActionMenuButton(version).click();
+            return fixture.debugElement.query(By.css(`[id="adf-version-list-action-restore-${version}"]`))?.nativeElement;
+        };
 
         describe('showActions', () => {
-
             beforeEach(() => {
                 fixture.detectChanges();
                 component.node = new Node({ id: nodeId });
                 spyOn(component.versionsApi, 'listVersionHistory').and.callFake(() => Promise.resolve(new VersionPaging({
                     list: {
                         entries: [
+                            {
+                                entry: { name: 'test-file-name', id: '1.1', versionComment: 'test-version-comment' }
+                            },
                             {
                                 entry: { name: 'test-file-name', id: '1.0', versionComment: 'test-version-comment' }
                             }
@@ -343,10 +354,7 @@ describe('VersionListComponent', () => {
                 fixture.detectChanges();
 
                 fixture.whenStable().then(() => {
-                    fixture.detectChanges();
-                    const menuButton = fixture.nativeElement.querySelector('[id="adf-version-list-action-menu-button-1.0"]');
-
-                    expect(menuButton).not.toBeNull();
+                    expect(getActionMenuButton()).toBeDefined();
                     done();
                 });
             });
@@ -356,10 +364,21 @@ describe('VersionListComponent', () => {
                 fixture.detectChanges();
 
                 fixture.whenStable().then(() => {
-                    fixture.detectChanges();
-                    const menuButton = fixture.nativeElement.querySelector('[id="adf-version-list-action-menu-button-1.0"]');
+                    expect(getActionMenuButton()).toBeUndefined();
+                    done();
+                });
+            });
 
-                    expect(menuButton).toBeNull();
+            it('should show restore action for old version', (done) => {
+                fixture.whenStable().then(() => {
+                    expect(getRestoreButton()).toBeDefined();
+                    done();
+                });
+            });
+
+            it('should show restore action for the latest version', (done) => {
+                fixture.whenStable().then(() => {
+                    expect(getRestoreButton('1.1')).toBeUndefined();
                     done();
                 });
             });
@@ -388,9 +407,7 @@ describe('VersionListComponent', () => {
 
             it('should disable delete action if is not allowed', (done) => {
                 fixture.whenStable().then(() => {
-                    fixture.detectChanges();
-                    const menuButton = fixture.nativeElement.querySelector('[id="adf-version-list-action-menu-button-1.1"]');
-                    menuButton.click();
+                    getActionMenuButton('1.1').click();
 
                     const deleteButton: any = document.querySelector('[id="adf-version-list-action-delete-1.1"]');
 
@@ -401,13 +418,7 @@ describe('VersionListComponent', () => {
 
             it('should disable restore action if is not allowed', (done) => {
                 fixture.whenStable().then(() => {
-                    fixture.detectChanges();
-                    const menuButton = fixture.nativeElement.querySelector('[id="adf-version-list-action-menu-button-1.1"]');
-                    menuButton.click();
-
-                    const restoreButton: any = document.querySelector('[id="adf-version-list-action-restore-1.1"]');
-
-                    expect(restoreButton.disabled).toBe(true);
+                    expect(getRestoreButton().disabled).toBe(true);
                     done();
                 });
             });
@@ -436,9 +447,7 @@ describe('VersionListComponent', () => {
 
             it('should enable delete action if is allowed', (done) => {
                 fixture.whenStable().then(() => {
-                    fixture.detectChanges();
-                    const menuButton = fixture.nativeElement.querySelector('[id="adf-version-list-action-menu-button-1.1"]');
-                    menuButton.click();
+                    getActionMenuButton('1.1').click();
 
                     const deleteButton: any = document.querySelector('[id="adf-version-list-action-delete-1.1"]');
 
@@ -449,13 +458,7 @@ describe('VersionListComponent', () => {
 
             it('should enable restore action if is allowed', (done) => {
                 fixture.whenStable().then(() => {
-                    fixture.detectChanges();
-                    const menuButton = fixture.nativeElement.querySelector('[id="adf-version-list-action-menu-button-1.1"]');
-                    menuButton.click();
-
-                    const restoreButton: any = document.querySelector('[id="adf-version-list-action-restore-1.1"]');
-
-                    expect(restoreButton.disabled).toBe(false);
+                    expect(getRestoreButton().disabled).toBe(false);
                     done();
                 });
             });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ACS-5797


**What is the new behaviour?**
Restore button is disabled for the latest version so user can restore to only old versions (not latest). 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
