### PR TITLE
[ACS-6643] Incorrect layout for Search widgets of the Text type

### DIFF
--- a/lib/content-services/src/lib/search/components/search-text/search-text.component.scss
+++ b/lib/content-services/src/lib/search/components/search-text/search-text.component.scss
@@ -1,6 +1,5 @@
 .adf-search-text {
     .mat-form-field {
         width: 100%;
-        max-width: 168px;
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Constant width for textfield
[ACS-6643](https://alfresco.atlassian.net/browse/ACS-6643)


**What is the new behaviour?**
Textfield adjust to parent width


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:


[ACS-6643]: https://alfresco.atlassian.net/browse/ACS-6643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ