### PR TITLE
[ACA-4729] Add infinite scroll to version list

### DIFF
--- a/docs/content-services/components/infinite-scroll-datasource.md
+++ b/docs/content-services/components/infinite-scroll-datasource.md
@@ -29,7 +29,7 @@ export class VersionListDataSource extends InfiniteScrollDatasource<VersionEntry
 
 Then in component that will have the infinite scroll define the datasource as instance of a class created in previous step, optionally you can set custom size of the items batch or listen to loading state changes:
 ```ts
- this.versionsDataSource = new VersionListDataSource(this.versionsApi, this.node);
+this.versionsDataSource = new VersionListDataSource(this.versionsApi, this.node);
 this.versionsDataSource.batchSize = 50;
 this.versionsDataSource.isLoading.pipe(takeUntil(this.onDestroy$)).subscribe((isLoading) => this.isLoading = isLoading);
 ```

--- a/docs/content-services/components/infinite-scroll-datasource.md
+++ b/docs/content-services/components/infinite-scroll-datasource.md
@@ -1,0 +1,66 @@
+---
+Title: Infinite Scroll Datasource
+Added: v6.6.0
+Status: Active
+Last reviewed: 2024-01-15
+---
+
+# [Infinite Scroll Datasource](../../../lib/content-services/src/lib/infinite-scroll-datasource/infinite-scroll-datasource.ts "Defined in infinite-scroll-datasource.ts")
+
+Contains abstract class acting as a baseline for various datasources for infinite scrolls. 
+
+## Basic Usage
+
+First step to use infinite scroll datasource in any component is creating a datasource class extending `InfiniteScrollDatasource` using specific source of data e.g. one of the content endpoints.
+```ts
+export class VersionListDataSource extends InfiniteScrollDatasource<VersionEntry> {
+    constructor(private versionsApi: VersionsApi, private node: Node) {
+        super();
+    }
+
+    getNextBatch(pagingOptions: ContentPagingQuery): Observable<VersionEntry[]> {
+        return from(this.versionsApi.listVersionHistory(this.node.id, pagingOptions)).pipe(
+            take(1),
+            map((versionPaging) => versionPaging.list.entries)
+        );
+    }
+}
+```
+
+Then in component that will have the infinite scroll define the datasource as instance of a class created in previous step, optionally you can set custom size of the items batch or listen to loading state changes:
+```ts
+ this.versionsDataSource = new VersionListDataSource(this.versionsApi, this.node);
+this.versionsDataSource.batchSize = 50;
+this.versionsDataSource.isLoading.pipe(takeUntil(this.onDestroy$)).subscribe((isLoading) => this.isLoading = isLoading);
+```
+
+Final step is to add the [CdkVirtualScrollViewport](https://material.angular.io/cdk/scrolling/api#CdkVirtualScrollViewport) with [CdkVirtualFor](https://material.angular.io/cdk/scrolling/api#CdkVirtualForOf) loop displaying items from the datasource.
+```html
+<cdk-virtual-scroll-viewport appendOnly itemSize="88">
+    <div *cdkVirtualFor="let version of versionsDataSource"></div>
+</cdk-virtual-scroll-viewport>
+```
+
+When user will scroll down to the bottom of the list next batch of items will be fetched until all items are visible.
+
+## Class members
+
+### Properties
+
+| Name | Type | Default value | Description |
+| ---- | ---- | ------------- | ----------- |
+| batchSize | `number` | 100 | Determines how much items will be fetched within one batch. |
+| firstItem | `T` | | Returns the first item ever fetched. |
+| isLoading | [`Observable`](https://rxjs.dev/api/index/class/Observable)`<boolean>` | | Observable representing the state of loading the first batch. |
+| itemsCount | `number` | | Number of items fetched so far. |
+
+### Methods
+
+-   **connect**(collectionViewer: [`CollectionViewer`](https://material.angular.io/cdk/collections/api)): [`Observable`](https://rxjs.dev/api/index/class/Observable)`<T>`<br/>
+    Called by the virtual scroll viewport to receive a stream that emits the data array that should be rendered.
+    -   collectionViewer:_ [`CollectionViewer`](https://material.angular.io/cdk/collections/api)  - collection viewer providing view changes that are listened to so that next batch can be fetched
+    -   **Returns** [`Observable`](https://rxjs.dev/api/index/class/Observable)`<T>` - Data stream containing fetched items.
+-   **disconnect**(): void<br/>
+    Called when viewport is destroyed, disconnects the datasource, unsubscribes from the view changes.
+-   **reset**(): void<br/>
+    Resets the datasource by fetching the first batch.

--- a/lib/content-services/src/lib/infinite-scroll-datasource/index.ts
+++ b/lib/content-services/src/lib/infinite-scroll-datasource/index.ts
@@ -1,0 +1,18 @@
+/*!
+ * @license
+ * Copyright © 2005-2023 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './public-api';

--- a/lib/content-services/src/lib/infinite-scroll-datasource/infinite-scroll-datasource.spec.ts
+++ b/lib/content-services/src/lib/infinite-scroll-datasource/infinite-scroll-datasource.spec.ts
@@ -97,7 +97,7 @@ describe('InfiniteScrollDatasource', () => {
     let component: TestComponent;
 
     const getRenderedItems = (): HTMLDivElement[] => {
-        return fixture.debugElement.queryAll(By.css('.test-item')).map((element) => element.nativeElement);
+        return fixture.debugElement.queryAll(By.css('.test-item')).map(element => element.nativeElement);
     };
 
     beforeEach(() => {

--- a/lib/content-services/src/lib/infinite-scroll-datasource/infinite-scroll-datasource.spec.ts
+++ b/lib/content-services/src/lib/infinite-scroll-datasource/infinite-scroll-datasource.spec.ts
@@ -96,9 +96,7 @@ describe('InfiniteScrollDatasource', () => {
     let fixture: ComponentFixture<TestComponent>;
     let component: TestComponent;
 
-    const getRenderedItems = (): HTMLDivElement[] => {
-        return fixture.debugElement.queryAll(By.css('.test-item')).map(element => element.nativeElement);
-    };
+    const getRenderedItems = (): HTMLDivElement[] => fixture.debugElement.queryAll(By.css('.test-item')).map(element => element.nativeElement);
 
     beforeEach(() => {
         TestBed.configureTestingModule({

--- a/lib/content-services/src/lib/infinite-scroll-datasource/infinite-scroll-datasource.spec.ts
+++ b/lib/content-services/src/lib/infinite-scroll-datasource/infinite-scroll-datasource.spec.ts
@@ -1,0 +1,161 @@
+/*!
+ * @license
+ * Copyright © 2005-2023 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ContentPagingQuery } from '@alfresco/js-api';
+import { ScrollingModule } from '@angular/cdk/scrolling';
+import { Component, OnInit } from '@angular/core';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { TranslateModule } from '@ngx-translate/core';
+import { from, Observable } from 'rxjs';
+import { ContentTestingModule } from '../testing/content.testing.module';
+import { InfiniteScrollDatasource } from './infinite-scroll-datasource';
+
+class TestData {
+    testId: number;
+    testDescription: string;
+
+    constructor(input?: Partial<TestData>) {
+        if (input) {
+            Object.assign(this, input);
+        }
+    }
+}
+
+class TestDataSource extends InfiniteScrollDatasource<TestData> {
+    testDataBatch1: TestData[] = [
+        {
+            testId: 1,
+            testDescription: 'test1'
+        },
+        {
+            testId: 2,
+            testDescription: 'test2'
+        },
+        {
+            testId: 3,
+            testDescription: 'test3'
+        },
+        {
+            testId: 4,
+            testDescription: 'test4'
+        }
+    ];
+    testDataBatch2: TestData[] = [
+        {
+            testId: 5,
+            testDescription: 'test5'
+        },
+        {
+            testId: 6,
+            testDescription: 'test6'
+        }
+    ];
+
+    getNextBatch(pagingOptions: ContentPagingQuery): Observable<TestData[]> {
+        if (pagingOptions.skipCount === 4) {
+            return from([this.testDataBatch2]);
+        } else if (pagingOptions.skipCount === 0) {
+            return from([this.testDataBatch1]);
+        } else {
+            return from([]);
+        }
+    }
+}
+
+@Component({
+    template: ` <cdk-virtual-scroll-viewport appendOnly itemSize="300" style="height: 500px; width: 100%;">
+        <div *cdkVirtualFor="let item of testDatasource" class="test-item" style="display: block; height: 100%; width: 100%;">
+            {{ item.testDescription }}
+        </div>
+    </cdk-virtual-scroll-viewport>`
+})
+class TestComponent implements OnInit {
+    testDatasource = new TestDataSource();
+
+    ngOnInit() {
+        this.testDatasource.batchSize = 4;
+    }
+}
+
+describe('InfiniteScrollDatasource', () => {
+    let fixture: ComponentFixture<TestComponent>;
+    let component: TestComponent;
+
+    const getRenderedItems = (): HTMLDivElement[] => {
+        return fixture.debugElement.queryAll(By.css('.test-item')).map((element) => element.nativeElement);
+    };
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [TranslateModule.forRoot(), ContentTestingModule, ScrollingModule],
+            declarations: [TestComponent]
+        });
+        fixture = TestBed.createComponent(TestComponent);
+        component = fixture.componentInstance;
+    });
+
+    it('should connect to the datasource and fetch first batch of items on init', async () => {
+        spyOn(component.testDatasource, 'connect').and.callThrough();
+        spyOn(component.testDatasource, 'getNextBatch').and.callThrough();
+        fixture.autoDetectChanges();
+        await fixture.whenStable();
+        await fixture.whenRenderingDone();
+
+        expect(component.testDatasource.connect).toHaveBeenCalled();
+        expect(component.testDatasource.itemsCount).toBe(4);
+        expect(component.testDatasource.getNextBatch).toHaveBeenCalledWith({ skipCount: 0, maxItems: 4 });
+        const renderedItems = getRenderedItems();
+        // only 3 elements fit the viewport
+        expect(renderedItems.length).toBe(3);
+        expect(renderedItems[0].innerText).toBe('test1');
+        expect(renderedItems[2].innerText).toBe('test3');
+    });
+
+    it('should load next batch when user scrolls towards the end of the list', fakeAsync(() => {
+        fixture.autoDetectChanges();
+        const stable = fixture.whenStable();
+        const renderingDone = fixture.whenRenderingDone();
+        Promise.all([stable, renderingDone]).then(() => {
+            spyOn(component.testDatasource, 'getNextBatch').and.callThrough();
+            const viewport = fixture.debugElement.query(By.css('cdk-virtual-scroll-viewport')).nativeElement;
+            viewport.scrollTop = 400;
+            tick(100);
+
+            const renderedItems = getRenderedItems();
+            expect(component.testDatasource.getNextBatch).toHaveBeenCalledWith({ skipCount: 4, maxItems: 4 });
+            expect(component.testDatasource.itemsCount).toBe(6);
+            expect(renderedItems[3].innerText).toBe('test4');
+        });
+    }));
+
+    it('should reset the datastream and fetch first batch on reset', fakeAsync(() => {
+        fixture.autoDetectChanges();
+        const stable = fixture.whenStable();
+        const renderingDone = fixture.whenRenderingDone();
+        Promise.all([stable, renderingDone]).then(() => {
+            spyOn(component.testDatasource, 'getNextBatch').and.callThrough();
+            component.testDatasource.reset();
+            tick(100);
+
+            const renderedItems = getRenderedItems();
+            expect(component.testDatasource.getNextBatch).toHaveBeenCalledWith({ skipCount: 0, maxItems: 4 });
+            expect(renderedItems.length).toBe(3);
+            expect(renderedItems[2].innerText).toBe('test3');
+        });
+    }));
+});

--- a/lib/content-services/src/lib/infinite-scroll-datasource/infinite-scroll-datasource.ts
+++ b/lib/content-services/src/lib/infinite-scroll-datasource/infinite-scroll-datasource.ts
@@ -72,7 +72,7 @@ export abstract class InfiniteScrollDatasource<T> extends DataSource<T> {
         this.getNextBatch({ skipCount: 0, maxItems: this.batchSize })
             .pipe(take(1))
             .subscribe((firstBatch) => {
-                this._itemsCount += firstBatch.length;
+                this._itemsCount = firstBatch.length;
                 this._firstItem = firstBatch[0];
                 this.dataStream.next(firstBatch);
                 this.isLoading$.next(false);

--- a/lib/content-services/src/lib/infinite-scroll-datasource/infinite-scroll-datasource.ts
+++ b/lib/content-services/src/lib/infinite-scroll-datasource/infinite-scroll-datasource.ts
@@ -45,16 +45,7 @@ export abstract class InfiniteScrollDatasource<T> extends DataSource<T> {
     abstract getNextBatch(pagingOptions: ContentPagingQuery): Observable<T[]>;
 
     connect(collectionViewer: CollectionViewer): Observable<T[]> {
-        this.isLoading$.next(true);
-        this.getNextBatch({ skipCount: 0, maxItems: this.batchSize })
-            .pipe(take(1))
-            .subscribe((firstBatch) => {
-                this._itemsCount += firstBatch.length;
-                this._firstItem = firstBatch[0];
-                this.dataStream.next(firstBatch);
-                this.isLoading$.next(false);
-            });
-        this.batchesFetched += 1;
+        this.reset();
         this.subscription.add(
             collectionViewer.viewChange.subscribe((range) => {
                 if (this.batchesFetched * this.batchSize <= range.end) {

--- a/lib/content-services/src/lib/infinite-scroll-datasource/infinite-scroll-datasource.ts
+++ b/lib/content-services/src/lib/infinite-scroll-datasource/infinite-scroll-datasource.ts
@@ -1,0 +1,91 @@
+/*!
+ * @license
+ * Copyright © 2005-2023 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ContentPagingQuery } from '@alfresco/js-api';
+import { CollectionViewer, DataSource } from '@angular/cdk/collections';
+import { BehaviorSubject, forkJoin, Observable, Subject, Subscription } from 'rxjs';
+import { take, tap } from 'rxjs/operators';
+
+export abstract class InfiniteScrollDatasource<T> extends DataSource<T> {
+    protected readonly dataStream = new BehaviorSubject<T[]>([]);
+    private isLoading$ = new Subject<boolean>();
+    private subscription = new Subscription();
+    private batchesFetched = 0;
+    private _itemsCount = 0;
+    private _firstItem: T;
+
+    /* Determines size of each batch to be fetched */
+    batchSize = 100;
+
+    /* Observable with initial and on reset loading state */
+    isLoading = this.isLoading$.asObservable();
+
+    get itemsCount(): number {
+        return this._itemsCount;
+    }
+
+    get firstItem(): T {
+        return this._firstItem;
+    }
+
+    abstract getNextBatch(pagingOptions: ContentPagingQuery): Observable<T[]>;
+
+    connect(collectionViewer: CollectionViewer): Observable<T[]> {
+        this.isLoading$.next(true);
+        this.getNextBatch({ skipCount: 0, maxItems: this.batchSize })
+            .pipe(take(1))
+            .subscribe((firstBatch) => {
+                this._itemsCount += firstBatch.length;
+                this._firstItem = firstBatch[0];
+                this.dataStream.next(firstBatch);
+                this.isLoading$.next(false);
+            });
+        this.batchesFetched += 1;
+        this.subscription.add(
+            collectionViewer.viewChange.subscribe((range) => {
+                if (this.batchesFetched * this.batchSize <= range.end) {
+                    forkJoin([
+                        this.dataStream.asObservable().pipe(take(1)),
+                        this.getNextBatch({ skipCount: this.batchSize * this.batchesFetched, maxItems: this.batchSize }).pipe(
+                            take(1),
+                            tap((nextBatch) => (this._itemsCount += nextBatch.length))
+                        )
+                    ]).subscribe((batchesArray) => this.dataStream.next([...batchesArray[0], ...batchesArray[1]]));
+                    this.batchesFetched += 1;
+                }
+            })
+        );
+        return this.dataStream;
+    }
+
+    disconnect(): void {
+        this.subscription.unsubscribe();
+    }
+
+    reset(): void {
+        this.isLoading$.next(true);
+        this.getNextBatch({ skipCount: 0, maxItems: this.batchSize })
+            .pipe(take(1))
+            .subscribe((firstBatch) => {
+                this._itemsCount += firstBatch.length;
+                this._firstItem = firstBatch[0];
+                this.dataStream.next(firstBatch);
+                this.isLoading$.next(false);
+            });
+        this.batchesFetched = 1;
+    }
+}

--- a/lib/content-services/src/lib/infinite-scroll-datasource/public-api.ts
+++ b/lib/content-services/src/lib/infinite-scroll-datasource/public-api.ts
@@ -1,0 +1,18 @@
+/*!
+ * @license
+ * Copyright © 2005-2023 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './infinite-scroll-datasource';

--- a/lib/content-services/src/lib/version-manager/version-list.component.html
+++ b/lib/content-services/src/lib/version-manager/version-list.component.html
@@ -1,55 +1,53 @@
-<mat-list class="adf-version-list" *ngIf="!isLoading; else loading_template">
-    <mat-list-item *ngFor="let version of versions; let idx = index; let latestVersion = first">
-        <mat-icon mat-list-icon>insert_drive_file</mat-icon>
-        <p mat-line class="adf-version-list-item-name" [id]="'adf-version-list-item-name-' + version.entry.id" >{{version.entry.name}}</p>
-        <p mat-line>
-            <span class="adf-version-list-item-version"  [id]="'adf-version-list-item-version-' + version.entry.id" >{{version.entry.id}}</span> -
-            <span class="adf-version-list-item-date"     [id]="'adf-version-list-item-date-' + version.entry.id" >{{version.entry.modifiedAt | date}}</span>
-        </p>
-        <p mat-line [id]="'adf-version-list-item-comment-'+ version.entry.id" class="adf-version-list-item-comment"
-           *ngIf="showComments">{{version.entry.versionComment}}</p>
+<mat-progress-bar *ngIf="isLoading" data-automation-id="version-history-loading-bar" mode="indeterminate" color="accent"></mat-progress-bar>
+<mat-list class="adf-version-list" [hidden]="isLoading">
+    <cdk-virtual-scroll-viewport #viewport itemSize="88" class="adf-version-list-viewport">
+        <mat-list-item *cdkVirtualFor="let version of versionsDataSource; let idx = index; let latestVersion = first">
+            <mat-icon mat-list-icon>insert_drive_file</mat-icon>
+            <p mat-line class="adf-version-list-item-name" [id]="'adf-version-list-item-name-' + version.entry.id" >{{version.entry.name}}</p>
+            <p mat-line>
+                <span class="adf-version-list-item-version"  [id]="'adf-version-list-item-version-' + version.entry.id" >{{version.entry.id}}</span> -
+                <span class="adf-version-list-item-date"     [id]="'adf-version-list-item-date-' + version.entry.id" >{{version.entry.modifiedAt | date}}</span>
+            </p>
+            <p mat-line [id]="'adf-version-list-item-comment-'+ version.entry.id" class="adf-version-list-item-comment"
+               *ngIf="showComments">{{version.entry.versionComment}}</p>
 
-        <div *ngIf="showActions">
-            <mat-menu [id]="'adf-version-list-action-menu-'+version.entry.id"
-                      #versionMenu="matMenu" yPosition="below" xPosition="before">
-                <ng-container *adf-acs-version="'7'">
-                    <button *ngIf="allowViewVersions"
-                            [id]="'adf-version-list-action-view-'+version.entry.id"
-                            mat-menu-item
-                            (click)="onViewVersion(version.entry.id)">
-                        {{ 'ADF_VERSION_LIST.ACTIONS.VIEW' | translate }}
-                    </button>
-                </ng-container>
-                <button
-                    [id]="'adf-version-list-action-restore-'+version.entry.id"
-                    [disabled]="!canUpdate() || latestVersion"
-                    mat-menu-item
-                    (click)="restore(version.entry.id)">
-                    {{ 'ADF_VERSION_LIST.ACTIONS.RESTORE' | translate }}
-                </button>
-                <button *ngIf="allowDownload"
-                        [id]="'adf-version-list-action-download-'+version.entry.id"
+            <div *ngIf="showActions">
+                <mat-menu [id]="'adf-version-list-action-menu-'+version.entry.id"
+                          #versionMenu="matMenu" yPosition="below" xPosition="before">
+                    <ng-container *adf-acs-version="'7'">
+                        <button *ngIf="allowViewVersions"
+                                [id]="'adf-version-list-action-view-'+version.entry.id"
+                                mat-menu-item
+                                (click)="onViewVersion(version.entry.id)">
+                            {{ 'ADF_VERSION_LIST.ACTIONS.VIEW' | translate }}
+                        </button>
+                    </ng-container>
+                    <button
+                        [id]="'adf-version-list-action-restore-'+version.entry.id"
+                        [disabled]="!canUpdate() || latestVersion"
                         mat-menu-item
-                        (click)="downloadVersion(version.entry.id)">
-                    {{ 'ADF_VERSION_LIST.ACTIONS.DOWNLOAD' | translate }}
-                </button>
-                <button
-                    [disabled]="!canDelete()"
-                    [id]="'adf-version-list-action-delete-'+version.entry.id"
-                    (click)="deleteVersion(version.entry.id)"
-                    mat-menu-item>
-                    {{ 'ADF_VERSION_LIST.ACTIONS.DELETE' | translate }}
-                </button>
-            </mat-menu>
+                        (click)="restore(version.entry.id)">
+                        {{ 'ADF_VERSION_LIST.ACTIONS.RESTORE' | translate }}
+                    </button>
+                    <button *ngIf="allowDownload"
+                            [id]="'adf-version-list-action-download-'+version.entry.id"
+                            mat-menu-item
+                            (click)="downloadVersion(version.entry.id)">
+                        {{ 'ADF_VERSION_LIST.ACTIONS.DOWNLOAD' | translate }}
+                    </button>
+                    <button
+                        [disabled]="!canDelete()"
+                        [id]="'adf-version-list-action-delete-'+version.entry.id"
+                        (click)="deleteVersion(version.entry.id)"
+                        mat-menu-item>
+                        {{ 'ADF_VERSION_LIST.ACTIONS.DELETE' | translate }}
+                    </button>
+                </mat-menu>
 
-            <button mat-icon-button [matMenuTriggerFor]="versionMenu" [id]="'adf-version-list-action-menu-button-'+version.entry.id" title="{{ 'ADF_VERSION_LIST.MANAGE_VERSION_OPTIONS' | translate }}">
-                <mat-icon>more_vert</mat-icon>
-            </button>
-        </div>
-    </mat-list-item>
+                <button mat-icon-button [matMenuTriggerFor]="versionMenu" [id]="'adf-version-list-action-menu-button-'+version.entry.id" title="{{ 'ADF_VERSION_LIST.MANAGE_VERSION_OPTIONS' | translate }}">
+                    <mat-icon>more_vert</mat-icon>
+                </button>
+            </div>
+        </mat-list-item>
+    </cdk-virtual-scroll-viewport>
 </mat-list>
-
-<ng-template #loading_template>
-    <mat-progress-bar data-automation-id="version-history-loading-bar" mode="indeterminate"
-                      color="accent"></mat-progress-bar>
-</ng-template>

--- a/lib/content-services/src/lib/version-manager/version-list.component.scss
+++ b/lib/content-services/src/lib/version-manager/version-list.component.scss
@@ -1,4 +1,8 @@
 .adf-version-list {
+    &-viewport {
+        height: 100%;
+    }
+
     .mat-list-item-content {
         border-bottom: 1px solid #d8d8d8;
     }

--- a/lib/content-services/src/lib/version-manager/version-manager.component.html
+++ b/lib/content-services/src/lib/version-manager/version-manager.component.html
@@ -10,7 +10,7 @@
                         id="adf-version-upload-button"
                         [node]="node"
                         [newFileVersion]="newFileVersion"
-                        [currentVersion]="versionList?.versions[0]?.entry"
+                        [currentVersion]="versionList?.latestVersion?.entry"
                         (success)="onUploadSuccess($event)"
                         (cancel)="onUploadCancel()"
                         (error)="onUploadError($event)">

--- a/lib/content-services/src/lib/version-manager/version-manager.component.spec.ts
+++ b/lib/content-services/src/lib/version-manager/version-manager.component.spec.ts
@@ -55,7 +55,7 @@ describe('VersionManagerComponent', () => {
 
     it('should load the versions for a given node', () => {
         fixture.detectChanges();
-        expect(spyOnListVersionHistory).toHaveBeenCalledWith(node.id);
+        expect(spyOnListVersionHistory).toHaveBeenCalledWith(node.id, { skipCount: 0, maxItems: 100 });
     });
 
     it('should toggle new version if given a new file as input', () => {

--- a/lib/content-services/src/lib/version-manager/version-manager.module.ts
+++ b/lib/content-services/src/lib/version-manager/version-manager.module.ts
@@ -27,6 +27,7 @@ import { UploadModule } from '../upload/upload.module';
 import { VersionCompatibilityModule } from '../version-compatibility/version-compatibility.module';
 import { CoreModule } from '@alfresco/adf-core';
 import { VersionComparisonComponent } from './version-comparison.component';
+import { ScrollingModule } from '@angular/cdk/scrolling';
 
 @NgModule({
     imports: [
@@ -35,7 +36,8 @@ import { VersionComparisonComponent } from './version-comparison.component';
         CoreModule,
         UploadModule,
         VersionCompatibilityModule,
-        FormsModule
+        FormsModule,
+        ScrollingModule
     ],
     exports: [
         VersionUploadComponent,

--- a/lib/content-services/src/public-api.ts
+++ b/lib/content-services/src/public-api.ts
@@ -46,5 +46,6 @@ export * from './lib/tree/index';
 export * from './lib/category/index';
 export * from './lib/viewer/index';
 export * from './lib/security/index';
+export * from './lib/infinite-scroll-datasource';
 
 export * from './lib/content.module';


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

If a node has over 100 versions only first 100 is displayed.

**What is the new behaviour?**

There is a infinite scroll added to the version list, right now if node has more than 100 versions and user will scroll near the end of the list next batch of versions will be fetched. Closes Alfresco/alfresco-content-app#3568

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
