### PR TITLE
[ACS-5373] - Every getPerson() call changes current user

### DIFF
--- a/lib/content-services/src/lib/common/services/people-content.service.ts
+++ b/lib/content-services/src/lib/common/services/people-content.service.ts
@@ -16,10 +16,10 @@
  */
 
 import { Injectable } from '@angular/core';
-import { Observable, from, throwError, of } from 'rxjs';
-import { AuthenticationService, AlfrescoApiService, LogService } from '@alfresco/adf-core';
+import { from, Observable, of, throwError } from 'rxjs';
+import { AlfrescoApiService, AuthenticationService, LogService } from '@alfresco/adf-core';
 import { catchError, map, tap } from 'rxjs/operators';
-import { PeopleApi, PersonBodyCreate, Pagination, PersonBodyUpdate } from '@alfresco/js-api';
+import { Pagination, PeopleApi, PersonBodyCreate, PersonBodyUpdate } from '@alfresco/js-api';
 import { EcmUserModel } from '../models/ecm-user.model';
 import { ContentService } from './content.service';
 
@@ -77,7 +77,6 @@ export class PeopleContentService {
         return from(this.peopleApi.getPerson(personId))
             .pipe(
                 map((personEntry) => new EcmUserModel(personEntry.entry)),
-                tap(user => this.currentUser = user),
                 catchError((error) => this.handleError(error)));
     }
 
@@ -94,7 +93,7 @@ export class PeopleContentService {
         if (this.currentUser) {
             return of(this.currentUser);
         }
-        return this.getPerson('-me-');
+        return this.getPerson('-me-').pipe(tap(user => (this.currentUser = user)));
     }
 
     /**


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
When PeopleContentService.getPerson() is called it changes state of current user. So every time we check someone from list of users, the context of current user changes and it causes many problems, eg auth and roles checks are failing and loging out.


**What is the new behaviour?**
Context of current user is set only once. Fetching data of other users is not causing any problems in app.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
