### PR TITLE
[APPS-2133] migration of dependency from moment to date-fns in start-task.component

### DIFF
--- a/lib/process-services/src/lib/task-list/components/start-task.component.ts
+++ b/lib/process-services/src/lib/task-list/components/start-task.component.ts
@@ -119,8 +119,8 @@ export class StartTaskComponent implements OnInit, OnDestroy {
     whitespaceValidator(control: UntypedFormControl): any {
         if (control.value) {
             const isWhitespace = (control.value || '').trim().length === 0;
-            const isValid =  control.value.length === 0 || !isWhitespace;
-            return isValid ? null : { whitespace: true };
+            const isControlValid =  control.value.length === 0 || !isWhitespace;
+            return isControlValid ? null : { whitespace: true };
         }
         return null;
     }

--- a/lib/process-services/src/lib/task-list/components/start-task.component.ts
+++ b/lib/process-services/src/lib/task-list/components/start-task.component.ts
@@ -16,12 +16,10 @@
  */
 
 import {
-    LogService, UserPreferencesService, UserPreferenceValues, FormFieldModel, FormModel,
-    MOMENT_DATE_FORMATS, MomentDateAdapter
+    LogService, UserPreferencesService, UserPreferenceValues, FormFieldModel, FormModel, DateFnsUtils
 } from '@alfresco/adf-core';
 import { Component, EventEmitter, Input, OnInit, Output, ViewEncapsulation, OnDestroy } from '@angular/core';
 import { DateAdapter, MAT_DATE_FORMATS } from '@angular/material/core';
-import moment, { Moment } from 'moment';
 import { EMPTY, Observable, Subject } from 'rxjs';
 import { Form } from '../models/form.model';
 import { TaskDetailsModel } from '../models/task-details.model';
@@ -29,8 +27,10 @@ import { TaskListService } from './../services/tasklist.service';
 import { switchMap, defaultIfEmpty, takeUntil } from 'rxjs/operators';
 import { UntypedFormBuilder, AbstractControl, Validators, UntypedFormGroup, UntypedFormControl } from '@angular/forms';
 import { UserProcessModel } from '../../common/models/user-process.model';
+import { format } from 'date-fns';
+import { DateFnsAdapter, MAT_DATE_FNS_FORMATS } from '@angular/material-date-fns-adapter';
 
-const FORMAT_DATE = 'DD/MM/YYYY';
+const FORMAT_DATE = 'dd/MM/yyyy';
 const MAX_LENGTH = 255;
 
 @Component({
@@ -38,8 +38,8 @@ const MAX_LENGTH = 255;
     templateUrl: './start-task.component.html',
     styleUrls: ['./start-task.component.scss'],
     providers: [
-        { provide: DateAdapter, useClass: MomentDateAdapter },
-        { provide: MAT_DATE_FORMATS, useValue: MOMENT_DATE_FORMATS }],
+        { provide: DateAdapter, useClass: DateFnsAdapter },
+        { provide: MAT_DATE_FORMATS, useValue: MAT_DATE_FNS_FORMATS }],
     encapsulation: ViewEncapsulation.None
 })
 export class StartTaskComponent implements OnInit, OnDestroy {
@@ -75,7 +75,7 @@ export class StartTaskComponent implements OnInit, OnDestroy {
     private onDestroy$ = new Subject<boolean>();
 
     constructor(private taskService: TaskListService,
-                private dateAdapter: DateAdapter<Moment>,
+                private dateAdapter: DateAdapter<DateFnsAdapter>,
                 private userPreferencesService: UserPreferencesService,
                 private formBuilder: UntypedFormBuilder,
                 private logService: LogService) {
@@ -93,7 +93,7 @@ export class StartTaskComponent implements OnInit, OnDestroy {
         this.userPreferencesService
             .select(UserPreferenceValues.Locale)
             .pipe(takeUntil(this.onDestroy$))
-            .subscribe(locale => this.dateAdapter.setLocale(locale));
+            .subscribe(locale => this.dateAdapter.setLocale(DateFnsUtils.getLocaleFromString(locale)));
 
         this.loadFormsTask();
         this.buildForm();
@@ -187,16 +187,16 @@ export class StartTaskComponent implements OnInit, OnDestroy {
         this.dateError = false;
 
         if (newDateValue) {
-            let momentDate: moment.Moment;
+            let date: string | Date;
 
             if (typeof newDateValue === 'string') {
-                momentDate = moment(newDateValue, FORMAT_DATE, true);
+                date = format(new Date(newDateValue), FORMAT_DATE);
             } else {
-                momentDate = newDateValue;
+                date = newDateValue;
             }
 
-            if (momentDate.isValid()) {
-                this.taskDetailsModel.dueDate = momentDate.toDate();
+            if (date) {
+                this.taskDetailsModel.dueDate = new Date(date);
             } else {
                 this.dateError = true;
                 this.taskDetailsModel.dueDate = null;

--- a/lib/process-services/src/lib/task-list/components/start-task.component.ts
+++ b/lib/process-services/src/lib/task-list/components/start-task.component.ts
@@ -27,10 +27,10 @@ import { TaskListService } from './../services/tasklist.service';
 import { switchMap, defaultIfEmpty, takeUntil } from 'rxjs/operators';
 import { UntypedFormBuilder, AbstractControl, Validators, UntypedFormGroup, UntypedFormControl } from '@angular/forms';
 import { UserProcessModel } from '../../common/models/user-process.model';
-import { isValid, parse } from 'date-fns';
+import { isValid } from 'date-fns';
 import { DateFnsAdapter, MAT_DATE_FNS_FORMATS } from '@angular/material-date-fns-adapter';
 
-const FORMAT_DATE = 'dd/MM/yyyy';
+const FORMAT_DATE = 'DD/MM/YYYY';
 const MAX_LENGTH = 255;
 
 @Component({
@@ -190,7 +190,7 @@ export class StartTaskComponent implements OnInit, OnDestroy {
             let date: Date;
 
             if (typeof newDateValue === 'string') {
-                date = parse(newDateValue, FORMAT_DATE, new Date());
+                date = DateFnsUtils.parseDate(newDateValue, FORMAT_DATE);
             } else {
                 date = newDateValue;
             }

--- a/lib/process-services/src/lib/task-list/components/start-task.component.ts
+++ b/lib/process-services/src/lib/task-list/components/start-task.component.ts
@@ -27,7 +27,7 @@ import { TaskListService } from './../services/tasklist.service';
 import { switchMap, defaultIfEmpty, takeUntil } from 'rxjs/operators';
 import { UntypedFormBuilder, AbstractControl, Validators, UntypedFormGroup, UntypedFormControl } from '@angular/forms';
 import { UserProcessModel } from '../../common/models/user-process.model';
-import { format } from 'date-fns';
+import { isValid, parse } from 'date-fns';
 import { DateFnsAdapter, MAT_DATE_FNS_FORMATS } from '@angular/material-date-fns-adapter';
 
 const FORMAT_DATE = 'dd/MM/yyyy';
@@ -187,16 +187,16 @@ export class StartTaskComponent implements OnInit, OnDestroy {
         this.dateError = false;
 
         if (newDateValue) {
-            let date: string | Date;
+            let date: Date;
 
             if (typeof newDateValue === 'string') {
-                date = format(new Date(newDateValue), FORMAT_DATE);
+                date = parse(newDateValue, FORMAT_DATE, new Date());
             } else {
                 date = newDateValue;
             }
 
-            if (date) {
-                this.taskDetailsModel.dueDate = new Date(date);
+            if (isValid(date)) {
+                this.taskDetailsModel.dueDate = date;
             } else {
                 this.dateError = true;
                 this.taskDetailsModel.dueDate = null;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
moment depedency is being used in start-task.component


**What is the new behaviour?**
migrated dependency from moment to date-fns in start-task.component


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
