### PR TITLE
[ACS-5281] Allow to change editable of content metadata from parent

### DIFF
--- a/docs/content-services/components/content-metadata-card.component.md
+++ b/docs/content-services/components/content-metadata-card.component.md
@@ -16,6 +16,7 @@ Displays and edits metadata related to a node.
 -   [Basic Usage](#basic-usage)
 -   [Class members](#class-members)
     -   [Properties](#properties)
+    -   [Events](#events)
 -   [Details](#details)
     -   [Application config presets](#application-config-presets)
     -   [Layout oriented config](#layout-oriented-config)
@@ -51,6 +52,13 @@ Displays and edits metadata related to a node.
 | preset | `string \| `[`PresetConfig`](../../../lib/content-services/src/lib/content-metadata/interfaces/preset-config.interface.ts) |  | (required) Name or configuration of the metadata preset, which defines aspects and their properties. |
 | readOnly | `boolean` | false | (optional) This flag sets the metadata in read only mode preventing changes. |
 | displayDefaultProperties | `boolean` |  | (optional) This flag displays/hides the metadata properties. |
+| editable | `boolean` |  | (optional) This flag toggles editable of content. |
+
+### Events
+
+| Name           | Type                                                                  | Description                                       |
+|----------------|-----------------------------------------------------------------------|---------------------------------------------------|
+| editableChange | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<boolean>` | Emitted when content's editable state is changed. |
 
 ## Details
 

--- a/lib/content-services/src/lib/content-metadata/components/content-metadata-card/content-metadata-card.component.spec.ts
+++ b/lib/content-services/src/lib/content-metadata/components/content-metadata-card/content-metadata-card.component.spec.ts
@@ -37,6 +37,8 @@ describe('ContentMetadataCardComponent', () => {
     const preset = 'custom-preset';
     let nodeAspectService: NodeAspectService = null;
 
+    const getToggleEditButton = () => fixture.debugElement.query(By.css('[data-automation-id="meta-data-card-toggle-edit"]'));
+
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [
@@ -150,11 +152,19 @@ describe('ContentMetadataCardComponent', () => {
         component.node.allowableOperations = [AllowableOperationsEnum.UPDATE];
         fixture.detectChanges();
 
-        const button = fixture.debugElement.query(By.css('[data-automation-id="meta-data-card-toggle-edit"]'));
-        button.triggerEventHandler('click', {});
+        getToggleEditButton().triggerEventHandler('click', {});
         fixture.detectChanges();
 
         expect(component.editable).toBe(false);
+    });
+
+    it('should emit editableChange by clicking on toggle edit button', () => {
+        component.node.allowableOperations = [AllowableOperationsEnum.UPDATE];
+        fixture.detectChanges();
+        spyOn(component.editableChange, 'emit');
+
+        getToggleEditButton().nativeElement.click();
+        expect(component.editableChange.emit).toHaveBeenCalledWith(true);
     });
 
     it('should toggle expanded by clicking on the button', () => {
@@ -190,8 +200,7 @@ describe('ContentMetadataCardComponent', () => {
         component.readOnly = true;
         fixture.detectChanges();
 
-        const button = fixture.debugElement.query(By.css('[data-automation-id="meta-data-card-toggle-edit"]'));
-        expect(button).toBeNull();
+        expect(getToggleEditButton()).toBeNull();
     });
 
     it('should hide the edit button if node does not have `update` permissions', () => {
@@ -199,8 +208,7 @@ describe('ContentMetadataCardComponent', () => {
         component.node.allowableOperations = null;
         fixture.detectChanges();
 
-        const button = fixture.debugElement.query(By.css('[data-automation-id="meta-data-card-toggle-edit"]'));
-        expect(button).toBeNull();
+        expect(getToggleEditButton()).toBeNull();
     });
 
     it('should show the edit button if node does has `update` permissions', () => {
@@ -208,8 +216,7 @@ describe('ContentMetadataCardComponent', () => {
         component.node.allowableOperations = [AllowableOperationsEnum.UPDATE];
         fixture.detectChanges();
 
-        const button = fixture.debugElement.query(By.css('[data-automation-id="meta-data-card-toggle-edit"]'));
-        expect(button).not.toBeNull();
+        expect(getToggleEditButton()).not.toBeNull();
     });
 
     it('should expand the card when custom display aspect is valid', () => {

--- a/lib/content-services/src/lib/content-metadata/components/content-metadata-card/content-metadata-card.component.ts
+++ b/lib/content-services/src/lib/content-metadata/components/content-metadata-card/content-metadata-card.component.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import {Component, EventEmitter, Input, OnChanges, Output, SimpleChanges, ViewEncapsulation} from '@angular/core';
+import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges, ViewEncapsulation } from '@angular/core';
 import { Node } from '@alfresco/js-api';
 import { NodeAspectService } from '../../../aspect-list/services/node-aspect.service';
 import { PresetConfig } from '../../interfaces/content-metadata.interfaces';

--- a/lib/content-services/src/lib/content-metadata/components/content-metadata-card/content-metadata-card.component.ts
+++ b/lib/content-services/src/lib/content-metadata/components/content-metadata-card/content-metadata-card.component.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Component, Input, OnChanges, SimpleChanges, ViewEncapsulation } from '@angular/core';
+import {Component, EventEmitter, Input, OnChanges, Output, SimpleChanges, ViewEncapsulation} from '@angular/core';
 import { Node } from '@alfresco/js-api';
 import { NodeAspectService } from '../../../aspect-list/services/node-aspect.service';
 import { PresetConfig } from '../../interfaces/content-metadata.interfaces';
@@ -74,6 +74,14 @@ export class ContentMetadataCardComponent implements OnChanges {
     @Input()
     multi = false;
 
+    /** (optional) This flag toggles editable of content. **/
+    @Input()
+    editable = false;
+
+    /** Emitted when content's editable state is changed. **/
+    @Output()
+    editableChange = new EventEmitter<boolean>();
+
     private _displayDefaultProperties: boolean = true;
 
     /** (optional) This flag displays/hides the metadata
@@ -88,8 +96,6 @@ export class ContentMetadataCardComponent implements OnChanges {
     get displayDefaultProperties(): boolean {
         return this._displayDefaultProperties;
     }
-
-    editable: boolean = false;
 
     expanded: boolean;
 
@@ -111,6 +117,7 @@ export class ContentMetadataCardComponent implements OnChanges {
 
     toggleEdit(): void {
         this.editable = !this.editable;
+        this.editableChange.emit(this.editable);
     }
 
     toggleExpanded(): void {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ACS-5281


**What is the new behaviour?**
Editable of metadata content can be now set from parent so whenever lock state of file is changed - editable of metadata content is updated to disallow editing when file is locked. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
ACA PR: https://github.com/Alfresco/alfresco-content-app/pull/3400