### PR TITLE
[ACS-7380][ADF] Break Context Menu dependency on Material Module

### DIFF
--- a/lib/core/src/lib/context-menu/context-menu-list.component.html
+++ b/lib/core/src/lib/context-menu/context-menu-list.component.html
@@ -1,0 +1,14 @@
+<div mat-menu class="mat-menu-panel" @panelAnimation>
+    <div id="adf-context-menu-content" class="mat-menu-content">
+        <ng-container *ngFor="let link of links">
+            <button *ngIf="link.model?.visible"
+                    [attr.data-automation-id]="'context-' + (link.title || link.model?.title | translate)"
+                    mat-menu-item
+                    [disabled]="link.model?.disabled"
+                    (click)="onMenuItemClick($event, link)">
+                <mat-icon *ngIf="link.model?.icon">{{ link.model.icon }}</mat-icon>
+                <span>{{ link.title || link.model?.title | translate }}</span>
+            </button>
+        </ng-container>
+    </div>
+</div>

--- a/lib/core/src/lib/context-menu/context-menu-list.component.ts
+++ b/lib/core/src/lib/context-menu/context-menu-list.component.ts
@@ -19,36 +19,24 @@ import { Component, ViewEncapsulation, HostListener, AfterViewInit, Optional, In
 import { trigger } from '@angular/animations';
 import { DOWN_ARROW, UP_ARROW } from '@angular/cdk/keycodes';
 import { FocusKeyManager } from '@angular/cdk/a11y';
-import { MatMenuItem } from '@angular/material/menu';
+import { MatMenuItem, MatMenuModule } from '@angular/material/menu';
 import { ContextMenuOverlayRef } from './context-menu-overlay';
 import { contextMenuAnimation } from './animations';
 import { CONTEXT_MENU_DATA } from './context-menu.tokens';
+import { MatIconModule } from '@angular/material/icon';
+import { NgForOf, NgIf } from '@angular/common';
+import { TranslateModule } from '@ngx-translate/core';
 
 @Component({
     selector: 'adf-context-menu',
-    template: `
-        <div mat-menu class="mat-menu-panel" @panelAnimation>
-            <div id="adf-context-menu-content" class="mat-menu-content">
-                <ng-container *ngFor="let link of links">
-                    <button
-                        *ngIf="link.model?.visible"
-                        [attr.data-automation-id]="'context-' + (link.title || link.model?.title | translate)"
-                        mat-menu-item
-                        [disabled]="link.model?.disabled"
-                        (click)="onMenuItemClick($event, link)"
-                    >
-                        <mat-icon *ngIf="link.model?.icon">{{ link.model.icon }}</mat-icon>
-                        <span>{{ link.title || link.model?.title | translate }}</span>
-                    </button>
-                </ng-container>
-            </div>
-        </div>
-    `,
+    standalone: true,
+    templateUrl: './context-menu-list.component.html',
     host: {
         role: 'menu',
         class: 'adf-context-menu'
     },
     encapsulation: ViewEncapsulation.None,
+    imports: [MatIconModule, MatMenuModule, NgForOf, NgIf, TranslateModule],
     animations: [trigger('panelAnimation', contextMenuAnimation)]
 })
 export class ContextMenuListComponent implements AfterViewInit {

--- a/lib/core/src/lib/context-menu/context-menu-list.component.ts
+++ b/lib/core/src/lib/context-menu/context-menu-list.component.ts
@@ -15,17 +15,17 @@
  * limitations under the License.
  */
 
-import { Component, ViewEncapsulation, HostListener, AfterViewInit, Optional, Inject, QueryList, ViewChildren } from '@angular/core';
 import { trigger } from '@angular/animations';
-import { DOWN_ARROW, UP_ARROW } from '@angular/cdk/keycodes';
 import { FocusKeyManager } from '@angular/cdk/a11y';
-import { MatMenuItem, MatMenuModule } from '@angular/material/menu';
-import { ContextMenuOverlayRef } from './context-menu-overlay';
-import { contextMenuAnimation } from './animations';
-import { CONTEXT_MENU_DATA } from './context-menu.tokens';
-import { MatIconModule } from '@angular/material/icon';
+import { DOWN_ARROW, UP_ARROW } from '@angular/cdk/keycodes';
 import { NgForOf, NgIf } from '@angular/common';
+import { AfterViewInit, Component, HostListener, Inject, Optional, QueryList, ViewChildren, ViewEncapsulation } from '@angular/core';
+import { MatIconModule } from '@angular/material/icon';
+import { MatMenuItem, MatMenuModule } from '@angular/material/menu';
 import { TranslateModule } from '@ngx-translate/core';
+import { contextMenuAnimation } from './animations';
+import { ContextMenuOverlayRef } from './context-menu-overlay';
+import { CONTEXT_MENU_DATA } from './context-menu.tokens';
 
 @Component({
     selector: 'adf-context-menu',

--- a/lib/core/src/lib/context-menu/context-menu.directive.ts
+++ b/lib/core/src/lib/context-menu/context-menu.directive.ts
@@ -21,7 +21,8 @@ import { Directive, HostListener, Input } from '@angular/core';
 import { ContextMenuOverlayService } from './context-menu-overlay.service';
 
 @Directive({
-    selector: '[adf-context-menu]'
+    selector: '[adf-context-menu]',
+    standalone: true
 })
 export class ContextMenuDirective {
     /** Items for the menu. */

--- a/lib/core/src/lib/context-menu/context-menu.module.ts
+++ b/lib/core/src/lib/context-menu/context-menu.module.ts
@@ -17,24 +17,13 @@
 
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { MaterialModule } from '../material.module';
 import { TranslateModule } from '@ngx-translate/core';
 
 import { ContextMenuDirective } from './context-menu.directive';
 import { ContextMenuListComponent } from './context-menu-list.component';
 
 @NgModule({
-    imports: [
-        CommonModule,
-        MaterialModule,
-        TranslateModule
-    ],
-    declarations: [
-        ContextMenuDirective,
-        ContextMenuListComponent
-    ],
-    exports: [
-        ContextMenuDirective
-    ]
+    imports: [CommonModule, ContextMenuListComponent, ContextMenuDirective, TranslateModule],
+    exports: [ContextMenuListComponent, ContextMenuDirective]
 })
 export class ContextMenuModule {}

--- a/lib/core/src/lib/context-menu/context-menu.module.ts
+++ b/lib/core/src/lib/context-menu/context-menu.module.ts
@@ -15,15 +15,12 @@
  * limitations under the License.
  */
 
-import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { TranslateModule } from '@ngx-translate/core';
-
 import { ContextMenuDirective } from './context-menu.directive';
 import { ContextMenuListComponent } from './context-menu-list.component';
 
 @NgModule({
-    imports: [CommonModule, ContextMenuListComponent, ContextMenuDirective, TranslateModule],
+    imports: [ContextMenuListComponent, ContextMenuDirective],
     exports: [ContextMenuListComponent, ContextMenuDirective]
 })
 export class ContextMenuModule {}

--- a/lib/core/src/lib/context-menu/public-api.ts
+++ b/lib/core/src/lib/context-menu/public-api.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
+export * from './context-menu-list.component';
 export * from './context-menu.directive';
 export * from './context-menu-overlay.service';
-
 export * from './context-menu.module';


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [x] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/ACS-7380


**What is the new behaviour?**
Context menu is standalone 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
