### PR TITLE
Allow to use extension value in addition to passing JSON file name

### DIFF
--- a/lib/extensions/src/lib/services/extension-loader.service.spec.ts
+++ b/lib/extensions/src/lib/services/extension-loader.service.spec.ts
@@ -142,7 +142,7 @@ describe('ExtensionLoaderService', () => {
             });
     });
 
-    it('should load extensions if we passed only extension value', (done) => {
+    it('should load extensions if only extension value was passed', (done) => {
         extensionLoaderService.load(
             'assets/app.extensions.json',
             'assets/plugins',
@@ -160,7 +160,7 @@ describe('ExtensionLoaderService', () => {
             });
     });
 
-    it('should load extensions few extension values', (done) => {
+    it('should load extensions with multiple extension values', (done) => {
         appExtensionsConfig.$references = ['test.extension.1.json'];
 
         extensionLoaderService.load(

--- a/lib/extensions/src/lib/services/extension-loader.service.spec.ts
+++ b/lib/extensions/src/lib/services/extension-loader.service.spec.ts
@@ -121,4 +121,70 @@ describe('ExtensionLoaderService', () => {
             done();
         });
     });
+
+    it('should load extensions from passed extension value', (done) => {
+        appExtensionsConfig.$references = ['test.extension.1.json'];
+
+        extensionLoaderService.load(
+            'assets/app.extensions.json',
+            'assets/plugins',
+            undefined,
+            [{
+                $id: 'extension-value-id',
+                $license: 'license',
+                $name: 'name',
+                $version:'version',
+                $vendor: 'vendor'
+            }]).then((config: ExtensionConfig) => {
+                const hasExtensionValue = config.$references.some((entry: ExtensionConfig) => entry.$id === 'extension-value-id');
+                expect(hasExtensionValue).toBe(true);
+                done();
+            });
+    });
+
+    it('should load extensions if we passed only extension value', (done) => {
+        extensionLoaderService.load(
+            'assets/app.extensions.json',
+            'assets/plugins',
+            undefined,
+            [{
+                $id: 'extension-value-id',
+                $license: 'license',
+                $name: 'name',
+                $version:'version',
+                $vendor: 'vendor'
+            }]).then((config: ExtensionConfig) => {
+                const hasExtensionValue = config.$references.some((entry: ExtensionConfig) => entry.$id === 'extension-value-id');
+                expect(hasExtensionValue).toBe(true);
+                done();
+            });
+    });
+
+    it('should load extensions few extension values', (done) => {
+        appExtensionsConfig.$references = ['test.extension.1.json'];
+
+        extensionLoaderService.load(
+            'assets/app.extensions.json',
+            'assets/plugins',
+            undefined,
+            [{
+                $id: 'extension-value-id-1',
+                $license: 'license',
+                $name: 'name',
+                $version:'version',
+                $vendor: 'vendor'
+            },{
+                $id: 'extension-value-id-2',
+                $license: 'license',
+                $name: 'name',
+                $version:'version',
+                $vendor: 'vendor'
+            }]).then((config: ExtensionConfig) => {
+                const hasFirstExtensionValue = config.$references.some((entry: ExtensionConfig) => entry.$id === 'extension-value-id-1');
+                expect(hasFirstExtensionValue).toBe(true);
+                const hasSecondExtensionValue = config.$references.some((entry: ExtensionConfig) => entry.$id === 'extension-value-id-2');
+                expect(hasSecondExtensionValue).toBe(true);
+                done();
+            });
+    });
 });

--- a/lib/extensions/src/lib/services/extension.service.spec.ts
+++ b/lib/extensions/src/lib/services/extension.service.spec.ts
@@ -43,7 +43,7 @@ describe('ExtensionService', () => {
         loader = new ExtensionLoaderService(null);
         componentRegister = new ComponentRegisterService();
         ruleService = new RuleService(loader);
-        service = new ExtensionService(loader, componentRegister, ruleService, []);
+        service = new ExtensionService(loader, componentRegister, ruleService, [], []);
     });
 
     it('should load and setup a config', async () => {
@@ -53,7 +53,7 @@ describe('ExtensionService', () => {
         await service.load();
 
         expect(loader.load).toHaveBeenCalled();
-        expect(loader.load).toHaveBeenCalledWith('assets/app.extensions.json', 'assets/plugins', []);
+        expect(loader.load).toHaveBeenCalledWith('assets/app.extensions.json', 'assets/plugins', [], []);
         expect(service.setup).toHaveBeenCalledWith(blankConfig);
     });
 

--- a/lib/extensions/src/lib/services/extension.service.ts
+++ b/lib/extensions/src/lib/services/extension.service.ts
@@ -42,6 +42,11 @@ export const EXTENSION_JSONS = new InjectionToken<string[][]>('extension-jsons',
     factory: extensionJsonsFactory
 });
 
+export const EXTENSION_JSON_VALUES = new InjectionToken<string[][]>('extension-jsons-values', {
+    providedIn: 'root',
+    factory: extensionJsonsFactory
+});
+
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
 /**
  * Provides the extension json values for the angular modules
@@ -53,6 +58,20 @@ export function provideExtensionConfig(jsons: string[]) {
     return {
         provide: EXTENSION_JSONS,
         useValue: jsons,
+        multi: true
+    };
+};
+
+/**
+ * Provides the extension json raw values for the angular modules
+ *
+ * @param extensionConfigValue config value
+ * @returns a provider section
+ */
+export function provideExtensionConfigValues(extensionConfigValue: ExtensionConfig[]) {
+    return {
+        provide: EXTENSION_JSON_VALUES,
+        useValue: extensionConfigValue,
         multi: true
     };
 };
@@ -78,7 +97,8 @@ export class ExtensionService {
         protected loader: ExtensionLoaderService,
         protected componentRegister: ComponentRegisterService,
         protected ruleService: RuleService,
-        @Inject(EXTENSION_JSONS) protected extensionJsons: string[]
+        @Inject(EXTENSION_JSONS) protected extensionJsons: string[],
+        @Inject(EXTENSION_JSON_VALUES) protected extensionJsonValues: ExtensionConfig[]
     ) {
         this.setup$ = this.onSetup$.asObservable();
     }
@@ -92,8 +112,10 @@ export class ExtensionService {
         const config = await this.loader.load(
             this.configPath,
             this.pluginsPath,
-            this.extensionJsons.flat()
+            this.extensionJsons.flat(),
+            this.extensionJsonValues.flat()
         );
+
         this.setup(config);
         return config;
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**
We can pass directly extension value instead of adding json file name which is fetched via network


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
