### PR TITLE
[ADF-5568] Removed important property from 'card-view-dateitem.component.scss' in ADF

### DIFF
--- a/lib/core/src/lib/card-view/components/card-view-dateitem/card-view-dateitem.component.scss
+++ b/lib/core/src/lib/card-view/components/card-view-dateitem/card-view-dateitem.component.scss
@@ -26,8 +26,8 @@
         float: right;
     }
 
-    .adf-dateitem-chip-list-container.adf-property-field {
-        margin-bottom: -7px !important;
+    &-card-view-dateitem .adf-dateitem-chip-list-container.adf-property-field {
+        margin-bottom: -7px;
         border-bottom: 0;
         cursor: pointer;
     }

--- a/lib/core/src/lib/card-view/components/card-view-dateitem/card-view-dateitem.component.scss
+++ b/lib/core/src/lib/card-view/components/card-view-dateitem/card-view-dateitem.component.scss
@@ -26,7 +26,7 @@
         float: right;
     }
 
-    &-card-view-dateitem .adf-dateitem-chip-list-container.adf-property-field {
+    .adf-dateitem-chip-list-container.adf-property-field {
         margin-bottom: -7px;
         border-bottom: 0;
         cursor: pointer;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [x] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
use !important for styles should be disallowed.


**What is the new behaviour?**
I have removed 'important' property from ''card-view-dateitem.component.scss'. After removing the important property I tested ACA, ADF, and ADW, and it’s working as expected.




**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://alfresco.atlassian.net/browse/ADF-5568