### PR TITLE
[ACS-6002] Add permissions displaying Site Permissions outside of Sites

### DIFF
--- a/lib/content-services/src/lib/mock/permission-list.component.mock.ts
+++ b/lib/content-services/src/lib/mock/permission-list.component.mock.ts
@@ -258,6 +258,83 @@ export const fakeReadOnlyNodeInherited = {
     }
 };
 
+export const fakeNodeWithoutSite: any = {
+    aspectNames: [
+        'cm:auditable',
+        'cm:taggable',
+        'cm:author',
+        'cm:titled',
+        'app:uifacets'
+    ],
+    createdAt: '2017-11-16T16:29:38.638+0000',
+    path: {
+        name: '/Company Home/User Homes/user/documentLibrary',
+        isComplete: true,
+        elements: [
+            {
+                id: '2be275a1-b00d-4e45-83d8-66af43ac2252',
+                name: 'Company Home',
+                nodeType: 'cm:folder'
+            },
+            {
+                id: '1be10a97-6eb9-4b60-b6c6-1673900e9631',
+                name: 'User Homes',
+                nodeType: 'cm:folder'
+            },
+            {
+                id: 'e002c740-b8f9-482a-a554-8fff4e4c9dc0',
+                name: 'user',
+                nodeType: 'cm:folder'
+            },
+            {
+                id: '71626fae-0c04-4d0c-a129-20fa4c178716',
+                name: 'documentLibrary',
+                nodeType: 'cm:folder'
+            }
+        ]
+    },
+    isFolder: true,
+    isFile: false,
+    createdByUser: {
+        id: 'System',
+        displayName: 'System'
+    },
+    modifiedAt: '2018-03-21T03:17:58.783+0000',
+    permissions: {
+        locallySet: [
+            {
+                authorityId: 'GROUP_EVERYONE',
+                name: 'Contributor',
+                accessStatus: 'ALLOWED'
+            }
+        ],
+        settable: [
+            'Contributor',
+            'Collaborator',
+            'Coordinator',
+            'Editor',
+            'Consumer'
+        ],
+        isInheritanceEnabled: false
+    },
+    modifiedByUser: {
+        id: 'admin',
+        displayName: 'PedroH Hernandez'
+    },
+    name: 'test',
+    id: 'f472543f-7218-403d-917b-7a5861257244',
+    nodeType: 'cm:folder',
+    properties: {
+        'cm:title': 'test',
+        'cm:author': 'yagud',
+        'cm:taggable': [
+            'e8c8fbba-03ba-4fa6-86b1-f7ad7c296409'
+        ],
+        'cm:description': 'sleepery',
+        'app:icon': 'space-icon-default'
+    }
+};
+
 export const fakeNodeWithOnlyLocally: any = {
     aspectNames: [
         'cm:auditable',
@@ -273,19 +350,23 @@ export const fakeNodeWithOnlyLocally: any = {
         elements: [
           {
             id: '2be275a1-b00d-4e45-83d8-66af43ac2252',
-            name: 'Company Home'
+            name: 'Company Home',
+            nodeType: 'cm:folder'
           },
           {
             id: '1be10a97-6eb9-4b60-b6c6-1673900e9631',
-            name: 'Sites'
+            name: 'Sites',
+            nodeType: 'st:sites'
           },
           {
             id: 'e002c740-b8f9-482a-a554-8fff4e4c9dc0',
-            name: 'testsite'
+            name: 'testsite',
+            nodeType: 'st:site'
           },
           {
             id: '71626fae-0c04-4d0c-a129-20fa4c178716',
-            name: 'documentLibrary'
+            name: 'documentLibrary',
+            nodeType: 'cm:folder'
           }
         ]
     },

--- a/lib/content-services/src/lib/permission-manager/services/node-permission.service.spec.ts
+++ b/lib/content-services/src/lib/permission-manager/services/node-permission.service.spec.ts
@@ -20,8 +20,10 @@ import { NodePermissionService } from './node-permission.service';
 import { SearchService } from '../../search/services/search.service';
 import { Node, PermissionElement } from '@alfresco/js-api';
 import { of, throwError } from 'rxjs';
-import { fakeEmptyResponse, fakeNodeWithOnlyLocally, fakeSiteRoles, fakeSiteNodeResponse,
-         fakeNodeToRemovePermission, fakeNodeWithoutPermissions } from '../../mock/permission-list.component.mock';
+import {
+    fakeNodeWithOnlyLocally, fakeSiteRoles, fakeSiteNodeResponse,
+    fakeNodeToRemovePermission, fakeNodeWithoutPermissions, fakeNodeWithoutSite
+} from '../../mock/permission-list.component.mock';
 import { fakeAuthorityResults } from '../../mock/add-permission.component.mock';
 import { ContentTestingModule } from '../../testing/content.testing.module';
 import { TranslateModule } from '@ngx-translate/core';
@@ -79,10 +81,11 @@ describe('NodePermissionService', () => {
         });
     });
 
-    it('should return a list of settable if node has no site', (done) => {
-        spyOn(searchApiService, 'searchByQueryBody').and.returnValue(of(fakeEmptyResponse));
+    it('should not call search api and return a list of settable if node has no site', (done) => {
+        spyOn(searchApiService, 'searchByQueryBody');
 
-        service.getNodeRoles(fakeNodeWithOnlyLocally).subscribe((roleArray: string[]) => {
+        service.getNodeRoles(fakeNodeWithoutSite).subscribe((roleArray: string[]) => {
+            expect(searchApiService.searchByQueryBody).not.toHaveBeenCalled();
             expect(roleArray).not.toBeNull();
             expect(roleArray.length).toBe(5);
             expect(roleArray[0]).toBe('Contributor');

--- a/lib/content-services/src/lib/permission-manager/services/node-permission.service.ts
+++ b/lib/content-services/src/lib/permission-manager/services/node-permission.service.ts
@@ -50,17 +50,16 @@ export class NodePermissionService {
      * @returns Array of strings representing the roles
      */
     getNodeRoles(node: Node): Observable<string[]> {
-        const searchRequest = this.buildRetrieveSiteQueryBody(node.path.elements);
-        return this.searchApiService.searchByQueryBody(searchRequest).pipe(
-            switchMap((siteNodeList: any) => {
-                if (siteNodeList.list.entries.length > 0) {
+        if (node.path.elements.some(el => (el.nodeType === 'st:site' || el.nodeType === 'st:sites'))) {
+            const searchRequest = this.buildRetrieveSiteQueryBody(node.path.elements);
+            return this.searchApiService.searchByQueryBody(searchRequest).pipe(
+                switchMap((siteNodeList: any) => {
                     const siteName = siteNodeList.list.entries[0].entry.name;
                     return this.getGroupMembersBySiteName(siteName);
-                } else {
-                    return of(node.permissions?.settable);
-                }
-            })
-        );
+                }));
+        } else {
+            return of(node.permissions?.settable);
+        }
     }
 
     /**

--- a/lib/content-services/src/lib/permission-manager/services/node-permission.service.ts
+++ b/lib/content-services/src/lib/permission-manager/services/node-permission.service.ts
@@ -18,7 +18,17 @@
 import { AlfrescoApiService, TranslationService } from '@alfresco/adf-core';
 import { NodesApiService } from '../../common/services/nodes-api.service';
 import { EcmUserModel } from '../../common/models/ecm-user.model';
-import { Group, GroupMemberEntry, GroupMemberPaging, GroupsApi, Node, PathElement, PermissionElement, SearchRequest } from '@alfresco/js-api';
+import {
+    Group,
+    GroupMemberEntry,
+    GroupMemberPaging,
+    GroupsApi,
+    Node,
+    PathElement,
+    PermissionElement,
+    ResultSetPaging,
+    SearchRequest
+} from '@alfresco/js-api';
 import { SearchService } from '../../search/services/search.service';
 import { Injectable } from '@angular/core';
 import { forkJoin, from, Observable, of, throwError } from 'rxjs';
@@ -53,7 +63,7 @@ export class NodePermissionService {
         if (node.path.elements.some(el => (el.nodeType === 'st:site' || el.nodeType === 'st:sites'))) {
             const searchRequest = this.buildRetrieveSiteQueryBody(node.path.elements);
             return this.searchApiService.searchByQueryBody(searchRequest).pipe(
-                switchMap((siteNodeList: any) => {
+                switchMap((siteNodeList: ResultSetPaging) => {
                     const siteName = siteNodeList.list.entries[0].entry.name;
                     return this.getGroupMembersBySiteName(siteName);
                 }));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

When a user creates a folder with the same name as a site, the wrong permissions are applied.

**What is the new behaviour?**

The node is checked for the presence of the site before executing the search query.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://alfresco.atlassian.net/browse/ACS-6002
closes [#3411](https://github.com/Alfresco/alfresco-content-app/issues/3411)