### PR TITLE
[MNT-23648] Clicking on Load More button no longer causes scroll position to reset to top

### DIFF
--- a/lib/content-services/src/lib/document-list/components/document-list.component.spec.ts
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.spec.ts
@@ -1427,6 +1427,31 @@ describe('DocumentList', () => {
         expect(documentList.reload).toHaveBeenCalled();
     });
 
+    it('should not show loading state if pagination is updated with merge setting as true', fakeAsync (() => {
+        spyFolderNode = spyOn(documentListService, 'loadFolderByNodeId').and.callFake(() =>
+            of(new DocumentLoaderNode(null, {
+                list: {
+                    pagination: {},
+                    entries: mockPreselectedNodes
+                }
+            }))
+        );
+        fixture.detectChanges();
+        const fakeDatatableRows = [
+            new ShareDataRow(mockPreselectedNodes[0], contentService, null),
+            new ShareDataRow(mockPreselectedNodes[1], contentService, null)
+        ];
+        documentList.data.setRows(fakeDatatableRows);
+        documentList.updatePagination({
+            maxItems: 10,
+            skipCount: 0,
+            merge: true
+        });
+        fixture.detectChanges();
+
+        expect(element.querySelector('#adf-document-list-loading')).toBe(null);
+    }));
+
     it('should NOT reload data on first call of ngOnChanges', () => {
         spyOn(documentList, 'reload').and.stub();
 

--- a/lib/content-services/src/lib/document-list/components/document-list.component.ts
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.ts
@@ -550,12 +550,12 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
         }
     }
 
-    reload() {
+    reload(hideLoadingSpinner = false) {
         this.resetSelection();
-        this.reloadWithoutResettingSelection();
+        this.reloadWithoutResettingSelection(hideLoadingSpinner);
     }
 
-    reloadWithoutResettingSelection() {
+    reloadWithoutResettingSelection(hideLoadingSpinner = false) {
         if (this.node) {
             if (this.data) {
                 this.data.loadPage(this.node, this._pagination.merge, null);
@@ -565,7 +565,7 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
             this.syncPagination();
             this.onDataReady(this.node);
         } else {
-            this.loadFolder();
+            this.loadFolder(hideLoadingSpinner);
         }
     }
 
@@ -713,8 +713,8 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
         }
     }
 
-    loadFolder() {
-        if (!this._pagination.merge) {
+    loadFolder(hideLoadingSpinner = false) {
+        if (!hideLoadingSpinner) {
             this.setLoadingState(true);
         }
 
@@ -944,9 +944,8 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
 
     updatePagination(requestPaginationModel: RequestPaginationModel) {
         this._pagination.maxItems = requestPaginationModel.maxItems;
-        this._pagination.merge = requestPaginationModel.merge;
         this._pagination.skipCount = requestPaginationModel.skipCount;
-        this.reload();
+        this.reload(requestPaginationModel.merge);
     }
 
     private syncPagination() {

--- a/lib/content-services/src/lib/document-list/components/document-list.component.ts
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.ts
@@ -565,7 +565,7 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
             this.syncPagination();
             this.onDataReady(this.node);
         } else {
-            this.loadFolder(true);
+            this.loadFolder();
         }
     }
 
@@ -713,8 +713,8 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
         }
     }
 
-    loadFolder(hideLoadingSpinner = false) {
-        if (!hideLoadingSpinner) {
+    loadFolder() {
+        if (!this._pagination.merge) {
             this.setLoadingState(true);
         }
 

--- a/lib/content-services/src/lib/document-list/components/document-list.component.ts
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.ts
@@ -565,7 +565,7 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
             this.syncPagination();
             this.onDataReady(this.node);
         } else {
-            this.loadFolder();
+            this.loadFolder(true);
         }
     }
 
@@ -713,8 +713,8 @@ export class DocumentListComponent implements OnInit, OnChanges, OnDestroy, Afte
         }
     }
 
-    loadFolder() {
-        if (!this._pagination.merge) {
+    loadFolder(hideLoadingSpinner = false) {
+        if (!hideLoadingSpinner) {
             this.setLoadingState(true);
         }
 

--- a/lib/core/src/lib/pagination/infinite-pagination.component.spec.ts
+++ b/lib/core/src/lib/pagination/infinite-pagination.component.spec.ts
@@ -174,7 +174,7 @@ describe('InfinitePaginationComponent', () => {
             loadMoreButton.triggerEventHandler('click', {});
         });
 
-        it('should trigger the loadMore event with merge false to reload all the elements', (done) => {
+        it('should trigger the loadMore event with merge true to reload all the elements', (done) => {
             pagination = {maxItems: 444, skipCount: 25, totalItems: 55, hasMoreItems: true};
 
             component.target.pagination.next(pagination);
@@ -184,7 +184,7 @@ describe('InfinitePaginationComponent', () => {
             changeDetectorRef.detectChanges();
 
             component.loadMore.subscribe((newPagination: RequestPaginationModel) => {
-                expect(newPagination.merge).toBe(false);
+                expect(newPagination.merge).toBe(true);
                 done();
             });
 
@@ -222,7 +222,7 @@ describe('InfinitePaginationComponent', () => {
                 skipCount: 0,
                 maxItems: 50,
                 hasMoreItems: false,
-                merge: false
+                merge: true
             });
         });
 
@@ -237,7 +237,7 @@ describe('InfinitePaginationComponent', () => {
                 maxItems: 14,
                 skipCount: 0,
                 hasMoreItems: false,
-                merge: false
+                merge: true
             });
         });
 

--- a/lib/core/src/lib/pagination/infinite-pagination.component.ts
+++ b/lib/core/src/lib/pagination/infinite-pagination.component.ts
@@ -109,7 +109,7 @@ export class InfinitePaginationComponent implements OnInit, OnDestroy, Paginatio
 
     onLoadMore() {
         this.requestPaginationModel.skipCount = 0;
-        this.requestPaginationModel.merge = false;
+        this.requestPaginationModel.merge = true;
 
         this.requestPaginationModel.maxItems += this.pageSize;
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Clicking on load more on the copy/move file/folder dialog would refresh the list and scroll to top


**What is the new behaviour?**
Clicking on load more adds new items to the bottom of the list, and maintains the scroll position


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
