### PR TITLE
[AEV-4] - Expose isLoading viewer input

### DIFF
--- a/lib/core/src/lib/viewer/components/viewer.component.html
+++ b/lib/core/src/lib/viewer/components/viewer.component.html
@@ -155,6 +155,7 @@
                 [fileName]="fileName"
                 [blobFile]="blobFile"
                 [readOnly]="readOnly"
+                [isLoading]="isLoading"
                 (submitFile)="onSubmitFile($event)"
                 [urlFile]="urlFile"
                 (isSaving)="allowNavigate = !$event"

--- a/lib/core/src/lib/viewer/components/viewer.component.ts
+++ b/lib/core/src/lib/viewer/components/viewer.component.ts
@@ -102,6 +102,10 @@ export class ViewerComponent<T> implements OnDestroy, OnInit, OnChanges {
     @Input()
     showToolbar = true;
 
+    /** Override loading status */
+    @Input()
+    isLoading?: boolean
+
     /**
      * If `true` then show the Viewer as a full page over the current content.
      * Otherwise fit inside the parent div.


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
ADF users weren't able to toggle viewer loading state, even though the input already existed in viewer-renderer.


**What is the new behaviour?**
The vierew-renderer isLoading is exposed further in viewer component, so it can be actually used.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
