### PR TITLE
[ACS-5748] The file gets unshared when setting the past expiration date

### DIFF
--- a/lib/content-services/src/lib/content-node-share/content-node-share.dialog.html
+++ b/lib/content-services/src/lib/content-node-share/content-node-share.dialog.html
@@ -51,7 +51,12 @@
                             [attr.aria-label]="'SHARE.EXPIRATION-LABEL' | translate"
                             [min]="minDate"
                             formControlName="time"
-                            [matDatepicker]="datePicker" />
+                            (keydown)="preventIncorrectCharacters($event)"
+                            (blur)="onTimeChanged()"
+                            (keydown.enter)="datePickerInput.blur()"
+                            [matDatepicker]="datePicker"/>
+                        <mat-error *ngIf="time.errors?.['invalidDate'] && (time.dirty || time.touched)"
+                                   data-automation-id="adf-share-link-input-warning">{{ 'SHARE.INVALID_DATE_ERROR' | translate }}</mat-error>
                     </mat-form-field>
                 </div>
                 <p class="adf-share-link__info adf-share-link__para">{{ 'SHARE.SHARE-LINK' | translate }}</p>

--- a/lib/content-services/src/lib/content-node-share/content-node-share.dialog.spec.ts
+++ b/lib/content-services/src/lib/content-node-share/content-node-share.dialog.spec.ts
@@ -330,8 +330,7 @@ describe('ShareDialogComponent', () => {
             spyOn(appConfigService, 'get').and.returnValue(dateTimePickerType);
 
             fixture.detectChanges();
-            fixture.nativeElement.querySelector('mat-slide-toggle[data-automation-id="adf-expire-toggle"] label')
-                .dispatchEvent(new MouseEvent('click'));
+            clickExpireToggleButton();
 
             fixture.componentInstance.type = 'datetime';
             fixture.componentInstance.time.setValue(date);
@@ -377,7 +376,7 @@ describe('ShareDialogComponent', () => {
             expect(component.time.hasError('invalidDate')).toBeTrue();
         });
 
-        it('should show an error when provided date is valid', () => {
+        it('should not show an error when provided date is valid', () => {
             fixture.detectChanges();
             clickExpireToggleButton();
             fillInDatepickerInput('12.12.2525');

--- a/lib/content-services/src/lib/content-node-share/content-node-share.dialog.spec.ts
+++ b/lib/content-services/src/lib/content-node-share/content-node-share.dialog.spec.ts
@@ -261,15 +261,10 @@ describe('ShareDialogComponent', () => {
         };
 
         fixture.detectChanges();
-
         component.form.controls['time'].setValue(new Date());
-
         fixture.detectChanges();
-
         clickExpireToggleButton();
-
         fixture.detectChanges();
-
         await fixture.whenStable();
 
         expect(sharedLinksApiService.deleteSharedLink).toHaveBeenCalled();
@@ -366,7 +361,6 @@ describe('ShareDialogComponent', () => {
         it('should not accept alphabets in the datepicker input', () => {
             fixture.detectChanges();
             clickExpireToggleButton();
-
             fillInDatepickerInput('test');
 
             expect(component.form.invalid).toBeTrue();

--- a/lib/content-services/src/lib/content-node-share/content-node-share.dialog.ts
+++ b/lib/content-services/src/lib/content-node-share/content-node-share.dialog.ts
@@ -153,7 +153,7 @@ export class ShareDialogComponent implements OnInit, OnDestroy {
 
     preventIncorrectCharacters(e: KeyboardEvent): boolean {
         const regex = /[^\d/.-]/;
-        return e.key.length == 1 ? !regex.test(e.key) : true;
+        return e.key.length === 1 ? !regex.test(e.key) : true;
     }
 
     private openConfirmationDialog() {

--- a/lib/content-services/src/lib/content-node-share/content-node-share.dialog.ts
+++ b/lib/content-services/src/lib/content-node-share/content-node-share.dialog.ts
@@ -152,7 +152,7 @@ export class ShareDialogComponent implements OnInit, OnDestroy {
     }
 
     preventIncorrectCharacters(e: KeyboardEvent): boolean {
-        const regex = /[^\d\/.\-]/;
+        const regex = /[^\d/.-]/;
         return e.key.length == 1 ? !regex.test(e.key) : true;
     }
 

--- a/lib/content-services/src/lib/i18n/en.json
+++ b/lib/content-services/src/lib/i18n/en.json
@@ -533,7 +533,8 @@
       "REMOVE": "Remove"
     },
     "UNSHARE_ERROR": "Error unsharing this file",
-    "UNSHARE_PERMISSION_ERROR": "You don't have permission to unshare this file"
+    "UNSHARE_PERMISSION_ERROR": "You don't have permission to unshare this file",
+    "INVALID_DATE_ERROR": "Invalid date"
   },
   "PERMISSION_MANAGER": {
     "PERMISSION_DISPLAY": {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

- Currently it is possible to type in past date for link expiration, which leads to an request error and file is being unshared
- Input is not filtering alphabets.
- Currently API request being triggered on every change to the input, so it is impossible to set fully the date manually as you constantly being unfocused from the input.

**What is the new behaviour?**

- Added input validation to prevent old date from being submitted.
- Now the user cannot enter alphabets in the date picker input.
- Now form is being submitted by 'enter' or blur event, which allows to type in the date fully 

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://alfresco.atlassian.net/browse/ACS-5748