### PR TITLE
[ACS-6748] BasicAlfrescoAuthService.requireAlfTicket should not be in adf/core

### DIFF
--- a/lib/content-services/src/lib/auth-loader/content-auth-loader-factory.ts
+++ b/lib/content-services/src/lib/auth-loader/content-auth-loader-factory.ts
@@ -24,6 +24,6 @@ import { ContentAuthLoaderService } from './content-auth-loader.service';
  * @param authLoaderService service dependency
  * @returns factory function
  */
-export function contentAuthLoaderFactory(authLoaderService: ContentAuthLoaderService) {
+export function contentAuthLoaderFactory(authLoaderService: ContentAuthLoaderService): () => void {
     return () => authLoaderService.init();
 }

--- a/lib/content-services/src/lib/auth-loader/content-auth-loader-factory.ts
+++ b/lib/content-services/src/lib/auth-loader/content-auth-loader-factory.ts
@@ -1,0 +1,29 @@
+/*!
+ * @license
+ * Copyright © 2005-2023 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ContentAuthLoaderService } from './content-auth-loader.service';
+
+// eslint-disable-next-line prefer-arrow/prefer-arrow-functions
+/**
+ * Create a content auth factory
+ *
+ * @param authLoaderService service dependency
+ * @returns factory function
+ */
+export function contentAuthLoaderFactory(authLoaderService: ContentAuthLoaderService) {
+    return () => authLoaderService.init();
+}

--- a/lib/content-services/src/lib/auth-loader/content-auth-loader.service.spec.ts
+++ b/lib/content-services/src/lib/auth-loader/content-auth-loader.service.spec.ts
@@ -73,6 +73,6 @@ describe('ContentAuthLoaderService', () => {
         onLoginSubject.next();
         tick();
 
-        expect(basicAlfrescoAuthService.requireAlfTicket).toHaveBeenCalled();
+        expect(basicAlfrescoAuthService.requireAlfTicket).not.toHaveBeenCalled();
     }));
 });

--- a/lib/content-services/src/lib/auth-loader/content-auth-loader.service.spec.ts
+++ b/lib/content-services/src/lib/auth-loader/content-auth-loader.service.spec.ts
@@ -1,0 +1,78 @@
+/*!
+ * @license
+ * Copyright © 2005-2023 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { AuthenticationService, BasicAlfrescoAuthService } from '@alfresco/adf-core';
+import { ContentAuthLoaderService } from './content-auth-loader.service';
+import { Subject } from 'rxjs';
+
+describe('ContentAuthLoaderService', () => {
+    let service: ContentAuthLoaderService;
+    let authService: AuthenticationService;
+    let basicAlfrescoAuthService: BasicAlfrescoAuthService;
+    let onLoginSubject: Subject<void>;
+
+    beforeEach(() => {
+        onLoginSubject = new Subject<void>();
+        TestBed.configureTestingModule({
+            providers: [
+                ContentAuthLoaderService,
+                {
+                    provide: AuthenticationService,
+                    useValue: {
+                        onLogin: onLoginSubject.asObservable(),
+                        isOauth: () => false,
+                        isALLProvider: () => false,
+                        isECMProvider: () => false
+                    }
+                },
+                {
+                    provide: BasicAlfrescoAuthService,
+                    useValue: {
+                        requireAlfTicket: jasmine.createSpy()
+                    }
+                }
+            ]
+        });
+
+        service = TestBed.inject(ContentAuthLoaderService);
+        authService = TestBed.inject(AuthenticationService);
+        basicAlfrescoAuthService = TestBed.inject(BasicAlfrescoAuthService);
+    });
+
+
+    it('should require Alf ticket on login if OAuth and provider is ALL or ECM', fakeAsync(() => {
+        spyOn(authService, 'isOauth').and.returnValue(true);
+        spyOn(authService, 'isALLProvider').and.returnValue(true);
+
+        service.init();
+        onLoginSubject.next();
+        tick();
+
+        expect(basicAlfrescoAuthService.requireAlfTicket).toHaveBeenCalled();
+    }));
+
+    it('should not require Alf ticket on login if not OAuth', fakeAsync(() => {
+        spyOn(authService, 'isOauth').and.returnValue(false);
+
+        service.init();
+        onLoginSubject.next();
+        tick();
+
+        expect(basicAlfrescoAuthService.requireAlfTicket).toHaveBeenCalled();
+    }));
+});

--- a/lib/content-services/src/lib/auth-loader/content-auth-loader.service.ts
+++ b/lib/content-services/src/lib/auth-loader/content-auth-loader.service.ts
@@ -17,6 +17,7 @@
 
 import { Injectable } from '@angular/core';
 import { AuthenticationService, BasicAlfrescoAuthService } from '@alfresco/adf-core';
+import { take } from 'rxjs/operators';
 
 @Injectable()
 export class ContentAuthLoaderService {
@@ -28,12 +29,14 @@ export class ContentAuthLoaderService {
     }
 
     init(): void {
-        this.authService.onLogin.subscribe({
-            next: async () => {
-                if (this.authService.isOauth() && (this.authService.isALLProvider() || this.authService.isECMProvider())) {
-                    await this.basicAlfrescoAuthService.requireAlfTicket();
+        this.authService.onLogin
+            .pipe(take(1))
+            .subscribe({
+                next: async () => {
+                    if (this.authService.isOauth() && (this.authService.isALLProvider() || this.authService.isECMProvider())) {
+                        await this.basicAlfrescoAuthService.requireAlfTicket();
+                    }
                 }
-            }
-        });
+            });
     }
 }

--- a/lib/content-services/src/lib/auth-loader/content-auth-loader.service.ts
+++ b/lib/content-services/src/lib/auth-loader/content-auth-loader.service.ts
@@ -1,0 +1,36 @@
+/*!
+ * @license
+ * Copyright © 2005-2023 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Injectable } from '@angular/core';
+import { AuthenticationService, BasicAlfrescoAuthService } from '@alfresco/adf-core';
+
+@Injectable()
+export class ContentAuthLoaderService {
+
+    constructor(
+        private readonly basicAlfrescoAuthService: BasicAlfrescoAuthService,
+        private readonly authService: AuthenticationService,
+    ) {
+    }
+    init(): void {
+        this.authService.onLogin.subscribe(async () => {
+            if (this.authService.isOauth() && (this.authService.isALLProvider() || this.authService.isECMProvider())) {
+                await this.basicAlfrescoAuthService.requireAlfTicket();
+            }
+        });
+    }
+}

--- a/lib/content-services/src/lib/auth-loader/content-auth-loader.service.ts
+++ b/lib/content-services/src/lib/auth-loader/content-auth-loader.service.ts
@@ -23,13 +23,16 @@ export class ContentAuthLoaderService {
 
     constructor(
         private readonly basicAlfrescoAuthService: BasicAlfrescoAuthService,
-        private readonly authService: AuthenticationService,
+        private readonly authService: AuthenticationService
     ) {
     }
+
     init(): void {
-        this.authService.onLogin.subscribe(async () => {
-            if (this.authService.isOauth() && (this.authService.isALLProvider() || this.authService.isECMProvider())) {
-                await this.basicAlfrescoAuthService.requireAlfTicket();
+        this.authService.onLogin.subscribe({
+            next: async () => {
+                if (this.authService.isOauth() && (this.authService.isALLProvider() || this.authService.isECMProvider())) {
+                    await this.basicAlfrescoAuthService.requireAlfTicket();
+                }
             }
         });
     }

--- a/lib/content-services/src/lib/content.module.ts
+++ b/lib/content-services/src/lib/content.module.ts
@@ -51,6 +51,8 @@ import { AlfrescoViewerModule } from './viewer/alfresco-viewer.module';
 import { ContentUserInfoModule } from './content-user-info/content-user-info.module';
 import { SecurityControlsServiceModule } from './security/services/security-controls-service.module';
 import { CategoriesModule } from './category/category.module';
+import { contentAuthLoaderFactory } from './auth-loader/content-auth-loader-factory';
+import { ContentAuthLoaderService } from './auth-loader/content-auth-loader.service';
 
 @NgModule({
     imports: [
@@ -128,13 +130,20 @@ export class ContentModule {
             ngModule: ContentModule,
             providers: [
                 provideTranslations('adf-content-services', 'assets/adf-content-services'),
+                ContentAuthLoaderService,
                 {
                     provide: APP_INITIALIZER,
                     useFactory: versionCompatibilityFactory,
                     deps: [VersionCompatibilityService],
                     multi: true
+                },
+                {
+                    provide: APP_INITIALIZER,
+                    useFactory: contentAuthLoaderFactory,
+                    deps: [ContentAuthLoaderService],
+                    multi: true
                 }
-            ]
+                ]
         };
     }
 

--- a/lib/content-services/src/lib/content.module.ts
+++ b/lib/content-services/src/lib/content.module.ts
@@ -143,7 +143,7 @@ export class ContentModule {
                     deps: [ContentAuthLoaderService],
                     multi: true
                 }
-                ]
+            ]
         };
     }
 

--- a/lib/core/src/lib/api-factories/alfresco-api-v2-loader.service.ts
+++ b/lib/core/src/lib/api-factories/alfresco-api-v2-loader.service.ts
@@ -20,7 +20,6 @@ import { Injectable } from '@angular/core';
 import { AppConfigService, AppConfigValues } from '../app-config/app-config.service';
 import { AlfrescoApiService } from '../services/alfresco-api.service';
 import { StorageService } from '../common/services/storage.service';
-import { AuthenticationService, BasicAlfrescoAuthService } from '../auth';
 
 /**
  * Create a factory to resolve an api service instance
@@ -38,20 +37,11 @@ export function createAlfrescoApiInstance(angularAlfrescoApiService: AlfrescoApi
 export class AlfrescoApiLoaderService {
     constructor(private readonly appConfig: AppConfigService,
                 private readonly apiService: AlfrescoApiService,
-                private readonly basicAlfrescoAuthService: BasicAlfrescoAuthService,
-                private readonly authService: AuthenticationService,
                 private storageService: StorageService) {
     }
 
     async init(): Promise<any> {
         await this.appConfig.load();
-
-        this.authService.onLogin.subscribe(async () => {
-            if (this.authService.isOauth() && (this.authService.isALLProvider() || this.authService.isECMProvider())) {
-                await this.basicAlfrescoAuthService.requireAlfTicket();
-            }
-        });
-
         return this.initAngularAlfrescoApi();
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
requireAlfTicket is triggered in apps which don't need it and it causes errors in console.


**What is the new behaviour?**
https://alfresco.atlassian.net/browse/ACS-6748
requireAlfTicket method is triggered only when necessary.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
