### PR TITLE
[ACS-6804] Fix upload API file placement when relative path is undefined

### DIFF
--- a/lib/js-api/src/api/content-custom-api/api/upload.api.ts
+++ b/lib/js-api/src/api/content-custom-api/api/upload.api.ts
@@ -31,7 +31,7 @@ export class UploadApi extends NodesApi {
         const nodeBodyRequired = {
             name: fileDefinition.name,
             nodeType: 'cm:content',
-            relativePath
+            relativePath: relativePath ?? null
         };
 
         nodeBody = Object.assign(nodeBodyRequired, nodeBody);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

When `relativePath` is undefined the file is being created under `undefined` folder instead of the root one. 

**What is the new behaviour?**

File is created under root folder. Closes Alfresco/alfresco-ng2-components#9313

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
