### PR TITLE
[ACS-5898] prevent custom task filters from always sending due after date

### DIFF
--- a/demo-shell/src/app/components/task-list-demo/task-list-demo.component.ts
+++ b/demo-shell/src/app/components/task-list-demo/task-list-demo.component.ts
@@ -20,6 +20,7 @@ import { UntypedFormGroup, UntypedFormBuilder, Validators, UntypedFormControl, A
 import { ActivatedRoute, Params } from '@angular/router';
 import { debounceTime, takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
+import { set } from 'date-fns';
 
 const DEFAULT_SIZE = 20;
 
@@ -141,7 +142,7 @@ export class TaskListDemoComponent implements OnInit, OnDestroy {
         this.state = taskFilter.taskState;
         this.sort = taskFilter.taskSort;
         this.start = taskFilter.taskStart;
-        this.dueAfter = taskFilter.taskDueAfter;
+        this.dueAfter = taskFilter.taskDueAfter ? this.setDueAfterFilter(taskFilter.taskDueAfter) : null;
         this.dueBefore = taskFilter.taskDueBefore;
 
         if (taskFilter.taskSize) {
@@ -156,6 +157,15 @@ export class TaskListDemoComponent implements OnInit, OnDestroy {
         }
 
         this.includeProcessInstance = taskFilter.taskIncludeProcessInstance === 'include';
+    }
+
+    setDueAfterFilter(date): string {
+        const dueDateFilter = set(new Date(date), {
+            hours: 23,
+            minutes: 59,
+            seconds: 59
+        });
+        return dueDateFilter.toString();
     }
 
     resetTaskForm() {

--- a/demo-shell/src/app/components/task-list-demo/task-list-demo.component.ts
+++ b/demo-shell/src/app/components/task-list-demo/task-list-demo.component.ts
@@ -20,7 +20,6 @@ import { UntypedFormGroup, UntypedFormBuilder, Validators, UntypedFormControl, A
 import { ActivatedRoute, Params } from '@angular/router';
 import { debounceTime, takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
-import { set } from 'date-fns';
 
 const DEFAULT_SIZE = 20;
 
@@ -105,19 +104,19 @@ export class TaskListDemoComponent implements OnInit, OnDestroy {
     buildForm() {
         this.taskListForm = this.formBuilder.group({
             taskAppId: new UntypedFormControl(this.defaultAppId, [Validators.pattern('^[0-9]*$')]),
-            taskName: new UntypedFormControl(''),
-            taskId: new UntypedFormControl(''),
-            taskProcessDefinitionId: new UntypedFormControl(''),
-            taskProcessInstanceId: new UntypedFormControl(''),
-            taskAssignment: new UntypedFormControl(''),
-            taskState: new UntypedFormControl(''),
-            taskSort: new UntypedFormControl(''),
-            taskSize: new UntypedFormControl('', [Validators.pattern('^[0-9]*$'), Validators.min(this.minValue)]),
-            taskPage: new UntypedFormControl('', [Validators.pattern('^[0-9]*$'), Validators.min(this.minValue)]),
-            taskDueAfter: new UntypedFormControl(''),
-            taskDueBefore: new UntypedFormControl(''),
-            taskStart: new UntypedFormControl('', [Validators.pattern('^[0-9]*$')]),
-            taskIncludeProcessInstance: new UntypedFormControl('')
+            taskName: new UntypedFormControl(),
+            taskId: new UntypedFormControl(),
+            taskProcessDefinitionId: new UntypedFormControl(),
+            taskProcessInstanceId: new UntypedFormControl(),
+            taskAssignment: new UntypedFormControl(),
+            taskState: new UntypedFormControl(),
+            taskSort: new UntypedFormControl(),
+            taskSize: new UntypedFormControl(null, [Validators.pattern('^[0-9]*$'), Validators.min(this.minValue)]),
+            taskPage: new UntypedFormControl(null, [Validators.pattern('^[0-9]*$'), Validators.min(this.minValue)]),
+            taskDueAfter: new UntypedFormControl(),
+            taskDueBefore: new UntypedFormControl(),
+            taskStart: new UntypedFormControl(null, [Validators.pattern('^[0-9]*$')]),
+            taskIncludeProcessInstance: new UntypedFormControl()
         });
 
         this.taskListForm.valueChanges
@@ -142,7 +141,7 @@ export class TaskListDemoComponent implements OnInit, OnDestroy {
         this.state = taskFilter.taskState;
         this.sort = taskFilter.taskSort;
         this.start = taskFilter.taskStart;
-        this.dueAfter = this.setDueAfterFilter(taskFilter.taskDueAfter);
+        this.dueAfter = taskFilter.taskDueAfter;
         this.dueBefore = taskFilter.taskDueBefore;
 
         if (taskFilter.taskSize) {
@@ -157,15 +156,6 @@ export class TaskListDemoComponent implements OnInit, OnDestroy {
         }
 
         this.includeProcessInstance = taskFilter.taskIncludeProcessInstance === 'include';
-    }
-
-    setDueAfterFilter(date): string {
-        const dueDateFilter = set(new Date(date), {
-            hours: 23,
-            minutes: 59,
-            seconds: 59
-        });
-        return dueDateFilter.toString();
     }
 
     resetTaskForm() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ACS-5898
- setDueAfterFilter with moment library always sent Invalid Date, when Due After Filter parameter was null or initialized with empty quotes, after change to date-fns, the date in proper format was always sent, even with empty filter field, which resulted in not listing tasks without due date
- Custom filters form parameters were initialized with empty brackets, which resulted in wrong query parameters before clicking reset button or updating every parameter in form


**What is the new behaviour?**
- Custom task filters query does not include due after date when corresponding filter is empty
- Form parameters are not initialized with any value


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
