### PR TITLE
[AAE-19070] Disable broken column types ("location" and "image") in data table widget

### DIFF
--- a/lib/process-services-cloud/src/lib/form/components/widgets/data-table/data-table-adapter.widget.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/data-table/data-table-adapter.widget.spec.ts
@@ -20,7 +20,9 @@ import {
     mockEuropeCountriesData,
     mockCountriesIncorrectData,
     mockInvalidSchemaDefinition,
-    mockSchemaDefinition
+    mockSchemaDefinition,
+    mockMultipleTypesData,
+    mockMultipleTypesSchemaDefinition
 } from '../../../mocks/data-table-widget.mock';
 import { ObjectDataRow } from '@alfresco/adf-core';
 
@@ -63,5 +65,18 @@ describe('WidgetDataTableAdapter', () => {
         const isValid = widgetDataTableAdapter.isDataSourceValid();
 
         expect(isValid).toBeTrue();
+    });
+
+    it('should hide specific column types', () => {
+        widgetDataTableAdapter = new WidgetDataTableAdapter(mockMultipleTypesData, mockMultipleTypesSchemaDefinition);
+        const columns = widgetDataTableAdapter.getColumns();
+
+        expect(columns.length).toBe(4);
+
+        columns.forEach(column => {
+            WidgetDataTableAdapter.hiddenColumnTypes.includes(column.type)
+                ? expect(column.isHidden).toBeTrue()
+                : expect(column.isHidden).toBeFalse();
+        });
     });
 });

--- a/lib/process-services-cloud/src/lib/form/components/widgets/data-table/data-table-adapter.widget.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/data-table/data-table-adapter.widget.ts
@@ -23,6 +23,7 @@ import {
 
 export class WidgetDataTableAdapter extends ObjectDataTableAdapter {
 
+    static readonly hiddenColumnTypes = ['image', 'location'];
     private rows: DataRow[];
     private columns: DataColumn[];
 
@@ -30,6 +31,7 @@ export class WidgetDataTableAdapter extends ObjectDataTableAdapter {
         super(data, schema);
         this.rows = super.getRows();
         this.columns = super.getColumns();
+        this.hideColumnTypes(WidgetDataTableAdapter.hiddenColumnTypes);
     }
 
     getRows(): DataRow[] {
@@ -42,6 +44,12 @@ export class WidgetDataTableAdapter extends ObjectDataTableAdapter {
 
     isDataSourceValid(): boolean {
         return this.hasAllColumnsLinkedToData() && this.hasAllMandatoryColumnPropertiesHaveValues();
+    }
+
+    private hideColumnTypes(typesToHide: string[]): void {
+        this.columns
+            .filter(column => typesToHide.includes(column.type))
+            .forEach(column => column.isHidden = true);
     }
 
     private hasAllMandatoryColumnPropertiesHaveValues(): boolean {

--- a/lib/process-services-cloud/src/lib/form/mocks/data-table-widget.mock.ts
+++ b/lib/process-services-cloud/src/lib/form/mocks/data-table-widget.mock.ts
@@ -52,6 +52,46 @@ export const mockInvalidSchemaDefinition: DataColumn[] = [
     }
 ];
 
+export const mockMultipleTypesSchemaDefinition: DataColumn[] = [
+    {
+        type: 'text',
+        key: 'text',
+        title: 'Text column',
+        sortable: true,
+        draggable: true
+    },
+    {
+        type: 'location',
+        key: 'location',
+        title: 'Location column',
+        sortable: true,
+        draggable: true
+    },
+    {
+        type: 'image',
+        key: 'imageUrl',
+        title: 'Image column',
+        sortable: true,
+        draggable: true
+    },
+    {
+        type: 'fileSize',
+        key: 'fileSize',
+        title: 'FileSize column',
+        sortable: true,
+        draggable: true
+    }
+];
+
+export const mockMultipleTypesData = [
+    {
+        text: 'Example text',
+        location: '-me-/logo.jpg',
+        imageUrl: 'https://exmaple.domain.com/logo.jpg',
+        fileSize: 223400
+    }
+];
+
 export const mockEuropeCountriesData = [
     {
         id: 'PL',


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://alfresco.atlassian.net/browse/AAE-19070

**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
