### PR TITLE
[ACS-7242] Resizing columns with panel opened on the right, e.g. nfo …

### DIFF
--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.html
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.html
@@ -39,7 +39,7 @@
                     'adf-datatable__cursor--pointer': !isResizing,
                     'adf-datatable__header--sorted-asc': isColumnSorted(col, 'asc'),
                     'adf-datatable__header--sorted-desc': isColumnSorted(col, 'desc')}"
-                 [ngStyle]="(col.width) && {'flex': getFlexValue(col)}"
+                 [ngStyle]="(col.width) && !lastColumn && {'flex': getFlexValue(col)}"
                  [attr.aria-label]="col.title | translate"
                  (click)="onColumnHeaderClick(col, $event)"
                  (keyup.enter)="onColumnHeaderClick(col, $event)"
@@ -103,7 +103,7 @@
                     </span>
                 </div>
                 <div
-                    *ngIf="isResizingEnabled && col.resizable"
+                    *ngIf="isResizingEnabled && col.resizable && !lastColumn"
                     [ngClass]="hoveredHeaderColumnIndex === columnIndex && !isResizing || resizingColumnIndex === columnIndex ? 'adf-datatable__resize-handle-visible' : 'adf-datatable__resize-handle-hidden'"
                     adf-resize-handle
                     (click)="$event.stopPropagation()"
@@ -216,7 +216,7 @@
                      [adf-context-menu]="getContextMenuActions(row, col)"
                      [adf-context-menu-enabled]="contextMenu"
                      adf-drop-zone dropTarget="cell" [dropColumn]="col" [dropRow]="row"
-                     [ngStyle]="(col.width) && {'flex': getFlexValue(col)}">
+                     [ngStyle]="(col.width) && !lastColumn && {'flex': getFlexValue(col)}">
                     <div *ngIf="!col.template" class="adf-datatable-cell-container">
                         <ng-container [ngSwitch]="data.getColumnType(row, col)">
                             <div *ngSwitchCase="'image'" class="adf-cell-value">

--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.spec.ts
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.spec.ts
@@ -1738,20 +1738,20 @@ describe('Column Resizing', () => {
         });
     });
 
-    it('should display resize handle for each column by default', () => {
+    it('should display resize handle for each column, but not for the last one, by default', () => {
         dataTable.isResizingEnabled = true;
         fixture.detectChanges();
 
-        expect(getResizeHandlersCount()).toBe(2);
+        expect(getResizeHandlersCount()).toBe(1);
     });
 
-    it('should NOT display resize handle for the column when the column has resizable param set to false', () => {
+    it('should NOT display resize handle for the column when the column has resizable param set to false and column is not the last one', () => {
         dataTable.isResizingEnabled = true;
         dataTableSchema[0].resizable = false;
         dataTable.data = new ObjectDataTableAdapter([...data], [...dataTableSchema]);
         fixture.detectChanges();
 
-        expect(getResizeHandlersCount()).toBe(1);
+        expect(getResizeHandlersCount()).toBe(0);
     });
 
     it('should display resize handle when the feature is Enabled [isResizingEnabled=true]', () => {


### PR DESCRIPTION
…Drawer creates empty columns space when panel is closed.

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://alfresco.atlassian.net/browse/ACS-7242


**What is the new behaviour?**
After talking to Share, we decided to remove the resize handler of the last column.
The last column should always take the rest of the remaining space (have flex-grow property) and should not be resizable by user.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
