### PR TITLE
[ACS-5878] Updated ProcessService to use custom date-fns methods

### DIFF
--- a/lib/process-services/src/lib/process-list/services/process.service.spec.ts
+++ b/lib/process-services/src/lib/process-list/services/process.service.spec.ts
@@ -20,9 +20,8 @@ import { exampleProcess, mockError, fakeProcessDef, fakeTasksList } from '../../
 import { ProcessFilterParamRepresentationModel } from '../models/filter-process.model';
 import { ProcessInstanceVariable } from '../models/process-instance-variable.model';
 import { ProcessService } from './process.service';
-import { CoreModule } from '@alfresco/adf-core';
+import { CoreModule, DateFnsUtils } from '@alfresco/adf-core';
 import { ProcessTestingModule } from '../../testing/process.testing.module';
-import { format } from 'date-fns';
 
 describe('ProcessService', () => {
     let service: ProcessService;
@@ -288,7 +287,7 @@ describe('ProcessService', () => {
                 const task = tasks[0];
                 expect(task.id).toBe(fakeTasks[0].id);
                 expect(task.name).toBe(fakeTasks[0].name);
-                expect(task.created).toEqual(format(new Date('2016-11-10T00:00:00+00:00'), 'yyyy-MM-dd'));
+                expect(task.created).toEqual(DateFnsUtils.formatDate(new Date('2016-11-10T00:00:00+00:00'), 'YYYY-MM-DD'));
                 done();
             });
         });

--- a/lib/process-services/src/lib/process-list/services/process.service.ts
+++ b/lib/process-services/src/lib/process-list/services/process.service.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { AlfrescoApiService, FormValues } from '@alfresco/adf-core';
+import { AlfrescoApiService, DateFnsUtils, FormValues } from '@alfresco/adf-core';
 import { Injectable } from '@angular/core';
 import {
     TasksApi,
@@ -34,7 +34,6 @@ import { ProcessInstance } from '../models/process-instance.model';
 import { ProcessListModel } from '../models/process-list.model';
 import { map, catchError } from 'rxjs/operators';
 import { DatePipe } from '@angular/common';
-import { format } from 'date-fns';
 
 @Injectable({
     providedIn: 'root'
@@ -213,7 +212,7 @@ export class ProcessService {
             .pipe(
                 map(this.extractData),
                 map((tasks) => tasks.map((task: any) => {
-                    task.created = format(new Date(task.created), 'yyyy-MM-dd');
+                    task.created = DateFnsUtils.formatDate(new Date(task.created), 'YYYY-MM-DD');
                     return task;
                 })),
                 catchError((err) => this.handleProcessError(err))


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Direct date-fns methods are used process.service.ts which needed date format changes when migrated from Moment.


**What is the new behaviour?**
Used custom date-fns methods from DateFnsUtils to avoid changing the date formats.

**Does this PR introduce a breaking change?** (check one with "x")

> - [x] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://alfresco.atlassian.net/browse/ACS-5878