### PR TITLE
AAE-21361 Modify date widget to handle negative values

### DIFF
--- a/lib/process-services-cloud/src/lib/form/components/widgets/date/date-cloud.widget.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/date/date-cloud.widget.spec.ts
@@ -28,7 +28,6 @@ import { MatTooltipHarness } from '@angular/material/tooltip/testing';
 import { MatInputHarness } from '@angular/material/input/testing';
 
 describe('DateWidgetComponent', () => {
-
     let widget: DateCloudWidgetComponent;
     let fixture: ComponentFixture<DateCloudWidgetComponent>;
     let element: HTMLElement;
@@ -38,10 +37,7 @@ describe('DateWidgetComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [
-                TranslateModule.forRoot(),
-                ProcessServiceCloudTestingModule
-            ]
+            imports: [TranslateModule.forRoot(), ProcessServiceCloudTestingModule]
         });
 
         form = new FormModel();
@@ -112,7 +108,6 @@ describe('DateWidgetComponent', () => {
     });
 
     describe('template check', () => {
-
         afterEach(() => {
             fixture.destroy();
             TestBed.resetTestingModule();
@@ -173,7 +168,7 @@ describe('DateWidgetComponent', () => {
             fixture.detectChanges();
             await fixture.whenStable();
 
-            dateButton = element.querySelector<HTMLButtonElement> ('button');
+            dateButton = element.querySelector<HTMLButtonElement>('button');
             expect(dateButton.disabled).toBeTruthy();
         });
 
@@ -224,7 +219,6 @@ describe('DateWidgetComponent', () => {
     });
 
     describe('when form model has left labels', () => {
-
         it('should have left labels classes on leftLabels true', async () => {
             widget.field = new FormFieldModel(new FormModel({ taskId: 'fake-task-id', leftLabels: true }), {
                 id: 'date-id',
@@ -296,203 +290,166 @@ describe('DateWidgetComponent', () => {
     });
 
     describe('Set dynamic dates', () => {
-        it('should min date equal to the today date minus minimum date range value', async () => {
-            widget.field = new FormFieldModel(form, {
-                type: FormFieldTypes.DATE,
-                dynamicDateRangeSelection: true,
-                minDateRangeValue: 4
-            });
+        const todayString = '22-02-2022';
 
-            fixture.detectChanges();
-            await fixture.whenStable();
-
-            const expected = subDays(adapter.today(), widget.field.minDateRangeValue);
-            expect(widget.minDate.toDateString()).toBe(expected.toDateString());
+        beforeEach(() => {
+            const todayStringReversed = '2022-02-22';
+            spyOn(adapter, 'today').and.returnValue(new Date(todayStringReversed));
         });
 
-        it('should min date and max date be undefined if dynamic min and max date are not set', async () => {
-            widget.field = new FormFieldModel(form, {
-                type: FormFieldTypes.DATE,
-                dynamicDateRangeSelection: true
-            });
-
-            fixture.detectChanges();
-            await fixture.whenStable();
-
-            expect(widget.minDate).toBeUndefined();
-            expect(widget.maxDate).toBeUndefined();
-        });
-
-        it('should max date be undefined if only minimum date range value is set', async () => {
-            widget.field = new FormFieldModel(form, {
-                type: FormFieldTypes.DATE,
-                dynamicDateRangeSelection: true,
-                minDateRangeValue: 4
-            });
-
-            fixture.detectChanges();
-            await fixture.whenStable();
-
-            expect(widget.maxDate).toBeUndefined();
-        });
-
-        it('should min date be undefined if only maximum date range value is set', async () => {
-            widget.field = new FormFieldModel(form, {
-                type: FormFieldTypes.DATE,
-                dynamicDateRangeSelection: true,
-                maxDateRangeValue: 4
-            });
-
-            fixture.detectChanges();
-            await fixture.whenStable();
-
-            expect(widget.minDate).toBeUndefined();
-        });
-
-        it('should max date equal to the today date plus maximum date range value', async () => {
-            widget.field = new FormFieldModel(form, {
-                type: FormFieldTypes.DATE,
-                dynamicDateRangeSelection: true,
-                maxDateRangeValue: 5
-            });
-
-            fixture.detectChanges();
-            await fixture.whenStable();
-
-            const expected = addDays(adapter.today(), widget.field.maxDateRangeValue);
-            expect(widget.maxDate.toDateString()).toBe(expected.toDateString());
-        });
-
-        it('should maxDate and minDate be undefined if minDateRangeValue and maxDateRangeValue are null', async () => {
-            widget.field = new FormFieldModel(form, {
-                type: FormFieldTypes.DATE,
-                dynamicDateRangeSelection: true,
-                maxDateRangeValue: null,
-                minDateRangeValue: null
-            });
-
-            fixture.detectChanges();
-            await fixture.whenStable();
-
-            expect(widget.maxDate).toBeUndefined();
-            expect(widget.minDate).toBeUndefined();
-        });
-
-        it('should minDate be undefined if minDateRangeValue is null and maxDateRangeValue is greater than 0', async () => {
-            widget.field = new FormFieldModel(form, {
-                type: FormFieldTypes.DATE,
-                dynamicDateRangeSelection: true,
-                maxDateRangeValue: 15,
-                minDateRangeValue: null
-            });
-
-            fixture.detectChanges();
-            await fixture.whenStable();
-
-            expect(widget.maxDate).not.toBeUndefined();
-            expect(widget.minDate).toBeUndefined();
-        });
-
-        it('should maxDate be undefined if maxDateRangeValue is null and minDateRangeValue is greater than 0', async () => {
-            widget.field = new FormFieldModel(form, {
-                type: FormFieldTypes.DATE,
-                dynamicDateRangeSelection: true,
-                maxDateRangeValue: null,
-                minDateRangeValue: 10
-            });
-
-            fixture.detectChanges();
-            await fixture.whenStable();
-
-            expect(widget.minDate).not.toBeUndefined();
-            expect(widget.maxDate).toBeUndefined();
-        });
-
-        describe('check date validation by dynamic date ranges', () => {
-            it('should minValue be equal to today date minus minDateRangeValue', async () => {
-                spyOn(adapter, 'today').and.returnValue(new Date('2022-07-22'));
-
+        describe('minDateRangeValue', () => {
+            it('should min date be today if minDateRangeValue is 0', async () => {
                 widget.field = new FormFieldModel(form, {
                     type: FormFieldTypes.DATE,
                     dynamicDateRangeSelection: true,
-                    maxDateRangeValue: null,
-                    minDateRangeValue: 1,
-                    maxValue: null,
-                    minValue: null
+                    minDateRangeValue: 0,
+                    maxDateRangeValue: null
                 });
 
                 fixture.detectChanges();
                 await fixture.whenStable();
 
-                expect(widget.field.minValue).toEqual('21-07-2022');
-                expect(widget.maxDate).toBeUndefined();
-                expect(widget.field.maxValue).toBeNull();
+                const expectedMinDate = adapter.today();
+
+                expect(adapter.compareDate(widget.minDate, expectedMinDate)).toEqual(0);
+                expect(widget.field.minValue).toBe(todayString);
             });
 
-            it('should maxValue be equal to today date plus maxDateRangeValue', async () => {
-                spyOn(adapter, 'today').and.returnValue(new Date('2022-07-22'));
-
+            it('should min date be null if minDateRangeValue is null', async () => {
                 widget.field = new FormFieldModel(form, {
                     type: FormFieldTypes.DATE,
                     dynamicDateRangeSelection: true,
-                    maxDateRangeValue: 8,
                     minDateRangeValue: null,
-                    maxValue: null,
-                    minValue: null
+                    maxDateRangeValue: null
                 });
 
                 fixture.detectChanges();
                 await fixture.whenStable();
 
-                expect(widget.field.maxValue).toEqual('30-07-2022');
-                expect(widget.minDate).toBeUndefined();
+                expect(widget.minDate).toBeNull();
                 expect(widget.field.minValue).toBeNull();
             });
 
-            it('should maxValue and minValue be null if maxDateRangeValue and minDateRangeValue are null', async () => {
-                spyOn(adapter, 'today').and.returnValue(new Date('2022-07-22'));
-
+            it('should min date be today minus abs(minDateRangeValue) if minDateRangeValue negative', async () => {
                 widget.field = new FormFieldModel(form, {
                     type: FormFieldTypes.DATE,
                     dynamicDateRangeSelection: true,
-                    maxDateRangeValue: null,
-                    minDateRangeValue: null,
-                    maxValue: null,
-                    minValue: null
+                    minDateRangeValue: -2,
+                    maxDateRangeValue: null
                 });
 
                 fixture.detectChanges();
                 await fixture.whenStable();
 
-                expect(widget.minDate).toBeUndefined();
-                expect(widget.maxDate).toBeUndefined();
-                expect(widget.field.minValue).toBeNull();
+                const expectedMinDate = subDays(adapter.today(), 2);
+
+                expect(adapter.compareDate(widget.minDate, expectedMinDate)).toEqual(0);
+                expect(widget.field.minValue).toBe('20-02-2022');
+            });
+        });
+
+        describe('maxDateRangeValue', () => {
+            it('should max date be today if maxDateRangeValue is 0', async () => {
+                widget.field = new FormFieldModel(form, {
+                    type: FormFieldTypes.DATE,
+                    dynamicDateRangeSelection: true,
+                    minDateRangeValue: null,
+                    maxDateRangeValue: 0
+                });
+
+                fixture.detectChanges();
+                await fixture.whenStable();
+
+                const expectedMaxDate = adapter.today();
+
+                expect(adapter.compareDate(widget.maxDate, expectedMaxDate)).toEqual(0);
+                expect(widget.field.maxValue).toBe(todayString);
+            });
+
+            it('should max date be null if maxDateRangeValue is null', async () => {
+                widget.field = new FormFieldModel(form, {
+                    type: FormFieldTypes.DATE,
+                    dynamicDateRangeSelection: true,
+                    minDateRangeValue: null,
+                    maxDateRangeValue: null
+                });
+
+                fixture.detectChanges();
+                await fixture.whenStable();
+
+                expect(widget.maxDate).toBeNull();
                 expect(widget.field.maxValue).toBeNull();
             });
 
-            it('should maxValue and minValue not be null if maxDateRangeVale and minDateRangeValue are not null', async () => {
-                spyOn(adapter, 'today').and.returnValue(new Date('2022-07-22'));
-
+            it('should max date be today minus abs(maxDateRangeValue) if maxDateRangeValue negative', async () => {
                 widget.field = new FormFieldModel(form, {
                     type: FormFieldTypes.DATE,
                     dynamicDateRangeSelection: true,
-                    maxDateRangeValue: 8,
-                    minDateRangeValue: 10,
-                    maxValue: null,
-                    minValue: null
+                    minDateRangeValue: null,
+                    maxDateRangeValue: -2
                 });
 
                 fixture.detectChanges();
                 await fixture.whenStable();
 
-                expect(widget.field.minValue).toEqual('12-07-2022');
-                expect(widget.field.maxValue).toEqual('30-07-2022');
+                const expectedMaxDate = subDays(adapter.today(), 2);
+
+                expect(adapter.compareDate(widget.maxDate, expectedMaxDate)).toEqual(0);
+                expect(widget.field.maxValue).toBe('20-02-2022');
             });
+        });
+
+        it('should min date be today plus minDateRangeValue if minDateRangeValue positive', async () => {
+            widget.field = new FormFieldModel(form, {
+                type: FormFieldTypes.DATE,
+                dynamicDateRangeSelection: true,
+                minDateRangeValue: 2,
+                maxDateRangeValue: null
+            });
+
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            const expectedMinDate = addDays(adapter.today(), 2);
+
+            expect(adapter.compareDate(widget.minDate, expectedMinDate)).toEqual(0);
+            expect(widget.field.minValue).toBe('24-02-2022');
+        });
+        it('should max date be today minus abs(maxDateRangeValue) if maxDateRangeValue negative', async () => {
+            widget.field = new FormFieldModel(form, {
+                type: FormFieldTypes.DATE,
+                dynamicDateRangeSelection: true,
+                minDateRangeValue: null,
+                maxDateRangeValue: -2
+            });
+
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            const expectedMaxDate = subDays(adapter.today(), 2);
+
+            expect(adapter.compareDate(widget.maxDate, expectedMaxDate)).toEqual(0);
+            expect(widget.field.maxValue).toBe('20-02-2022');
+        });
+        it('should max date be today plus maxDateRangeValue if maxDateRangeValue positive', async () => {
+            widget.field = new FormFieldModel(form, {
+                type: FormFieldTypes.DATE,
+                dynamicDateRangeSelection: true,
+                minDateRangeValue: null,
+                maxDateRangeValue: 2
+            });
+
+            fixture.detectChanges();
+            await fixture.whenStable();
+
+            const expectedMaxDate = addDays(adapter.today(), 2);
+
+            expect(adapter.compareDate(widget.maxDate, expectedMaxDate)).toEqual(0);
+            expect(widget.field.maxValue).toBe('24-02-2022');
         });
     });
 
     describe('when tooltip is set', () => {
-
         beforeEach(() => {
             widget.field = new FormFieldModel(new FormModel({ taskId: '<id>' }), {
                 type: FormFieldTypes.DATE,
@@ -521,9 +478,8 @@ describe('DateWidgetComponent', () => {
     });
 
     describe('when is required', () => {
-
         beforeEach(() => {
-            widget.field = new FormFieldModel( new FormModel({ taskId: '<id>' }), {
+            widget.field = new FormFieldModel(new FormModel({ taskId: '<id>' }), {
                 type: FormFieldTypes.DATE,
                 required: true
             });

--- a/lib/process-services-cloud/src/lib/form/components/widgets/date/date-cloud.widget.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/date/date-cloud.widget.spec.ts
@@ -297,8 +297,8 @@ describe('DateWidgetComponent', () => {
             spyOn(adapter, 'today').and.returnValue(new Date(todayStringReversed));
         });
 
-        describe('minDateRangeValue', () => {
-            it('should min date be today if minDateRangeValue is 0', async () => {
+        describe('Minimum date range value and date', () => {
+            it('should set minimum date range date to today if minimum date range value is 0', async () => {
                 widget.field = new FormFieldModel(form, {
                     type: FormFieldTypes.DATE,
                     dynamicDateRangeSelection: true,
@@ -315,7 +315,7 @@ describe('DateWidgetComponent', () => {
                 expect(widget.field.minValue).toBe(todayString);
             });
 
-            it('should min date be null if minDateRangeValue is null', async () => {
+            it('should set minimum date range date to null if minimum date range value is null', async () => {
                 widget.field = new FormFieldModel(form, {
                     type: FormFieldTypes.DATE,
                     dynamicDateRangeSelection: true,
@@ -330,7 +330,7 @@ describe('DateWidgetComponent', () => {
                 expect(widget.field.minValue).toBeNull();
             });
 
-            it('should min date be today minus abs(minDateRangeValue) if minDateRangeValue negative', async () => {
+            it('should set minimum date range date to today minus abs(minDateRangeValue) if minimum date range value is negative', async () => {
                 widget.field = new FormFieldModel(form, {
                     type: FormFieldTypes.DATE,
                     dynamicDateRangeSelection: true,
@@ -346,10 +346,27 @@ describe('DateWidgetComponent', () => {
                 expect(adapter.compareDate(widget.minDate, expectedMinDate)).toEqual(0);
                 expect(widget.field.minValue).toBe('20-02-2022');
             });
+
+            it('should set minimum date range date to today plus minDateRangeValue if minimum date range value is positive', async () => {
+                widget.field = new FormFieldModel(form, {
+                    type: FormFieldTypes.DATE,
+                    dynamicDateRangeSelection: true,
+                    minDateRangeValue: 2,
+                    maxDateRangeValue: null
+                });
+
+                fixture.detectChanges();
+                await fixture.whenStable();
+
+                const expectedMinDate = addDays(adapter.today(), 2);
+
+                expect(adapter.compareDate(widget.minDate, expectedMinDate)).toEqual(0);
+                expect(widget.field.minValue).toBe('24-02-2022');
+            });
         });
 
-        describe('maxDateRangeValue', () => {
-            it('should max date be today if maxDateRangeValue is 0', async () => {
+        describe('Maximum date range value and date', () => {
+            it('should set maximum date range date to today if maximum date range value is 0', async () => {
                 widget.field = new FormFieldModel(form, {
                     type: FormFieldTypes.DATE,
                     dynamicDateRangeSelection: true,
@@ -366,7 +383,7 @@ describe('DateWidgetComponent', () => {
                 expect(widget.field.maxValue).toBe(todayString);
             });
 
-            it('should max date be null if maxDateRangeValue is null', async () => {
+            it('should set maximum date range date to null if maximum date range value is null', async () => {
                 widget.field = new FormFieldModel(form, {
                     type: FormFieldTypes.DATE,
                     dynamicDateRangeSelection: true,
@@ -381,7 +398,7 @@ describe('DateWidgetComponent', () => {
                 expect(widget.field.maxValue).toBeNull();
             });
 
-            it('should max date be today minus abs(maxDateRangeValue) if maxDateRangeValue negative', async () => {
+            it('should set maximum date range date to today minus abs(maxDateRangeValue) if maximum date range value is negative', async () => {
                 widget.field = new FormFieldModel(form, {
                     type: FormFieldTypes.DATE,
                     dynamicDateRangeSelection: true,
@@ -397,55 +414,23 @@ describe('DateWidgetComponent', () => {
                 expect(adapter.compareDate(widget.maxDate, expectedMaxDate)).toEqual(0);
                 expect(widget.field.maxValue).toBe('20-02-2022');
             });
-        });
 
-        it('should min date be today plus minDateRangeValue if minDateRangeValue positive', async () => {
-            widget.field = new FormFieldModel(form, {
-                type: FormFieldTypes.DATE,
-                dynamicDateRangeSelection: true,
-                minDateRangeValue: 2,
-                maxDateRangeValue: null
+            it('should set maximum date range date to today plus maxDateRangeValue if maximum date range value is positive', async () => {
+                widget.field = new FormFieldModel(form, {
+                    type: FormFieldTypes.DATE,
+                    dynamicDateRangeSelection: true,
+                    minDateRangeValue: null,
+                    maxDateRangeValue: 2
+                });
+
+                fixture.detectChanges();
+                await fixture.whenStable();
+
+                const expectedMaxDate = addDays(adapter.today(), 2);
+
+                expect(adapter.compareDate(widget.maxDate, expectedMaxDate)).toEqual(0);
+                expect(widget.field.maxValue).toBe('24-02-2022');
             });
-
-            fixture.detectChanges();
-            await fixture.whenStable();
-
-            const expectedMinDate = addDays(adapter.today(), 2);
-
-            expect(adapter.compareDate(widget.minDate, expectedMinDate)).toEqual(0);
-            expect(widget.field.minValue).toBe('24-02-2022');
-        });
-        it('should max date be today minus abs(maxDateRangeValue) if maxDateRangeValue negative', async () => {
-            widget.field = new FormFieldModel(form, {
-                type: FormFieldTypes.DATE,
-                dynamicDateRangeSelection: true,
-                minDateRangeValue: null,
-                maxDateRangeValue: -2
-            });
-
-            fixture.detectChanges();
-            await fixture.whenStable();
-
-            const expectedMaxDate = subDays(adapter.today(), 2);
-
-            expect(adapter.compareDate(widget.maxDate, expectedMaxDate)).toEqual(0);
-            expect(widget.field.maxValue).toBe('20-02-2022');
-        });
-        it('should max date be today plus maxDateRangeValue if maxDateRangeValue positive', async () => {
-            widget.field = new FormFieldModel(form, {
-                type: FormFieldTypes.DATE,
-                dynamicDateRangeSelection: true,
-                minDateRangeValue: null,
-                maxDateRangeValue: 2
-            });
-
-            fixture.detectChanges();
-            await fixture.whenStable();
-
-            const expectedMaxDate = addDays(adapter.today(), 2);
-
-            expect(adapter.compareDate(widget.maxDate, expectedMaxDate)).toEqual(0);
-            expect(widget.field.maxValue).toBe('24-02-2022');
         });
     });
 
@@ -465,7 +450,7 @@ describe('DateWidgetComponent', () => {
             const tooltipElement = await loader.getHarness(MatTooltipHarness);
             expect(await tooltipElement.isOpen()).toBeTruthy();
             expect(await tooltipElement.getTooltipText()).toEqual('my custom tooltip');
-          });
+        });
 
         it('should hide tooltip', async () => {
             const dateCloudInput = await loader.getHarness(MatInputHarness);

--- a/lib/process-services-cloud/src/lib/form/components/widgets/date/date-cloud.widget.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/date/date-cloud.widget.ts
@@ -22,7 +22,7 @@ import { DateAdapter, MAT_DATE_FORMATS } from '@angular/material/core';
 import { Subject } from 'rxjs';
 import { WidgetComponent, FormService, AdfDateFnsAdapter, DateFnsUtils, ADF_DATE_FORMATS } from '@alfresco/adf-core';
 import { MatDatepickerInputEvent } from '@angular/material/datepicker';
-import { addDays, subDays } from 'date-fns';
+import { addDays } from 'date-fns';
 
 @Component({
     selector: 'date-widget',
@@ -49,9 +49,9 @@ export class DateCloudWidgetComponent extends WidgetComponent implements OnInit,
     typeId = 'DateCloudWidgetComponent';
     readonly DATE_FORMAT = 'dd-MM-yyyy';
 
-    minDate: Date;
-    maxDate: Date;
-    startAt: Date;
+    minDate: Date = null;
+    maxDate: Date = null;
+    startAt: Date = null;
 
     /**
      * Current date value.
@@ -63,8 +63,7 @@ export class DateCloudWidgetComponent extends WidgetComponent implements OnInit,
 
     private onDestroy$ = new Subject<boolean>();
 
-    constructor(public formService: FormService,
-                private dateAdapter: DateAdapter<Date>) {
+    constructor(public formService: FormService, private dateAdapter: DateAdapter<Date>) {
         super(formService);
     }
 
@@ -76,11 +75,17 @@ export class DateCloudWidgetComponent extends WidgetComponent implements OnInit,
 
         if (this.field) {
             if (this.field.dynamicDateRangeSelection) {
-                if (Number.isInteger(this.field.minDateRangeValue)) {
-                    this.minDate = subDays(this.dateAdapter.today(), this.field.minDateRangeValue);
+                if (this.field.minDateRangeValue === null) {
+                    this.minDate = null;
+                    this.field.minValue = null;
+                } else {
+                    this.minDate = addDays(this.dateAdapter.today(), this.field.minDateRangeValue);
                     this.field.minValue = DateFnsUtils.formatDate(this.minDate, this.DATE_FORMAT);
                 }
-                if (Number.isInteger(this.field.maxDateRangeValue)) {
+                if (this.field.maxDateRangeValue === null) {
+                    this.maxDate = null;
+                    this.field.maxValue = null;
+                } else {
                     this.maxDate = addDays(this.dateAdapter.today(), this.field.maxDateRangeValue);
                     this.field.maxValue = DateFnsUtils.formatDate(this.maxDate, this.DATE_FORMAT);
                 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/AAE-21361
Currently, date widget treats minDateRangeValue as always earlier than today (negative) and maxDateRangeValue as always later than today (positive). With changes in https://hyland.atlassian.net/browse/AAE-20895 now both values can be either positive (later than today), negative (earlier than today), zero (today), or null (inf). 


**What is the new behaviour?**
Modified the init method to reflect the desired behaviour and added tests


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
