### PR TITLE
[ACS-6596] - verify ticket on app loading

### DIFF
--- a/lib/core/src/lib/auth/basic-auth/basic-alfresco-auth.service.ts
+++ b/lib/core/src/lib/auth/basic-auth/basic-alfresco-auth.service.ts
@@ -57,7 +57,12 @@ export class BasicAlfrescoAuthService extends BaseAuthenticationService {
         this.appConfig.onLoad
             .subscribe(() => {
                 if (!this.isOauth() && this.isLoggedIn()) {
-                    this.onLogin.next('logged-in');
+                    this.requireAlfTicket().then(() => {
+                        this.onLogin.next('logged-in');
+                    }).catch(() => {
+                        this.contentAuth.invalidateSession();
+                        this.onLogout.next('logout');
+                    });
                 }
             });
 

--- a/lib/core/src/lib/auth/services/authentication.service.spec.ts
+++ b/lib/core/src/lib/auth/services/authentication.service.spec.ts
@@ -70,6 +70,7 @@ describe('AuthenticationService', () => {
         });
 
        it('should emit login event for kerberos', (done) => {
+            spyOn(basicAlfrescoAuthService, 'requireAlfTicket').and.returnValue(Promise.resolve());
             const disposableLogin = authService.onLogin.subscribe(() => {
                 disposableLogin.unsubscribe();
                 done();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ACS-6596

If Alfresco ticket (ticket-ECM) has been invalidated (or timed out), BaseAuthenticationService onLogin ReplaySubject property emit value before ADF login screen appears and not emit value after successful login.


**What is the new behaviour?**
BaseAuthenticationService onLogin ReplaySubject should emit value only after successful authentication.




**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
