### PR TITLE
[ADF-5569] Removed !important from card-view-mapitem Component

### DIFF
--- a/lib/core/src/lib/card-view/components/card-view-mapitem/card-view-mapitem.component.scss
+++ b/lib/core/src/lib/card-view/components/card-view-mapitem/card-view-mapitem.component.scss
@@ -1,6 +1,6 @@
 .adf {
     &-mapitem-clickable-value {
-        cursor: pointer !important;
+        cursor: pointer;
     }
 
     &-map-item-padding {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
The css of card-view-mapitem uses '!important'


**What is the new behaviour?**
removed '!important' from the css. The UI/styling works as expected.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://alfresco.atlassian.net/browse/ADF-5569