### PR TITLE
[APPS-2159] [APPS-2163] migration of e2e test cases from moment to date-fns

### DIFF
--- a/e2e/process-services-cloud/process/process-filter-results.e2e.ts
+++ b/e2e/process-services-cloud/process/process-filter-results.e2e.ts
@@ -35,7 +35,7 @@ import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
 import { ProcessListPage } from '../../process-services/pages/process-list.page';
 import { EditProcessFilterConfiguration } from './../config/edit-process-filter.config';
 import { ProcessListCloudConfiguration } from './../config/process-list-cloud.config';
-import * as moment from 'moment';
+import { addDays, format, subDays } from 'date-fns';
 
 describe('Process filters cloud', () => {
 
@@ -66,9 +66,9 @@ describe('Process filters cloud', () => {
     const queryService = new QueryService(apiService);
     const tasksService = new TasksService(apiService);
 
-    const beforeDate = moment().add(-1, 'days').format('DD/MM/YYYY');
+    const beforeDate = format(subDays(new Date(), 1), 'dd/MM/yyyy');
     const currentDate = DateUtil.formatDate('DD/MM/YYYY');
-    const afterDate = moment().add(1, 'days').format('DD/MM/YYYY');
+    const afterDate = format(addDays(new Date(), 1), 'dd/MM/yyyy');
     const processListCloudConfiguration = new ProcessListCloudConfiguration();
     const editProcessFilterConfiguration = new EditProcessFilterConfiguration();
     const processListCloudConfigFile = processListCloudConfiguration.getConfiguration();

--- a/e2e/process-services/tasks/task-details.e2e.ts
+++ b/e2e/process-services/tasks/task-details.e2e.ts
@@ -35,7 +35,7 @@ import Task = require('../../models/APS/Task');
 import TaskModel = require('../../models/APS/TaskModel');
 import FormModel = require('../../models/APS/FormModel');
 import CONSTANTS = require('../../util/constants');
-import * as moment from 'moment';
+import { format } from 'date-fns';
 
 describe('Task Details component', () => {
     const app = browser.params.resources.Files.SIMPLE_APP_WITH_USER_FORM;
@@ -55,7 +55,7 @@ describe('Task Details component', () => {
     let processUserModel: UserModel;
     let appModel: AppDefinitionRepresentation;
     const tasks = ['Modifying task', 'Information box', 'No form', 'Not Created', 'Refreshing form', 'Assignee task', 'Attach File'];
-    const TASK_DATE_FORMAT = 'll';
+    const TASK_DATE_FORMAT = 'PP';
     let formModel: any;
 
     const taskFormModel = {
@@ -96,7 +96,7 @@ describe('Task Details component', () => {
 
         const taskModel = new TaskModel(allTasks.data[0]);
         await taskPage.tasksListPage().checkContentIsDisplayed(taskModel.getName());
-        await expect(await taskPage.taskDetails().getCreated()).toEqual(moment(taskModel.getCreated()).format(TASK_DATE_FORMAT));
+        await expect(await taskPage.taskDetails().getCreated()).toEqual(format(new Date(taskModel.getCreated()), TASK_DATE_FORMAT));
         await expect(await taskPage.taskDetails().getId()).toEqual(taskModel.getId());
         await expect(await taskPage.taskDetails().getDescription()).toEqual(taskModel.getDescription());
         await expect(await taskPage.taskDetails().getAssignee()).toEqual(taskModel.getAssignee().getEntireName());
@@ -126,7 +126,7 @@ describe('Task Details component', () => {
         const taskModel = new TaskModel(allTasks.data[0]);
         await taskPage.tasksListPage().checkContentIsDisplayed(taskModel.getName());
 
-        await expect(await taskPage.taskDetails().getCreated()).toEqual(moment(taskModel.getCreated()).format(TASK_DATE_FORMAT));
+        await expect(await taskPage.taskDetails().getCreated()).toEqual(format(new Date(taskModel.getCreated()), TASK_DATE_FORMAT));
         await expect(await taskPage.taskDetails().getId()).toEqual(taskModel.getId());
         await expect(await taskPage.taskDetails().getDescription()).toEqual(taskModel.getDescription());
         await expect(await taskPage.taskDetails().getAssignee()).toEqual(taskModel.getAssignee().getEntireName());
@@ -160,7 +160,7 @@ describe('Task Details component', () => {
         const taskModel = new TaskModel(allTasks.data[0]);
 
         await taskPage.tasksListPage().checkContentIsDisplayed(taskModel.getName());
-        await expect(await taskPage.taskDetails().getCreated()).toEqual(moment(taskModel.getCreated()).format(TASK_DATE_FORMAT));
+        await expect(await taskPage.taskDetails().getCreated()).toEqual(format(new Date(taskModel.getCreated()), TASK_DATE_FORMAT));
         await expect(await taskPage.taskDetails().getId()).toEqual(taskModel.getId());
         await expect(await taskPage.taskDetails().getDescription()).toEqual(CONSTANTS.TASK_DETAILS.NO_DESCRIPTION);
         await expect(await taskPage.taskDetails().getAssignee()).toEqual(taskModel.getAssignee().getEntireName());
@@ -191,7 +191,7 @@ describe('Task Details component', () => {
         const taskModel = new TaskModel(allTasks.data[0]);
 
         await taskPage.tasksListPage().checkContentIsDisplayed(taskModel.getName());
-        await expect(await taskPage.taskDetails().getCreated()).toEqual(moment(taskModel.getCreated()).format(TASK_DATE_FORMAT));
+        await expect(await taskPage.taskDetails().getCreated()).toEqual(format(new Date(taskModel.getCreated()), TASK_DATE_FORMAT));
         await expect(await taskPage.taskDetails().getId()).toEqual(taskModel.getId());
         await expect(await taskPage.taskDetails().getDescription()).toEqual(CONSTANTS.TASK_DETAILS.NO_DESCRIPTION);
         await expect(await taskPage.taskDetails().getAssignee()).toEqual(taskModel.getAssignee().getEntireName());
@@ -233,7 +233,7 @@ describe('Task Details component', () => {
 
         const taskModel = new TaskModel(allTasks.data[0]);
         await taskPage.tasksListPage().checkContentIsDisplayed(taskModel.getName());
-        await expect(await taskPage.taskDetails().getCreated()).toEqual(moment(taskModel.getCreated()).format(TASK_DATE_FORMAT));
+        await expect(await taskPage.taskDetails().getCreated()).toEqual(format(new Date(taskModel.getCreated()), TASK_DATE_FORMAT));
         await expect(await taskPage.taskDetails().getId()).toEqual(taskModel.getId());
         await expect(await taskPage.taskDetails().getDescription()).toEqual(CONSTANTS.TASK_DETAILS.NO_DESCRIPTION);
         await expect(await taskPage.taskDetails().getAssignee()).toEqual(taskModel.getAssignee().getEntireName());
@@ -270,7 +270,7 @@ describe('Task Details component', () => {
 
         const taskModel = new TaskModel(allTasks.data[0]);
         await taskPage.tasksListPage().checkContentIsDisplayed(taskModel.getName());
-        await expect(await taskPage.taskDetails().getCreated()).toEqual(moment(taskModel.getCreated()).format(TASK_DATE_FORMAT));
+        await expect(await taskPage.taskDetails().getCreated()).toEqual(format(new Date(taskModel.getCreated()), TASK_DATE_FORMAT));
         await expect(await taskPage.taskDetails().getId()).toEqual(taskModel.getId());
         await expect(await taskPage.taskDetails().getDescription()).toEqual(CONSTANTS.TASK_DETAILS.NO_DESCRIPTION);
         await expect(await taskPage.taskDetails().getAssignee()).toEqual(taskModel.getAssignee().getEntireName());
@@ -301,7 +301,7 @@ describe('Task Details component', () => {
 
         const taskModel = new TaskModel(getTaskResponse);
         await taskPage.tasksListPage().checkContentIsDisplayed(taskModel.getName());
-        await expect(await taskPage.taskDetails().getCreated()).toEqual(moment(taskModel.getCreated()).format(TASK_DATE_FORMAT));
+        await expect(await taskPage.taskDetails().getCreated()).toEqual(format(new Date(taskModel.getCreated()), TASK_DATE_FORMAT));
         await expect(await taskPage.taskDetails().getId()).toEqual(taskModel.getId());
         await expect(await taskPage.taskDetails().getDescription()).toEqual(CONSTANTS.TASK_DETAILS.NO_DESCRIPTION);
         await expect(await taskPage.taskDetails().getAssignee()).toEqual(taskModel.getAssignee().getEntireName());


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
moment dependency is being used in e2e.ts file below
1. task-details.e2e.ts 
2.process-filter-results.e2e.ts


**What is the new behaviour?**
migrated e2e's from moment to date-fns


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://alfresco.atlassian.net/browse/APPS-2159
https://alfresco.atlassian.net/browse/APPS-2163