### PR TITLE
[ACS-6628] Display arrows for tabs for extensions manager

### DIFF
--- a/lib/core/src/lib/layout/components/layout-container/layout-container.component.scss
+++ b/lib/core/src/lib/layout/components/layout-container/layout-container.component.scss
@@ -6,6 +6,7 @@ adf-layout-container {
 }
 
 .adf-container-full-width {
+    height: 100%;
     width: inherit;
 }
 
@@ -47,7 +48,6 @@ mat-sidenav-content.mat-sidenav-content,
 }
 
 mat-sidenav-content > div {
-    display: flex;
     height: 100%;
 
     > div {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/ACS-6628


**What is the new behaviour?**
Arrows in tabs are displayed for extension manager. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
alfresco-applications PR: https://github.com/Alfresco/alfresco-applications/pull/553