### PR TITLE
[AAE-15813] Fix - deployed application named 'idp' doesn't work

### DIFF
--- a/lib/core/src/lib/auth/authentication-interceptor/auth-bearer.interceptor.spec.ts
+++ b/lib/core/src/lib/auth/authentication-interceptor/auth-bearer.interceptor.spec.ts
@@ -1,0 +1,105 @@
+/*!
+ * @license
+ * Copyright © 2005-2023 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { HttpClient, HttpHandler, HttpRequest } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { Observable, of } from 'rxjs';
+import { AuthBearerInterceptor } from './auth-bearer.interceptor';
+import { AuthenticationService } from '../services/authentication.service';
+
+const mockNext: HttpHandler = {
+    handle: () => new Observable(subscriber => {
+        subscriber.complete();
+    })
+};
+
+const mockRequest = (url) => new HttpRequest('GET', url);
+
+describe('AuthBearerInterceptor', () => {
+    let interceptor: AuthBearerInterceptor;
+    let authService: AuthenticationService;
+    let addTokenToHeaderSpy: jasmine.Spy;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [
+                HttpClient,
+                HttpHandler,
+                AuthBearerInterceptor,
+                AuthenticationService
+            ]
+        });
+
+        interceptor = TestBed.inject(AuthBearerInterceptor);
+        authService = TestBed.inject(AuthenticationService);
+
+        addTokenToHeaderSpy = spyOn(authService, 'addTokenToHeader').and.returnValue(of());
+    });
+
+    it('should interceptor add auth token to NOT excluded URLs', () => {
+        const mockUrls = [
+            'https://example.com/someotherpath',
+            'https://example.com/someotherpath/anotherpath',
+            'https://example.com/test/v1/applications/service/idp/rb',
+            'http://localhost:4200/deployment-service/v1/applications/idp/logs/rb',
+            'http://localhost:4200/path/idp/v1/applications/idp/logs/rb',
+            'http://example.com/api/auth/realms/v1/applications/idp/logs/rb'
+        ];
+
+        mockUrls.forEach((url) => {
+            interceptor.intercept(mockRequest(url), mockNext);
+        });
+
+        expect(addTokenToHeaderSpy).toHaveBeenCalledTimes(mockUrls.length);
+    });
+
+    it('should interceptor pass excluded URLs without add auth token', () => {
+        const mockExcludedUrls = [
+            'https://example.com/resources/somepath',
+            'https://example.com/assets/anotherpath',
+            'http://example.com/auth/realms/testpath',
+            'https://example.com/idp/',
+            'https://example.com/idp/v1/applications/service/test/',
+            'https://example.com/auth/realms/somepath'
+        ];
+
+        mockExcludedUrls.forEach((url) => {
+            interceptor.intercept(mockRequest(url), mockNext);
+        });
+
+        expect(addTokenToHeaderSpy).not.toHaveBeenCalled();
+    });
+
+    it('should interceptor add auth token to every URL if excluded URLs array is empty', () => {
+        spyOn(authService, 'getBearerExcludedUrls').and.returnValue([]);
+
+        const mockUrls = [
+            'http://example.com/auth/realms/testpath',
+            'https://example.com/idp/',
+            'https://example.com/idp/v1/applications/service/test/',
+            'http://example.com/someotherpath',
+            'https://example.com/someotherpath/anotherpath',
+            'https://example.com/test/v1/applications/service/idp/rb'
+        ];
+
+        mockUrls.forEach((url) => {
+            interceptor.intercept(mockRequest(url), mockNext);
+        });
+
+        expect(addTokenToHeaderSpy).toHaveBeenCalledTimes(mockUrls.length);
+    });
+});

--- a/lib/core/src/lib/auth/authentication-interceptor/auth-bearer.interceptor.ts
+++ b/lib/core/src/lib/auth/authentication-interceptor/auth-bearer.interceptor.ts
@@ -32,7 +32,7 @@ export class AuthBearerInterceptor implements HttpInterceptor {
 
   private loadExcludedUrlsRegex() {
     const excludedUrls = this.authService.getBearerExcludedUrls();
-    this.excludedUrlsRegex = excludedUrls.map((urlPattern) => new RegExp(urlPattern, 'i')) || [];
+    this.excludedUrlsRegex = excludedUrls.map((urlPattern) => new RegExp(`^https?://[^/]+/${urlPattern}`, 'i')) || [];
   }
 
   intercept(req: HttpRequest<any>, next: HttpHandler):


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
The problem with the failed RB download is that it calls the
`deployment-service/v1/applications/idp/logs/rb`
API, and it contains idp  keyword.
In the [authentication service](https://github.com/Alfresco/alfresco-ng2-components/blob/bd518b6c59a34992d7c305230c9abe0a07cdf6f0/lib/core/src/lib/auth/services/base-authentication.service.ts#L37) (ADF), we have a list of excluded keywords (`idp`, `resources`, `assets`) that we take into account when we add a token to authorize our request. If the request URL contains any of these words, the authentication token will not be added resulting in a 401 unauthorized error.