### PR TITLE
[HXCS-2818] - fix issues with ERROR RangeError: Invalid time value

### DIFF
--- a/lib/core/src/lib/card-view/models/card-view-dateitem.model.ts
+++ b/lib/core/src/lib/card-view/models/card-view-dateitem.model.ts
@@ -63,6 +63,11 @@ export class CardViewDateItemModel extends CardViewBaseItemModel<DateItemType> i
     }
 
     private prepareDate(date: Date): Date {
-        return this.type === 'date' ? DateFnsUtils.forceLocal(date) : date;
+        if (this.type === 'date') {
+            const dateInstance = date instanceof Date ? date : new Date(date);
+            return DateFnsUtils.forceLocal(dateInstance);
+        } else {
+            return date;
+        }
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
There are errors in the console when opening the details tab for record files in ADW and they are not rendered correctly. Errors: 
core.mjs:7626 ERROR RangeError: Invalid time value
    at lightFormat (index.js:80:11)
    at DateFnsUtils.forceLocal (adf-core.mjs:1846:36)
    at CardViewDateItemModel.prepareDate (adf-core.mjs:16821:52)
    at get displayValue (adf-core.mjs:16812:43)
    at adf-content-services.mjs:19853:89
    at Array.filter (<anonymous>)
    at ContentMetadataComponent.showGroup (adf-content-services.mjs:19853:45)
    at ContentMetadataComponent_ng_container_5_div_1_Template (adf-content-services.mjs:19986:13666)
    at executeTemplate (core.mjs:12108:9)
    at refreshView (core.mjs:11971:13)
at toDate (index.js:48:20)
    at lightFormat (index.js:78:28)
    at DateFnsUtils.forceLocal (adf-core.mjs:1846:36)
    at CardViewDateItemModel.prepareDate (adf-core.mjs:16821:52)
    at get displayValue (adf-core.mjs:16812:43)
    at adf-content-services.mjs:19853:89
    at Array.filter (<anonymous>)
    at ContentMetadataComponent.showGroup (adf-content-services.mjs:19853:45)
    at ContentMetadataComponent_ng_container_5_div_1_Template (adf-content-services.mjs:19986:13666)
    at executeTemplate (core.mjs:12108:9)



**What is the new behaviour?**
Details tab is rendered correctly and there are no errors in the console.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
