### PR TITLE
Use icon for "mark all" notifications

### DIFF
--- a/lib/core/src/lib/notifications/components/notification-history.component.html
+++ b/lib/core/src/lib/notifications/components/notification-history.component.html
@@ -21,12 +21,12 @@
              (click)="$event.stopPropagation()">
             <div mat-subheader role="menuitem">
                 <span>{{ 'NOTIFICATIONS.TITLE' | translate }}</span>
-                <button (click)="markAsRead()"
+                <button *ngIf="notifications.length"
                         id="adf-notification-history-mark-as-read"
-                        mat-button
-                        color="accent"
-                        *ngIf="notifications.length">
-                    {{ 'NOTIFICATIONS.MARK_AS_READ' | translate }}
+                        mat-icon-button
+                        title="{{ 'NOTIFICATIONS.MARK_AS_READ' | translate }}"
+                        (click)="markAsRead()">
+                    <mat-icon>done_all</mat-icon>
                 </button>
             </div>
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

- the "mark all" for notifications history has issues with translations (i.e. German)
- see https://github.com/Alfresco/alfresco-content-app/issues/3404

![image](https://github.com/Alfresco/alfresco-ng2-components/assets/503991/46ea7e27-0f1e-4a37-b303-c577fbc30050)


**What is the new behaviour?**

- use icon for "mark all"

<img width="659" alt="Screenshot 2023-09-11 at 14 17 11" src="https://github.com/Alfresco/alfresco-ng2-components/assets/503991/6a22d7c9-28f4-4ed6-a285-0b4f1874df2d">

<img width="601" alt="Screenshot 2023-09-11 at 14 17 30" src="https://github.com/Alfresco/alfresco-ng2-components/assets/503991/23772d72-45a1-49bd-8a90-be66ec866f3e">

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
