### PR TITLE
AAE-19762 Fix login redirect

### DIFF
--- a/lib/core/src/lib/auth/oidc/auth-config.service.ts
+++ b/lib/core/src/lib/auth/oidc/auth-config.service.ts
@@ -58,6 +58,7 @@ export class AuthConfigService {
             ...oauth2,
             oidc: oauth2.implicitFlow || oauth2.codeFlow || false,
             issuer: oauth2.host,
+            nonceStateSeparator: '~',
             redirectUri,
             silentRefreshRedirectUri: oauth2.redirectSilentIframeUri,
             postLogoutRedirectUri: `${origin}/${oauth2.redirectUriLogout}`,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Currently there is no way for a user to be redirect to a specific page after login (happening only in HxP)


**What is the new behaviour?**
Users are now redirected to a specific page after login
`NonceStateSeparator` was using default value ";" which is not supported by the AWS API Gateway


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
