### PR TITLE
[ACS-6888] - The root folder of breadcrumbs is misplaced when viewed from a folder view

### DIFF
--- a/lib/content-services/src/lib/breadcrumb/breadcrumb.component.scss
+++ b/lib/content-services/src/lib/breadcrumb/breadcrumb.component.scss
@@ -106,7 +106,7 @@
             text-overflow: ellipsis;
             overflow: hidden;
             flex: 0 1 auto;
-            padding: 0 2px;
+            padding: 0;
             text-align: center;
 
             &:focus {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ACS-6888
There is a small padding for a breadcrumb when inside a folder


**What is the new behaviour?**
No padding.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
