### PR TITLE
AAE-21233 Enable no angular material selectors rule for adf

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,13 +37,11 @@ module.exports = {
                 'eslint-plugin-import',
                 '@angular-eslint/eslint-plugin',
                 '@typescript-eslint',
-                'jsdoc',
-                '@alfresco/eslint-angular'
+                'jsdoc'
             ],
             rules: {
                 // Uncomment this to enable prettier checks as part of the ESLint
                 // 'prettier/prettier': 'error',
-                '@alfresco/eslint-angular/no-angular-material-selectors': 'error',
                 'ban/ban': [
                     'error',
                     { name: 'eval', message: 'Calls to eval is not allowed.' },
@@ -185,6 +183,13 @@ module.exports = {
             files: ['*.html'],
             extends: ['plugin:@angular-eslint/template/recommended'],
             rules: {}
+        },
+        {
+            files: ['*.spec.ts'],
+            plugins: ['@alfresco/eslint-angular'],
+            rules: {
+                '@alfresco/eslint-angular/no-angular-material-selectors': 'error'
+            }
         }
     ]
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,11 +37,13 @@ module.exports = {
                 'eslint-plugin-import',
                 '@angular-eslint/eslint-plugin',
                 '@typescript-eslint',
-                'jsdoc'
+                'jsdoc',
+                '@alfresco/eslint-angular'
             ],
             rules: {
                 // Uncomment this to enable prettier checks as part of the ESLint
                 // 'prettier/prettier': 'error',
+                '@alfresco/eslint-angular/no-angular-material-selectors': 'error',
                 'ban/ban': [
                     'error',
                     { name: 'eval', message: 'Calls to eval is not allowed.' },

--- a/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.spec.ts
+++ b/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.spec.ts
@@ -751,7 +751,7 @@ describe('ContentMetadataComponent', () => {
             fixture.detectChanges();
             await fixture.whenStable();
 
-            const basicPropertiesGroup = fixture.debugElement.query(By.css('.adf-metadata-grouped-properties-container mat-expansion-panel'));
+            const basicPropertiesGroup = fixture.debugElement.query(By.css('.adf-metadata-grouped-properties-container .adf-content-metadata-panel'));
             expect(basicPropertiesGroup).toBeNull();
         });
 
@@ -764,7 +764,7 @@ describe('ContentMetadataComponent', () => {
             fixture.detectChanges();
             await fixture.whenStable();
 
-            const basicPropertiesGroup = fixture.debugElement.query(By.css('.adf-metadata-grouped-properties-container mat-expansion-panel'));
+            const basicPropertiesGroup = fixture.debugElement.query(By.css('.adf-metadata-grouped-properties-container .adf-content-metadata-panel'));
             expect(basicPropertiesGroup).toBeDefined();
         });
 

--- a/lib/content-services/src/lib/permission-manager/components/user-icon-column/user-icon-column.component.spec.ts
+++ b/lib/content-services/src/lib/permission-manager/components/user-icon-column/user-icon-column.component.spec.ts
@@ -116,7 +116,7 @@ describe('UserIconColumnComponent', () => {
         component.selected = true;
         component.ngOnInit();
         fixture.detectChanges();
-        expect(element.querySelector('mat-icon[svgIcon="selected"]')).toBeDefined();
+        expect(element.querySelector('.adf-people-select-icon[svgIcon="selected"]')).toBeDefined();
         expect(component.isSelected).toBe(true);
     });
 });

--- a/lib/core/src/lib/datatable/components/icon-cell/icon-cell.component.spec.ts
+++ b/lib/core/src/lib/datatable/components/icon-cell/icon-cell.component.spec.ts
@@ -20,20 +20,23 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { IconCellComponent } from './icon-cell.component';
 import { ObjectDataTableAdapter } from '../../data/object-datatable-adapter';
 import { ObjectDataColumn } from '../../data/object-datacolumn.model';
+import { HarnessLoader } from '@angular/cdk/testing';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatIconHarness } from '@angular/material/icon/testing';
 
 describe('IconCellComponent', () => {
     let component: IconCellComponent;
     let fixture: ComponentFixture<IconCellComponent>;
-    const getIconElement = () => fixture.debugElement.nativeElement.querySelector('mat-icon');
-    const renderAndCheckResult = (value: any, expectedOccurrence: boolean, expectedIconName?: string) => {
+    let loader: HarnessLoader;
+    const renderAndCheckResult = async (value: any, expectedOccurrence: boolean, expectedIconName?: string) => {
         component.value$.next(value);
         fixture.detectChanges();
 
-        const iconElement = getIconElement();
+        const icon = await loader.getHarnessOrNull(MatIconHarness);
 
-        expectedOccurrence ? expect(iconElement).toBeTruthy() : expect(iconElement).toBeFalsy();
+        expectedOccurrence ? expect(icon).not.toBeNull() : expect(icon).toBeNull();
         if (expectedIconName) {
-            expect(iconElement.textContent.trim()).toBe(expectedIconName);
+            expect(await icon?.getName()).toBe(expectedIconName);
         }
     };
 
@@ -44,6 +47,7 @@ describe('IconCellComponent', () => {
 
         fixture = TestBed.createComponent(IconCellComponent);
         component = fixture.componentInstance;
+        loader = TestbedHarnessEnvironment.loader(fixture);
     });
 
     describe('Initialization', () => {
@@ -80,23 +84,23 @@ describe('IconCellComponent', () => {
     });
 
     describe('UI', () => {
-        it('should render icon element in case of non-empty string (icon name validation NOT included)', () => {
-            renderAndCheckResult('group', true, 'group');
-            renderAndCheckResult('groupe', true, 'groupe');
-            renderAndCheckResult('0', true, '0');
-            renderAndCheckResult('false', true, 'false');
+        it('should render icon element in case of non-empty string (icon name validation NOT included)', async () => {
+            await renderAndCheckResult('group', true, 'group');
+            await renderAndCheckResult('groupe', true, 'groupe');
+            await renderAndCheckResult('0', true, '0');
+            await renderAndCheckResult('false', true, 'false');
         });
 
-        it('should NOT render icon element in case of empty string', () => {
-            renderAndCheckResult('', false);
+        it('should NOT render icon element in case of empty string', async () => {
+            await renderAndCheckResult('', false);
         });
 
-        it('should NOT render icon element in case of type different than string', () => {
-            renderAndCheckResult(0, false);
-            renderAndCheckResult({}, false);
-            renderAndCheckResult(null, false);
-            renderAndCheckResult(undefined, false);
-            renderAndCheckResult(NaN, false);
+        it('should NOT render icon element in case of type different than string', async () => {
+            await renderAndCheckResult(0, false);
+            await renderAndCheckResult({}, false);
+            await renderAndCheckResult(null, false);
+            await renderAndCheckResult(undefined, false);
+            await renderAndCheckResult(NaN, false);
         });
     });
 });

--- a/lib/core/src/lib/dialogs/unsaved-changes-dialog/unsaved-changes-dialog.component.spec.ts
+++ b/lib/core/src/lib/dialogs/unsaved-changes-dialog/unsaved-changes-dialog.component.spec.ts
@@ -36,12 +36,10 @@ describe('UnsavedChangesDialog', () => {
         let closeIconButton: DebugElement;
 
         beforeEach(() => {
-           closeIconButton = fixture.debugElement.query(By.css(
-               '[data-automation-id="adf-unsaved-changes-dialog-close-button"]'
-           ));
+            closeIconButton = fixture.debugElement.query(By.css('[data-automation-id="adf-unsaved-changes-dialog-close-button"]'));
         });
 
-        it('should have assigned mat-dialog-close with false as result', () => {
+        it('should have assigned dialog close button with false as result', () => {
             expect(closeIconButton.injector.get(MatDialogClose).dialogResult).toBeFalse();
         });
 
@@ -51,18 +49,21 @@ describe('UnsavedChangesDialog', () => {
     });
 
     describe('Cancel button', () => {
-        it('should have assigned mat-dialog-close with false as result', () => {
-            expect(fixture.debugElement.query(By.css(
-                '[data-automation-id="adf-unsaved-changes-dialog-cancel-button"]'
-            )).injector.get(MatDialogClose).dialogResult).toBeFalse();
+        it('should have assigned dialog close button with false as result', () => {
+            expect(
+                fixture.debugElement.query(By.css('[data-automation-id="adf-unsaved-changes-dialog-cancel-button"]')).injector.get(MatDialogClose)
+                    .dialogResult
+            ).toBeFalse();
         });
     });
 
     describe('Discard changes button', () => {
-        it('should have assigned mat-dialog-close with true as result', () => {
-            expect(fixture.debugElement.query(By.css(
-                '[data-automation-id="adf-unsaved-changes-dialog-discard-changes-button"]'
-            )).injector.get(MatDialogClose).dialogResult).toBeTrue();
+        it('should have assigned dialog close button with true as result', () => {
+            expect(
+                fixture.debugElement
+                    .query(By.css('[data-automation-id="adf-unsaved-changes-dialog-discard-changes-button"]'))
+                    .injector.get(MatDialogClose).dialogResult
+            ).toBeTrue();
         });
     });
 });

--- a/lib/eslint-angular/main.js
+++ b/lib/eslint-angular/main.js
@@ -1,0 +1,8 @@
+require('ts-node').register({
+    compilerOptions: {
+        module: 'commonjs',
+        target: 'es2019',
+    },
+});
+
+module.exports = require('./index.ts');

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "alfresco-ng2-components",
       "version": "6.8.0",
       "license": "Apache-2.0",
-      "workspaces": [
-        "./lib/eslint-angular"
-      ],
       "dependencies": {
         "@angular/animations": "14.1.3",
         "@angular/cdk": "14.1.2",
@@ -50,6 +47,7 @@
         "zone.js": "~0.11.4"
       },
       "devDependencies": {
+        "@alfresco/eslint-plugin-eslint-angular": "file:lib/eslint-angular",
         "@angular-devkit/build-angular": "14.1.3",
         "@angular-devkit/schematics": "~14.2.12",
         "@angular-eslint/eslint-plugin": "15.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "alfresco-ng2-components",
       "version": "6.8.0",
       "license": "Apache-2.0",
+      "workspaces": [
+        "./lib/eslint-angular"
+      ],
       "dependencies": {
         "@angular/animations": "14.1.3",
         "@angular/cdk": "14.1.2",
@@ -158,6 +161,10 @@
         "node": ">=6.0.0"
       }
     },
+    "lib/eslint-angular": {
+      "version": "6.7.1",
+      "license": "Apache-2.0"
+    },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
@@ -166,6 +173,10 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/@alfresco/eslint-plugin-eslint-angular": {
+      "resolved": "lib/eslint-angular",
+      "link": true
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -162,6 +162,7 @@
       }
     },
     "lib/eslint-angular": {
+      "name": "@alfresco/eslint-plugin-eslint-angular",
       "version": "6.7.1",
       "license": "Apache-2.0"
     },

--- a/package.json
+++ b/package.json
@@ -234,5 +234,8 @@
     "node": ">=6.0.0"
   },
   "module": "./index.js",
-  "typings": "./index.d.ts"
+  "typings": "./index.d.ts",
+  "workspaces": [
+    "./lib/eslint-angular"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "zone.js": "~0.11.4"
   },
   "devDependencies": {
+    "@alfresco/eslint-plugin-eslint-angular": "file:lib/eslint-angular",
     "@angular-devkit/build-angular": "14.1.3",
     "@angular-devkit/schematics": "~14.2.12",
     "@angular-eslint/eslint-plugin": "15.2.1",
@@ -234,8 +235,5 @@
     "node": ">=6.0.0"
   },
   "module": "./index.js",
-  "typings": "./index.d.ts",
-  "workspaces": [
-    "./lib/eslint-angular"
-  ]
+  "typings": "./index.d.ts"
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [x] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://hyland.atlassian.net/browse/AAE-21233

**What is the new behaviour?**

Enables eslint rule for angular selectors.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Check if this approach is correct, as enabling a eslint rule within the same repo it's created isn't so straight-forward.