### PR TITLE
[ACS-6140] - search-tab-content does not show when changing tab multiple times

### DIFF
--- a/lib/content-services/src/lib/search/components/search-filter-tabbed/search-filter-tabbed.component.html
+++ b/lib/content-services/src/lib/search/components/search-filter-tabbed/search-filter-tabbed.component.html
@@ -1,6 +1,7 @@
 <mat-tab-group (selectedIndexChange)="onTabIndexChanged($event)">
     <mat-tab *ngFor="let tabContent of tabsContents; let i = index"
              [labelClass]='selectedIndex === i ? "adf-search-tab-label-active" : ""'
+             [bodyClass]='selectedIndex === i ? "adf-search-tab-content-active" : ""'
              label="{{tabContent.name | translate}}">
         <ng-container *ngTemplateOutlet="tabContent.templateRef"></ng-container>
     </mat-tab>

--- a/lib/content-services/src/lib/search/components/search-filter-tabbed/search-filter-tabbed.component.scss
+++ b/lib/content-services/src/lib/search/components/search-filter-tabbed/search-filter-tabbed.component.scss
@@ -2,4 +2,13 @@ adf-search-filter-tabbed {
     .adf-search-tab-label-active {
         border-bottom: 2px solid var(--theme-primary-color);
     }
+
+    // The important tag is used here as a workaround for a bug in angular material, when MatTabs are used in conjunction with MatMenu
+    // https://github.com/angular/components/issues/27426
+    .adf-search-tab-content-active {
+        & > div {
+            visibility: visible !important;
+            display: block !important;
+        }
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
After removing references to internal angular material classes, there is problem when clicking multiple times on different tab in search-filter-tab.


**What is the new behaviour?**
Everything is displaying properly.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
