### PR TITLE
[ACS-6721] [ACA] Aspects dialog does not display butons on smaller screens

### DIFF
--- a/lib/content-services/src/lib/aspect-list/aspect-list.component.scss
+++ b/lib/content-services/src/lib/aspect-list/aspect-list.component.scss
@@ -1,14 +1,25 @@
+$dialog-title-height: 100px;
+$dialog-information-height: 44px;
+$dialog-buttons-height: 68px;
+
+$dialog-list-height: calc(65vh - ($dialog-title-height + $dialog-information-height + $dialog-buttons-height));
+
 .adf {
+    &-aspect-list-spinner,
+    &-aspect-list-container {
+        padding-top: 3px;
+        box-sizing: border-box;
+    }
+
     &-aspect-list-spinner {
         display: flex;
         align-items: center;
         justify-content: center;
-        min-height: 400px;
+        min-height: $dialog-list-height;
     }
 
     &-aspect-list-container {
-        padding-top: 3px;
-        height: 400px;
+        max-height: $dialog-list-height;
         overflow: auto;
         border: 1px solid var(--adf-theme-foreground-text-color-007);
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
On small screens we don't see action buttons. Modal jumped in 5px after loading mode.


https://github.com/Alfresco/alfresco-ng2-components/assets/166367848/51e69c2d-e28d-434e-aae9-1f2aa388edb5



**What is the new behaviour?**
Now you can see action buttons. Also there was a fix with loading behavior.
Before this, the modal jumped by `5px` because of padding and borders in the list. I added the `padding-top` like in the list (but do we really need this padding? :thinking_face:) and `border-box` property to fix this behavior


https://github.com/Alfresco/alfresco-ng2-components/assets/166367848/97f8a369-547b-4219-b273-27b36df0f57e


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
