### PR TITLE
[ACS-5311] Notification History Bug Fix

### DIFF
--- a/lib/core/src/lib/notifications/components/notification-history.component.html
+++ b/lib/core/src/lib/notifications/components/notification-history.component.html
@@ -7,7 +7,7 @@
             id="adf-notification-history-open-button"
             (menuOpened)="onMenuOpened()">
         <mat-icon matBadge="&#8288;"
-                  [matBadgeHidden]="!notifications.length"
+                  [matBadgeHidden]="!unreadNotifications.length || badgeHidden"
                   matBadgeColor="accent"
                   matBadgeSize="small">notifications</mat-icon>
     </button>
@@ -21,7 +21,7 @@
              (click)="$event.stopPropagation()">
             <div mat-subheader role="menuitem">
                 <span>{{ 'NOTIFICATIONS.TITLE' | translate }}</span>
-                <button *ngIf="notifications.length"
+                <button *ngIf="unreadNotifications.length"
                         id="adf-notification-history-mark-as-read"
                         mat-icon-button
                         title="{{ 'NOTIFICATIONS.MARK_AS_READ' | translate }}"
@@ -33,7 +33,7 @@
             <mat-divider></mat-divider>
 
             <mat-list role="menuitem">
-                <ng-container *ngIf="notifications.length; else empty_list_template">
+                <ng-container *ngIf="unreadNotifications.length; else empty_list_template">
                     <mat-list-item *ngFor="let notification of paginatedNotifications"
                                    class="adf-notification-history-menu-item"
                                    (click)="onNotificationClick(notification)">

--- a/lib/core/src/lib/notifications/components/notification-history.component.html
+++ b/lib/core/src/lib/notifications/components/notification-history.component.html
@@ -7,7 +7,7 @@
             id="adf-notification-history-open-button"
             (menuOpened)="onMenuOpened()">
         <mat-icon matBadge="&#8288;"
-                  [matBadgeHidden]="!unreadNotifications.length || badgeHidden"
+                  [matBadgeHidden]="!unreadNotifications.length"
                   matBadgeColor="accent"
                   matBadgeSize="small">notifications</mat-icon>
     </button>

--- a/lib/core/src/lib/notifications/components/notification-history.component.spec.ts
+++ b/lib/core/src/lib/notifications/components/notification-history.component.spec.ts
@@ -37,7 +37,7 @@ fdescribe('Notification History Component', () => {
     const openNotification = () => {
         fixture.detectChanges();
         const button = element.querySelector<HTMLButtonElement>('#adf-notification-history-open-button');
-        button.click();
+        button?.click();
         fixture.detectChanges();
     };
 
@@ -87,7 +87,7 @@ fdescribe('Notification History Component', () => {
                 fixture.detectChanges();
                 expect(component.unreadNotifications.length).toBe(1);
                 const markAllAsRead = overlayContainerElement.querySelector<HTMLButtonElement>('#adf-notification-history-mark-as-read');
-                markAllAsRead.click();
+                markAllAsRead?.click();
                 fixture.detectChanges();
                 expect(component.unreadNotifications).toEqual([]);
                 expect(component.unreadNotifications.length).toBe(0);
@@ -125,7 +125,7 @@ fdescribe('Notification History Component', () => {
             fixture.whenStable().then(() => {
                 fixture.detectChanges();
                 const notification = overlayContainerElement.querySelector<HTMLButtonElement>('.adf-notification-history-menu-item');
-                notification.click();
+                notification?.click();
                 expect(callBackSpy).toHaveBeenCalled();
                 done();
             });
@@ -186,39 +186,39 @@ fdescribe('Notification History Component', () => {
     });
 
     it('should return true when there are unread notifications', () => {
-    
-        component.unreadNotifications = [{
-            "type": NOTIFICATION_TYPE.INFO,
-            "icon": "info",
-            "datetime": new Date(),
-            "initiator": { "key": "*", "displayName": "SYSTEM" },
-            "messages": ["Moved 1 item."],
-            "read": false
-          }, {
-            "type": NOTIFICATION_TYPE.INFO,
-            "icon": "info",
-            "datetime": new Date(),
-            "initiator": { "key": "*", "displayName": "SYSTEM" },
-            "messages": ["Copied 1 item."],
-            "read": false
-          }];
-    
-        const result = component.badge();
+        component.unreadNotifications = [
+            {
+                type: NOTIFICATION_TYPE.INFO,
+                icon: 'info',
+                datetime: new Date(),
+                initiator: { key: '*', displayName: 'SYSTEM' },
+                messages: ['Moved 1 item.'],
+                read: false
+            },
+            {
+                type: NOTIFICATION_TYPE.INFO,
+                icon: 'info',
+                datetime: new Date(),
+                initiator: { key: '*', displayName: 'SYSTEM' },
+                messages: ['Copied 1 item.'],
+                read: false
+            }
+        ];
 
-        const matIconDebugElement = fixture.debugElement.query(By.css('[matBadge]'));
-        const matIconElement = matIconDebugElement.nativeElement;
+        const result = component.badgeVisibility();
+        const matIconDebugElement = fixture.debugElement.query(By.css('[matBadge]')).nativeElement;
+
         expect(result).toBe(true);
-        expect(matIconElement.textContent).toContain('notifications');
-      });
-    
-      it('should return false when there are no unread notifications', () => {
+        expect(matIconDebugElement.textContent).toContain('notifications');
+    });
+
+    it('should return false when there are no unread notifications', () => {
         component.unreadNotifications = [];
-    
-        const result = component.badge();
-        const matBadgeDebugElement = fixture.debugElement.query(By.css('[matBadge]'));
-        const matIconElement = matBadgeDebugElement.nativeElement;
+
+        const result = component.badgeVisibility();
+        const matBadgeDebugElement = fixture.debugElement.query(By.css('[matBadge]')).nativeElement;
 
         expect(result).toBe(false);
-        expect(matIconElement.textContent).toContain('');
-      });
+        expect(matBadgeDebugElement.textContent).toContain('');
+    });
 });

--- a/lib/core/src/lib/notifications/components/notification-history.component.spec.ts
+++ b/lib/core/src/lib/notifications/components/notification-history.component.spec.ts
@@ -42,9 +42,7 @@ describe('Notification History Component', () => {
         fixture.detectChanges();
     };
 
-    const getMatBadgeElement = () => {
-        return fixture.debugElement.query(By.css('[matBadge]')).nativeElement;
-    };
+    const getMatBadgeElement = (): HTMLElement => fixture.debugElement.query(By.css('[matBadge]')).nativeElement;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -237,7 +235,7 @@ describe('Notification History Component', () => {
     it('should return isbadgeVisibile as true when there are unread notifications', () => {
         component.unreadNotifications = testNotifications;
 
-        const result = component.isbadgeVisible();
+        const result = component.isBadgeVisible();
         const matIconDebugElement = getMatBadgeElement();
 
         expect(result).toBe(true);
@@ -251,7 +249,7 @@ describe('Notification History Component', () => {
         component.notifications = testNotifications;
         fixture.detectChanges();
 
-        const result = component.isbadgeVisible();
+        const result = component.isBadgeVisible();
         const matBadgeDebugElement = getMatBadgeElement();
 
         expect(component.unreadNotifications).toEqual([]);

--- a/lib/core/src/lib/notifications/components/notification-history.component.spec.ts
+++ b/lib/core/src/lib/notifications/components/notification-history.component.spec.ts
@@ -33,12 +33,17 @@ describe('Notification History Component', () => {
     let notificationService: NotificationService;
     let overlayContainerElement: HTMLElement;
     let storage: StorageService;
+    let testNotifications: NotificationModel[];
 
     const openNotification = () => {
         fixture.detectChanges();
         const button = element.querySelector<HTMLButtonElement>('#adf-notification-history-open-button');
         button?.click();
         fixture.detectChanges();
+    };
+
+    const getMatBadgeElement = (fixture, matBadgeQuery) => {
+        return fixture.debugElement.query(By.css(matBadgeQuery)).nativeElement;
     };
 
     beforeEach(() => {
@@ -56,6 +61,25 @@ describe('Notification History Component', () => {
         notificationService = TestBed.inject(NotificationService);
         component.notifications = [];
         component.unreadNotifications = [];
+
+        testNotifications = [
+            {
+                type: NOTIFICATION_TYPE.INFO,
+                icon: 'info',
+                datetime: new Date(),
+                initiator: { key: '*', displayName: 'SYSTEM' },
+                messages: ['Moved 1 item.'],
+                read: false
+            },
+            {
+                type: NOTIFICATION_TYPE.INFO,
+                icon: 'info',
+                datetime: new Date(),
+                initiator: { key: '*', displayName: 'SYSTEM' },
+                messages: ['Copied 1 item.'],
+                read: false
+            }
+        ];
     });
 
     beforeEach(inject([OverlayContainer], (oc: OverlayContainer) => {
@@ -90,7 +114,6 @@ describe('Notification History Component', () => {
                 markAllAsRead?.click();
                 fixture.detectChanges();
                 expect(component.unreadNotifications).toEqual([]);
-                expect(component.unreadNotifications.length).toBe(0);
                 done();
             });
         });
@@ -192,108 +215,44 @@ describe('Notification History Component', () => {
         expect(component.unreadNotifications).toEqual([]);
     });
 
-    it('should set unreadNotifications to an empty array when all notifcations are read', () => {
-        const notifications = [
-            {
-                type: NOTIFICATION_TYPE.INFO,
-                icon: 'info',
-                datetime: new Date(),
-                initiator: { key: '*', displayName: 'SYSTEM' },
-                messages: ['Moved 1 item.'],
-                read: true
-            },
-            {
-                type: NOTIFICATION_TYPE.INFO,
-                icon: 'info',
-                datetime: new Date(),
-                initiator: { key: '*', displayName: 'SYSTEM' },
-                messages: ['Copied 1 item.'],
-                read: true
-            }
-        ];
-        storage.setItem(NotificationHistoryComponent.NOTIFICATION_STORAGE, JSON.stringify(notifications));
+    it('should set unreadNotifications to an empty array when all notifications are read', () => {
+        testNotifications.forEach((notification: NotificationModel) => {
+            notification.read = true;
+        });
+        storage.setItem(NotificationHistoryComponent.NOTIFICATION_STORAGE, JSON.stringify(testNotifications));
         fixture.detectChanges();
 
-        expect(component.unreadNotifications.length).toEqual(0);
         expect(component.unreadNotifications).toEqual([]);
     });
 
     it('should set unreadNotifications by filtering notifications where read is false', () => {
-        const notifications = [
-            {
-                type: NOTIFICATION_TYPE.INFO,
-                icon: 'info',
-                datetime: '',
-                initiator: { key: '*', displayName: 'SYSTEM' },
-                messages: ['Moved 1 item.'],
-                read: false
-            },
-            {
-                type: NOTIFICATION_TYPE.INFO,
-                icon: 'info',
-                datetime: new Date(),
-                initiator: { key: '*', displayName: 'SYSTEM' },
-                messages: ['Copied 1 item.'],
-                read: true
-            }
-        ];
-        storage.setItem(NotificationHistoryComponent.NOTIFICATION_STORAGE, JSON.stringify(notifications));
+        testNotifications[0].read = true;
+        storage.setItem(NotificationHistoryComponent.NOTIFICATION_STORAGE, JSON.stringify(testNotifications));
         fixture.detectChanges();
 
         expect(component.unreadNotifications.length).toEqual(1);
         expect(component.unreadNotifications[0].read).toEqual(false);
     });
 
-    it('should return badgeVisibility true when there are unread notifications', () => {
-        component.unreadNotifications = [
-            {
-                type: NOTIFICATION_TYPE.INFO,
-                icon: 'info',
-                datetime: new Date(),
-                initiator: { key: '*', displayName: 'SYSTEM' },
-                messages: ['Moved 1 item.'],
-                read: false
-            },
-            {
-                type: NOTIFICATION_TYPE.INFO,
-                icon: 'info',
-                datetime: new Date(),
-                initiator: { key: '*', displayName: 'SYSTEM' },
-                messages: ['Copied 1 item.'],
-                read: false
-            }
-        ];
+    it('should return isbadgeVisibile as true when there are unread notifications', () => {
+        component.unreadNotifications = testNotifications;
 
-        const result = component.badgeVisibility();
-        const matIconDebugElement = fixture.debugElement.query(By.css('[matBadge]')).nativeElement;
+        const result = component.isbadgeVisible();
+        const matIconDebugElement = getMatBadgeElement(fixture, '[matBadge]');
 
         expect(result).toBe(true);
         expect(matIconDebugElement.textContent).toContain('notifications');
     });
 
-    it('should return badgeVisibility false when there are no unread notifications', () => {
-        component.notifications = [
-            {
-                type: NOTIFICATION_TYPE.INFO,
-                icon: 'info',
-                datetime: new Date(),
-                initiator: { key: '*', displayName: 'SYSTEM' },
-                messages: ['Moved 1 item.'],
-                read: true
-            },
-            {
-                type: NOTIFICATION_TYPE.INFO,
-                icon: 'info',
-                datetime: new Date(),
-                initiator: { key: '*', displayName: 'SYSTEM' },
-                messages: ['Copied 1 item.'],
-                read: true
-            }
-        ];
+    it('should return isbadgeVisibile as false when there are no unread notifications', () => {
+        testNotifications.forEach((notification: NotificationModel) => {
+            notification.read = true;
+        });
+        component.notifications = testNotifications;
         fixture.detectChanges();
 
-        const result = component.badgeVisibility();
-        const matBadgeDebugElement = fixture.debugElement.query(By.css('[matBadge]')).nativeElement;
+        const result = component.isbadgeVisible();
+        const matBadgeDebugElement = getMatBadgeElement(fixture, '[matBadge]');
 
         expect(component.unreadNotifications).toEqual([]);
         expect(result).toBe(false);

--- a/lib/core/src/lib/notifications/components/notification-history.component.spec.ts
+++ b/lib/core/src/lib/notifications/components/notification-history.component.spec.ts
@@ -213,7 +213,7 @@ describe('Notification History Component', () => {
     });
 
     it('should return false when there are no unread notifications', () => {
-        component.unreadNotifications = [
+        component.notifications = [
             {
                 type: NOTIFICATION_TYPE.INFO,
                 icon: 'info',

--- a/lib/core/src/lib/notifications/components/notification-history.component.spec.ts
+++ b/lib/core/src/lib/notifications/components/notification-history.component.spec.ts
@@ -22,7 +22,7 @@ import { OverlayContainer } from '@angular/cdk/overlay';
 import { NotificationService } from '../services/notification.service';
 import { StorageService } from '../../common/services/storage.service';
 import { TranslateModule } from '@ngx-translate/core';
-import { NotificationModel, NOTIFICATION_TYPE } from '../models/notification.model';
+import { NotificationModel, NOTIFICATION_TYPE, NOTIFICATION_STORAGE } from '../models/notification.model';
 import { By } from '@angular/platform-browser';
 
 describe('Notification History Component', () => {
@@ -85,7 +85,7 @@ describe('Notification History Component', () => {
     }));
 
     afterEach(() => {
-        storage.removeItem(NotificationHistoryComponent.NOTIFICATION_STORAGE);
+        storage.removeItem(NOTIFICATION_STORAGE);
         fixture.destroy();
     });
 
@@ -171,7 +171,7 @@ describe('Notification History Component', () => {
         });
 
         it('should read notifications from local storage', (done) => {
-            storage.setItem(NotificationHistoryComponent.NOTIFICATION_STORAGE, JSON.stringify([{
+            storage.setItem(NOTIFICATION_STORAGE, JSON.stringify([{
                 messages: ['My new message'],
                 datetime: new Date(),
                 type: NOTIFICATION_TYPE.RECURSIVE
@@ -217,7 +217,7 @@ describe('Notification History Component', () => {
         testNotifications.forEach((notification: NotificationModel) => {
             notification.read = true;
         });
-        storage.setItem(NotificationHistoryComponent.NOTIFICATION_STORAGE, JSON.stringify(testNotifications));
+        storage.setItem(NOTIFICATION_STORAGE, JSON.stringify(testNotifications));
         fixture.detectChanges();
 
         expect(component.unreadNotifications).toEqual([]);
@@ -225,7 +225,7 @@ describe('Notification History Component', () => {
 
     it('should set unreadNotifications by filtering notifications where read is false', () => {
         testNotifications[0].read = true;
-        storage.setItem(NotificationHistoryComponent.NOTIFICATION_STORAGE, JSON.stringify(testNotifications));
+        storage.setItem(NOTIFICATION_STORAGE, JSON.stringify(testNotifications));
         fixture.detectChanges();
 
         expect(component.unreadNotifications.length).toEqual(1);

--- a/lib/core/src/lib/notifications/components/notification-history.component.spec.ts
+++ b/lib/core/src/lib/notifications/components/notification-history.component.spec.ts
@@ -232,7 +232,7 @@ describe('Notification History Component', () => {
         expect(component.unreadNotifications[0].read).toEqual(false);
     });
 
-    it('should return isbadgeVisibile as true when there are unread notifications', () => {
+    it('should return isBadgeVisible as true when there are unread notifications', () => {
         component.unreadNotifications = testNotifications;
 
         const result = component.isBadgeVisible();
@@ -242,7 +242,7 @@ describe('Notification History Component', () => {
         expect(matIconDebugElement.textContent).toContain('notifications');
     });
 
-    it('should return isbadgeVisibile as false when there are no unread notifications', () => {
+    it('should return isBadgeVisible as false when there are no unread notifications', () => {
         testNotifications.forEach((notification: NotificationModel) => {
             notification.read = true;
         });

--- a/lib/core/src/lib/notifications/components/notification-history.component.spec.ts
+++ b/lib/core/src/lib/notifications/components/notification-history.component.spec.ts
@@ -42,8 +42,8 @@ describe('Notification History Component', () => {
         fixture.detectChanges();
     };
 
-    const getMatBadgeElement = (fixture, matBadgeQuery) => {
-        return fixture.debugElement.query(By.css(matBadgeQuery)).nativeElement;
+    const getMatBadgeElement = () => {
+        return fixture.debugElement.query(By.css('[matBadge]')).nativeElement;
     };
 
     beforeEach(() => {
@@ -238,7 +238,7 @@ describe('Notification History Component', () => {
         component.unreadNotifications = testNotifications;
 
         const result = component.isbadgeVisible();
-        const matIconDebugElement = getMatBadgeElement(fixture, '[matBadge]');
+        const matIconDebugElement = getMatBadgeElement();
 
         expect(result).toBe(true);
         expect(matIconDebugElement.textContent).toContain('notifications');
@@ -252,7 +252,7 @@ describe('Notification History Component', () => {
         fixture.detectChanges();
 
         const result = component.isbadgeVisible();
-        const matBadgeDebugElement = getMatBadgeElement(fixture, '[matBadge]');
+        const matBadgeDebugElement = getMatBadgeElement();
 
         expect(component.unreadNotifications).toEqual([]);
         expect(result).toBe(false);

--- a/lib/core/src/lib/notifications/components/notification-history.component.spec.ts
+++ b/lib/core/src/lib/notifications/components/notification-history.component.spec.ts
@@ -25,7 +25,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import { NotificationModel, NOTIFICATION_TYPE } from '../models/notification.model';
 import { By } from '@angular/platform-browser';
 
-fdescribe('Notification History Component', () => {
+describe('Notification History Component', () => {
 
     let fixture: ComponentFixture<NotificationHistoryComponent>;
     let component: NotificationHistoryComponent;

--- a/lib/core/src/lib/notifications/components/notification-history.component.spec.ts
+++ b/lib/core/src/lib/notifications/components/notification-history.component.spec.ts
@@ -185,7 +185,66 @@ describe('Notification History Component', () => {
         }, 45000);
     });
 
-    it('should return true when there are unread notifications', () => {
+    it('should set unreadNotifications to an empty array when there are no notifications', () => {
+        component.notifications = [];
+        fixture.detectChanges();
+
+        expect(component.unreadNotifications).toEqual([]);
+    });
+
+    it('should set unreadNotifications to an empty array when all notifcations are read', () => {
+        const notifications = [
+            {
+                type: NOTIFICATION_TYPE.INFO,
+                icon: 'info',
+                datetime: new Date(),
+                initiator: { key: '*', displayName: 'SYSTEM' },
+                messages: ['Moved 1 item.'],
+                read: true
+            },
+            {
+                type: NOTIFICATION_TYPE.INFO,
+                icon: 'info',
+                datetime: new Date(),
+                initiator: { key: '*', displayName: 'SYSTEM' },
+                messages: ['Copied 1 item.'],
+                read: true
+            }
+        ];
+        storage.setItem(NotificationHistoryComponent.NOTIFICATION_STORAGE, JSON.stringify(notifications));
+        fixture.detectChanges();
+
+        expect(component.unreadNotifications.length).toEqual(0);
+        expect(component.unreadNotifications).toEqual([]);
+    });
+
+    it('should set unreadNotifications by filtering notifications where read is false', () => {
+        const notifications = [
+            {
+                type: NOTIFICATION_TYPE.INFO,
+                icon: 'info',
+                datetime: '',
+                initiator: { key: '*', displayName: 'SYSTEM' },
+                messages: ['Moved 1 item.'],
+                read: false
+            },
+            {
+                type: NOTIFICATION_TYPE.INFO,
+                icon: 'info',
+                datetime: new Date(),
+                initiator: { key: '*', displayName: 'SYSTEM' },
+                messages: ['Copied 1 item.'],
+                read: true
+            }
+        ];
+        storage.setItem(NotificationHistoryComponent.NOTIFICATION_STORAGE, JSON.stringify(notifications));
+        fixture.detectChanges();
+
+        expect(component.unreadNotifications.length).toEqual(1);
+        expect(component.unreadNotifications[0].read).toEqual(false);
+    });
+
+    it('should return badgeVisibility true when there are unread notifications', () => {
         component.unreadNotifications = [
             {
                 type: NOTIFICATION_TYPE.INFO,
@@ -212,7 +271,7 @@ describe('Notification History Component', () => {
         expect(matIconDebugElement.textContent).toContain('notifications');
     });
 
-    it('should return false when there are no unread notifications', () => {
+    it('should return badgeVisibility false when there are no unread notifications', () => {
         component.notifications = [
             {
                 type: NOTIFICATION_TYPE.INFO,

--- a/lib/core/src/lib/notifications/components/notification-history.component.spec.ts
+++ b/lib/core/src/lib/notifications/components/notification-history.component.spec.ts
@@ -213,11 +213,30 @@ describe('Notification History Component', () => {
     });
 
     it('should return false when there are no unread notifications', () => {
-        component.unreadNotifications = [];
+        component.unreadNotifications = [
+            {
+                type: NOTIFICATION_TYPE.INFO,
+                icon: 'info',
+                datetime: new Date(),
+                initiator: { key: '*', displayName: 'SYSTEM' },
+                messages: ['Moved 1 item.'],
+                read: true
+            },
+            {
+                type: NOTIFICATION_TYPE.INFO,
+                icon: 'info',
+                datetime: new Date(),
+                initiator: { key: '*', displayName: 'SYSTEM' },
+                messages: ['Copied 1 item.'],
+                read: true
+            }
+        ];
+        fixture.detectChanges();
 
         const result = component.badgeVisibility();
         const matBadgeDebugElement = fixture.debugElement.query(By.css('[matBadge]')).nativeElement;
 
+        expect(component.unreadNotifications).toEqual([]);
         expect(result).toBe(false);
         expect(matBadgeDebugElement.textContent).toContain('');
     });

--- a/lib/core/src/lib/notifications/components/notification-history.component.spec.ts
+++ b/lib/core/src/lib/notifications/components/notification-history.component.spec.ts
@@ -23,8 +23,9 @@ import { NotificationService } from '../services/notification.service';
 import { StorageService } from '../../common/services/storage.service';
 import { TranslateModule } from '@ngx-translate/core';
 import { NotificationModel, NOTIFICATION_TYPE } from '../models/notification.model';
+import { By } from '@angular/platform-browser';
 
-describe('Notification History Component', () => {
+fdescribe('Notification History Component', () => {
 
     let fixture: ComponentFixture<NotificationHistoryComponent>;
     let component: NotificationHistoryComponent;
@@ -54,6 +55,7 @@ describe('Notification History Component', () => {
         storage = TestBed.inject(StorageService);
         notificationService = TestBed.inject(NotificationService);
         component.notifications = [];
+        component.unreadNotifications = [];
     });
 
     beforeEach(inject([OverlayContainer], (oc: OverlayContainer) => {
@@ -83,12 +85,12 @@ describe('Notification History Component', () => {
             fixture.detectChanges();
             fixture.whenStable().then(() => {
                 fixture.detectChanges();
-                expect(component.notifications.length).toBe(1);
+                expect(component.unreadNotifications.length).toBe(1);
                 const markAllAsRead = overlayContainerElement.querySelector<HTMLButtonElement>('#adf-notification-history-mark-as-read');
                 markAllAsRead.click();
                 fixture.detectChanges();
-                expect(storage.getItem(NotificationHistoryComponent.NOTIFICATION_STORAGE)).toBeNull();
-                expect(component.notifications.length).toBe(0);
+                expect(component.unreadNotifications).toEqual([]);
+                expect(component.unreadNotifications.length).toBe(0);
                 done();
             });
         });
@@ -101,7 +103,7 @@ describe('Notification History Component', () => {
             fixture.whenStable().then(() => {
                 fixture.detectChanges();
                 expect(overlayContainerElement.querySelector('#adf-notification-history-component-no-message')).toBeNull();
-                expect(overlayContainerElement.querySelector('.adf-notification-history-list').innerHTML).toContain('Example Message');
+                expect(overlayContainerElement.querySelector('.adf-notification-history-list')?.innerHTML).toContain('Example Message');
                 done();
             });
         });
@@ -182,4 +184,41 @@ describe('Notification History Component', () => {
             });
         }, 45000);
     });
+
+    it('should return true when there are unread notifications', () => {
+    
+        component.unreadNotifications = [{
+            "type": NOTIFICATION_TYPE.INFO,
+            "icon": "info",
+            "datetime": new Date(),
+            "initiator": { "key": "*", "displayName": "SYSTEM" },
+            "messages": ["Moved 1 item."],
+            "read": false
+          }, {
+            "type": NOTIFICATION_TYPE.INFO,
+            "icon": "info",
+            "datetime": new Date(),
+            "initiator": { "key": "*", "displayName": "SYSTEM" },
+            "messages": ["Copied 1 item."],
+            "read": false
+          }];
+    
+        const result = component.badge();
+
+        const matIconDebugElement = fixture.debugElement.query(By.css('[matBadge]'));
+        const matIconElement = matIconDebugElement.nativeElement;
+        expect(result).toBe(true);
+        expect(matIconElement.textContent).toContain('notifications');
+      });
+    
+      it('should return false when there are no unread notifications', () => {
+        component.unreadNotifications = [];
+    
+        const result = component.badge();
+        const matBadgeDebugElement = fixture.debugElement.query(By.css('[matBadge]'));
+        const matIconElement = matBadgeDebugElement.nativeElement;
+
+        expect(result).toBe(false);
+        expect(matIconElement.textContent).toContain('');
+      });
 });

--- a/lib/core/src/lib/notifications/components/notification-history.component.spec.ts
+++ b/lib/core/src/lib/notifications/components/notification-history.component.spec.ts
@@ -23,7 +23,6 @@ import { NotificationService } from '../services/notification.service';
 import { StorageService } from '../../common/services/storage.service';
 import { TranslateModule } from '@ngx-translate/core';
 import { NotificationModel, NOTIFICATION_TYPE, NOTIFICATION_STORAGE } from '../models/notification.model';
-import { By } from '@angular/platform-browser';
 
 describe('Notification History Component', () => {
 
@@ -41,8 +40,6 @@ describe('Notification History Component', () => {
         button?.click();
         fixture.detectChanges();
     };
-
-    const getMatBadgeElement = (): HTMLElement => fixture.debugElement.query(By.css('[matBadge]')).nativeElement;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -230,30 +227,5 @@ describe('Notification History Component', () => {
 
         expect(component.unreadNotifications.length).toEqual(1);
         expect(component.unreadNotifications[0].read).toEqual(false);
-    });
-
-    it('should return isBadgeVisible as true when there are unread notifications', () => {
-        component.unreadNotifications = testNotifications;
-
-        const result = component.isBadgeVisible();
-        const matIconDebugElement = getMatBadgeElement();
-
-        expect(result).toBe(true);
-        expect(matIconDebugElement.textContent).toContain('notifications');
-    });
-
-    it('should return isBadgeVisible as false when there are no unread notifications', () => {
-        testNotifications.forEach((notification: NotificationModel) => {
-            notification.read = true;
-        });
-        component.notifications = testNotifications;
-        fixture.detectChanges();
-
-        const result = component.isBadgeVisible();
-        const matBadgeDebugElement = getMatBadgeElement();
-
-        expect(component.unreadNotifications).toEqual([]);
-        expect(result).toBe(false);
-        expect(matBadgeDebugElement.textContent).toContain('');
     });
 });

--- a/lib/core/src/lib/notifications/components/notification-history.component.ts
+++ b/lib/core/src/lib/notifications/components/notification-history.component.ts
@@ -63,7 +63,7 @@ export class NotificationHistoryComponent implements OnDestroy, OnInit, AfterVie
         this.notifications = JSON.parse(this.storageService.getItem(NotificationHistoryComponent.NOTIFICATION_STORAGE)) || [];
         this.unreadNotifications =
             JSON.parse(this.storageService.getItem(NotificationHistoryComponent.NOTIFICATION_STORAGE))?.filter(
-                (notification) => !notification.read
+                (notification: NotificationModel) => !notification.read
             ) || [];
         this.badgeHidden = !this.badgeVisibility();
     }
@@ -95,7 +95,7 @@ export class NotificationHistoryComponent implements OnDestroy, OnInit, AfterVie
     }
 
     saveNotifications() {
-        this.unreadNotifications.forEach((notification) => {
+        this.unreadNotifications.forEach((notification: NotificationModel) => {
             this.notifications.push(notification);
         });
 
@@ -119,7 +119,7 @@ export class NotificationHistoryComponent implements OnDestroy, OnInit, AfterVie
 
     markAsRead() {
         this.unreadNotifications = [];
-        this.notifications.forEach((notification) => {
+        this.notifications.forEach((notification: NotificationModel) => {
             notification['read'] = true;
         });
 

--- a/lib/core/src/lib/notifications/components/notification-history.component.ts
+++ b/lib/core/src/lib/notifications/components/notification-history.component.ts
@@ -65,7 +65,7 @@ export class NotificationHistoryComponent implements OnDestroy, OnInit, AfterVie
             JSON.parse(this.storageService.getItem(NotificationHistoryComponent.NOTIFICATION_STORAGE))?.filter(
                 (notification: NotificationModel) => !notification.read
             ) || [];
-        this.badgeHidden = !this.isbadgeVisible();
+        this.badgeHidden = !this.isBadgeVisible();
     }
 
     ngAfterViewInit(): void {
@@ -83,7 +83,7 @@ export class NotificationHistoryComponent implements OnDestroy, OnInit, AfterVie
     }
 
     addNewNotification(notification: NotificationModel) {
-        this.badgeHidden = !this.isbadgeVisible();
+        this.badgeHidden = !this.isBadgeVisible();
         this.unreadNotifications.unshift(notification);
 
         if (this.unreadNotifications.length > NotificationHistoryComponent.MAX_NOTIFICATION_STACK_LENGTH) {
@@ -100,7 +100,7 @@ export class NotificationHistoryComponent implements OnDestroy, OnInit, AfterVie
         });
 
         this.storageService.setItem(NotificationHistoryComponent.NOTIFICATION_STORAGE, JSON.stringify(this.notifications));
-        this.badgeHidden = !this.isbadgeVisible();
+        this.badgeHidden = !this.isBadgeVisible();
     }
 
     onMenuOpened() {
@@ -123,7 +123,7 @@ export class NotificationHistoryComponent implements OnDestroy, OnInit, AfterVie
             notification.read = true;
         });
 
-        this.badgeHidden = !this.isbadgeVisible();
+        this.badgeHidden = !this.isBadgeVisible();
         this.storageService.setItem(NotificationHistoryComponent.NOTIFICATION_STORAGE, JSON.stringify(this.notifications));
         this.paginatedNotifications = [];
         this.createPagination();
@@ -157,7 +157,7 @@ export class NotificationHistoryComponent implements OnDestroy, OnInit, AfterVie
         }
     }
 
-    isbadgeVisible(): boolean {
+    isBadgeVisible(): boolean {
         return this.unreadNotifications.length > 0;
     }
 }

--- a/lib/core/src/lib/notifications/components/notification-history.component.ts
+++ b/lib/core/src/lib/notifications/components/notification-history.component.ts
@@ -17,9 +17,7 @@
 
 import { Component, Input, ViewChild, OnDestroy, OnInit, AfterViewInit, ChangeDetectorRef, ViewEncapsulation } from '@angular/core';
 import { NotificationService } from '../services/notification.service';
-import { NotificationModel, 
-    //NOTIFICATION_TYPE 
-} from '../models/notification.model';
+import { NotificationModel } from '../models/notification.model';
 import { MatMenuTrigger, MenuPositionX, MenuPositionY } from '@angular/material/menu';
 import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
@@ -55,28 +53,19 @@ export class NotificationHistoryComponent implements OnDestroy, OnInit, AfterVie
     onDestroy$ = new Subject<boolean>();
     notifications: NotificationModel[] = [];
     paginatedNotifications: NotificationModel[] = [];
+    unreadNotifications: NotificationModel[] = [];
     pagination: PaginationModel;
     badgeHidden: boolean;
-    unreadNotifications: NotificationModel[] = [];
 
-    constructor(
-        private notificationService: NotificationService,
-        public storageService: StorageService,
-        public cd: ChangeDetectorRef) {
-
-    }
+    constructor(private notificationService: NotificationService, public storageService: StorageService, public cd: ChangeDetectorRef) {}
 
     ngOnInit() {
         this.notifications = JSON.parse(this.storageService.getItem(NotificationHistoryComponent.NOTIFICATION_STORAGE)) || [];
-
-        this.unreadNotifications = JSON.parse(this.storageService.getItem(NotificationHistoryComponent.NOTIFICATION_STORAGE))?.filter( (notification) => notification.read == false ) || [];
-
-        
-
-        //this.badgeHidden = this.badge() ? this.badgeHidden = false : this.badgeHidden = true
-        this.badgeHidden = !this.badge();
-
-        console.log('HTML CHECK', !this.notifications.length || this.badgeHidden);
+        this.unreadNotifications =
+            JSON.parse(this.storageService.getItem(NotificationHistoryComponent.NOTIFICATION_STORAGE))?.filter(
+                (notification) => notification.read == false
+            ) || [];
+        this.badgeHidden = !this.badgeVisibility();
     }
 
     ngAfterViewInit(): void {
@@ -94,10 +83,7 @@ export class NotificationHistoryComponent implements OnDestroy, OnInit, AfterVie
     }
 
     addNewNotification(notification: NotificationModel) {
-        //this.badgeHidden = this.badge() ? this.badgeHidden = false : this.badgeHidden = true
-        this.badgeHidden = !this.badge();
-        console.log('ADD CHECK', !this.unreadNotifications.length || this.badgeHidden);
-
+        this.badgeHidden = !this.badgeVisibility();
         this.unreadNotifications.unshift(notification);
 
         if (this.unreadNotifications.length > NotificationHistoryComponent.MAX_NOTIFICATION_STACK_LENGTH) {
@@ -109,17 +95,12 @@ export class NotificationHistoryComponent implements OnDestroy, OnInit, AfterVie
     }
 
     saveNotifications() {
-        // this.storageService.setItem(NotificationHistoryComponent.NOTIFICATION_STORAGE, JSON.stringify(this.notifications.filter((notification) =>
-        //     notification.type !== NOTIFICATION_TYPE.RECURSIVE
-        // )));
-        
-        this.unreadNotifications.forEach( notification => {
-            this.notifications.push(notification)
+        this.unreadNotifications.forEach((notification) => {
+            this.notifications.push(notification);
         });
 
         this.storageService.setItem(NotificationHistoryComponent.NOTIFICATION_STORAGE, JSON.stringify(this.notifications));
-        this.badgeHidden = !this.badge();
-
+        this.badgeHidden = !this.badgeVisibility();
     }
 
     onMenuOpened() {
@@ -137,26 +118,14 @@ export class NotificationHistoryComponent implements OnDestroy, OnInit, AfterVie
     }
 
     markAsRead() {
-
-        // this.unreadNotifications.forEach( notification => {
-        //     this.notifications.push(notification)
-        // });
-
-        this.unreadNotifications = []
-        
-        this.notifications.forEach( notification => {
+        this.unreadNotifications = [];
+        this.notifications.forEach((notification) => {
             notification['read'] = true;
         });
 
-        this.badgeHidden = this.badge() ? this.badgeHidden = false : this.badgeHidden = true
-        console.log('MARK AS READ CHECK', !this.notifications.length || this.badgeHidden);
-
+        this.badgeHidden = !this.badgeVisibility();
         this.storageService.setItem('notification-history', JSON.stringify(this.notifications));
-
-
-        //this.notifications = [];
-        //this.paginatedNotifications = [];
-        //this.storageService.removeItem(NotificationHistoryComponent.NOTIFICATION_STORAGE);
+        this.paginatedNotifications = [];
         this.createPagination();
         this.trigger.closeMenu();
     }
@@ -188,18 +157,7 @@ export class NotificationHistoryComponent implements OnDestroy, OnInit, AfterVie
         }
     }
 
-    // badge (): boolean {
-    //     //this.notifications = JSON.parse(this.storageService.getItem(NotificationHistoryComponent.NOTIFICATION_STORAGE)) || [];
-    //     const arr = this.notifications.filter( (notif) => notif.read == false)
-    //     console.log('badge', arr, arr.length > 0)
-    //     return arr.length > 0; 
-    // }
-
-    // badge(): boolean {
-    //     return this.notifications.some(notif => !notif.read);
-    // }
-
-    badge(): boolean {
-        return this.unreadNotifications.length > 0
+    badgeVisibility(): boolean {
+        return this.unreadNotifications.length > 0;
     }
 }

--- a/lib/core/src/lib/notifications/components/notification-history.component.ts
+++ b/lib/core/src/lib/notifications/components/notification-history.component.ts
@@ -65,7 +65,7 @@ export class NotificationHistoryComponent implements OnDestroy, OnInit, AfterVie
             JSON.parse(this.storageService.getItem(NotificationHistoryComponent.NOTIFICATION_STORAGE))?.filter(
                 (notification: NotificationModel) => !notification.read
             ) || [];
-        this.badgeHidden = !this.badgeVisibility();
+        this.badgeHidden = !this.isbadgeVisible();
     }
 
     ngAfterViewInit(): void {
@@ -83,7 +83,7 @@ export class NotificationHistoryComponent implements OnDestroy, OnInit, AfterVie
     }
 
     addNewNotification(notification: NotificationModel) {
-        this.badgeHidden = !this.badgeVisibility();
+        this.badgeHidden = !this.isbadgeVisible();
         this.unreadNotifications.unshift(notification);
 
         if (this.unreadNotifications.length > NotificationHistoryComponent.MAX_NOTIFICATION_STACK_LENGTH) {
@@ -100,7 +100,7 @@ export class NotificationHistoryComponent implements OnDestroy, OnInit, AfterVie
         });
 
         this.storageService.setItem(NotificationHistoryComponent.NOTIFICATION_STORAGE, JSON.stringify(this.notifications));
-        this.badgeHidden = !this.badgeVisibility();
+        this.badgeHidden = !this.isbadgeVisible();
     }
 
     onMenuOpened() {
@@ -120,11 +120,11 @@ export class NotificationHistoryComponent implements OnDestroy, OnInit, AfterVie
     markAsRead() {
         this.unreadNotifications = [];
         this.notifications.forEach((notification: NotificationModel) => {
-            notification['read'] = true;
+            notification.read = true;
         });
 
-        this.badgeHidden = !this.badgeVisibility();
-        this.storageService.setItem('notification-history', JSON.stringify(this.notifications));
+        this.badgeHidden = !this.isbadgeVisible();
+        this.storageService.setItem(NotificationHistoryComponent.NOTIFICATION_STORAGE, JSON.stringify(this.notifications));
         this.paginatedNotifications = [];
         this.createPagination();
         this.trigger.closeMenu();
@@ -157,7 +157,7 @@ export class NotificationHistoryComponent implements OnDestroy, OnInit, AfterVie
         }
     }
 
-    badgeVisibility(): boolean {
+    isbadgeVisible(): boolean {
         return this.unreadNotifications.length > 0;
     }
 }

--- a/lib/core/src/lib/notifications/components/notification-history.component.ts
+++ b/lib/core/src/lib/notifications/components/notification-history.component.ts
@@ -63,7 +63,7 @@ export class NotificationHistoryComponent implements OnDestroy, OnInit, AfterVie
         this.notifications = JSON.parse(this.storageService.getItem(NotificationHistoryComponent.NOTIFICATION_STORAGE)) || [];
         this.unreadNotifications =
             JSON.parse(this.storageService.getItem(NotificationHistoryComponent.NOTIFICATION_STORAGE))?.filter(
-                (notification) => notification.read == false
+                (notification) => !notification.read
             ) || [];
         this.badgeHidden = !this.badgeVisibility();
     }

--- a/lib/core/src/lib/notifications/components/notification-history.component.ts
+++ b/lib/core/src/lib/notifications/components/notification-history.component.ts
@@ -17,7 +17,7 @@
 
 import { Component, Input, ViewChild, OnDestroy, OnInit, AfterViewInit, ChangeDetectorRef, ViewEncapsulation } from '@angular/core';
 import { NotificationService } from '../services/notification.service';
-import { NotificationModel } from '../models/notification.model';
+import { NOTIFICATION_STORAGE, NotificationModel } from '../models/notification.model';
 import { MatMenuTrigger, MenuPositionX, MenuPositionY } from '@angular/material/menu';
 import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
@@ -33,7 +33,6 @@ import { PaginationModel } from '../../models/pagination.model';
 export class NotificationHistoryComponent implements OnDestroy, OnInit, AfterViewInit {
 
     public static MAX_NOTIFICATION_STACK_LENGTH = 100;
-    public static NOTIFICATION_STORAGE = 'notification-history';
 
     @ViewChild(MatMenuTrigger, { static: true })
     trigger: MatMenuTrigger;
@@ -60,9 +59,9 @@ export class NotificationHistoryComponent implements OnDestroy, OnInit, AfterVie
     constructor(private notificationService: NotificationService, public storageService: StorageService, public cd: ChangeDetectorRef) {}
 
     ngOnInit() {
-        this.notifications = JSON.parse(this.storageService.getItem(NotificationHistoryComponent.NOTIFICATION_STORAGE)) || [];
+        this.notifications = JSON.parse(this.storageService.getItem(NOTIFICATION_STORAGE)) || [];
         this.unreadNotifications =
-            JSON.parse(this.storageService.getItem(NotificationHistoryComponent.NOTIFICATION_STORAGE))?.filter(
+            JSON.parse(this.storageService.getItem(NOTIFICATION_STORAGE))?.filter(
                 (notification: NotificationModel) => !notification.read
             ) || [];
         this.badgeHidden = !this.isBadgeVisible();
@@ -99,7 +98,7 @@ export class NotificationHistoryComponent implements OnDestroy, OnInit, AfterVie
             this.notifications.push(notification);
         });
 
-        this.storageService.setItem(NotificationHistoryComponent.NOTIFICATION_STORAGE, JSON.stringify(this.notifications));
+        this.storageService.setItem(NOTIFICATION_STORAGE, JSON.stringify(this.notifications));
         this.badgeHidden = !this.isBadgeVisible();
     }
 
@@ -124,7 +123,7 @@ export class NotificationHistoryComponent implements OnDestroy, OnInit, AfterVie
         });
 
         this.badgeHidden = !this.isBadgeVisible();
-        this.storageService.setItem(NotificationHistoryComponent.NOTIFICATION_STORAGE, JSON.stringify(this.notifications));
+        this.storageService.setItem(NOTIFICATION_STORAGE, JSON.stringify(this.notifications));
         this.paginatedNotifications = [];
         this.createPagination();
         this.trigger.closeMenu();

--- a/lib/core/src/lib/notifications/components/notification-history.component.ts
+++ b/lib/core/src/lib/notifications/components/notification-history.component.ts
@@ -54,7 +54,6 @@ export class NotificationHistoryComponent implements OnDestroy, OnInit, AfterVie
     paginatedNotifications: NotificationModel[] = [];
     unreadNotifications: NotificationModel[] = [];
     pagination: PaginationModel;
-    badgeHidden: boolean;
 
     constructor(private notificationService: NotificationService, public storageService: StorageService, public cd: ChangeDetectorRef) {}
 
@@ -64,7 +63,6 @@ export class NotificationHistoryComponent implements OnDestroy, OnInit, AfterVie
             JSON.parse(this.storageService.getItem(NOTIFICATION_STORAGE))?.filter(
                 (notification: NotificationModel) => !notification.read
             ) || [];
-        this.badgeHidden = !this.isBadgeVisible();
     }
 
     ngAfterViewInit(): void {
@@ -82,7 +80,6 @@ export class NotificationHistoryComponent implements OnDestroy, OnInit, AfterVie
     }
 
     addNewNotification(notification: NotificationModel) {
-        this.badgeHidden = !this.isBadgeVisible();
         this.unreadNotifications.unshift(notification);
 
         if (this.unreadNotifications.length > NotificationHistoryComponent.MAX_NOTIFICATION_STACK_LENGTH) {
@@ -99,7 +96,6 @@ export class NotificationHistoryComponent implements OnDestroy, OnInit, AfterVie
         });
 
         this.storageService.setItem(NOTIFICATION_STORAGE, JSON.stringify(this.notifications));
-        this.badgeHidden = !this.isBadgeVisible();
     }
 
     onMenuOpened() {
@@ -122,7 +118,6 @@ export class NotificationHistoryComponent implements OnDestroy, OnInit, AfterVie
             notification.read = true;
         });
 
-        this.badgeHidden = !this.isBadgeVisible();
         this.storageService.setItem(NOTIFICATION_STORAGE, JSON.stringify(this.notifications));
         this.paginatedNotifications = [];
         this.createPagination();
@@ -154,9 +149,5 @@ export class NotificationHistoryComponent implements OnDestroy, OnInit, AfterVie
             notification.clickCallBack(notification.args);
             this.trigger.closeMenu();
         }
-    }
-
-    isBadgeVisible(): boolean {
-        return this.unreadNotifications.length > 0;
     }
 }

--- a/lib/core/src/lib/notifications/helpers/notification.factory.ts
+++ b/lib/core/src/lib/notifications/helpers/notification.factory.ts
@@ -52,9 +52,3 @@ export const error = (messages: string | string[], initiator: NotificationInitia
     messages: [].concat(messages),
     read: false
 });
-
-// export const getId() => ({
-//     var randomStr = String.fromCharCode(65 + Math.floor(Math.random() * 26));
-//     var id = randomStr + Date.now();
-//     return id
-// })

--- a/lib/core/src/lib/notifications/helpers/notification.factory.ts
+++ b/lib/core/src/lib/notifications/helpers/notification.factory.ts
@@ -31,7 +31,8 @@ export const info = (messages: string | string[], initiator: NotificationInitiat
     icon: 'info',
     datetime: new Date(),
     initiator,
-    messages: [].concat(messages)
+    messages: [].concat(messages),
+    read: false
 });
 
 export const warning = (messages: string | string[], initiator: NotificationInitiator = rootInitiator): NotificationModel => ({
@@ -39,7 +40,8 @@ export const warning = (messages: string | string[], initiator: NotificationInit
     icon: 'warning',
     datetime: new Date(),
     initiator,
-    messages: [].concat(messages)
+    messages: [].concat(messages),
+    read: false
 });
 
 export const error = (messages: string | string[], initiator: NotificationInitiator = rootInitiator): NotificationModel => ({
@@ -47,5 +49,12 @@ export const error = (messages: string | string[], initiator: NotificationInitia
     icon: 'error',
     datetime: new Date(),
     initiator,
-    messages: [].concat(messages)
+    messages: [].concat(messages),
+    read: false
 });
+
+// export const getId() => ({
+//     var randomStr = String.fromCharCode(65 + Math.floor(Math.random() * 26));
+//     var id = randomStr + Date.now();
+//     return id
+// })

--- a/lib/core/src/lib/notifications/models/notification.model.ts
+++ b/lib/core/src/lib/notifications/models/notification.model.ts
@@ -39,5 +39,5 @@ export interface NotificationModel {
     icon?: string;
     clickCallBack?: any;
     args?: any;
-    read: boolean;
+    read?: boolean;
 }

--- a/lib/core/src/lib/notifications/models/notification.model.ts
+++ b/lib/core/src/lib/notifications/models/notification.model.ts
@@ -39,4 +39,5 @@ export interface NotificationModel {
     icon?: string;
     clickCallBack?: any;
     args?: any;
+    read: boolean
 }

--- a/lib/core/src/lib/notifications/models/notification.model.ts
+++ b/lib/core/src/lib/notifications/models/notification.model.ts
@@ -41,3 +41,5 @@ export interface NotificationModel {
     args?: any;
     read?: boolean;
 }
+
+export const NOTIFICATION_STORAGE = 'notification-history';

--- a/lib/core/src/lib/notifications/models/notification.model.ts
+++ b/lib/core/src/lib/notifications/models/notification.model.ts
@@ -39,5 +39,5 @@ export interface NotificationModel {
     icon?: string;
     clickCallBack?: any;
     args?: any;
-    read: boolean
+    read: boolean;
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
If 'mark as all is pressed', the notifications restore upon reloading the page.


**What is the new behaviour?**
Added logic to maintain a 'read' flag in notification-history (local storage). Now 
1. the notifications menu will render only unread notifications and
2. if 'mark as all is pressed', the notifications will clear from the menu and will not restore upon reloading the page.


https://github.com/Alfresco/alfresco-ng2-components/assets/110394264/699e0bd5-07c9-4e97-97db-cb47dea5e6d4



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://alfresco.atlassian.net/browse/ACS-5311
Once this PR is merged,  ADW PR https://github.com/Alfresco/alfresco-applications/pull/412 needs to be merged to complete the fix
