### PR TITLE
[AAE-19365] Fix for changelog generation

### DIFF
--- a/lib/cli/scripts/changelog.ts
+++ b/lib/cli/scripts/changelog.ts
@@ -23,6 +23,7 @@ import { argv, exit } from 'node:process';
 import * as shell from 'shelljs';
 import * as path from 'path';
 import program from 'commander';
+import { logger } from './logger';
 import * as fs from 'fs';
 import * as ejs from 'ejs';
 
@@ -116,7 +117,15 @@ function getCommits(options: DiffOptions): Array<Commit> {
 
     return log
         .split('\\n')
-        .map((str: string) => JSON.parse(str) as Commit)
+        .map((str: string) => {
+            try {
+                return JSON.parse(str) as Commit;
+            } catch (error) {
+                logger.error(`Unparsable commit message: ${str}, dropping it... Please apply manual fix.`);
+                return null;
+            }
+        })
+        .filter((commit) => commit !== null)
         .filter((commit: Commit) => commitAuthorAllowed(commit, authorFilter));
 }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?**
https://alfresco.atlassian.net/browse/AAE-19365
Changelog generation fails in special cases, when commit message contains special characters like "\n".


**What is the new behaviour?**
Changelog generation doesn't throw error in such extreme cases and informs the developer to apply patch manually.

![new-behaviour](https://github.com/Alfresco/alfresco-ng2-components/assets/1637232/93b4d00f-0acc-498c-9b5e-61e6100ada7e)



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
