### PR TITLE
[ACS-5566] - Add configurable columns to document list

### DIFF
--- a/docs/content-services/components/document-list.component.md
+++ b/docs/content-services/components/document-list.component.md
@@ -60,6 +60,7 @@ Displays the documents from a repository.
 | ---- | ---- | ------------- | ----------- |
 | additionalSorting | [`DataSorting`](../../../lib/core/src/lib/datatable/data/data-sorting.model.ts) |  | Defines default sorting. The format is an array of strings `[key direction, otherKey otherDirection]` i.e. `['name desc', 'nodeType asc']` or `['name asc']`. Set this value if you want a base rule to be added to the sorting apart from the one driven by the header. |
 | allowDropFiles | `boolean` | false | When true, this enables you to drop files directly into subfolders shown as items in the list or into another file to trigger updating it's version. When false, the dropped file will be added to the current folder (ie, the one containing all the items shown in the list). See the [Upload directive](../../core/directives/upload.directive.md) for further details about how the file drop is handled. |
+| columnsPresetKey | `string` |  | Key of columns preset set in extension.json|
 | contentActions | `boolean` | false | Toggles content actions for each row |
 | contentActionsPosition | `string` | "right" | Position of the content actions dropdown menu. Can be set to "left" or "right". |
 | contextMenuActions | `boolean` | false | Toggles context menus for each row |
@@ -72,6 +73,7 @@ Displays the documents from a repository.
 | includeFields | `string[]` |  | Include additional information about the node in the server request. For example: association, isLink, isLocked and others. |
 | loading | `boolean` | false | Toggles the loading state and animated spinners for the component. Used in combination with `navigate=false` to perform custom navigation and loading state indication. |
 | locationFormat | `string` | "/" | The default route for all the location-based columns (if declared). |
+| maxColumnsVisible | `number` |  | Limit of possible visible columns, including "$thumbnail" column if provided |
 | maxItems | `number` |  | Default value is stored in the user preference settings. Use this only if you are not using pagination. |
 | multiselect | `boolean` | false | Toggles multiselect mode |
 | navigate | `boolean` | true | Toggles navigation to folder content or file preview |

--- a/lib/content-services/src/lib/document-list/components/document-list.component.html
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.html
@@ -8,6 +8,7 @@
     [contextMenu]="contextMenuActions"
     [rowStyle]="rowStyle"
     [rowStyleClass]="rowStyleClass"
+    [showMainDatatableActions]="true"
     [loading]="loading"
     [display]="display"
     [noPermission]="noPermission"
@@ -71,5 +72,16 @@
             <ng-content select="adf-custom-loading-content-template"></ng-content>
         </ng-template>
     </adf-loading-content-template>
+
+    <adf-main-menu-datatable-template>
+        <ng-template let-mainMenuTrigger>
+            <adf-datatable-column-selector
+              [columns]="data.getColumns()"
+              [mainMenuTrigger]="mainMenuTrigger"
+              [columnsSorting]="false"
+              (submitColumnsVisibility)="onColumnsVisibilityChange($event)">
+            </adf-datatable-column-selector>
+        </ng-template>
+    </adf-main-menu-datatable-template>
 
 </adf-datatable>

--- a/lib/content-services/src/lib/document-list/components/document-list.component.html
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.html
@@ -79,6 +79,7 @@
               [columns]="data.getColumns()"
               [mainMenuTrigger]="mainMenuTrigger"
               [columnsSorting]="false"
+              [maxColumnsVisible]="maxColumnsVisible"
               (submitColumnsVisibility)="onColumnsVisibilityChange($event)">
             </adf-datatable-column-selector>
         </ng-template>

--- a/lib/content-services/src/lib/document-list/components/document-list.component.spec.ts
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.spec.ts
@@ -132,57 +132,39 @@ describe('DocumentList', () => {
             });
         };
 
-        it('should load -trashcan- preset', async () => {
-            documentList.currentFolderId = '-trashcan-';
-
-            fixture.detectChanges();
-            await fixture.whenStable();
-
+        it('should load -trashcan- preset', () => {
+            documentList.presetColumn = '-trashcan-';
+            documentList.ngAfterContentInit();
             validatePreset(['$thumbnail', 'name', 'path', 'content.sizeInBytes', 'archivedAt', 'archivedByUser.displayName']);
         });
 
         it('should load -sites- preset', async () => {
-            documentList.currentFolderId = '-sites-';
-
-            fixture.detectChanges();
-            await fixture.whenStable();
-
+            documentList.presetColumn = '-sites-';
+            documentList.ngAfterContentInit();
             validatePreset(['$thumbnail', 'title', 'visibility']);
         });
 
         it('shuld load -mysites- preset', async () => {
-            documentList.currentFolderId = '-mysites-';
-
-            fixture.detectChanges();
-            await fixture.whenStable();
-
+            documentList.presetColumn = '-mysites-';
+            documentList.ngAfterContentInit();
             validatePreset(['$thumbnail', 'title', 'visibility']);
         });
 
         it('should load -favorites- preset', async () => {
-            documentList.currentFolderId = '-favorites-';
-
-            fixture.detectChanges();
-            await fixture.whenStable();
-
+            documentList.presetColumn = '-favorites-';
+            documentList.ngAfterContentInit();
             validatePreset(['$thumbnail', 'name', 'path', 'content.sizeInBytes', 'modifiedAt', 'modifiedByUser.displayName']);
         });
 
         it('should load -recent- preset', async () => {
-            documentList.currentFolderId = '-recent-';
-
-            fixture.detectChanges();
-            await fixture.whenStable();
-
+            documentList.presetColumn = '-recent-';
+            documentList.ngAfterContentInit();
             validatePreset(['$thumbnail', 'name', 'path', 'content.sizeInBytes', 'modifiedAt']);
         });
 
         it('should load -sharedlinks- preset', async () => {
-            documentList.currentFolderId = '-sharedlinks-';
-
-            fixture.detectChanges();
-            await fixture.whenStable();
-
+            documentList.presetColumn = '-sharedlinks-';
+            documentList.ngAfterContentInit();
             validatePreset([
                 '$thumbnail',
                 'name',
@@ -195,11 +177,8 @@ describe('DocumentList', () => {
         });
 
         it('should load default preset', async () => {
-            documentList.currentFolderId = 'f5dacdb9-6d07-4fe9-9f2a-dedc21bae603';
-
-            fixture.detectChanges();
-            await fixture.whenStable();
-
+            documentList.presetColumn = 'f5dacdb9-6d07-4fe9-9f2a-dedc21bae603';
+            documentList.ngAfterContentInit();
             validatePreset(['$thumbnail', 'name', 'content.sizeInBytes', 'modifiedAt', 'modifiedByUser.displayName']);
         });
     });

--- a/lib/content-services/src/lib/document-list/components/document-list.component.ts
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.ts
@@ -56,7 +56,9 @@ import {
     AlfrescoApiService,
     UserPreferenceValues,
     DataRow,
-    DataTableService, DataTableSchema, DataColumn
+    DataTableService,
+    DataTableSchema,
+    DataColumn
 } from '@alfresco/adf-core';
 import { NodesApiService } from '../../common/services/nodes-api.service';
 

--- a/lib/content-services/src/lib/document-list/components/document-list.component.ts
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.ts
@@ -313,7 +313,7 @@ export class DocumentListComponent extends DataTableSchema implements OnInit, On
     @Input()
     maxItems: number = this.DEFAULT_PAGINATION.maxItems;
 
-    /** Key of columns preset if columns are not specified  */
+    /** Key of columns preset set in extension.json  */
     @Input()
     columnsPresetKey?: string;
 

--- a/lib/content-services/src/lib/document-list/components/document-list.component.ts
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.ts
@@ -313,6 +313,14 @@ export class DocumentListComponent extends DataTableSchema implements OnInit, On
     @Input()
     maxItems: number = this.DEFAULT_PAGINATION.maxItems;
 
+    /** Key of columns preset if columns are not specified  */
+    @Input()
+    columnsPresetKey?: string;
+
+    /** Limit of possible visible columns, including "$thumbnail" column if provided */
+    @Input()
+    maxColumnsVisible?: number;
+
     /** Emitted when the user clicks a list node */
     @Output()
     nodeClick = new EventEmitter<NodeEntityEvent>();
@@ -467,6 +475,9 @@ export class DocumentListComponent extends DataTableSchema implements OnInit, On
         this.enforceSingleClickNavigationForMobile();
         if (this.filterValue && Object.keys(this.filterValue).length > 0) {
             this.showHeader = ShowHeaderMode.Always;
+        }
+        if (this.columnsPresetKey) {
+            this.setPresetKey(this.columnsPresetKey);
         }
     }
 

--- a/lib/content-services/src/lib/document-list/components/document-list.component.ts
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.ts
@@ -767,8 +767,8 @@ export class DocumentListComponent extends DataTableSchema implements OnInit, On
             }
         }
     }
-    onColumnsVisibilityChange(e: Array<DataColumn>): void {
-        this.data.setColumns(e);
+    onColumnsVisibilityChange(updatedColumns: Array<DataColumn>): void {
+        this.data.setColumns(updatedColumns);
     }
     onNodeClick(nodeEntry: NodeEntry) {
         const domEvent = new CustomEvent('node-click', {

--- a/lib/content-services/src/lib/document-list/components/document-list.component.ts
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.ts
@@ -482,14 +482,15 @@ export class DocumentListComponent extends DataTableSchema implements OnInit, On
     }
 
     ngAfterContentInit() {
-        this.setTableSchema();
-    }
-
-    private setTableSchema() {
+        if (this.columnList) {
+            this.columnList.columns.changes.pipe(takeUntil(this.onDestroy$)).subscribe(() => {
+                this.createColumns();
+                this.data.setColumns(this.columns);
+            });
+        }
         this.createDatatableSchema();
         this.data.setColumns(this.columns);
     }
-
     ngOnChanges(changes: SimpleChanges) {
         if (!changes['preselectNodes']) {
             this.resetSelection();

--- a/lib/content-services/src/lib/document-list/models/preset.model.ts
+++ b/lib/content-services/src/lib/document-list/models/preset.model.ts
@@ -24,6 +24,32 @@ export const presetsDefaultModel = {
             sortable: false
         },
         {
+            key: 'name',
+            type: 'text',
+            title: 'ADF-DOCUMENT-LIST.LAYOUT.NAME',
+            cssClass: 'full-width ellipsis-cell',
+            sortable: true
+        },
+        {
+            key: 'path',
+            type: 'location',
+            title: 'ADF-DOCUMENT-LIST.LAYOUT.LOCATION',
+            sortable: true
+        },
+        {
+            key: 'content.sizeInBytes',
+            type: 'fileSize',
+            title: 'ADF-DOCUMENT-LIST.LAYOUT.SIZE',
+            sortable: true
+        },
+        {
+            key: 'archivedAt',
+            type: 'date',
+            title: 'ADF-DOCUMENT-LIST.LAYOUT.DELETED_ON',
+            format: 'timeAgo',
+            sortable: true
+        },
+        {
             key: 'archivedByUser.displayName',
             type: 'text',
             title: 'ADF-DOCUMENT-LIST.LAYOUT.DELETED_BY',

--- a/lib/content-services/src/lib/document-list/models/preset.model.ts
+++ b/lib/content-services/src/lib/document-list/models/preset.model.ts
@@ -24,32 +24,6 @@ export const presetsDefaultModel = {
             sortable: false
         },
         {
-            key: 'name',
-            type: 'text',
-            title: 'ADF-DOCUMENT-LIST.LAYOUT.NAME',
-            cssClass: 'full-width ellipsis-cell',
-            sortable: true
-        },
-        {
-            key: 'path',
-            type: 'location',
-            title: 'ADF-DOCUMENT-LIST.LAYOUT.LOCATION',
-            sortable: true
-        },
-        {
-            key: 'content.sizeInBytes',
-            type: 'fileSize',
-            title: 'ADF-DOCUMENT-LIST.LAYOUT.SIZE',
-            sortable: true
-        },
-        {
-            key: 'archivedAt',
-            type: 'date',
-            title: 'ADF-DOCUMENT-LIST.LAYOUT.DELETED_ON',
-            format: 'timeAgo',
-            sortable: true
-        },
-        {
             key: 'archivedByUser.displayName',
             type: 'text',
             title: 'ADF-DOCUMENT-LIST.LAYOUT.DELETED_BY',

--- a/lib/core/src/lib/datatable/components/columns-selector/columns-selector.component.html
+++ b/lib/core/src/lib/datatable/components/columns-selector/columns-selector.component.html
@@ -43,6 +43,7 @@
                     class="adf-columns-selector-column-checkbox"
                     [attr.data-automation-id]="'adf-columns-selector-column-checkbox-' + column.title"
                     [checked]="!column.isHidden"
+                    [disabled]="isCheckboxDisabled(column)"
                     (change)="changeColumnVisibility(column)">
                     <div class="adf-columns-selector-list-content">{{translatedTitle}}</div>
                 </mat-checkbox>

--- a/lib/core/src/lib/datatable/components/columns-selector/columns-selector.component.spec.ts
+++ b/lib/core/src/lib/datatable/components/columns-selector/columns-selector.component.spec.ts
@@ -156,19 +156,35 @@ describe('ColumnsSelectorComponent', () => {
         expect(toggledColumnItem.isHidden).toBe(true);
     });
 
-    it('should set proper default state for checkboxes', async () => {
-        menuOpenedTrigger.next();
-        fixture.detectChanges();
 
-        const checkboxes = await loader.getAllHarnesses(MatCheckboxHarness);
+    describe('checkboxes', () => {
+        it('should have set proper default state', async () => {
+            menuOpenedTrigger.next();
+            fixture.detectChanges();
 
-        expect(await checkboxes[0].isChecked()).toBe(true);
-        expect(await checkboxes[1].isChecked()).toBe(true);
-        expect(await checkboxes[2].isChecked()).toBe(true);
-        expect(await checkboxes[3].isChecked()).toBe(false);
+            const checkboxes = await loader.getAllHarnesses(MatCheckboxHarness);
+
+            expect(await checkboxes[0].isChecked()).toBe(true);
+            expect(await checkboxes[1].isChecked()).toBe(true);
+            expect(await checkboxes[2].isChecked()).toBe(true);
+            expect(await checkboxes[3].isChecked()).toBe(false);
+        });
+
+        it('should be disabled when visible columns limit is reached', async () => {
+            component.maxColumnsVisible = 4;
+            menuOpenedTrigger.next();
+            fixture.detectChanges();
+
+            const checkboxes = await loader.getAllHarnesses(MatCheckboxHarness);
+
+            expect(await checkboxes[0].isDisabled()).toBe(false);
+            expect(await checkboxes[1].isDisabled()).toBe(false);
+            expect(await checkboxes[2].isDisabled()).toBe(false);
+            expect(await checkboxes[3].isDisabled()).toBe(true);
+        });
     });
 
-    it('should show hidden columns at the end of the list', async () => {
+    describe('sorting', () => {
         const hiddenDataColumn: DataColumn = {
             id: 'hiddenDataColumn',
             title: 'hiddenDataColumn',
@@ -183,14 +199,27 @@ describe('ColumnsSelectorComponent', () => {
             key: 'shownDataColumn',
             type: 'text'
         };
+        it('should show hidden columns at the end of the list by default', async () => {
+            component.columns = [hiddenDataColumn, shownDataColumn];
+            menuOpenedTrigger.next();
+            fixture.detectChanges();
 
-        component.columns = [hiddenDataColumn, shownDataColumn];
-        menuOpenedTrigger.next();
-        fixture.detectChanges();
+            const checkboxes = await loader.getAllHarnesses(MatCheckboxHarness);
 
-        const checkboxes = await loader.getAllHarnesses(MatCheckboxHarness);
+            expect(await checkboxes[0].getLabelText()).toBe(shownDataColumn.title);
+            expect(await checkboxes[1].getLabelText()).toBe(hiddenDataColumn.title);
+        });
 
-        expect(await checkboxes[0].getLabelText()).toBe(shownDataColumn.title);
-        expect(await checkboxes[1].getLabelText()).toBe(hiddenDataColumn.title);
+        it('should NOT show hidden columns at the end of the list if sorting is disabled', async () => {
+            component.columns = [hiddenDataColumn, shownDataColumn];
+            component.columnsSorting = false;
+            menuOpenedTrigger.next();
+            fixture.detectChanges();
+
+            const checkboxes = await loader.getAllHarnesses(MatCheckboxHarness);
+
+            expect(await checkboxes[0].getLabelText()).toBe(hiddenDataColumn.title);
+            expect(await checkboxes[1].getLabelText()).toBe(shownDataColumn.title);
+        });
     });
 });

--- a/lib/core/src/lib/datatable/components/columns-selector/columns-selector.component.ts
+++ b/lib/core/src/lib/datatable/components/columns-selector/columns-selector.component.ts
@@ -37,6 +37,9 @@ export class ColumnsSelectorComponent implements OnInit, OnDestroy {
     @Input()
     columnsSorting = true;
 
+    @Input()
+    maxColumnsVisible?: number;
+
     @Output()
     submitColumnsVisibility = new EventEmitter<DataColumn[]>();
 
@@ -83,6 +86,10 @@ export class ColumnsSelectorComponent implements OnInit, OnDestroy {
     apply(): void {
         this.submitColumnsVisibility.emit(this.columnItems);
         this.closeMenu();
+    }
+
+    isCheckboxDisabled(column: DataColumn): boolean {
+        return this.maxColumnsVisible && column.isHidden && this.maxColumnsVisible === this.columnItems.filter(column => !column.isHidden).length;
     }
 
     private sortColumns(columns: DataColumn[]): DataColumn[] {

--- a/lib/core/src/lib/datatable/components/columns-selector/columns-selector.component.ts
+++ b/lib/core/src/lib/datatable/components/columns-selector/columns-selector.component.ts
@@ -89,7 +89,7 @@ export class ColumnsSelectorComponent implements OnInit, OnDestroy {
     }
 
     isCheckboxDisabled(column: DataColumn): boolean {
-        return this.maxColumnsVisible && column.isHidden && this.maxColumnsVisible === this.columnItems.filter(column => !column.isHidden).length;
+        return this.maxColumnsVisible && column.isHidden && this.maxColumnsVisible === this.columnItems.filter(dataColumn => !dataColumn.isHidden).length;
     }
 
     private sortColumns(columns: DataColumn[]): DataColumn[] {

--- a/lib/core/src/lib/datatable/components/columns-selector/columns-selector.component.ts
+++ b/lib/core/src/lib/datatable/components/columns-selector/columns-selector.component.ts
@@ -34,6 +34,9 @@ export class ColumnsSelectorComponent implements OnInit, OnDestroy {
     @Input()
     mainMenuTrigger: MatMenuTrigger;
 
+    @Input()
+    columnsSorting = true;
+
     @Output()
     submitColumnsVisibility = new EventEmitter<DataColumn[]>();
 
@@ -47,7 +50,7 @@ export class ColumnsSelectorComponent implements OnInit, OnDestroy {
             takeUntil(this.onDestroy$)
         ).subscribe(() => {
             const columns = this.columns.map(column => ({...column}));
-            this.columnItems = this.sortColumns(columns);
+            this.columnItems = this.columnsSorting ? this.sortColumns(columns) : columns;
         });
 
         this.mainMenuTrigger.menuClosed.pipe(

--- a/lib/core/src/lib/datatable/data/data-table.schema.ts
+++ b/lib/core/src/lib/datatable/data/data-table.schema.ts
@@ -93,7 +93,6 @@ export abstract class DataTableSchema<T = unknown> {
         if (columnList?.columns?.length > 0) {
             schema = columnList.columns.map((c) => c as DataColumn);
         }
-        console.log(schema);
         return schema;
     }
 

--- a/lib/core/src/lib/datatable/data/data-table.schema.ts
+++ b/lib/core/src/lib/datatable/data/data-table.schema.ts
@@ -49,7 +49,6 @@ export abstract class DataTableSchema<T = unknown> {
 
     public createDatatableSchema(): void {
         this.loadLayoutPresets();
-
         if (!this.columns || this.columns.length === 0) {
             this.createColumns();
             this.columnsSchemaSubject$.next(true);
@@ -94,11 +93,12 @@ export abstract class DataTableSchema<T = unknown> {
         if (columnList?.columns?.length > 0) {
             schema = columnList.columns.map((c) => c as DataColumn);
         }
+        console.log(schema);
         return schema;
     }
 
     public getSchemaFromConfig(presetColumn: string): DataColumn[] {
-        return presetColumn ? this.layoutPresets[presetColumn].map((col) => new ObjectDataColumn(col)) : [];
+        return presetColumn && this.layoutPresets[presetColumn] ? this.layoutPresets[presetColumn].map((col) => new ObjectDataColumn(col)) : [];
     }
 
     private getDefaultLayoutPreset(): DataColumn[] {

--- a/lib/extensions/src/lib/config/document-list.extensions.ts
+++ b/lib/extensions/src/lib/config/document-list.extensions.ts
@@ -27,6 +27,7 @@ export interface DocumentListPresetRef extends ExtensionElement {
   template: string;
   desktopOnly: boolean;
   sortingKey: string;
+  isHidden?: boolean;
   rules?: {
     [key: string]: string;
     visible?: string;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
In document list component columns are static. Once configured via html or json, they can't be configured by end user


**What is the new behaviour?**
Document list component has possiblity to hide/show columns. Columns hidden by default have their property 'isHidden' both in component's inputs properties and in json. Maximum amount of visible columns is limited.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
