### PR TITLE
[ADF-5567] Removed important property from 'permission-list.component.scss' in ADF

### DIFF
--- a/lib/content-services/src/lib/permission-manager/components/permission-container/permission-container.component.scss
+++ b/lib/content-services/src/lib/permission-manager/components/permission-container/permission-container.component.scss
@@ -6,6 +6,10 @@
     &.adf-datatable {
         overflow: hidden;
 
+        .adf-datatable-row .adf-permission-role-column-header {
+            position: relative;
+        }
+
         .adf-delete-permission-column {
             min-width: 80px;
 

--- a/lib/content-services/src/lib/permission-manager/components/permission-list/permission-list.component.scss
+++ b/lib/content-services/src/lib/permission-manager/components/permission-list/permission-list.component.scss
@@ -1,12 +1,13 @@
-.adf {
-    &-permission-card {
-        height: 100%;
-        box-sizing: border-box;
-        display: flex !important;
-        flex-direction: column;
-        overflow: hidden;
-    }
 
+adf-permission-list .adf-permission-card {
+    height: 100%;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.adf {
     &-permission-loader {
         margin-left: 45%;
         overflow: hidden;
@@ -45,15 +46,6 @@
         flex-direction: row;
         align-items: center;
         padding: 5px 15px;
-    }
-
-    &-permission-role-column-header {
-        position: relative !important;
-        height: 40px;
-
-        .mat-form-field-infix {
-            border: none;
-        }
     }
 
     &-permission-header {

--- a/lib/content-services/src/lib/permission-manager/components/permission-list/permission-list.component.scss
+++ b/lib/content-services/src/lib/permission-manager/components/permission-list/permission-list.component.scss
@@ -1,4 +1,3 @@
-
 .adf {
     &-permission-card {
         height: 100%;

--- a/lib/content-services/src/lib/permission-manager/components/permission-list/permission-list.component.scss
+++ b/lib/content-services/src/lib/permission-manager/components/permission-list/permission-list.component.scss
@@ -1,4 +1,3 @@
-
 adf-permission-list .adf-permission-card {
     height: 100%;
     box-sizing: border-box;

--- a/lib/content-services/src/lib/permission-manager/components/permission-list/permission-list.component.scss
+++ b/lib/content-services/src/lib/permission-manager/components/permission-list/permission-list.component.scss
@@ -1,12 +1,13 @@
-adf-permission-list .adf-permission-card {
-    height: 100%;
-    box-sizing: border-box;
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
-}
 
 .adf {
+    &-permission-card {
+        height: 100%;
+        box-sizing: border-box;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+    }
+
     &-permission-loader {
         margin-left: 45%;
         overflow: hidden;
@@ -45,6 +46,15 @@ adf-permission-list .adf-permission-card {
         flex-direction: row;
         align-items: center;
         padding: 5px 15px;
+    }
+
+    &-permission-role-column-header {
+        position: relative;
+        height: 40px;
+
+        .mat-form-field-infix {
+            border: none;
+        }
     }
 
     &-permission-header {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [x] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
use !important for styles should be disallowed.


**What is the new behaviour?**
I have removed 'important' property from ''permission-list.component.scss''. After removing the important property I tested ACA, ADF, and ADW, and it’s working as expected.




**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://alfresco.atlassian.net/browse/ADF-5567