### PR TITLE
[ACS-6812] Add new chip only when input value is valid

### DIFF
--- a/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
@@ -233,6 +233,38 @@ describe('CardViewTextItemComponent', () => {
             renderChipsForMultiValuedProperties(cardViewTextItemObject, true, 3, '1.1', '2.2', '3.3');
         });
 
+        it('should only render new chip when provided value is valid for specified validators set', async () => {
+            const cardViewTextItemObject = {
+                label: 'Text label',
+                value: [1.1, 2.2, 3.3],
+                key: 'textkey',
+                editable: true,
+                multivalued: true,
+                type: 'float'
+            };
+            component.editable = true;
+            renderChipsForMultiValuedProperties(cardViewTextItemObject, true, 3, '1.1', '2.2', '3.3');
+            const floatValidator: CardViewItemValidator = new CardViewItemFloatValidator();
+            component.property.validators = [floatValidator];
+            const inputElement = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-editchipinput-textkey"]')).nativeElement;
+            component.addValueToList({ value: 'abcd', chipInput: inputElement, input: inputElement });
+            fixture.detectChanges();
+
+            let error: HTMLLIElement = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-error-textkey"] li')).nativeElement;
+            expect(error.innerText).toBe('CORE.CARDVIEW.VALIDATORS.FLOAT_VALIDATION_ERROR');
+            let valueChips = await loader.getAllHarnesses(MatChipHarness);
+            expect(valueChips.length).toBe(3);
+
+            component.addValueToList({ value: '22.1', chipInput: inputElement, input: inputElement });
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            error = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-error-textkey"]'))?.nativeElement;
+            expect(error).toBe(undefined);
+            valueChips = await loader.getAllHarnesses(MatChipHarness);
+            expect(valueChips.length).toBe(4);
+        });
+
         it('should render string for multivalue properties when chips are disabled', async () => {
             component.property = new CardViewTextItemModel({
                 label: 'Text label',

--- a/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
@@ -734,7 +734,7 @@ describe('CardViewTextItemComponent', () => {
             fixture.detectChanges();
 
             const errorElement = getErrorElement('textkey');
-            expect(errorElement).toBeNull();
+            expect(errorElement.length).toBe(0);
         });
 
         it('should NOT show validation error for null', async () => {
@@ -746,7 +746,7 @@ describe('CardViewTextItemComponent', () => {
             const errorElement = getErrorElement('textkey');
 
             expect(inputElement.nativeElement.value).toBe('');
-            expect(errorElement).toBeNull();
+            expect(errorElement.length).toBe(0);
         });
 
         it('should show validation error for only spaces string', async () => {
@@ -764,7 +764,7 @@ describe('CardViewTextItemComponent', () => {
             fixture.detectChanges();
 
             const errorElement = getErrorElement('textkey');
-            expect(errorElement).toBeNull();
+            expect(errorElement.length).toBe(0);
         });
 
         it('should NOT show validation error for null', async () => {
@@ -775,7 +775,7 @@ describe('CardViewTextItemComponent', () => {
             const inputElement = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-textkey"]'));
             const errorElement = getErrorElement('textkey');
             expect(inputElement.nativeElement.value).toBe('');
-            expect(errorElement).toBeNull();
+            expect(errorElement.length).toBe(0);
         });
 
         it('should show validation error for float number', async () => {

--- a/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
@@ -25,9 +25,9 @@ import { CardViewItemFloatValidator } from '../../validators/card-view-item-floa
 import { CardViewItemIntValidator } from '../../validators/card-view-item-int.validator';
 import { CardViewIntItemModel } from '../../models/card-view-intitem.model';
 import { CardViewFloatItemModel } from '../../models/card-view-floatitem.model';
-import { MatChipsModule } from '@angular/material/chips';
+import { MatChipInputEvent, MatChipsModule } from '@angular/material/chips';
 import { ClipboardService } from '../../../clipboard/clipboard.service';
-import { SimpleChange } from '@angular/core';
+import { DebugElement, SimpleChange } from '@angular/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { CardViewItemValidator } from '../../interfaces/card-view-item-validator.interface';
 import { HarnessLoader } from '@angular/cdk/testing';
@@ -95,6 +95,10 @@ describe('CardViewTextItemComponent', () => {
         expect(await valueChips[0].getText()).toBe(param1);
         expect(await valueChips[1].getText()).toBe(param2);
         expect(await valueChips[2].getText()).toBe(param3);
+    };
+
+    const getErrorElement = (key: string, includeItems = false): DebugElement[] => {
+        return fixture.debugElement.queryAll(By.css(`[data-automation-id="card-textitem-error-${key}"]${includeItems ? ' li' : ''}`));
     };
 
     beforeEach(() => {
@@ -208,7 +212,7 @@ describe('CardViewTextItemComponent', () => {
                 editable: true,
                 multivalued: true
             };
-            renderChipsForMultiValuedProperties(cardViewTextItemObject, true, 3, 'item1', 'item2', 'item3');
+            await renderChipsForMultiValuedProperties(cardViewTextItemObject, true, 3, 'item1', 'item2', 'item3');
         });
 
         it('should render chips for multivalue integers when chips are enabled', async () => {
@@ -219,7 +223,7 @@ describe('CardViewTextItemComponent', () => {
                 editable: true,
                 multivalued: true
             };
-            renderChipsForMultiValuedProperties(cardViewTextItemObject, true, 3, '1', '2', '3');
+            await renderChipsForMultiValuedProperties(cardViewTextItemObject, true, 3, '1', '2', '3');
         });
 
         it('should render chips for multivalue decimal numbers when chips are enabled', async () => {
@@ -230,7 +234,7 @@ describe('CardViewTextItemComponent', () => {
                 editable: true,
                 multivalued: true
             };
-            renderChipsForMultiValuedProperties(cardViewTextItemObject, true, 3, '1.1', '2.2', '3.3');
+            await renderChipsForMultiValuedProperties(cardViewTextItemObject, true, 3, '1.1', '2.2', '3.3');
         });
 
         it('should only render new chip when provided value is valid for specified validators set', async () => {
@@ -243,23 +247,23 @@ describe('CardViewTextItemComponent', () => {
                 type: 'float'
             };
             component.editable = true;
-            renderChipsForMultiValuedProperties(cardViewTextItemObject, true, 3, '1.1', '2.2', '3.3');
+            await renderChipsForMultiValuedProperties(cardViewTextItemObject, true, 3, '1.1', '2.2', '3.3');
             const floatValidator: CardViewItemValidator = new CardViewItemFloatValidator();
             component.property.validators = [floatValidator];
             const inputElement = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-editchipinput-textkey"]')).nativeElement;
-            component.addValueToList({ value: 'abcd', chipInput: inputElement, input: inputElement });
+            component.addValueToList({ value: 'abcd', chipInput: inputElement } as MatChipInputEvent);
             fixture.detectChanges();
 
-            let error: HTMLLIElement = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-error-textkey"] li')).nativeElement;
+            let error: HTMLLIElement = getErrorElement('textkey', true)[0].nativeElement;
             expect(error.innerText).toBe('CORE.CARDVIEW.VALIDATORS.FLOAT_VALIDATION_ERROR');
             let valueChips = await loader.getAllHarnesses(MatChipHarness);
             expect(valueChips.length).toBe(3);
 
-            component.addValueToList({ value: '22.1', chipInput: inputElement, input: inputElement });
+            component.addValueToList({ value: '22.1', chipInput: inputElement } as MatChipInputEvent);
             fixture.detectChanges();
             await fixture.whenStable();
 
-            error = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-error-textkey"]'))?.nativeElement;
+            error = getErrorElement('textkey', true)[0]?.nativeElement;
             expect(error).toBe(undefined);
             valueChips = await loader.getAllHarnesses(MatChipHarness);
             expect(valueChips.length).toBe(4);
@@ -729,7 +733,7 @@ describe('CardViewTextItemComponent', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            const errorElement = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-error-textkey"]'));
+            const errorElement = getErrorElement('textkey');
             expect(errorElement).toBeNull();
         });
 
@@ -739,7 +743,7 @@ describe('CardViewTextItemComponent', () => {
             fixture.detectChanges();
 
             const inputElement = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-textkey"]'));
-            const errorElement = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-error-textkey"]'));
+            const errorElement = getErrorElement('textkey');
 
             expect(inputElement.nativeElement.value).toBe('');
             expect(errorElement).toBeNull();
@@ -759,7 +763,7 @@ describe('CardViewTextItemComponent', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            const errorElement = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-error-textkey"]'));
+            const errorElement = getErrorElement('textkey');
             expect(errorElement).toBeNull();
         });
 
@@ -769,8 +773,7 @@ describe('CardViewTextItemComponent', () => {
             fixture.detectChanges();
 
             const inputElement = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-textkey"]'));
-            const errorElement = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-error-textkey"]'));
-
+            const errorElement = getErrorElement('textkey');
             expect(inputElement.nativeElement.value).toBe('');
             expect(errorElement).toBeNull();
         });

--- a/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
@@ -41,17 +41,21 @@ describe('CardViewTextItemComponent', () => {
 
     const expectedErrorMessages = [{ message: 'Something went wrong' } as CardViewItemValidator];
 
-    const updateTextField = (key, value) => {
-        const editInput = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-value-${key}"]`));
-        editInput.nativeElement.value = value;
-        editInput.nativeElement.dispatchEvent(new Event('input'));
+    const getTextField = (key: string): HTMLInputElement => {
+        return fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-value-${key}"]`)).nativeElement;
+    }
+
+    const updateTextField = (key: string, value) => {
+        const editInput = getTextField(key);
+        editInput.value = value;
+        editInput.dispatchEvent(new Event('input'));
         fixture.detectChanges();
     };
 
-    const getTextFieldValue = (key): string => {
-        const textItemInput = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-value-${key}"]`));
+    const getTextFieldValue = (key: string): string => {
+        const textItemInput = getTextField(key);
         expect(textItemInput).not.toBeNull();
-        return textItemInput.nativeElement.value;
+        return textItemInput.value;
     };
 
     const getErrorElements = (key: string, includeItems = false): DebugElement[] => {
@@ -743,9 +747,8 @@ describe('CardViewTextItemComponent', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            const inputElement = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-textkey"]'));
-
-            expect(inputElement.nativeElement.value).toBe('');
+            const inputElement = getTextField('textkey');
+            expect(inputElement.value).toBe('');
             verifyNoErrors('textkey');
         });
 
@@ -756,24 +759,6 @@ describe('CardViewTextItemComponent', () => {
 
             const errorMessage = getTextFieldError(component.property.key);
             expect(errorMessage).toEqual('CORE.CARDVIEW.VALIDATORS.INT_VALIDATION_ERROR');
-        });
-
-        it('should NOT show validation error for empty string', async () => {
-            updateTextField(component.property.key, '');
-            await fixture.whenStable();
-            fixture.detectChanges();
-
-            verifyNoErrors('textkey');
-        });
-
-        it('should NOT show validation error for null', async () => {
-            updateTextField(component.property.key, null);
-            await fixture.whenStable();
-            fixture.detectChanges();
-
-            const inputElement = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-textkey"]'));
-            expect(inputElement.nativeElement.value).toBe('');
-            verifyNoErrors('textkey');
         });
 
         it('should show validation error for float number', async () => {

--- a/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
@@ -34,7 +34,7 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatChipHarness, MatChipListHarness } from '@angular/material/chips/testing';
 
-fdescribe('CardViewTextItemComponent', () => {
+describe('CardViewTextItemComponent', () => {
     let loader: HarnessLoader;
     let fixture: ComponentFixture<CardViewTextItemComponent>;
     let component: CardViewTextItemComponent;
@@ -244,8 +244,8 @@ fdescribe('CardViewTextItemComponent', () => {
 
         it('should only render new chip when provided value is valid for specified validators set', async () => {
             const cardViewTextItemFloatObject = {
-                label: 'Text label',
-                value: [1.1, 2.2, 3.3],
+                label: 'Test label',
+                value: [10, 20.2, 35.8],
                 key: 'textkey',
                 editable: true,
                 multivalued: true,

--- a/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
@@ -54,10 +54,19 @@ describe('CardViewTextItemComponent', () => {
         return textItemInput.nativeElement.value;
     };
 
-    const getTextFieldError = (key): string => {
-        const textItemInputError = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-error-${key}"] li`));
-        expect(textItemInputError).not.toBeNull();
-        return textItemInputError.nativeElement.innerText;
+    const getErrorElements = (key: string, includeItems = false): DebugElement[] => {
+        return fixture.debugElement.queryAll(By.css(`[data-automation-id="card-textitem-error-${key}"]${includeItems ? ' li' : ''}`));
+    };
+
+    const getTextFieldError = (key: string): string => {
+        const textItemInputErrors = getErrorElements(key, true);
+        expect(textItemInputErrors.length).not.toBe(0);
+        return textItemInputErrors[0].nativeElement.innerText;
+    };
+
+    const verifyNoErrors = (key: string) => {
+        const errorElement = getErrorElements(key);
+        expect(errorElement.length).toBe(0);
     };
 
     const checkCtrlZActions = (ctrlKeyValue: boolean, codeValue: string, metaKeyValue: boolean, mockTestValue: string, flag: boolean) => {
@@ -95,15 +104,6 @@ describe('CardViewTextItemComponent', () => {
         expect(await valueChips[0].getText()).toBe(param1);
         expect(await valueChips[1].getText()).toBe(param2);
         expect(await valueChips[2].getText()).toBe(param3);
-    };
-
-    const getErrorElement = (key: string, includeItems = false): DebugElement[] => {
-        return fixture.debugElement.queryAll(By.css(`[data-automation-id="card-textitem-error-${key}"]${includeItems ? ' li' : ''}`));
-    };
-
-    const verifyNoErrors = (key: string) => {
-        const errorElement = getErrorElement(key);
-        expect(errorElement.length).toBe(0);
     };
 
     beforeEach(() => {
@@ -252,15 +252,14 @@ describe('CardViewTextItemComponent', () => {
                 type: 'float'
             };
             component.editable = true;
-            await renderChipsForMultiValuedProperties(cardViewTextItemFloatObject, true, 3, '1.1', '2.2', '3.3');
+            await renderChipsForMultiValuedProperties(cardViewTextItemFloatObject, true, 3, '10', '20.2', '35.8');
             const floatValidator: CardViewItemValidator = new CardViewItemFloatValidator();
             component.property.validators = [floatValidator];
             const inputElement = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-editchipinput-textkey"]')).nativeElement;
             component.addValueToList({ value: 'abcd', chipInput: inputElement } as MatChipInputEvent);
             fixture.detectChanges();
 
-            let error: HTMLLIElement = getErrorElement('textkey', true)[0].nativeElement;
-            expect(error.innerText).toBe('CORE.CARDVIEW.VALIDATORS.FLOAT_VALIDATION_ERROR');
+            expect(getTextFieldError('textkey')).toBe('CORE.CARDVIEW.VALIDATORS.FLOAT_VALIDATION_ERROR');
             let valueChips = await loader.getAllHarnesses(MatChipHarness);
             expect(valueChips.length).toBe(3);
 
@@ -802,8 +801,7 @@ describe('CardViewTextItemComponent', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            const error = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-error-${component.property.key}"] li`));
-            expect(error).toBeFalsy();
+            verifyNoErrors(component.property.key);
             expect(component.property.value).toBe('2147483647');
         });
 
@@ -822,8 +820,7 @@ describe('CardViewTextItemComponent', () => {
                 }
             });
 
-            const error = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-error-${component.property.key}"] li`));
-            expect(error).toBeFalsy();
+            verifyNoErrors(component.property.key);
             expect(getTextFieldValue(component.property.key)).toEqual(expectedNumber.toString());
             expect(component.property.value).toBe(expectedNumber.toString());
         });
@@ -883,8 +880,7 @@ describe('CardViewTextItemComponent', () => {
                 }
             });
 
-            const error = fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-error-${component.property.key}"] li`));
-            expect(error).toBeFalsy();
+            verifyNoErrors(component.property.key);
             expect(getTextFieldValue(component.property.key)).toEqual(expectedNumber.toString());
             expect(component.property.value).toBe(expectedNumber.toString());
         });

--- a/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
@@ -34,7 +34,7 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatChipHarness, MatChipListHarness } from '@angular/material/chips/testing';
 
-describe('CardViewTextItemComponent', () => {
+fdescribe('CardViewTextItemComponent', () => {
     let loader: HarnessLoader;
     let fixture: ComponentFixture<CardViewTextItemComponent>;
     let component: CardViewTextItemComponent;
@@ -99,6 +99,11 @@ describe('CardViewTextItemComponent', () => {
 
     const getErrorElement = (key: string, includeItems = false): DebugElement[] => {
         return fixture.debugElement.queryAll(By.css(`[data-automation-id="card-textitem-error-${key}"]${includeItems ? ' li' : ''}`));
+    };
+
+    const verifyNoErrors = (key: string) => {
+        const errorElement = getErrorElement(key);
+        expect(errorElement.length).toBe(0);
     };
 
     beforeEach(() => {
@@ -238,7 +243,7 @@ describe('CardViewTextItemComponent', () => {
         });
 
         it('should only render new chip when provided value is valid for specified validators set', async () => {
-            const cardViewTextItemObject = {
+            const cardViewTextItemFloatObject = {
                 label: 'Text label',
                 value: [1.1, 2.2, 3.3],
                 key: 'textkey',
@@ -247,7 +252,7 @@ describe('CardViewTextItemComponent', () => {
                 type: 'float'
             };
             component.editable = true;
-            await renderChipsForMultiValuedProperties(cardViewTextItemObject, true, 3, '1.1', '2.2', '3.3');
+            await renderChipsForMultiValuedProperties(cardViewTextItemFloatObject, true, 3, '1.1', '2.2', '3.3');
             const floatValidator: CardViewItemValidator = new CardViewItemFloatValidator();
             component.property.validators = [floatValidator];
             const inputElement = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-editchipinput-textkey"]')).nativeElement;
@@ -261,10 +266,8 @@ describe('CardViewTextItemComponent', () => {
 
             component.addValueToList({ value: '22.1', chipInput: inputElement } as MatChipInputEvent);
             fixture.detectChanges();
-            await fixture.whenStable();
 
-            error = getErrorElement('textkey', true)[0]?.nativeElement;
-            expect(error).toBe(undefined);
+            verifyNoErrors('textkey');
             valueChips = await loader.getAllHarnesses(MatChipHarness);
             expect(valueChips.length).toBe(4);
         });
@@ -733,8 +736,7 @@ describe('CardViewTextItemComponent', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            const errorElement = getErrorElement('textkey');
-            expect(errorElement.length).toBe(0);
+            verifyNoErrors('textkey');
         });
 
         it('should NOT show validation error for null', async () => {
@@ -743,10 +745,9 @@ describe('CardViewTextItemComponent', () => {
             fixture.detectChanges();
 
             const inputElement = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-textkey"]'));
-            const errorElement = getErrorElement('textkey');
 
             expect(inputElement.nativeElement.value).toBe('');
-            expect(errorElement.length).toBe(0);
+            verifyNoErrors('textkey');
         });
 
         it('should show validation error for only spaces string', async () => {
@@ -763,8 +764,7 @@ describe('CardViewTextItemComponent', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            const errorElement = getErrorElement('textkey');
-            expect(errorElement.length).toBe(0);
+            verifyNoErrors('textkey');
         });
 
         it('should NOT show validation error for null', async () => {
@@ -773,9 +773,8 @@ describe('CardViewTextItemComponent', () => {
             fixture.detectChanges();
 
             const inputElement = fixture.debugElement.query(By.css('[data-automation-id="card-textitem-value-textkey"]'));
-            const errorElement = getErrorElement('textkey');
             expect(inputElement.nativeElement.value).toBe('');
-            expect(errorElement.length).toBe(0);
+            verifyNoErrors('textkey');
         });
 
         it('should show validation error for float number', async () => {

--- a/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
@@ -43,7 +43,7 @@ describe('CardViewTextItemComponent', () => {
 
     const getTextField = (key: string): HTMLInputElement => {
         return fixture.debugElement.query(By.css(`[data-automation-id="card-textitem-value-${key}"]`)).nativeElement;
-    }
+    };
 
     const updateTextField = (key: string, value) => {
         const editInput = getTextField(key);

--- a/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.ts
+++ b/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.ts
@@ -148,17 +148,21 @@ export class CardViewTextItemComponent extends BaseCardView<CardViewTextItemMode
     }
 
     addValueToList(newListItem: MatChipInputEvent) {
-        const chipInput = newListItem.input;
+        const chipInput = newListItem.chipInput.inputElement;
         const chipValue = newListItem.value.trim() || '';
 
         if (typeof this.editedValue !== 'string') {
-            if (chipValue) {
-                this.editedValue.push(chipValue);
-                this.update();
-            }
+            if (this.property.isValid(chipValue)) {
+                if (chipValue) {
+                    this.editedValue.push(chipValue);
+                    this.update();
+                }
 
-            if (chipInput) {
-                chipInput.value = '';
+                if (chipInput) {
+                    chipInput.value = '';
+                }
+            } else {
+                this.errors = this.property.getValidationErrors(chipValue);
             }
         }
     }

--- a/lib/core/src/lib/pipes/decimal-number.pipe.spec.ts
+++ b/lib/core/src/lib/pipes/decimal-number.pipe.spec.ts
@@ -44,6 +44,10 @@ describe('DecimalNumberPipe', () => {
         expect(pipe.transform(1234.567)).toBe('1,234.57');
     });
 
+    it('should properly transform array of values', () => {
+        expect(pipe.transform([1234.567, 22])).toEqual(['1,234.57', '22']);
+    });
+
     it('should return number with at least the minimum of digints in the integer part', () => {
         const decimalValues = {
             minIntegerDigits: 6,

--- a/lib/core/src/lib/pipes/decimal-number.pipe.ts
+++ b/lib/core/src/lib/pipes/decimal-number.pipe.ts
@@ -74,7 +74,12 @@ export class DecimalNumberPipe implements PipeTransform, OnDestroy {
         const actualLocale = locale || this.defaultLocale;
 
         const decimalPipe: DecimalPipe = new DecimalPipe(actualLocale);
-        return decimalPipe.transform(value, actualDigitsInfo);
+
+        if (value instanceof Array) {
+            return value.map((val) => decimalPipe.transform(val, actualDigitsInfo));
+        } else {
+            return decimalPipe.transform(value, actualDigitsInfo);
+        }
     }
 
     ngOnDestroy(): void {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Decimal pipe is not able to handle arrays and new chips are added regardless applied validators which leads to exception being thrown.

**What is the new behaviour?**

Decimal pipe now correctly handles arrays, new chips are added only when input value passes the validation. Closes Alfresco/alfresco-ng2-components#8919 https://alfresco.atlassian.net/browse/ACS-6812

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
