### PR TITLE
[ACS-6950] - Tabs in properties panel change their background color a…

### DIFF
--- a/lib/core/src/lib/info-drawer/info-drawer.component.scss
+++ b/lib/core/src/lib/info-drawer/info-drawer.component.scss
@@ -78,7 +78,6 @@
 
         &:focus {
             color: var(--adf-info-drawer-tab-active-focused-color);
-            background-color: var(--adf-info-drawer-tab-active-focused-background);
             border-bottom: var(--adf-info-drawer-tab-active-focused-bottom-line);
         }
     }


### PR DESCRIPTION
…fter clicking on them

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/ACS-6950
There is unnecessary background color when property tab element is active.


**What is the new behaviour?**
There is no additional background color when property tab element is active.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
