### PR TITLE
OPSEXP-2250 Fix s3 download command in init aps

### DIFF
--- a/lib/cli/scripts/init-aps-env.ts
+++ b/lib/cli/scripts/init-aps-env.ts
@@ -435,13 +435,13 @@ async function authorizeUserToContentWithBasic(username: string, contentId: stri
 }
 
 async function downloadLicenseFile(apsLicensePath: string) {
-    let args = [
+    const args = [
         `s3`,
         `cp`,
         apsLicensePath,
         `./`
-    ]
-    let result = spawnSync(`aws`, args, {
+    ];
+    const result = spawnSync(`aws`, args, {
         cwd: path.resolve(__dirname, `./`),
         shell: false
     });

--- a/lib/cli/scripts/init-aps-env.ts
+++ b/lib/cli/scripts/init-aps-env.ts
@@ -435,17 +435,23 @@ async function authorizeUserToContentWithBasic(username: string, contentId: stri
 }
 
 async function downloadLicenseFile(apsLicensePath: string) {
-    try {
-        spawnSync(` aws s3 cp ${apsLicensePath} ./ `, {
-            cwd: path.resolve(__dirname, `./`),
-            shell: false
-        });
-        logger.info(`Aps license file download from S3 bucket`);
-        return true;
-    } catch (error) {
-        logger.error(`Not able to download the APS license from S3 bucket` );
+    let args = [
+        `s3`,
+        `cp`,
+        apsLicensePath,
+        `./`
+    ]
+    let result = spawnSync(`aws`, args, {
+        cwd: path.resolve(__dirname, `./`),
+        shell: false
+    });
+
+    if (result.status !== 0) {
+        logger.error(`Not able to download the APS license from S3 bucket.\nCommand aws ${args.join(' ')} - failed with:\n${result.output}`);
         return false;
     }
+    logger.info(`Aps license file download from S3 bucket`);
+    return true;
 }
 
 function sleep(delay: number) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix


**What is the current behaviour?** (You can also link to an open issue here)

```
***** Step 1 - Check License *****
Aps does NOT have a valid License!
Aps License missing
Aps license file download from S3 bucket
Aps License failed! undefined
APS license error: check the configuration
```


**What is the new behaviour?**

```
***** Step 1 - Check License *****
Aps does NOT have a valid License!
Aps License missing
Not able to download the APS license from S3 bucket.
Command aws s3 cp s3://aps-licenses/multi-tenant/activiti.lic ./ failed with:
,,fatal error: An error occurred (400) when calling the HeadObject operation: Bad Request

APS license error: check the configuration
```

```
***** Step 1 - Check License *****
Aps does NOT have a valid License!
Aps License missing
Aps license file download from S3 bucket
Aps License uploaded!
```


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
