### PR TITLE
[ACS-6003] - waitRendition in rendition.service.ts not working

### DIFF
--- a/lib/content-services/src/lib/common/services/rendition.service.ts
+++ b/lib/content-services/src/lib/common/services/rendition.service.ts
@@ -88,9 +88,8 @@ export class RenditionService {
     }
 
     private async waitRendition(nodeId: string, renditionId: string, retries: number): Promise<RenditionEntry> {
-        const rendition = await this.renditionsApi.getRendition(nodeId, renditionId);
-
-        if (this.maxRetries >= retries) {
+        if (this.maxRetries > retries) {
+            const rendition = await this.renditionsApi.getRendition(nodeId, renditionId);
             const status = rendition.entry.status.toString();
 
             if (status === 'CREATED') {

--- a/lib/content-services/src/lib/common/services/rendition.service.ts
+++ b/lib/content-services/src/lib/common/services/rendition.service.ts
@@ -90,7 +90,7 @@ export class RenditionService {
     private async waitRendition(nodeId: string, renditionId: string, retries: number): Promise<RenditionEntry> {
         const rendition = await this.renditionsApi.getRendition(nodeId, renditionId);
 
-        if (this.maxRetries < retries) {
+        if (this.maxRetries >= retries) {
             const status = rendition.entry.status.toString();
 
             if (status === 'CREATED') {

--- a/lib/content-services/src/lib/common/services/rendition.services.spec.ts
+++ b/lib/content-services/src/lib/common/services/rendition.services.spec.ts
@@ -1,0 +1,105 @@
+/*!
+ * @license
+ * Copyright © 2005-2023 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { AlfrescoApiService, LogService, TranslationService, ViewUtilService } from '@alfresco/adf-core';
+import { RenditionEntry, RenditionPaging, RenditionsApi } from '@alfresco/js-api';
+import { RenditionService } from '@alfresco/adf-content-services';
+
+const getRenditionEntry = (status: 'NOT_CREATED' | 'CREATED'): RenditionEntry => {
+    return {
+        entry: {
+            id: 'pdf',
+            status: status,
+            content: { mimeType: 'application/pdf', mimeTypeName: 'application/pdf', sizeInBytes: 10 }
+        }
+    };
+};
+const getRenditionPaging = (status: 'NOT_CREATED' | 'CREATED'): RenditionPaging =>  {
+    return {
+        list: {
+            entries: [getRenditionEntry(status)]
+        }
+    };
+};
+describe('RenditionService', () => {
+    let renditionService: RenditionService;
+    let renditionsApi: any;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            providers: [
+                RenditionService,
+                { provide: AlfrescoApiService, useValue: {} },
+                { provide: LogService, useValue: { error: jasmine.createSpy('error') } },
+                { provide: TranslationService, useValue: {} },
+                { provide: ViewUtilService, useValue: {} },
+                { provide: RenditionsApi, useValue: {
+                        listRenditions: jasmine.createSpy('listRenditions'),
+                        getRendition: jasmine.createSpy('getRendition'),
+                        createRendition: jasmine.createSpy('createRendition')
+                    } }
+            ]
+        });
+        renditionService = TestBed.inject(RenditionService);
+        renditionsApi = TestBed.inject(RenditionsApi);
+        // eslint-disable-next-line no-underscore-dangle
+        renditionService._renditionsApi = renditionsApi;
+    });
+
+    describe('getRendition', () => {
+        it('should retry getting the rendition until maxRetries if status is NOT_CREATED', async () => {
+            const mockRenditionPaging: RenditionPaging = getRenditionPaging('NOT_CREATED');
+            const mockRenditionEntry: RenditionEntry = getRenditionEntry('NOT_CREATED');
+
+            renditionsApi.listRenditions.and.returnValue(Promise.resolve(mockRenditionPaging));
+            renditionsApi.getRendition.and.returnValue(Promise.resolve(mockRenditionEntry));
+
+            await renditionService.getRendition('nodeId', 'pdf');
+            expect(renditionsApi.getRendition).toHaveBeenCalledTimes(renditionService.maxRetries);
+        }, 10000);
+    });
+
+    it('should return the rendition when status transitions from PENDING to CREATED', async () => {
+        const mockRenditionPaging: RenditionPaging = getRenditionPaging('NOT_CREATED');
+        const mockRenditionEntry: RenditionEntry = getRenditionEntry('CREATED');
+
+        renditionsApi.listRenditions.and.returnValue(Promise.resolve(mockRenditionPaging));
+        renditionsApi.getRendition.and.returnValues(
+          Promise.resolve(getRenditionEntry('NOT_CREATED')),
+          Promise.resolve(getRenditionEntry('NOT_CREATED')),
+          Promise.resolve(mockRenditionEntry)
+        );
+
+        const result = await renditionService.getRendition('nodeId', 'pdf');
+
+        expect(result).toEqual(mockRenditionEntry);
+        expect(renditionsApi.getRendition).toHaveBeenCalledTimes(3);
+    });
+
+    it('should return the rendition when status is CREATED on the first run', async () => {
+        const mockRenditionPaging: RenditionPaging = getRenditionPaging('CREATED');
+
+        renditionsApi.listRenditions.and.returnValue(Promise.resolve(mockRenditionPaging));
+
+        const result = await renditionService.getRendition('nodeId', 'pdf');
+
+        expect(result).toEqual(mockRenditionPaging.list.entries[0]);
+        expect(renditionsApi.getRendition).not.toHaveBeenCalled();
+    });
+
+});

--- a/lib/content-services/src/lib/common/services/rendition.services.spec.ts
+++ b/lib/content-services/src/lib/common/services/rendition.services.spec.ts
@@ -57,7 +57,7 @@ describe('RenditionService', () => {
         });
         renditionService = TestBed.inject(RenditionService);
         renditionsApi = TestBed.inject(RenditionsApi);
-        spyOnProperty(renditionService, 'renditionsApi').and.returnValue(renditionsApi)
+        spyOnProperty(renditionService, 'renditionsApi').and.returnValue(renditionsApi);
     });
 
     describe('getRendition', () => {

--- a/lib/content-services/src/lib/common/services/rendition.services.spec.ts
+++ b/lib/content-services/src/lib/common/services/rendition.services.spec.ts
@@ -17,10 +17,10 @@
 
 import { TestBed } from '@angular/core/testing';
 import { AlfrescoApiService, LogService, TranslationService, ViewUtilService } from '@alfresco/adf-core';
-import { RenditionEntry, RenditionPaging, RenditionsApi } from '@alfresco/js-api';
+import { Rendition, RenditionEntry, RenditionPaging, RenditionsApi } from '@alfresco/js-api';
 import { RenditionService } from '@alfresco/adf-content-services';
 
-const getRenditionEntry = (status: 'NOT_CREATED' | 'CREATED'): RenditionEntry => {
+const getRenditionEntry = (status: Rendition.StatusEnum): RenditionEntry => {
     return {
         entry: {
             id: 'pdf',
@@ -29,7 +29,7 @@ const getRenditionEntry = (status: 'NOT_CREATED' | 'CREATED'): RenditionEntry =>
         }
     };
 };
-const getRenditionPaging = (status: 'NOT_CREATED' | 'CREATED'): RenditionPaging =>  {
+const getRenditionPaging = (status: Rendition.StatusEnum): RenditionPaging =>  {
     return {
         list: {
             entries: [getRenditionEntry(status)]
@@ -57,14 +57,13 @@ describe('RenditionService', () => {
         });
         renditionService = TestBed.inject(RenditionService);
         renditionsApi = TestBed.inject(RenditionsApi);
-        // eslint-disable-next-line no-underscore-dangle
-        renditionService._renditionsApi = renditionsApi;
+        spyOnProperty(renditionService, 'renditionsApi').and.returnValue(renditionsApi)
     });
 
     describe('getRendition', () => {
         it('should retry getting the rendition until maxRetries if status is NOT_CREATED', async () => {
-            const mockRenditionPaging: RenditionPaging = getRenditionPaging('NOT_CREATED');
-            const mockRenditionEntry: RenditionEntry = getRenditionEntry('NOT_CREATED');
+            const mockRenditionPaging: RenditionPaging = getRenditionPaging(Rendition.StatusEnum.NOTCREATED);
+            const mockRenditionEntry: RenditionEntry = getRenditionEntry(Rendition.StatusEnum.NOTCREATED);
 
             renditionsApi.listRenditions.and.returnValue(Promise.resolve(mockRenditionPaging));
             renditionsApi.getRendition.and.returnValue(Promise.resolve(mockRenditionEntry));
@@ -75,13 +74,13 @@ describe('RenditionService', () => {
     });
 
     it('should return the rendition when status transitions from PENDING to CREATED', async () => {
-        const mockRenditionPaging: RenditionPaging = getRenditionPaging('NOT_CREATED');
-        const mockRenditionEntry: RenditionEntry = getRenditionEntry('CREATED');
+        const mockRenditionPaging: RenditionPaging = getRenditionPaging(Rendition.StatusEnum.NOTCREATED);
+        const mockRenditionEntry: RenditionEntry = getRenditionEntry(Rendition.StatusEnum.CREATED);
 
         renditionsApi.listRenditions.and.returnValue(Promise.resolve(mockRenditionPaging));
         renditionsApi.getRendition.and.returnValues(
-          Promise.resolve(getRenditionEntry('NOT_CREATED')),
-          Promise.resolve(getRenditionEntry('NOT_CREATED')),
+          Promise.resolve(getRenditionEntry(Rendition.StatusEnum.NOTCREATED)),
+          Promise.resolve(getRenditionEntry(Rendition.StatusEnum.NOTCREATED)),
           Promise.resolve(mockRenditionEntry)
         );
 
@@ -92,7 +91,7 @@ describe('RenditionService', () => {
     });
 
     it('should return the rendition when status is CREATED on the first run', async () => {
-        const mockRenditionPaging: RenditionPaging = getRenditionPaging('CREATED');
+        const mockRenditionPaging: RenditionPaging = getRenditionPaging(Rendition.StatusEnum.CREATED);
 
         renditionsApi.listRenditions.and.returnValue(Promise.resolve(mockRenditionPaging));
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
the Retry feature from method: getRendition does not work, because of wrong condition in rendition service

https://alfresco.atlassian.net/browse/ACS-6003

**What is the new behaviour?**
Calling the getRendition waits until the rendition is available.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
