### PR TITLE
[MNT-23433] configure position for close button on Viewer

### DIFF
--- a/demo-shell/src/app.config.json
+++ b/demo-shell/src/app.config.json
@@ -1493,7 +1493,6 @@
     "downloadPromptDelay": 50,
     "downloadPromptReminderDelay": 30,
     "enableFileAutoDownload": true,
-    "fileAutoDownloadSizeThresholdInMB": 15,
-    "isCloseButtonOnLeft": false
+    "fileAutoDownloadSizeThresholdInMB": 15
   }
 }

--- a/demo-shell/src/app.config.json
+++ b/demo-shell/src/app.config.json
@@ -1493,6 +1493,7 @@
     "downloadPromptDelay": 50,
     "downloadPromptReminderDelay": 30,
     "enableFileAutoDownload": true,
-    "fileAutoDownloadSizeThresholdInMB": 15
+    "fileAutoDownloadSizeThresholdInMB": 15,
+    "isCloseButtonOnLeft": false
   }
 }

--- a/docs/content-services/components/alfresco-viewer.component.md
+++ b/docs/content-services/components/alfresco-viewer.component.md
@@ -67,7 +67,8 @@ See the [Custom layout](#custom-layout) section for full details of all availabl
 | ---- | ---- | ------------- | ----------- |
 | allowDownload | `boolean` | true | Toggles downloading. |
 | allowFullScreen | `boolean` | true | Toggles the 'Full Screen' feature. |
-| allowGoBack | `boolean` | true | Allows `back` navigation |
+| allowGoBack | `boolean` | true | Allows `back` navigation on left or right position. |
+| showCloseButton | `boolean` | true | Show/hide close button. |
 | allowLeftSidebar | `boolean` | false | Allow the left the sidebar. |
 | allowNavigate | `boolean` | false | Toggles before/next navigation. You can use the arrow buttons to navigate between documents in the collection. |
 | allowPrint | `boolean` | false | Toggles printing. |

--- a/docs/content-services/components/alfresco-viewer.component.md
+++ b/docs/content-services/components/alfresco-viewer.component.md
@@ -68,7 +68,7 @@ See the [Custom layout](#custom-layout) section for full details of all availabl
 | allowDownload | `boolean` | true | Toggles downloading. |
 | allowFullScreen | `boolean` | true | Toggles the 'Full Screen' feature. |
 | allowGoBack | `boolean` | true | Allows `back` navigation. |
-| closeButtonPosition | `string` | `right` | Set close button position right/left. |
+| closeButtonPosition | `string` | `left` | Set close button position right/left. |
 | allowLeftSidebar | `boolean` | false | Allow the left the sidebar. |
 | allowNavigate | `boolean` | false | Toggles before/next navigation. You can use the arrow buttons to navigate between documents in the collection. |
 | allowPrint | `boolean` | false | Toggles printing. |

--- a/docs/content-services/components/alfresco-viewer.component.md
+++ b/docs/content-services/components/alfresco-viewer.component.md
@@ -67,8 +67,8 @@ See the [Custom layout](#custom-layout) section for full details of all availabl
 | ---- | ---- | ------------- | ----------- |
 | allowDownload | `boolean` | true | Toggles downloading. |
 | allowFullScreen | `boolean` | true | Toggles the 'Full Screen' feature. |
-| allowGoBack | `boolean` | true | Allows `back` navigation on left or right position. |
-| showCloseButton | `boolean` | true | Show/hide close button. |
+| allowGoBack | `boolean` | true | Allows `back` navigation. |
+| closeButtonPosition | `string` | `right` | Set close button position right/left. |
 | allowLeftSidebar | `boolean` | false | Allow the left the sidebar. |
 | allowNavigate | `boolean` | false | Toggles before/next navigation. You can use the arrow buttons to navigate between documents in the collection. |
 | allowPrint | `boolean` | false | Toggles printing. |

--- a/docs/content-services/components/alfresco-viewer.component.md
+++ b/docs/content-services/components/alfresco-viewer.component.md
@@ -69,6 +69,7 @@ See the [Custom layout](#custom-layout) section for full details of all availabl
 | allowFullScreen | `boolean` | true | Toggles the 'Full Screen' feature. |
 | allowGoBack | `boolean` | true | Allows `back` navigation. |
 | closeButtonPosition | `CloseButtonPosition` | `left` | Set close button position right/left. |
+| hideInfoButton | `boolean` | `false` | Toggles Info button. |
 | allowLeftSidebar | `boolean` | false | Allow the left the sidebar. |
 | allowNavigate | `boolean` | false | Toggles before/next navigation. You can use the arrow buttons to navigate between documents in the collection. |
 | allowPrint | `boolean` | false | Toggles printing. |

--- a/docs/content-services/components/alfresco-viewer.component.md
+++ b/docs/content-services/components/alfresco-viewer.component.md
@@ -69,7 +69,7 @@ See the [Custom layout](#custom-layout) section for full details of all availabl
 | allowFullScreen | `boolean` | true | Toggles the 'Full Screen' feature. |
 | allowGoBack | `boolean` | true | Allows `back` navigation. |
 | closeButtonPosition | `CloseButtonPosition` | `left` | Set close button position right/left. |
-| hideInfoButton | `boolean` | `false` | Toggles Info button. |
+| hideInfoButton | `boolean` | false | Toggles Info button. |
 | allowLeftSidebar | `boolean` | false | Allow the left the sidebar. |
 | allowNavigate | `boolean` | false | Toggles before/next navigation. You can use the arrow buttons to navigate between documents in the collection. |
 | allowPrint | `boolean` | false | Toggles printing. |

--- a/docs/content-services/components/alfresco-viewer.component.md
+++ b/docs/content-services/components/alfresco-viewer.component.md
@@ -68,7 +68,7 @@ See the [Custom layout](#custom-layout) section for full details of all availabl
 | allowDownload | `boolean` | true | Toggles downloading. |
 | allowFullScreen | `boolean` | true | Toggles the 'Full Screen' feature. |
 | allowGoBack | `boolean` | true | Allows `back` navigation. |
-| closeButtonPosition | `string` | `left` | Set close button position right/left. |
+| closeButtonPosition | `CloseButtonPosition` | `left` | Set close button position right/left. |
 | allowLeftSidebar | `boolean` | false | Allow the left the sidebar. |
 | allowNavigate | `boolean` | false | Toggles before/next navigation. You can use the arrow buttons to navigate between documents in the collection. |
 | allowPrint | `boolean` | false | Toggles printing. |

--- a/docs/core/components/viewer.component.md
+++ b/docs/core/components/viewer.component.md
@@ -63,7 +63,7 @@ See the [Custom layout](#custom-layout) section for full details of all availabl
 | allowFullScreen | `boolean` | true | Toggles the 'Full Screen' feature. |
 | allowGoBack | `boolean` | true | Allows `back` navigation. |
 | closeButtonPosition | `CloseButtonPosition` | `left` | Set close button position right/left. |
-| hideInfoButton | `boolean` | `false` | Toggles Info button. |
+| hideInfoButton | `boolean` | false | Toggles Info button. |
 | allowLeftSidebar | `boolean` | false | Allow the left the sidebar. |
 | allowNavigate | `boolean` | false | Toggles before/next navigation. You can use the arrow buttons to navigate between documents in the collection. |
 | allowRightSidebar | `boolean` | false | Allow the right sidebar. |

--- a/docs/core/components/viewer.component.md
+++ b/docs/core/components/viewer.component.md
@@ -62,7 +62,7 @@ See the [Custom layout](#custom-layout) section for full details of all availabl
 | ---- | ---- | ------------- | ----------- |
 | allowFullScreen | `boolean` | true | Toggles the 'Full Screen' feature. |
 | allowGoBack | `boolean` | true | Allows `back` navigation. |
-| closeButtonPosition | `string` | `left` | Set close button position right/left. |
+| closeButtonPosition | `CloseButtonPosition` | `left` | Set close button position right/left. |
 | allowLeftSidebar | `boolean` | false | Allow the left the sidebar. |
 | allowNavigate | `boolean` | false | Toggles before/next navigation. You can use the arrow buttons to navigate between documents in the collection. |
 | allowRightSidebar | `boolean` | false | Allow the right sidebar. |

--- a/docs/core/components/viewer.component.md
+++ b/docs/core/components/viewer.component.md
@@ -62,7 +62,7 @@ See the [Custom layout](#custom-layout) section for full details of all availabl
 | ---- | ---- | ------------- | ----------- |
 | allowFullScreen | `boolean` | true | Toggles the 'Full Screen' feature. |
 | allowGoBack | `boolean` | true | Allows `back` navigation. |
-| closeButtonPosition | `string` | `right` | Set close button position right/left. |
+| closeButtonPosition | `string` | `left` | Set close button position right/left. |
 | allowLeftSidebar | `boolean` | false | Allow the left the sidebar. |
 | allowNavigate | `boolean` | false | Toggles before/next navigation. You can use the arrow buttons to navigate between documents in the collection. |
 | allowRightSidebar | `boolean` | false | Allow the right sidebar. |

--- a/docs/core/components/viewer.component.md
+++ b/docs/core/components/viewer.component.md
@@ -63,6 +63,7 @@ See the [Custom layout](#custom-layout) section for full details of all availabl
 | allowFullScreen | `boolean` | true | Toggles the 'Full Screen' feature. |
 | allowGoBack | `boolean` | true | Allows `back` navigation. |
 | closeButtonPosition | `CloseButtonPosition` | `left` | Set close button position right/left. |
+| hideInfoButton | `boolean` | `false` | Toggles Info button. |
 | allowLeftSidebar | `boolean` | false | Allow the left the sidebar. |
 | allowNavigate | `boolean` | false | Toggles before/next navigation. You can use the arrow buttons to navigate between documents in the collection. |
 | allowRightSidebar | `boolean` | false | Allow the right sidebar. |

--- a/docs/core/components/viewer.component.md
+++ b/docs/core/components/viewer.component.md
@@ -61,8 +61,8 @@ See the [Custom layout](#custom-layout) section for full details of all availabl
 | Name | Type | Default value | Description |
 | ---- | ---- | ------------- | ----------- |
 | allowFullScreen | `boolean` | true | Toggles the 'Full Screen' feature. |
-| allowGoBack | `boolean` | true | Allows `back` navigation on left or right position. |
-| showCloseButton | `boolean` | true | Show/hide close button. |
+| allowGoBack | `boolean` | true | Allows `back` navigation. |
+| closeButtonPosition | `string` | `right` | Set close button position right/left. |
 | allowLeftSidebar | `boolean` | false | Allow the left the sidebar. |
 | allowNavigate | `boolean` | false | Toggles before/next navigation. You can use the arrow buttons to navigate between documents in the collection. |
 | allowRightSidebar | `boolean` | false | Allow the right sidebar. |

--- a/docs/core/components/viewer.component.md
+++ b/docs/core/components/viewer.component.md
@@ -61,7 +61,8 @@ See the [Custom layout](#custom-layout) section for full details of all availabl
 | Name | Type | Default value | Description |
 | ---- | ---- | ------------- | ----------- |
 | allowFullScreen | `boolean` | true | Toggles the 'Full Screen' feature. |
-| allowGoBack | `boolean` | true | Allows `back` navigation |
+| allowGoBack | `boolean` | true | Allows `back` navigation on left or right position. |
+| showCloseButton | `boolean` | true | Show/hide close button. |
 | allowLeftSidebar | `boolean` | false | Allow the left the sidebar. |
 | allowNavigate | `boolean` | false | Toggles before/next navigation. You can use the arrow buttons to navigate between documents in the collection. |
 | allowRightSidebar | `boolean` | false | Allow the right sidebar. |

--- a/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.html
+++ b/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.html
@@ -16,6 +16,7 @@
     [sidebarLeftTemplate]="sidebarLeftTemplate"
     [sidebarRightTemplateContext]="sidebarRightTemplateContext"
     [sidebarLeftTemplateContext]="sidebarLeftTemplateContext"
+    [showCloseButton]="showCloseButton"
     [fileName]="fileName"
     [mimeType]="mimeType"
     [originalMimeType]="originalMimeType"

--- a/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.html
+++ b/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.html
@@ -17,6 +17,7 @@
     [sidebarRightTemplateContext]="sidebarRightTemplateContext"
     [sidebarLeftTemplateContext]="sidebarLeftTemplateContext"
     [closeButtonPosition]="closeButtonPosition"
+    [hideInfoButton]="hideInfoButton"
     [fileName]="fileName"
     [mimeType]="mimeType"
     [originalMimeType]="originalMimeType"

--- a/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.html
+++ b/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.html
@@ -16,7 +16,7 @@
     [sidebarLeftTemplate]="sidebarLeftTemplate"
     [sidebarRightTemplateContext]="sidebarRightTemplateContext"
     [sidebarLeftTemplateContext]="sidebarLeftTemplateContext"
-    [showCloseButton]="showCloseButton"
+    [closeButtonPosition]="closeButtonPosition"
     [fileName]="fileName"
     [mimeType]="mimeType"
     [originalMimeType]="originalMimeType"

--- a/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.spec.ts
+++ b/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.spec.ts
@@ -695,7 +695,6 @@ describe('AlfrescoViewerComponent', () => {
             fixture.detectChanges();
             fixture.whenStable().then(() => {
                 fixture.detectChanges();
-                expect(element.querySelector('[data-automation-id="adf-toolbar-left-back"]')).toBeDefined();
                 expect(element.querySelector('[data-automation-id="adf-toolbar-left-back"]')).not.toBeNull();
                 done();
             });

--- a/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.spec.ts
+++ b/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.spec.ts
@@ -26,7 +26,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { ContentInfo, Node, NodeEntry, VersionEntry } from '@alfresco/js-api';
 import { AlfrescoViewerComponent, NodeActionsService, RenditionService } from '@alfresco/adf-content-services';
-import { CoreTestingModule, EventMock, ViewUtilService, ViewerComponent } from '@alfresco/adf-core';
+import { CloseButtonPosition, CoreTestingModule, EventMock, ViewUtilService, ViewerComponent } from '@alfresco/adf-core';
 import { NodesApiService } from '../../common/services/nodes-api.service';
 import { UploadService } from '../../common/services/upload.service';
 import { FileModel } from '../../common/models/file.model';
@@ -691,11 +691,12 @@ describe('AlfrescoViewerComponent', () => {
         });
 
         it('should render close viewer button if it is not a shared link', (done) => {
+            component.closeButtonPosition = CloseButtonPosition.Left;
             fixture.detectChanges();
             fixture.whenStable().then(() => {
                 fixture.detectChanges();
-                expect(element.querySelector('[data-automation-id="adf-toolbar-back"]')).toBeDefined();
-                expect(element.querySelector('[data-automation-id="adf-toolbar-back"]')).not.toBeNull();
+                expect(element.querySelector('[data-automation-id="adf-toolbar-left-back"]')).toBeDefined();
+                expect(element.querySelector('[data-automation-id="adf-toolbar-left-back"]')).not.toBeNull();
                 done();
             });
         });
@@ -709,7 +710,7 @@ describe('AlfrescoViewerComponent', () => {
             component.ngOnChanges();
             fixture.whenStable().then(() => {
                 fixture.detectChanges();
-                expect(element.querySelector('[data-automation-id="adf-toolbar-back"]')).toBeNull();
+                expect(element.querySelector('[data-automation-id="adf-toolbar-left-back"]')).toBeNull();
                 done();
             });
         });

--- a/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.ts
+++ b/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.ts
@@ -31,7 +31,6 @@ import {
 } from '@angular/core';
 import {
     AlfrescoApiService,
-    AppConfigService,
     LogService,
     Track,
     ViewerComponent,
@@ -161,6 +160,10 @@ export class AlfrescoViewerComponent implements OnChanges, OnInit, OnDestroy {
     @Input()
     allowFullScreen = true;
 
+    /** Change the close button position Right/Left */
+    @Input()
+    closeButtonPosition = 'right';
+
     /** The template for the right sidebar. The template context contains the loaded node data. */
     @Input()
     sidebarRightTemplate: TemplateRef<any> = null;
@@ -197,7 +200,6 @@ export class AlfrescoViewerComponent implements OnChanges, OnInit, OnDestroy {
     nodeEntry: NodeEntry;
     tracks: Track[] = [];
     readOnly: boolean = true;
-    showCloseButton: boolean = true;
 
     sidebarRightTemplateContext: { node: Node } = { node: null };
     sidebarLeftTemplateContext: { node: Node } = { node: null };
@@ -236,11 +238,9 @@ export class AlfrescoViewerComponent implements OnChanges, OnInit, OnDestroy {
         private uploadService: UploadService,
         public dialog: MatDialog,
         private cdr: ChangeDetectorRef,
-        private nodeActionsService: NodeActionsService,
-        private appConfig: AppConfigService
+        private nodeActionsService: NodeActionsService
     ) {
         renditionService.maxRetries = this.maxRetries;
-        this.allowGoBack = this.appConfig.get('viewer.isCloseButtonOnLeft', false);
     }
 
     ngOnInit() {
@@ -270,7 +270,7 @@ export class AlfrescoViewerComponent implements OnChanges, OnInit, OnDestroy {
     }
 
     private async setupSharedLink() {
-        this.showCloseButton = false;
+        this.allowGoBack = false;
 
         try {
             const sharedLinkEntry = await this.sharedLinksApi.getSharedLink(this.sharedLinkId);

--- a/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.ts
+++ b/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.ts
@@ -31,6 +31,7 @@ import {
 } from '@angular/core';
 import {
     AlfrescoApiService,
+    AppConfigService,
     LogService,
     Track,
     ViewerComponent,
@@ -196,6 +197,7 @@ export class AlfrescoViewerComponent implements OnChanges, OnInit, OnDestroy {
     nodeEntry: NodeEntry;
     tracks: Track[] = [];
     readOnly: boolean = true;
+    showCloseButton: boolean = true;
 
     sidebarRightTemplateContext: { node: Node } = { node: null };
     sidebarLeftTemplateContext: { node: Node } = { node: null };
@@ -234,9 +236,11 @@ export class AlfrescoViewerComponent implements OnChanges, OnInit, OnDestroy {
         private uploadService: UploadService,
         public dialog: MatDialog,
         private cdr: ChangeDetectorRef,
-        private nodeActionsService: NodeActionsService
+        private nodeActionsService: NodeActionsService,
+        private appConfig: AppConfigService
     ) {
         renditionService.maxRetries = this.maxRetries;
+        this.allowGoBack = this.appConfig.get('viewer.isCloseButtonOnLeft', false);
     }
 
     ngOnInit() {
@@ -266,7 +270,7 @@ export class AlfrescoViewerComponent implements OnChanges, OnInit, OnDestroy {
     }
 
     private async setupSharedLink() {
-        this.allowGoBack = false;
+        this.showCloseButton = false;
 
         try {
             const sharedLinkEntry = await this.sharedLinksApi.getSharedLink(this.sharedLinkId);

--- a/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.ts
+++ b/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.ts
@@ -161,6 +161,10 @@ export class AlfrescoViewerComponent implements OnChanges, OnInit, OnDestroy {
     @Input()
     allowFullScreen = true;
 
+    /** Toggles the 'Info Button' */
+    @Input()
+    hideInfoButton = false;
+
     /** Change the close button position Right/Left */
     @Input()
     closeButtonPosition = CloseButtonPosition.Left;

--- a/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.ts
+++ b/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.ts
@@ -31,6 +31,7 @@ import {
 } from '@angular/core';
 import {
     AlfrescoApiService,
+    CloseButtonPosition,
     LogService,
     Track,
     ViewerComponent,
@@ -162,7 +163,7 @@ export class AlfrescoViewerComponent implements OnChanges, OnInit, OnDestroy {
 
     /** Change the close button position Right/Left */
     @Input()
-    closeButtonPosition = 'right';
+    closeButtonPosition = CloseButtonPosition.Left;
 
     /** The template for the right sidebar. The template context contains the loaded node data. */
     @Input()

--- a/lib/core/src/lib/viewer/components/viewer.component.html
+++ b/lib/core/src/lib/viewer/components/viewer.component.html
@@ -8,7 +8,7 @@
          cdkTrapFocusAutoCapture>
         <ng-content select="adf-viewer-toolbar"></ng-content>
         <ng-container *ngIf="showToolbar && !toolbar">
-                  <adf-toolbar id="adf-viewer-toolbar" class="adf-viewer-toolbar">
+            <adf-toolbar id="adf-viewer-toolbar" class="adf-viewer-toolbar">
                 <adf-toolbar-title>
 
                     <ng-container *ngIf="allowLeftSidebar">

--- a/lib/core/src/lib/viewer/components/viewer.component.html
+++ b/lib/core/src/lib/viewer/components/viewer.component.html
@@ -8,7 +8,9 @@
          cdkTrapFocusAutoCapture>
         <ng-content select="adf-viewer-toolbar"></ng-content>
         <ng-container *ngIf="showToolbar && !toolbar">
-            <adf-toolbar id="adf-viewer-toolbar" class="adf-viewer-toolbar">
+                  <adf-toolbar id="adf-viewer-toolbar" class="adf-viewer-toolbar" 
+                  [ngClass]="{ 'adf-viewer-right-close-button': closeButtonPosition === 'right'}"
+                  >
                 <adf-toolbar-title>
 
                     <ng-container *ngIf="allowLeftSidebar">
@@ -24,8 +26,8 @@
                     </ng-container>
 
                     <button *ngIf="allowGoBack && closeButtonPosition === 'left'"
-                            class="adf-viewer-close-button adf-left-close-button"
-                            data-automation-id="adf-toolbar-back"
+                            class="adf-viewer-close-button"
+                            data-automation-id="adf-toolbar-left-back"
                             [attr.aria-label]="'ADF_VIEWER.ACTIONS.CLOSE' | translate"
                             mat-icon-button
                             title="{{ 'ADF_VIEWER.ACTIONS.CLOSE' | translate }}"
@@ -124,7 +126,7 @@
                     <adf-toolbar-divider></adf-toolbar-divider>
 
                     <button class="adf-viewer-close-button adf-right-close-button"
-                            data-automation-id="adf-toolbar-back"
+                            data-automation-id="adf-toolbar-right-back"
                             [attr.aria-label]="'ADF_VIEWER.ACTIONS.CLOSE' | translate"
                             mat-icon-button
                             title="{{ 'ADF_VIEWER.ACTIONS.CLOSE' | translate }}"

--- a/lib/core/src/lib/viewer/components/viewer.component.html
+++ b/lib/core/src/lib/viewer/components/viewer.component.html
@@ -23,7 +23,7 @@
                         </button>
                     </ng-container>
 
-                    <button *ngIf="allowGoBack && closeButtonPosition === 'left'"
+                    <button *ngIf="allowGoBack && closeButtonPosition === CloseButtonPosition.Left"
                             class="adf-viewer-close-button"
                             data-automation-id="adf-toolbar-left-back"
                             [attr.aria-label]="'ADF_VIEWER.ACTIONS.CLOSE' | translate"
@@ -120,7 +120,7 @@
                     </mat-menu>
                 </ng-container>
 
-                <ng-container *ngIf="allowGoBack && closeButtonPosition === 'right'">
+                <ng-container *ngIf="allowGoBack && closeButtonPosition === CloseButtonPosition.Right">
                     <adf-toolbar-divider></adf-toolbar-divider>
 
                     <button class="adf-viewer-close-button"

--- a/lib/core/src/lib/viewer/components/viewer.component.html
+++ b/lib/core/src/lib/viewer/components/viewer.component.html
@@ -8,7 +8,7 @@
          cdkTrapFocusAutoCapture>
         <ng-content select="adf-viewer-toolbar"></ng-content>
         <ng-container *ngIf="showToolbar && !toolbar">
-            <adf-toolbar id="adf-viewer-toolbar" class="adf-viewer-toolbar">
+            <adf-toolbar id="adf-viewer-toolbar" class="adf-viewer-toolbar" >
                 <adf-toolbar-title>
 
                     <ng-container *ngIf="allowLeftSidebar">
@@ -23,8 +23,8 @@
                         </button>
                     </ng-container>
 
-                    <button *ngIf="showCloseButton && allowGoBack"
-                            class="adf-viewer-close-button"
+                    <button *ngIf="allowGoBack && closeButtonPosition === 'left'"
+                            class="adf-viewer-close-button adf-left-close-button"
                             data-automation-id="adf-toolbar-back"
                             [attr.aria-label]="'ADF_VIEWER.ACTIONS.CLOSE' | translate"
                             mat-icon-button
@@ -120,16 +120,15 @@
                     </mat-menu>
                 </ng-container>
 
-                <ng-container *ngIf="showCloseButton && !allowGoBack">
+                <ng-container *ngIf="allowGoBack && closeButtonPosition === 'right'">
                     <adf-toolbar-divider></adf-toolbar-divider>
 
-                    <button 
-                    class="adf-viewer-close-button"
-                    data-automation-id="adf-toolbar-back"
-                    [attr.aria-label]="'ADF_VIEWER.ACTIONS.CLOSE' | translate"
-                    mat-icon-button
-                    title="{{ 'ADF_VIEWER.ACTIONS.CLOSE' | translate }}"
-                    (click)="onClose()">
+                    <button class="adf-viewer-close-button adf-right-close-button"
+                            data-automation-id="adf-toolbar-back"
+                            [attr.aria-label]="'ADF_VIEWER.ACTIONS.CLOSE' | translate"
+                            mat-icon-button
+                            title="{{ 'ADF_VIEWER.ACTIONS.CLOSE' | translate }}"
+                            (click)="onClose()">
                         <mat-icon>close</mat-icon>
                     </button>
                 </ng-container>

--- a/lib/core/src/lib/viewer/components/viewer.component.html
+++ b/lib/core/src/lib/viewer/components/viewer.component.html
@@ -8,7 +8,7 @@
          cdkTrapFocusAutoCapture>
         <ng-content select="adf-viewer-toolbar"></ng-content>
         <ng-container *ngIf="showToolbar && !toolbar">
-            <adf-toolbar id="adf-viewer-toolbar" class="adf-viewer-toolbar" >
+            <adf-toolbar id="adf-viewer-toolbar" class="adf-viewer-toolbar">
                 <adf-toolbar-title>
 
                     <ng-container *ngIf="allowLeftSidebar">

--- a/lib/core/src/lib/viewer/components/viewer.component.html
+++ b/lib/core/src/lib/viewer/components/viewer.component.html
@@ -23,7 +23,7 @@
                         </button>
                     </ng-container>
 
-                    <button *ngIf="allowGoBack"
+                    <button *ngIf="showCloseButton && allowGoBack"
                             class="adf-viewer-close-button"
                             data-automation-id="adf-toolbar-back"
                             [attr.aria-label]="'ADF_VIEWER.ACTIONS.CLOSE' | translate"
@@ -118,6 +118,20 @@
                               [overlapTrigger]="false">
                         <ng-content select="adf-viewer-more-actions"></ng-content>
                     </mat-menu>
+                </ng-container>
+
+                <ng-container *ngIf="showCloseButton && !allowGoBack">
+                    <adf-toolbar-divider></adf-toolbar-divider>
+
+                    <button 
+                    class="adf-viewer-close-button"
+                    data-automation-id="adf-toolbar-back"
+                    [attr.aria-label]="'ADF_VIEWER.ACTIONS.CLOSE' | translate"
+                    mat-icon-button
+                    title="{{ 'ADF_VIEWER.ACTIONS.CLOSE' | translate }}"
+                    (click)="onClose()">
+                        <mat-icon>close</mat-icon>
+                    </button>
                 </ng-container>
 
             </adf-toolbar>

--- a/lib/core/src/lib/viewer/components/viewer.component.html
+++ b/lib/core/src/lib/viewer/components/viewer.component.html
@@ -8,9 +8,7 @@
          cdkTrapFocusAutoCapture>
         <ng-content select="adf-viewer-toolbar"></ng-content>
         <ng-container *ngIf="showToolbar && !toolbar">
-                  <adf-toolbar id="adf-viewer-toolbar" class="adf-viewer-toolbar" 
-                  [ngClass]="{ 'adf-viewer-right-close-button': closeButtonPosition === 'right'}"
-                  >
+                  <adf-toolbar id="adf-viewer-toolbar" class="adf-viewer-toolbar">
                 <adf-toolbar-title>
 
                     <ng-container *ngIf="allowLeftSidebar">
@@ -92,7 +90,7 @@
                     <mat-icon>fullscreen</mat-icon>
                 </button>
 
-                <ng-container *ngIf="allowRightSidebar">
+                <ng-container *ngIf="allowRightSidebar && !hideInfoButton">
                     <adf-toolbar-divider></adf-toolbar-divider>
 
                     <button mat-icon-button
@@ -125,7 +123,7 @@
                 <ng-container *ngIf="allowGoBack && closeButtonPosition === 'right'">
                     <adf-toolbar-divider></adf-toolbar-divider>
 
-                    <button class="adf-viewer-close-button adf-right-close-button"
+                    <button class="adf-viewer-close-button"
                             data-automation-id="adf-toolbar-right-back"
                             [attr.aria-label]="'ADF_VIEWER.ACTIONS.CLOSE' | translate"
                             mat-icon-button

--- a/lib/core/src/lib/viewer/components/viewer.component.spec.ts
+++ b/lib/core/src/lib/viewer/components/viewer.component.spec.ts
@@ -29,7 +29,8 @@ import {
     ViewUtilService,
     AppConfigService,
     DownloadPromptDialogComponent,
-    DownloadPromptActions
+    DownloadPromptActions,
+    CloseButtonPosition
 } from '@alfresco/adf-core';
 import { of } from 'rxjs';
 import { ViewerWithCustomMoreActionsComponent } from './mock/adf-viewer-container-more-actions.component.mock';
@@ -351,11 +352,12 @@ describe('ViewerComponent', () => {
         });
 
         it('should render close viewer button if it is not a shared link', (done) => {
+            component.closeButtonPosition = CloseButtonPosition.Left;
             fixture.detectChanges();
             fixture.whenStable().then(() => {
                 fixture.detectChanges();
-                expect(element.querySelector('[data-automation-id="adf-toolbar-back"]')).toBeDefined();
-                expect(element.querySelector('[data-automation-id="adf-toolbar-back"]')).not.toBeNull();
+                expect(element.querySelector('[data-automation-id="adf-toolbar-left-back"]')).toBeDefined();
+                expect(element.querySelector('[data-automation-id="adf-toolbar-left-back"]')).not.toBeNull();
                 done();
             });
         });
@@ -527,28 +529,33 @@ describe('ViewerComponent', () => {
 
         describe('Close Button', () => {
 
+            const getRightCloseButton = () => element.querySelector<HTMLButtonElement>('[data-automation-id="adf-toolbar-right-back"]');
+            const getLeftCloseButton = () => element.querySelector<HTMLButtonElement>('[data-automation-id="adf-toolbar-left-back"]');
+
             it('should show close button on left side when closeButtonPosition is left and allowGoBack is true', () => {
                 component.allowGoBack = true;
-                component.closeButtonPosition = 'left';
+                component.closeButtonPosition = CloseButtonPosition.Left;
                 fixture.detectChanges();
 
-                expect(element.querySelector('.adf-left-close-button')).not.toBeNull();
+                expect(getLeftCloseButton()).not.toBeNull();
+                expect(getRightCloseButton()).toBeNull();
             });
 
             it('should show close button on right side when closeButtonPosition is right and allowGoBack is true', () => {
                 component.allowGoBack = true;
-                component.closeButtonPosition = 'right';
+                component.closeButtonPosition =  CloseButtonPosition.Right;
                 fixture.detectChanges();
 
-                expect(element.querySelector('.adf-right-close-button')).not.toBeNull();
+                expect(getRightCloseButton()).not.toBeNull();
+                expect(getLeftCloseButton()).toBeNull();
             });
 
             it('should hide close button allowGoBack is false', () => {
                 component.allowGoBack = false;
                 fixture.detectChanges();
 
-                expect(element.querySelector('.adf-right-close-button')).toBeNull();
-                expect(element.querySelector('.adf-left-close-button')).toBeNull();
+                expect(getRightCloseButton()).toBeNull();
+                expect(getLeftCloseButton()).toBeNull();
             });
         });
 

--- a/lib/core/src/lib/viewer/components/viewer.component.spec.ts
+++ b/lib/core/src/lib/viewer/components/viewer.component.spec.ts
@@ -424,6 +424,35 @@ describe('ViewerComponent', () => {
             });
         });
 
+        describe('Info Button', () => {
+
+            const infoButton = () => element.querySelector<HTMLButtonElement>('[data-automation-id="adf-toolbar-sidebar"]');
+
+            it('should NOT display info button on the right side', (done) => {
+                component.allowRightSidebar = true;
+                component.hideInfoButton = true;
+
+                fixture.detectChanges();
+
+                fixture.whenStable().then(() => {
+                    expect(infoButton()).toBeNull();
+                    done();
+                });
+            });
+
+            it('should display info button on the right side', (done) => {
+                component.allowRightSidebar = true;
+                component.hideInfoButton = false;
+
+                fixture.detectChanges();
+
+                fixture.whenStable().then(() => {
+                    expect(infoButton()).not.toBeNull();
+                    done();
+                });
+            });
+        });
+
         describe('View', () => {
 
             describe('Overlay mode true', () => {

--- a/lib/core/src/lib/viewer/components/viewer.component.spec.ts
+++ b/lib/core/src/lib/viewer/components/viewer.component.spec.ts
@@ -425,22 +425,19 @@ describe('ViewerComponent', () => {
         });
 
         describe('Info Button', () => {
-
             const infoButton = () => element.querySelector<HTMLButtonElement>('[data-automation-id="adf-toolbar-sidebar"]');
 
             it('should NOT display info button on the right side', () => {
                 component.allowRightSidebar = true;
                 component.hideInfoButton = true;
-
                 fixture.detectChanges();
 
-                expect(infoButton()).toBeNull(); 
+                expect(infoButton()).toBeNull();
             });
 
             it('should display info button on the right side', () => {
                 component.allowRightSidebar = true;
                 component.hideInfoButton = false;
-
                 fixture.detectChanges();
 
                 expect(infoButton()).not.toBeNull();

--- a/lib/core/src/lib/viewer/components/viewer.component.spec.ts
+++ b/lib/core/src/lib/viewer/components/viewer.component.spec.ts
@@ -536,7 +536,7 @@ describe('ViewerComponent', () => {
 
             });
 
-            it('should show close button on right side when showCloseButton is true and allowGoBack is true', () => {
+            it('should show close button on right side when showCloseButton is true and allowGoBack is false', () => {
                 component.showCloseButton = true;
                 component.allowGoBack = false;
                 fixture.detectChanges();
@@ -545,7 +545,7 @@ describe('ViewerComponent', () => {
 
             });
 
-            it('should hide close button on right side when showCloseButton is false', () => {
+            it('should hide close button when showCloseButton is false', () => {
                 component.showCloseButton = false;
                 fixture.detectChanges();
 

--- a/lib/core/src/lib/viewer/components/viewer.component.spec.ts
+++ b/lib/core/src/lib/viewer/components/viewer.component.spec.ts
@@ -527,29 +527,28 @@ describe('ViewerComponent', () => {
 
         describe('Close Button', () => {
 
-            it('should show close button on left side when showCloseButton is true and allowGoBack is true', () => {
-                component.showCloseButton = true;
+            it('should show close button on left side when closeButtonPosition is left and allowGoBack is true', () => {
                 component.allowGoBack = true;
+                component.closeButtonPosition = 'left';
                 fixture.detectChanges();
 
-                expect(element.querySelector('.adf-viewer-close-button')).not.toBeNull();
-
+                expect(element.querySelector('.adf-left-close-button')).not.toBeNull();
             });
 
-            it('should show close button on right side when showCloseButton is true and allowGoBack is false', () => {
-                component.showCloseButton = true;
+            it('should show close button on right side when closeButtonPosition is right and allowGoBack is true', () => {
+                component.allowGoBack = true;
+                component.closeButtonPosition = 'right';
+                fixture.detectChanges();
+
+                expect(element.querySelector('.adf-right-close-button')).not.toBeNull();
+            });
+
+            it('should hide close button allowGoBack is false', () => {
                 component.allowGoBack = false;
                 fixture.detectChanges();
 
-                expect(element.querySelector('.adf-viewer-close-button')).not.toBeNull();
-
-            });
-
-            it('should hide close button when showCloseButton is false', () => {
-                component.showCloseButton = false;
-                fixture.detectChanges();
-
-                expect(element.querySelector('.adf-viewer-close-button')).toBeNull();
+                expect(element.querySelector('.adf-right-close-button')).toBeNull();
+                expect(element.querySelector('.adf-left-close-button')).toBeNull();
             });
         });
 

--- a/lib/core/src/lib/viewer/components/viewer.component.spec.ts
+++ b/lib/core/src/lib/viewer/components/viewer.component.spec.ts
@@ -428,28 +428,22 @@ describe('ViewerComponent', () => {
 
             const infoButton = () => element.querySelector<HTMLButtonElement>('[data-automation-id="adf-toolbar-sidebar"]');
 
-            it('should NOT display info button on the right side', (done) => {
+            it('should NOT display info button on the right side', () => {
                 component.allowRightSidebar = true;
                 component.hideInfoButton = true;
 
                 fixture.detectChanges();
 
-                fixture.whenStable().then(() => {
-                    expect(infoButton()).toBeNull();
-                    done();
-                });
+                expect(infoButton()).toBeNull(); 
             });
 
-            it('should display info button on the right side', (done) => {
+            it('should display info button on the right side', () => {
                 component.allowRightSidebar = true;
                 component.hideInfoButton = false;
 
                 fixture.detectChanges();
 
-                fixture.whenStable().then(() => {
-                    expect(infoButton()).not.toBeNull();
-                    done();
-                });
+                expect(infoButton()).not.toBeNull();
             });
         });
 

--- a/lib/core/src/lib/viewer/components/viewer.component.spec.ts
+++ b/lib/core/src/lib/viewer/components/viewer.component.spec.ts
@@ -525,6 +525,34 @@ describe('ViewerComponent', () => {
             });
         });
 
+        describe('Close Button', () => {
+
+            it('should show close button on left side when showCloseButton is true and allowGoBack is true', () => {
+                component.showCloseButton = true;
+                component.allowGoBack = true;
+                fixture.detectChanges();
+
+                expect(element.querySelector('.adf-viewer-close-button')).not.toBeNull();
+
+            });
+
+            it('should show close button on right side when showCloseButton is true and allowGoBack is true', () => {
+                component.showCloseButton = true;
+                component.allowGoBack = false;
+                fixture.detectChanges();
+
+                expect(element.querySelector('.adf-viewer-close-button')).not.toBeNull();
+
+            });
+
+            it('should hide close button on right side when showCloseButton is false', () => {
+                component.showCloseButton = false;
+                fixture.detectChanges();
+
+                expect(element.querySelector('.adf-viewer-close-button')).toBeNull();
+            });
+        });
+
         describe('Viewer component - Full Screen Mode - Mocking fixture element', () => {
 
             beforeEach(() => {

--- a/lib/core/src/lib/viewer/components/viewer.component.spec.ts
+++ b/lib/core/src/lib/viewer/components/viewer.component.spec.ts
@@ -356,7 +356,6 @@ describe('ViewerComponent', () => {
             fixture.detectChanges();
             fixture.whenStable().then(() => {
                 fixture.detectChanges();
-                expect(element.querySelector('[data-automation-id="adf-toolbar-left-back"]')).toBeDefined();
                 expect(element.querySelector('[data-automation-id="adf-toolbar-left-back"]')).not.toBeNull();
                 done();
             });

--- a/lib/core/src/lib/viewer/components/viewer.component.ts
+++ b/lib/core/src/lib/viewer/components/viewer.component.ts
@@ -182,6 +182,10 @@ export class ViewerComponent<T> implements OnDestroy, OnInit, OnChanges {
     @Input()
     closeButtonPosition = CloseButtonPosition.Left;
 
+    /** Toggles the 'Info Button' */
+    @Input()
+    hideInfoButton = false;
+
     /**
      * Enable dialog box to allow user to download the previewed file, in case the preview is not responding for a set period of time.
      */

--- a/lib/core/src/lib/viewer/components/viewer.component.ts
+++ b/lib/core/src/lib/viewer/components/viewer.component.ts
@@ -176,7 +176,7 @@ export class ViewerComponent<T> implements OnDestroy, OnInit, OnChanges {
     @Input()
     sidebarLeftTemplateContext: T = null;
 
-     /**
+    /**
      * Change the close button position Right/Left.
      */
     @Input()

--- a/lib/core/src/lib/viewer/components/viewer.component.ts
+++ b/lib/core/src/lib/viewer/components/viewer.component.ts
@@ -37,7 +37,7 @@ import { ViewerOpenWithComponent } from './viewer-open-with.component';
 import { ViewerMoreActionsComponent } from './viewer-more-actions.component';
 import { ViewerSidebarComponent } from './viewer-sidebar.component';
 import { filter, first, skipWhile, takeUntil } from 'rxjs/operators';
-import { Track } from '../models/viewer.model';
+import { CloseButtonPosition, Track } from '../models/viewer.model';
 import { ViewUtilService } from '../services/view-util.service';
 import { DownloadPromptDialogComponent } from './download-prompt-dialog/download-prompt-dialog.component';
 import { AppConfigService } from '../../app-config';
@@ -180,7 +180,7 @@ export class ViewerComponent<T> implements OnDestroy, OnInit, OnChanges {
      * Change the close button position Right/Left.
      */
     @Input()
-    closeButtonPosition = 'right';
+    closeButtonPosition = CloseButtonPosition.Left;
 
     /**
      * Enable dialog box to allow user to download the previewed file, in case the preview is not responding for a set period of time.

--- a/lib/core/src/lib/viewer/components/viewer.component.ts
+++ b/lib/core/src/lib/viewer/components/viewer.component.ts
@@ -176,11 +176,11 @@ export class ViewerComponent<T> implements OnDestroy, OnInit, OnChanges {
     @Input()
     sidebarLeftTemplateContext: T = null;
 
-    /**
-     * show/hide close button on shareable link.
+     /**
+     * Change the close button position Right/Left.
      */
     @Input()
-    showCloseButton = true;
+    closeButtonPosition = 'right';
 
     /**
      * Enable dialog box to allow user to download the previewed file, in case the preview is not responding for a set period of time.

--- a/lib/core/src/lib/viewer/components/viewer.component.ts
+++ b/lib/core/src/lib/viewer/components/viewer.component.ts
@@ -72,7 +72,7 @@ export class ViewerComponent<T> implements OnDestroy, OnInit, OnChanges {
     mnuMoreActions: ViewerMoreActionsComponent;
 
     get CloseButtonPosition() {
-        return CloseButtonPosition; 
+        return CloseButtonPosition;
     }
 
     /**

--- a/lib/core/src/lib/viewer/components/viewer.component.ts
+++ b/lib/core/src/lib/viewer/components/viewer.component.ts
@@ -71,6 +71,10 @@ export class ViewerComponent<T> implements OnDestroy, OnInit, OnChanges {
     @ContentChild(ViewerMoreActionsComponent)
     mnuMoreActions: ViewerMoreActionsComponent;
 
+    get CloseButtonPosition() {
+        return CloseButtonPosition; 
+    }
+
     /**
      * If you want to load an external file that does not come from ACS you
      * can use this URL to specify where to load the file from.

--- a/lib/core/src/lib/viewer/components/viewer.component.ts
+++ b/lib/core/src/lib/viewer/components/viewer.component.ts
@@ -177,6 +177,12 @@ export class ViewerComponent<T> implements OnDestroy, OnInit, OnChanges {
     sidebarLeftTemplateContext: T = null;
 
     /**
+     * show/hide close button on shareable link.
+     */
+    @Input()
+    showCloseButton = true;
+
+    /**
      * Enable dialog box to allow user to download the previewed file, in case the preview is not responding for a set period of time.
      */
     enableDownloadPrompt: boolean = false;

--- a/lib/core/src/lib/viewer/models/viewer.model.ts
+++ b/lib/core/src/lib/viewer/models/viewer.model.ts
@@ -15,6 +15,11 @@
  * limitations under the License.
  */
 
+export enum CloseButtonPosition {
+    Right = 'right',
+    Left = 'left'
+}
+
 export interface Track {
     src: string;
     label?: string;

--- a/lib/testing/src/lib/protractor/core/pages/viewer.page.ts
+++ b/lib/testing/src/lib/protractor/core/pages/viewer.page.ts
@@ -25,7 +25,7 @@ const MAX_LOADING_TIME = 120000;
 
 export class ViewerPage {
     tabsPage = new TabsPage();
-    closeButton = $('.adf-viewer-close-button');
+    closeButton = $('button.adf-viewer-close-button');
     fileName = $('#adf-viewer-display-name');
     infoButton = $('button[data-automation-id="adf-toolbar-sidebar"]');
     previousPageButton = $('#viewer-previous-page-button');

--- a/lib/testing/src/lib/protractor/core/pages/viewer.page.ts
+++ b/lib/testing/src/lib/protractor/core/pages/viewer.page.ts
@@ -25,7 +25,7 @@ const MAX_LOADING_TIME = 120000;
 
 export class ViewerPage {
     tabsPage = new TabsPage();
-    closeButton = $('button[data-automation-id="adf-toolbar-back"]');
+    closeButton = $('.adf-viewer-close-button');
     fileName = $('#adf-viewer-display-name');
     infoButton = $('button[data-automation-id="adf-toolbar-sidebar"]');
     previousPageButton = $('#viewer-previous-page-button');


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
The button to close the preview is located on the left side while the other control buttons are on the right.

**What is the new behaviour?**
The button to close the preview is now configurable, customer can set the position of close button either left or right.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://alfresco.atlassian.net/browse/MNT-23433

Dependent PR link :  https://github.com/Alfresco/alfresco-content-app/pull/3535