### PR TITLE
[ACS-5831] Added Generic Error to Library Dialog.

### DIFF
--- a/lib/content-services/src/lib/dialogs/library/library.dialog.ts
+++ b/lib/content-services/src/lib/dialogs/library/library.dialog.ts
@@ -86,12 +86,22 @@ export class LibraryDialogComponent implements OnInit, OnDestroy {
         private formBuilder: UntypedFormBuilder,
         private dialog: MatDialogRef<LibraryDialogComponent>,
         private notificationService: NotificationService
-    ) {}
+    ) {
+    }
 
     ngOnInit() {
         const validators = {
-            id: [Validators.required, Validators.maxLength(72), this.forbidSpecialCharacters],
-            title: [Validators.required, this.forbidOnlySpaces, Validators.minLength(2), Validators.maxLength(256)],
+            id: [
+                Validators.required,
+                Validators.maxLength(72),
+                this.forbidSpecialCharacters
+            ],
+            title: [
+                Validators.required,
+                this.forbidOnlySpaces,
+                Validators.minLength(2),
+                Validators.maxLength(256)
+            ],
             description: [Validators.maxLength(512)]
         };
 
@@ -155,15 +165,13 @@ export class LibraryDialogComponent implements OnInit, OnDestroy {
         }
 
         this.disableCreateButton = true;
-        this.create()
-            .pipe(finalize(() => (this.disableCreateButton = false)))
-            .subscribe(
-                (node: SiteEntry) => {
-                    this.success.emit(node);
-                    dialog.close(node);
-                },
-                (error) => this.handleError(error)
-            );
+        this.create().pipe(finalize(() => this.disableCreateButton = false)).subscribe(
+            (node: SiteEntry) => {
+                this.success.emit(node);
+                dialog.close(node);
+            },
+            (error) => this.handleError(error)
+        );
     }
 
     visibilityChangeHandler(event) {
@@ -228,8 +236,8 @@ export class LibraryDialogComponent implements OnInit, OnDestroy {
 
     private findLibraryByTitle(libraryTitle: string): Promise<SitePaging> {
         return this.queriesApi.findSites(libraryTitle, {
-            maxItems: 1,
-            fields: ['title']
+                maxItems: 1,
+                fields: ['title']
         });
     }
 
@@ -244,8 +252,8 @@ export class LibraryDialogComponent implements OnInit, OnDestroy {
         return isValid
             ? null
             : {
-                  message: 'LIBRARY.ERRORS.ILLEGAL_CHARACTERS'
-              };
+                message: 'LIBRARY.ERRORS.ILLEGAL_CHARACTERS'
+            };
     }
 
     private forbidOnlySpaces({ value }: UntypedFormControl) {
@@ -258,8 +266,8 @@ export class LibraryDialogComponent implements OnInit, OnDestroy {
         return isValid
             ? null
             : {
-                  message: 'LIBRARY.ERRORS.ONLY_SPACES'
-              };
+                message: 'LIBRARY.ERRORS.ONLY_SPACES'
+            };
     }
 
     private createSiteIdValidator() {
@@ -271,14 +279,10 @@ export class LibraryDialogComponent implements OnInit, OnDestroy {
             }
 
             return new Promise((resolve) => {
-                timer = setTimeout(
-                    () =>
-                        this.sitesService.getSite(control.value).subscribe(
-                            () => resolve({ message: 'LIBRARY.ERRORS.EXISTENT_SITE' }),
-                            () => resolve(null)
-                        ),
-                    300
-                );
+                timer = setTimeout(() => this.sitesService.getSite(control.value).subscribe(
+                    () => resolve({ message: 'LIBRARY.ERRORS.EXISTENT_SITE' }),
+                    () => resolve(null)
+                ), 300);
             });
         };
     }

--- a/lib/content-services/src/lib/dialogs/library/library.dialog.ts
+++ b/lib/content-services/src/lib/dialogs/library/library.dialog.ts
@@ -238,7 +238,7 @@ export class LibraryDialogComponent implements OnInit, OnDestroy {
         return this.queriesApi.findSites(libraryTitle, {
                 maxItems: 1,
                 fields: ['title']
-        });
+            });
     }
 
     private forbidSpecialCharacters({ value }: UntypedFormControl) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Library dialog showed no error when user was not created at backend.

**What is the new behaviour?**

Added a generic error for all unknown BE status codes.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
