### PR TITLE
[ACS-7338] Fix search input formatting for asterisk

### DIFF
--- a/lib/content-services/src/lib/search/components/search-input/search-input.component.spec.ts
+++ b/lib/content-services/src/lib/search/components/search-input/search-input.component.spec.ts
@@ -84,6 +84,15 @@ describe('SearchInputComponent', () => {
         expect(formatted).toBe('(cm:name:"test*")');
     });
 
+    it('should not append asterisk if one is already provided', async () => {
+        let formatted = '';
+        component.changed.subscribe((val) => (formatted = val));
+
+        await setInputValue('*');
+
+        expect(formatted).toBe('(cm:name:"*")');
+    });
+
     it('should format with AND by default', async () => {
         let formatted = '';
         component.changed.subscribe((val) => (formatted = val));

--- a/lib/content-services/src/lib/search/components/search-input/search-input.component.ts
+++ b/lib/content-services/src/lib/search/components/search-input/search-input.component.ts
@@ -66,6 +66,10 @@ export class SearchInputComponent {
 
         userInput = userInput.trim();
 
+        if (userInput === '*') {
+            return userInput;
+        }
+
         if (userInput.includes(':') || userInput.includes('"')) {
             return userInput;
         }

--- a/lib/content-services/src/lib/search/components/search-input/search-input.component.ts
+++ b/lib/content-services/src/lib/search/components/search-input/search-input.component.ts
@@ -66,10 +66,6 @@ export class SearchInputComponent {
 
         userInput = userInput.trim();
 
-        if (userInput === '*') {
-            return userInput;
-        }
-
         if (userInput.includes(':') || userInput.includes('"')) {
             return userInput;
         }

--- a/lib/content-services/src/lib/search/components/search-input/search-input.component.ts
+++ b/lib/content-services/src/lib/search/components/search-input/search-input.component.ts
@@ -104,6 +104,11 @@ export class SearchInputComponent {
             term = term.substring(1);
         }
 
+        if (term === '*') {
+            prefix = '';
+            suffix = '';
+        }
+
         return '(' + fields.map((field) => `${prefix}${field}:"${term}${suffix}"`).join(' OR ') + ')';
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

- fix formatting for asterisk (`*`), do not append extra one

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://alfresco.atlassian.net/browse/ACS-7338