### PR TITLE
[ACS-6399] - ACA search properties facet clear button do not clear search filter

### DIFF
--- a/lib/content-services/src/lib/search/components/search-properties/search-properties.component.spec.ts
+++ b/lib/content-services/src/lib/search/components/search-properties/search-properties.component.spec.ts
@@ -29,6 +29,7 @@ import { SearchProperties } from './search-properties';
 describe('SearchPropertiesComponent', () => {
     let component: SearchPropertiesComponent;
     let fixture: ComponentFixture<SearchPropertiesComponent>;
+    let searchQueryBuilderService = jasmine.createSpyObj('SearchQueryBuilderService', ['update']);
 
     const clickFileSizeOperatorsSelect = () => {
         fixture.debugElement.query(By.css('[data-automation-id=adf-search-properties-file-size-operator-select]')).nativeElement.click();
@@ -63,7 +64,10 @@ describe('SearchPropertiesComponent', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             declarations: [ SearchPropertiesComponent ],
-            imports: [ ContentTestingModule, TranslateModule.forRoot() ]
+            imports: [ ContentTestingModule, TranslateModule.forRoot() ],
+            providers: [
+                { provide: SearchQueryBuilderService, useValue: searchQueryBuilderService }
+            ]
         }).compileComponents();
 
         fixture = TestBed.createComponent(SearchPropertiesComponent);
@@ -344,6 +348,9 @@ describe('SearchPropertiesComponent', () => {
             fixture.detectChanges();
             searchChipAutocompleteInputComponent = getSearchChipAutocompleteInputComponent();
             searchChipAutocompleteInputComponent.optionsChanged.emit([{value: 'pdf'}, {value: 'txt'}]);
+            searchQueryBuilderService.queryFragments = {};
+            component.id = 'testId';
+            component.context = searchQueryBuilderService;
         });
 
         it('should reset form', () => {
@@ -364,6 +371,15 @@ describe('SearchPropertiesComponent', () => {
 
             component.reset();
             expect(component.displayValue$.next).toHaveBeenCalledWith('');
+        });
+
+        it('should clear the queryFragments for the component id and call update', () => {
+            component.context.queryFragments[component.id] = 'some query';
+
+            component.reset();
+
+            expect(component.context.queryFragments[component.id]).toBe('');
+            expect(component.context.update).toHaveBeenCalled();
         });
     });
 

--- a/lib/content-services/src/lib/search/components/search-properties/search-properties.component.spec.ts
+++ b/lib/content-services/src/lib/search/components/search-properties/search-properties.component.spec.ts
@@ -29,7 +29,6 @@ import { SearchProperties } from './search-properties';
 describe('SearchPropertiesComponent', () => {
     let component: SearchPropertiesComponent;
     let fixture: ComponentFixture<SearchPropertiesComponent>;
-    let searchQueryBuilderService = jasmine.createSpyObj('SearchQueryBuilderService', ['update']);
 
     const clickFileSizeOperatorsSelect = () => {
         fixture.debugElement.query(By.css('[data-automation-id=adf-search-properties-file-size-operator-select]')).nativeElement.click();
@@ -65,9 +64,6 @@ describe('SearchPropertiesComponent', () => {
         TestBed.configureTestingModule({
             declarations: [ SearchPropertiesComponent ],
             imports: [ ContentTestingModule, TranslateModule.forRoot() ],
-            providers: [
-                { provide: SearchQueryBuilderService, useValue: searchQueryBuilderService }
-            ]
         }).compileComponents();
 
         fixture = TestBed.createComponent(SearchPropertiesComponent);
@@ -348,9 +344,6 @@ describe('SearchPropertiesComponent', () => {
             fixture.detectChanges();
             searchChipAutocompleteInputComponent = getSearchChipAutocompleteInputComponent();
             searchChipAutocompleteInputComponent.optionsChanged.emit([{value: 'pdf'}, {value: 'txt'}]);
-            searchQueryBuilderService.queryFragments = {};
-            component.id = 'testId';
-            component.context = searchQueryBuilderService;
         });
 
         it('should reset form', () => {
@@ -374,8 +367,11 @@ describe('SearchPropertiesComponent', () => {
         });
 
         it('should clear the queryFragments for the component id and call update', () => {
-            component.context.queryFragments[component.id] = 'some query';
-
+            component.context = TestBed.inject(SearchQueryBuilderService);
+            component.id = 'test-id'
+            component.context.queryFragments[component.id] = 'test-query'
+            fixture.detectChanges();
+            spyOn(component.context, 'update');
             component.reset();
 
             expect(component.context.queryFragments[component.id]).toBe('');

--- a/lib/content-services/src/lib/search/components/search-properties/search-properties.component.spec.ts
+++ b/lib/content-services/src/lib/search/components/search-properties/search-properties.component.spec.ts
@@ -63,7 +63,7 @@ describe('SearchPropertiesComponent', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             declarations: [ SearchPropertiesComponent ],
-            imports: [ ContentTestingModule, TranslateModule.forRoot() ],
+            imports: [ ContentTestingModule, TranslateModule.forRoot() ]
         }).compileComponents();
 
         fixture = TestBed.createComponent(SearchPropertiesComponent);
@@ -368,8 +368,8 @@ describe('SearchPropertiesComponent', () => {
 
         it('should clear the queryFragments for the component id and call update', () => {
             component.context = TestBed.inject(SearchQueryBuilderService);
-            component.id = 'test-id'
-            component.context.queryFragments[component.id] = 'test-query'
+            component.id = 'test-id';
+            component.context.queryFragments[component.id] = 'test-query';
             fixture.detectChanges();
             spyOn(component.context, 'update');
             component.reset();

--- a/lib/content-services/src/lib/search/components/search-properties/search-properties.component.ts
+++ b/lib/content-services/src/lib/search/components/search-properties/search-properties.component.ts
@@ -149,9 +149,11 @@ export class SearchPropertiesComponent implements OnInit, AfterViewChecked, Sear
     };
 
     reset() {
-        this.context.queryFragments[this.id] = '';
-        this.context.update();
         this.form.reset();
+        if (this.id && this.context) {
+            this.context.queryFragments[this.id] = '';
+            this.context.update();
+        }
         this.reset$.next();
         this.displayValue$.next('');
     }

--- a/lib/content-services/src/lib/search/components/search-properties/search-properties.component.ts
+++ b/lib/content-services/src/lib/search/components/search-properties/search-properties.component.ts
@@ -149,6 +149,8 @@ export class SearchPropertiesComponent implements OnInit, AfterViewChecked, Sear
     };
 
     reset() {
+        this.context.queryFragments[this.id] = '';
+        this.context.update();
         this.form.reset();
         this.reset$.next();
         this.displayValue$.next('');


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Search properties facet clear button do not clear search filter


**What is the new behaviour?**
Search properties facet clear button does clear search filter and refreshed search results


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
