### PR TITLE
[AAE-18459] Fix invalidateSession is called when auth is not initilized by js-api

### DIFF
--- a/lib/core/src/lib/app-config/app-config.service.spec.ts
+++ b/lib/core/src/lib/app-config/app-config.service.spec.ts
@@ -198,4 +198,20 @@ describe('AppConfigService', () => {
         expect(fakeCallBack).toHaveBeenCalled();
     });
 
+    it('should replace all the configuration placeholders if the provided key is an object', () => {
+        appConfigService.config.objectKey = {
+            firstUrl: '{protocol}//{hostname}{:port}',
+            secondUrl: '{protocol}//{hostname}{:port}',
+            thirdUrl: '{protocol}//{hostname}{:port}'
+        };
+        spyOn(appConfigService, 'getLocationHostname').and.returnValue('localhost');
+        spyOn(appConfigService, 'getLocationPort').and.returnValue(':8080');
+        spyOn(appConfigService, 'getLocationProtocol').and.returnValue('http:');
+
+        expect(appConfigService.get<any>('objectKey').firstUrl).toEqual('http://localhost:8080');
+        expect(appConfigService.get<any>('objectKey').secondUrl).toEqual('http://localhost:8080');
+        expect(appConfigService.get<any>('objectKey').thirdUrl).toEqual('http://localhost:8080');
+    });
+
+
 });

--- a/lib/core/src/lib/app-config/app-config.service.ts
+++ b/lib/core/src/lib/app-config/app-config.service.ts
@@ -123,9 +123,9 @@ export class AppConfigService {
         }
 
         if (typeof result === 'object') {
-            result = JSON.parse(JSON.stringify(result).replace('{hostname}', this.getLocationHostname()));
-            result = JSON.parse(JSON.stringify(result).replace('{:port}', this.getLocationPort(':')));
-            result = JSON.parse(JSON.stringify(result).replace('{protocol}', this.getLocationProtocol()));
+            result = JSON.parse(JSON.stringify(result).replace(/{hostname}/g, this.getLocationHostname()));
+            result = JSON.parse(JSON.stringify(result).replace(/{:port}/g, this.getLocationPort(':')));
+            result = JSON.parse(JSON.stringify(result).replace(/{protocol}/g, this.getLocationProtocol()));
         }
 
         if (result === undefined) {

--- a/lib/js-api/src/alfrescoApi.ts
+++ b/lib/js-api/src/alfrescoApi.ts
@@ -207,7 +207,7 @@ export class AlfrescoApi implements Emitter, AlfrescoApiType {
 
     /**@private? */
     errorHandler(error: { status?: number }) {
-        if (error.status === 401) {
+        if (this.config.oauthInit && error.status === 401) {
             this.invalidateSession();
         }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/AAE-18459


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
