### PR TITLE
AAE-21256 Fix form widget styles

### DIFF
--- a/lib/core/src/lib/form/components/form-renderer.component.scss
+++ b/lib/core/src/lib/form/components/form-renderer.component.scss
@@ -17,6 +17,11 @@
     }
 }
 
+.adf-container-widget__header-text, .adf-label {
+    font-family: var(--theme-font-family);
+    color: var(--theme-primary-color);
+}
+
 .adf-field-list {
     padding: 0;
     list-style-type: none;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe:
Style fix

**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**
<img width="1454" alt="Screenshot 2024-04-23 at 15 46 32" src="https://github.com/Alfresco/alfresco-ng2-components/assets/50139916/2bc6e2cf-5ad2-46b1-86b0-e1447f7815f4">
<img width="138" alt="Screenshot 2024-04-23 at 15 46 38" src="https://github.com/Alfresco/alfresco-ng2-components/assets/50139916/dbbb8e15-9afd-4212-ba10-6aa12d655225">
<img width="139" alt="Screenshot 2024-04-23 at 15 46 47" src="https://github.com/Alfresco/alfresco-ng2-components/assets/50139916/b0a831c0-5708-441b-80b0-0f6d6a0022b4">
<img width="729" alt="Screenshot 2024-04-23 at 15 46 52" src="https://github.com/Alfresco/alfresco-ng2-components/assets/50139916/1d6ab08b-316f-40fc-b360-613e2b4a1cf0">
<img width="704" alt="Screenshot 2024-04-23 at 15 46 59" src="https://github.com/Alfresco/alfresco-ng2-components/assets/50139916/24d42a0d-f0da-40d4-868b-99f527e3ff7d">



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
