### PR TITLE
[ACS-7679] Reduce the usage of AppConfigService in components and tests

### DIFF
--- a/lib/content-services/src/lib/content-node-selector/content-node-dialog.service.spec.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-dialog.service.spec.ts
@@ -17,14 +17,12 @@
 
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { NodeEntry, Node, SitePaging, Site } from '@alfresco/js-api';
-import { AppConfigService } from '@alfresco/adf-core';
-import { DocumentListService } from '../document-list/services/document-list.service';
+import { DocumentListService, NodeAction } from '../document-list';
 import { ContentNodeDialogService } from './content-node-dialog.service';
 import { MatDialog } from '@angular/material/dialog';
 import { Subject, of } from 'rxjs';
 import { ContentTestingModule } from '../testing/content.testing.module';
-import { NodeAction } from '../document-list/models/node-action.enum';
-import { SitesService } from '../common/services/sites.service';
+import { SitesService } from '../common';
 
 const fakeNodeEntry = {
     entry: {
@@ -71,9 +69,6 @@ describe('ContentNodeDialogService', () => {
         TestBed.configureTestingModule({
             imports: [ContentTestingModule]
         });
-        const appConfig: AppConfigService = TestBed.inject(AppConfigService);
-        appConfig.config.ecmHost = 'http://localhost:9876/ecm';
-
         service = TestBed.inject(ContentNodeDialogService);
         documentListService = TestBed.inject(DocumentListService);
         materialDialog = TestBed.inject(MatDialog);

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.spec.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.spec.ts
@@ -19,12 +19,8 @@ import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { Node, NodeEntry, NodePaging, ResultSetPaging, Site, SiteEntry, SitePaging, SitePagingList, UserInfo } from '@alfresco/js-api';
-import { AppConfigService, DataRow, ThumbnailService, DataColumn } from '@alfresco/adf-core';
-import { ContentService } from '../common/services/content.service';
-import { UploadService } from '../common/services/upload.service';
-import { NodesApiService } from '../common/services/nodes-api.service';
-import { FileModel, FileUploadStatus } from '../common/models/file.model';
-import { FileUploadCompleteEvent } from '../common/events/file.event';
+import { DataRow, ThumbnailService, DataColumn } from '@alfresco/adf-core';
+import { ContentService, UploadService, NodesApiService, SitesService, FileModel, FileUploadStatus, FileUploadCompleteEvent } from '../common';
 import { of, throwError } from 'rxjs';
 import { DropdownBreadcrumbComponent } from '../breadcrumb';
 import { ContentNodeSelectorPanelComponent } from './content-node-selector-panel.component';
@@ -35,7 +31,6 @@ import { NodeEntryEvent, ShareDataRow, ShareDataTableAdapter } from '../document
 import { SearchQueryBuilderService } from '../search';
 import { ContentNodeSelectorPanelService } from './content-node-selector-panel.service';
 import { mockContentModelTextProperty } from '../mock/content-model.mock';
-import { SitesService } from '../common/services/sites.service';
 
 const fakeResultSetPaging: ResultSetPaging = {
     list: {
@@ -729,32 +724,6 @@ describe('ContentNodeSelectorPanelComponent', () => {
                 const toggleFiltersPanelButton = fixture.debugElement.query(By.css('[data-automation-id="adf-toggle-search-panel-button"]'));
 
                 expect(toggleFiltersPanelButton).toEqual(null);
-            });
-        });
-
-        describe('Sorting', () => {
-            let appConfigService: AppConfigService;
-
-            beforeEach(() => {
-                appConfigService = TestBed.inject(AppConfigService);
-            });
-
-            it('should read the sorting value from appConfig json in case it is present', async () => {
-                const fakeSortingConfig = ['fakeKey', 'fakeAsc'];
-
-                appConfigService.config = Object.assign(appConfigService.config, {
-                    'adf-content-node-selector': { sorting: fakeSortingConfig }
-                });
-                fixture.detectChanges();
-
-                expect(component.sorting).toEqual(fakeSortingConfig);
-            });
-
-            it('should take default sorting when there is no content node selector sorting config in appConfig json', async () => {
-                appConfigService.config = null;
-                fixture.detectChanges();
-
-                expect(component.sorting).toEqual(['createdAt', 'desc']);
             });
         });
 

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.ts
@@ -22,26 +22,17 @@ import {
     UserPreferenceValues,
     InfinitePaginationComponent,
     PaginatedComponent,
-    AppConfigService,
     DataSorting,
     ShowHeaderMode
 } from '@alfresco/adf-core';
-import { NodesApiService } from '../common/services/nodes-api.service';
-import { UploadService } from '../common/services/upload.service';
-import { FileUploadCompleteEvent, FileUploadDeleteEvent } from '../common/events/file.event';
+import { NodesApiService, UploadService, FileUploadCompleteEvent, FileUploadDeleteEvent, SitesService } from '../common';
 import { UntypedFormControl } from '@angular/forms';
 import { Node, NodePaging, Pagination, SiteEntry, SitePaging, NodeEntry, SearchRequest, RequestScope } from '@alfresco/js-api';
-import { DocumentListComponent } from '../document-list/components/document-list.component';
-import { RowFilter } from '../document-list/data/row-filter.model';
-import { ImageResolver } from '../document-list/data/image-resolver.model';
+import { DocumentListComponent, RowFilter, ImageResolver, CustomResourcesService, ShareDataRow, NodeEntryEvent } from '../document-list';
 import { debounceTime, takeUntil } from 'rxjs/operators';
-import { CustomResourcesService } from '../document-list/services/custom-resources.service';
-import { ShareDataRow } from '../document-list/data/share-data-row.model';
 import { Subject } from 'rxjs';
-import { SearchQueryBuilderService } from '../search/services/search-query-builder.service';
+import { SearchQueryBuilderService } from '../search';
 import { ContentNodeSelectorPanelService } from './content-node-selector-panel.service';
-import { NodeEntryEvent } from '../document-list/components/node.event';
-import { SitesService } from '../common/services/sites.service';
 
 export type ValidationFunction = (entry: Node) => boolean;
 
@@ -262,7 +253,7 @@ export class ContentNodeSelectorPanelComponent implements OnInit, OnDestroy {
     preselectedNodes: NodeEntry[] = [];
     currentUploadBatch: NodeEntry[] = [];
 
-    sorting: string[] | DataSorting;
+    sorting: string[] | DataSorting = ['createdAt', 'desc'];
 
     searchPanelExpanded: boolean = false;
 
@@ -275,7 +266,6 @@ export class ContentNodeSelectorPanelComponent implements OnInit, OnDestroy {
         private nodesApiService: NodesApiService,
         private uploadService: UploadService,
         private sitesService: SitesService,
-        private appConfigService: AppConfigService,
         private contentNodeSelectorPanelService: ContentNodeSelectorPanelService
     ) {}
 
@@ -347,8 +337,6 @@ export class ContentNodeSelectorPanelComponent implements OnInit, OnDestroy {
         this.documentList.$folderNode.pipe(takeUntil(this.onDestroy$)).subscribe((currentNode: Node) => {
             this.currentFolder.emit(currentNode);
         });
-
-        this.sorting = this.appConfigService.get('adf-content-node-selector.sorting', ['createdAt', 'desc']);
     }
 
     ngOnDestroy() {

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.ts
@@ -28,7 +28,12 @@ import {
 import { NodesApiService, UploadService, FileUploadCompleteEvent, FileUploadDeleteEvent, SitesService } from '../common';
 import { UntypedFormControl } from '@angular/forms';
 import { Node, NodePaging, Pagination, SiteEntry, SitePaging, NodeEntry, SearchRequest, RequestScope } from '@alfresco/js-api';
-import { DocumentListComponent, RowFilter, ImageResolver, CustomResourcesService, ShareDataRow, NodeEntryEvent } from '../document-list';
+import { DocumentListComponent } from '../document-list/components/document-list.component';
+import { RowFilter } from '../document-list/data/row-filter.model';
+import { ImageResolver } from '../document-list/data/image-resolver.model';
+import { CustomResourcesService } from '../document-list/services/custom-resources.service';
+import { ShareDataRow } from '../document-list/data/share-data-row.model';
+import { NodeEntryEvent } from '../document-list/components/node.event';
 import { debounceTime, takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 import { SearchQueryBuilderService } from '../search';

--- a/lib/content-services/src/lib/content-node-share/content-node-share.dialog.spec.ts
+++ b/lib/content-services/src/lib/content-node-share/content-node-share.dialog.spec.ts
@@ -18,9 +18,8 @@
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
 import { of } from 'rxjs';
-import { NotificationService, AppConfigService } from '@alfresco/adf-core';
-import { NodesApiService } from '../common/services/nodes-api.service';
-import { RenditionService } from '../common/services/rendition.service';
+import { NotificationService } from '@alfresco/adf-core';
+import { NodesApiService, RenditionService } from '../common';
 import { SharedLinksApiService } from './services/shared-links-api.service';
 import { ShareDialogComponent } from './content-node-share.dialog';
 import { ContentTestingModule } from '../testing/content.testing.module';
@@ -43,7 +42,6 @@ describe('ShareDialogComponent', () => {
     let nodesApiService: NodesApiService;
     let fixture: ComponentFixture<ShareDialogComponent>;
     let component: ShareDialogComponent;
-    let appConfigService: AppConfigService;
 
     const shareToggleId = '[data-automation-id="adf-share-toggle"]';
     const expireToggle = '[data-automation-id="adf-expire-toggle"]';
@@ -77,7 +75,6 @@ describe('ShareDialogComponent', () => {
         sharedLinksApiService = TestBed.inject(SharedLinksApiService);
         renditionService = TestBed.inject(RenditionService);
         nodesApiService = TestBed.inject(NodesApiService);
-        appConfigService = TestBed.inject(AppConfigService);
 
         node = {
             entry: {
@@ -330,10 +327,7 @@ describe('ShareDialogComponent', () => {
         });
 
         it('should update node with input date and end of day time when type is `date`', async () => {
-            const dateTimePickerType = 'date';
             const date = new Date('2525-01-01');
-            spyOn(appConfigService, 'get').and.callFake(() => dateTimePickerType as any);
-
             fixture.detectChanges();
 
             const toggle = await loader.getHarness(MatSlideToggleHarness.with({ selector: expireToggle }));

--- a/lib/content-services/src/lib/content-node-share/content-node-share.module.ts
+++ b/lib/content-services/src/lib/content-node-share/content-node-share.module.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { NgModule, ModuleWithProviders } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { CoreModule } from '@alfresco/adf-core';
 import { MaterialModule } from '../material.module';
@@ -23,30 +23,8 @@ import { ShareDialogComponent } from './content-node-share.dialog';
 import { NodeSharedDirective } from './content-node-share.directive';
 
 @NgModule({
-    imports: [
-        CoreModule,
-        CommonModule,
-        MaterialModule
-    ],
-    declarations: [
-        ShareDialogComponent,
-        NodeSharedDirective
-    ],
-    exports: [
-        ShareDialogComponent,
-        NodeSharedDirective
-    ]
+    imports: [CoreModule, CommonModule, MaterialModule],
+    declarations: [ShareDialogComponent, NodeSharedDirective],
+    exports: [ShareDialogComponent, NodeSharedDirective]
 })
-export class ContentNodeShareModule {
-    static forRoot(): ModuleWithProviders<ContentNodeShareModule> {
-        return {
-            ngModule: ContentNodeShareModule
-        };
-    }
-
-    static forChild(): ModuleWithProviders<ContentNodeShareModule> {
-        return {
-            ngModule: ContentNodeShareModule
-        };
-    }
-}
+export class ContentNodeShareModule {}

--- a/lib/content-services/src/lib/document-list/components/document-list.component.ts
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.ts
@@ -57,7 +57,8 @@ import {
     DataRow,
     DataTableService,
     DataTableSchema,
-    DataColumn
+    DataColumn,
+    ViewerComponentConfig
 } from '@alfresco/adf-core';
 import { NodesApiService } from '../../common/services/nodes-api.service';
 import { Node, NodeEntry, NodePaging, NodesApi, Pagination } from '@alfresco/js-api';
@@ -789,9 +790,10 @@ export class DocumentListComponent extends DataTableSchema implements OnInit, On
     onPreviewFile(node: NodeEntry) {
         if (node) {
             const sizeInMB = node.entry?.content?.sizeInBytes / BYTES_TO_MB_CONVERSION_VALUE;
+            const config = this.appConfig.get<ViewerComponentConfig>('viewer');
 
-            const fileAutoDownloadFlag: boolean = this.appConfig.get('viewer.enableFileAutoDownload', true);
-            const sizeThreshold: number = this.appConfig.get('viewer.fileAutoDownloadSizeThresholdInMB', 15);
+            const fileAutoDownloadFlag = config?.enableFileAutoDownload ?? true;
+            const sizeThreshold = config?.fileAutoDownloadSizeThresholdInMB ?? 15;
 
             if (fileAutoDownloadFlag && sizeInMB && sizeInMB > sizeThreshold) {
                 this.dialog.open(FileAutoDownloadComponent, { disableClose: true, data: node });

--- a/lib/content-services/src/lib/document-list/services/folder-actions.service.spec.ts
+++ b/lib/content-services/src/lib/document-list/services/folder-actions.service.spec.ts
@@ -16,7 +16,6 @@
  */
 
 import { TestBed } from '@angular/core/testing';
-import { AppConfigService } from '@alfresco/adf-core';
 import { Observable } from 'rxjs';
 import { FileNode, FolderNode } from '../../mock';
 import { ContentActionHandler } from '../models/content-action.model';
@@ -33,9 +32,6 @@ describe('FolderActionsService', () => {
         TestBed.configureTestingModule({
             imports: [ContentTestingModule]
         });
-        const appConfig: AppConfigService = TestBed.inject(AppConfigService);
-        appConfig.config.ecmHost = 'http://localhost:9876/ecm';
-
         documentListService = TestBed.inject(DocumentListService);
         service = TestBed.inject(FolderActionsService);
     });

--- a/lib/content-services/src/lib/document-list/services/node-actions.service.spec.ts
+++ b/lib/content-services/src/lib/document-list/services/node-actions.service.spec.ts
@@ -17,7 +17,6 @@
 
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { Node, NodeEntry } from '@alfresco/js-api';
-import { AppConfigService } from '@alfresco/adf-core';
 import { DocumentListService } from './document-list.service';
 import { NodeActionsService } from './node-actions.service';
 import { ContentNodeDialogService } from '../../content-node-selector/content-node-dialog.service';
@@ -43,9 +42,6 @@ describe('NodeActionsService', () => {
             imports: [ContentTestingModule],
             providers: [{ provide: MatDialogRef, useValue: dialogRef }]
         });
-        const appConfig: AppConfigService = TestBed.inject(AppConfigService);
-        appConfig.config.ecmHost = 'http://localhost:9876/ecm';
-
         service = TestBed.inject(NodeActionsService);
         documentListService = TestBed.inject(DocumentListService);
         contentDialogService = TestBed.inject(ContentNodeDialogService);

--- a/lib/content-services/src/lib/permission-manager/services/node-permission-dialog.service.spec.ts
+++ b/lib/content-services/src/lib/permission-manager/services/node-permission-dialog.service.spec.ts
@@ -16,7 +16,6 @@
  */
 
 import { TestBed } from '@angular/core/testing';
-import { AppConfigService } from '@alfresco/adf-core';
 import { NodePermissionDialogService } from './node-permission-dialog.service';
 import { MatDialog } from '@angular/material/dialog';
 import { of, Subject, throwError } from 'rxjs';
@@ -35,8 +34,6 @@ describe('NodePermissionDialogService', () => {
         TestBed.configureTestingModule({
             imports: [ContentTestingModule]
         });
-        const appConfig: AppConfigService = TestBed.inject(AppConfigService);
-        appConfig.config.ecmHost = 'http://localhost:9876/ecm';
         service = TestBed.inject(NodePermissionDialogService);
         materialDialog = TestBed.inject(MatDialog);
         afterOpenObservable = new Subject<any>();

--- a/lib/content-services/src/lib/tag/tag-list.component.spec.ts
+++ b/lib/content-services/src/lib/tag/tag-list.component.spec.ts
@@ -16,7 +16,6 @@
  */
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { AppConfigService } from '@alfresco/adf-core';
 import { TagService } from './services/tag.service';
 import { TagListComponent } from '././tag-list.component';
 import { of } from 'rxjs';
@@ -53,8 +52,6 @@ describe('TagList', () => {
         TestBed.configureTestingModule({
             imports: [ContentTestingModule]
         });
-        const appConfig: AppConfigService = TestBed.inject(AppConfigService);
-        appConfig.config.ecmHost = 'http://localhost:9876/ecm';
 
         tagService = TestBed.inject(TagService);
         spyOn(tagService, 'getAllTheTags').and.returnValue(of(dataTag));

--- a/lib/core/src/lib/card-view/components/card-view-dateitem/card-view-dateitem.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view-dateitem/card-view-dateitem.component.spec.ts
@@ -24,7 +24,6 @@ import { CoreTestingModule } from '../../../testing/core.testing.module';
 import { ClipboardService } from '../../../clipboard/clipboard.service';
 import { CardViewDatetimeItemModel } from '../../models/card-view-datetimeitem.model';
 import { TranslateModule } from '@ngx-translate/core';
-import { AppConfigService } from '../../../app-config/app-config.service';
 import { MatDatetimepickerInputEvent } from '@mat-datetimepicker/core';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
@@ -34,18 +33,11 @@ describe('CardViewDateItemComponent', () => {
     let loader: HarnessLoader;
     let fixture: ComponentFixture<CardViewDateItemComponent>;
     let component: CardViewDateItemComponent;
-    let appConfigService: AppConfigService;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [TranslateModule.forRoot(), CoreTestingModule]
         });
-        appConfigService = TestBed.inject(AppConfigService);
-        appConfigService.config.dateValues = {
-            defaultDateFormat: 'shortDate',
-            defaultDateTimeFormat: 'M/d/yy, h:mm a',
-            defaultLocale: 'uk'
-        };
 
         fixture = TestBed.createComponent(CardViewDateItemComponent);
         component = fixture.componentInstance;

--- a/lib/core/src/lib/viewer/components/viewer.component.ts
+++ b/lib/core/src/lib/viewer/components/viewer.component.ts
@@ -43,12 +43,14 @@ import { DownloadPromptDialogComponent } from './download-prompt-dialog/download
 import { AppConfigService } from '../../app-config';
 import { DownloadPromptActions } from '../models/download-prompt.actions';
 
-const DEFAULT_NON_PREVIEW_CONFIG = {
-    enableDownloadPrompt: false,
-    enableDownloadPromptReminder: false,
-    downloadPromptDelay: 50,
-    downloadPromptReminderDelay: 30
-};
+export interface ViewerComponentConfig {
+    enableDownloadPrompt?: boolean;
+    enableDownloadPromptReminder?: boolean;
+    downloadPromptDelay?: number;
+    downloadPromptReminderDelay?: number;
+    enableFileAutoDownload?: boolean;
+    fileAutoDownloadSizeThresholdInMB?: number;
+}
 
 @Component({
     selector: 'adf-viewer',
@@ -200,22 +202,26 @@ export class ViewerComponent<T> implements OnDestroy, OnInit, OnChanges {
     /**
      * Enable dialog box to allow user to download the previewed file, in case the preview is not responding for a set period of time.
      */
-    enableDownloadPrompt: boolean = false;
+    @Input()
+    enableDownloadPrompt = false;
 
     /**
      * Enable reminder dialogs to prompt user to download the file, in case the preview is not responding for a set period of time.
      */
-    enableDownloadPromptReminder: boolean = false;
+    @Input()
+    enableDownloadPromptReminder = false;
 
     /**
      * Initial time in seconds to wait before giving the first prompt to user to download the file
      */
-    downloadPromptDelay: number = 50;
+    @Input()
+    downloadPromptDelay = 50;
 
     /**
      * Time in seconds to wait before giving the second and consequent reminders to the user to download the file.
      */
-    downloadPromptReminderDelay: number = 15;
+    @Input()
+    downloadPromptReminderDelay = 15;
 
     /**
      * Emitted when user clicks on download button on download prompt dialog.
@@ -390,12 +396,20 @@ export class ViewerComponent<T> implements OnDestroy, OnInit, OnChanges {
     }
 
     private configureDownloadPromptProperties() {
-        const nonResponsivePreviewConfig = this.appConfigService.get('viewer', DEFAULT_NON_PREVIEW_CONFIG);
+        const config = this.appConfigService.get<ViewerComponentConfig>('viewer');
 
-        this.enableDownloadPrompt = nonResponsivePreviewConfig.enableDownloadPrompt;
-        this.enableDownloadPromptReminder = nonResponsivePreviewConfig.enableDownloadPromptReminder;
-        this.downloadPromptDelay = nonResponsivePreviewConfig.downloadPromptDelay;
-        this.downloadPromptReminderDelay = nonResponsivePreviewConfig.downloadPromptReminderDelay;
+        if (config) {
+            this.enableDownloadPrompt = config.enableDownloadPrompt === true;
+            this.enableDownloadPromptReminder = config.enableDownloadPromptReminder === true;
+
+            if (config.downloadPromptDelay !== undefined) {
+                this.downloadPromptDelay = config.downloadPromptDelay;
+            }
+
+            if (config.downloadPromptReminderDelay !== undefined) {
+                this.downloadPromptReminderDelay = config.downloadPromptReminderDelay;
+            }
+        }
     }
 
     private initDownloadPrompt() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

Jira: ACS-7679

- remove the useless imports of the `AppConfigService` in unit tests
- remove the usage of `AppConfigService` with unused/dead parameters
- support optional app config for the Viewer, improved app config typings 
- minor code cleanup

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
