### PR TITLE
[ACS-5929] Open datatable actions menu on enter

### DIFF
--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.html
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.html
@@ -127,6 +127,7 @@
                         data-automation-id="adf-datatable-main-menu-button"
                         mat-icon-button
                         #mainMenuTrigger="matMenuTrigger"
+                        (keydown.enter)="mainMenuTrigger.openMenu()"
                         [matMenuTriggerFor]="mainMenu">
                         <mat-icon>more_vert</mat-icon>
                     </button>
@@ -323,7 +324,8 @@
                                 [attr.aria-label]="'ADF-DATATABLE.ACCESSIBILITY.ROW_OPTION_BUTTON' | translate"
                                 [title]="'ADF-DATATABLE.CONTENT-ACTIONS.TOOLTIP' | translate"
                                 [attr.id]="'action_menu_right_' + idx"
-                                [attr.data-automation-id]="'action_menu_' + idx">
+                                [attr.data-automation-id]="'action_menu_' + idx"
+                                (keydown.enter)="actionsMenuTrigger.openMenu()">
                             <mat-icon>more_vert</mat-icon>
                         </button>
                         <mat-menu #menu="matMenu">


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Actions menu trigger button doesn't open menu on enter. https://alfresco.atlassian.net/browse/ACS-5929

**What is the new behaviour?**

Actions menu trigger opens menu on enter.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
