### PR TITLE
[ACS-6584] Added validation for illegal characters when creating a tag

### DIFF
--- a/lib/content-services/src/lib/i18n/en.json
+++ b/lib/content-services/src/lib/i18n/en.json
@@ -155,7 +155,8 @@
         "EMPTY_TAG": "Tag name can't contain only spaces",
         "REQUIRED": "Tag name is required",
         "FETCH_TAGS": "Error while fetching the tags",
-        "CREATE_TAGS": "Error while creating the tags"
+        "CREATE_TAGS": "Error while creating the tags",
+        "SPECIAL_CHARACTERS": "Tag name cannot contain prohibited characters"
       },
       "TOOLTIPS": {
         "DELETE_TAG": "Delete tag"

--- a/lib/content-services/src/lib/tag/tags-creator/tags-creator.component.spec.ts
+++ b/lib/content-services/src/lib/tag/tags-creator/tags-creator.component.spec.ts
@@ -524,7 +524,7 @@ describe('TagsCreatorComponent', () => {
                 typeTag(name);
 
                 expect(tagService.findTagByName).toHaveBeenCalledWith(name);
-            }))
+            }));
 
             it('should not perform search if an illegal character is specified', fakeAsync(() => {
                 spyOn(tagService, 'findTagByName').and.returnValue(EMPTY);

--- a/lib/content-services/src/lib/tag/tags-creator/tags-creator.component.spec.ts
+++ b/lib/content-services/src/lib/tag/tags-creator/tags-creator.component.spec.ts
@@ -32,7 +32,7 @@ import { DebugElement } from '@angular/core';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatListModule, MatSelectionList, MatSelectionListChange } from '@angular/material/list';
 
-fdescribe('TagsCreatorComponent', () => {
+describe('TagsCreatorComponent', () => {
     let fixture: ComponentFixture<TagsCreatorComponent>;
     let component: TagsCreatorComponent;
     let tagService: TagService;

--- a/lib/content-services/src/lib/tag/tags-creator/tags-creator.component.spec.ts
+++ b/lib/content-services/src/lib/tag/tags-creator/tags-creator.component.spec.ts
@@ -32,7 +32,7 @@ import { DebugElement } from '@angular/core';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatListModule, MatSelectionList, MatSelectionListChange } from '@angular/material/list';
 
-describe('TagsCreatorComponent', () => {
+fdescribe('TagsCreatorComponent', () => {
     let fixture: ComponentFixture<TagsCreatorComponent>;
     let component: TagsCreatorComponent;
     let tagService: TagService;
@@ -382,6 +382,14 @@ describe('TagsCreatorComponent', () => {
                 expect(getFirstError()).toBe('TAG.TAGS_CREATOR.ERRORS.ALREADY_ADDED_TAG');
             }));
 
+            it('should show error for prohibited characters', fakeAsync(() => {
+                typeTag('tag*"<>\\/?:|');
+                component.tagNameControl.markAsTouched();
+                fixture.detectChanges();
+                const error = getFirstError();
+                expect(error).toBe('TAG.TAGS_CREATOR.ERRORS.SPECIAL_CHARACTERS');
+            }));
+
             it('should show error when duplicated already existing tag', fakeAsync(() => {
                 const tag = 'Some tag';
 
@@ -516,6 +524,17 @@ describe('TagsCreatorComponent', () => {
                 typeTag(name);
 
                 expect(tagService.findTagByName).toHaveBeenCalledWith(name);
+            }))
+
+            it('should not perform search if an illegal character is specified', fakeAsync(() => {
+                spyOn(tagService, 'findTagByName').and.returnValue(EMPTY);
+                spyOn(tagService, 'searchTags').and.returnValue(EMPTY);
+
+                const name = 'Tag:"\'>';
+                typeTag(name);
+
+                expect(tagService.findTagByName).not.toHaveBeenCalled();
+                expect(tagService.searchTags).not.toHaveBeenCalled();
             }));
 
             it('should call searchTags on tagService using name set in input and correct params', fakeAsync(() => {

--- a/lib/content-services/src/lib/tag/tags-creator/tags-creator.component.ts
+++ b/lib/content-services/src/lib/tag/tags-creator/tags-creator.component.ts
@@ -41,6 +41,7 @@ interface TagNameControlErrors {
     duplicatedAddedTag?: boolean;
     emptyTag?: boolean;
     required?: boolean;
+    specialCharacters?: boolean;
 }
 
 const DEFAULT_TAGS_SORTING = {
@@ -132,7 +133,8 @@ export class TagsCreatorComponent implements OnInit, OnDestroy {
         ['duplicatedExistingTag', 'EXISTING_TAG'],
         ['duplicatedAddedTag', 'ALREADY_ADDED_TAG'],
         ['emptyTag', 'EMPTY_TAG'],
-        ['required', 'REQUIRED']
+        ['required', 'REQUIRED'],
+        ['specialCharacters', 'SPECIAL_CHARACTERS']
     ]);
 
     private readonly existingTagsListLimit = 15;
@@ -144,7 +146,8 @@ export class TagsCreatorComponent implements OnInit, OnDestroy {
         [
             this.validateIfNotAlreadyAdded.bind(this),
             Validators.required,
-            this.validateEmptyTag
+            this.validateEmptyTag,
+            this.validateSpecialCharacters
         ],
         this.validateIfNotExistingTag.bind(this)
     );
@@ -301,7 +304,7 @@ export class TagsCreatorComponent implements OnInit, OnDestroy {
     }
 
     private loadTags(name: string) {
-        if (name) {
+        if (name && !this.tagNameControl.hasError('specialCharacters')) {
             forkJoin({
                 exactResult: this.tagService.findTagByName(name),
                 searchedResult: this.tagService.searchTags(name, DEFAULT_TAGS_SORTING, false, 0, this.existingTagsListLimit)
@@ -366,6 +369,13 @@ export class TagsCreatorComponent implements OnInit, OnDestroy {
     private validateEmptyTag(tagNameControl: FormControl<string>): TagNameControlErrors | null {
         return tagNameControl.value.length && !tagNameControl.value.trim()
             ? { emptyTag: true }
+            : null;
+    }
+
+    private validateSpecialCharacters(tagNameControl: FormControl<string>): TagNameControlErrors | null {
+        const specialSymbolsRegex: RegExp = /[':"\\|<>\/?]/;
+        return tagNameControl.value.length && specialSymbolsRegex.test(tagNameControl.value)
+            ? { specialCharacters: true }
             : null;
     }
 

--- a/lib/content-services/src/lib/tag/tags-creator/tags-creator.component.ts
+++ b/lib/content-services/src/lib/tag/tags-creator/tags-creator.component.ts
@@ -373,7 +373,7 @@ export class TagsCreatorComponent implements OnInit, OnDestroy {
     }
 
     private validateSpecialCharacters(tagNameControl: FormControl<string>): TagNameControlErrors | null {
-        const specialSymbolsRegex: RegExp = /[':"\\|<>\/?]/;
+        const specialSymbolsRegex = /[':"\\|<>/?]/;
         return tagNameControl.value.length && specialSymbolsRegex.test(tagNameControl.value)
             ? { specialCharacters: true }
             : null;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://alfresco.atlassian.net/browse/ACS-6584
Some symbols are forbidden by the API, creating tags with them result to an error.

**What is the new behaviour?**

Tag name is now being validated for prohibited characters before creating / fetching  tags.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
