### PR TITLE
[ACS-6585] - [ACC] Removing a to be created tag, while the create tag input field has a 'Tag already exists' error, removes the error

### DIFF
--- a/lib/content-services/src/lib/tag/tags-creator/tags-creator.component.spec.ts
+++ b/lib/content-services/src/lib/tag/tags-creator/tags-creator.component.spec.ts
@@ -396,6 +396,27 @@ describe('TagsCreatorComponent', () => {
                 expect(error).toBe('TAG.TAGS_CREATOR.ERRORS.EXISTING_TAG');
             }));
 
+            it('should show error when deleting other Tag1 and Tag2 is typed and already existing tag', fakeAsync(() => {
+                const tag1 = 'Some tag';
+                const tag2 = 'Other tag';
+
+                addTagToAddedList(tag1, true, 0);
+                tick();
+
+                spyOn(tagService, 'findTagByName').and.returnValue(of({
+                    entry: {
+                        tag: tag2,
+                        id: 'tag-1'
+                    }
+                }));
+                typeTag(tag2);
+                component.removeTag(tag1);
+                tick();
+                fixture.detectChanges();
+                const error = getFirstError();
+                expect(error).toBe('TAG.TAGS_CREATOR.ERRORS.EXISTING_TAG');
+            }));
+
             it('should error for required when not typed anything and blur input', fakeAsync(() => {
                 component.tagNameControlVisible = true;
                 component.tagNameControl.markAsTouched();

--- a/lib/content-services/src/lib/tag/tags-creator/tags-creator.component.ts
+++ b/lib/content-services/src/lib/tag/tags-creator/tags-creator.component.ts
@@ -270,6 +270,7 @@ export class TagsCreatorComponent implements OnInit, OnDestroy {
         this.removeTagFromArray(this.tags, tag);
         this.tagNameControl.updateValueAndValidity();
         this.updateExistingTagsListOnRemoveFromTagsToConfirm(tag);
+        this.exactTagSet$.next();
         this.checkScrollbarVisibility();
         this.tagsChange.emit(this.tags);
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://alfresco.atlassian.net/browse/ACS-6585

**What is the new behaviour?**

If tag is existing, than it will always be blocked to be added again.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
