### PR TITLE
[ACS-6211] Fixed UI alignment issues in create rules screen (CardView and child components)

### DIFF
--- a/lib/core/src/lib/card-view/components/card-view-boolitem/card-view-boolitem.component.ts
+++ b/lib/core/src/lib/card-view/components/card-view-boolitem/card-view-boolitem.component.ts
@@ -22,7 +22,14 @@ import { BaseCardView } from '../base-card-view';
 
 @Component({
     selector: 'adf-card-view-boolitem',
-    templateUrl: './card-view-boolitem.component.html'
+    templateUrl: './card-view-boolitem.component.html',
+    styles: [
+        `
+            .adf-property-value {
+                padding: 15px 0;
+            }
+        `
+    ]
 })
 
 export class CardViewBoolItemComponent extends BaseCardView<CardViewBoolItemModel> {

--- a/lib/core/src/lib/card-view/components/card-view-selectitem/card-view-selectitem.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view-selectitem/card-view-selectitem.component.spec.ts
@@ -26,6 +26,7 @@ import { AppConfigService } from '../../../app-config/app-config.service';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatSelectHarness } from '@angular/material/select/testing';
+import { MatLabel } from '@angular/material/form-field';
 
 describe('CardViewSelectItemComponent', () => {
     let loader: HarnessLoader;
@@ -73,6 +74,25 @@ describe('CardViewSelectItemComponent', () => {
     });
 
     describe('Rendering', () => {
+        it('should render custom label when editable is set to false', () => {
+            component.property = new CardViewSelectItemModel({
+                ...mockDefaultProps,
+                editable: false
+            });
+            fixture.detectChanges();
+            const labelValue = fixture.debugElement.query(By.css('.adf-property-label'));
+            expect(labelValue).not.toBeNull();
+            expect(labelValue.nativeElement.innerText).toBe('Select box label');
+        });
+
+        it('should render mat label when editable is set to true', () => {
+            component.editable = true;
+            fixture.detectChanges();
+            const labelValue = fixture.debugElement.query(By.directive(MatLabel));
+            expect(labelValue).not.toBeNull();
+            expect(labelValue.nativeElement.innerText).toBe('Select box label');
+        });
+
         it('should render readOnly value is editable property is FALSE', () => {
             component.property = new CardViewSelectItemModel({
                 ...mockDefaultProps,

--- a/lib/core/src/lib/card-view/components/card-view-selectitem/card-view-selectitem.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view-selectitem/card-view-selectitem.component.spec.ts
@@ -26,7 +26,6 @@ import { AppConfigService } from '../../../app-config/app-config.service';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatSelectHarness } from '@angular/material/select/testing';
-import { MatLabel } from '@angular/material/form-field';
 
 describe('CardViewSelectItemComponent', () => {
     let loader: HarnessLoader;
@@ -81,14 +80,6 @@ describe('CardViewSelectItemComponent', () => {
             });
             fixture.detectChanges();
             const labelValue = fixture.debugElement.query(By.css('.adf-property-label'));
-            expect(labelValue).not.toBeNull();
-            expect(labelValue.nativeElement.innerText).toBe('Select box label');
-        });
-
-        it('should render mat label when editable is set to true', () => {
-            component.editable = true;
-            fixture.detectChanges();
-            const labelValue = fixture.debugElement.query(By.directive(MatLabel));
             expect(labelValue).not.toBeNull();
             expect(labelValue.nativeElement.innerText).toBe('Select box label');
         });

--- a/lib/core/src/lib/card-view/components/card-view-selectitem/card-view-selectitem.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view-selectitem/card-view-selectitem.component.spec.ts
@@ -73,14 +73,6 @@ describe('CardViewSelectItemComponent', () => {
     });
 
     describe('Rendering', () => {
-        it('should render the label', () => {
-            fixture.detectChanges();
-
-            const labelValue = fixture.debugElement.query(By.css('.adf-property-label'));
-            expect(labelValue).not.toBeNull();
-            expect(labelValue.nativeElement.innerText).toBe('Select box label');
-        });
-
         it('should render readOnly value is editable property is FALSE', () => {
             component.property = new CardViewSelectItemModel({
                 ...mockDefaultProps,

--- a/lib/core/src/lib/card-view/components/card-view/card-view.component.html
+++ b/lib/core/src/lib/card-view/components/card-view/card-view.component.html
@@ -1,5 +1,5 @@
 <div class="adf-property-list">
-    <div *ngFor="let property of properties">
+    <div *ngFor="let property of properties" class="adf-property-container">
         <div [attr.data-automation-id]="'header-'+property.key" class="adf-property">
             <adf-card-view-item-dispatcher
                 [property]="property"

--- a/lib/core/src/lib/card-view/components/card-view/card-view.component.scss
+++ b/lib/core/src/lib/card-view/components/card-view/card-view.component.scss
@@ -19,6 +19,10 @@
         }
     }
 
+    .adf-property-container {
+        margin-bottom: 10px;
+    }
+
     .adf-property {
         .adf-property-field {
             width: 100%;
@@ -30,7 +34,7 @@
             .mat-input-element {
                 text-overflow: ellipsis;
                 color: var(--adf-metadata-property-panel-title-color);
-                margin-top: 32px;
+                margin-top: 20px;
                 padding: 6px 0;
                 line-height: 20px;
             }
@@ -57,7 +61,7 @@
             }
 
             .mat-form-field-label {
-                padding: 6px 0;
+                padding: 0;
                 justify-content: center;
                 display: flex;
                 flex-direction: column;
@@ -83,7 +87,7 @@
             &.mat-input-element {
                 color: var(--adf-metadata-action-button-clear-color);
                 padding: 6px 0 6px 12px;
-                margin: 32px 0 0;
+                margin: 20px 0 0;
             }
         }
 

--- a/lib/core/src/lib/card-view/components/card-view/card-view.component.scss
+++ b/lib/core/src/lib/card-view/components/card-view/card-view.component.scss
@@ -7,7 +7,7 @@
     .adf-property-label {
         color: var(--adf-metadata-property-panel-text-color);
         display: flex;
-        padding: 6px 0;
+        padding: 3px 0;
         line-height: 20px;
 
         &.adf-property-value-editable {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe:
Minor UI and styling adjustments

**What is the current behaviour?** (You can also link to an open issue here)
UI for the cardView Component when viewed inside CreateRules section in ACA had alignment issues


**What is the new behaviour?**
Adjusted the UI/styling slightly, to fix alignment issues


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
This PR links to [this](https://github.com/Alfresco/alfresco-content-app/pull/3505#issuecomment-1794497287) comment on [this](https://github.com/Alfresco/alfresco-content-app/pull/3531) PR