### PR TITLE
[ACS-6067] viewer thumbnails not refresh on file change

### DIFF
--- a/lib/core/src/lib/viewer/components/pdf-viewer.component.html
+++ b/lib/core/src/lib/viewer/components/pdf-viewer.component.html
@@ -17,7 +17,7 @@
                     <ng-container *ngTemplateOutlet="thumbnailsTemplate;context:pdfThumbnailsContext"></ng-container>
                 </ng-container>
 
-                <ng-container *ngIf="!thumbnailsTemplate">
+                <ng-container *ngIf="!thumbnailsTemplate && !isPanelDisabled">
                     <adf-pdf-thumbnails (close)="toggleThumbnails()" [pdfViewer]="pdfViewer"></adf-pdf-thumbnails>
                 </ng-container>
             </div>

--- a/lib/core/src/lib/viewer/components/pdf-viewer.component.html
+++ b/lib/core/src/lib/viewer/components/pdf-viewer.component.html
@@ -16,10 +16,8 @@
                 <ng-container *ngIf="thumbnailsTemplate">
                     <ng-container *ngTemplateOutlet="thumbnailsTemplate;context:pdfThumbnailsContext"></ng-container>
                 </ng-container>
-
-                <ng-container *ngIf="!thumbnailsTemplate && !isPanelDisabled">
-                    <adf-pdf-thumbnails (close)="toggleThumbnails()" [pdfViewer]="pdfViewer"></adf-pdf-thumbnails>
-                </ng-container>
+                <adf-pdf-thumbnails *ngIf="!thumbnailsTemplate && !isPanelDisabled" (close)="toggleThumbnails()" [pdfViewer]="pdfViewer">
+                </adf-pdf-thumbnails>
             </div>
         </div>
     </ng-container>

--- a/lib/core/src/lib/viewer/components/pdf-viewer.component.spec.ts
+++ b/lib/core/src/lib/viewer/components/pdf-viewer.component.spec.ts
@@ -27,6 +27,8 @@ import { take } from 'rxjs/operators';
 import { AppConfigService } from '../../app-config/app-config.service';
 import { CoreTestingModule } from '../../testing/core.testing.module';
 import { TranslateModule } from '@ngx-translate/core';
+import { PdfThumbListComponent } from '@alfresco/adf-core';
+import { By } from '@angular/platform-browser';
 
 declare const pdfjsLib: any;
 
@@ -354,6 +356,13 @@ describe('Test PdfViewer component', () => {
                     done();
                 });
             }, 55000);
+
+            it('should not render PdfThumbListComponent during initialization of new pdfViewer', () => {
+                componentUrlTestComponent.pdfViewerComponent.toggleThumbnails();
+                componentUrlTestComponent.urlFile = 'file.pdf';
+                fixtureUrlTestComponent.detectChanges();
+                expect(fixtureUrlTestComponent.debugElement.query(By.directive(PdfThumbListComponent))).toBeNull();
+            });
         });
 
         describe('Viewer events', () => {

--- a/lib/core/src/lib/viewer/components/pdf-viewer.component.ts
+++ b/lib/core/src/lib/viewer/components/pdf-viewer.component.ts
@@ -230,7 +230,6 @@ export class PdfViewerComponent implements OnChanges, OnDestroy {
                 renderingQueue: this.renderingQueueServices,
                 eventBus: this.eventBus
             });
-            this.isPanelDisabled = true;
 
             // cspell: disable-next
             this.eventBus.on('pagechanging', this.onPageChange);

--- a/lib/core/src/lib/viewer/components/pdf-viewer.component.ts
+++ b/lib/core/src/lib/viewer/components/pdf-viewer.component.ts
@@ -205,6 +205,7 @@ export class PdfViewerComponent implements OnChanges, OnDestroy {
             this.loadingPercent = Math.round(level * 100);
         };
 
+        this.isPanelDisabled = true;
         this.loadingTask.promise
             .then((pdfDocument: PDFDocumentProxy) => {
                 this.totalPages = pdfDocument.numPages;

--- a/lib/core/src/lib/viewer/components/pdf-viewer.component.ts
+++ b/lib/core/src/lib/viewer/components/pdf-viewer.component.ts
@@ -229,6 +229,7 @@ export class PdfViewerComponent implements OnChanges, OnDestroy {
                 renderingQueue: this.renderingQueueServices,
                 eventBus: this.eventBus
             });
+            this.isPanelDisabled = true;
 
             // cspell: disable-next
             this.eventBus.on('pagechanging', this.onPageChange);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ACS-6067


**What is the new behaviour?**
When we change file then thumbnails are updated and they are displayed for just changed file. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
