### PR TITLE
[MNT-24082] fix aspect overwriting from dialog

### DIFF
--- a/lib/content-services/src/lib/aspect-list/aspect-list.component.spec.ts
+++ b/lib/content-services/src/lib/aspect-list/aspect-list.component.spec.ts
@@ -152,7 +152,7 @@ describe('AspectListComponent', () => {
             spyOn(aspectListService, 'getCustomAspects').and.returnValue(of(customAspectListMock));
             spyOn(aspectListService, 'getVisibleAspects').and.returnValue(['frs:AspectOne']);
             nodeService = TestBed.inject(NodesApiService);
-            spyOn(nodeService, 'getNode').and.returnValue(of({ id: 'fake-node-id', aspectNames: ['frs:AspectOne'] } as any));
+            spyOn(nodeService, 'getNode').and.returnValue(of({ id: 'fake-node-id', aspectNames: ['frs:AspectOne', 'stored:aspect'] } as any));
             component.nodeId = 'fake-node-id';
             loader = TestbedHarnessEnvironment.loader(fixture);
         });
@@ -249,6 +249,21 @@ describe('AspectListComponent', () => {
                 expect(component.nodeAspects.length).toBe(1);
                 component.clear();
                 expect(component.nodeAspects.length).toBe(0);
+            });
+
+            it('should store node aspects that are not listed and emit then on value change', async () => {
+                const storedAspect: string[] = ['stored:aspect'];
+
+                expect(component.notDisplayedAspects).toEqual(storedAspect);
+
+                spyOn(component.valueChanged, 'emit');
+                const panel = await loader.getAllHarnesses(MatExpansionPanelHarness);
+                await panel[0].expand();
+                const checkbox = await panel[0].getHarness(MatCheckboxHarness);
+                await checkbox.toggle();
+                fixture.detectChanges();
+
+                expect(component.valueChanged.emit).toHaveBeenCalledWith(storedAspect);
             });
         });
 

--- a/lib/content-services/src/lib/aspect-list/aspect-list.component.spec.ts
+++ b/lib/content-services/src/lib/aspect-list/aspect-list.component.spec.ts
@@ -187,83 +187,70 @@ describe('AspectListComponent', () => {
                 expect(noNameAspect.innerText).toBe('cst:nonamedAspect');
             });
 
-            it('should show the details when a row is clicked', async () => {
+            it('should show aspect`s properties in expanded aspect panel', async () => {
                 const panel = await loader.getHarness(MatExpansionPanelHarness);
-                await panel.expand();
                 expect(await panel.getDescription()).not.toBeNull();
 
                 const table = await panel.getHarness(MatTableHarness);
                 const [row1, row2] = await table.getRows();
                 const [r1c1, r1c2, r1c3] = await row1.getCells();
+                const [r2c1, r2c2, r2c3] = await row2.getCells();
                 expect(await r1c1.getText()).toBe('channelPassword');
                 expect(await r1c2.getText()).toBe('The authenticated channel password');
                 expect(await r1c3.getText()).toBe('d:propA');
-
-                const [r2c1, r2c2, r2c3] = await row2.getCells();
                 expect(await r2c1.getText()).toBe('channelUsername');
                 expect(await r2c2.getText()).toBe('The authenticated channel username');
                 expect(await r2c3.getText()).toBe('d:propB');
             });
 
-            it('should show as checked the node properties', async () => {
+            it('should show node aspects as checked', async () => {
                 const panel = await loader.getHarness(MatExpansionPanelHarness);
-                await panel.expand();
-
                 const checkbox = await panel.getHarness(MatCheckboxHarness);
                 expect(await checkbox.isChecked()).toBe(true);
             });
 
-            it('should remove aspects unchecked', async () => {
-                const panel = await loader.getAllHarnesses(MatExpansionPanelHarness);
-                await panel[1].expand();
-
-                const checkbox = await panel[1].getHarness(MatCheckboxHarness);
+            it('should add checked and remove unchecked aspects', async () => {
+                const panel = (await loader.getAllHarnesses(MatExpansionPanelHarness))[1];
+                const checkbox = await panel.getHarness(MatCheckboxHarness);
                 expect(await checkbox.isChecked()).toBe(false);
 
                 await checkbox.toggle();
-
                 expect(component.nodeAspects.length).toBe(2);
                 expect(component.nodeAspects[1]).toBe('frs:SecondAspect');
 
                 await checkbox.toggle();
-
                 expect(component.nodeAspects.length).toBe(1);
                 expect(component.nodeAspects[0]).toBe('frs:AspectOne');
             });
 
-            it('should reset the properties on reset', async () => {
-                const panel = await loader.getAllHarnesses(MatExpansionPanelHarness);
-                await panel[1].expand();
-
-                const checkbox = await panel[1].getHarness(MatCheckboxHarness);
+            it('should reset aspects on reset', async () => {
+                const panel = (await loader.getAllHarnesses(MatExpansionPanelHarness))[1];
+                const checkbox = await panel.getHarness(MatCheckboxHarness);
                 expect(await checkbox.isChecked()).toBe(false);
 
                 await checkbox.toggle();
-
                 expect(component.nodeAspects.length).toBe(2);
+
                 component.reset();
                 expect(component.nodeAspects.length).toBe(1);
             });
 
-            it('should clear all the properties on clear', async () => {
+            it('should clear all aspects on clear', async () => {
                 expect(component.nodeAspects.length).toBe(1);
                 component.clear();
                 expect(component.nodeAspects.length).toBe(0);
             });
 
-            it('should store node aspects that are not listed and emit then on value change', async () => {
-                const storedAspect: string[] = ['stored:aspect'];
-
+            it('should store not listed aspects and emit all aspects on value change', async () => {
+                const storedAspect = ['stored:aspect'];
                 expect(component.notDisplayedAspects).toEqual(storedAspect);
 
                 spyOn(component.valueChanged, 'emit');
-                const panel = await loader.getAllHarnesses(MatExpansionPanelHarness);
-                await panel[0].expand();
-                const checkbox = await panel[0].getHarness(MatCheckboxHarness);
+                const panel = (await loader.getAllHarnesses(MatExpansionPanelHarness))[1];
+                const checkbox = await panel.getHarness(MatCheckboxHarness);
                 await checkbox.toggle();
                 fixture.detectChanges();
-
-                expect(component.valueChanged.emit).toHaveBeenCalledWith(storedAspect);
+                expect(component.valueChanged.emit).toHaveBeenCalledWith(['frs:AspectOne', 'frs:SecondAspect', ...storedAspect]);
             });
         });
 

--- a/lib/content-services/src/lib/aspect-list/aspect-list.component.ts
+++ b/lib/content-services/src/lib/aspect-list/aspect-list.component.ts
@@ -47,6 +47,7 @@ export class AspectListComponent implements OnInit, OnDestroy {
     aspects$: Observable<AspectEntry[]> = null;
     nodeAspects: string[] = [];
     nodeAspectStatus: string[] = [];
+    notDisplayedAspects: string[] = [];
     hasEqualAspect: boolean = true;
 
     private onDestroy$ = new Subject<boolean>();
@@ -71,7 +72,8 @@ export class AspectListComponent implements OnInit, OnDestroy {
                 tap(([node, customAspects]) => {
                     this.nodeAspects = node.aspectNames.filter((aspect) => this.aspectListService.getVisibleAspects().includes(aspect) || customAspects.includes(aspect));
                     this.nodeAspectStatus = [ ...this.nodeAspects ];
-                    this.valueChanged.emit(this.nodeAspects);
+                    this.notDisplayedAspects = node.aspectNames.filter((aspect) => !this.aspectListService.getVisibleAspects().includes(aspect) && !customAspects.includes(aspect));
+                    this.valueChanged.emit([...this.nodeAspects, ...this.notDisplayedAspects]);
                 }),
                 concatMap(() => this.aspectListService.getAspects()),
                 takeUntil(this.onDestroy$));
@@ -94,14 +96,14 @@ export class AspectListComponent implements OnInit, OnDestroy {
             this.nodeAspects.splice(this.nodeAspects.indexOf(prefixedName), 1);
         }
         this.updateEqualityOfAspectList();
-        this.valueChanged.emit(this.nodeAspects);
+        this.valueChanged.emit([...this.nodeAspects, ...this.notDisplayedAspects]);
     }
 
     reset() {
         if (this.nodeAspectStatus && this.nodeAspectStatus.length > 0) {
             this.nodeAspects.splice(0, this.nodeAspects.length, ...this.nodeAspectStatus);
             this.hasEqualAspect = true;
-            this.valueChanged.emit(this.nodeAspects);
+            this.valueChanged.emit([...this.nodeAspects, ...this.notDisplayedAspects]);
         } else {
             this.clear();
         }
@@ -110,7 +112,7 @@ export class AspectListComponent implements OnInit, OnDestroy {
     clear() {
         this.nodeAspects = [];
         this.updateEqualityOfAspectList();
-        this.valueChanged.emit(this.nodeAspects);
+        this.valueChanged.emit([...this.nodeAspects, ...this.notDisplayedAspects]);
     }
 
     getId(aspect: any): string {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/MNT-24028
Updating aspects with Aspect List Dialog Component overwrites all current node aspects.


**What is the new behaviour?**
Not listable aspects are stored and emitted on selection value change, as api requires.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
