### PR TITLE
[ACS-6819][FE] Document List View Header - move and resize columns icons are overlapping

### DIFF
--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.scss
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.scss
@@ -437,14 +437,14 @@ $data-table-cell-min-width-file-size: $data-table-cell-min-width-1 !default;
     }
 
     .adf-cell-value {
-        padding-left: 10px;
+        padding-left: 5px;
         display: flex;
         min-height: inherit;
         align-items: center;
         word-break: break-all;
         width: 100%;
 
-        img {
+        > img {
             padding-left: 5px;
         }
     }
@@ -662,9 +662,7 @@ $data-table-cell-min-width-file-size: $data-table-cell-min-width-1 !default;
         display: flex;
         flex-grow: 1;
         align-items: center;
-        margin: 0 2px;
         padding: 0 8px;
-        column-gap: 5px;
 
         .adf-datatable-cell-header-drag-icon-placeholder {
             min-width: 15px;

--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.scss
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.scss
@@ -192,7 +192,6 @@ $data-table-cell-min-width-file-size: $data-table-cell-min-width-1 !default;
     }
 
     .adf-datatable-header {
-        margin-right: 18px;
         float: right;
     }
 }
@@ -238,7 +237,7 @@ $data-table-cell-min-width-file-size: $data-table-cell-min-width-1 !default;
         box-sizing: border-box;
 
         .adf-datatable-row {
-            padding-right: 15px;
+            padding-right: 5px;
 
             &:hover,
             &:focus {
@@ -400,12 +399,11 @@ $data-table-cell-min-width-file-size: $data-table-cell-min-width-1 !default;
         min-height: inherit;
 
         &:first-child {
-            margin-left: 15px;
+            padding-left: 15px;
             box-sizing: content-box;
         }
 
         &:last-child {
-            padding-right: 15px;
             box-sizing: content-box;
         }
 
@@ -415,7 +413,7 @@ $data-table-cell-min-width-file-size: $data-table-cell-min-width-1 !default;
             align-items: center;
             display: flex;
             width: 100%;
-            padding: 0 10px;
+            padding: 0;
         }
 
         .adf-datatable-cell-value {
@@ -439,11 +437,16 @@ $data-table-cell-min-width-file-size: $data-table-cell-min-width-1 !default;
     }
 
     .adf-cell-value {
+        padding-left: 10px;
         display: flex;
         min-height: inherit;
         align-items: center;
         word-break: break-all;
         width: 100%;
+
+        img {
+            padding-left: 5px;
+        }
     }
 
     .adf-datatable__actions-cell,

--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.scss
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.scss
@@ -698,7 +698,6 @@ $data-table-cell-min-width-file-size: $data-table-cell-min-width-1 !default;
 .adf-drop-header-cell-placeholder {
     display: flex;
     flex: 1;
-    flex-grow: 1;
     background: var(--adf-theme-background-hover-color);
     border: dotted 1px rgba(0, 0, 0, 0.25);
     min-height: 55px;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Header icons move and resize are overlapping
[ACS-6819](https://alfresco.atlassian.net/browse/ACS-6819)


**What is the new behaviour?**
Header move and resize aren't overlapping


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:


[ACS-6819]: https://alfresco.atlassian.net/browse/ACS-6819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ