### PR TITLE
[ACS-6489] Add resizable option for column data model

### DIFF
--- a/docs/core/components/data-column.component.md
+++ b/docs/core/components/data-column.component.md
@@ -48,6 +48,7 @@ Defines column properties for DataTable, Tasklist, Document List and other compo
 | cssClass | `string` |  | Additional CSS class to be applied to column (header and cells). |
 | customData | `any` |  | You can specify any custom data which can be used by any specific feature |
 | draggable | `boolean` | false | Enable drag and drop for header column |
+| resizable | `boolean` | true | Enable column resizing |
 | editable | `boolean` | false | Toggles the editing support of the column data. |
 | focus | `boolean` | true | Enable or disable cell focus |
 | format | `string` |  | Value format (if supported by the parent component), for example format of the date. |

--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.html
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.html
@@ -96,7 +96,7 @@
                     </span>
                 </div>
                 <div
-                    *ngIf="isResizingEnabled"
+                    *ngIf="isResizingEnabled && col.resizable"
                     adf-resize-handle
                     class="adf-datatable__resize-handle"
                     [resizableContainer]="resizableElement">

--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.spec.ts
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.spec.ts
@@ -1694,6 +1694,11 @@ describe('Column Resizing', () => {
 
     const getResizeHandler = (): HTMLDivElement => fixture.debugElement.nativeElement.querySelector('.adf-datatable__resize-handle');
 
+    const getResizeHandlersCount = (): number => {
+        const resizeHandlers = fixture.debugElement.nativeElement.querySelectorAll('.adf-datatable__resize-handle');
+        return resizeHandlers.length;
+    }
+
 
     const testClassesAfterResizing = (headerColumnsSelector = '.adf-datatable-cell-header', excludedClass = 'adf-datatable__cursor--pointer') => {
         dataTable.isResizingEnabled = true;
@@ -1742,6 +1747,22 @@ describe('Column Resizing', () => {
         headerColumns.forEach((header: HTMLElement) => {
             expect(header.classList).toContain('adf-datatable__cursor--pointer');
         });
+    });
+
+    it('should display resize handle for each column by default', () => {
+        dataTable.isResizingEnabled = true;
+        fixture.detectChanges();
+
+        expect(getResizeHandlersCount()).toBe(2);
+    });
+
+    it('should NOT display resize handle for the column when the column has resizable param set to false', () => {
+        dataTable.isResizingEnabled = true;
+        dataTableSchema[0].resizable = false;
+        dataTable.data = new ObjectDataTableAdapter([...data], [...dataTableSchema]);
+        fixture.detectChanges();
+
+        expect(getResizeHandlersCount()).toBe(1);
     });
 
     it('should display resize handle when the feature is Enabled [isResizingEnabled=true]', () => {

--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.spec.ts
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.spec.ts
@@ -1697,8 +1697,7 @@ describe('Column Resizing', () => {
     const getResizeHandlersCount = (): number => {
         const resizeHandlers = fixture.debugElement.nativeElement.querySelectorAll('.adf-datatable__resize-handle');
         return resizeHandlers.length;
-    }
-
+    };
 
     const testClassesAfterResizing = (headerColumnsSelector = '.adf-datatable-cell-header', excludedClass = 'adf-datatable__cursor--pointer') => {
         dataTable.isResizingEnabled = true;

--- a/lib/core/src/lib/datatable/data-column/data-column.component.stories.ts
+++ b/lib/core/src/lib/datatable/data-column/data-column.component.stories.ts
@@ -85,6 +85,20 @@ export default {
                 }
             }
         },
+        resizable: {
+            description: 'Toggles resize for column.',
+            control: { type: 'boolean' },
+            defaultValue: true,
+            table: {
+                category: 'Component Inputs',
+                type: {
+                    summary: 'boolean'
+                },
+                defaultValue: {
+                    summary: true
+                }
+            }
+        },
         editable: {
             description: 'Toggles the editing support of the column data.',
             control: { type: 'boolean', disable: true },
@@ -328,8 +342,8 @@ const template: Story<DataColumnComponent> = (args: DataColumnComponent & { rows
     template: `
         <adf-datatable [rows]="rows">
             <data-columns>
-                <data-column 
-                    [key]="key" 
+                <data-column
+                    [key]="key"
                     [type]="type"
                     [title]="title"
                     [editable]="editable"

--- a/lib/core/src/lib/datatable/data-column/data-column.component.ts
+++ b/lib/core/src/lib/datatable/data-column/data-column.component.ts
@@ -61,6 +61,10 @@ export class DataColumnComponent implements OnInit {
     @Input()
     draggable: boolean = false;
 
+    /** Enable resize for column */
+    @Input()
+    resizable: boolean = true;
+
     /** Hide column */
     @Input()
     isHidden: boolean = false;

--- a/lib/core/src/lib/datatable/data-column/data-column.component.ts
+++ b/lib/core/src/lib/datatable/data-column/data-column.component.ts
@@ -63,7 +63,7 @@ export class DataColumnComponent implements OnInit {
 
     /** Enable resize for column */
     @Input()
-    resizable: boolean = true;
+    resizable = true;
 
     /** Hide column */
     @Input()

--- a/lib/core/src/lib/datatable/data/data-column.model.ts
+++ b/lib/core/src/lib/datatable/data/data-column.model.ts
@@ -37,6 +37,7 @@ export interface DataColumn<T = unknown> {
     sortingKey?: string;
     header?: TemplateRef<any>;
     draggable?: boolean;
+    resizable?: boolean;
     isHidden?: boolean;
     width?: number;
     customData?: T;

--- a/lib/core/src/lib/datatable/data/object-datacolumn.model.ts
+++ b/lib/core/src/lib/datatable/data/object-datacolumn.model.ts
@@ -35,6 +35,7 @@ export class ObjectDataColumn<T = unknown> implements DataColumn<T> {
     sortingKey?: string;
     header?: TemplateRef<any>;
     draggable: boolean;
+    resizable: boolean;
     isHidden: boolean;
     customData?: T;
     width?: number;
@@ -58,6 +59,7 @@ export class ObjectDataColumn<T = unknown> implements DataColumn<T> {
         this.sortingKey = input.sortingKey;
         this.header = input.header;
         this.draggable = input.draggable ?? false;
+        this.resizable = input.resizable ?? true;
         this.isHidden = input.isHidden ?? false;
         this.customData = input.customData;
         this.width = input.width;

--- a/lib/core/src/lib/mock/data-column.mock.ts
+++ b/lib/core/src/lib/mock/data-column.mock.ts
@@ -36,6 +36,7 @@ export const getDataColumnMock = <T = unknown>(
     sortingKey: 'sortingKey',
     header: undefined,
     draggable: false,
+    resizable: true,
     isHidden: false,
     customData: undefined,
     ...column

--- a/lib/extensions/src/lib/config/document-list.extensions.ts
+++ b/lib/extensions/src/lib/config/document-list.extensions.ts
@@ -50,4 +50,5 @@ export interface DocumentListPresetRef extends ExtensionElement {
         visible?: string;
     };
     draggable?: boolean;
+    resizable?: boolean;
 }

--- a/lib/extensions/src/lib/config/schema/plugin-extension.schema.json
+++ b/lib/extensions/src/lib/config/schema/plugin-extension.schema.json
@@ -565,6 +565,10 @@
         "desktopOnly": {
           "description": "Display column only for large screens",
           "type": "boolean"
+        },
+        "resizable": {
+          "description": "Toggles resizable state of the column",
+          "type": "boolean"
         }
       }
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

All columns are resizable and it can't be changed.

**What is the new behaviour?**

`resizable` option has been added to column data model allowing user to set which columns should be resizable, all of them are resizable by default. https://alfresco.atlassian.net/browse/ACS-6489

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
