### PR TITLE
[ACS-6805] getNodeContent allows adding additional options

### DIFF
--- a/lib/js-api/src/api/content-rest-api/api/nodes.api.ts
+++ b/lib/js-api/src/api/content-rest-api/api/nodes.api.ts
@@ -477,13 +477,18 @@ export class NodesApi extends BaseApi {
         };
 
         const queryParams = {
-            attachment: opts?.attachment
+            attachment: opts?.attachment ?? null
         };
 
-        const headerParams = {
-            'If-Modified-Since': opts?.ifModifiedSince,
-            Range: opts?.range
-        };
+        const headerParams = {};
+
+        if (opts?.ifModifiedSince) {
+            Object.defineProperty(headerParams, 'If-Modified-Since', { value: opts?.ifModifiedSince });
+        }
+
+        if (opts?.range) {
+            Object.defineProperty(headerParams, 'Range', { value: opts?.range });
+        }
 
         const accepts = ['application/octet-stream'];
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

getNodeContent throws an JS error when additional options are passed.

**What is the new behaviour?**

Any combination of additional options can be passed and request is sent successfully. Closes Alfresco/alfresco-ng2-components#9314

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
