### PR TITLE
[PRODENG-211] fix js-api version bump

### DIFF
--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -69,15 +69,17 @@ version_js_change() {
 }
 
 update_library_version() {
-    echo "====== $1@$VERSION ======"
-
     DESTDIR="$DIR/../lib/$1"
-    if [[ $1 == "js-api" ]]; then
-        DESTDIR="$DESTDIR/src"
-    fi
 
-    cd $DESTDIR
-    npm version --allow-same-version --no-git-tag-version --force --loglevel=error $VERSION
+    if [[ $1 == "js-api" ]]; then
+        cd $DESTDIR/src
+        echo "====== $1@$JS_API_VERSION ======"
+        npm version --allow-same-version --no-git-tag-version --force --loglevel=error $JS_API_VERSION
+    else
+        cd $DESTDIR
+        echo "====== $1@$VERSION ======"
+        npm version --allow-same-version --no-git-tag-version --force --loglevel=error $VERSION
+    fi
 }
 
 update_dependency_version() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

- fix the bug with JS-API own package not bumping after all libs are upgraded to new JS-API version

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://alfresco.atlassian.net/browse/PRODENG-211