### PR TITLE
[ACS-6222] Fixed missing display name for groups

### DIFF
--- a/lib/content-services/src/lib/permission-manager/components/user-name-column/user-name-column.component.spec.ts
+++ b/lib/content-services/src/lib/permission-manager/components/user-name-column/user-name-column.component.spec.ts
@@ -104,6 +104,21 @@ describe('UserNameColumnComponent', () => {
             expect(element.querySelector('[title="fake authority"]').textContent.trim()).toBe('fake authority');
         });
 
+        it('should display group id when display name is not provided', () => {
+            component.context = {
+                row: {
+                    obj: {
+                        entry: {
+                            group: { id: 'fake_group_id' }
+                        }
+                    }
+                }
+            };
+            component.ngOnInit();
+            fixture.detectChanges();
+            expect(element.querySelector('[title="fake_group_id"]').textContent.trim()).toBe('fake_group_id');
+        });
+
         it('should render group for authorityId', () => {
             component.context = {
                 row: {

--- a/lib/content-services/src/lib/permission-manager/components/user-name-column/user-name-column.component.ts
+++ b/lib/content-services/src/lib/permission-manager/components/user-name-column/user-name-column.component.ts
@@ -72,7 +72,7 @@ export class UserNameColumnComponent implements OnInit {
 
     private updateGroup(group: Group) {
         if (group) {
-            this.displayText$.next(group.displayName);
+            group.displayName ? this.displayText$.next(group.displayName) : this.displayText$.next(group.id);
         }
     }
 }

--- a/lib/content-services/src/lib/permission-manager/components/user-name-column/user-name-column.component.ts
+++ b/lib/content-services/src/lib/permission-manager/components/user-name-column/user-name-column.component.ts
@@ -72,7 +72,7 @@ export class UserNameColumnComponent implements OnInit {
 
     private updateGroup(group: Group) {
         if (group) {
-            group.displayName ? this.displayText$.next(group.displayName) : this.displayText$.next(group.id);
+            this.displayText$.next(group.displayName || group.id);
         }
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://alfresco.atlassian.net/browse/ACS-6222

**What is the new behaviour?**

When displayName is not provided for a group, the id of the group is being displayed

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
