### PR TITLE
[ACS-6842] [ACA] Clicking "Create" button multiple times in folder creation modal sends the same folder creation request multiple times

### DIFF
--- a/lib/content-services/src/lib/dialogs/folder.dialog.html
+++ b/lib/content-services/src/lib/dialogs/folder.dialog.html
@@ -63,7 +63,7 @@
             id="adf-folder-create-button"
             mat-button
             (click)="submit()"
-            [disabled]="!form.valid">
+            [disabled]="!form.valid || disableSubmitButton">
         {{
         (editing
         ? 'CORE.FOLDER_DIALOG.UPDATE_BUTTON.LABEL'

--- a/lib/content-services/src/lib/dialogs/folder.dialog.spec.ts
+++ b/lib/content-services/src/lib/dialogs/folder.dialog.spec.ts
@@ -302,4 +302,18 @@ describe('FolderDialogComponent', () => {
             });
         });
     });
+
+    it('should disable the submit button after submitting the form', () => {
+        const submitButton = fixture.nativeElement.querySelector('#adf-folder-create-button');
+        component.data = {
+            parentNodeId: 'parentNodeId',
+            folder: null
+        };
+        fixture.detectChanges();
+
+        component.submit();
+
+        expect(component.disableSubmitButton).toBeTrue();
+        expect(submitButton.disabled).toBeTrue();
+    });
 });

--- a/lib/content-services/src/lib/dialogs/folder.dialog.spec.ts
+++ b/lib/content-services/src/lib/dialogs/folder.dialog.spec.ts
@@ -88,9 +88,7 @@ describe('FolderDialogComponent', () => {
         });
 
         it('should update form input', () => {
-            component.form.controls['name'].setValue('folder-name-update');
-            component.form.controls['title'].setValue('folder-title-update');
-            component.form.controls['description'].setValue('folder-description-update');
+            setFormValues();
 
             expect(component.name).toBe('folder-name-update');
             expect(component.title).toBe('folder-title-update');
@@ -100,9 +98,7 @@ describe('FolderDialogComponent', () => {
         it('should submit updated values if form is valid', () => {
             updateNode$.next(null);
 
-            component.form.controls['name'].setValue('folder-name-update');
-            component.form.controls['title'].setValue('folder-title-update');
-            component.form.controls['description'].setValue('folder-description-update');
+            setFormValues();
 
             fixture.detectChanges();
             submitButton.click();
@@ -193,8 +189,7 @@ describe('FolderDialogComponent', () => {
         });
 
         it('should update form input', () => {
-            component.form.controls['name'].setValue('folder-name-update');
-            component.form.controls['description'].setValue('folder-description-update');
+            setFormValues();
 
             expect(component.name).toBe('folder-name-update');
             expect(component.description).toBe('folder-description-update');
@@ -203,10 +198,7 @@ describe('FolderDialogComponent', () => {
         describe('when form is valid', () => {
             beforeEach(() => {
                 createFolderNode$.next(null);
-
-                component.form.controls['name'].setValue('folder-name-update');
-                component.form.controls['title'].setValue('folder-title-update');
-                component.form.controls['description'].setValue('folder-description-update');
+                setFormValues();
             });
 
             it('should submit updated values', () => {
@@ -249,9 +241,7 @@ describe('FolderDialogComponent', () => {
                 data: 'folder-data'
             };
 
-            component.form.controls['name'].setValue('name');
-            component.form.controls['title'].setValue('title');
-            component.form.controls['description'].setValue('description');
+            setFormValues();
 
             createFolderNode$.next(folder);
 
@@ -322,4 +312,13 @@ describe('FolderDialogComponent', () => {
             });
         });
     });
+
+    /**
+     * Set mock values to form
+     */
+    function setFormValues() {
+        component.form.controls['name'].setValue('folder-name-update');
+        component.form.controls['title'].setValue('folder-title-update');
+        component.form.controls['description'].setValue('folder-description-update');
+    }
 });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Create button still enable after clicking. Multiple API calls.

https://github.com/Alfresco/alfresco-ng2-components/assets/166367848/a5286810-1f51-4597-8f8a-ab17b34d1c64



**What is the new behaviour?**
Create button disable after clicking.
Also did small refactor with names and code organization (moved private functions to the end of the file, refactor some variable declarations, added subjects in tests to prevent multiple spy creation)

https://github.com/Alfresco/alfresco-ng2-components/assets/166367848/ce0c8a23-ef99-4f5c-99eb-f4cfadee2980



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
