### PR TITLE
FIX js-api unit test unknown extension error

### DIFF
--- a/lib/js-api/src/alfrescoApi.ts
+++ b/lib/js-api/src/alfrescoApi.ts
@@ -65,6 +65,8 @@ export class AlfrescoApi implements Emitter, AlfrescoApiType {
             config = {};
         }
 
+        this.fakeChangeToTriggerAffectedTest();
+
         this.storage = Storage.getInstance();
         this.storage.setDomainPrefix(config.domainPrefix);
 
@@ -83,6 +85,11 @@ export class AlfrescoApi implements Emitter, AlfrescoApiType {
 
         return config;
     }
+
+    private fakeChangeToTriggerAffectedTest() {
+        return '';
+    }
+
 
     private initAuth(config: AlfrescoApiConfig): void {
         if (this.isOauthConfiguration()) {
@@ -574,3 +581,4 @@ export class AlfrescoApi implements Emitter, AlfrescoApiType {
         }
     }
 }
+


### PR DESCRIPTION
Checked out from the last commit 3677bfb78e8fb09e2175cdccc39442dd08bc1a5b the js-api tests were green
https://github.com/Alfresco/alfresco-ng2-components/actions/runs/7002869077/job/19047611179?pr=9114#step:5:85