### PR TITLE
[AAE-16369] use layout-bp mixin where applicable

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -272,6 +272,11 @@
             "karmaConfig": "lib/core/karma.conf.js",
             "sourceMap": true,
             "codeCoverage": true,
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "lib", "lib/core/src/lib"
+              ]
+            },
             "styles": [
               "demo-shell/src/styles.scss"
             ]
@@ -420,7 +425,12 @@
             "tsConfig": "lib/content-services/tsconfig.spec.json",
             "karmaConfig": "lib/content-services/karma.conf.js",
             "sourceMap": true,
-            "codeCoverage": true
+            "codeCoverage": true,
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "lib", "lib/core/src/lib"
+              ]
+            }
           }
         },
         "lint": {
@@ -538,7 +548,12 @@
             "tsConfig": "lib/process-services/tsconfig.spec.json",
             "karmaConfig": "lib/process-services/karma.conf.js",
             "sourceMap": true,
-            "codeCoverage": true
+            "codeCoverage": true,
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "lib", "lib/core/src/lib"
+              ]
+            }
           }
         },
         "lint": {
@@ -604,7 +619,12 @@
             "tsConfig": "lib/process-services-cloud/tsconfig.spec.json",
             "karmaConfig": "lib/process-services-cloud/karma.conf.js",
             "sourceMap": true,
-            "codeCoverage": true
+            "codeCoverage": true,
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "lib", "lib/core/src/lib"
+              ]
+            }
           }
         },
         "lint": {
@@ -733,7 +753,12 @@
             "tsConfig": "lib/insights/tsconfig.spec.json",
             "karmaConfig": "lib/insights/karma.conf.js",
             "sourceMap": true,
-            "codeCoverage": true
+            "codeCoverage": true,
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "lib", "lib/core/src/lib"
+              ]
+            }
           }
         },
         "lint": {
@@ -798,7 +823,12 @@
             "tsConfig": "lib/extensions/tsconfig.spec.json",
             "karmaConfig": "lib/extensions/karma.conf.js",
             "sourceMap": true,
-            "codeCoverage": true
+            "codeCoverage": true,
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "lib", "lib/core/src/lib"
+              ]
+            }
           }
         },
         "lint": {

--- a/angular.json
+++ b/angular.json
@@ -250,12 +250,7 @@
           "builder": "@angular-devkit/build-angular:ng-packagr",
           "options": {
             "tsConfig": "lib/core/tsconfig.lib.json",
-            "project": "lib/core/ng-package.json",
-            "stylePreprocessorOptions": {
-              "includePaths": [
-                "lib", "lib/core/src/lib"
-              ]
-            }
+            "project": "lib/core/ng-package.json"
           },
           "dependsOn": ["^build", "license"],
           "configurations": {
@@ -408,12 +403,7 @@
           "builder": "@angular-devkit/build-angular:ng-packagr",
           "options": {
             "tsConfig": "lib/content-services/tsconfig.lib.json",
-            "project": "lib/content-services/ng-package.json",
-            "stylePreprocessorOptions": {
-              "includePaths": [
-                "lib", "lib/core/src/lib"
-              ]
-            }
+            "project": "lib/content-services/ng-package.json"
           },
           "configurations": {
             "production": {
@@ -531,12 +521,7 @@
           "builder": "@angular-devkit/build-angular:ng-packagr",
           "options": {
             "tsConfig": "lib/process-services/tsconfig.lib.json",
-            "project": "lib/process-services/ng-package.json",
-            "stylePreprocessorOptions": {
-              "includePaths": [
-                "lib", "lib/core/src/lib"
-              ]
-            }
+            "project": "lib/process-services/ng-package.json"
           },
           "configurations": {
             "production": {
@@ -602,12 +587,7 @@
           "builder": "@angular-devkit/build-angular:ng-packagr",
           "options": {
             "tsConfig": "lib/process-services-cloud/tsconfig.lib.json",
-            "project": "lib/process-services-cloud/ng-package.json",
-            "stylePreprocessorOptions": {
-              "includePaths": [
-                "lib", "lib/core/src/lib"
-              ]
-            }
+            "project": "lib/process-services-cloud/ng-package.json"
           },
           "configurations": {
             "production": {
@@ -736,12 +716,7 @@
           "builder": "@angular-devkit/build-angular:ng-packagr",
           "options": {
             "tsConfig": "lib/insights/tsconfig.lib.json",
-            "project": "lib/insights/ng-package.json",
-            "stylePreprocessorOptions": {
-              "includePaths": [
-                "lib", "lib/core/src/lib"
-              ]
-            }
+            "project": "lib/insights/ng-package.json"
           },
           "configurations": {
             "production": {

--- a/angular.json
+++ b/angular.json
@@ -29,7 +29,7 @@
             "polyfills": "demo-shell/src/polyfills.ts",
             "stylePreprocessorOptions": {
               "includePaths": [
-                "lib"
+                "lib", "lib/core/src/lib"
               ]
             },
             "assets": [
@@ -250,7 +250,12 @@
           "builder": "@angular-devkit/build-angular:ng-packagr",
           "options": {
             "tsConfig": "lib/core/tsconfig.lib.json",
-            "project": "lib/core/ng-package.json"
+            "project": "lib/core/ng-package.json",
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "lib", "lib/core/src/lib"
+              ]
+            }
           },
           "dependsOn": ["^build", "license"],
           "configurations": {
@@ -307,7 +312,12 @@
               "demo-shell/src/custom-style-dev.scss",
               "node_modules/cropperjs/dist/cropper.min.css",
               "node_modules/pdfjs-dist/web/pdf_viewer.css"
-            ]
+            ],
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "lib", "lib/core/src/lib"
+              ]
+            }
           },
           "configurations": {
             "ci": {
@@ -328,7 +338,12 @@
               "demo-shell/src/custom-style-dev.scss",
               "node_modules/cropperjs/dist/cropper.min.css",
               "node_modules/pdfjs-dist/web/pdf_viewer.css"
-            ]
+            ],
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "lib", "lib/core/src/lib"
+              ]
+            }
           },
           "configurations": {
             "ci": {
@@ -393,7 +408,12 @@
           "builder": "@angular-devkit/build-angular:ng-packagr",
           "options": {
             "tsConfig": "lib/content-services/tsconfig.lib.json",
-            "project": "lib/content-services/ng-package.json"
+            "project": "lib/content-services/ng-package.json",
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "lib", "lib/core/src/lib"
+              ]
+            }
           },
           "configurations": {
             "production": {
@@ -435,7 +455,12 @@
               "demo-shell/src/custom-style-dev.scss",
               "node_modules/cropperjs/dist/cropper.min.css",
               "node_modules/pdfjs-dist/web/pdf_viewer.css"
-            ]
+            ],
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "lib", "lib/core/src/lib"
+              ]
+            }
           },
           "configurations": {
             "ci": {
@@ -456,7 +481,12 @@
               "demo-shell/src/custom-style-dev.scss",
               "node_modules/cropperjs/dist/cropper.min.css",
               "node_modules/pdfjs-dist/web/pdf_viewer.css"
-            ]
+            ],
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "lib", "lib/core/src/lib"
+              ]
+            }
           },
           "configurations": {
             "ci": {
@@ -501,7 +531,12 @@
           "builder": "@angular-devkit/build-angular:ng-packagr",
           "options": {
             "tsConfig": "lib/process-services/tsconfig.lib.json",
-            "project": "lib/process-services/ng-package.json"
+            "project": "lib/process-services/ng-package.json",
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "lib", "lib/core/src/lib"
+              ]
+            }
           },
           "configurations": {
             "production": {
@@ -567,7 +602,12 @@
           "builder": "@angular-devkit/build-angular:ng-packagr",
           "options": {
             "tsConfig": "lib/process-services-cloud/tsconfig.lib.json",
-            "project": "lib/process-services-cloud/ng-package.json"
+            "project": "lib/process-services-cloud/ng-package.json",
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "lib", "lib/core/src/lib"
+              ]
+            }
           },
           "configurations": {
             "production": {
@@ -609,7 +649,12 @@
               "demo-shell/src/custom-style-dev.scss",
               "node_modules/cropperjs/dist/cropper.min.css",
               "node_modules/pdfjs-dist/web/pdf_viewer.css"
-            ]
+            ],
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "lib", "lib/core/src/lib"
+              ]
+            }
           },
           "configurations": {
             "ci": {
@@ -630,7 +675,12 @@
               "demo-shell/src/custom-style-dev.scss",
               "node_modules/cropperjs/dist/cropper.min.css",
               "node_modules/pdfjs-dist/web/pdf_viewer.css"
-            ]
+            ],
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "lib", "lib/core/src/lib"
+              ]
+            }
           },
           "configurations": {
             "ci": {
@@ -686,7 +736,12 @@
           "builder": "@angular-devkit/build-angular:ng-packagr",
           "options": {
             "tsConfig": "lib/insights/tsconfig.lib.json",
-            "project": "lib/insights/ng-package.json"
+            "project": "lib/insights/ng-package.json",
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "lib", "lib/core/src/lib"
+              ]
+            }
           },
           "configurations": {
             "production": {
@@ -816,7 +871,12 @@
                 "entryName": "shared",
                 "entryPath": "/lib/testing/src/lib/shared/index.ts"
               }
-            ]
+            ],
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "lib", "lib/core/src/lib"
+              ]
+            }
           },
           "configurations": {
             "production": {
@@ -897,7 +957,12 @@
             "outputPath": "dist/libs/eslint-plugin-eslint-angular",
             "main": "lib/eslint-angular/index.ts",
             "generatePackageJson" : true,
-            "tsConfig": "lib/eslint-angular/tsconfig.lib.prod.json"
+            "tsConfig": "lib/eslint-angular/tsconfig.lib.prod.json",
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "lib", "lib/core/src/lib"
+              ]
+            }
           },
           "configurations": {
             "production": {
@@ -956,7 +1021,12 @@
           "options": {
             "commands": [
               "cd lib/cli && npm i && npm run dist"
-            ]
+            ],
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "lib", "lib/core/src/lib"
+              ]
+            }
           },
           "configurations": {
             "production": {
@@ -1032,6 +1102,11 @@
             "browserTarget": "stories:storybook",
             "configDir": "lib/stories/.storybook",
             "compodoc": false,
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "lib", "lib/core/src/lib"
+              ]
+            },
             "styles": [
               "demo-shell/src/assets/fonts/muli/muli.css",
               "demo-shell/src/styles.scss",
@@ -1059,7 +1134,12 @@
               "demo-shell/src/custom-style-dev.scss",
               "node_modules/cropperjs/dist/cropper.min.css",
               "node_modules/pdfjs-dist/web/pdf_viewer.css"
-            ]
+            ],
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "lib", "lib/core/src/lib"
+              ]
+            }
           },
           "configurations": {
             "ci": {

--- a/angular.json
+++ b/angular.json
@@ -393,7 +393,12 @@
                 "command": "npm publish --tag {args.tag}",
                 "forwardAllArgs": true
               }
-            ]
+            ],
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "lib", "lib/core/src/lib"
+              ]
+            }
           }
         }
       }

--- a/lib/config/webpack.style.js
+++ b/lib/config/webpack.style.js
@@ -41,5 +41,11 @@ module.exports = {
         new DisableOutputWebpackPlugin({
             test: /\.js$/,
         })
-    ]
+    ],
+
+    resolve: {
+        alias: {
+            'styles': path.resolve(__dirname, '../core/src/lib/styles'),
+        }
+    }
 };

--- a/lib/content-services/ng-package.json
+++ b/lib/content-services/ng-package.json
@@ -22,7 +22,7 @@
     "entryFile": "src/public-api.ts",
     "flatModuleFile": "adf-content-services",
     "styleIncludePaths": [
-      "../../dist/libs/core/lib"
+      "../core/src/lib"
     ]
   }
 }

--- a/lib/content-services/ng-package.json
+++ b/lib/content-services/ng-package.json
@@ -20,6 +20,9 @@
   ],
   "lib": {
     "entryFile": "src/public-api.ts",
-    "flatModuleFile": "adf-content-services"
+    "flatModuleFile": "adf-content-services",
+    "styleIncludePaths": [
+      "../../dist/libs/core/lib"
+    ]
   }
 }

--- a/lib/content-services/src/lib/content-user-info/content-user-info.component.scss
+++ b/lib/content-services/src/lib/content-user-info/content-user-info.component.scss
@@ -1,3 +1,5 @@
+@import '../../../../core/src/lib/styles/flex';
+
 .adf {
     &-userinfo-container {
         display: flex;
@@ -12,7 +14,7 @@
     &-userinfo-name {
         padding: 0 5px;
 
-        @media screen and (max-width: 959px) {
+        @include layout-bp(lt-md) {
             display: none;
         }
     }
@@ -90,7 +92,7 @@
         display: flex;
         justify-content: space-between;
 
-        @media screen and (max-width: 599px) {
+        @include layout-bp(lt-sm) {
             padding: 10px;
         }
     }

--- a/lib/content-services/src/lib/content-user-info/content-user-info.component.scss
+++ b/lib/content-services/src/lib/content-user-info/content-user-info.component.scss
@@ -1,4 +1,4 @@
-@import '../../../../core/src/lib/styles/flex';
+@import 'styles/flex';
 
 .adf {
     &-userinfo-container {

--- a/lib/content-services/src/lib/document-list/components/document-list.component.scss
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.scss
@@ -1,3 +1,5 @@
+@import '../../../../../core/src/lib/styles/flex';
+
 .adf-document-list {
     min-height: 0;
     height: 100%;
@@ -141,7 +143,7 @@
         word-break: break-all;
         white-space: pre-line;
 
-        @media screen and (max-width: 599px) {
+        @include layout-bp(lt-sm) {
             font-size: 48px;
         }
     }
@@ -163,12 +165,12 @@
         object-fit: contain;
         margin-top: 17px;
 
-        @media screen and (max-width: 599px) {
+        @include layout-bp(lt-sm) {
             width: 250px;
         }
     }
 
-    @media screen and (max-width: 960px) {
+    @include layout-bp(lt-md) {
         &-drag-drop,
         &-any-files-here-to-add {
             display: none;

--- a/lib/content-services/src/lib/document-list/components/document-list.component.scss
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.scss
@@ -1,4 +1,4 @@
-@import '../../../../../core/src/lib/styles/flex';
+@import 'styles/flex';
 
 .adf-document-list {
     min-height: 0;

--- a/lib/content-services/src/lib/search/components/search-control.component.scss
+++ b/lib/content-services/src/lib/search/components/search-control.component.scss
@@ -1,5 +1,5 @@
 @use '@angular/material' as mat;
-@import '../../../../../core/src/lib/styles/flex';
+@import 'styles/flex';
 
 $mat-menu-overlay-min-width: 112px !default;   // 56 * 2
 $mat-menu-overlay-max-width: 280px !default;   // 56 * 5

--- a/lib/content-services/src/lib/search/components/search-control.component.scss
+++ b/lib/content-services/src/lib/search/components/search-control.component.scss
@@ -1,4 +1,5 @@
 @use '@angular/material' as mat;
+@import '../../../../../core/src/lib/styles/flex';
 
 $mat-menu-overlay-min-width: 112px !default;   // 56 * 2
 $mat-menu-overlay-max-width: 280px !default;   // 56 * 5
@@ -23,7 +24,7 @@ $mat-menu-overlay-max-width: 280px !default;   // 56 * 5
         background-color: var(--adf-theme-background-card-color);
         border-radius: 2px;
 
-        @media screen and (max-width: 959px) {
+        @include layout-bp(lt-md) {
             white-space: nowrap;
             text-overflow: ellipsis;
             overflow: hidden;

--- a/lib/core/ng-package.json
+++ b/lib/core/ng-package.json
@@ -35,7 +35,10 @@
   ],
   "lib": {
     "entryFile": "./src/public-api.ts",
-    "flatModuleFile": "adf-core"
+    "flatModuleFile": "adf-core",
+    "styleIncludePaths": [
+      "../core/src/lib"
+    ]
   },
   "allowedNonPeerDependencies": [
     "cropperjs",

--- a/lib/core/ng-package.json
+++ b/lib/core/ng-package.json
@@ -37,7 +37,7 @@
     "entryFile": "./src/public-api.ts",
     "flatModuleFile": "adf-core",
     "styleIncludePaths": [
-      "../core/src/lib"
+      "./src/lib"
     ]
   },
   "allowedNonPeerDependencies": [

--- a/lib/core/shell/ng-package.json
+++ b/lib/core/shell/ng-package.json
@@ -1,6 +1,9 @@
 {
-  "$schema": "../../../../../node_modules/ng-packagr/ng-package.schema.json",
+  "$schema": "../../../node_modules/ng-packagr/ng-package.schema.json",
   "lib": {
-    "entryFile": "src/index.ts"
+    "entryFile": "src/index.ts",
+    "styleIncludePaths": [
+      "../src/lib"
+    ]
   }
 }

--- a/lib/core/shell/src/lib/components/shell/shell.component.scss
+++ b/lib/core/shell/src/lib/components/shell/shell.component.scss
@@ -1,4 +1,4 @@
-@import '../../../../../src/lib/styles/flex';
+@import 'styles/flex';
 
 .app-shell {
     display: flex;

--- a/lib/core/shell/src/lib/components/shell/shell.component.scss
+++ b/lib/core/shell/src/lib/components/shell/shell.component.scss
@@ -1,3 +1,5 @@
+@import '../../../../../src/lib/styles/flex';
+
 .app-shell {
     display: flex;
     flex-direction: column;
@@ -21,7 +23,7 @@
     }
 }
 
-@media screen and (max-width: 599px) {
+@include layout-bp(lt-sm) {
     .adf-app-title {
         display: none;
     }

--- a/lib/core/src/lib/form/components/form-renderer.component.scss
+++ b/lib/core/src/lib/form/components/form-renderer.component.scss
@@ -1,4 +1,5 @@
-@import '../../styles/flex';
+@import 'styles/flex';
+
 .adf-hidden {
     display: none;
 }

--- a/lib/core/src/lib/form/components/form-renderer.component.scss
+++ b/lib/core/src/lib/form/components/form-renderer.component.scss
@@ -23,7 +23,7 @@
 
 .adf-container-widget {
     .adf-grid-list-column-view {
-        @include layout-bp(lt-sm) {
+        @include layout-bp(lt-md) {
             display: flow;
         }
 

--- a/lib/core/src/lib/form/components/form-renderer.component.scss
+++ b/lib/core/src/lib/form/components/form-renderer.component.scss
@@ -1,3 +1,4 @@
+@import '../../styles/flex';
 .adf-hidden {
     display: none;
 }
@@ -22,7 +23,7 @@
 
 .adf-container-widget {
     .adf-grid-list-column-view {
-        @media screen and (max-width: 959px) {
+        @include layout-bp(lt-sm) {
             display: flow;
         }
 
@@ -56,7 +57,7 @@
         padding-right: 3px;
     }
 
-    @media screen and (max-width: 959px) {
+    @include layout-bp(lt-md) {
         .adf-grid-list-item {
             flex: 1 0 100%;
         }

--- a/lib/core/src/lib/identity-user-info/identity-user-info.component.scss
+++ b/lib/core/src/lib/identity-user-info/identity-user-info.component.scss
@@ -1,4 +1,4 @@
-@import '../styles/flex';
+@import 'styles/flex';
 
 .adf {
     &-userinfo-container {

--- a/lib/core/src/lib/identity-user-info/identity-user-info.component.scss
+++ b/lib/core/src/lib/identity-user-info/identity-user-info.component.scss
@@ -1,3 +1,5 @@
+@import '../styles/flex';
+
 .adf {
     &-userinfo-container {
         display: flex;
@@ -11,8 +13,7 @@
 
     &-userinfo-name {
         padding: 0 5px;
-
-        @media screen and (max-width: 959px) {
+        @include layout-bp(lt-md) {
             display: none;
         }
     }
@@ -78,7 +79,7 @@
         display: flex;
         flex-direction: column;
 
-        @media screen and (max-width: 599px) {
+        @include layout-bp(lt-sm) {
             padding: 10px;
         }
     }

--- a/lib/core/src/lib/layout/components/header/header.component.scss
+++ b/lib/core/src/lib/layout/components/header/header.component.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/_flex.scss';
+@import '../../../styles/flex';
 
 adf-layout-header .mat-toolbar-single-row {
     color: var(--theme-header-text-color) !important;

--- a/lib/core/src/lib/layout/components/header/header.component.scss
+++ b/lib/core/src/lib/layout/components/header/header.component.scss
@@ -52,7 +52,7 @@ adf-layout-header .mat-toolbar-single-row {
         padding: 0;
     }
 
-    @include layout-bp(sm) {
+    @include layout-bp(lt-sm) {
         .adf-app-logo,
         .adf-app-title {
             display: none;

--- a/lib/core/src/lib/layout/components/header/header.component.scss
+++ b/lib/core/src/lib/layout/components/header/header.component.scss
@@ -1,3 +1,5 @@
+@import '../../../styles/_flex.scss';
+
 adf-layout-header .mat-toolbar-single-row {
     color: var(--theme-header-text-color) !important;
     background-color: var(--theme-primary-color);
@@ -50,7 +52,7 @@ adf-layout-header .mat-toolbar-single-row {
         padding: 0;
     }
 
-    @media screen and (max-width: 599px) {
+    @include layout-bp(sm) {
         .adf-app-logo,
         .adf-app-title {
             display: none;

--- a/lib/core/src/lib/layout/components/header/header.component.scss
+++ b/lib/core/src/lib/layout/components/header/header.component.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/flex';
+@import 'styles/flex';
 
 adf-layout-header .mat-toolbar-single-row {
     color: var(--theme-header-text-color) !important;

--- a/lib/core/src/lib/styles/_default-class.scss
+++ b/lib/core/src/lib/styles/_default-class.scss
@@ -1,4 +1,4 @@
-@import 'styles/flex';
+@import './flex';
 
 .adf-hide-small {
     @include layout-bp(lt-md) {

--- a/lib/core/src/lib/styles/_default-class.scss
+++ b/lib/core/src/lib/styles/_default-class.scss
@@ -1,4 +1,4 @@
-@import '../styles/flex';
+@import 'styles/flex';
 
 .adf-hide-small {
     @include layout-bp(lt-md) {

--- a/lib/core/src/lib/styles/_default-class.scss
+++ b/lib/core/src/lib/styles/_default-class.scss
@@ -1,11 +1,13 @@
+@import '../styles/flex';
+
 .adf-hide-small {
-    @media screen and (max-width: 959px) {
+    @include layout-bp(lt-md) {
         display: none !important;
     }
 }
 
 .adf-hide-xsmall {
-    @media screen and (max-width: 599px) {
+    @include layout-bp(lt-sm) {
         display: none !important;
     }
 }

--- a/lib/core/src/lib/templates/error-content/error-content.component.scss
+++ b/lib/core/src/lib/templates/error-content/error-content.component.scss
@@ -1,3 +1,5 @@
+@import '../../styles/flex';
+
 .adf-error-content {
     color: var(--adf-theme-foreground-text-color-054);
     display: flex;
@@ -30,5 +32,28 @@
         width: 50%;
         min-width: 250px;
         margin-bottom: 60px;
+        line-height: 30px;
+    }
+}
+
+@include layout-bp(lt-md) {
+    .adf-error-content {
+        &-code {
+            margin-top: 100px;
+            font-size: 50px;
+            margin-bottom: 25px;
+        }
+
+        &-shadow {
+            width: 100px;
+        }
+
+        &-title {
+            font-size: var(--theme-headline-font-size);
+        }
+
+        &-description {
+            font-size: var(--theme-subheading-2-font-size);
+        }
     }
 }

--- a/lib/core/src/lib/templates/error-content/error-content.component.scss
+++ b/lib/core/src/lib/templates/error-content/error-content.component.scss
@@ -1,4 +1,4 @@
-@import '../../styles/flex';
+@import 'styles/flex';
 
 .adf-error-content {
     color: var(--adf-theme-foreground-text-color-054);

--- a/lib/extensions/ng-package.json
+++ b/lib/extensions/ng-package.json
@@ -6,7 +6,7 @@
     "entryFile": "src/public-api.ts",
     "flatModuleFile": "adf-extensions",
     "styleIncludePaths": [
-      "../../dist/libs/core/src/lib"
+      "../core/src/lib"
     ]
   }
 }

--- a/lib/extensions/ng-package.json
+++ b/lib/extensions/ng-package.json
@@ -4,6 +4,9 @@
   "deleteDestPath": false,
   "lib": {
     "entryFile": "src/public-api.ts",
-    "flatModuleFile": "adf-extensions"
+    "flatModuleFile": "adf-extensions",
+    "styleIncludePaths": [
+      "../../dist/libs/core/src/lib"
+    ]
   }
 }

--- a/lib/insights/ng-package.json
+++ b/lib/insights/ng-package.json
@@ -15,6 +15,9 @@
   ],
   "lib": {
     "entryFile": "src/public-api.ts",
-    "flatModuleFile": "adf-insights"
+    "flatModuleFile": "adf-insights",
+    "styleIncludePaths": [
+      "../../dist/libs/core/lib"
+    ]
   }
 }

--- a/lib/insights/ng-package.json
+++ b/lib/insights/ng-package.json
@@ -17,7 +17,7 @@
     "entryFile": "src/public-api.ts",
     "flatModuleFile": "adf-insights",
     "styleIncludePaths": [
-      "../../dist/libs/core/lib"
+      "../core/src/lib"
     ]
   }
 }

--- a/lib/process-services-cloud/ng-package.json
+++ b/lib/process-services-cloud/ng-package.json
@@ -23,7 +23,7 @@
     "entryFile": "src/public-api.ts",
     "flatModuleFile": "adf-process-services-cloud",
     "styleIncludePaths": [
-      "../../dist/libs/core/lib"
+      "../core/src/lib"
     ]
   },
   "allowedNonPeerDependencies": [

--- a/lib/process-services-cloud/ng-package.json
+++ b/lib/process-services-cloud/ng-package.json
@@ -21,7 +21,10 @@
 
   "lib": {
     "entryFile": "src/public-api.ts",
-    "flatModuleFile": "adf-process-services-cloud"
+    "flatModuleFile": "adf-process-services-cloud",
+    "styleIncludePaths": [
+      "../../dist/libs/core/lib"
+    ]
   },
   "allowedNonPeerDependencies": [
     "@apollo/client",

--- a/lib/process-services-cloud/src/lib/app/components/app-list-cloud.component.scss
+++ b/lib/process-services-cloud/src/lib/app/components/app-list-cloud.component.scss
@@ -1,3 +1,5 @@
+@import '../../../../../core/src/lib/styles/flex';
+
 adf-cloud-app-list {
     width: 100%;
 
@@ -27,11 +29,11 @@ adf-cloud-app-list {
             flex: 1 1 100%;
             max-width: 33.3333%;
 
-            @media screen and (max-width: 960px) {
+            @include layout-bp(lt-md){
                 max-width: 50%;
             }
 
-            @media screen and (max-width: 600px) {
+            @include layout-bp(lt-sm) {
                 max-width: 100%;
             }
         }

--- a/lib/process-services-cloud/src/lib/app/components/app-list-cloud.component.scss
+++ b/lib/process-services-cloud/src/lib/app/components/app-list-cloud.component.scss
@@ -29,7 +29,7 @@ adf-cloud-app-list {
             flex: 1 1 100%;
             max-width: 33.3333%;
 
-            @include layout-bp(lt-md){
+            @include layout-bp(lt-md) {
                 max-width: 50%;
             }
 

--- a/lib/process-services-cloud/src/lib/app/components/app-list-cloud.component.scss
+++ b/lib/process-services-cloud/src/lib/app/components/app-list-cloud.component.scss
@@ -1,4 +1,4 @@
-@import '../../../../../core/src/lib/styles/flex';
+@import 'styles/flex';
 
 adf-cloud-app-list {
     width: 100%;

--- a/lib/process-services-cloud/src/lib/process/process-filters/components/edit-process-filter-cloud.component.scss
+++ b/lib/process-services-cloud/src/lib/process/process-filters/components/edit-process-filter-cloud.component.scss
@@ -1,3 +1,5 @@
+@import '../../../../../../core/src/lib/styles/flex';
+
 .adf-edit-process-filter-date-error-container {
     position: absolute;
     height: 20px;
@@ -48,7 +50,7 @@
             max-width: 23%;
         }
 
-        @media screen and (max-width: 600px) {
+        @include layout-bp(lt-sm) {
             flex-flow: column;
 
             :not(:last-child) {

--- a/lib/process-services-cloud/src/lib/process/process-filters/components/edit-process-filter-cloud.component.scss
+++ b/lib/process-services-cloud/src/lib/process/process-filters/components/edit-process-filter-cloud.component.scss
@@ -1,4 +1,4 @@
-@import '../../../../../../core/src/lib/styles/flex';
+@import 'styles/flex';
 
 .adf-edit-process-filter-date-error-container {
     position: absolute;

--- a/lib/process-services-cloud/src/lib/task/start-task/components/start-task-cloud.component.scss
+++ b/lib/process-services-cloud/src/lib/task/start-task/components/start-task-cloud.component.scss
@@ -1,3 +1,5 @@
+@import '../../../../../../core/src/lib/styles/flex';
+
 .adf-cloud-start-task-heading {
     border-bottom: 1px solid var(--adf-theme-foreground-divider-color);
     margin-bottom: 10px;
@@ -83,7 +85,7 @@ adf-cloud-start-task {
                 }
             }
 
-            @media screen and (max-width: 960px) {
+            @include layout-bp(lt-md) {
                 flex-direction: column;
 
                 mat-form-field,

--- a/lib/process-services-cloud/src/lib/task/start-task/components/start-task-cloud.component.scss
+++ b/lib/process-services-cloud/src/lib/task/start-task/components/start-task-cloud.component.scss
@@ -1,4 +1,4 @@
-@import '../../../../../../core/src/lib/styles/flex';
+@import 'styles/flex';
 
 .adf-cloud-start-task-heading {
     border-bottom: 1px solid var(--adf-theme-foreground-divider-color);

--- a/lib/process-services-cloud/src/lib/task/task-filters/components/edit-task-filters/base-edit-task-filter-cloud.component.scss
+++ b/lib/process-services-cloud/src/lib/task/task-filters/components/edit-task-filters/base-edit-task-filter-cloud.component.scss
@@ -1,4 +1,4 @@
-@import '../../../../../../../core/src/lib/styles/flex';
+@import 'styles/flex';
 
 .adf-edit-task-filter-checkbox {
     font-size: var(--theme-subheading-2-font-size);

--- a/lib/process-services-cloud/src/lib/task/task-filters/components/edit-task-filters/base-edit-task-filter-cloud.component.scss
+++ b/lib/process-services-cloud/src/lib/task/task-filters/components/edit-task-filters/base-edit-task-filter-cloud.component.scss
@@ -1,3 +1,5 @@
+@import '../../../../../../../core/src/lib/styles/flex';
+
 .adf-edit-task-filter-checkbox {
     font-size: var(--theme-subheading-2-font-size);
     padding-top: 10px;
@@ -58,7 +60,7 @@
             flex: 1 1 23%;
         }
 
-        @media screen and (max-width: 600px) {
+        @include layout-bp(lt-sm) {
             flex-flow: column;
 
             :not(:last-child) {

--- a/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.scss
+++ b/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.scss
@@ -1,3 +1,5 @@
+@import '../../../../../../core/src/lib/styles/flex';
+
 .adf {
     &-controls {
         display: flex;
@@ -26,7 +28,7 @@
     }
 }
 
-@media screen and (max-width: 959px) {
+@include layout-bp(lt-md) {
     adf-card-view .adf-property-value {
         text-overflow: ellipsis;
         overflow: hidden;

--- a/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.scss
+++ b/lib/process-services-cloud/src/lib/task/task-header/components/task-header-cloud.component.scss
@@ -1,4 +1,4 @@
-@import '../../../../../../core/src/lib/styles/flex';
+@import 'styles/flex';
 
 .adf {
     &-controls {

--- a/lib/process-services/ng-package.json
+++ b/lib/process-services/ng-package.json
@@ -22,7 +22,7 @@
     "entryFile": "src/public-api.ts",
     "flatModuleFile": "adf-process-services",
     "styleIncludePaths": [
-      "../../dist/libs/core/lib"
+      "../core/src/lib"
     ]
   }
 }

--- a/lib/process-services/ng-package.json
+++ b/lib/process-services/ng-package.json
@@ -20,6 +20,9 @@
   ],
   "lib": {
     "entryFile": "src/public-api.ts",
-    "flatModuleFile": "adf-process-services"
+    "flatModuleFile": "adf-process-services",
+    "styleIncludePaths": [
+      "../../dist/libs/core/lib"
+    ]
   }
 }

--- a/lib/process-services/src/lib/app-list/apps-list.component.scss
+++ b/lib/process-services/src/lib/app-list/apps-list.component.scss
@@ -1,4 +1,4 @@
-@import '../../../../core/src/lib/styles/flex';
+@import 'styles/flex';
 
 /* stylelint-disable scss/no-global-function-names */
 @mixin adf-line-clamp($line-height: 1.25, $lines: 3) {

--- a/lib/process-services/src/lib/app-list/apps-list.component.scss
+++ b/lib/process-services/src/lib/app-list/apps-list.component.scss
@@ -1,3 +1,5 @@
+@import '../../../../core/src/lib/styles/flex';
+
 /* stylelint-disable scss/no-global-function-names */
 @mixin adf-line-clamp($line-height: 1.25, $lines: 3) {
     position: relative;
@@ -66,12 +68,12 @@ $tile-themes: (
             flex: 1 1 33.3333%;
             max-width: 33.3333%;
 
-            @media screen and (max-width: 960px) {
+            @include layout-bp(lt-md) {
                 flex: 1 1 50%;
                 max-width: 50%;
             }
 
-            @media screen and (max-width: 600px) {
+            @include layout-bp(lt-sm) {
                 flex: 1 1 100%;
                 max-width: 100%;
             }

--- a/lib/process-services/src/lib/attachment/process-attachment-list.component.scss
+++ b/lib/process-services/src/lib/attachment/process-attachment-list.component.scss
@@ -1,4 +1,4 @@
-@import '../../../../core/src/lib/styles';
+@import 'styles/flex';
 
 .adf-data-cell {
     cursor: pointer !important;

--- a/lib/process-services/src/lib/attachment/process-attachment-list.component.scss
+++ b/lib/process-services/src/lib/attachment/process-attachment-list.component.scss
@@ -1,3 +1,5 @@
+@import '../../../../core/src/lib/styles';
+
 .adf-data-cell {
     cursor: pointer !important;
 }
@@ -43,7 +45,7 @@
     object-fit: contain;
     margin-top: 17px;
 
-    @media screen and (max-width: 599px) {
+    @include layout-bp(lt-sm) {
         width: 250px;
     }
 }

--- a/lib/process-services/src/lib/attachment/task-attachment-list.component.scss
+++ b/lib/process-services/src/lib/attachment/task-attachment-list.component.scss
@@ -1,4 +1,4 @@
-@import '../../../../core/src/lib/styles/flex';
+@import 'styles/flex';
 
 adf-datatable .adf-data-cell {
     cursor: pointer !important;

--- a/lib/process-services/src/lib/attachment/task-attachment-list.component.scss
+++ b/lib/process-services/src/lib/attachment/task-attachment-list.component.scss
@@ -1,3 +1,5 @@
+@import '../../../../core/src/lib/styles/flex';
+
 adf-datatable .adf-data-cell {
     cursor: pointer !important;
 }
@@ -25,7 +27,7 @@ adf-datatable .adf-data-cell {
     word-break: break-all;
     white-space: pre-line;
 
-    @media screen and (max-width: 599px) {
+    @include layout-bp(lt-sm) {
         font-size: 40px;
     }
 }
@@ -48,7 +50,7 @@ adf-datatable .adf-data-cell {
     object-fit: contain;
     margin-top: 17px;
 
-    @media screen and (max-width: 599px) {
+    @include layout-bp(lt-sm) {
         width: 250px;
     }
 }

--- a/lib/process-services/src/lib/form/widgets/content-widget/attach-file-widget.component.scss
+++ b/lib/process-services/src/lib/form/widgets/content-widget/attach-file-widget.component.scss
@@ -1,3 +1,5 @@
+@import '../../../../../../core/src/lib/styles/flex';
+
 .adf {
     &-attach-widget-container {
         margin-bottom: 15px;
@@ -72,7 +74,7 @@
             max-width: 200px;
         }
 
-        @media screen and (max-width: 959px) {
+        @include layout-bp(lt-md) {
             .mat-list-text {
                 max-width: 150px;
             }

--- a/lib/process-services/src/lib/form/widgets/content-widget/attach-file-widget.component.scss
+++ b/lib/process-services/src/lib/form/widgets/content-widget/attach-file-widget.component.scss
@@ -1,4 +1,4 @@
-@import '../../../../../../core/src/lib/styles/flex';
+@import 'styles/flex';
 
 .adf {
     &-attach-widget-container {

--- a/lib/process-services/src/lib/process-list/components/start-process.component.scss
+++ b/lib/process-services/src/lib/process-list/components/start-process.component.scss
@@ -1,4 +1,4 @@
-@import '../../../../../core/src/lib/styles/flex';
+@import 'styles/flex';
 
 .adf {
     &-start-process {

--- a/lib/process-services/src/lib/process-list/components/start-process.component.scss
+++ b/lib/process-services/src/lib/process-list/components/start-process.component.scss
@@ -1,3 +1,5 @@
+@import '../../../../../core/src/lib/styles/flex';
+
 .adf {
     &-start-process {
         width: 96%;
@@ -71,7 +73,7 @@
     }
 }
 
-@media (max-width: 600px) {
+@include layout-bp(lt-sm) {
     .adf-start-process {
         width: 90%;
         margin-left: auto;

--- a/lib/process-services/src/lib/process-user-info/process-user-info.component.scss
+++ b/lib/process-services/src/lib/process-user-info/process-user-info.component.scss
@@ -1,3 +1,5 @@
+@import '../../../../core/src/lib/styles/flex';
+
 .adf {
     &-userinfo-container {
         display: flex;
@@ -12,7 +14,7 @@
     &-userinfo-name {
         padding: 0 5px;
 
-        @media screen and (max-width: 959px) {
+        @include layout-bp(lt-md) {
             display: none;
         }
     }
@@ -90,7 +92,7 @@
         display: flex;
         justify-content: space-between;
 
-        @media screen and (max-width: 599px) {
+        @include layout-bp(lt-sm) {
             padding: 10px;
         }
     }

--- a/lib/process-services/src/lib/process-user-info/process-user-info.component.scss
+++ b/lib/process-services/src/lib/process-user-info/process-user-info.component.scss
@@ -1,4 +1,4 @@
-@import '../../../../core/src/lib/styles/flex';
+@import 'styles/flex';
 
 .adf {
     &-userinfo-container {

--- a/lib/process-services/src/lib/task-list/components/start-task.component.scss
+++ b/lib/process-services/src/lib/task-list/components/start-task.component.scss
@@ -1,3 +1,5 @@
+@import '../../../../../core/src/lib/styles/flex';
+
 /* stylelint-disable no-descending-specificity */
 .adf-new-task-heading {
     padding-top: 12px;
@@ -28,11 +30,11 @@
         }
 
         .input-row {
-            @media screen and (max-width: 960px){
+            @include layout-bp(lt-md) {
                 flex-direction: column;
             }
 
-            @media screen and (min-width: 960px) {
+            @include layout-bp(lt-md) {
                 mat-form-field {
                     margin-right: 20px;
                 }
@@ -44,7 +46,7 @@
             box-sizing: border-box;
             max-width: 48%;
 
-            @media screen and (max-width: 600px){
+            @include layout-bp(lt-sm) {
                 max-width: 100%;
             }
         }

--- a/lib/process-services/src/lib/task-list/components/start-task.component.scss
+++ b/lib/process-services/src/lib/task-list/components/start-task.component.scss
@@ -1,4 +1,4 @@
-@import '../../../../../core/src/lib/styles/flex';
+@import 'styles/flex';
 
 /* stylelint-disable no-descending-specificity */
 .adf-new-task-heading {

--- a/lib/process-services/src/lib/task-list/components/task-details.component.scss
+++ b/lib/process-services/src/lib/task-list/components/task-details.component.scss
@@ -1,3 +1,5 @@
+@import '../../../../../core/src/lib/styles/flex';
+
 adf-task-details {
     width: 100%;
 
@@ -52,7 +54,7 @@ adf-task-details {
 
             &-sidebar {
                 &-drawer {
-                    @media screen and (max-width: 1279px) {
+                    @include layout-bp(lt-lg) {
                         margin-left: 0;
                     }
                 }

--- a/lib/process-services/src/lib/task-list/components/task-details.component.scss
+++ b/lib/process-services/src/lib/task-list/components/task-details.component.scss
@@ -1,4 +1,4 @@
-@import '../../../../../core/src/lib/styles/flex';
+@import 'styles/flex';
 
 adf-task-details {
     width: 100%;

--- a/lib/process-services/src/lib/task-list/components/task-header.component.scss
+++ b/lib/process-services/src/lib/task-list/components/task-header.component.scss
@@ -1,4 +1,4 @@
-@import '../../../../../core/src/lib/styles/flex';
+@import 'styles/flex';
 
 .adf {
     &-controls {

--- a/lib/process-services/src/lib/task-list/components/task-header.component.scss
+++ b/lib/process-services/src/lib/task-list/components/task-header.component.scss
@@ -1,3 +1,5 @@
+@import '../../../../../core/src/lib/styles/flex';
+
 .adf {
     &-controls {
         display: flex;
@@ -25,7 +27,7 @@
     }
 }
 
-@media screen and  (max-width: 959px) {
+@include layout-bp(lt-md) {
     adf-card-view .adf-property-value {
         text-overflow: ellipsis;
         overflow: hidden;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://alfresco.atlassian.net/browse/AAE-16369

**What is the new behaviour?**

Replaced `@media` rules where it was possible with `@mixin layout-bp` where it was possible to encourage the use of global variables for responsive breakpoints.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
