### PR TITLE
[ACS-6212] Fix overlaping labels and incorrect color for warning

### DIFF
--- a/lib/content-services/src/lib/content-node-share/content-node-share.dialog.html
+++ b/lib/content-services/src/lib/content-node-share/content-node-share.dialog.html
@@ -31,7 +31,7 @@
                     [style.display]="isExpiryDateToggleChecked ? 'block' : 'none'"
                     data-automation-id="adf-slide-toggle-checked"
                     class="adf-share-link__date-time-container">
-                    <mat-form-field class="adf-full-width adf-float-label">
+                    <mat-form-field class="adf-full-width" floatLabel="never" data-automation-id="adf-content-share-expiration-field">
                         <mat-label>{{ 'SHARE.EXPIRATION-PLACEHOLDER' | translate }}</mat-label>
                         <mat-datepicker-toggle
                             [disabled]="time.disabled"
@@ -73,7 +73,9 @@
                     </div>
                 </div>
                 <mat-form-field
-                    class="adf-full-width adf-float-label"
+                    class="adf-full-width"
+                    floatLabel="never"
+                    data-automation-id="adf-content-share-public-link-field"
                     [ngClass]="isLinkWithExpiryDate? 'adf-share-link__border-color' : ''">
                     <input
                         #sharedLinkInput

--- a/lib/content-services/src/lib/content-node-share/content-node-share.dialog.scss
+++ b/lib/content-services/src/lib/content-node-share/content-node-share.dialog.scss
@@ -1,7 +1,3 @@
-.adf-float-label {
-    padding-top: 20px;
-}
-
 .adf-share-link-dialog {
     .adf-share-link {
         &__dialog-content {
@@ -41,7 +37,7 @@
         }
 
         &__warn {
-            color: var(--theme-warn-color);
+            color: var(--theme-warn-color-a700);
             font-size: var(--theme-caption-font-size);
         }
 
@@ -91,7 +87,7 @@
         }
 
         &__border-color {
-            border: 1px solid var(--theme-warn-color);
+            border: 1px solid var(--theme-warn-color-a700);
         }
     }
 

--- a/lib/content-services/src/lib/content-node-share/content-node-share.dialog.spec.ts
+++ b/lib/content-services/src/lib/content-node-share/content-node-share.dialog.spec.ts
@@ -293,6 +293,28 @@ describe('ShareDialogComponent', () => {
         expect(fixture.nativeElement.querySelector('[data-automation-id="adf-slide-toggle-checked"]').style.display).toEqual('none');
     });
 
+    it('should not display floating label for expiration field', () => {
+        component.data = {
+            node,
+            baseShareUrl: 'some-url/'
+        };
+
+        fixture.detectChanges();
+        expect(fixture.debugElement.query(By.css('[data-automation-id="adf-content-share-expiration-field"]'))
+            .componentInstance.floatLabel).toBe('never');
+    });
+
+    it('should not display floating label for public link field', () => {
+        component.data = {
+            node,
+            baseShareUrl: 'some-url/'
+        };
+
+        fixture.detectChanges();
+        expect(fixture.debugElement.query(By.css('[data-automation-id="adf-content-share-public-link-field"]'))
+            .componentInstance.floatLabel).toBe('never');
+    });
+
     describe('datetimepicker type', () => {
         beforeEach(() => {
             spyOn(sharedLinksApiService, 'createSharedLinks').and.returnValue(of());

--- a/lib/core/src/lib/styles/_colors.scss
+++ b/lib/core/src/lib/styles/_colors.scss
@@ -153,7 +153,7 @@ $alfresco-warn: (
     A100: #ff8a80,
     A200: #ff5252,
     A400: #ff1744,
-    A700: #d50000,
+    A700: #c95100,
     contrast: (
         50: $black-87-opacity,
         100: $black-87-opacity,

--- a/lib/core/src/lib/styles/_index.scss
+++ b/lib/core/src/lib/styles/_index.scss
@@ -37,6 +37,7 @@
         --adf-theme-primary-900:mat.get-color-from-palette($primary, 900),
 
         --theme-warn-color: mat.get-color-from-palette($warn),
+        --theme-warn-color-a700: mat.get-color-from-palette($warn, A700),
         --theme-warn-color-default-contrast: mat.get-color-from-palette($warn, default-contrast),
 
         --theme-accent-color: mat.get-color-from-palette($accent),


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ACS-6212


**What is the new behaviour?**
Labels don't overlap with fields borders anymore and color for warning message for public link is correct now. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
ACA PR: https://github.com/Alfresco/alfresco-content-app/pull/3589