### PR TITLE
[ACS-6620] Proper viewer extension template projection to viewer renderer

### DIFF
--- a/demo-shell/src/assets/app.extensions.json
+++ b/demo-shell/src/assets/app.extensions.json
@@ -5,7 +5,7 @@
 
   "features": {
     "viewer": {
-      "content": []
+      "extensions": []
     },
 
     "documentList": {

--- a/docs/content-services/components/alfresco-viewer.component.md
+++ b/docs/content-services/components/alfresco-viewer.component.md
@@ -237,47 +237,48 @@ The Viewer supports dynamically-loaded viewer preview extensions, to know more a
 
 #### Code extension mechanism]
 
-You can define your own custom handler to handle other file formats that are not yet supported by
+You can define your own custom handler to override supported file formats or handle other file formats that are not yet supported by
 the [Alfresco Viewer component](viewer.component.md). Below is an example that shows how to use the `adf-viewer-extension`
 to handle 3D data files:
 
 ```html
 <adf-alfresco-viewer [nodeId]="nodeId">
-    
-    <adf-viewer-extension [supportedExtensions]="['obj','3ds']" #extension>
-        <ng-template let-urlFileContent="urlFileContent" let-extension="extension">
-            <threed-viewer 
-                [urlFile]="urlFileContent" 
-                [extension]="extension">
-            </threed-viewer>
-        </ng-template>
-    </adf-viewer-extension>
-
+    <ng-template #viewerExtensions>
+        <adf-viewer-extension [supportedExtensions]="['obj','3ds']" #extension>
+            <ng-template let-urlFileContent="urlFileContent" let-extension="extension">
+                <threed-viewer
+                    [urlFile]="urlFileContent"
+                    [extension]="extension">
+                </threed-viewer>
+            </ng-template>
+        </adf-viewer-extension>
+    </ng-template>
 </adf-alfresco-viewer> 
 ```
 
 Note: you need to add the `ng2-3d-editor` dependency to your `package.json` file to make the example above work.
 
-You can define multiple `adf-viewer-extension` templates if required:
+You need to keep all instances of `adf-viewer-extension` inside `viewerExtensions` template, also you can define multiple `adf-viewer-extension` templates if required:
 
 ```html
 <adf-alfresco-viewer [nodeId]="nodeId">
+    <ng-template #viewerExtensions>
+        <adf-viewer-extension [supportedExtensions]="['xls','xlsx']" #extension>
+            <ng-template let-urlFileContent="urlFileContent">
+                <my-custom-xls-component
+                    urlFileContent="urlFileContent">
+                </my-custom-xls-component>
+            </ng-template>
+        </adf-viewer-extension>
 
-    <adf-viewer-extension [supportedExtensions]="['xls','xlsx']" #extension>
-        <ng-template let-urlFileContent="urlFileContent">
-            <my-custom-xls-component 
-                urlFileContent="urlFileContent">
-            </my-custom-xls-component>
-        </ng-template>
-    </adf-viewer-extension>
-
-    <adf-viewer-extension [supportedExtensions]="['txt']" #extension>
-        <ng-template let-urlFileContent="urlFileContent" >               
-            <my-custom-txt-component 
-                urlFileContent="urlFileContent">
-            </my-custom-txt-component>
-        </ng-template>
-    </adf-viewer-extension>
+        <adf-viewer-extension [supportedExtensions]="['txt']" #extension>
+            <ng-template let-urlFileContent="urlFileContent" >
+                <my-custom-txt-component
+                    urlFileContent="urlFileContent">
+                </my-custom-txt-component>
+            </ng-template>
+        </adf-viewer-extension>
+    </ng-template>
 </adf-alfresco-viewer> 
 ```
 

--- a/docs/core/components/viewer-render.component.md
+++ b/docs/core/components/viewer-render.component.md
@@ -62,6 +62,7 @@ Using with file [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob):
 | thumbnailsTemplate | [`TemplateRef`](https://angular.io/api/core/TemplateRef)`<any>` | null | The template for the pdf thumbnails. |
 | tracks | [`Track`](../../../lib/core/src/lib/viewer/models/viewer.model.ts)`[]` | \[] | media subtitles for the media player |
 | urlFile | `string` | "" | If you want to load an external file that does not come from ACS you can use this URL to specify where to load the file from. |
+| viewerTemplateExtensions | [`TemplateRef`](https://angular.io/api/core/TemplateRef)`<any>` | null | Template containing ViewerExtensionDirective instances providing different viewer extensions based on supported file extension. |
 
 ### Events
 
@@ -200,34 +201,13 @@ The [Viewer render component](viewer.component.md) should now be able to display
 
 The Viewer supports dynamically-loaded viewer preview extensions, to know more about it [Preview Extension component](../../extensions/components/preview-extension.component.md). This 
 
-#### Code extension mechanism]
+#### Code extension mechanism
 
-You can define your own custom handler to handle other file formats that are not yet supported by
-the [Viewer render component](viewer.component.md). Below is an example that shows how to use the `adf-viewer-render-extension`
-to handle 3D data files:
+You can define your own custom handler to override supported file formats or handle other file formats that are not yet supported by
+the [Viewer render component](viewer.component.md). In order to do that first you need to define a template containing at least one `adf-viewer-extension`:
 
-```html
-<adf-viewer-render [nodeId]="nodeId">
-    
-    <adf-viewer-extension [supportedExtensions]="['obj','3ds']" #extension>
-        <ng-template let-urlFileContent="urlFileContent" let-extension="extension">
-            <threed-viewer 
-                [urlFile]="urlFileContent" 
-                [extension]="extension">
-            </threed-viewer>
-        </ng-template>
-    </adf-viewer-extension>
-
-</adf-viewer-render> 
-```
-
-Note: you need to add the `ng2-3d-editor` dependency to your `package.json` file to make the example above work.
-
-You can define multiple `adf-viewer-render-extension` templates if required:
-
-```html
-<adf-viewer-render [nodeId]="nodeId">
-
+```html    
+<ng-template #viewerExtensions>
     <adf-viewer-extension [supportedExtensions]="['xls','xlsx']" #extension>
         <ng-template let-urlFileContent="urlFileContent">
             <my-custom-xls-component 
@@ -243,6 +223,22 @@ You can define multiple `adf-viewer-render-extension` templates if required:
             </my-custom-txt-component>
         </ng-template>
     </adf-viewer-render-extension>
+</ng-template>
+```
+
+Next in your component you need to get a reference of created template
+
+```ts
+@ViewChild('viewerExtensions')
+viewerTemplateExtensions: TemplateRef<any>;
+```
+
+and pass it via `viewerTemplateExtensions` input:
+
+```html
+<adf-viewer-render>
+    ...
+    [viewerTemplateExtensions]="viewerTemplateExtensions"
 </adf-viewer-render> 
 ```
 

--- a/docs/core/components/viewer.component.md
+++ b/docs/core/components/viewer.component.md
@@ -85,6 +85,7 @@ See the [Custom layout](#custom-layout) section for full details of all availabl
 | sidebarRightTemplateContext |  | null | Context object available for binding by the local sidebarRightTemplate with let declarations. |
 | tracks | [`Track`](../../../lib/core/src/lib/viewer/models/viewer.model.ts)`[]` | \[] | media subtitles for the media player |
 | urlFile | `string` | "" | If you want to load an external file that does not come from ACS you can use this URL to specify where to load the file from. |
+| viewerExtensions | [`TemplateRef`](https://angular.io/api/core/TemplateRef)`<any>` | null | Template containing ViewerExtensionDirective instances providing different viewer extensions based on supported file extension. |
 
 ### Events
 
@@ -209,47 +210,47 @@ The Viewer supports dynamically-loaded viewer preview extensions, to know more a
 
 #### Code extension mechanism]
 
-You can define your own custom handler to handle other file formats that are not yet supported by
+You can define your own custom handler to override supported file formats or handle other file formats that are not yet supported by
 the [Viewer component](viewer.component.md). Below is an example that shows how to use the `adf-viewer-extension`
 to handle 3D data files:
 
 ```html
 <adf-viewer [urlFile]="urlFile">
-    
-    <adf-viewer-extension [supportedExtensions]="['obj','3ds']" #extension>
-        <ng-template let-urlFileContent="urlFileContent" let-extension="extension">
-            <threed-viewer 
-                [urlFile]="urlFileContent" 
-                [extension]="extension">
-            </threed-viewer>
-        </ng-template>
-    </adf-viewer-extension>
-
+    <ng-template #viewerExtensions>
+        <adf-viewer-extension [supportedExtensions]="['obj','3ds']" #extension>
+            <ng-template let-urlFileContent="urlFileContent" let-extension="extension">
+                <threed-viewer 
+                    [urlFile]="urlFileContent" 
+                    [extension]="extension">
+                </threed-viewer>
+            </ng-template>
+        </adf-viewer-extension>
+    </ng-template>
 </adf-viewer> 
 ```
 
 Note: you need to add the `ng2-3d-editor` dependency to your `package.json` file to make the example above work.
 
-You can define multiple `adf-viewer-extension` templates if required:
-
+You need to keep all instances of `adf-viewer-extension` inside `viewerExtensions` template, also you can define multiple `adf-viewer-extension` templates if required:
 ```html
 <adf-viewer [urlFile]="urlFile">
+    <ng-template #viewerExtensions>
+        <adf-viewer-extension [supportedExtensions]="['xls','xlsx']" #extension>
+            <ng-template let-urlFileContent="urlFileContent">
+                <my-custom-xls-component
+                    urlFileContent="urlFileContent">
+                </my-custom-xls-component>
+            </ng-template>
+        </adf-viewer-extension>
 
-    <adf-viewer-extension [supportedExtensions]="['xls','xlsx']" #extension>
-        <ng-template let-urlFileContent="urlFileContent">
-            <my-custom-xls-component 
-                urlFileContent="urlFileContent">
-            </my-custom-xls-component>
-        </ng-template>
-    </adf-viewer-extension>
-
-    <adf-viewer-extension [supportedExtensions]="['txt']" #extension>
-        <ng-template let-urlFileContent="urlFileContent" >               
-            <my-custom-txt-component 
-                urlFileContent="urlFileContent">
-            </my-custom-txt-component>
-        </ng-template>
-    </adf-viewer-extension>
+        <adf-viewer-extension [supportedExtensions]="['txt']" #extension>
+            <ng-template let-urlFileContent="urlFileContent" >
+                <my-custom-txt-component
+                    urlFileContent="urlFileContent">
+                </my-custom-txt-component>
+            </ng-template>
+        </adf-viewer-extension>
+    </ng-template>
 </adf-viewer> 
 ```
 

--- a/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.html
+++ b/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.html
@@ -24,6 +24,7 @@
     [urlFile]="urlFileContent"
     [tracks]="tracks"
     [readOnly]="readOnly"
+    [viewerExtensions]="viewerExtensions"
     (downloadFile)="onDownloadFile()"
     (navigateBefore)="onNavigateBeforeClick($event)"
     (navigateNext)="onNavigateNextClick($event)"

--- a/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.ts
+++ b/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.ts
@@ -80,6 +80,9 @@ export class AlfrescoViewerComponent implements OnChanges, OnInit, OnDestroy {
     @ContentChild(ViewerOpenWithComponent)
     openWith: ViewerOpenWithComponent;
 
+    @ContentChild('viewerExtensions', { static: false })
+    viewerExtensions: TemplateRef<any>;
+
     /** Node Id of the file to load. */
     @Input()
     nodeId: string = null;

--- a/lib/core/src/lib/viewer/components/viewer-render.component.html
+++ b/lib/core/src/lib/viewer/components/viewer-render.component.html
@@ -79,13 +79,13 @@
                     </adf-preview-extension>
                 </ng-container>
 
-                <span class="adf-viewer-render-custom-content"
-                      *ngFor="let extensionTemplate of extensionTemplates">
-                                <ng-template *ngIf="extensionTemplate.isVisible"
-                                             [ngTemplateOutlet]="extensionTemplate.template"
-                                             [ngTemplateOutletContext]="{ urlFile: urlFile, extension:extension }">
-                                </ng-template>
-                            </span>
+                <ng-container *ngFor="let extensionTemplate of extensionTemplates">
+                    <span *ngIf="extensionTemplate.isVisible" class="adf-viewer-render-custom-content">
+                        <ng-template [ngTemplateOutlet]="extensionTemplate.template"
+                                     [ngTemplateOutletContext]="{ urlFile: urlFile, extension: extension }">
+                        </ng-template>
+                    </span>
+                </ng-container>
             </ng-container>
 
             <ng-container *ngSwitchDefault>
@@ -94,3 +94,6 @@
         </div>
     </div>
 </div>
+<ng-container *ngIf="viewerTemplateExtensions">
+    <ng-template [ngTemplateOutlet]="viewerTemplateExtensions" [ngTemplateOutletInjector]="injector"></ng-template>
+</ng-container>

--- a/lib/core/src/lib/viewer/components/viewer-render.component.spec.ts
+++ b/lib/core/src/lib/viewer/components/viewer-render.component.spec.ts
@@ -277,9 +277,8 @@ describe('ViewerComponent', () => {
     });
 
     describe('Custom viewer extension template', () => {
-        const getCustomViewerContent = (fixture: ComponentFixture<DoubleViewerComponent>): HTMLHeadingElement => {
-            return fixture.debugElement.query(By.css('.adf-viewer-render-custom-content h1')).nativeElement;
-        };
+        const getCustomViewerContent = (customFixture: ComponentFixture<DoubleViewerComponent>): HTMLHeadingElement =>
+            customFixture.debugElement.query(By.css('.adf-viewer-render-custom-content h1')).nativeElement;
 
         it('should render provided custom template when file type matches supported extensions', async () => {
             const fixtureCustom = TestBed.createComponent(DoubleViewerComponent);
@@ -390,7 +389,6 @@ describe('ViewerComponent', () => {
                 expect(element.querySelector('adf-pdf-viewer')).not.toBeNull();
                 done();
             });
-
         }, 25000);
 
         it('should display a PDF file identified by mimetype when the file extension is wrong', (done) => {

--- a/lib/core/src/lib/viewer/components/viewer-render.component.ts
+++ b/lib/core/src/lib/viewer/components/viewer-render.component.ts
@@ -18,7 +18,7 @@
 import {
     Component, EventEmitter,
     Input, OnChanges, Output, TemplateRef,
-    ViewEncapsulation, OnInit, OnDestroy
+    ViewEncapsulation, OnInit, OnDestroy, Injector
 } from '@angular/core';
 import { Subject } from 'rxjs';
 import { ViewUtilService } from '../services/view-util.service';
@@ -79,6 +79,10 @@ export class ViewerRenderComponent implements OnChanges, OnInit, OnDestroy {
     @Input()
     tracks: Track[] = [];
 
+    /** Template containing ViewerExtensionDirective instances providing different viewer extensions based on supported file extension. */
+    @Input()
+    viewerTemplateExtensions: TemplateRef<any>;
+
     /** Emitted when the filename extension changes. */
     @Output()
     extensionChange = new EventEmitter<string>();
@@ -96,6 +100,7 @@ export class ViewerRenderComponent implements OnChanges, OnInit, OnDestroy {
     isSaving = new EventEmitter<boolean>();
 
     extensionTemplates: { template: TemplateRef<any>; isVisible: boolean }[] = [];
+    extensionsSupportedByTemplates: string[] = [];
     extension: string;
     internalFileName: string;
     viewerType: string = 'unknown';
@@ -133,7 +138,8 @@ export class ViewerRenderComponent implements OnChanges, OnInit, OnDestroy {
 
     constructor(private viewUtilService: ViewUtilService,
                 private extensionService: AppExtensionService,
-                public dialog: MatDialog) {
+                public dialog: MatDialog,
+                public readonly injector: Injector) {
     }
 
     ngOnInit() {
@@ -166,7 +172,7 @@ export class ViewerRenderComponent implements OnChanges, OnInit, OnDestroy {
     private setUpUrlFile() {
         this.internalFileName = this.fileName ? this.fileName : this.viewUtilService.getFilenameFromUrl(this.urlFile);
         this.extension = this.viewUtilService.getFileExtension(this.internalFileName);
-        this.viewerType = this.viewUtilService.getViewerType(this.extension, this.mimeType);
+        this.viewerType = this.viewUtilService.getViewerType(this.extension, this.mimeType, this.extensionsSupportedByTemplates);
 
         this.extensionChange.emit(this.extension);
         this.scrollTop();

--- a/lib/core/src/lib/viewer/components/viewer.component.html
+++ b/lib/core/src/lib/viewer/components/viewer.component.html
@@ -171,7 +171,8 @@
                 (submitFile)="onSubmitFile($event)"
                 [urlFile]="urlFile"
                 (isSaving)="allowNavigate = !$event"
-                [tracks]="tracks">
+                [tracks]="tracks"
+                [viewerTemplateExtensions]="viewerExtensions ?? viewerTemplateExtensions">
             </adf-viewer-render>
 
         </div>

--- a/lib/core/src/lib/viewer/components/viewer.component.ts
+++ b/lib/core/src/lib/viewer/components/viewer.component.ts
@@ -71,6 +71,9 @@ export class ViewerComponent<T> implements OnDestroy, OnInit, OnChanges {
     @ContentChild(ViewerMoreActionsComponent)
     mnuMoreActions: ViewerMoreActionsComponent;
 
+    @ContentChild('viewerExtensions', { static: false })
+    viewerTemplateExtensions: TemplateRef<any>;
+
     get CloseButtonPosition() {
         return CloseButtonPosition;
     }
@@ -189,6 +192,10 @@ export class ViewerComponent<T> implements OnDestroy, OnInit, OnChanges {
     /** Toggles the 'Info Button' */
     @Input()
     hideInfoButton = false;
+
+    /** Template containing ViewerExtensionDirective instances providing different viewer extensions based on supported file extension. */
+    @Input()
+    viewerExtensions: TemplateRef<any>;
 
     /**
      * Enable dialog box to allow user to download the previewed file, in case the preview is not responding for a set period of time.

--- a/lib/core/src/lib/viewer/directives/viewer-extension.directive.spec.ts
+++ b/lib/core/src/lib/viewer/directives/viewer-extension.directive.spec.ts
@@ -26,6 +26,7 @@ import { TranslateModule } from '@ngx-translate/core';
 
 describe('ExtensionViewerDirective', () => {
     let extensionViewerDirective: ViewerExtensionDirective;
+    let viewerRenderer: ViewerRenderComponent;
 
     class MockElementRef extends ElementRef {
         constructor() {
@@ -42,12 +43,13 @@ describe('ExtensionViewerDirective', () => {
             providers: [
                 { provide: Location, useClass: SpyLocation },
                 ViewerExtensionDirective,
-                {provide: ElementRef, useClass: MockElementRef},
+                { provide: ElementRef, useClass: MockElementRef },
                 ViewerRenderComponent,
                 { provide: ChangeDetectorRef, useValue: { detectChanges: () => {} } }
             ]
         });
         extensionViewerDirective = TestBed.inject(ViewerExtensionDirective);
+        viewerRenderer = TestBed.inject(ViewerRenderComponent);
         extensionViewerDirective.templateModel = {template: '', isVisible: false};
     });
 
@@ -63,5 +65,13 @@ describe('ExtensionViewerDirective', () => {
     it('if the file in the viewer not has an extension handled by this extension isVisible should be false', () => {
         extensionViewerDirective.supportedExtensions = ['xls', 'sts'];
         expect(extensionViewerDirective.isVisible('png')).not.toBeTruthy();
+    });
+
+    it('should set correct template and supported extensions in viewer renderer component', () => {
+        extensionViewerDirective.supportedExtensions = ['png', 'txt'];
+        extensionViewerDirective.ngAfterContentInit();
+        expect(viewerRenderer.extensionTemplates.length).toBe(1);
+        expect(viewerRenderer.extensionTemplates[0]).toEqual(extensionViewerDirective.templateModel);
+        expect(viewerRenderer.extensionsSupportedByTemplates).toEqual(extensionViewerDirective.supportedExtensions);
     });
 });

--- a/lib/core/src/lib/viewer/directives/viewer-extension.directive.ts
+++ b/lib/core/src/lib/viewer/directives/viewer-extension.directive.ts
@@ -46,7 +46,7 @@ export class ViewerExtensionDirective implements AfterContentInit, OnDestroy {
 
     ngAfterContentInit() {
         this.templateModel = { template: this.template, isVisible: false };
-
+        this.viewerComponent.extensionsSupportedByTemplates.push(...this.supportedExtensions);
         this.viewerComponent.extensionTemplates.push(this.templateModel);
 
         this.viewerComponent.extensionChange
@@ -54,12 +54,6 @@ export class ViewerExtensionDirective implements AfterContentInit, OnDestroy {
             .subscribe(fileExtension => {
                 this.templateModel.isVisible = this.isVisible(fileExtension);
             });
-
-        if (this.supportedExtensions instanceof Array) {
-            this.supportedExtensions.forEach((extension) => {
-                this.viewerComponent.externalExtensions.push(extension);
-            });
-        }
     }
 
     ngOnDestroy() {

--- a/lib/core/src/lib/viewer/services/view-util.service.spec.ts
+++ b/lib/core/src/lib/viewer/services/view-util.service.spec.ts
@@ -1,0 +1,78 @@
+/*!
+ * @license
+ * Copyright © 2005-2023 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AppExtensionService } from '@alfresco/adf-extensions';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { ViewUtilService } from './view-util.service';
+
+describe('ViewUtilService', () => {
+    let viewUtilService: ViewUtilService;
+    let appExtensionService: AppExtensionService;
+    const extensionsSupportedByTemplates = ['dmn', 'txt'];
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [HttpClientTestingModule],
+            providers: [AppExtensionService]
+        });
+
+        viewUtilService = TestBed.inject(ViewUtilService);
+        appExtensionService = TestBed.inject(AppExtensionService);
+    });
+
+    it('should extract file name from url', () => {
+        expect(viewUtilService.getFilenameFromUrl('http://localhost/test.jpg?cache=1000')).toBe('test.jpg');
+        expect(viewUtilService.getFilenameFromUrl('http://localhost:4200/test-path/test2.json#cache=1000')).toBe('test2.json');
+    });
+
+    it('should extract file extension from url', () => {
+        expect(viewUtilService.getFileExtension('http://localhost/test.jpg?cache=1000')).toBe('jpg');
+        expect(viewUtilService.getFileExtension('http://localhost:4200/test-path/test2.json#cache=1000')).toBe('json');
+    });
+
+    it('should return correct viewer type based on file mime type', () => {
+        expect(viewUtilService.getViewerTypeByMimeType('text/plain')).toBe('text');
+        expect(viewUtilService.getViewerTypeByMimeType('application/pdf')).toBe('pdf');
+        expect(viewUtilService.getViewerTypeByMimeType('image/gif')).toBe('image');
+        expect(viewUtilService.getViewerTypeByMimeType('video/webm')).toBe('media');
+        expect(viewUtilService.getViewerTypeByMimeType('image/test')).toBe('unknown');
+    });
+
+    it('should check if extension is custom one added either by extension service or by a template in viewer renderer', () => {
+        spyOn(appExtensionService, 'getViewerExtensions').and.returnValue([{ fileExtension: 'json', component: 'test', id: 'test' }]);
+        expect(viewUtilService.isCustomViewerExtension('pdf')).toBeFalse();
+        expect(viewUtilService.isCustomViewerExtension('txt')).toBeFalse();
+        expect(viewUtilService.isCustomViewerExtension('json')).toBeTrue();
+        expect(viewUtilService.isCustomViewerExtension('docx', extensionsSupportedByTemplates)).toBeFalse();
+        expect(viewUtilService.isCustomViewerExtension('dmn', extensionsSupportedByTemplates)).toBeTrue();
+        expect(viewUtilService.isCustomViewerExtension('txt', extensionsSupportedByTemplates)).toBeTrue();
+    });
+
+    it('should return correct viewer type based on extension and mime type', () => {
+        spyOn(appExtensionService, 'getViewerExtensions').and.returnValue([{ fileExtension: '*', component: 'test', id: 'test' }]);
+        expect(viewUtilService.getViewerType('pdf', 'application/pdf')).toBe('external');
+
+        appExtensionService.getViewerExtensions = jasmine.createSpy().and.returnValue([{ fileExtension: 'json', component: 'test', id: 'test' }]);
+        expect(viewUtilService.getViewerType('json', '')).toBe('custom');
+        expect(viewUtilService.getViewerType('dmn', '')).toBe('unknown');
+        expect(viewUtilService.getViewerType('dmn', '', extensionsSupportedByTemplates)).toBe('custom');
+
+        expect(viewUtilService.getViewerType('pdf', '')).toBe('pdf');
+        expect(viewUtilService.getViewerType('', 'application/pdf')).toBe('pdf');
+    });
+});

--- a/lib/core/src/lib/viewer/services/view-util.service.ts
+++ b/lib/core/src/lib/viewer/services/view-util.service.ts
@@ -88,8 +88,8 @@ export class ViewUtilService {
         return null;
     }
 
-    getViewerType(extension: string, mimeType: string): string {
-        let viewerType = this.getViewerTypeByExtension(extension);
+    getViewerType(extension: string, mimeType: string, extensionsSupportedByTemplates?: string[]): string {
+        let viewerType = this.getViewerTypeByExtension(extension, extensionsSupportedByTemplates);
 
         if (viewerType === 'unknown') {
             viewerType = this.getViewerTypeByMimeType(mimeType);
@@ -112,7 +112,7 @@ export class ViewUtilService {
         return 'unknown';
     }
 
-    private getViewerTypeByExtension(extension: string): string {
+    private getViewerTypeByExtension(extension: string, extensionsSupportedByTemplates?: string[]): string {
         if (extension) {
             extension = extension.toLowerCase();
         }
@@ -121,7 +121,7 @@ export class ViewUtilService {
             return 'external';
         }
 
-        if (this.isCustomViewerExtension(extension)) {
+        if (this.isCustomViewerExtension(extension, extensionsSupportedByTemplates)) {
             return 'custom';
         }
 
@@ -148,8 +148,11 @@ export class ViewUtilService {
         return !!this.viewerExtensions.find((ext) => ext.fileExtension === '*');
     }
 
-    isCustomViewerExtension(extension: string): boolean {
+    isCustomViewerExtension(extension: string, extensionsSupportedByTemplates?: string[]): boolean {
         const extensions = this.externalExtensions || [];
+        if (extensionsSupportedByTemplates) {
+            extensions.push(...extensionsSupportedByTemplates);
+        }
 
         if (extension && extensions.length > 0) {
             extension = extension.toLowerCase();

--- a/lib/extensions/src/lib/services/app-extension.service.ts
+++ b/lib/extensions/src/lib/services/app-extension.service.ts
@@ -72,7 +72,7 @@ export class AppExtensionService {
      */
     getViewerExtensions(): ViewerExtensionRef[] {
         return this.extensionService
-            .getElements<ViewerExtensionRef>('features.viewer.content')
+            .getElements<ViewerExtensionRef>('features.viewer.extensions')
             .filter((extension) => !this.isViewerExtensionDisabled(extension));
     }
 

--- a/lib/extensions/src/lib/services/extension-loader.service.ts
+++ b/lib/extensions/src/lib/services/extension-loader.service.ts
@@ -96,7 +96,7 @@ export class ExtensionLoaderService {
      * Retrieves configuration elements.
      * Filters element by **enabled** and **order** attributes.
      * Example:
-     *  `getElements<ViewerExtensionRef>(config, 'features.viewer.content')`
+     *  `getElements<ViewerExtensionRef>(config, 'features.viewer.extensions')`
      *
      * @param config configuration settings
      * @param key element key


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Extensions provided via HTML projection stopped working after viewer refactoring.

**What is the new behaviour?**

The solution has been adapted to the new viewer structure after the refactoring, right now it's possible to provide a template with one or multiple `ViewerExtensionDirective` on both viewer levels. Provided extensions will be correctly displayed based on file extension and mime type and will override default ones if specified in `supportedExtensions` input. See https://alfresco.atlassian.net/browse/ACS-6620

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
