### PR TITLE
ESLint: cleanup `await expect` from protractor tests

### DIFF
--- a/e2e-playwright/process-services-cloud/specs/people-cloud.e2e.ts
+++ b/e2e-playwright/process-services-cloud/specs/people-cloud.e2e.ts
@@ -27,9 +27,9 @@ test.describe('People component stories tests', () => {
             Kielbasa Sausage  cancel
         `;
 
-        await processServicesCloud.navigateTo({moduleNames:['people-cloud'], componentName: 'people-cloud', story: 'valid-preselected-users' });
+        await processServicesCloud.navigateTo({ moduleNames: ['people-cloud'], componentName: 'people-cloud', story: 'valid-preselected-users' });
 
-        await expect(peopleComponent.usersNaming).toContainText(expectedUsersName);
+        expect(peopleComponent.usersNaming).toContainText(expectedUsersName);
     });
 
     test('Mandatory Preselected Users', async ({ processServicesCloud, peopleComponent }) => {
@@ -38,20 +38,20 @@ test.describe('People component stories tests', () => {
             Shepherds Pie  cancel
         `;
 
-        await processServicesCloud.navigateTo({moduleNames:['people-cloud'], componentName: 'people-cloud', story: 'mandatory-preselected-users' });
+        await processServicesCloud.navigateTo({ moduleNames: ['people-cloud'], componentName: 'people-cloud', story: 'mandatory-preselected-users' });
         await peopleComponent.getUserLocator('Kielbasa Sausage').hover();
 
-        await expect.soft(peopleComponent.usersNaming).toContainText(expectedUsersName);
-        await expect(peopleComponent.tooltip.content).toContainText('Mandatory');
+        expect.soft(peopleComponent.usersNaming).toContainText(expectedUsersName);
+        expect(peopleComponent.tooltip.content).toContainText('Mandatory');
     });
 
     test('Invalid Preselected Users', async ({ processServicesCloud, peopleComponent }) => {
         const expectedWarningMessage = 'No user found with the username Invalid User';
         const expectedWarningIcon = 'error_outline';
 
-        await processServicesCloud.navigateTo({moduleNames:['people-cloud'], componentName: 'people-cloud', story: 'invalid-preselected-users' });
+        await processServicesCloud.navigateTo({ moduleNames: ['people-cloud'], componentName: 'people-cloud', story: 'invalid-preselected-users' });
 
-        await expect(peopleComponent.error.content).toContainText(expectedWarningIcon + expectedWarningMessage);
+        expect(peopleComponent.error.content).toContainText(expectedWarningIcon + expectedWarningMessage);
     });
 
     test('Excluded Users', async ({ processServicesCloud, peopleComponent }) => {
@@ -60,18 +60,18 @@ test.describe('People component stories tests', () => {
             yorkshire
         `;
 
-        await processServicesCloud.navigateTo({moduleNames:['people-cloud'], componentName: 'people-cloud', story: 'excluded-users' });
+        await processServicesCloud.navigateTo({ moduleNames: ['people-cloud'], componentName: 'people-cloud', story: 'excluded-users' });
         await peopleComponent.usersInput.type('user');
 
-        await expect(peopleComponent.listbox.allOptions).not.toContainText(expectedExcludedUsers);
+        expect(peopleComponent.listbox.allOptions).not.toContainText(expectedExcludedUsers);
     });
 
     test('No Users', async ({ processServicesCloud, peopleComponent }) => {
         const expectedInformation = 'No user found with the username user';
 
-        await processServicesCloud.navigateTo({moduleNames:['people-cloud'], componentName: 'people-cloud', story: 'no-users' });
+        await processServicesCloud.navigateTo({ moduleNames: ['people-cloud'], componentName: 'people-cloud', story: 'no-users' });
         await peopleComponent.usersInput.type('user');
 
-        await expect(peopleComponent.listbox.oneOption).toContainText(expectedInformation);
+        expect(peopleComponent.listbox.oneOption).toContainText(expectedInformation);
     });
 });

--- a/e2e/content-services/components/comment-component.e2e.ts
+++ b/e2e/content-services/components/comment-component.e2e.ts
@@ -15,14 +15,7 @@
  * limitations under the License.
  */
 
-import { createApiService,
-    LoginPage,
-    StringUtil,
-    UploadActions,
-    UserModel,
-    UsersActions,
-    ViewerPage
-} from '@alfresco/adf-testing';
+import { createApiService, LoginPage, StringUtil, UploadActions, UserModel, UsersActions, ViewerPage } from '@alfresco/adf-testing';
 import { ContentServicesPage } from '../../core/pages/content-services.page';
 import { CommentsPage } from '../../core/pages/comments.page';
 import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
@@ -66,7 +59,6 @@ describe('Comment', () => {
     });
 
     describe('component', () => {
-
         beforeEach(async () => {
             await apiService.login(acsUser.username, acsUser.password);
 
@@ -100,9 +92,9 @@ describe('Comment', () => {
             await commentsPage.checkCommentInputIsDisplayed();
 
             await commentsPage.getTotalNumberOfComments('Comments (1)');
-            await expect(await commentsPage.getMessage(0)).toEqual(comments.test);
-            await expect(await commentsPage.getUserName(0)).toEqual(userFullName);
-            await expect(await commentsPage.getTime(0)).toMatch(/(ago|few)/);
+            expect(await commentsPage.getMessage(0)).toEqual(comments.test);
+            expect(await commentsPage.getUserName(0)).toEqual(userFullName);
+            expect(await commentsPage.getTime(0)).toMatch(/(ago|few)/);
         });
 
         it('[C276948] Should be able to add a comment on a file', async () => {
@@ -116,9 +108,9 @@ describe('Comment', () => {
             await commentsPage.checkUserIconIsDisplayed();
 
             await commentsPage.getTotalNumberOfComments('Comments (1)');
-            await expect(await commentsPage.getMessage(0)).toEqual(comments.first);
-            await expect(await commentsPage.getUserName(0)).toEqual(userFullName);
-            await expect(await commentsPage.getTime(0)).toMatch(/(ago|few)/);
+            expect(await commentsPage.getMessage(0)).toEqual(comments.first);
+            expect(await commentsPage.getUserName(0)).toEqual(userFullName);
+            expect(await commentsPage.getTime(0)).toMatch(/(ago|few)/);
         });
 
         it('[C280021] Should be able to add a multiline comment on a file', async () => {
@@ -132,17 +124,17 @@ describe('Comment', () => {
             await commentsPage.checkUserIconIsDisplayed();
 
             await commentsPage.getTotalNumberOfComments('Comments (1)');
-            await expect(await commentsPage.getMessage(0)).toEqual(comments.multiline);
-            await expect(await commentsPage.getUserName(0)).toEqual(userFullName);
-            await expect(await commentsPage.getTime(0)).toMatch(/(ago|few)/);
+            expect(await commentsPage.getMessage(0)).toEqual(comments.multiline);
+            expect(await commentsPage.getUserName(0)).toEqual(userFullName);
+            expect(await commentsPage.getTime(0)).toMatch(/(ago|few)/);
 
             await commentsPage.addComment(comments.second);
             await commentsPage.checkUserIconIsDisplayed();
 
             await commentsPage.getTotalNumberOfComments('Comments (2)');
-            await expect(await commentsPage.getMessage(0)).toEqual(comments.second);
-            await expect(await commentsPage.getUserName(0)).toEqual(userFullName);
-            await expect(await commentsPage.getTime(0)).toMatch(/(ago|few)/);
+            expect(await commentsPage.getMessage(0)).toEqual(comments.second);
+            expect(await commentsPage.getUserName(0)).toEqual(userFullName);
+            expect(await commentsPage.getTime(0)).toMatch(/(ago|few)/);
         });
     });
 

--- a/e2e/content-services/components/viewer-content-services-component.e2e.ts
+++ b/e2e/content-services/components/viewer-content-services-component.e2e.ts
@@ -169,16 +169,16 @@ describe('Content Services Viewer', () => {
             const initialHeight = await viewerPage.getCanvasHeight();
 
             await viewerPage.clickZoomInButton();
-            await expect(+(await viewerPage.getCanvasWidth())).toBeGreaterThan(+initialWidth);
-            await expect(+(await viewerPage.getCanvasHeight())).toBeGreaterThan(+initialHeight);
+            expect(+(await viewerPage.getCanvasWidth())).toBeGreaterThan(+initialWidth);
+            expect(+(await viewerPage.getCanvasHeight())).toBeGreaterThan(+initialHeight);
 
             await viewerPage.clickActualSize();
-            await expect(+(await viewerPage.getCanvasWidth())).toEqual(+initialWidth);
-            await expect(+(await viewerPage.getCanvasHeight())).toEqual(+initialHeight);
+            expect(+(await viewerPage.getCanvasWidth())).toEqual(+initialWidth);
+            expect(+(await viewerPage.getCanvasHeight())).toEqual(+initialHeight);
 
             await viewerPage.clickZoomOutButton();
-            await expect(+(await viewerPage.getCanvasWidth())).toBeLessThan(+initialWidth);
-            await expect(+(await viewerPage.getCanvasHeight())).toBeLessThan(+initialHeight);
+            expect(+(await viewerPage.getCanvasWidth())).toBeLessThan(+initialWidth);
+            expect(+(await viewerPage.getCanvasHeight())).toBeLessThan(+initialHeight);
 
             await viewerPage.clickCloseButton();
         });
@@ -298,7 +298,7 @@ describe('Content Services Viewer', () => {
 
             await viewerPage.checkZoomInButtonIsNotDisplayed();
             await viewerPage.checkUnknownFormatIsDisplayed();
-            await expect(await viewerPage.getUnknownFormatMessage()).toBe("Couldn't load preview. Unknown format.");
+            expect(await viewerPage.getUnknownFormatMessage()).toBe(`Couldn't load preview. Unknown format.`);
 
             await viewerPage.clickCloseButton();
         });
@@ -397,6 +397,12 @@ describe('Content Services Viewer', () => {
         });
     });
 
+    /**
+     * Upload a new version of a file
+     *
+     * @param originalFileName The name of the original file
+     * @param newVersionLocation The location of the new version
+     */
     async function uploadNewVersion(originalFileName: string, newVersionLocation: string): Promise<void> {
         await contentServicesPage.doubleClickRow(originalFileName);
         await viewerPage.waitTillContentLoaded();
@@ -410,14 +416,25 @@ describe('Content Services Viewer', () => {
         await browser.refresh();
     }
 
+    /**
+     * Preview an unsupported file
+     *
+     * @param unsupportedFileName The name of the unsupported file
+     */
     async function previewUnsupportedFile(unsupportedFileName: string): Promise<void> {
         await contentServicesPage.doubleClickRow(unsupportedFileName);
         await viewerPage.waitTillContentLoaded();
         await viewerPage.checkUnknownFormatIsDisplayed();
-        await expect(await viewerPage.getUnknownFormatMessage()).toBe("Couldn't load preview. Unknown format.");
+        expect(await viewerPage.getUnknownFormatMessage()).toBe(`Couldn't load preview. Unknown format.`);
         await viewerPage.clickCloseButton();
     }
 
+    /**
+     * Change the name of the file in the viewer
+     *
+     * @param fileName The name of the file to be changed
+     * @param newName The new name of the file
+     */
     async function changeFileNameInViewer(fileName: string, newName: string): Promise<void> {
         await contentServicesPage.doubleClickRow(fileName);
         await viewerPage.waitTillContentLoaded();

--- a/e2e/content-services/document-list/document-list-component.e2e.ts
+++ b/e2e/content-services/document-list/document-list-component.e2e.ts
@@ -114,12 +114,12 @@ describe('Document List Component', () => {
             await navigationBarPage.clickLogoutButton();
         });
 
-        it("[C279926] Should only display the user's files and folders", async () => {
+        it('[C279926] Should only display the user files and folders', async () => {
             await contentServicesPage.goToDocumentList();
             await contentServicesPage.checkContentIsDisplayed(folderName);
             await contentServicesPage.checkContentIsDisplayed(pdfFileModel.name);
             await contentServicesPage.checkContentIsDisplayed(docxFileModel.name);
-            await expect(await contentServicesPage.getDocumentListRowNumber()).toBe(4);
+            expect(await contentServicesPage.getDocumentListRowNumber()).toBe(4);
         });
 
         it('[C279927] Should display default columns', async () => {
@@ -182,27 +182,27 @@ describe('Document List Component', () => {
         });
 
         it('[C260112] Should be able to sort by name (Ascending)', async () => {
-            await expect(await contentServicesPage.sortAndCheckListIsOrderedByName('asc')).toBe(true, 'List is not sorted.');
+            expect(await contentServicesPage.sortAndCheckListIsOrderedByName('asc')).toBe(true);
         });
 
         it('[C272770] Should be able to sort by name (Descending)', async () => {
-            await expect(await contentServicesPage.sortAndCheckListIsOrderedByName('desc')).toBe(true, 'List is not sorted.');
+            expect(await contentServicesPage.sortAndCheckListIsOrderedByName('desc')).toBe(true);
         });
 
         it('[C272771] Should be able to sort by author (Ascending)', async () => {
-            await expect(await contentServicesPage.sortAndCheckListIsOrderedByAuthor('asc')).toBe(true, 'List is not sorted.');
+            expect(await contentServicesPage.sortAndCheckListIsOrderedByAuthor('asc')).toBe(true);
         });
 
         it('[C272772] Should be able to sort by author (Descending)', async () => {
-            await expect(await contentServicesPage.sortAndCheckListIsOrderedByAuthor('desc')).toBe(true, 'List is not sorted.');
+            expect(await contentServicesPage.sortAndCheckListIsOrderedByAuthor('desc')).toBe(true);
         });
 
         it('[C272773] Should be able to sort by date (Ascending)', async () => {
-            await expect(await contentServicesPage.sortAndCheckListIsOrderedByCreated('asc')).toBe(true, 'List is not sorted.');
+            expect(await contentServicesPage.sortAndCheckListIsOrderedByCreated('asc')).toBe(true);
         });
 
         it('[C272774] Should be able to sort by date (Descending)', async () => {
-            await expect(await contentServicesPage.sortAndCheckListIsOrderedByCreated('desc')).toBe(true, 'List is not sorted.');
+            expect(await contentServicesPage.sortAndCheckListIsOrderedByCreated('desc')).toBe(true);
         });
     });
 

--- a/e2e/content-services/document-list/document-list-pagination.e2e.ts
+++ b/e2e/content-services/document-list/document-list-pagination.e2e.ts
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 
-import { createApiService,
+import {
+    createApiService,
     ArrayUtil,
     FileBrowserUtil,
     LocalStorageUtil,
@@ -95,11 +96,11 @@ describe('Document List - Pagination', () => {
 
     it('[C260062] Should use default pagination settings', async () => {
         await contentServicesPage.openFolder(newFolderModel.name);
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual('20');
-        await expect(await paginationPage.getPaginationRange()).toEqual(`Showing 1-${nrOfFiles} of ${nrOfFiles}`);
-        await expect(await contentServicesPage.numberOfResultsDisplayed()).toBe(nrOfFiles);
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual('20');
+        expect(await paginationPage.getPaginationRange()).toEqual(`Showing 1-${nrOfFiles} of ${nrOfFiles}`);
+        expect(await contentServicesPage.numberOfResultsDisplayed()).toBe(nrOfFiles);
         const list = await contentServicesPage.getAllRowsNameColumn();
-        await expect(ArrayUtil.arrayContainsArray(list, fileNames)).toEqual(true);
+        expect(ArrayUtil.arrayContainsArray(list, fileNames)).toEqual(true);
         await paginationPage.checkNextPageButtonIsDisabled();
         await paginationPage.checkPreviousPageButtonIsDisabled();
     });
@@ -109,11 +110,11 @@ describe('Document List - Pagination', () => {
         await paginationPage.selectItemsPerPage('20');
         await contentServicesPage.contentList.dataTablePage().waitTillContentLoaded();
 
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual('20');
-        await expect(await paginationPage.getPaginationRange()).toEqual(`Showing 1-${nrOfFiles} of ${nrOfFiles}`);
-        await expect(await contentServicesPage.numberOfResultsDisplayed()).toBe(nrOfFiles);
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual('20');
+        expect(await paginationPage.getPaginationRange()).toEqual(`Showing 1-${nrOfFiles} of ${nrOfFiles}`);
+        expect(await contentServicesPage.numberOfResultsDisplayed()).toBe(nrOfFiles);
         const list = await contentServicesPage.getAllRowsNameColumn();
-        await expect(ArrayUtil.arrayContainsArray(list, fileNames)).toEqual(true);
+        expect(ArrayUtil.arrayContainsArray(list, fileNames)).toEqual(true);
         await paginationPage.checkNextPageButtonIsDisabled();
         await paginationPage.checkPreviousPageButtonIsDisabled();
 
@@ -121,7 +122,7 @@ describe('Document List - Pagination', () => {
         await loginPage.login(acsUser.username, acsUser.password);
 
         await contentServicesPage.goToDocumentList();
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual('20');
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual('20');
 
         await navigationBarPage.clickLogoutButton();
         await loginPage.login(acsUser.username, acsUser.password);
@@ -133,45 +134,45 @@ describe('Document List - Pagination', () => {
         await paginationPage.selectItemsPerPage('5');
         await contentServicesPage.contentList.dataTablePage().waitTillContentLoaded();
 
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual('5');
-        await expect(await paginationPage.getPaginationRange()).toEqual(`Showing 1-${5 * currentPage} of ${nrOfFiles}`);
-        await expect(await contentServicesPage.numberOfResultsDisplayed()).toBe(5);
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual('5');
+        expect(await paginationPage.getPaginationRange()).toEqual(`Showing 1-${5 * currentPage} of ${nrOfFiles}`);
+        expect(await contentServicesPage.numberOfResultsDisplayed()).toBe(5);
         let list = await contentServicesPage.getAllRowsNameColumn();
-        await expect(ArrayUtil.arrayContainsArray(list, fileNames.slice(0, 5))).toEqual(true);
+        expect(ArrayUtil.arrayContainsArray(list, fileNames.slice(0, 5))).toEqual(true);
 
         await paginationPage.clickOnNextPage();
         currentPage++;
         await contentServicesPage.contentList.dataTablePage().waitTillContentLoaded();
 
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual('5');
-        await expect(await paginationPage.getPaginationRange()).toEqual(`Showing 6-${5 * currentPage} of ${nrOfFiles}`);
-        await expect(await contentServicesPage.numberOfResultsDisplayed()).toBe(5);
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual('5');
+        expect(await paginationPage.getPaginationRange()).toEqual(`Showing 6-${5 * currentPage} of ${nrOfFiles}`);
+        expect(await contentServicesPage.numberOfResultsDisplayed()).toBe(5);
         list = await contentServicesPage.getAllRowsNameColumn();
-        await expect(ArrayUtil.arrayContainsArray(list, fileNames.slice(5, 10))).toEqual(true);
+        expect(ArrayUtil.arrayContainsArray(list, fileNames.slice(5, 10))).toEqual(true);
 
         await paginationPage.clickOnNextPage();
         currentPage++;
         await contentServicesPage.contentList.dataTablePage().waitTillContentLoaded();
 
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual('5');
-        await expect(await paginationPage.getPaginationRange()).toEqual(`Showing 11-${5 * currentPage} of ${nrOfFiles}`);
-        await expect(await contentServicesPage.numberOfResultsDisplayed()).toBe(5);
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual('5');
+        expect(await paginationPage.getPaginationRange()).toEqual(`Showing 11-${5 * currentPage} of ${nrOfFiles}`);
+        expect(await contentServicesPage.numberOfResultsDisplayed()).toBe(5);
         list = await contentServicesPage.getAllRowsNameColumn();
-        await expect(ArrayUtil.arrayContainsArray(list, fileNames.slice(10, 15))).toEqual(true);
+        expect(ArrayUtil.arrayContainsArray(list, fileNames.slice(10, 15))).toEqual(true);
 
         await paginationPage.clickOnNextPage();
         currentPage++;
         await contentServicesPage.contentList.dataTablePage().waitTillContentLoaded();
 
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual('5');
-        await expect(await paginationPage.getPaginationRange()).toEqual(`Showing 16-${5 * currentPage} of ${nrOfFiles}`);
-        await expect(await contentServicesPage.numberOfResultsDisplayed()).toBe(5);
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual('5');
+        expect(await paginationPage.getPaginationRange()).toEqual(`Showing 16-${5 * currentPage} of ${nrOfFiles}`);
+        expect(await contentServicesPage.numberOfResultsDisplayed()).toBe(5);
         list = await contentServicesPage.getAllRowsNameColumn();
-        await expect(ArrayUtil.arrayContainsArray(list, fileNames.slice(15, 20))).toEqual(true);
+        expect(ArrayUtil.arrayContainsArray(list, fileNames.slice(15, 20))).toEqual(true);
 
         await browser.refresh();
         await contentServicesPage.contentList.dataTablePage().waitTillContentLoaded();
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual('5');
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual('5');
         await navigationBarPage.clickLogoutButton();
         await loginPage.login(acsUser.username, acsUser.password);
     });
@@ -182,24 +183,24 @@ describe('Document List - Pagination', () => {
         await paginationPage.selectItemsPerPage('10');
         await contentServicesPage.contentList.dataTablePage().waitTillContentLoaded();
 
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual('10');
-        await expect(await paginationPage.getPaginationRange()).toEqual(`Showing 1-${10 * currentPage} of ${nrOfFiles}`);
-        await expect(await contentServicesPage.numberOfResultsDisplayed()).toBe(10);
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual('10');
+        expect(await paginationPage.getPaginationRange()).toEqual(`Showing 1-${10 * currentPage} of ${nrOfFiles}`);
+        expect(await contentServicesPage.numberOfResultsDisplayed()).toBe(10);
         let list = await contentServicesPage.getAllRowsNameColumn();
-        await expect(ArrayUtil.arrayContainsArray(list, fileNames.slice(0, 10))).toEqual(true);
+        expect(ArrayUtil.arrayContainsArray(list, fileNames.slice(0, 10))).toEqual(true);
         await paginationPage.clickOnNextPage();
         currentPage++;
         await contentServicesPage.contentList.dataTablePage().waitTillContentLoaded();
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual('10');
-        await expect(await paginationPage.getPaginationRange()).toEqual(`Showing 11-${10 * currentPage} of ${nrOfFiles}`);
-        await expect(await contentServicesPage.numberOfResultsDisplayed()).toBe(10);
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual('10');
+        expect(await paginationPage.getPaginationRange()).toEqual(`Showing 11-${10 * currentPage} of ${nrOfFiles}`);
+        expect(await contentServicesPage.numberOfResultsDisplayed()).toBe(10);
         list = await contentServicesPage.getAllRowsNameColumn();
-        await expect(ArrayUtil.arrayContainsArray(list, fileNames.slice(10, 20))).toEqual(true);
+        expect(ArrayUtil.arrayContainsArray(list, fileNames.slice(10, 20))).toEqual(true);
 
         await browser.refresh();
         await contentServicesPage.contentList.dataTablePage().waitTillContentLoaded();
 
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual('10');
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual('10');
         await navigationBarPage.clickLogoutButton();
         await loginPage.login(acsUser.username, acsUser.password);
         currentPage = 1;
@@ -211,25 +212,25 @@ describe('Document List - Pagination', () => {
         await paginationPage.selectItemsPerPage('15');
         await contentServicesPage.contentList.dataTablePage().waitTillContentLoaded();
 
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual('15');
-        await expect(await paginationPage.getPaginationRange()).toEqual(`Showing 1-${15 * currentPage} of ${nrOfFiles}`);
-        await expect(await contentServicesPage.numberOfResultsDisplayed()).toBe(15);
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual('15');
+        expect(await paginationPage.getPaginationRange()).toEqual(`Showing 1-${15 * currentPage} of ${nrOfFiles}`);
+        expect(await contentServicesPage.numberOfResultsDisplayed()).toBe(15);
         let list = await contentServicesPage.getAllRowsNameColumn();
-        await expect(ArrayUtil.arrayContainsArray(list, fileNames.slice(0, 15))).toEqual(true);
+        expect(ArrayUtil.arrayContainsArray(list, fileNames.slice(0, 15))).toEqual(true);
         currentPage++;
         await paginationPage.clickOnNextPage();
         await contentServicesPage.contentList.dataTablePage().waitTillContentLoaded();
 
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual('15');
-        await expect(await paginationPage.getPaginationRange()).toEqual(`Showing 16-${nrOfFiles} of ${nrOfFiles}`);
-        await expect(await contentServicesPage.numberOfResultsDisplayed()).toBe(nrOfFiles - 15);
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual('15');
+        expect(await paginationPage.getPaginationRange()).toEqual(`Showing 16-${nrOfFiles} of ${nrOfFiles}`);
+        expect(await contentServicesPage.numberOfResultsDisplayed()).toBe(nrOfFiles - 15);
         list = await contentServicesPage.getAllRowsNameColumn();
-        await expect(ArrayUtil.arrayContainsArray(list, fileNames.slice(15, 20))).toEqual(true);
+        expect(ArrayUtil.arrayContainsArray(list, fileNames.slice(15, 20))).toEqual(true);
 
         await browser.refresh();
         await contentServicesPage.contentList.dataTablePage().waitTillContentLoaded();
 
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual('15');
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual('15');
     });
 
     it('[C91320] Pagination should preserve sorting', async () => {
@@ -238,35 +239,35 @@ describe('Document List - Pagination', () => {
         await paginationPage.selectItemsPerPage('20');
         await contentServicesPage.contentList.dataTablePage().waitTillContentLoaded();
 
-        await expect(await contentServicesPage.getDocumentList().dataTablePage().checkListIsSorted('ASC', 'Display name'));
+        expect(await contentServicesPage.getDocumentList().dataTablePage().checkListIsSorted('ASC', 'Display name'));
 
         await contentServicesPage.sortByName('DESC');
-        await expect(await contentServicesPage.getDocumentList().dataTablePage().checkListIsSorted('DESC', 'Display name'));
+        expect(await contentServicesPage.getDocumentList().dataTablePage().checkListIsSorted('DESC', 'Display name'));
 
         await paginationPage.selectItemsPerPage('5');
         await contentServicesPage.contentList.dataTablePage().waitTillContentLoaded();
 
-        await expect(await contentServicesPage.getDocumentList().dataTablePage().checkListIsSorted('DESC', 'Display name'));
+        expect(await contentServicesPage.getDocumentList().dataTablePage().checkListIsSorted('DESC', 'Display name'));
 
         await paginationPage.clickOnNextPage();
         await contentServicesPage.contentList.dataTablePage().waitTillContentLoaded();
 
-        await expect(await contentServicesPage.getDocumentList().dataTablePage().checkListIsSorted('DESC', 'Display name'));
+        expect(await contentServicesPage.getDocumentList().dataTablePage().checkListIsSorted('DESC', 'Display name'));
 
         await paginationPage.selectItemsPerPage('10');
         await contentServicesPage.contentList.dataTablePage().waitTillContentLoaded();
 
-        await expect(await contentServicesPage.getDocumentList().dataTablePage().checkListIsSorted('DESC', 'Display name'));
+        expect(await contentServicesPage.getDocumentList().dataTablePage().checkListIsSorted('DESC', 'Display name'));
     });
 
     it('[C260107] Should not display pagination bar when a folder is empty', async () => {
         await paginationPage.selectItemsPerPage('5');
         await contentServicesPage.contentList.dataTablePage().waitTillContentLoaded();
 
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual('5');
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual('5');
         await contentServicesPage.openFolder(newFolderModel.name);
 
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual('5');
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual('5');
 
         await contentServicesPage.createAndOpenNewFolder(folderTwoModel.name);
         await contentServicesPage.checkPaginationIsNotDisplayed();
@@ -279,45 +280,45 @@ describe('Document List - Pagination', () => {
         await paginationPage.selectItemsPerPage('15');
         await contentServicesPage.contentList.dataTablePage().waitTillContentLoaded();
 
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual('15');
-        await expect(await paginationPage.getPaginationRange()).toEqual(`Showing 1-${15 * currentPage} of ${secondSetNumber}`);
-        await expect(await contentServicesPage.numberOfResultsDisplayed()).toBe(15);
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual('15');
+        expect(await paginationPage.getPaginationRange()).toEqual(`Showing 1-${15 * currentPage} of ${secondSetNumber}`);
+        expect(await contentServicesPage.numberOfResultsDisplayed()).toBe(15);
         let list = await contentServicesPage.getAllRowsNameColumn();
-        await expect(ArrayUtil.arrayContainsArray(list, secondSetOfFiles.slice(0, 15))).toEqual(true);
+        expect(ArrayUtil.arrayContainsArray(list, secondSetOfFiles.slice(0, 15))).toEqual(true);
 
         currentPage++;
         await paginationPage.clickOnNextPage();
         await contentServicesPage.contentList.dataTablePage().waitTillContentLoaded();
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual('15');
-        await expect(await paginationPage.getPaginationRange()).toEqual(`Showing 16-${secondSetNumber} of ${secondSetNumber}`);
-        await expect(await contentServicesPage.numberOfResultsDisplayed()).toBe(secondSetNumber - 15);
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual('15');
+        expect(await paginationPage.getPaginationRange()).toEqual(`Showing 16-${secondSetNumber} of ${secondSetNumber}`);
+        expect(await contentServicesPage.numberOfResultsDisplayed()).toBe(secondSetNumber - 15);
         list = await contentServicesPage.getAllRowsNameColumn();
-        await expect(ArrayUtil.arrayContainsArray(list, secondSetOfFiles.slice(15, 25))).toEqual(true);
+        expect(ArrayUtil.arrayContainsArray(list, secondSetOfFiles.slice(15, 25))).toEqual(true);
 
         currentPage = 1;
         await paginationPage.selectItemsPerPage('20');
         await contentServicesPage.contentList.dataTablePage().waitTillContentLoaded();
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual('20');
-        await expect(await paginationPage.getPaginationRange()).toEqual(`Showing 1-${20 * currentPage} of ${secondSetNumber}`);
-        await expect(await contentServicesPage.numberOfResultsDisplayed()).toBe(20);
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual('20');
+        expect(await paginationPage.getPaginationRange()).toEqual(`Showing 1-${20 * currentPage} of ${secondSetNumber}`);
+        expect(await contentServicesPage.numberOfResultsDisplayed()).toBe(20);
         list = await contentServicesPage.getAllRowsNameColumn();
-        await expect(ArrayUtil.arrayContainsArray(list, secondSetOfFiles.slice(0, 20))).toEqual(true);
+        expect(ArrayUtil.arrayContainsArray(list, secondSetOfFiles.slice(0, 20))).toEqual(true);
 
         currentPage++;
         await paginationPage.clickOnNextPage();
         await contentServicesPage.contentList.dataTablePage().waitTillContentLoaded();
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual('20');
-        await expect(await paginationPage.getPaginationRange()).toEqual(`Showing 21-${secondSetNumber} of ${secondSetNumber}`);
-        await expect(await contentServicesPage.numberOfResultsDisplayed()).toBe(secondSetNumber - 20);
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual('20');
+        expect(await paginationPage.getPaginationRange()).toEqual(`Showing 21-${secondSetNumber} of ${secondSetNumber}`);
+        expect(await contentServicesPage.numberOfResultsDisplayed()).toBe(secondSetNumber - 20);
         list = await contentServicesPage.getAllRowsNameColumn();
-        await expect(ArrayUtil.arrayContainsArray(list, secondSetOfFiles.slice(20, 25))).toEqual(true);
+        expect(ArrayUtil.arrayContainsArray(list, secondSetOfFiles.slice(20, 25))).toEqual(true);
     });
 
     it('[C216321] Should be able to modify the supported page size value', async () => {
         await paginationPage.clickItemsPerPageDropdown();
         await contentServicesPage.contentList.dataTablePage().waitTillContentLoaded();
 
-        await expect(await paginationPage.getItemsPerPageDropdownOptions()).toEqual(['5', '10', '15', '20']);
+        expect(await paginationPage.getItemsPerPageDropdownOptions()).toEqual(['5', '10', '15', '20']);
 
         await LocalStorageUtil.setUserPreference('supportedPageSizes', JSON.stringify([5, 10, 15, 21]));
         await contentServicesPage.goToDocumentList();
@@ -333,7 +334,7 @@ describe('Document List - Pagination', () => {
         await paginationPage.clickItemsPerPageDropdown();
         await contentServicesPage.contentList.dataTablePage().waitTillContentLoaded();
 
-        await expect(await paginationPage.getItemsPerPageDropdownOptions()).toEqual(['5', '10', '15', '21']);
+        expect(await paginationPage.getItemsPerPageDropdownOptions()).toEqual(['5', '10', '15', '21']);
 
         await paginationPage.clickItemsPerPageDropdown();
         await contentServicesPage.contentList.dataTablePage().waitTillContentLoaded();
@@ -341,12 +342,12 @@ describe('Document List - Pagination', () => {
         await paginationPage.selectItemsPerPage('21');
         await contentServicesPage.contentList.dataTablePage().waitTillContentLoaded();
 
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual('21');
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual('21');
         await browser.refresh();
 
         await contentServicesPage.contentList.dataTablePage().waitTillContentLoaded();
-        await expect(await paginationPage.getPaginationRange()).toEqual(`Showing 1-21 of ${numberOfFilesAfterUpload}`);
-        await expect(await contentServicesPage.numberOfResultsDisplayed()).toBe(21);
+        expect(await paginationPage.getPaginationRange()).toEqual(`Showing 1-21 of ${numberOfFilesAfterUpload}`);
+        expect(await contentServicesPage.numberOfResultsDisplayed()).toBe(21);
 
         await LocalStorageUtil.setUserPreference('supportedPageSizes', JSON.stringify([5, 10, 15, 20]));
         await browser.refresh();
@@ -355,7 +356,7 @@ describe('Document List - Pagination', () => {
         await paginationPage.clickItemsPerPageDropdown();
         await contentServicesPage.contentList.dataTablePage().waitTillContentLoaded();
 
-        await expect(await paginationPage.getItemsPerPageDropdownOptions()).toEqual(['5', '10', '15', '20']);
+        expect(await paginationPage.getItemsPerPageDropdownOptions()).toEqual(['5', '10', '15', '20']);
     });
 
     it('[C272767] Should propagate the option chosen regarding displaying items per page to files/folders inside a folder', async () => {
@@ -363,22 +364,24 @@ describe('Document List - Pagination', () => {
         await contentServicesPage.contentList.dataTablePage().waitTillContentLoaded();
 
         await contentServicesPage.openFolder(newFolderModel.name);
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual('5');
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual('5');
 
         await apiService.login(acsUser.username, acsUser.password);
         await contentServicesPage.createNewFolder(folderTwoModel.name);
         const nodeIdSubFolderTwo = await contentServicesPage.getAttributeValueForElement(folderTwoModel.name, 'Node id');
         await contentServicesPage.openFolder(folderTwoModel.name);
+
         for (let i = 0; i < numberOfSubFolders; i++) {
             await uploadActions.createFolder('subfolder' + (i + 1), nodeIdSubFolderTwo);
         }
+
         await browser.refresh();
         await contentServicesPage.contentList.dataTablePage().waitTillContentLoaded();
 
-        await expect(await paginationPage.getPaginationRange()).toEqual(`Showing 1-5 of ${numberOfSubFolders}`);
+        expect(await paginationPage.getPaginationRange()).toEqual(`Showing 1-5 of ${numberOfSubFolders}`);
 
         await paginationPage.clickOnNextPage();
-        await expect(await paginationPage.getPaginationRange()).toEqual(`Showing 6-${numberOfSubFolders} of ${numberOfSubFolders}`);
+        expect(await paginationPage.getPaginationRange()).toEqual(`Showing 6-${numberOfSubFolders} of ${numberOfSubFolders}`);
         const nodeIdSubFolder6 = await contentServicesPage.getAttributeValueForElement('subfolder6', 'Node id');
 
         for (let i = 0; i < numberOfSubFolders; i++) {
@@ -387,9 +390,9 @@ describe('Document List - Pagination', () => {
         await browser.refresh();
         await contentServicesPage.contentList.dataTablePage().waitTillContentLoaded();
 
-        await expect(await paginationPage.getPaginationRange()).toEqual(`Showing 1-5 of ${numberOfSubFolders}`);
-        await expect(await paginationPage.getCurrentPage()).toEqual('Page 1');
-        await expect(await paginationPage.getTotalPages()).toEqual('of 2');
+        expect(await paginationPage.getPaginationRange()).toEqual(`Showing 1-5 of ${numberOfSubFolders}`);
+        expect(await paginationPage.getCurrentPage()).toEqual('Page 1');
+        expect(await paginationPage.getTotalPages()).toEqual('of 2');
 
         await contentServicesPage.deleteSubFolderUnderRoot(newFolderModel.name, folderTwoModel.name);
     });
@@ -399,13 +402,14 @@ describe('Document List - Pagination', () => {
         await contentServicesPage.contentList.dataTablePage().waitTillContentLoaded();
 
         await contentServicesPage.openFolder(newFolderModel.name);
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual('5');
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual('5');
 
         await contentServicesPage.createNewFolder(folderTwoModel.name);
         const nodeIdSubFolderTwo = await contentServicesPage.getAttributeValueForElement(folderTwoModel.name, 'Node id');
         await contentServicesPage.openFolder(folderTwoModel.name);
 
         await apiService.login(acsUser.username, acsUser.password);
+
         for (let i = 0; i < numberOfSubFolders; i++) {
             await uploadActions.createFolder('subfolder' + (i + 1), nodeIdSubFolderTwo);
         }
@@ -413,13 +417,13 @@ describe('Document List - Pagination', () => {
         await browser.refresh();
         await contentServicesPage.contentList.dataTablePage().waitTillContentLoaded();
 
-        await expect(await paginationPage.getPaginationRange()).toEqual(`Showing 1-5 of ${numberOfSubFolders}`);
+        expect(await paginationPage.getPaginationRange()).toEqual(`Showing 1-5 of ${numberOfSubFolders}`);
 
         await contentServicesPage.chooseSelectionMode('Single');
 
         await contentServicesPage.selectFolder('subfolder1');
         await paginationPage.clickOnNextPage();
-        await expect(await paginationPage.getPaginationRange()).toEqual(`Showing 6-${numberOfSubFolders} of ${numberOfSubFolders}`);
+        expect(await paginationPage.getPaginationRange()).toEqual(`Showing 6-${numberOfSubFolders} of ${numberOfSubFolders}`);
         await contentServicesPage.selectFolderWithCommandKey('subfolder6');
         await contentServicesPage.clickDownloadButton();
 

--- a/e2e/content-services/metadata/metadata-content-type.e2e.ts
+++ b/e2e/content-services/metadata/metadata-content-type.e2e.ts
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 
-import { createApiService,
+import {
+    createApiService,
     BrowserActions,
     LoginPage,
     ModelActions,
@@ -46,7 +47,7 @@ describe('content type', () => {
     const loginPage = new LoginPage();
     const randomString = StringUtil.generateRandomString();
 
-    const model: CustomModel =  {
+    const model: CustomModel = {
         name: `test-${randomString}`,
         namespaceUri: `http://www.customModel.com/model/${randomString}/1.0`,
         namespacePrefix: `e2e-${randomString}`,
@@ -55,7 +56,12 @@ describe('content type', () => {
         status: 'DRAFT'
     };
     const type: CustomType = { name: `test-type-${randomString}`, parentName: 'cm:content', title: `Test type - ${randomString}` };
-    const property = { name: `test-property-${randomString}`, title: `Test property - ${randomString}`, dataType: 'd:text', defaultValue: randomString };
+    const property = {
+        name: `test-property-${randomString}`,
+        title: `Test property - ${randomString}`,
+        dataType: 'd:text',
+        defaultValue: randomString
+    };
     const pdfFile = new FileModel({ name: browser.params.resources.Files.ADF_DOCUMENTS.PDF.file_name });
     const docxFileModel = new FileModel({
         name: browser.params.resources.Files.ADF_DOCUMENTS.TEST.file_name,
@@ -63,12 +69,12 @@ describe('content type', () => {
     });
     let acsUser: UserModel;
 
-    beforeAll( async () => {
+    beforeAll(async () => {
         try {
             await apiService.loginWithProfile('admin');
             await modelActions.createModel(model);
-            await modelActions.createType(model.name,  type);
-            await modelActions.addPropertyToType(model.name,  type.name, [property]);
+            await modelActions.createType(model.name, type);
+            await modelActions.addPropertyToType(model.name, type.name, [property]);
             await modelActions.activateCustomModel(model.name);
             await modelActions.isCustomTypeSearchable(type.title);
 
@@ -79,7 +85,6 @@ describe('content type', () => {
             pdfFile.id = filePdfNode.entry.id;
             const docsNode = await uploadActions.uploadFile(docxFileModel.location, docxFileModel.name, '-my-');
             docxFileModel.id = docsNode.entry.id;
-
         } catch (e) {
             fail('Failed to setup custom types :: ' + JSON.stringify(e, null, 2));
         }
@@ -98,17 +103,17 @@ describe('content type', () => {
         }
     });
 
-    beforeEach( async () => {
+    beforeEach(async () => {
         await loginPage.login(acsUser.username, acsUser.password);
         await navigationBarPage.navigateToContentServices();
         await contentServicesPage.contentList.dataTablePage().waitTillContentLoaded();
     });
 
-    afterEach( async () => {
+    afterEach(async () => {
         await navigationBarPage.clickLogoutButton();
     });
 
-    it('[C593560] Should the user be able to select a new content type and save it only after the confirmation dialog',  async () => {
+    it('[C593560] Should the user be able to select a new content type and save it only after the confirmation dialog', async () => {
         await BrowserActions.getUrl(browser.baseUrl + `/files(overlay:files/${pdfFile.id}/view)`);
         await viewerPage.checkFileIsLoaded(pdfFile.name);
         await viewerPage.clickInfoButton();
@@ -116,19 +121,20 @@ describe('content type', () => {
         await metadataViewPage.clickOnPropertiesTab();
         await metadataViewPage.isEditGeneralIconDisplayed();
 
-        await expect(await viewerPage.getActiveTab()).toEqual('Properties');
-        const defaultType  = (await metadataViewPage.hasContentType('Content')) || (await metadataViewPage.hasContentType('cm:content'));
-        await expect(defaultType).toBe(true, 'Content type not found');
+        expect(await viewerPage.getActiveTab()).toEqual('Properties');
+        const defaultType = (await metadataViewPage.hasContentType('Content')) || (await metadataViewPage.hasContentType('cm:content'));
+        expect(defaultType).toBe(true);
 
         await metadataViewPage.clickEditIconGeneral();
 
-        await expect(await metadataViewPage.changeContentType(type.title)).toBe(true, 'Failed to update node type.');
+        expect(await metadataViewPage.changeContentType(type.title)).toBe(true, 'Failed to update node type.');
         await metadataViewPage.clickSaveGeneralMetadata();
         await metadataViewPage.checkConfirmDialogDisplayed();
         await metadataViewPage.applyNodeProperties();
 
-        await expect(await metadataViewPage.checkPropertyDisplayed(`properties.${model.namespacePrefix}:${property.name}`))
-            .toContain(property.defaultValue, 'Custom property not found');
+        expect(await metadataViewPage.checkPropertyDisplayed(`properties.${model.namespacePrefix}:${property.name}`)).toContain(
+            property.defaultValue
+        );
 
         await navigationBarPage.clickLogoutButton();
         await loginPage.login(acsUser.username, acsUser.password);
@@ -141,15 +147,16 @@ describe('content type', () => {
         await metadataViewPage.clickOnPropertiesTab();
         await metadataViewPage.isEditGeneralIconDisplayed();
 
-        await expect(await viewerPage.getActiveTab()).toEqual('Properties');
-        const customType  = (await metadataViewPage.hasContentType(type.title)) || (await metadataViewPage.hasContentType(`${model.namespacePrefix}:${type.name}`));
-        await expect(customType).toBe(true, 'Custom type not found');
-        await expect(await metadataViewPage.getPropertyText(`properties.${model.namespacePrefix}:${property.name}`)).toContain(property.defaultValue);
+        expect(await viewerPage.getActiveTab()).toEqual('Properties');
+        const customType =
+            (await metadataViewPage.hasContentType(type.title)) || (await metadataViewPage.hasContentType(`${model.namespacePrefix}:${type.name}`));
+        expect(customType).toBe(true);
+        expect(await metadataViewPage.getPropertyText(`properties.${model.namespacePrefix}:${property.name}`)).toContain(property.defaultValue);
 
         await viewerPage.clickCloseButton();
     });
 
-    it('[C593559] Should the user be able to select a new content type and not save it when press cancel in the confirmation dialog',  async () => {
+    it('[C593559] Should the user be able to select a new content type and not save it when press cancel in the confirmation dialog', async () => {
         await BrowserActions.getUrl(browser.baseUrl + `/files(overlay:files/${docxFileModel.id}/view)`);
         await viewerPage.checkFileIsLoaded(docxFileModel.name);
         await viewerPage.clickInfoButton();
@@ -157,13 +164,13 @@ describe('content type', () => {
         await metadataViewPage.clickOnPropertiesTab();
         await metadataViewPage.isEditGeneralIconDisplayed();
 
-        await expect(await viewerPage.getActiveTab()).toEqual('Properties');
-        let defaultType  = (await metadataViewPage.hasContentType('Content')) || (await metadataViewPage.hasContentType('cm:content'));
-        await expect(defaultType).toBe(true, 'Content type not found');
+        expect(await viewerPage.getActiveTab()).toEqual('Properties');
+        let defaultType = (await metadataViewPage.hasContentType('Content')) || (await metadataViewPage.hasContentType('cm:content'));
+        expect(defaultType).toBe(true);
 
         await metadataViewPage.clickEditIconGeneral();
 
-        await expect(await metadataViewPage.changeContentType(type.title)).toBe(true, 'Failed to update node type.');
+        expect(await metadataViewPage.changeContentType(type.title)).toBe(true);
         await metadataViewPage.clickSaveGeneralMetadata();
 
         await metadataViewPage.checkConfirmDialogDisplayed();
@@ -180,9 +187,9 @@ describe('content type', () => {
         await metadataViewPage.clickOnPropertiesTab();
         await metadataViewPage.isEditGeneralIconDisplayed();
 
-        await expect(await viewerPage.getActiveTab()).toEqual('Properties');
-        defaultType  = (await metadataViewPage.hasContentType('Content')) || (await metadataViewPage.hasContentType('cm:content'));
-        await expect(defaultType).toBe(true, 'Content type not found');
+        expect(await viewerPage.getActiveTab()).toEqual('Properties');
+        defaultType = (await metadataViewPage.hasContentType('Content')) || (await metadataViewPage.hasContentType('cm:content'));
+        expect(defaultType).toBe(true);
         await viewerPage.clickCloseButton();
     });
 });

--- a/e2e/content-services/metadata/metadata-permissions.e2e.ts
+++ b/e2e/content-services/metadata/metadata-permissions.e2e.ts
@@ -109,7 +109,7 @@ describe('permissions', () => {
         await metadataViewPage.clickOnPropertiesTab();
         await metadataViewPage.editIconIsDisplayed();
 
-        await expect(await viewerPage.getActiveTab()).toEqual('Properties');
+        expect(await viewerPage.getActiveTab()).toEqual('Properties');
 
         await metadataViewPage.clickMetadataGroup('EXIF');
 
@@ -127,7 +127,7 @@ describe('permissions', () => {
         await metadataViewPage.clickOnPropertiesTab();
         await metadataViewPage.editIconIsDisplayed();
 
-        await expect(await viewerPage.getActiveTab()).toEqual('Properties');
+        expect(await viewerPage.getActiveTab()).toEqual('Properties');
 
         await metadataViewPage.clickMetadataGroup('EXIF');
 

--- a/e2e/content-services/metadata/metadata-properties.e2e.ts
+++ b/e2e/content-services/metadata/metadata-properties.e2e.ts
@@ -15,14 +15,7 @@
  * limitations under the License.
  */
 
-import { createApiService,
-    CheckboxPage,
-    LoginPage,
-    UploadActions,
-    UserModel,
-    UsersActions,
-    ViewerPage
-} from '@alfresco/adf-testing';
+import { createApiService, CheckboxPage, LoginPage, UploadActions, UserModel, UsersActions, ViewerPage } from '@alfresco/adf-testing';
 import { MetadataViewPage } from '../../core/pages/metadata-view.page';
 import { FileModel } from '../../models/ACS/file.model';
 import { browser } from 'protractor';
@@ -30,7 +23,6 @@ import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
 import { ContentServicesPage } from '../../core/pages/content-services.page';
 
 describe('CardView Component - properties', () => {
-
     const METADATA = {
         DATA_FORMAT: 'mmm dd yyyy',
         TITLE: 'Details',
@@ -71,7 +63,7 @@ describe('CardView Component - properties', () => {
 
         await navigationBarPage.navigateToContentServices();
         await contentServicesPage.waitForTableBody();
-   });
+    });
 
     afterEach(async () => {
         await viewerPage.clickCloseButton();
@@ -84,8 +76,7 @@ describe('CardView Component - properties', () => {
         await metadataViewPage.clickOnPropertiesTab();
         await metadataViewPage.editIconIsDisplayed();
 
-        await expect(await viewerPage.getActiveTab()).toEqual(METADATA.PROPERTY_TAB);
-
+        expect(await viewerPage.getActiveTab()).toEqual(METADATA.PROPERTY_TAB);
 
         await metadataViewPage.clickMetadataGroup('EXIF');
 
@@ -114,7 +105,6 @@ describe('CardView Component - properties', () => {
         await viewerPage.checkInfoSideBarIsDisplayed();
         await metadataViewPage.clickOnPropertiesTab();
 
-
         await metadataViewPage.checkMetadataGroupIsExpand('properties');
         await metadataViewPage.checkMetadataGroupIsNotExpand('EXIF');
 
@@ -129,7 +119,7 @@ describe('CardView Component - properties', () => {
 
         await metadataViewPage.checkMetadataGroupIsExpand('EXIF');
         await metadataViewPage.checkMetadataGroupIsExpand('properties');
-   });
+    });
 
     it('[C280559] Should show/hide the default metadata properties when displayDefaultProperties is true/false', async () => {
         await viewerPage.viewFile(pngFileModel.name);

--- a/e2e/content-services/metadata/metadata-smoke-tests.e2e.ts
+++ b/e2e/content-services/metadata/metadata-smoke-tests.e2e.ts
@@ -134,9 +134,9 @@ describe('Metadata component', () => {
             await viewerPage.checkInfoSideBarIsNotDisplayed();
             await viewerPage.clickInfoButton();
             await viewerPage.checkInfoSideBarIsDisplayed();
-            await expect(await viewerPage.getActiveTab()).toEqual(METADATA.COMMENTS_TAB);
+            expect(await viewerPage.getActiveTab()).toEqual(METADATA.COMMENTS_TAB);
             await metadataViewPage.clickOnPropertiesTab();
-            await expect(await viewerPage.getActiveTab()).toEqual(METADATA.PROPERTY_TAB);
+            expect(await viewerPage.getActiveTab()).toEqual(METADATA.PROPERTY_TAB);
         });
 
         it('[C245654] Should be possible edit the basic Metadata Info of a Document', async () => {
@@ -145,15 +145,13 @@ describe('Metadata component', () => {
             await metadataViewPage.clickOnPropertiesTab();
             await metadataViewPage.isEditGeneralIconDisplayed();
 
-            await expect(await viewerPage.getActiveTab()).toEqual(METADATA.PROPERTY_TAB);
+            expect(await viewerPage.getActiveTab()).toEqual(METADATA.PROPERTY_TAB);
 
             await metadataViewPage.clickEditIconGeneral();
 
             await metadataViewPage.enterPropertyText('properties.cm:name', 'exampleText');
             await metadataViewPage.clickResetMetadata();
-            await expect(await metadataViewPage.getPropertyText('properties.cm:name')).toEqual(
-                browser.params.resources.Files.ADF_DOCUMENTS.PNG.file_name
-            );
+            expect(await metadataViewPage.getPropertyText('properties.cm:name')).toEqual(browser.params.resources.Files.ADF_DOCUMENTS.PNG.file_name);
 
             await metadataViewPage.clickEditIconGeneral();
             await metadataViewPage.enterPropertyText('properties.cm:name', 'exampleText.png');
@@ -161,9 +159,9 @@ describe('Metadata component', () => {
             await metadataViewPage.enterDescriptionText('example description');
             await metadataViewPage.clickSaveGeneralMetadata();
 
-            await expect(await metadataViewPage.getPropertyText('properties.cm:name')).toEqual('exampleText.png');
-            await expect(await metadataViewPage.getPropertyText('properties.cm:title')).toEqual('example title');
-            await expect(await metadataViewPage.getPropertyText('properties.cm:description')).toEqual('example description');
+            expect(await metadataViewPage.getPropertyText('properties.cm:name')).toEqual('exampleText.png');
+            expect(await metadataViewPage.getPropertyText('properties.cm:title')).toEqual('example title');
+            expect(await metadataViewPage.getPropertyText('properties.cm:description')).toEqual('example description');
 
             await viewerPage.clickCloseButton();
             await contentServicesPage.waitForTableBody();
@@ -174,14 +172,12 @@ describe('Metadata component', () => {
             await metadataViewPage.clickOnPropertiesTab();
             await metadataViewPage.isEditGeneralIconDisplayed();
 
-            await expect(await metadataViewPage.getPropertyText('properties.cm:name')).toEqual('exampleText.png');
-            await expect(await metadataViewPage.getPropertyText('properties.cm:title')).toEqual('example title');
+            expect(await metadataViewPage.getPropertyText('properties.cm:name')).toEqual('exampleText.png');
+            expect(await metadataViewPage.getPropertyText('properties.cm:title')).toEqual('example title');
 
             await metadataViewPage.clickEditIconGeneral();
             await metadataViewPage.enterPropertyText('properties.cm:name', browser.params.resources.Files.ADF_DOCUMENTS.PNG.file_name);
-            await expect(await metadataViewPage.getPropertyText('properties.cm:name')).toEqual(
-                browser.params.resources.Files.ADF_DOCUMENTS.PNG.file_name
-            );
+            expect(await metadataViewPage.getPropertyText('properties.cm:name')).toEqual(browser.params.resources.Files.ADF_DOCUMENTS.PNG.file_name);
             await metadataViewPage.clickSaveGeneralMetadata();
         });
 
@@ -190,7 +186,7 @@ describe('Metadata component', () => {
             await viewerPage.checkInfoSideBarIsDisplayed();
             await metadataViewPage.clickOnPropertiesTab();
 
-            await expect(await viewerPage.getActiveTab()).toEqual(METADATA.PROPERTY_TAB);
+            expect(await viewerPage.getActiveTab()).toEqual(METADATA.PROPERTY_TAB);
             await metadataViewPage.clickMetadataGroupEditIcon('EXIF');
 
             await metadataViewPage.enterPropertyText('properties.exif:software', 'test custom text software');
@@ -198,9 +194,9 @@ describe('Metadata component', () => {
             await metadataViewPage.enterPropertyText('properties.exif:fNumber', 22);
             await metadataViewPage.clickSaveMetadata();
 
-            await expect(await metadataViewPage.getPropertyText('properties.exif:isoSpeedRatings')).toEqual('test custom text isoSpeedRatings');
-            await expect(await metadataViewPage.getPropertyText('properties.exif:software')).toEqual('test custom text software');
-            await expect(await metadataViewPage.getPropertyText('properties.exif:fNumber')).toEqual('22');
+            expect(await metadataViewPage.getPropertyText('properties.exif:isoSpeedRatings')).toEqual('test custom text isoSpeedRatings');
+            expect(await metadataViewPage.getPropertyText('properties.exif:software')).toEqual('test custom text software');
+            expect(await metadataViewPage.getPropertyText('properties.exif:fNumber')).toEqual('22');
         });
     });
 
@@ -214,13 +210,13 @@ describe('Metadata component', () => {
         await metadataViewPage.clickOnPropertiesTab();
         await metadataViewPage.isEditGeneralIconDisplayed();
 
-        await expect(await viewerPage.getActiveTab()).toEqual(METADATA.PROPERTY_TAB);
+        expect(await viewerPage.getActiveTab()).toEqual(METADATA.PROPERTY_TAB);
 
         await metadataViewPage.clickEditIconGeneral();
 
         await metadataViewPage.enterDescriptionText('check author example description');
         await metadataViewPage.clickSaveGeneralMetadata();
-        await expect(await metadataViewPage.getPropertyText('properties.cm:description')).toEqual('check author example description');
+        expect(await metadataViewPage.getPropertyText('properties.cm:description')).toEqual('check author example description');
 
         await navigationBarPage.clickLogoutButton();
         await loginPage.login(acsUser.username, acsUser.password);
@@ -233,7 +229,7 @@ describe('Metadata component', () => {
         await viewerPage.checkInfoSideBarIsDisplayed();
         await metadataViewPage.clickOnPropertiesTab();
 
-        await expect(await metadataViewPage.getPropertyText('modifiedByUser.displayName')).toEqual('Administrator');
+        expect(await metadataViewPage.getPropertyText('modifiedByUser.displayName')).toEqual('Administrator');
 
         await viewerPage.clickCloseButton();
         await contentServicesPage.waitForTableBody();

--- a/e2e/content-services/upload/cancel-upload.e2e.ts
+++ b/e2e/content-services/upload/cancel-upload.e2e.ts
@@ -23,7 +23,6 @@ import { UploadTogglesPage } from '../../core/pages/dialog/upload-toggles.page';
 import { FileModel } from '../../models/ACS/file.model';
 
 describe('Upload component', async () => {
-
     const apiService = createApiService();
     const contentServicesPage = new ContentServicesPage();
     const uploadDialog = new UploadDialogPage();
@@ -58,14 +57,13 @@ describe('Upload component', async () => {
         await contentServicesPage.goToDocumentList();
     });
 
-    const deleteNodesInCurrentPage = async function() {
+    const deleteNodesInCurrentPage = async () => {
         const nodeList = await contentServicesPage.getElementsDisplayedId();
 
         for (const node of nodeList) {
             try {
                 await uploadActions.deleteFileOrFolder(node);
-            } catch (error) {
-            }
+            } catch (error) {}
         }
     };
 
@@ -74,18 +72,20 @@ describe('Upload component', async () => {
 
         await contentServicesPage.uploadFile(mediumFile.location);
 
-        await expect(await uploadDialog.getTitleText()).toEqual('Upload canceled');
+        expect(await uploadDialog.getTitleText()).toEqual('Upload canceled');
         await uploadDialog.clickOnCloseButton();
         await uploadDialog.dialogIsNotDisplayed();
         await contentServicesPage.checkContentIsNotDisplayed(mediumFile.name);
     });
 
     it('[C287790] Should be possible to cancel upload of a big file through the cancel uploads button', async () => {
-        await browser.executeScript(' setInterval(() => {document.querySelector("#adf-upload-dialog-cancel-all").click();' +
-            'document.querySelector("#adf-upload-dialog-cancel").click();  }, 500)');
+        await browser.executeScript(
+            ' setInterval(() => {document.querySelector("#adf-upload-dialog-cancel-all").click();' +
+                'document.querySelector("#adf-upload-dialog-cancel").click();  }, 500)'
+        );
 
         await contentServicesPage.uploadFile(largeFile.location);
-        await expect(await uploadDialog.getTitleText()).toEqual('Upload canceled');
+        expect(await uploadDialog.getTitleText()).toEqual('Upload canceled');
         await uploadDialog.clickOnCloseButton();
         await uploadDialog.dialogIsNotDisplayed();
         await contentServicesPage.checkContentIsNotDisplayed(largeFile.name);
@@ -94,12 +94,14 @@ describe('Upload component', async () => {
     it('[C272793] Should be able to cancel multiple files upload', async () => {
         await uploadToggles.enableMultipleFileUpload();
 
-        await browser.executeScript(' setInterval(() => {document.querySelector("#adf-upload-dialog-cancel-all").click();' +
-            'document.querySelector("#adf-upload-dialog-cancel").click();  }, 500)');
+        await browser.executeScript(
+            ' setInterval(() => {document.querySelector("#adf-upload-dialog-cancel-all").click();' +
+                'document.querySelector("#adf-upload-dialog-cancel").click();  }, 500)'
+        );
 
         await contentServicesPage.uploadMultipleFile([mediumFile.location, largeFile.location]);
 
-        await expect(await uploadDialog.getTitleText()).toEqual('Upload canceled');
+        expect(await uploadDialog.getTitleText()).toEqual('Upload canceled');
         await uploadDialog.clickOnCloseButton();
         await uploadDialog.dialogIsNotDisplayed();
         await contentServicesPage.checkContentIsNotDisplayed(mediumFile.name);

--- a/e2e/content-services/upload/upload-dialog.e2e.ts
+++ b/e2e/content-services/upload/upload-dialog.e2e.ts
@@ -24,7 +24,6 @@ import { browser } from 'protractor';
 import { VersionManagePage } from '../pages/version-manager.page';
 
 describe('Upload component', () => {
-
     const contentServicesPage = new ContentServicesPage();
     const uploadDialog = new UploadDialogPage();
     const uploadToggles = new UploadTogglesPage();
@@ -90,17 +89,17 @@ describe('Upload component', () => {
 
         await uploadDialog.fileIsUploaded(docxFileModel.name);
         await uploadDialog.checkCloseButtonIsDisplayed();
-        await expect(await uploadDialog.numberOfCurrentFilesUploaded()).toEqual('1');
-        await expect(await uploadDialog.numberOfInitialFilesUploaded()).toEqual('1');
+        expect(await uploadDialog.numberOfCurrentFilesUploaded()).toEqual('1');
+        expect(await uploadDialog.numberOfInitialFilesUploaded()).toEqual('1');
         await uploadDialog.minimizeUploadDialog();
         await uploadDialog.dialogIsMinimized();
-        await expect(await uploadDialog.numberOfCurrentFilesUploaded()).toEqual('1');
-        await expect(await uploadDialog.numberOfInitialFilesUploaded()).toEqual('1');
+        expect(await uploadDialog.numberOfCurrentFilesUploaded()).toEqual('1');
+        expect(await uploadDialog.numberOfInitialFilesUploaded()).toEqual('1');
         await uploadDialog.maximizeUploadDialog();
         await uploadDialog.dialogIsDisplayed();
         await uploadDialog.fileIsUploaded(docxFileModel.name);
-        await expect(await uploadDialog.numberOfCurrentFilesUploaded()).toEqual('1');
-        await expect(await uploadDialog.numberOfInitialFilesUploaded()).toEqual('1');
+        expect(await uploadDialog.numberOfCurrentFilesUploaded()).toEqual('1');
+        expect(await uploadDialog.numberOfInitialFilesUploaded()).toEqual('1');
         await uploadDialog.checkCloseButtonIsDisplayed();
         await uploadDialog.clickOnCloseButton();
         await uploadDialog.dialogIsNotDisplayed();
@@ -112,7 +111,7 @@ describe('Upload component', () => {
 
         await uploadDialog.fileIsUploaded(docxFileModel.name);
         await uploadDialog.checkCloseButtonIsDisplayed();
-        await expect(await uploadDialog.getTitleText()).toEqual('Uploaded 1 / 1');
+        expect(await uploadDialog.getTitleText()).toEqual('Uploaded 1 / 1');
         await uploadDialog.checkCloseButtonIsDisplayed();
         await uploadDialog.clickOnCloseButton();
         await uploadDialog.dialogIsNotDisplayed();
@@ -144,7 +143,7 @@ describe('Upload component', () => {
         await contentServicesPage.uploadMultipleFile(filesLocation);
         await contentServicesPage.checkContentsAreDisplayed(filesName);
         await uploadDialog.filesAreUploaded(filesName);
-        await expect(await uploadDialog.getTitleText()).toEqual('Uploaded 4 / 4');
+        expect(await uploadDialog.getTitleText()).toEqual('Uploaded 4 / 4');
         await uploadDialog.clickOnCloseButton();
         await uploadDialog.dialogIsNotDisplayed();
         await uploadToggles.disableMultipleFileUpload();

--- a/e2e/content-services/upload/uploader-component.e2e.ts
+++ b/e2e/content-services/upload/uploader-component.e2e.ts
@@ -190,7 +190,7 @@ describe('Upload component', () => {
             await uploadToggles.enableMaxSize();
             await uploadToggles.addMaxSize('0');
             await contentServicesPage.uploadFile(fileWithSpecificSize.location);
-            // await expect(await contentServicesPage.getErrorMessage()).toEqual('File ' + fileWithSpecificSize.name + ' is larger than the allowed file size');
+            // expect(await contentServicesPage.getErrorMessage()).toEqual('File ' + fileWithSpecificSize.name + ' is larger than the allowed file size');
 
             await uploadDialog.fileIsNotDisplayedInDialog(fileWithSpecificSize.name);
             await contentServicesPage.uploadFile(emptyFile.location);
@@ -250,6 +250,6 @@ describe('Upload component', () => {
         await contentServicesPage.uploadFile(pdfFileModel.location);
 
         await uploadDialog.displayTooltip();
-        await expect(await uploadDialog.getTooltip()).toEqual('Upload location no longer exists [404]');
+        expect(await uploadDialog.getTooltip()).toEqual('Upload location no longer exists [404]');
     });
 });

--- a/e2e/content-services/upload/user-permission.e2e.ts
+++ b/e2e/content-services/upload/user-permission.e2e.ts
@@ -25,7 +25,6 @@ import CONSTANTS = require('../../util/constants');
 import { SiteEntry, SitesApi } from '@alfresco/js-api';
 
 describe('Upload - User permission', () => {
-
     const contentServicesPage = new ContentServicesPage();
     const uploadDialog = new UploadDialogPage();
     const loginPage = new LoginPage();
@@ -84,7 +83,6 @@ describe('Upload - User permission', () => {
     });
 
     describe('Consumer permissions', () => {
-
         beforeEach(async () => {
             await contentServicesPage.goToDocumentList();
         });
@@ -99,7 +97,7 @@ describe('Upload - User permission', () => {
             await uploadDialog.fileIsError(emptyFile.name);
             await uploadDialog.displayTooltip();
 
-            await expect(await uploadDialog.getTooltip()).toEqual('Insufficient permissions to upload in this location [403]');
+            expect(await uploadDialog.getTooltip()).toEqual('Insufficient permissions to upload in this location [403]');
         });
 
         it('[C279915] Should not be allowed to upload a file in folder with consumer permissions', async () => {
@@ -118,7 +116,7 @@ describe('Upload - User permission', () => {
             await contentServicesPage.uploadFile(emptyFile.location);
 
             const message = await new SnackbarPage().getSnackBarMessage();
-            expect(message).toEqual('You don\'t have the create permission to upload the content');
+            expect(message).toEqual(`You don't have the create permission to upload the content`);
         });
     });
 

--- a/e2e/content-services/upload/version-actions.e2e.ts
+++ b/e2e/content-services/upload/version-actions.e2e.ts
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 
-import { createApiService,
+import {
+    createApiService,
     BrowserActions,
     BrowserVisibility,
     FileBrowserUtil,
@@ -33,7 +34,6 @@ import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
 import { VersionManagePage } from '../pages/version-manager.page';
 
 describe('Version component actions', () => {
-
     const loginPage = new LoginPage();
     const contentServicesPage = new ContentServicesPage();
     const versionManagePage = new VersionManagePage();
@@ -72,7 +72,7 @@ describe('Version component actions', () => {
         await loginPage.login(acsUser.username, acsUser.password);
         await navigationBarPage.navigateToContentServices();
         await contentServicesPage.waitForTableBody();
-   });
+    });
 
     beforeEach(async () => {
         await contentServicesPage.versionManagerContent(txtFileModel.name);
@@ -84,14 +84,14 @@ describe('Version component actions', () => {
 
     it('[C280003] Should not be possible delete a file version if there is only one version', async () => {
         await versionManagePage.clickActionButton('1.0');
-        await expect(await element(by.css(`[id="adf-version-list-action-delete-1.0"]`)).isEnabled()).toBe(false);
+        expect(await element(by.css(`[id="adf-version-list-action-delete-1.0"]`)).isEnabled()).toBe(false);
         await versionManagePage.closeActionsMenu();
         await BrowserVisibility.waitUntilElementIsNotVisible(element(by.css(`[id="adf-version-list-action-delete-1.0"]`)));
     });
 
     it('[C280004] Should not be possible restore the version if there is only one version', async () => {
         await versionManagePage.clickActionButton('1.0');
-        await expect(await element(by.css(`[id="adf-version-list-action-restore-1.0"]`)).isEnabled()).toBe(false);
+        expect(await element(by.css(`[id="adf-version-list-action-restore-1.0"]`)).isEnabled()).toBe(false);
         await versionManagePage.closeActionsMenu();
         await BrowserVisibility.waitUntilElementIsNotVisible(element(by.css(`[id="adf-version-list-action-restore-1.0"]`)));
     });
@@ -169,11 +169,13 @@ describe('Version component actions', () => {
 
         await versionManagePage.showNewVersionButton.click();
 
-        await browser.executeScript(' setTimeout(() => {document.querySelector("div[data-automation-id=\'cancel-upload-progress\']").click();}, 1000)');
+        await browser.executeScript(
+            ' setTimeout(() => {document.querySelector("div[data-automation-id=\'cancel-upload-progress\']").click();}, 1000)'
+        );
         await versionManagePage.uploadNewVersionFile(bigFileToCancel.location);
         await versionManagePage.closeVersionDialog();
 
-        await expect(await uploadDialog.getTitleText()).toEqual('Upload canceled');
+        expect(await uploadDialog.getTitleText()).toEqual('Upload canceled');
 
         await browser.refresh();
 

--- a/e2e/content-services/upload/version-actions.e2e.ts
+++ b/e2e/content-services/upload/version-actions.e2e.ts
@@ -54,7 +54,6 @@ describe('Version component actions', () => {
         name: browser.params.resources.Files.ADF_DOCUMENTS.TXT.file_name,
         location: browser.params.resources.Files.ADF_DOCUMENTS.TXT.file_location
     });
-    let uploadActions;
 
     const bigFileToCancel = new FileModel({
         name: browser.params.resources.Files.ADF_DOCUMENTS.LARGE_FILE.file_name,
@@ -62,7 +61,7 @@ describe('Version component actions', () => {
     });
 
     beforeAll(async () => {
-        uploadActions = new UploadActions(apiService);
+        const uploadActions = new UploadActions(apiService);
         await apiService.loginWithProfile('admin');
         acsUser = await usersActions.createUser();
         await apiService.login(acsUser.username, acsUser.password);

--- a/e2e/content-services/upload/version-permissions.e2e.ts
+++ b/e2e/content-services/upload/version-permissions.e2e.ts
@@ -16,15 +16,7 @@
  */
 
 import { browser, by, element } from 'protractor';
-import {
-    createApiService,
-    LoginPage,
-    SnackbarPage,
-    StringUtil,
-    UploadActions,
-    UserModel,
-    UsersActions
-} from '@alfresco/adf-testing';
+import { createApiService, LoginPage, SnackbarPage, StringUtil, UploadActions, UserModel, UsersActions } from '@alfresco/adf-testing';
 import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
 import { VersionManagePage } from '../pages/version-manager.page';
 import { UploadDialogPage } from '../pages/upload-dialog.page';
@@ -34,7 +26,6 @@ import CONSTANTS = require('../../util/constants');
 import { NodesApi, SitesApi } from '@alfresco/js-api';
 
 describe('Version component permissions', () => {
-
     const loginPage = new LoginPage();
     const versionManagePage = new VersionManagePage();
     const navigationBarPage = new NavigationBarPage();
@@ -115,9 +106,9 @@ describe('Version component permissions', () => {
         Object.assign(lockFileModel, lockFileUploaded.entry);
 
         await nodesApi.lockNode(lockFileModel.id, {
-                type: 'FULL',
-                lifetime: 'PERSISTENT'
-            });
+            type: 'FULL',
+            lifetime: 'PERSISTENT'
+        });
 
         await apiService.login(fileCreatorUser.username, fileCreatorUser.password);
 
@@ -161,8 +152,8 @@ describe('Version component permissions', () => {
             await versionManagePage.uploadNewVersionFile(newVersionFile.location);
 
             await versionManagePage.checkFileVersionExist('1.1');
-            await expect(await versionManagePage.getFileVersionName('1.1')).toEqual(newVersionFile.name);
-            await expect(await versionManagePage.getFileVersionDate('1.1')).not.toBeUndefined();
+            expect(await versionManagePage.getFileVersionName('1.1')).toEqual(newVersionFile.name);
+            expect(await versionManagePage.getFileVersionDate('1.1')).not.toBeUndefined();
 
             await versionManagePage.deleteFileVersion('1.1');
             await versionManagePage.confirmAccept.click();
@@ -176,7 +167,7 @@ describe('Version component permissions', () => {
 
         it('[C277204] Should be disabled the option for locked file', async () => {
             await contentServices.getDocumentList().rightClickOnRow(lockFileModel.name);
-            await expect(await contentServices.isContextActionEnabled('Manage versions')).toBe(false, 'Manage versions is enabled');
+            expect(await contentServices.isContextActionEnabled('Manage versions')).toBe(false, 'Manage versions is enabled');
         });
     });
 
@@ -200,7 +191,7 @@ describe('Version component permissions', () => {
 
         it('[C277201] Should a user with Consumer permission not be able to upload a new version for a locked file', async () => {
             await contentServices.getDocumentList().rightClickOnRow(lockFileModel.name);
-            await expect(await contentServices.isContextActionEnabled('Manage versions')).toBe(false, 'Manage version is enabled');
+            expect(await contentServices.isContextActionEnabled('Manage versions')).toBe(false);
         });
     });
 
@@ -234,8 +225,8 @@ describe('Version component permissions', () => {
             await versionManagePage.uploadNewVersionFile(newVersionFile.location);
 
             await versionManagePage.checkFileVersionExist('1.1');
-            await expect(await versionManagePage.getFileVersionName('1.1')).toEqual(newVersionFile.name);
-            await expect(await versionManagePage.getFileVersionDate('1.1')).not.toBeUndefined();
+            expect(await versionManagePage.getFileVersionName('1.1')).toEqual(newVersionFile.name);
+            expect(await versionManagePage.getFileVersionDate('1.1')).not.toBeUndefined();
 
             await versionManagePage.deleteFileVersion('1.1');
             await versionManagePage.confirmAccept.click();
@@ -256,7 +247,7 @@ describe('Version component permissions', () => {
 
         it('[C277202] Should be disabled the option for a locked file', async () => {
             await contentServices.getDocumentList().rightClickOnRow(lockFileModel.name);
-            await expect(await contentServices.isContextActionEnabled('Manage versions')).toBe(false, 'Manage versions is enabled');
+            expect(await contentServices.isContextActionEnabled('Manage versions')).toBe(false);
         });
     });
 
@@ -290,8 +281,8 @@ describe('Version component permissions', () => {
             await versionManagePage.uploadNewVersionFile(newVersionFile.location);
 
             await versionManagePage.checkFileVersionExist('1.1');
-            await expect(await versionManagePage.getFileVersionName('1.1')).toEqual(newVersionFile.name);
-            await expect(await versionManagePage.getFileVersionDate('1.1')).not.toBeUndefined();
+            expect(await versionManagePage.getFileVersionName('1.1')).toEqual(newVersionFile.name);
+            expect(await versionManagePage.getFileVersionDate('1.1')).not.toBeUndefined();
 
             await versionManagePage.deleteFileVersion('1.1');
             await versionManagePage.confirmAccept.click();
@@ -310,12 +301,12 @@ describe('Version component permissions', () => {
             await versionManagePage.uploadNewVersionFile(newVersionFile.location);
 
             await versionManagePage.checkFileVersionExist('1.1');
-            await expect(await versionManagePage.getFileVersionName('1.1')).toEqual(newVersionFile.name);
-            await expect(await versionManagePage.getFileVersionDate('1.1')).not.toBeUndefined();
+            expect(await versionManagePage.getFileVersionName('1.1')).toEqual(newVersionFile.name);
+            expect(await versionManagePage.getFileVersionDate('1.1')).not.toBeUndefined();
 
             await versionManagePage.clickActionButton('1.1');
 
-            await expect(await element(by.css(`[id="adf-version-list-action-delete-1.1"]`)).isEnabled()).toBe(false);
+            expect(await element(by.css(`[id="adf-version-list-action-delete-1.1"]`)).isEnabled()).toBe(false);
 
             await versionManagePage.closeActionsMenu();
 
@@ -324,7 +315,7 @@ describe('Version component permissions', () => {
 
         it('[C277203] Should a user with Collaborator permission not be able to upload a new version for a locked file', async () => {
             await contentServices.getDocumentList().rightClickOnRow(lockFileModel.name);
-            await expect(await contentServices.isContextActionEnabled('Manage versions')).toBe(false, 'Manage versions is enabled');
+            expect(await contentServices.isContextActionEnabled('Manage versions')).toBe(false);
         });
     });
 });

--- a/e2e/content-services/upload/version-properties.e2e.ts
+++ b/e2e/content-services/upload/version-properties.e2e.ts
@@ -16,20 +16,13 @@
  */
 
 import { browser, by, element } from 'protractor';
-import { createApiService,
-    BrowserVisibility,
-    LoginPage,
-    UploadActions,
-    UserModel,
-    UsersActions, ViewerPage
-} from '@alfresco/adf-testing';
+import { createApiService, BrowserVisibility, LoginPage, UploadActions, UserModel, UsersActions, ViewerPage } from '@alfresco/adf-testing';
 import { ContentServicesPage } from '../../core/pages/content-services.page';
 import { VersionManagePage } from '../pages/version-manager.page';
 import { FileModel } from '../../models/ACS/file.model';
 import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
 
 describe('Version Properties', () => {
-
     const loginPage = new LoginPage();
     const contentServicesPage = new ContentServicesPage();
     const versionManagePage = new VersionManagePage();
@@ -111,9 +104,8 @@ describe('Version Properties', () => {
         await versionManagePage.commentText.typeText('Example comment text');
         await versionManagePage.uploadNewVersionFile(fileModelVersionTwo.location);
         await versionManagePage.checkFileVersionExist('1.1');
-        await expect(await versionManagePage.getFileVersionComment('1.1')).toEqual('Example comment text');
+        expect(await versionManagePage.getFileVersionComment('1.1')).toEqual('Example comment text');
         await versionManagePage.disableComments();
         await BrowserVisibility.waitUntilElementIsNotVisible(element(by.css(`[id="adf-version-list-item-comment-1.1"]`)));
     });
-
 });

--- a/e2e/content-services/upload/version-smoke-tests.e2e.ts
+++ b/e2e/content-services/upload/version-smoke-tests.e2e.ts
@@ -23,7 +23,6 @@ import { FileModel } from '../../models/ACS/file.model';
 import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
 
 describe('Version component', () => {
-
     let txtUploadedFile;
     const loginPage = new LoginPage();
     const contentServicesPage = new ContentServicesPage();
@@ -79,14 +78,14 @@ describe('Version component', () => {
         await navigationBarPage.navigateToContentServices();
         await contentServicesPage.waitForTableBody();
         await contentServicesPage.versionManagerContent(txtFileModel.name);
-   });
+    });
 
     it('[C272768] Should be visible the first file version when you upload a file', async () => {
         await versionManagePage.showNewVersionButton.waitVisible();
 
         await versionManagePage.checkFileVersionExist('1.0');
-        await expect(await versionManagePage.getFileVersionName('1.0')).toEqual(txtFileModel.name);
-        await expect(await versionManagePage.getFileVersionDate('1.0')).not.toBeUndefined();
+        expect(await versionManagePage.getFileVersionName('1.0')).toEqual(txtFileModel.name);
+        expect(await versionManagePage.getFileVersionDate('1.0')).not.toBeUndefined();
     });
 
     it('[C279995] Should show/hide the new upload file options when click on add New version/cancel button', async () => {
@@ -114,12 +113,12 @@ describe('Version component', () => {
         await versionManagePage.uploadNewVersionFile(fileModelVersionTwo.location);
 
         await versionManagePage.checkFileVersionExist('1.0');
-        await expect(await versionManagePage.getFileVersionName('1.0')).toEqual(txtFileModel.name);
-        await expect(await versionManagePage.getFileVersionDate('1.0')).not.toBeUndefined();
+        expect(await versionManagePage.getFileVersionName('1.0')).toEqual(txtFileModel.name);
+        expect(await versionManagePage.getFileVersionDate('1.0')).not.toBeUndefined();
 
         await versionManagePage.checkFileVersionExist('1.1');
-        await expect(await versionManagePage.getFileVersionName('1.1')).toEqual(fileModelVersionTwo.name);
-        await expect(await versionManagePage.getFileVersionDate('1.1')).not.toBeUndefined();
+        expect(await versionManagePage.getFileVersionName('1.1')).toEqual(fileModelVersionTwo.name);
+        expect(await versionManagePage.getFileVersionDate('1.1')).not.toBeUndefined();
     });
 
     it('[C269084] Should be possible add a comment when add a new version', async () => {
@@ -128,9 +127,9 @@ describe('Version component', () => {
         await versionManagePage.uploadNewVersionFile(fileModelVersionThree.location);
 
         await versionManagePage.checkFileVersionExist('1.2');
-        await expect(await versionManagePage.getFileVersionName('1.2')).toEqual(fileModelVersionThree.name);
-        await expect(await versionManagePage.getFileVersionDate('1.2')).not.toBeUndefined();
-        await expect(await versionManagePage.getFileVersionComment('1.2')).toEqual('Example comment text');
+        expect(await versionManagePage.getFileVersionName('1.2')).toEqual(fileModelVersionThree.name);
+        expect(await versionManagePage.getFileVersionDate('1.2')).not.toBeUndefined();
+        expect(await versionManagePage.getFileVersionComment('1.2')).toEqual('Example comment text');
     });
 
     it('[C275719] Should be possible preview the file when you add a new version', async () => {
@@ -140,7 +139,7 @@ describe('Version component', () => {
         await versionManagePage.uploadNewVersionFile(fileModelVersionFor.location);
 
         await versionManagePage.checkFileVersionExist('2.0');
-        await expect(await versionManagePage.getFileVersionName('2.0')).toEqual(fileModelVersionFor.name);
+        expect(await versionManagePage.getFileVersionName('2.0')).toEqual(fileModelVersionFor.name);
 
         await versionManagePage.showNewVersionButton.click();
         await versionManagePage.minorRadio.click();
@@ -148,6 +147,6 @@ describe('Version component', () => {
         await versionManagePage.uploadNewVersionFile(fileModelVersionFive.location);
 
         await versionManagePage.checkFileVersionExist('2.1');
-        await expect(await versionManagePage.getFileVersionName('2.1')).toEqual(fileModelVersionFive.name);
+        expect(await versionManagePage.getFileVersionName('2.1')).toEqual(fileModelVersionFive.name);
     });
 });

--- a/e2e/core/pages/content-services.page.ts
+++ b/e2e/core/pages/content-services.page.ts
@@ -281,11 +281,11 @@ export class ContentServicesPage {
 
     async checkEmptyFolderTextToBe(text: string): Promise<void> {
         await BrowserVisibility.waitUntilElementIsVisible(this.emptyFolder);
-        await expect(await this.emptyFolder.getText()).toContain(text);
+        expect(await this.emptyFolder.getText()).toContain(text);
     }
 
     async checkEmptyFolderImageUrlToContain(url): Promise<void> {
-        await expect(await BrowserActions.getAttribute(this.emptyFolderImage, 'src')).toContain(url);
+        expect(await BrowserActions.getAttribute(this.emptyFolderImage, 'src')).toContain(url);
     }
 
     async getAttributeValueForElement(elementName: string, propertyName: string): Promise<string> {

--- a/e2e/core/pages/metadata-view.page.ts
+++ b/e2e/core/pages/metadata-view.page.ts
@@ -114,7 +114,10 @@ export class MetadataViewPage {
 
     async clickOnPropertiesTab(): Promise<void> {
         const propertiesTab = element(
-            by.cssContainingText(`.adf-info-drawer-layout-content div${materialLocators.Tab.labels.class} div ${materialLocators.Tab.label.content.class}`, `Properties`)
+            by.cssContainingText(
+                `.adf-info-drawer-layout-content div${materialLocators.Tab.labels.class} div ${materialLocators.Tab.label.content.class}`,
+                `Properties`
+            )
         );
         await BrowserActions.click(propertiesTab);
     }
@@ -164,12 +167,12 @@ export class MetadataViewPage {
 
     async checkMetadataGroupIsExpand(groupName: string): Promise<void> {
         const group = await this.getExpandedMetadataGroupLocator(groupName);
-        await expect(await BrowserActions.getAttribute(group, 'class')).toContain(materialLocators.Expanded.root);
+        expect(await BrowserActions.getAttribute(group, 'class')).toContain(materialLocators.Expanded.root);
     }
 
     async checkMetadataGroupIsNotExpand(groupName: string): Promise<void> {
         const group = await this.getExpandedMetadataGroupLocator(groupName);
-        await expect(await BrowserActions.getAttribute(group, 'class')).not.toContain(materialLocators.Expanded.root);
+        expect(await BrowserActions.getAttribute(group, 'class')).not.toContain(materialLocators.Expanded.root);
     }
 
     async checkPropertyIsVisible(propertyName: string, type: string): Promise<void> {

--- a/e2e/core/pagination-empty-current-page.e2e.ts
+++ b/e2e/core/pagination-empty-current-page.e2e.ts
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 
-import { createApiService,
+import {
+    createApiService,
     ArrayUtil,
     LoginPage,
     PaginationPage,
@@ -104,24 +105,24 @@ describe('Pagination - returns to previous page when current is empty', () => {
         await contentServicesPage.checkDocumentListElementsAreDisplayed();
         await contentServicesPage.contentList.dataTablePage().waitTillContentLoaded();
 
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.five);
-        await expect(await contentServicesPage.numberOfResultsDisplayed()).toBe(itemsPerPage.fiveValue);
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.five);
+        expect(await contentServicesPage.numberOfResultsDisplayed()).toBe(itemsPerPage.fiveValue);
         let list = await contentServicesPage.getAllRowsNameColumn();
-        await expect(ArrayUtil.arrayContainsArray(list, fileNames.slice(0, 5))).toEqual(true);
+        expect(ArrayUtil.arrayContainsArray(list, fileNames.slice(0, 5))).toEqual(true);
         await paginationPage.clickOnNextPage();
         await contentServicesPage.contentList.dataTablePage().waitTillContentLoaded();
 
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.five);
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.five);
         list = await contentServicesPage.getAllRowsNameColumn();
-        await expect(ArrayUtil.arrayContainsArray(list, fileNames.slice(5, 6))).toEqual(true);
+        expect(ArrayUtil.arrayContainsArray(list, fileNames.slice(5, 6))).toEqual(true);
         await contentServicesPage.deleteContent(lastFile);
         await contentServicesPage.checkContentIsNotDisplayed(lastFile);
 
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.five);
-        await expect(await contentServicesPage.numberOfResultsDisplayed()).toBe(itemsPerPage.fiveValue);
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.five);
+        expect(await contentServicesPage.numberOfResultsDisplayed()).toBe(itemsPerPage.fiveValue);
 
         list = await contentServicesPage.getAllRowsNameColumn();
-        await expect(ArrayUtil.arrayContainsArray(list, fileNames.slice(0, 5))).toEqual(true);
+        expect(ArrayUtil.arrayContainsArray(list, fileNames.slice(0, 5))).toEqual(true);
     });
 
     it('[C297494] Should display content when navigating to a non-empty folder not in the first page', async () => {
@@ -132,8 +133,8 @@ describe('Pagination - returns to previous page when current is empty', () => {
         await contentServicesPage.checkDocumentListElementsAreDisplayed();
         await contentServicesPage.contentList.dataTablePage().waitTillContentLoaded();
 
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.five);
-        await expect(await contentServicesPage.numberOfResultsDisplayed()).toBe(itemsPerPage.fiveValue);
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.five);
+        expect(await contentServicesPage.numberOfResultsDisplayed()).toBe(itemsPerPage.fiveValue);
 
         await paginationPage.clickOnNextPage();
         await contentServicesPage.checkDocumentListElementsAreDisplayed();

--- a/e2e/process-services-cloud/form-field/dropdown-widget.e2e.ts
+++ b/e2e/process-services-cloud/form-field/dropdown-widget.e2e.ts
@@ -16,17 +16,26 @@
  */
 
 import {
-    createApiService, AppListCloudPage, GroupIdentityService, IdentityService,
-    LoginPage, ProcessCloudWidgetPage, ProcessDefinitionsService,
-    ProcessInstancesService, QueryService, TaskFormCloudComponent, TaskHeaderCloudPage,
-    TasksService, SnackbarPage, materialLocators
+    createApiService,
+    AppListCloudPage,
+    GroupIdentityService,
+    IdentityService,
+    LoginPage,
+    ProcessCloudWidgetPage,
+    ProcessDefinitionsService,
+    ProcessInstancesService,
+    QueryService,
+    TaskFormCloudComponent,
+    TaskHeaderCloudPage,
+    TasksService,
+    SnackbarPage,
+    materialLocators
 } from '@alfresco/adf-testing';
 import { browser } from 'protractor';
 import { TasksCloudDemoPage } from '.././pages/tasks-cloud-demo.page';
 import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
 
 describe('Form Field Component - Dropdown Widget', () => {
-
     const loginSSOPage = new LoginPage();
     const navigationBarPage = new NavigationBarPage();
     const appListCloudComponent = new AppListCloudPage();
@@ -80,7 +89,7 @@ describe('Form Field Component - Dropdown Widget', () => {
     afterAll(async () => {
         await apiService.loginWithProfile('identityAdmin');
         await identityService.deleteIdentityUser(testUser.idIdentityService);
-   });
+    });
 
     beforeEach(async () => {
         await navigationBarPage.navigateToProcessServicesCloudPage();
@@ -118,7 +127,7 @@ describe('Form Field Component - Dropdown Widget', () => {
 
         optionsSelected.push(await dropdown.getSelectedOptionText('DropdownMultiselect'));
 
-        await expect(optionsSelected.toString().replace(/\s+/g, '')).toEqual([optionsToSelect, optionsToSelect].toString());
+        expect(optionsSelected.toString().replace(/\s+/g, '')).toEqual([optionsToSelect, optionsToSelect].toString());
     });
 
     it('[C309878] Should be able to select a dropdown option, save and complete the task form', async () => {
@@ -135,17 +144,17 @@ describe('Form Field Component - Dropdown Widget', () => {
         await taskFormCloudComponent.formFields().checkWidgetIsVisible('DropdownOptions');
         await dropdown.selectOption('option2', `dropdown-cloud-widget ${materialLocators.Select.root}`);
 
-        await expect(await dropdown.getSelectedOptionText('DropdownOptions')).toBe('option2');
+        expect(await dropdown.getSelectedOptionText('DropdownOptions')).toBe('option2');
 
         await taskFormCloudComponent.checkSaveButtonIsDisplayed();
         await taskFormCloudComponent.clickSaveButton();
 
-        await expect(await dropdown.getSelectedOptionText('DropdownOptions')).toBe('option2');
+        expect(await dropdown.getSelectedOptionText('DropdownOptions')).toBe('option2');
 
         await taskFormCloudComponent.checkCompleteButtonIsDisplayed();
         await taskFormCloudComponent.clickCompleteButton();
 
-        await expect(await taskFilter.getActiveFilterName()).toBe('My Tasks');
+        expect(await taskFilter.getActiveFilterName()).toBe('My Tasks');
 
         await taskList.checkContentIsNotDisplayedByName(dropdownOptionTaskName);
 
@@ -161,7 +170,7 @@ describe('Form Field Component - Dropdown Widget', () => {
         await taskFormCloudComponent.formFields().checkFormIsDisplayed();
         await taskFormCloudComponent.formFields().checkWidgetIsVisible('DropdownOptions');
 
-        await expect(await dropdown.getSelectedOptionText('DropdownOptions')).toBe('option2');
+        expect(await dropdown.getSelectedOptionText('DropdownOptions')).toBe('option2');
 
         await taskFormCloudComponent.checkCompleteButtonIsNotDisplayed();
     });
@@ -185,7 +194,7 @@ describe('Form Field Component - Dropdown Widget', () => {
         await dropdown.closeDropdownFor(dropdownId);
 
         const actualSelectedOptions = await dropdown.getSelectedOptionText(dropdownId);
-        await expect(actualSelectedOptions).toEqual(expectedOptions.join(', '));
+        expect(actualSelectedOptions).toEqual(expectedOptions.join(', '));
     });
 
     it('[C601606] Should be able to search and select single options from the single choice dropdown', async () => {
@@ -209,7 +218,7 @@ describe('Form Field Component - Dropdown Widget', () => {
         await dropdown.searchAndChooseOptionFromList(expectedOption);
 
         const actualSelectedOptions = await dropdown.getSelectedOptionText(dropdownId);
-        await expect(actualSelectedOptions).toEqual(expectedOption);
+        expect(actualSelectedOptions).toEqual(expectedOption);
     });
 
     it('[C601606] Should not be able to search if there is less than 6 options to choose', async () => {
@@ -227,6 +236,6 @@ describe('Form Field Component - Dropdown Widget', () => {
         await dropdown.openDropdown(`#${dropdownId}`);
 
         const searchDropdownFieldIsPresent = await dropdown.searchElementLocator.isPresent(1000);
-        await expect(searchDropdownFieldIsPresent).toBeFalsy();
+        expect(searchDropdownFieldIsPresent).toBeFalsy();
     });
 });

--- a/e2e/process-services-cloud/form-field/json-widget.e2e.ts
+++ b/e2e/process-services-cloud/form-field/json-widget.e2e.ts
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 
-import { createApiService,
+import {
+    createApiService,
     AppListCloudPage,
     GroupIdentityService,
     IdentityService,
@@ -33,7 +34,6 @@ import { TasksCloudDemoPage } from '.././pages/tasks-cloud-demo.page';
 import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
 
 describe('Form Field Component - JSON Widget', () => {
-
     const loginSSOPage = new LoginPage();
     const navigationBarPage = new NavigationBarPage();
     const appListCloudComponent = new AppListCloudPage();
@@ -63,7 +63,7 @@ describe('Form Field Component - JSON Widget', () => {
     beforeAll(async () => {
         await apiService.loginWithProfile('identityAdmin');
 
-        testUser = await identityService.createIdentityUserWithRole( [identityService.ROLES.ACTIVITI_USER]);
+        testUser = await identityService.createIdentityUserWithRole([identityService.ROLES.ACTIVITI_USER]);
 
         groupInfo = await groupIdentityService.getGroupInfoByGroupName('hr');
         await identityService.addUserToGroup(testUser.idIdentityService, groupInfo.id);
@@ -79,7 +79,7 @@ describe('Form Field Component - JSON Widget', () => {
     afterAll(async () => {
         await apiService.loginWithProfile('identityAdmin');
         await identityService.deleteIdentityUser(testUser.idIdentityService);
-   });
+    });
 
     beforeEach(async () => {
         await navigationBarPage.navigateToProcessServicesCloudPage();
@@ -99,7 +99,7 @@ describe('Form Field Component - JSON Widget', () => {
         await jsonWidget.clickJsonButton(formWithJson.widgets.displayJsonWidgetId);
 
         await editJsonDialog.checkDialogIsDisplayed();
-        await expect(await editJsonDialog.getDialogContent()).toBe('{}');
+        expect(await editJsonDialog.getDialogContent()).toBe('{}');
         await editJsonDialog.clickCloseButton();
         await editJsonDialog.checkDialogIsNotDisplayed();
     });

--- a/e2e/process-services-cloud/form-field/people-group-of-people.e2e.ts
+++ b/e2e/process-services-cloud/form-field/people-group-of-people.e2e.ts
@@ -15,12 +15,7 @@
  * limitations under the License.
  */
 
-import {
-    FormCloudComponentPage,
-    FormPage,
-    LoginPage,
-    ProcessCloudWidgetPage
-} from '@alfresco/adf-testing';
+import { FormCloudComponentPage, FormPage, LoginPage, ProcessCloudWidgetPage } from '@alfresco/adf-testing';
 import {
     peopleSingleModeFormMock,
     peopleMultipleModeFormMock,
@@ -34,7 +29,6 @@ import {
 import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
 
 describe('People and Group of people Widgets', () => {
-
     const loginSSOPage = new LoginPage();
     const navigationBarPage = new NavigationBarPage();
     const formCloudComponentPage = new FormCloudComponentPage();
@@ -80,7 +74,7 @@ describe('People and Group of people Widgets', () => {
         await peopleCloudWidget.clickPeopleInput(widgets.peopleCloudWidgetSingleModeId);
         await peopleCloudWidget.isPeopleWidgetVisible(peopleValueString.peopleCloudWidgetSingleModeField);
         const peopleSingleMode = await peopleCloudWidget.getFieldValue(widgets.peopleCloudWidgetSingleModeId);
-        await expect(peopleSingleMode).toEqual('');
+        expect(peopleSingleMode).toEqual('');
 
         await peopleCloudWidget.searchAssigneeAndSelect('HR User');
         await peopleCloudWidget.checkSelectedPeople('HR User');
@@ -92,7 +86,7 @@ describe('People and Group of people Widgets', () => {
         await peopleCloudWidget.clickPeopleInput(widgets.peopleCloudWidgetMultipleModeId);
         await peopleCloudWidget.isPeopleWidgetVisible(peopleValueString.peopleCloudWidgetMultipleModeField);
         const peopleMultipleMode = await peopleCloudWidget.getFieldValue(widgets.peopleCloudWidgetMultipleModeId);
-        await expect(peopleMultipleMode).toEqual('');
+        expect(peopleMultipleMode).toEqual('');
 
         await peopleCloudWidget.searchAssigneeAndSelect('HR User');
         await peopleCloudWidget.searchAssigneeAndSelect('Sales User');
@@ -106,24 +100,24 @@ describe('People and Group of people Widgets', () => {
         const readOnlyAttribute = await peopleCloudWidget.checkPeopleWidgetIsReadOnly();
         const activePeopleField = await peopleCloudWidget.checkPeopleActiveField('HR User');
 
-        await expect (readOnlyAttribute).toBe(true);
-        await expect (activePeopleField).toBe(false);
+        expect(readOnlyAttribute).toBe(true);
+        expect(activePeopleField).toBe(false);
     });
 
     it('[C325004] Should save button be enabled for both valid and invalid inputs in the People field', async () => {
         await formCloudComponentPage.setConfigToEditor(peopleRequiredFormMock);
 
         await peopleCloudWidget.isPeopleWidgetVisible(peopleValueString.peopleCloudWidgetRequiredField);
-        await expect(await formPage.isSaveButtonDisabled()).toBe(false);
-        await expect(await formPage.isValidationIconRed()).toBe(true);
+        expect(await formPage.isSaveButtonDisabled()).toBe(false);
+        expect(await formPage.isValidationIconRed()).toBe(true);
 
         const requiredPeople = await peopleCloudWidget.getFieldValue(widgets.peopleCloudWidgetRequiredId);
-        await expect(requiredPeople).toEqual('');
+        expect(requiredPeople).toEqual('');
         await peopleCloudWidget.searchAssigneeAndSelect('HR User');
 
         await peopleCloudWidget.checkSelectedPeople('HR User');
-        await expect(await formPage.isSaveButtonDisabled()).toBe(false);
-        await expect(await formPage.isValidationIconBlue()).toBe(true);
+        expect(await formPage.isSaveButtonDisabled()).toBe(false);
+        expect(await formPage.isValidationIconBlue()).toBe(true);
     });
 
     it('[C325003] Should be able to add a user in Group of people field when Single mode is chosen', async () => {
@@ -131,7 +125,7 @@ describe('People and Group of people Widgets', () => {
 
         await groupCloudWidget.isGroupWidgetVisible(groupValueString.groupCloudWidgetSingleModeField);
         const groupSingleMode = await groupCloudWidget.getGroupsFieldContent();
-        await expect(groupSingleMode).toEqual('');
+        expect(groupSingleMode).toEqual('');
 
         await groupCloudWidget.searchGroups('hr');
         await groupCloudWidget.selectGroupFromList('hr');
@@ -143,7 +137,7 @@ describe('People and Group of people Widgets', () => {
 
         await groupCloudWidget.isGroupWidgetVisible(groupValueString.groupCloudWidgetMultipleModeField);
         const groupSingleMode = await groupCloudWidget.getGroupsFieldContent();
-        await expect(groupSingleMode).toEqual('');
+        expect(groupSingleMode).toEqual('');
 
         await groupCloudWidget.searchGroups('hr');
         await groupCloudWidget.selectGroupFromList('hr');
@@ -159,24 +153,24 @@ describe('People and Group of people Widgets', () => {
         const readOnlyGroupAttribute = await groupCloudWidget.checkGroupWidgetIsReadOnly();
         const activeGroupField = await groupCloudWidget.checkGroupActiveField('hr');
 
-        await expect (readOnlyGroupAttribute).toBe(true);
-        await expect (activeGroupField).toBe(false);
+        expect(readOnlyGroupAttribute).toBe(true);
+        expect(activeGroupField).toBe(false);
     });
 
     it('[C325005] Should save button be enabled for both valid and invalid inputs in the Group of people field', async () => {
         await formCloudComponentPage.setConfigToEditor(groupRequiredFormMock);
 
         await groupCloudWidget.isGroupWidgetVisible(groupValueString.groupCloudWidgetRequiredField);
-        await expect(await formPage.isSaveButtonDisabled()).toBe(false);
-        await expect(await formPage.isValidationIconRed()).toBe(true);
+        expect(await formPage.isSaveButtonDisabled()).toBe(false);
+        expect(await formPage.isValidationIconRed()).toBe(true);
 
         const groupRequired = await groupCloudWidget.getGroupsFieldContent();
-        await expect(groupRequired).toEqual('');
+        expect(groupRequired).toEqual('');
         await groupCloudWidget.searchGroups('hr');
         await groupCloudWidget.selectGroupFromList('hr');
 
         await groupCloudWidget.checkSelectedGroup('hr');
-        await expect(await formPage.isSaveButtonDisabled()).toBe(false);
-        await expect(await formPage.isValidationIconBlue()).toBe(true);
+        expect(await formPage.isSaveButtonDisabled()).toBe(false);
+        expect(await formPage.isValidationIconBlue()).toBe(true);
     });
 });

--- a/e2e/process-services-cloud/form-field/task-visibility-condition.e2e.ts
+++ b/e2e/process-services-cloud/form-field/task-visibility-condition.e2e.ts
@@ -19,11 +19,13 @@ import {
     LoginPage,
     AppListCloudPage,
     IdentityService,
-    GroupIdentityService, createApiService,
+    GroupIdentityService,
+    createApiService,
     StringUtil,
     StartTasksCloudPage,
     TaskFormCloudComponent,
-    StartProcessCloudPage, ProcessCloudWidgetPage
+    StartProcessCloudPage,
+    ProcessCloudWidgetPage
 } from '@alfresco/adf-testing';
 import { browser } from 'protractor';
 
@@ -32,7 +34,6 @@ import { TasksCloudDemoPage } from '.././pages/tasks-cloud-demo.page';
 import { ProcessCloudDemoPage } from '.././pages/process-cloud-demo.page';
 
 describe('Task cloud visibility', async () => {
-
     const simpleApp = browser.params.resources.ACTIVITI_CLOUD_APPS.SIMPLE_APP.name;
 
     const navigationBarPage = new NavigationBarPage();
@@ -59,7 +60,8 @@ describe('Task cloud visibility', async () => {
     const standaloneTaskName = StringUtil.generateRandomString(5);
     const processName = StringUtil.generateRandomString(5);
 
-    let testUser; let groupInfo;
+    let testUser;
+    let groupInfo;
 
     beforeAll(async () => {
         await apiService.loginWithProfile('identityAdmin');
@@ -94,14 +96,14 @@ describe('Task cloud visibility', async () => {
 
         await taskFormCloudComponent.formFields().checkWidgetIsVisible('Number1');
         await taskFormCloudComponent.formFields().checkWidgetIsHidden('Number2');
-        await expect(await taskFormCloudComponent.formFields().isCompleteFormButtonEnabled()).toEqual(false);
+        expect(await taskFormCloudComponent.formFields().isCompleteFormButtonEnabled()).toEqual(false);
 
         await taskFormCloudComponent.formFields().setFieldValue('Number1', '5');
         await taskFormCloudComponent.formFields().checkWidgetIsVisible('Number2');
-        await expect(await taskFormCloudComponent.formFields().isCompleteFormButtonEnabled()).toEqual(true);
+        expect(await taskFormCloudComponent.formFields().isCompleteFormButtonEnabled()).toEqual(true);
 
         await taskFormCloudComponent.formFields().setFieldValue('Number1', '123');
-        await expect(await taskFormCloudComponent.formFields().isCompleteFormButtonEnabled()).toEqual(false);
+        expect(await taskFormCloudComponent.formFields().isCompleteFormButtonEnabled()).toEqual(false);
         await taskFormCloudComponent.formFields().checkWidgetIsHidden('Number2');
     });
 
@@ -124,13 +126,13 @@ describe('Task cloud visibility', async () => {
 
         await taskFormCloudComponent.formFields().checkWidgetIsVisible('Checkbox2');
         await taskFormCloudComponent.formFields().checkWidgetIsHidden('Checkbox3');
-        await expect(await taskFormCloudComponent.formFields().isCompleteFormButtonEnabled()).toEqual(false);
+        expect(await taskFormCloudComponent.formFields().isCompleteFormButtonEnabled()).toEqual(false);
 
         await widget.checkboxWidget().clickCheckboxInput('Checkbox1');
         await widget.checkboxWidget().clickCheckboxInput('Checkbox2');
 
         await widget.checkboxWidget().isCheckboxDisplayed('Checkbox3');
-        await expect(await taskFormCloudComponent.formFields().isCompleteFormButtonEnabled()).toEqual(true);
+        expect(await taskFormCloudComponent.formFields().isCompleteFormButtonEnabled()).toEqual(true);
 
         await taskFormCloudComponent.clickCompleteButton();
     });
@@ -147,13 +149,13 @@ describe('Task cloud visibility', async () => {
 
         await taskFormCloudComponent.formFields().checkWidgetIsVisible('Checkbox2');
         await taskFormCloudComponent.formFields().checkWidgetIsHidden('Checkbox3');
-        await expect(await taskFormCloudComponent.formFields().isCompleteFormButtonEnabled()).toEqual(false);
+        expect(await taskFormCloudComponent.formFields().isCompleteFormButtonEnabled()).toEqual(false);
 
         await widget.checkboxWidget().clickCheckboxInput('Checkbox1');
         await widget.checkboxWidget().clickCheckboxInput('Checkbox2');
 
         await widget.checkboxWidget().isCheckboxDisplayed('Checkbox3');
-        await expect(await taskFormCloudComponent.formFields().isCompleteFormButtonEnabled()).toEqual(true);
+        expect(await taskFormCloudComponent.formFields().isCompleteFormButtonEnabled()).toEqual(true);
 
         await taskFormCloudComponent.clickCompleteButton();
     });

--- a/e2e/process-services-cloud/form-field/visibility-condition.e2e.ts
+++ b/e2e/process-services-cloud/form-field/visibility-condition.e2e.ts
@@ -24,7 +24,6 @@ import { displayValueTextJson } from '../../resources/forms/display-value-visibi
 import { dropdownVisibilityFormFieldJson, dropdownVisibilityFormVariableJson } from '../../resources/forms/dropdown-visibility-condition';
 
 describe('Visibility conditions - cloud', () => {
-
     const loginSSOPage = new LoginPage();
     const navigationBarPage = new NavigationBarPage();
     const formCloudDemoPage = new FormCloudComponentPage();
@@ -72,6 +71,7 @@ describe('Visibility conditions - cloud', () => {
         },
         displayValue: {
             text: 'text1',
+            // eslint-disable-next-line
             number: '11'
         },
         notDisplayValue: {
@@ -187,57 +187,58 @@ describe('Visibility conditions - cloud', () => {
 
         await widget.checkboxWidget().clickCheckboxInput('Checkbox2');
         await widget.checkboxWidget().isCheckboxHidden(checkbox.checkbox1);
-   });
+    });
 
     it('[C309650] Should be able to see Checkbox widget when has multiple visibility conditions and next condition operators', async () => {
-        let text1; let text2;
+        let text1;
+        let text2;
 
         await formCloudDemoPage.setConfigToEditor(multipleVisibilityFormJson);
         await widget.textWidget().isWidgetVisible(widgets.textOneId);
         text1 = await widget.textWidget().getFieldValue(widgets.textOneId);
         text2 = await widget.textWidget().getFieldValue(widgets.textTwoId);
 
-        await expect(text1).toEqual('');
-        await expect(text2).toEqual('');
+        expect(text1).toEqual('');
+        expect(text2).toEqual('');
 
         await widget.textWidget().setValue(widgets.textOneId, 'aaa');
         text1 = await widget.textWidget().getFieldValue(widgets.textOneId);
         text2 = await widget.textWidget().getFieldValue(widgets.textTwoId);
 
-        await expect(text1).toEqual('aaa');
-        await expect(text2).toEqual('');
+        expect(text1).toEqual('aaa');
+        expect(text2).toEqual('');
         await widget.checkboxWidget().isCheckboxDisplayed(widgets.checkboxBasicVariable);
 
         await widget.textWidget().setValue(widgets.textOneId, 'bbb');
         text1 = await widget.textWidget().getFieldValue(widgets.textOneId);
         text2 = await widget.textWidget().getFieldValue(widgets.textTwoId);
 
-        await expect(text1).toEqual('bbb');
-        await expect(text2).toEqual('');
+        expect(text1).toEqual('bbb');
+        expect(text2).toEqual('');
         await widget.checkboxWidget().isCheckboxHidden(widgets.checkboxBasicField);
 
         await widget.textWidget().setValue(widgets.textTwoId, 'aaa');
         text1 = await widget.textWidget().getFieldValue(widgets.textOneId);
         text2 = await widget.textWidget().getFieldValue(widgets.textTwoId);
 
-        await expect(text1).toEqual('bbb');
-        await expect(text2).toEqual('aaa');
+        expect(text1).toEqual('bbb');
+        expect(text2).toEqual('aaa');
         await widget.checkboxWidget().isCheckboxHidden(widgets.checkboxBasicField);
 
         await widget.textWidget().setValue(widgets.textOneId, 'aaa');
         text1 = await widget.textWidget().getFieldValue(widgets.textOneId);
         text2 = await widget.textWidget().getFieldValue(widgets.textTwoId);
 
-        await expect(text1).toEqual('aaa');
-        await expect(text2).toEqual('aaa');
+        expect(text1).toEqual('aaa');
+        expect(text2).toEqual('aaa');
         await widget.checkboxWidget().isCheckboxHidden(widgets.checkboxBasicField);
 
         await widget.textWidget().setValue(widgets.textTwoId, 'bbb');
         text1 = await widget.textWidget().getFieldValue(widgets.textOneId);
         text2 = await widget.textWidget().getFieldValue(widgets.textTwoId);
 
-        await expect(text1).toEqual('aaa');
-        await expect(text2).toEqual('bbb');
+        expect(text1).toEqual('aaa');
+        expect(text2).toEqual('bbb');
 
         await widget.checkboxWidget().isCheckboxDisplayed(widgets.checkboxBasicField);
     });
@@ -268,72 +269,74 @@ describe('Visibility conditions - cloud', () => {
         await widget.displayValueWidget().isDisplayValueWidgetVisible(displayValueString.displayValueNoConditionField);
 
         const textDisplayWidgetNoCondition = await widget.displayValueWidget().getFieldValue(displayValueString.displayValueNoConditionField);
-        await expect(textDisplayWidgetNoCondition).toEqual('No cats');
-   });
+        expect(textDisplayWidgetNoCondition).toEqual('No cats');
+    });
 
     it('[C309869] Should be able to see Display text widget when visibility condition refers to a form variable and a field', async () => {
         await formCloudDemoPage.setConfigToEditor(displayValueTextJson);
 
         await widget.textWidget().isWidgetVisible(widgets.textOneDisplay);
         let textOneField = await widget.textWidget().getFieldValue(widgets.textOneDisplay);
-        await expect(textOneField).toEqual('');
+        expect(textOneField).toEqual('');
         await widget.displayValueWidget().checkDisplayValueWidgetIsHidden(displayValueString.displayValueSingleConditionField);
 
         await widget.textWidget().setValue(widgets.textOneDisplay, 'cat');
         textOneField = await widget.textWidget().getFieldValue(widgets.textOneDisplay);
-        await expect(textOneField).toEqual('cat');
+        expect(textOneField).toEqual('cat');
         await widget.displayValueWidget().isDisplayValueWidgetVisible(displayValueString.displayValueSingleConditionField);
         const textDisplayWidgetSingleCondition = await widget.displayValueWidget().getFieldValue(displayValueString.displayValueSingleConditionField);
-        await expect(textDisplayWidgetSingleCondition).toEqual('cat');
+        expect(textDisplayWidgetSingleCondition).toEqual('cat');
 
         await widget.textWidget().setValue(widgets.textOneDisplay, 'dog');
         textOneField = await widget.textWidget().getFieldValue(widgets.textOneDisplay);
-        await expect(textOneField).toEqual('dog');
+        expect(textOneField).toEqual('dog');
         await widget.displayValueWidget().checkDisplayValueWidgetIsHidden(displayValueString.displayValueSingleConditionField);
-   });
+    });
 
     it('[C309871] Should be able to see Display text widget when has multiple visibility conditions and next condition operators', async () => {
         await formCloudDemoPage.setConfigToEditor(displayValueTextJson);
 
         await widget.textWidget().isWidgetVisible(widgets.textOneDisplay);
         let textOneField = await widget.textWidget().getFieldValue(widgets.textOneDisplay);
-        await expect(textOneField).toEqual('');
+        expect(textOneField).toEqual('');
 
         await widget.textWidget().isWidgetVisible(widgets.textTwoDisplay);
         let textTwoField = await widget.textWidget().getFieldValue(widgets.textTwoDisplay);
-        await expect(textTwoField).toEqual('');
+        expect(textTwoField).toEqual('');
 
         await widget.displayValueWidget().checkDisplayValueWidgetIsHidden(displayValueString.displayValueSingleConditionField);
         await widget.displayValueWidget().checkDisplayValueWidgetIsHidden(displayValueString.displayValueMultipleConditionsField);
 
         await widget.textWidget().setValue(widgets.textOneDisplay, 'cat');
         textOneField = await widget.textWidget().getFieldValue(widgets.textOneDisplay);
-        await expect(textOneField).toEqual('cat');
+        expect(textOneField).toEqual('cat');
         await widget.displayValueWidget().isDisplayValueWidgetVisible(displayValueString.displayValueMultipleConditionsField);
-        const textDisplayWidgetMultipleCondition = await widget.displayValueWidget().getFieldValue(displayValueString.displayValueMultipleConditionsField);
-        await expect(textDisplayWidgetMultipleCondition).toEqual('more cats');
+        const textDisplayWidgetMultipleCondition = await widget
+            .displayValueWidget()
+            .getFieldValue(displayValueString.displayValueMultipleConditionsField);
+        expect(textDisplayWidgetMultipleCondition).toEqual('more cats');
 
         await widget.textWidget().setValue(widgets.textOneDisplay, 'dog');
         textOneField = await widget.textWidget().getFieldValue(widgets.textOneDisplay);
-        await expect(textOneField).toEqual('dog');
+        expect(textOneField).toEqual('dog');
         await widget.displayValueWidget().checkDisplayValueWidgetIsHidden(displayValueString.displayValueMultipleConditionsField);
 
         await widget.textWidget().setValue(widgets.textTwoDisplay, 'cat');
         textTwoField = await widget.textWidget().getFieldValue(widgets.textTwoDisplay);
-        await expect(textTwoField).toEqual('cat');
+        expect(textTwoField).toEqual('cat');
         await widget.displayValueWidget().checkDisplayValueWidgetIsHidden(displayValueString.displayValueMultipleConditionsField);
 
         await widget.textWidget().setValue(widgets.textOneDisplay, 'cat');
         textOneField = await widget.textWidget().getFieldValue(widgets.textOneDisplay);
-        await expect(textOneField).toEqual('cat');
+        expect(textOneField).toEqual('cat');
         await widget.displayValueWidget().checkDisplayValueWidgetIsHidden(displayValueString.displayValueMultipleConditionsField);
 
         await widget.textWidget().setValue(widgets.textTwoDisplay, 'dog');
         textTwoField = await widget.textWidget().getFieldValue(widgets.textTwoDisplay);
-        await expect(textTwoField).toEqual('dog');
+        expect(textTwoField).toEqual('dog');
         await widget.displayValueWidget().isDisplayValueWidgetVisible(displayValueString.displayValueMultipleConditionsField);
-        await expect(textDisplayWidgetMultipleCondition).toEqual('more cats');
-   });
+        expect(textDisplayWidgetMultipleCondition).toEqual('more cats');
+    });
 
     it('[C309680] Should be able to see dropdown widget when has multiple Visibility Conditions set on Form Fields', async () => {
         await formCloudDemoPage.setConfigToEditor(dropdownVisibilityFormFieldJson);
@@ -348,11 +351,11 @@ describe('Visibility conditions - cloud', () => {
 
         await widget.amountWidget().setFieldValue(dropdownVisibilityTest.widgets.amountId, dropdownVisibilityTest.notDisplayValue.amount);
         await widget.dropdown().isWidgetHidden(dropdownVisibilityTest.widgets.dropdownId);
-   });
+    });
 
     it('[C309682] Should be able to see dropdown widget when has multiple Visibility Conditions set on Form Variables', async () => {
         await formCloudDemoPage.setConfigToEditor(dropdownVisibilityFormVariableJson);
 
         await widget.dropdown().isWidgetVisible(dropdownVisibilityTest.widgets.dropdownId);
-   });
+    });
 });

--- a/e2e/process-services-cloud/process/process-custom-filters.e2e.ts
+++ b/e2e/process-services-cloud/process/process-custom-filters.e2e.ts
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 
-import { createApiService,
+import {
+    createApiService,
     AppListCloudPage,
     BrowserActions,
     FilterProps,
@@ -37,7 +38,6 @@ import { EditProcessFilterConfiguration } from './../config/edit-process-filter.
 import { ProcessListCloudConfiguration } from './../config/process-list-cloud.config';
 
 describe('Process list cloud', () => {
-
     // en-US values for the process status
     const PROCESS_STATUS = {
         ALL: 'All',
@@ -53,7 +53,6 @@ describe('Process list cloud', () => {
     };
 
     describe('Process List', () => {
-
         const loginSSOPage = new LoginPage();
         const navigationBarPage = new NavigationBarPage();
         const appListCloudComponent = new AppListCloudPage();
@@ -77,54 +76,63 @@ describe('Process list cloud', () => {
         const processListCloudConfigFile = processListCloudConfiguration.getConfiguration();
         const editProcessFilterConfigFile = editProcessFilterConfiguration.getConfiguration();
 
-        let completedProcess; let runningProcessInstance; let switchProcessInstance; let noOfApps; let testUser; let groupInfo;
-            let anotherProcessInstance;
+        let completedProcess;
+        let runningProcessInstance;
+        let switchProcessInstance;
+        let noOfApps;
+        let testUser;
+        let groupInfo;
+        let anotherProcessInstance;
         const candidateBaseApp = browser.params.resources.ACTIVITI_CLOUD_APPS.CANDIDATE_BASE_APP.name;
 
         beforeAll(async () => {
-        await apiService.loginWithProfile('identityAdmin');
+            await apiService.loginWithProfile('identityAdmin');
 
-        testUser = await identityService.createIdentityUserWithRole( [identityService.ROLES.ACTIVITI_USER]);
+            testUser = await identityService.createIdentityUserWithRole([identityService.ROLES.ACTIVITI_USER]);
 
-        groupInfo = await groupIdentityService.getGroupInfoByGroupName('hr');
-        await identityService.addUserToGroup(testUser.idIdentityService, groupInfo.id);
-        await apiService.login(testUser.username, testUser.password);
+            groupInfo = await groupIdentityService.getGroupInfoByGroupName('hr');
+            await identityService.addUserToGroup(testUser.idIdentityService, groupInfo.id);
+            await apiService.login(testUser.username, testUser.password);
 
-        const processDefinition = await processDefinitionService
-                .getProcessDefinitionByName(browser.params.resources.ACTIVITI_CLOUD_APPS.CANDIDATE_BASE_APP.processes.candidateGroupProcess, candidateBaseApp);
+            const processDefinition = await processDefinitionService.getProcessDefinitionByName(
+                browser.params.resources.ACTIVITI_CLOUD_APPS.CANDIDATE_BASE_APP.processes.candidateGroupProcess,
+                candidateBaseApp
+            );
 
-        const anotherProcessDefinition = await processDefinitionService
-                .getProcessDefinitionByName(browser.params.resources.ACTIVITI_CLOUD_APPS.CANDIDATE_BASE_APP.processes.anotherCandidateGroupProcess, candidateBaseApp);
+            const anotherProcessDefinition = await processDefinitionService.getProcessDefinitionByName(
+                browser.params.resources.ACTIVITI_CLOUD_APPS.CANDIDATE_BASE_APP.processes.anotherCandidateGroupProcess,
+                candidateBaseApp
+            );
 
-        await processInstancesService.createProcessInstance(processDefinition.entry.key, candidateBaseApp);
+            await processInstancesService.createProcessInstance(processDefinition.entry.key, candidateBaseApp);
 
-        runningProcessInstance = await processInstancesService.createProcessInstance(processDefinition.entry.key, candidateBaseApp, {
+            runningProcessInstance = await processInstancesService.createProcessInstance(processDefinition.entry.key, candidateBaseApp, {
                 name: StringUtil.generateRandomString(),
                 businessKey: StringUtil.generateRandomString()
             });
 
-        anotherProcessInstance = await processInstancesService.createProcessInstance(anotherProcessDefinition.entry.key, candidateBaseApp, {
+            anotherProcessInstance = await processInstancesService.createProcessInstance(anotherProcessDefinition.entry.key, candidateBaseApp, {
                 name: StringUtil.generateRandomString(),
                 businessKey: StringUtil.generateRandomString()
             });
 
-        switchProcessInstance = await processInstancesService.createProcessInstance(processDefinition.entry.key, candidateBaseApp, {
+            switchProcessInstance = await processInstancesService.createProcessInstance(processDefinition.entry.key, candidateBaseApp, {
                 name: StringUtil.generateRandomString(),
                 businessKey: StringUtil.generateRandomString()
             });
 
-        completedProcess = await processInstancesService.createProcessInstance(processDefinition.entry.key, candidateBaseApp, {
+            completedProcess = await processInstancesService.createProcessInstance(processDefinition.entry.key, candidateBaseApp, {
                 name: StringUtil.generateRandomString(),
                 businessKey: StringUtil.generateRandomString()
             });
 
-        const task = await queryService.getProcessInstanceTasks(completedProcess.entry.id, candidateBaseApp);
-        const claimedTask = await tasksService.claimTask(task.list.entries[0].entry.id, candidateBaseApp);
-        await tasksService.completeTask(claimedTask.entry.id, candidateBaseApp);
+            const task = await queryService.getProcessInstanceTasks(completedProcess.entry.id, candidateBaseApp);
+            const claimedTask = await tasksService.claimTask(task.list.entries[0].entry.id, candidateBaseApp);
+            await tasksService.completeTask(claimedTask.entry.id, candidateBaseApp);
 
-        await loginSSOPage.login(testUser.username, testUser.password);
-        await LocalStorageUtil.setConfigField('adf-edit-process-filter', JSON.stringify(editProcessFilterConfigFile));
-        await LocalStorageUtil.setConfigField('adf-cloud-process-list', JSON.stringify(processListCloudConfigFile));
+            await loginSSOPage.login(testUser.username, testUser.password);
+            await LocalStorageUtil.setConfigField('adf-edit-process-filter', JSON.stringify(editProcessFilterConfigFile));
+            await LocalStorageUtil.setConfigField('adf-cloud-process-list', JSON.stringify(processListCloudConfigFile));
         });
 
         afterAll(async () => {
@@ -142,24 +150,32 @@ describe('Process list cloud', () => {
             await processCloudDemoPage.processFilterCloudComponent.clickOnProcessFilters();
         });
 
+        /**
+         * Set the filter
+         *
+         * @param props FilterProps
+         */
         async function setFilter(props: FilterProps): Promise<void> {
             await editProcessFilter.setFilter(props);
             await waitTillContentLoaded();
         }
 
+        /**
+         * Wait for the content to be loaded
+         */
         async function waitTillContentLoaded() {
             await processList.getDataTable().waitTillContentLoaded();
         }
 
         it('[C291783] Should display processes ordered by id when Id is selected from sort dropdown', async () => {
             await setFilter({ status: PROCESS_STATUS.RUNNING });
-            await setFilter({ sort: 'Id'});
+            await setFilter({ sort: 'Id' });
             await setFilter({ order: SORT_DIRECTION.ASC });
 
-            await expect(await processList.getDataTable().checkListIsSorted(SORT_DIRECTION.ASC, 'Id')).toBe(true);
+            expect(await processList.getDataTable().checkListIsSorted(SORT_DIRECTION.ASC, 'Id')).toBe(true);
 
-            await setFilter({ order: SORT_DIRECTION.DESC});
-            await expect(await processList.getDataTable().checkListIsSorted(SORT_DIRECTION.DESC, 'Id')).toBe(true);
+            await setFilter({ order: SORT_DIRECTION.DESC });
+            expect(await processList.getDataTable().checkListIsSorted(SORT_DIRECTION.DESC, 'Id')).toBe(true);
         });
 
         it('[C305054] Should display processes ordered by status when Status is selected from sort dropdown', async () => {
@@ -167,10 +183,10 @@ describe('Process list cloud', () => {
             await setFilter({ sort: 'Status' });
             await setFilter({ order: SORT_DIRECTION.ASC });
 
-            await expect(await processList.getDataTable().checkListIsSorted(SORT_DIRECTION.ASC, 'Status')).toBe(true);
+            expect(await processList.getDataTable().checkListIsSorted(SORT_DIRECTION.ASC, 'Status')).toBe(true);
 
-            await setFilter({ order: SORT_DIRECTION.DESC});
-            await expect(await processList.getDataTable().checkListIsSorted(SORT_DIRECTION.DESC, 'Status')).toBe(true);
+            await setFilter({ order: SORT_DIRECTION.DESC });
+            expect(await processList.getDataTable().checkListIsSorted(SORT_DIRECTION.DESC, 'Status')).toBe(true);
         });
 
         it('[C305054] Should display processes ordered by last modified date when Last Modified is selected from sort dropdown', async () => {
@@ -178,10 +194,10 @@ describe('Process list cloud', () => {
             await setFilter({ sort: 'Last Modified' });
             await setFilter({ order: SORT_DIRECTION.ASC });
 
-            await expect(await processList.getDataTable().checkListIsSorted(SORT_DIRECTION.ASC, 'Last Modified')).toBe(true);
+            expect(await processList.getDataTable().checkListIsSorted(SORT_DIRECTION.ASC, 'Last Modified')).toBe(true);
 
             await setFilter({ order: SORT_DIRECTION.DESC });
-            await expect(await processList.getDataTable().checkListIsSorted(SORT_DIRECTION.DESC, 'Last Modified')).toBe(true);
+            expect(await processList.getDataTable().checkListIsSorted(SORT_DIRECTION.DESC, 'Last Modified')).toBe(true);
         });
 
         it('[C305054] Should display processes ordered by business key date when BusinessKey is selected from sort dropdown', async () => {
@@ -189,10 +205,10 @@ describe('Process list cloud', () => {
             await setFilter({ sort: 'Business Key' });
             await setFilter({ order: SORT_DIRECTION.ASC });
 
-            await expect(await processList.getDataTable().checkListIsSorted(SORT_DIRECTION.ASC, 'Business Key')).toBe(true);
+            expect(await processList.getDataTable().checkListIsSorted(SORT_DIRECTION.ASC, 'Business Key')).toBe(true);
 
-            await setFilter({ order: SORT_DIRECTION.DESC});
-            await expect(await processList.getDataTable().checkListIsSorted(SORT_DIRECTION.DESC, 'Business Key')).toBe(true);
+            await setFilter({ order: SORT_DIRECTION.DESC });
+            expect(await processList.getDataTable().checkListIsSorted(SORT_DIRECTION.DESC, 'Business Key')).toBe(true);
         });
 
         it('[C297697] The value of the filter should be preserved when saving it', async () => {
@@ -202,19 +218,19 @@ describe('Process list cloud', () => {
 
             await editProcessFilter.saveAs('New');
 
-            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('New');
+            expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('New');
 
             await processList.checkContentIsDisplayedById(completedProcess.entry.id);
-            await expect(await processList.getDataTable().numberOfRows()).toBe(1);
+            expect(await processList.getDataTable().numberOfRows()).toBe(1);
 
-            await expect(await editProcessFilter.getProcessInstanceId()).toEqual(completedProcess.entry.id);
+            expect(await editProcessFilter.getProcessInstanceId()).toEqual(completedProcess.entry.id);
         });
 
         it('[C297646] Should display the filter dropdown fine , after switching between saved filters', async () => {
             await editProcessFilter.openFilter();
             noOfApps = await editProcessFilter.getNumberOfAppNameOptions();
 
-            await expect(await editProcessFilter.checkAppNamesAreUnique()).toBe(true);
+            expect(await editProcessFilter.checkAppNamesAreUnique()).toBe(true);
             await BrowserActions.closeMenuAndDialogs();
             await editProcessFilter.setStatusFilterDropDown(PROCESS_STATUS.RUNNING);
             await editProcessFilter.setAppNameDropDown(candidateBaseApp);
@@ -222,14 +238,14 @@ describe('Process list cloud', () => {
             await waitTillContentLoaded();
 
             await processList.checkContentIsDisplayedById(runningProcessInstance.entry.id);
-            await expect(await editProcessFilter.getNumberOfAppNameOptions()).toBe(noOfApps);
-            await expect(await editProcessFilter.checkAppNamesAreUnique()).toBe(true);
+            expect(await editProcessFilter.getNumberOfAppNameOptions()).toBe(noOfApps);
+            expect(await editProcessFilter.checkAppNamesAreUnique()).toBe(true);
             await BrowserActions.closeMenuAndDialogs();
 
             await editProcessFilter.saveAs('SavedFilter');
-            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('SavedFilter');
+            expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('SavedFilter');
 
-            await expect(await editProcessFilter.getProcessInstanceId()).toEqual(runningProcessInstance.entry.id);
+            expect(await editProcessFilter.getProcessInstanceId()).toEqual(runningProcessInstance.entry.id);
 
             await editProcessFilter.setStatusFilterDropDown(PROCESS_STATUS.RUNNING);
             await editProcessFilter.setAppNameDropDown(candidateBaseApp);
@@ -238,13 +254,12 @@ describe('Process list cloud', () => {
 
             await processList.checkContentIsDisplayedById(switchProcessInstance.entry.id);
             await editProcessFilter.saveAs('SwitchFilter');
-            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('SwitchFilter');
+            expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe('SwitchFilter');
 
-            await expect(await editProcessFilter.getProcessInstanceId()).toEqual(switchProcessInstance.entry.id);
-            await expect(await editProcessFilter.getNumberOfAppNameOptions()).toBe(noOfApps);
-            await expect(await editProcessFilter.checkAppNamesAreUnique()).toBe(true);
+            expect(await editProcessFilter.getProcessInstanceId()).toEqual(switchProcessInstance.entry.id);
+            expect(await editProcessFilter.getNumberOfAppNameOptions()).toBe(noOfApps);
+            expect(await editProcessFilter.checkAppNamesAreUnique()).toBe(true);
             await BrowserActions.closeMenuAndDialogs();
         });
-
-   });
+    });
 });

--- a/e2e/process-services-cloud/process/process-filter-results.e2e.ts
+++ b/e2e/process-services-cloud/process/process-filter-results.e2e.ts
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 
-import { createApiService,
+import {
+    createApiService,
     AppListCloudPage,
     GroupIdentityService,
     IdentityService,
@@ -36,9 +37,7 @@ import { EditProcessFilterConfiguration } from './../config/edit-process-filter.
 import { ProcessListCloudConfiguration } from './../config/process-list-cloud.config';
 import { addDays, format, subDays } from 'date-fns';
 
-
 describe('Process filters cloud', () => {
-
     // en-US values for the process status
     const PROCESS_STATUS = {
         ALL: 'All',
@@ -99,16 +98,18 @@ describe('Process filters cloud', () => {
     beforeAll(async () => {
         await apiService.loginWithProfile('identityAdmin');
 
-        testUser = await identityService.createIdentityUserWithRole( [identityService.ROLES.ACTIVITI_USER]);
-        anotherUser = await identityService.createIdentityUserWithRole( [identityService.ROLES.ACTIVITI_USER]);
+        testUser = await identityService.createIdentityUserWithRole([identityService.ROLES.ACTIVITI_USER]);
+        anotherUser = await identityService.createIdentityUserWithRole([identityService.ROLES.ACTIVITI_USER]);
 
         groupInfo = await groupIdentityService.getGroupInfoByGroupName('hr');
         await identityService.addUserToGroup(testUser.idIdentityService, groupInfo.id);
         await identityService.addUserToGroup(anotherUser.idIdentityService, groupInfo.id);
 
         await apiService.login(anotherUser.username, anotherUser.password);
-        simpleAppProcessDefinition = await processDefinitionService
-            .getProcessDefinitionByName(browser.params.resources.ACTIVITI_CLOUD_APPS.SIMPLE_APP.processes.simpleProcess, simpleApp);
+        simpleAppProcessDefinition = await processDefinitionService.getProcessDefinitionByName(
+            browser.params.resources.ACTIVITI_CLOUD_APPS.SIMPLE_APP.processes.simpleProcess,
+            simpleApp
+        );
 
         differentAppUserProcessInstance = await processInstancesService.createProcessInstance(simpleAppProcessDefinition.entry.key, simpleApp, {
             name: StringUtil.generateRandomString(),
@@ -116,11 +117,15 @@ describe('Process filters cloud', () => {
         });
 
         await apiService.login(testUser.username, testUser.password);
-        processDefinition = await processDefinitionService
-            .getProcessDefinitionByName(browser.params.resources.ACTIVITI_CLOUD_APPS.CANDIDATE_BASE_APP.processes.candidateGroupProcess, candidateBaseApp);
+        processDefinition = await processDefinitionService.getProcessDefinitionByName(
+            browser.params.resources.ACTIVITI_CLOUD_APPS.CANDIDATE_BASE_APP.processes.candidateGroupProcess,
+            candidateBaseApp
+        );
 
-        anotherProcessDefinition = await processDefinitionService
-            .getProcessDefinitionByName(browser.params.resources.ACTIVITI_CLOUD_APPS.CANDIDATE_BASE_APP.processes.anotherCandidateGroupProcess, candidateBaseApp);
+        anotherProcessDefinition = await processDefinitionService.getProcessDefinitionByName(
+            browser.params.resources.ACTIVITI_CLOUD_APPS.CANDIDATE_BASE_APP.processes.anotherCandidateGroupProcess,
+            candidateBaseApp
+        );
 
         runningProcessInstance = await processInstancesService.createProcessInstance(processDefinition.entry.key, candidateBaseApp, {
             name: StringUtil.generateRandomString(),
@@ -150,7 +155,7 @@ describe('Process filters cloud', () => {
         await loginSSOPage.login(testUser.username, testUser.password);
         await LocalStorageUtil.setConfigField('adf-edit-process-filter', JSON.stringify(editProcessFilterConfigFile));
         await LocalStorageUtil.setConfigField('adf-cloud-process-list', JSON.stringify(processListCloudConfigFile));
-   });
+    });
 
     afterAll(async () => {
         await processInstancesService.deleteProcessInstance(runningProcessInstance.entry.id, candidateBaseApp);
@@ -164,7 +169,7 @@ describe('Process filters cloud', () => {
 
         await identityService.deleteIdentityUser(testUser.idIdentityService);
         await identityService.deleteIdentityUser(anotherUser.idIdentityService);
-   });
+    });
 
     beforeEach(async () => {
         await navigationBarPage.navigateToProcessServicesCloudPage();
@@ -193,7 +198,7 @@ describe('Process filters cloud', () => {
         await editProcessFilter.setInitiator(`${testUser.firstName} ${testUser.lastName}`);
         await processList.getDataTable().waitTillContentLoaded();
 
-        await expect(await processListPage.getDisplayedProcessListTitle()).toEqual('No Processes Found');
+        expect(await processListPage.getDisplayedProcessListTitle()).toEqual('No Processes Found');
     });
 
     it('[C306890] Should be able to filter by initiator', async () => {
@@ -239,13 +244,13 @@ describe('Process filters cloud', () => {
         await processList.getDataTable().waitTillContentLoaded();
         await processList.checkContentIsDisplayedByName(runningProcessInstance.entry.name);
 
-        await expect(await processList.getDataTable().getNumberOfRows()).toBe(1);
+        expect(await processList.getDataTable().getNumberOfRows()).toBe(1);
 
         await editProcessFilter.setProperty('processInstanceId', anotherProcessInstance.entry.id);
         await processList.getDataTable().waitTillContentLoaded();
         await processList.checkContentIsDisplayedByName(anotherProcessInstance.entry.name);
         await processList.checkContentIsNotDisplayedByName(runningProcessInstance.entry.name);
-        await expect(await processList.getDataTable().getNumberOfRows()).toBe(1);
+        expect(await processList.getDataTable().getNumberOfRows()).toBe(1);
     });
 
     it('[C311321] Should be able to filter by process name', async () => {
@@ -364,6 +369,6 @@ describe('Process filters cloud', () => {
         await editProcessFilter.setProperty('lastModifiedFrom', afterDate);
         await processList.getDataTable().waitTillContentLoaded();
         await editProcessFilter.setProperty('lastModifiedTo', afterDate);
-        await expect(await processListPage.getDisplayedProcessListTitle()).toEqual('No Processes Found');
+        expect(await processListPage.getDisplayedProcessListTitle()).toEqual('No Processes Found');
     });
 });

--- a/e2e/process-services-cloud/process/process-filters-cloud.e2e.ts
+++ b/e2e/process-services-cloud/process/process-filters-cloud.e2e.ts
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 
-import { createApiService,
+import {
+    createApiService,
     AppListCloudPage,
     GroupIdentityService,
     IdentityService,
@@ -34,7 +35,6 @@ import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
 import CONSTANTS = require('../../util/constants');
 
 describe('Process filters cloud', () => {
-
     describe('Process Filters', () => {
         const loginSSOPage = new LoginPage();
         const navigationBarPage = new NavigationBarPage();
@@ -51,21 +51,26 @@ describe('Process filters cloud', () => {
         const tasksService = new TasksService(apiService);
         const processInstancesService = new ProcessInstancesService(apiService);
 
-        let runningProcess; let completedProcess; let testUser; let groupInfo;
+        let runningProcess;
+        let completedProcess;
+        let testUser;
+        let groupInfo;
         const candidateBaseApp = browser.params.resources.ACTIVITI_CLOUD_APPS.CANDIDATE_BASE_APP.name;
         const PROCESSES = CONSTANTS.PROCESS_FILTERS;
 
         beforeAll(async () => {
             await apiService.loginWithProfile('identityAdmin');
 
-            testUser = await identityService.createIdentityUserWithRole( [identityService.ROLES.ACTIVITI_USER]);
+            testUser = await identityService.createIdentityUserWithRole([identityService.ROLES.ACTIVITI_USER]);
 
             groupInfo = await groupIdentityService.getGroupInfoByGroupName('hr');
             await identityService.addUserToGroup(testUser.idIdentityService, groupInfo.id);
             await apiService.login(testUser.username, testUser.password);
 
-            const processDefinition = await processDefinitionService
-                .getProcessDefinitionByName(browser.params.resources.ACTIVITI_CLOUD_APPS.CANDIDATE_BASE_APP.processes.candidateGroupProcess, candidateBaseApp);
+            const processDefinition = await processDefinitionService.getProcessDefinitionByName(
+                browser.params.resources.ACTIVITI_CLOUD_APPS.CANDIDATE_BASE_APP.processes.candidateGroupProcess,
+                candidateBaseApp
+            );
 
             runningProcess = await processInstancesService.createProcessInstance(processDefinition.entry.key, candidateBaseApp, {
                 name: StringUtil.generateRandomString(),
@@ -82,7 +87,6 @@ describe('Process filters cloud', () => {
             await tasksService.completeTask(claimedTask.entry.id, candidateBaseApp);
 
             await loginSSOPage.login(testUser.username, testUser.password);
-
         }, 5 * 60 * 1000);
 
         afterAll(async () => {
@@ -108,17 +112,17 @@ describe('Process filters cloud', () => {
             await processCloudDemoPage.processFilterCloudComponent.clickRunningProcessesFilter();
             await editProcessFilterCloudComponentPage.openFilter();
             await editProcessFilterCloudComponentPage.setProcessName(runningProcess.entry.name);
-            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe(PROCESSES.RUNNING);
+            expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe(PROCESSES.RUNNING);
             await processCloudDemoPage.processListCloudComponent().checkContentIsDisplayedById(runningProcess.entry.id);
 
             await processCloudDemoPage.processFilterCloudComponent.clickCompletedProcessesFilter();
             await editProcessFilterCloudComponentPage.setProcessName(runningProcess.entry.name);
-            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe(PROCESSES.COMPLETED);
+            expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe(PROCESSES.COMPLETED);
             await processCloudDemoPage.processListCloudComponent().checkContentIsNotDisplayedById(runningProcess.entry.id);
 
             await processCloudDemoPage.processFilterCloudComponent.clickAllProcessesFilter();
             await editProcessFilterCloudComponentPage.setProcessName(runningProcess.entry.name);
-            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe(PROCESSES.ALL);
+            expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe(PROCESSES.ALL);
             await processCloudDemoPage.processListCloudComponent().checkContentIsDisplayedById(runningProcess.entry.id);
         });
 
@@ -126,17 +130,17 @@ describe('Process filters cloud', () => {
             await processCloudDemoPage.processFilterCloudComponent.clickRunningProcessesFilter();
             await editProcessFilterCloudComponentPage.openFilter();
             await editProcessFilterCloudComponentPage.setProcessName(completedProcess.entry.name);
-            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe(PROCESSES.RUNNING);
+            expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe(PROCESSES.RUNNING);
             await processCloudDemoPage.processListCloudComponent().checkContentIsNotDisplayedById(completedProcess.entry.id);
 
             await processCloudDemoPage.processFilterCloudComponent.clickCompletedProcessesFilter();
             await editProcessFilterCloudComponentPage.setProcessName(completedProcess.entry.name);
-            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe(PROCESSES.COMPLETED);
+            expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe(PROCESSES.COMPLETED);
             await processCloudDemoPage.processListCloudComponent().checkContentIsDisplayedById(completedProcess.entry.id);
 
             await processCloudDemoPage.processFilterCloudComponent.clickAllProcessesFilter();
             await editProcessFilterCloudComponentPage.setProcessName(completedProcess.entry.name);
-            await expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe(PROCESSES.ALL);
+            expect(await processCloudDemoPage.processFilterCloudComponent.getActiveFilterName()).toBe(PROCESSES.ALL);
             await processCloudDemoPage.processListCloudComponent().checkContentIsDisplayedById(completedProcess.entry.id);
         });
     });

--- a/e2e/process-services-cloud/process/process-header-cloud.e2e.ts
+++ b/e2e/process-services-cloud/process/process-header-cloud.e2e.ts
@@ -15,7 +15,19 @@
  * limitations under the License.
  */
 
-import { createApiService, AppListCloudPage, GroupIdentityService, IdentityService, LoginPage, ProcessDefinitionsService, ProcessHeaderCloudPage, ProcessInstancesService, QueryService, StringUtil, LocalStorageUtil } from '@alfresco/adf-testing';
+import {
+    createApiService,
+    AppListCloudPage,
+    GroupIdentityService,
+    IdentityService,
+    LoginPage,
+    ProcessDefinitionsService,
+    ProcessHeaderCloudPage,
+    ProcessInstancesService,
+    QueryService,
+    StringUtil,
+    LocalStorageUtil
+} from '@alfresco/adf-testing';
 import { browser } from 'protractor';
 import { ProcessCloudDemoPage } from './../pages/process-cloud-demo.page';
 import { TasksCloudDemoPage } from './../pages/tasks-cloud-demo.page';
@@ -25,7 +37,6 @@ import { EditProcessFilterConfiguration } from './../config/edit-process-filter.
 import { DateFnsUtils } from '../../../lib/core/src/lib/common/utils/date-fns-utils';
 
 describe('Process Header cloud component', () => {
-
     describe('Process Header cloud component', () => {
         const simpleApp = browser.params.resources.ACTIVITI_CLOUD_APPS.SIMPLE_APP.name;
         const subProcessApp = browser.params.resources.ACTIVITI_CLOUD_APPS.SUB_PROCESS_APP.name;
@@ -55,34 +66,45 @@ describe('Process Header cloud component', () => {
         const processInstancesService = new ProcessInstancesService(apiService);
         const queryService = new QueryService(apiService);
 
-        let testUser; let groupInfo;
+        let testUser;
+        let groupInfo;
 
-        let runningProcess; let runningCreatedDate; let parentCompleteProcess; let childCompleteProcess; let completedCreatedDate;
+        let runningProcess;
+        let runningCreatedDate;
+        let parentCompleteProcess;
+        let childCompleteProcess;
+        let completedCreatedDate;
         const PROCESSES = CONSTANTS.PROCESS_FILTERS;
 
         beforeAll(async () => {
             await apiService.loginWithProfile('identityAdmin');
 
-            testUser = await identityService.createIdentityUserWithRole( [identityService.ROLES.ACTIVITI_USER]);
+            testUser = await identityService.createIdentityUserWithRole([identityService.ROLES.ACTIVITI_USER]);
             groupInfo = await groupIdentityService.getGroupInfoByGroupName('hr');
             await identityService.addUserToGroup(testUser.idIdentityService, groupInfo.id);
 
             await apiService.login(testUser.username, testUser.password);
 
-            const simpleProcess = await processDefinitionService.getProcessDefinitionByName(browser.params.resources.ACTIVITI_CLOUD_APPS.SIMPLE_APP.processes.simpleProcess, simpleApp);
+            const simpleProcess = await processDefinitionService.getProcessDefinitionByName(
+                browser.params.resources.ACTIVITI_CLOUD_APPS.SIMPLE_APP.processes.simpleProcess,
+                simpleApp
+            );
 
-            const processparent = await processDefinitionService.getProcessDefinitionByName(browser.params.resources.ACTIVITI_CLOUD_APPS.SUB_PROCESS_APP.processes.processparent, subProcessApp);
+            const processparent = await processDefinitionService.getProcessDefinitionByName(
+                browser.params.resources.ACTIVITI_CLOUD_APPS.SUB_PROCESS_APP.processes.processparent,
+                subProcessApp
+            );
 
-            runningProcess = await processInstancesService.createProcessInstance(simpleProcess.entry.key,
-                simpleApp, { name: StringUtil.generateRandomString(), businessKey: 'test' });
+            runningProcess = await processInstancesService.createProcessInstance(simpleProcess.entry.key, simpleApp, {
+                name: StringUtil.generateRandomString(),
+                businessKey: 'test'
+            });
 
             runningCreatedDate = DateFnsUtils.formatDate(new Date(runningProcess.entry.startDate), formatDate);
 
-            parentCompleteProcess = await processInstancesService.createProcessInstance(processparent.entry.key,
-                subProcessApp);
+            parentCompleteProcess = await processInstancesService.createProcessInstance(processparent.entry.key, subProcessApp);
 
-            const parentProcessInstance = await queryService.getProcessInstanceSubProcesses(parentCompleteProcess.entry.id,
-                subProcessApp);
+            const parentProcessInstance = await queryService.getProcessInstanceSubProcesses(parentCompleteProcess.entry.id, subProcessApp);
 
             childCompleteProcess = parentProcessInstance.list.entries[0];
 
@@ -108,21 +130,21 @@ describe('Process Header cloud component', () => {
             await processFilter.clickOnProcessFilters();
             await processFilter.clickRunningProcessesFilter();
 
-            await expect(await processFilter.getActiveFilterName()).toBe(PROCESSES.RUNNING);
+            expect(await processFilter.getActiveFilterName()).toBe(PROCESSES.RUNNING);
 
             await editProcessFilter.setFilter({ processName: runningProcess.entry.name });
             await processList.getDataTable().waitTillContentLoaded();
             await processList.checkContentIsDisplayedByName(runningProcess.entry.name);
 
             await processList.selectRow(runningProcess.entry.name);
-            await expect(await processHeaderCloudPage.getId()).toEqual(runningProcess.entry.id);
-            await expect(await processHeaderCloudPage.getName()).toEqual(runningProcess.entry.name);
-            await expect(await processHeaderCloudPage.getStatus()).toEqual('RUNNING');
-            await expect(await processHeaderCloudPage.getInitiator()).toEqual(runningProcess.entry.initiator);
-            await expect(await processHeaderCloudPage.getStartDate()).toEqual(runningCreatedDate);
-            await expect(await processHeaderCloudPage.getParentId()).toEqual(CONSTANTS.PROCESS_DETAILS.NO_PARENT);
-            await expect(await processHeaderCloudPage.getBusinessKey()).toEqual(runningProcess.entry.businessKey);
-            await expect(await processHeaderCloudPage.getLastModified()).toEqual(runningCreatedDate);
+            expect(await processHeaderCloudPage.getId()).toEqual(runningProcess.entry.id);
+            expect(await processHeaderCloudPage.getName()).toEqual(runningProcess.entry.name);
+            expect(await processHeaderCloudPage.getStatus()).toEqual('RUNNING');
+            expect(await processHeaderCloudPage.getInitiator()).toEqual(runningProcess.entry.initiator);
+            expect(await processHeaderCloudPage.getStartDate()).toEqual(runningCreatedDate);
+            expect(await processHeaderCloudPage.getParentId()).toEqual(CONSTANTS.PROCESS_DETAILS.NO_PARENT);
+            expect(await processHeaderCloudPage.getBusinessKey()).toEqual(runningProcess.entry.businessKey);
+            expect(await processHeaderCloudPage.getLastModified()).toEqual(runningCreatedDate);
         });
 
         it('[C305008] Should display process details for completed process', async () => {
@@ -131,7 +153,7 @@ describe('Process Header cloud component', () => {
             await processFilter.clickOnProcessFilters();
 
             await processFilter.clickCompletedProcessesFilter();
-            await expect(await processFilter.getActiveFilterName()).toBe(PROCESSES.COMPLETED);
+            expect(await processFilter.getActiveFilterName()).toBe(PROCESSES.COMPLETED);
 
             await editProcessFilter.setFilter({ initiator: `${testUser.firstName} ${testUser.lastName}` });
             await processList.getDataTable().waitTillContentLoaded();
@@ -140,14 +162,14 @@ describe('Process Header cloud component', () => {
             await processList.checkProcessListIsLoaded();
             await processList.selectRowById(childCompleteProcess.entry.id);
 
-            await expect(await processHeaderCloudPage.getId()).toEqual(childCompleteProcess.entry.id);
-            await expect(await processHeaderCloudPage.getName()).toEqual(CONSTANTS.PROCESS_DETAILS.NO_NAME);
-            await expect(await processHeaderCloudPage.getStatus()).toEqual('COMPLETED');
-            await expect(await processHeaderCloudPage.getInitiator()).toEqual(childCompleteProcess.entry.initiator);
-            await expect(await processHeaderCloudPage.getStartDate()).toEqual(completedCreatedDate);
-            await expect(await processHeaderCloudPage.getParentId()).toEqual(childCompleteProcess.entry.parentId);
-            await expect(await processHeaderCloudPage.getBusinessKey()).toEqual(CONSTANTS.PROCESS_DETAILS.NO_BUSINESS_KEY);
-            await expect(await processHeaderCloudPage.getLastModified()).toEqual(completedCreatedDate);
+            expect(await processHeaderCloudPage.getId()).toEqual(childCompleteProcess.entry.id);
+            expect(await processHeaderCloudPage.getName()).toEqual(CONSTANTS.PROCESS_DETAILS.NO_NAME);
+            expect(await processHeaderCloudPage.getStatus()).toEqual('COMPLETED');
+            expect(await processHeaderCloudPage.getInitiator()).toEqual(childCompleteProcess.entry.initiator);
+            expect(await processHeaderCloudPage.getStartDate()).toEqual(completedCreatedDate);
+            expect(await processHeaderCloudPage.getParentId()).toEqual(childCompleteProcess.entry.parentId);
+            expect(await processHeaderCloudPage.getBusinessKey()).toEqual(CONSTANTS.PROCESS_DETAILS.NO_BUSINESS_KEY);
+            expect(await processHeaderCloudPage.getLastModified()).toEqual(completedCreatedDate);
         });
-   });
+    });
 });

--- a/e2e/process-services-cloud/start-task/start-process-cloud.e2e.ts
+++ b/e2e/process-services-cloud/start-task/start-process-cloud.e2e.ts
@@ -15,14 +15,22 @@
  * limitations under the License.
  */
 
-import { createApiService, AppListCloudPage, BrowserActions, GroupIdentityService, IdentityService, LoginPage, StartProcessCloudPage, StringUtil } from '@alfresco/adf-testing';
+import {
+    createApiService,
+    AppListCloudPage,
+    BrowserActions,
+    GroupIdentityService,
+    IdentityService,
+    LoginPage,
+    StartProcessCloudPage,
+    StringUtil
+} from '@alfresco/adf-testing';
 import { browser, protractor } from 'protractor';
 import { ProcessCloudDemoPage } from './../pages/process-cloud-demo.page';
 import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
 import CONSTANTS = require('../../util/constants');
 
 describe('Start Process', () => {
-
     const loginSSOPage = new LoginPage();
     const navigationBarPage = new NavigationBarPage();
     const appListCloudComponent = new AppListCloudPage();
@@ -44,12 +52,13 @@ describe('Start Process', () => {
     const lengthValidationError = 'Length exceeded, 255 characters max.';
     const requiredError = 'Process Name is required';
     const simpleApp = browser.params.resources.ACTIVITI_CLOUD_APPS.SIMPLE_APP.name;
-    let testUser; let groupInfo;
+    let testUser;
+    let groupInfo;
 
     beforeAll(async () => {
         await apiService.loginWithProfile('identityAdmin');
 
-        testUser = await identityService.createIdentityUserWithRole( [identityService.ROLES.ACTIVITI_USER]);
+        testUser = await identityService.createIdentityUserWithRole([identityService.ROLES.ACTIVITI_USER]);
         groupInfo = await groupIdentityService.getGroupInfoByGroupName('hr');
         await identityService.addUserToGroup(testUser.idIdentityService, groupInfo.id);
 
@@ -57,12 +66,12 @@ describe('Start Process', () => {
 
         await navigationBarPage.navigateToProcessServicesCloudPage();
         await appListCloudComponent.checkApsContainer();
-   });
+    });
 
     afterAll(async () => {
         await apiService.loginWithProfile('identityAdmin');
         await identityService.deleteIdentityUser(testUser.idIdentityService);
-   });
+    });
 
     afterEach(async () => {
         await navigationBarPage.navigateToProcessServicesCloudPage();
@@ -77,7 +86,7 @@ describe('Start Process', () => {
         await browser.actions().sendKeys(protractor.Key.ENTER).perform();
 
         await startProcessPage.checkValidationErrorIsDisplayed(requiredError);
-        await expect(await startProcessPage.isStartProcessButtonDisabled()).toEqual(true);
+        expect(await startProcessPage.isStartProcessButtonDisabled()).toEqual(true);
 
         await BrowserActions.closeMenuAndDialogs();
         await startProcessPage.clickCancelProcessButton();
@@ -90,11 +99,11 @@ describe('Start Process', () => {
         await startProcessPage.selectFirstOptionFromProcessDropdown();
 
         await startProcessPage.enterProcessName(processName255Characters);
-        await expect(await startProcessPage.isStartProcessButtonEnabled()).toEqual(true);
+        expect(await startProcessPage.isStartProcessButtonEnabled()).toEqual(true);
 
         await startProcessPage.enterProcessName(processNameBiggerThen255Characters);
         await startProcessPage.checkValidationErrorIsDisplayed(lengthValidationError);
-        await expect(await startProcessPage.isStartProcessButtonDisabled()).toEqual(true);
+        expect(await startProcessPage.isStartProcessButtonDisabled()).toEqual(true);
     });
 
     it('[C291860] Should be able to start a process', async () => {
@@ -105,14 +114,14 @@ describe('Start Process', () => {
 
         await startProcessPage.clearField(startProcessPage.processNameInput);
         await startProcessPage.enterProcessName(processName);
-        await expect(await startProcessPage.isStartProcessButtonEnabled()).toEqual(true);
+        expect(await startProcessPage.isStartProcessButtonEnabled()).toEqual(true);
         await startProcessPage.clickStartProcessButton();
         await processFilter.clickOnProcessFilters();
 
         await processFilter.clickRunningProcessesFilter();
         await editProcessFilter.openFilter();
         await editProcessFilter.setProcessName(processName);
-        await expect(await processFilter.getActiveFilterName()).toBe(CONSTANTS.PROCESS_FILTERS.RUNNING);
+        expect(await processFilter.getActiveFilterName()).toBe(CONSTANTS.PROCESS_FILTERS.RUNNING);
         await processList.checkContentIsDisplayedByName(processName);
-   });
+    });
 });

--- a/e2e/process-services-cloud/start-task/start-task-custom-app-cloud.e2e.ts
+++ b/e2e/process-services-cloud/start-task/start-task-custom-app-cloud.e2e.ts
@@ -25,13 +25,13 @@ import {
     TaskHeaderCloudPage,
     StartTasksCloudPage,
     PeopleCloudComponentPage,
-    TasksService, createApiService,
+    TasksService,
+    createApiService,
     IdentityService,
     GroupIdentityService
 } from '@alfresco/adf-testing';
 
 describe('Start Task', () => {
-
     const simpleApp = browser.params.resources.ACTIVITI_CLOUD_APPS.SIMPLE_APP.name;
 
     const loginSSOPage = new LoginPage();
@@ -59,7 +59,10 @@ describe('Start Task', () => {
     const lengthValidationError = 'Length exceeded, 255 characters max.';
     const requiredError = 'Field required';
     const dateValidationError = 'Date format DD/MM/YYYY';
-    let apsUser; let testUser; let activitiUser; let groupInfo;
+    let apsUser;
+    let testUser;
+    let activitiUser;
+    let groupInfo;
 
     beforeAll(async () => {
         await apiService.loginWithProfile('identityAdmin');
@@ -117,8 +120,8 @@ describe('Start Task', () => {
         const taskId = await taskList.getIdCellValue(unassignedTaskName);
         await taskList.selectRow(unassignedTaskName);
         await taskHeaderCloudPage.checkTaskPropertyListIsDisplayed();
-        await expect(await taskHeaderCloudPage.getId()).toBe(taskId);
-        await expect(await taskHeaderCloudPage.getAssignee()).toBe('No assignee');
+        expect(await taskHeaderCloudPage.getId()).toBe(taskId);
+        expect(await taskHeaderCloudPage.getAssignee()).toBe('No assignee');
     });
 
     it('[C291956] Should be able to create a new standalone task without assignee', async () => {
@@ -197,7 +200,7 @@ describe('Start Task', () => {
         await taskFilter.clickTaskFilter('my-tasks');
         await taskList.getDataTable().waitTillContentLoaded();
 
-        await expect(await taskFilter.getActiveFilterName()).toBe('My Tasks');
+        expect(await taskFilter.getActiveFilterName()).toBe('My Tasks');
     });
 
     it('[C305050] Should be able to reassign the removed user when starting a new task', async () => {
@@ -221,6 +224,6 @@ describe('Start Task', () => {
 
         await taskList.selectRow(reassignTaskName);
 
-        await expect(await taskHeaderCloudPage.getAssignee()).toBe(apsUser.username);
+        expect(await taskHeaderCloudPage.getAssignee()).toBe(apsUser.username);
     });
 });

--- a/e2e/process-services-cloud/start-task/start-task-form-cloud.e2e.ts
+++ b/e2e/process-services-cloud/start-task/start-task-form-cloud.e2e.ts
@@ -23,7 +23,8 @@ import {
     AppListCloudPage,
     BreadcrumbDropdownPage,
     StringUtil,
-    StartTasksCloudPage, createApiService,
+    StartTasksCloudPage,
+    createApiService,
     IdentityService,
     GroupIdentityService,
     TaskFormCloudComponent,
@@ -34,7 +35,8 @@ import {
     ContentNodeSelectorDialogPage,
     ProcessInstancesService,
     ProcessDefinitionsService,
-    FileBrowserUtil, ProcessCloudWidgetPage,
+    FileBrowserUtil,
+    ProcessCloudWidgetPage,
     QueryService
 } from '@alfresco/adf-testing';
 import { StartProcessCloudConfiguration } from './../config/start-process-cloud.config';
@@ -43,7 +45,6 @@ import { ProcessDetailsCloudDemoPage } from './../pages/process-details-cloud-de
 import { FileModel } from '../../models/ACS/file.model';
 
 describe('Start Task Form', () => {
-
     const loginSSOPage = new LoginPage();
     const taskFormCloudComponent = new TaskFormCloudComponent();
     const navigationBarPage = new NavigationBarPage();
@@ -77,11 +78,17 @@ describe('Start Task Form', () => {
     const startProcessCloudConfig = startProcessCloudConfiguration.getConfiguration();
 
     const standaloneTaskName = StringUtil.generateRandomString(5);
-    let testUser; let groupInfo;
+    let testUser;
+    let groupInfo;
     let processDefinitionService: ProcessDefinitionsService;
     let processInstancesService: ProcessInstancesService;
-    let processDefinition; let uploadLocalFileProcess; let uploadContentFileProcess; let uploadDefaultFileProcess;
-        let cancelUploadFileProcess; let completeUploadFileProcess; let downloadContentFileProcess;
+    let processDefinition;
+    let uploadLocalFileProcess;
+    let uploadContentFileProcess;
+    let uploadDefaultFileProcess;
+    let cancelUploadFileProcess;
+    let completeUploadFileProcess;
+    let downloadContentFileProcess;
     const candidateBaseApp = browser.params.resources.ACTIVITI_CLOUD_APPS.CANDIDATE_BASE_APP.name;
     const pdfFile = new FileModel({ name: browser.params.resources.Files.ADF_DOCUMENTS.PDF.file_name });
     const pdfFileModel = new FileModel({
@@ -99,15 +106,17 @@ describe('Start Task Form', () => {
     beforeAll(async () => {
         await apiService.loginWithProfile('identityAdmin');
 
-        testUser = await identityService.createIdentityUserWithRole( [identityService.ROLES.ACTIVITI_USER]);
+        testUser = await identityService.createIdentityUserWithRole([identityService.ROLES.ACTIVITI_USER]);
         groupInfo = await groupIdentityService.getGroupInfoByGroupName('hr');
         await identityService.addUserToGroup(testUser.idIdentityService, groupInfo.id);
 
         await apiService.login(testUser.username, testUser.password);
         processDefinitionService = new ProcessDefinitionsService(apiService);
         processInstancesService = new ProcessInstancesService(apiService);
-        processDefinition = await processDefinitionService
-            .getProcessDefinitionByName(browser.params.resources.ACTIVITI_CLOUD_APPS.CANDIDATE_BASE_APP.processes.uploadFileProcess, candidateBaseApp);
+        processDefinition = await processDefinitionService.getProcessDefinitionByName(
+            browser.params.resources.ACTIVITI_CLOUD_APPS.CANDIDATE_BASE_APP.processes.uploadFileProcess,
+            candidateBaseApp
+        );
 
         await processInstancesService.createProcessInstance(processDefinition.entry.key, candidateBaseApp);
 
@@ -186,8 +195,8 @@ describe('Start Task Form', () => {
             await widget.numberWidget().setFieldValue('Number07vyx9', 26);
             await taskFormCloudComponent.checkSaveButtonIsDisplayed();
             await taskFormCloudComponent.clickSaveButton();
-            await expect(await widget.textWidget().getFieldValue('FirstName')).toBe('sample');
-            await expect(await widget.numberWidget().getFieldValue('Number07vyx9')).toBe('26');
+            expect(await widget.textWidget().getFieldValue('FirstName')).toBe('sample');
+            expect(await widget.numberWidget().getFieldValue('Number07vyx9')).toBe('26');
 
             await navigationBarPage.navigateToProcessServicesCloudPage();
             await appListCloudComponent.checkApsContainer();
@@ -195,12 +204,12 @@ describe('Start Task Form', () => {
             await appListCloudComponent.goToApp(candidateBaseApp);
             await taskList.getDataTable().waitForTableBody();
 
-            await expect(await taskFilter.getActiveFilterName()).toBe('My Tasks');
+            expect(await taskFilter.getActiveFilterName()).toBe('My Tasks');
             await taskList.checkContentIsDisplayedByName(standaloneTaskName);
             await taskList.selectRow(standaloneTaskName);
             await taskFormCloudComponent.formFields().checkFormIsDisplayed();
-            await expect(await widget.textWidget().getFieldValue('FirstName')).toBe('sample');
-            await expect(await widget.numberWidget().getFieldValue('Number07vyx9')).toBe('26');
+            expect(await widget.textWidget().getFieldValue('FirstName')).toBe('sample');
+            expect(await widget.numberWidget().getFieldValue('Number07vyx9')).toBe('26');
             await taskFormCloudComponent.checkCompleteButtonIsDisplayed();
         });
 
@@ -209,9 +218,11 @@ describe('Start Task Form', () => {
             await startTask.checkFormIsDisplayed();
             await startTask.checkFormDefinitionIsNotDisplayed(browser.params.resources.ACTIVITI_CLOUD_APPS.CANDIDATE_BASE_APP.forms.uploadfileform);
             await startTask.checkFormDefinitionIsDisplayed(browser.params.resources.ACTIVITI_CLOUD_APPS.CANDIDATE_BASE_APP.forms.starteventform);
-            await startTask.checkFormDefinitionIsDisplayed(browser.params.resources.ACTIVITI_CLOUD_APPS.CANDIDATE_BASE_APP.forms.formtotestvalidations);
+            await startTask.checkFormDefinitionIsDisplayed(
+                browser.params.resources.ACTIVITI_CLOUD_APPS.CANDIDATE_BASE_APP.forms.formtotestvalidations
+            );
         });
-   });
+    });
 
     describe('Attach content to process-cloud task form using upload widget', async () => {
         beforeEach(async () => {
@@ -268,16 +279,16 @@ describe('Start Task Form', () => {
             const contentFileWidget = widget.attachFileWidgetCloud('Attachsinglecontentfile');
             await contentFileWidget.clickAttachContentFile('Attachsinglecontentfile');
             await contentNodeSelectorDialogPage.checkDialogIsDisplayed();
-            await expect(await breadCrumbDropdownPage.getTextOfCurrentFolder()).toBe(testUser.username);
+            expect(await breadCrumbDropdownPage.getTextOfCurrentFolder()).toBe(testUser.username);
             await contentNodeSelectorDialogPage.contentListPage().dataTablePage().waitTillContentLoaded();
             await contentNodeSelectorDialogPage.contentListPage().dataTablePage().checkRowContentIsDisplayed(folderName);
-            await expect(await contentNodeSelectorDialogPage.checkCancelButtonIsEnabled()).toBe(true);
-            await expect(await contentNodeSelectorDialogPage.checkCopyMoveButtonIsEnabled()).toBe(false);
+            expect(await contentNodeSelectorDialogPage.checkCancelButtonIsEnabled()).toBe(true);
+            expect(await contentNodeSelectorDialogPage.checkCopyMoveButtonIsEnabled()).toBe(false);
 
             await contentNodeSelectorDialogPage.contentListPage().dataTablePage().clickRowByContent(folderName);
             await contentNodeSelectorDialogPage.contentListPage().dataTablePage().checkRowByContentIsSelected(folderName);
-            await expect(await contentNodeSelectorDialogPage.checkCancelButtonIsEnabled()).toBe(true);
-            await expect(await contentNodeSelectorDialogPage.checkCopyMoveButtonIsEnabled()).toBe(false);
+            expect(await contentNodeSelectorDialogPage.checkCancelButtonIsEnabled()).toBe(true);
+            expect(await contentNodeSelectorDialogPage.checkCopyMoveButtonIsEnabled()).toBe(false);
             await contentNodeSelectorDialogPage.clickCancelButton();
             await contentNodeSelectorDialogPage.checkDialogIsNotDisplayed();
         });
@@ -379,7 +390,7 @@ describe('Start Task Form', () => {
             const taskId = await taskHeaderCloudPage.getId();
             await taskFormCloudComponent.checkCompleteButtonIsDisplayed();
             await taskFormCloudComponent.clickCompleteButton();
-            await expect(await taskFilter.getActiveFilterName()).toBe('My Tasks');
+            expect(await taskFilter.getActiveFilterName()).toBe('My Tasks');
             await taskList.checkContentIsNotDisplayedById(taskId);
 
             await taskFilter.clickTaskFilter('completed-tasks');
@@ -416,7 +427,7 @@ describe('Start Task Form', () => {
 
             const taskId = await taskHeaderCloudPage.getId();
             await taskFormCloudComponent.clickCompleteButton();
-            await expect(await taskFilter.getActiveFilterName()).toBe('My Tasks');
+            expect(await taskFilter.getActiveFilterName()).toBe('My Tasks');
             await taskList.checkContentIsNotDisplayedById(taskId);
 
             await taskFilter.clickTaskFilter('completed-tasks');
@@ -428,5 +439,5 @@ describe('Start Task Form', () => {
             await contentFileWidget.downloadFile(testFileModel.name);
             await FileBrowserUtil.isFileDownloaded(testFileModel.name);
         });
-   });
+    });
 });

--- a/e2e/process-services-cloud/task-list/edit-process-filters-component.e2e.ts
+++ b/e2e/process-services-cloud/task-list/edit-process-filters-component.e2e.ts
@@ -15,12 +15,7 @@
  * limitations under the License.
  */
 
-import { createApiService,
-    AppListCloudPage,
-    GroupIdentityService,
-    IdentityService,
-    LoginPage
-} from '@alfresco/adf-testing';
+import { createApiService, AppListCloudPage, GroupIdentityService, IdentityService, LoginPage } from '@alfresco/adf-testing';
 import { browser } from 'protractor';
 import { ProcessCloudDemoPage } from '../pages/process-cloud-demo.page';
 import { TasksCloudDemoPage } from '../pages/tasks-cloud-demo.page';
@@ -28,7 +23,6 @@ import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
 import CONSTANTS = require('../../util/constants');
 
 describe('Edit process filters cloud', () => {
-
     const simpleApp = browser.params.resources.ACTIVITI_CLOUD_APPS.SIMPLE_APP.name;
 
     const loginSSOPage = new LoginPage();
@@ -43,7 +37,8 @@ describe('Edit process filters cloud', () => {
     const identityService = new IdentityService(apiService);
     const groupIdentityService = new GroupIdentityService(apiService);
 
-    let testUser; let groupInfo;
+    let testUser;
+    let groupInfo;
 
     const PROCESSES = CONSTANTS.PROCESS_FILTERS;
 
@@ -75,7 +70,7 @@ describe('Edit process filters cloud', () => {
 
     it('[C291804] Delete Save and Save as actions should be displayed when clicking on default filter header', async () => {
         await processFilter.clickAllProcessesFilter();
-        await expect(await processFilter.getActiveFilterName()).toBe('All');
+        expect(await processFilter.getActiveFilterName()).toBe('All');
         await editProcessFilter.checkSaveButtonIsDisplayed();
         await editProcessFilter.checkSaveAsButtonIsDisplayed();
         await editProcessFilter.checkDeleteButtonIsDisplayed();
@@ -83,59 +78,59 @@ describe('Edit process filters cloud', () => {
 
     it('[C586757] Delete Save and Save as actions should be displayed and enabled when clicking on custom filter header', async () => {
         await createNewProcessCustomFilter('New');
-        await expect(await processFilter.getActiveFilterName()).toBe('New');
+        expect(await processFilter.getActiveFilterName()).toBe('New');
         await processFilter.clickProcessFilter('custom-new');
         await editProcessFilter.setSortFilterDropDown('Start Date');
-        await expect(await editProcessFilter.getSortFilterDropDownValue()).toEqual('Start Date');
-        await expect(await editProcessFilter.getOrderFilterDropDownValue()).toEqual('Descending');
-        await expect(await editProcessFilter.getStateFilterDropDownValue()).toEqual('All');
+        expect(await editProcessFilter.getSortFilterDropDownValue()).toEqual('Start Date');
+        expect(await editProcessFilter.getOrderFilterDropDownValue()).toEqual('Descending');
+        expect(await editProcessFilter.getStateFilterDropDownValue()).toEqual('All');
 
         await editProcessFilter.checkSaveButtonIsDisplayed();
         await editProcessFilter.checkSaveAsButtonIsDisplayed();
         await editProcessFilter.checkDeleteButtonIsDisplayed();
 
-        await expect(await editProcessFilter.isCustomFilterNameDisplayed('New')).toEqual(true);
-        await expect(await editProcessFilter.checkSaveButtonIsEnabled()).toEqual(true);
-        await expect(await editProcessFilter.checkSaveAsButtonIsEnabled()).toEqual(true);
-        await expect(await editProcessFilter.checkDeleteButtonIsEnabled()).toEqual(true);
+        expect(await editProcessFilter.isCustomFilterNameDisplayed('New')).toEqual(true);
+        expect(await editProcessFilter.checkSaveButtonIsEnabled()).toEqual(true);
+        expect(await editProcessFilter.checkSaveAsButtonIsEnabled()).toEqual(true);
+        expect(await editProcessFilter.checkDeleteButtonIsEnabled()).toEqual(true);
     });
 
     it('[C291805] New process filter is added when clicking Save As button', async () => {
         await createNewProcessCustomFilter('New');
 
-        await expect(await processFilter.getActiveFilterName()).toBe('New');
+        expect(await processFilter.getActiveFilterName()).toBe('New');
 
-        await expect(await editProcessFilter.getSortFilterDropDownValue()).toEqual('Id');
+        expect(await editProcessFilter.getSortFilterDropDownValue()).toEqual('Id');
         await processFilter.clickAllProcessesFilter();
-        await expect(await editProcessFilter.getSortFilterDropDownValue()).toEqual('Start Date');
+        expect(await editProcessFilter.getSortFilterDropDownValue()).toEqual('Start Date');
         await processFilter.clickProcessFilter('custom-new');
-        await expect(await editProcessFilter.getSortFilterDropDownValue()).toEqual('Id');
+        expect(await editProcessFilter.getSortFilterDropDownValue()).toEqual('Id');
         await editProcessFilter.clickDeleteButton();
     });
 
     it('[C291807] A process filter is updated when clicking on save button', async () => {
         await createNewProcessCustomFilter('New');
 
-        await expect(await processFilter.getActiveFilterName()).toBe('New');
+        expect(await processFilter.getActiveFilterName()).toBe('New');
         await editProcessFilter.setSortFilterDropDown('Process Name');
-        await expect(await editProcessFilter.getSortFilterDropDownValue()).toEqual('Process Name');
+        expect(await editProcessFilter.getSortFilterDropDownValue()).toEqual('Process Name');
         await editProcessFilter.clickSaveButton();
 
-        await expect(await processFilter.getActiveFilterName()).toBe('New');
-        await expect(await editProcessFilter.getSortFilterDropDownValue()).toEqual('Process Name');
+        expect(await processFilter.getActiveFilterName()).toBe('New');
+        expect(await editProcessFilter.getSortFilterDropDownValue()).toEqual('Process Name');
         await editProcessFilter.clickDeleteButton();
     });
 
     it('[C291808] A process filter is deleted when clicking on delete button', async () => {
         await createNewProcessCustomFilter('New');
 
-        await expect(await processFilter.getActiveFilterName()).toBe('New');
-        await expect(await editProcessFilter.getSortFilterDropDownValue()).toEqual('Id');
+        expect(await processFilter.getActiveFilterName()).toBe('New');
+        expect(await editProcessFilter.getSortFilterDropDownValue()).toEqual('Id');
         await editProcessFilter.clickDeleteButton();
 
         await browser.driver.sleep(1000);
 
-        await expect(await processFilter.getActiveFilterName()).toBe(CONSTANTS.PROCESS_FILTERS.RUNNING);
+        expect(await processFilter.getActiveFilterName()).toBe(CONSTANTS.PROCESS_FILTERS.RUNNING);
         await processFilter.checkProcessFilterNotDisplayed('New');
     });
 
@@ -143,15 +138,15 @@ describe('Edit process filters cloud', () => {
         await editProcessFilter.setSortFilterDropDown('Id');
         await editProcessFilter.clickSaveAsButton();
         await editProcessFilter.editProcessFilterDialog().setFilterName('Cancel');
-        await expect(await editProcessFilter.editProcessFilterDialog().getFilterName()).toEqual('Cancel');
+        expect(await editProcessFilter.editProcessFilterDialog().getFilterName()).toEqual('Cancel');
         await editProcessFilter.editProcessFilterDialog().clickOnCancelButton();
         await processFilter.checkProcessFilterNotDisplayed('Cancel');
-        await expect(await processFilter.getActiveFilterName()).toEqual(PROCESSES.ALL);
+        expect(await processFilter.getActiveFilterName()).toEqual(PROCESSES.ALL);
         await processFilter.clickRunningProcessesFilter();
-        await expect(await processFilter.getActiveFilterName()).toEqual(PROCESSES.RUNNING);
+        expect(await processFilter.getActiveFilterName()).toEqual(PROCESSES.RUNNING);
         await processFilter.clickAllProcessesFilter();
-        await expect(await processFilter.getActiveFilterName()).toEqual(PROCESSES.ALL);
-        await expect(await editProcessFilter.getSortFilterDropDownValue()).toEqual('Start Date');
+        expect(await processFilter.getActiveFilterName()).toEqual(PROCESSES.ALL);
+        expect(await editProcessFilter.getSortFilterDropDownValue()).toEqual('Start Date');
         await editProcessFilter.closeFilter();
     });
 
@@ -162,9 +157,9 @@ describe('Edit process filters cloud', () => {
         const dialog = editProcessFilter.editProcessFilterDialog();
         await dialog.clearFilterName();
 
-        await expect(await dialog.getFilterName()).toEqual('');
-        await expect(await dialog.checkSaveButtonIsEnabled()).toEqual(false);
-        await expect(await dialog.checkCancelButtonIsEnabled()).toEqual(true);
+        expect(await dialog.getFilterName()).toEqual('');
+        expect(await dialog.checkSaveButtonIsEnabled()).toEqual(false);
+        expect(await dialog.checkCancelButtonIsEnabled()).toEqual(true);
         await dialog.clickOnCancelButton();
     });
 
@@ -175,13 +170,19 @@ describe('Edit process filters cloud', () => {
         const dialog = editProcessFilter.editProcessFilterDialog();
         await dialog.clearFilterName();
 
-        await expect(await dialog.checkCancelButtonIsEnabled()).toEqual(true);
-        await expect(await dialog.checkSaveButtonIsEnabled()).toEqual(false);
-        await expect(await dialog.getTitle()).toEqual('Save filter as');
-        await expect(await dialog.getFilterName()).toEqual('');
+        expect(await dialog.checkCancelButtonIsEnabled()).toEqual(true);
+        expect(await dialog.checkSaveButtonIsEnabled()).toEqual(false);
+        expect(await dialog.getTitle()).toEqual('Save filter as');
+        expect(await dialog.getFilterName()).toEqual('');
         await dialog.clickOnCancelButton();
     });
 
+    /**
+     * Create a new process custom filter
+     *
+     * @param name Filter name
+     * @param sort Sort value
+     */
     async function createNewProcessCustomFilter(name: string, sort = 'Id'): Promise<void> {
         await processFilter.clickAllProcessesFilter();
         await editProcessFilter.setSortFilterDropDown(sort);

--- a/e2e/process-services-cloud/task-list/edit-task-filters-component.e2e.ts
+++ b/e2e/process-services-cloud/task-list/edit-task-filters-component.e2e.ts
@@ -18,7 +18,8 @@
 import { browser } from 'protractor';
 import {
     AppListCloudPage,
-    StringUtil, createApiService,
+    StringUtil,
+    createApiService,
     LoginPage,
     TasksService,
     IdentityService,
@@ -29,7 +30,6 @@ import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
 import { TasksCloudDemoPage } from './../pages/tasks-cloud-demo.page';
 
 describe('Edit task filters cloud', () => {
-
     const simpleApp = browser.params.resources.ACTIVITI_CLOUD_APPS.SIMPLE_APP.name;
 
     const loginSSOPage = new LoginPage();
@@ -46,10 +46,11 @@ describe('Edit task filters cloud', () => {
     const groupIdentityService = new GroupIdentityService(apiService);
     const tasksService = new TasksService(apiService);
 
-    let testUser; let groupInfo;
+    let testUser;
+    let groupInfo;
 
     const completedTaskName = StringUtil.generateRandomString();
-        const assignedTaskName = StringUtil.generateRandomString();
+    const assignedTaskName = StringUtil.generateRandomString();
 
     /**
      * Click on the specified task filter
@@ -103,10 +104,10 @@ describe('Edit task filters cloud', () => {
         await clickTaskFilter('my-tasks');
         await waitTillContentLoaded();
 
-        await expect(await taskFilter.getActiveFilterName()).toBe('My Tasks');
-        await expect(await editTaskFilter.getStatusFilterDropDownValue()).toEqual('Assigned', `Status is no 'Assigned'`);
-        await expect(await editTaskFilter.getSortFilterDropDownValue()).toEqual('createdDate', `Sort filter is not 'createdDate'`);
-        await expect(await editTaskFilter.getOrderFilterDropDownValue()).toEqual('Descending', `Order is not 'Descending'`);
+        expect(await taskFilter.getActiveFilterName()).toBe('My Tasks');
+        expect(await editTaskFilter.getStatusFilterDropDownValue()).toEqual('Assigned');
+        expect(await editTaskFilter.getSortFilterDropDownValue()).toEqual('createdDate');
+        expect(await editTaskFilter.getOrderFilterDropDownValue()).toEqual('Descending');
 
         await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(assignedTaskName);
         await tasksCloudDemoPage.taskListCloudComponent().checkContentIsNotDisplayedByName(completedTaskName);
@@ -114,10 +115,10 @@ describe('Edit task filters cloud', () => {
         await clickTaskFilter('completed-tasks');
         await waitTillContentLoaded();
 
-        await expect(await taskFilter.getActiveFilterName()).toBe('Completed Tasks');
-        await expect(await editTaskFilter.getStatusFilterDropDownValue()).toEqual('Completed', `Status is not 'Completed'`);
-        await expect(await editTaskFilter.getSortFilterDropDownValue()).toEqual('createdDate', `Sort filter is not 'createdDate'`);
-        await expect(await editTaskFilter.getOrderFilterDropDownValue()).toEqual('Descending', `Order is not 'Descending'`);
+        expect(await taskFilter.getActiveFilterName()).toBe('Completed Tasks');
+        expect(await editTaskFilter.getStatusFilterDropDownValue()).toEqual('Completed');
+        expect(await editTaskFilter.getSortFilterDropDownValue()).toEqual('createdDate');
+        expect(await editTaskFilter.getOrderFilterDropDownValue()).toEqual('Descending');
 
         await tasksCloudDemoPage.taskListCloudComponent().checkContentIsNotDisplayedByName(assignedTaskName);
         await tasksCloudDemoPage.taskListCloudComponent().checkContentIsDisplayedByName(completedTaskName);
@@ -132,15 +133,15 @@ describe('Edit task filters cloud', () => {
         await clickTaskFilter('my-tasks');
         await waitTillContentLoaded();
 
-        await expect(await taskFilter.getActiveFilterName()).toBe('My Tasks');
+        expect(await taskFilter.getActiveFilterName()).toBe('My Tasks');
 
         await editTaskFilter.checkSaveButtonIsDisplayed();
         await editTaskFilter.checkSaveAsButtonIsDisplayed();
         await editTaskFilter.checkDeleteButtonIsDisplayed();
 
-        await expect(await editTaskFilter.checkSaveButtonIsEnabled()).toEqual(false);
-        await expect(await editTaskFilter.checkSaveAsButtonIsEnabled()).toEqual(false);
-        await expect(await editTaskFilter.checkDeleteButtonIsEnabled()).toEqual(false);
+        expect(await editTaskFilter.checkSaveButtonIsEnabled()).toEqual(false);
+        expect(await editTaskFilter.checkSaveAsButtonIsEnabled()).toEqual(false);
+        expect(await editTaskFilter.checkDeleteButtonIsEnabled()).toEqual(false);
         await editTaskFilter.closeFilter();
     });
 
@@ -154,34 +155,34 @@ describe('Edit task filters cloud', () => {
         await clickTaskFilter('custom-new');
         await waitTillContentLoaded();
 
-        await expect(await taskFilter.getActiveFilterName()).toBe('New');
+        expect(await taskFilter.getActiveFilterName()).toBe('New');
 
         await editTaskFilter.setSortFilterDropDown('priority');
         await editTaskFilter.checkSaveButtonIsDisplayed();
         await editTaskFilter.checkSaveAsButtonIsDisplayed();
         await editTaskFilter.checkDeleteButtonIsDisplayed();
 
-        await expect(await editTaskFilter.checkSaveButtonIsEnabled()).toEqual(true);
-        await expect(await editTaskFilter.checkSaveAsButtonIsEnabled()).toEqual(true);
-        await expect(await editTaskFilter.checkDeleteButtonIsEnabled()).toEqual(true);
+        expect(await editTaskFilter.checkSaveButtonIsEnabled()).toEqual(true);
+        expect(await editTaskFilter.checkSaveAsButtonIsEnabled()).toEqual(true);
+        expect(await editTaskFilter.checkDeleteButtonIsEnabled()).toEqual(true);
     });
 
     it('[C291795] New filter is added when clicking Save As button', async () => {
         await createNewCustomFilter('New');
-        await expect(await taskFilter.getActiveFilterName()).toBe('New');
+        expect(await taskFilter.getActiveFilterName()).toBe('New');
         await editTaskFilter.openFilter();
-        await expect(await editTaskFilter.checkSaveButtonIsEnabled()).toEqual(false);
-        await expect(await editTaskFilter.getSortFilterDropDownValue()).toEqual('id');
-        await expect(await editTaskFilter.checkSaveAsButtonIsEnabled()).toEqual(false);
-        await expect(await editTaskFilter.checkDeleteButtonIsEnabled()).toEqual(true);
+        expect(await editTaskFilter.checkSaveButtonIsEnabled()).toEqual(false);
+        expect(await editTaskFilter.getSortFilterDropDownValue()).toEqual('id');
+        expect(await editTaskFilter.checkSaveAsButtonIsEnabled()).toEqual(false);
+        expect(await editTaskFilter.checkDeleteButtonIsEnabled()).toEqual(true);
         await clickTaskFilter('my-tasks');
         await waitTillContentLoaded();
 
-        await expect(await editTaskFilter.getSortFilterDropDownValue()).toEqual('createdDate');
+        expect(await editTaskFilter.getSortFilterDropDownValue()).toEqual('createdDate');
         await clickTaskFilter('custom-new');
         await waitTillContentLoaded();
 
-        await expect(await editTaskFilter.getSortFilterDropDownValue()).toEqual('id');
+        expect(await editTaskFilter.getSortFilterDropDownValue()).toEqual('id');
         await editTaskFilter.clickDeleteButton();
     });
 
@@ -200,24 +201,24 @@ describe('Edit task filters cloud', () => {
         await editTaskFilterDialog.setFilterName('New');
         await editTaskFilterDialog.clickOnSaveButton();
 
-        await expect(await taskFilter.getActiveFilterName()).toBe('New');
+        expect(await taskFilter.getActiveFilterName()).toBe('New');
         await editTaskFilter.openFilter();
 
-        await expect(await editTaskFilter.getSortFilterDropDownValue()).toEqual('id');
+        expect(await editTaskFilter.getSortFilterDropDownValue()).toEqual('id');
         await editTaskFilter.setSortFilterDropDown('priority');
         await editTaskFilter.clickSaveAsButton();
         await editTaskFilterDialog.setFilterName('New');
         await editTaskFilterDialog.clickOnSaveButton();
 
-        await expect(await taskFilter.getActiveFilterName()).toBe('New');
+        expect(await taskFilter.getActiveFilterName()).toBe('New');
         await editTaskFilter.openFilter();
-        await expect(await editTaskFilter.getSortFilterDropDownValue()).toEqual('priority');
+        expect(await editTaskFilter.getSortFilterDropDownValue()).toEqual('priority');
         await editTaskFilter.clickDeleteButton();
         await clickTaskFilter('custom-new');
         await waitTillContentLoaded();
 
         await editTaskFilter.openFilter();
-        await expect(await editTaskFilter.getSortFilterDropDownValue()).toEqual('id');
+        expect(await editTaskFilter.getSortFilterDropDownValue()).toEqual('id');
         await editTaskFilter.clickDeleteButton();
     });
 
@@ -236,15 +237,15 @@ describe('Edit task filters cloud', () => {
         await editTaskFilterDialog.setFilterName('New');
         await editTaskFilterDialog.clickOnSaveButton();
 
-        await expect(await taskFilter.getActiveFilterName()).toBe('New');
+        expect(await taskFilter.getActiveFilterName()).toBe('New');
         await editTaskFilter.openFilter();
-        await expect(await editTaskFilter.getSortFilterDropDownValue()).toEqual('id');
+        expect(await editTaskFilter.getSortFilterDropDownValue()).toEqual('id');
         await editTaskFilter.setSortFilterDropDown('name');
         await editTaskFilter.clickSaveButton();
         await editTaskFilter.openFilter();
 
-        await expect(await taskFilter.getActiveFilterName()).toBe('New');
-        await expect(await editTaskFilter.getSortFilterDropDownValue()).toEqual('name');
+        expect(await taskFilter.getActiveFilterName()).toBe('New');
+        expect(await editTaskFilter.getSortFilterDropDownValue()).toEqual('name');
         await editTaskFilter.clickDeleteButton();
     });
 
@@ -263,12 +264,12 @@ describe('Edit task filters cloud', () => {
         await editTaskFilterDialog.setFilterName('New');
         await editTaskFilterDialog.clickOnSaveButton();
 
-        await expect(await taskFilter.getActiveFilterName()).toBe('New');
+        expect(await taskFilter.getActiveFilterName()).toBe('New');
         await editTaskFilter.openFilter();
-        await expect(await editTaskFilter.getSortFilterDropDownValue()).toEqual('id');
+        expect(await editTaskFilter.getSortFilterDropDownValue()).toEqual('id');
         await editTaskFilter.clickDeleteButton();
 
-        await expect(await taskFilter.getActiveFilterName()).toBe('My Tasks');
+        expect(await taskFilter.getActiveFilterName()).toBe('My Tasks');
         await taskFilter.checkTaskFilterNotDisplayed('New');
     });
 
@@ -279,16 +280,16 @@ describe('Edit task filters cloud', () => {
         await editTaskFilter.openFilter();
         await editTaskFilter.setSortFilterDropDown('priority');
 
-        await expect(await editTaskFilter.getSortFilterDropDownValue()).toEqual('priority');
+        expect(await editTaskFilter.getSortFilterDropDownValue()).toEqual('priority');
         await editTaskFilter.clickSaveAsButton();
 
-        await expect(await editTaskFilterDialog.getFilterName()).toEqual('My Tasks');
+        expect(await editTaskFilterDialog.getFilterName()).toEqual('My Tasks');
         await editTaskFilterDialog.setFilterName('Cancel');
-        await expect(await editTaskFilterDialog.getFilterName()).toEqual('Cancel');
+        expect(await editTaskFilterDialog.getFilterName()).toEqual('Cancel');
         await editTaskFilterDialog.clickOnCancelButton();
 
         await taskFilter.checkTaskFilterNotDisplayed('Cancel');
-        await expect(await taskFilter.getActiveFilterName()).toEqual('My Tasks');
+        expect(await taskFilter.getActiveFilterName()).toEqual('My Tasks');
 
         await clickTaskFilter('completed-tasks');
         await waitTillContentLoaded();
@@ -296,8 +297,8 @@ describe('Edit task filters cloud', () => {
         await waitTillContentLoaded();
         await editTaskFilter.openFilter();
 
-        await expect(await taskFilter.getActiveFilterName()).toBe('My Tasks');
-        await expect(await editTaskFilter.getSortFilterDropDownValue()).toEqual('createdDate');
+        expect(await taskFilter.getActiveFilterName()).toBe('My Tasks');
+        expect(await editTaskFilter.getSortFilterDropDownValue()).toEqual('createdDate');
 
         await editTaskFilter.closeFilter();
     });
@@ -309,14 +310,14 @@ describe('Edit task filters cloud', () => {
         await editTaskFilter.openFilter();
         await editTaskFilter.setSortFilterDropDown('id');
 
-        await expect(await editTaskFilter.getSortFilterDropDownValue()).toEqual('id');
+        expect(await editTaskFilter.getSortFilterDropDownValue()).toEqual('id');
         await editTaskFilter.clickSaveAsButton();
 
-        await expect(await editTaskFilterDialog.getFilterName()).toEqual('My Tasks');
+        expect(await editTaskFilterDialog.getFilterName()).toEqual('My Tasks');
         await editTaskFilterDialog.clearFilterName();
-        await expect(await editTaskFilterDialog.getFilterName()).toEqual('');
-        await expect(await editTaskFilterDialog.checkSaveButtonIsEnabled()).toEqual(false);
-        await expect(await editTaskFilterDialog.checkCancelButtonIsEnabled()).toEqual(true);
+        expect(await editTaskFilterDialog.getFilterName()).toEqual('');
+        expect(await editTaskFilterDialog.checkSaveButtonIsEnabled()).toEqual(false);
+        expect(await editTaskFilterDialog.checkCancelButtonIsEnabled()).toEqual(true);
         await editTaskFilterDialog.clickOnCancelButton();
     });
 
@@ -326,13 +327,13 @@ describe('Edit task filters cloud', () => {
 
         await editTaskFilter.openFilter();
         await editTaskFilter.setSortFilterDropDown('id');
-        await expect(await editTaskFilter.getSortFilterDropDownValue()).toEqual('id');
+        expect(await editTaskFilter.getSortFilterDropDownValue()).toEqual('id');
         await editTaskFilter.clickSaveAsButton();
 
-        await expect(await editTaskFilterDialog.checkSaveButtonIsEnabled()).toEqual(true);
-        await expect(await editTaskFilterDialog.checkCancelButtonIsEnabled()).toEqual(true);
-        await expect(await editTaskFilterDialog.getTitle()).toEqual('Save filter as');
-        await expect(await editTaskFilterDialog.getFilterName()).toEqual('My Tasks');
+        expect(await editTaskFilterDialog.checkSaveButtonIsEnabled()).toEqual(true);
+        expect(await editTaskFilterDialog.checkCancelButtonIsEnabled()).toEqual(true);
+        expect(await editTaskFilterDialog.getTitle()).toEqual('Save filter as');
+        expect(await editTaskFilterDialog.getFilterName()).toEqual('My Tasks');
         await editTaskFilterDialog.clickOnCancelButton();
     });
 

--- a/e2e/process-services-cloud/task-list/task-filters-cloud.e2e.ts
+++ b/e2e/process-services-cloud/task-list/task-filters-cloud.e2e.ts
@@ -18,7 +18,8 @@
 import { browser } from 'protractor';
 import {
     LoginPage,
-    TasksService, createApiService,
+    TasksService,
+    createApiService,
     AppListCloudPage,
     StringUtil,
     IdentityService,
@@ -29,9 +30,7 @@ import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
 import { TasksCloudDemoPage } from './../pages/tasks-cloud-demo.page';
 
 describe('Task filters cloud', () => {
-
     describe('Task Filters', () => {
-
         const simpleApp = browser.params.resources.ACTIVITI_CLOUD_APPS.SIMPLE_APP.name;
 
         const loginSSOPage = new LoginPage();
@@ -47,9 +46,11 @@ describe('Task filters cloud', () => {
         const groupIdentityService = new GroupIdentityService(apiService);
         const tasksService = new TasksService(apiService);
 
-        let testUser; let groupInfo;
+        let testUser;
+        let groupInfo;
 
-        const newTask = StringUtil.generateRandomString(5); const completedTask = StringUtil.generateRandomString(5);
+        const newTask = StringUtil.generateRandomString(5);
+        const completedTask = StringUtil.generateRandomString(5);
 
         beforeAll(async () => {
             await apiService.loginWithProfile('identityAdmin');
@@ -81,13 +82,13 @@ describe('Task filters cloud', () => {
             await taskFilter.clickTaskFilter('completed-tasks');
             await taskList.getDataTable().waitTillContentLoaded();
 
-            await expect(await taskFilter.getActiveFilterName()).toBe('Completed Tasks');
+            expect(await taskFilter.getActiveFilterName()).toBe('Completed Tasks');
             await taskList.checkContentIsNotDisplayedByName(newTask);
 
             await taskFilter.clickTaskFilter('my-tasks');
             await taskList.getDataTable().waitTillContentLoaded();
 
-            await expect(await taskFilter.getActiveFilterName()).toBe('My Tasks');
+            expect(await taskFilter.getActiveFilterName()).toBe('My Tasks');
 
             await taskList.checkContentIsDisplayedByName(newTask);
         });
@@ -101,13 +102,13 @@ describe('Task filters cloud', () => {
             await taskFilter.clickTaskFilter('my-tasks');
             await taskList.getDataTable().waitTillContentLoaded();
 
-            await expect(await taskFilter.getActiveFilterName()).toBe('My Tasks');
+            expect(await taskFilter.getActiveFilterName()).toBe('My Tasks');
             await taskList.checkContentIsNotDisplayedByName(completedTask);
 
             await taskFilter.clickTaskFilter('completed-tasks');
             await taskList.getDataTable().waitTillContentLoaded();
 
-            await expect(await taskFilter.getActiveFilterName()).toBe('Completed Tasks');
+            expect(await taskFilter.getActiveFilterName()).toBe('Completed Tasks');
 
             await taskList.checkContentIsDisplayedByName(completedTask);
         });

--- a/e2e/process-services-cloud/task-list/task-form-cloud-component-tab.e2e.ts
+++ b/e2e/process-services-cloud/task-list/task-form-cloud-component-tab.e2e.ts
@@ -18,20 +18,23 @@
 import { browser } from 'protractor';
 import {
     AppListCloudPage,
-    StringUtil, createApiService,
+    StringUtil,
+    createApiService,
     LoginPage,
     TasksService,
     ProcessDefinitionsService,
     ProcessInstancesService,
     TaskHeaderCloudPage,
     TaskFormCloudComponent,
-    IdentityService, GroupIdentityService, ProcessCloudWidgetPage, FormCloudService
+    IdentityService,
+    GroupIdentityService,
+    ProcessCloudWidgetPage,
+    FormCloudService
 } from '@alfresco/adf-testing';
 import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
 import { TasksCloudDemoPage } from './../pages/tasks-cloud-demo.page';
 
 describe('Task form cloud component', () => {
-
     const loginSSOPage = new LoginPage();
     const navigationBarPage = new NavigationBarPage();
     const appListCloudComponent = new AppListCloudPage();
@@ -46,10 +49,15 @@ describe('Task form cloud component', () => {
     let processInstancesService: ProcessInstancesService;
     let identityService: IdentityService;
 
-    let completedTask; let assigneeTask; let toBeCompletedTask; let formValidationsTask; let testUser;
+    let completedTask;
+    let assigneeTask;
+    let toBeCompletedTask;
+    let formValidationsTask;
+    let testUser;
     const candidateBaseApp = browser.params.resources.ACTIVITI_CLOUD_APPS.CANDIDATE_BASE_APP.name;
     const simpleApp = browser.params.resources.ACTIVITI_CLOUD_APPS.SIMPLE_APP.name;
-    const completedTaskName = StringUtil.generateRandomString(); const assignedTaskName = StringUtil.generateRandomString();
+    const completedTaskName = StringUtil.generateRandomString();
+    const assignedTaskName = StringUtil.generateRandomString();
     const apiService = createApiService();
     const apiServiceHrUser = createApiService();
 
@@ -90,7 +98,7 @@ describe('Task form cloud component', () => {
         identityService = new IdentityService(apiService);
         const groupIdentityService = new GroupIdentityService(apiService);
 
-        testUser = await identityService.createIdentityUserWithRole( [identityService.ROLES.ACTIVITI_USER]);
+        testUser = await identityService.createIdentityUserWithRole([identityService.ROLES.ACTIVITI_USER]);
 
         const groupInfo = await groupIdentityService.getGroupInfoByGroupName('hr');
         await identityService.addUserToGroup(testUser.idIdentityService, groupInfo.id);
@@ -103,26 +111,44 @@ describe('Task form cloud component', () => {
 
         const formCloudService = new FormCloudService(apiServiceHrUser);
 
-        const tabVisibilityFieldsId = await formCloudService.getIdByFormName(simpleApp, browser.params.resources.ACTIVITI_CLOUD_APPS.SIMPLE_APP.forms.tabVisibilityFields.name);
+        const tabVisibilityFieldsId = await formCloudService.getIdByFormName(
+            simpleApp,
+            browser.params.resources.ACTIVITI_CLOUD_APPS.SIMPLE_APP.forms.tabVisibilityFields.name
+        );
 
-        const tabVisibilityVarsId = await formCloudService.getIdByFormName(simpleApp, browser.params.resources.ACTIVITI_CLOUD_APPS.SIMPLE_APP.forms.tabVisibilityVars.name);
+        const tabVisibilityVarsId = await formCloudService.getIdByFormName(
+            simpleApp,
+            browser.params.resources.ACTIVITI_CLOUD_APPS.SIMPLE_APP.forms.tabVisibilityVars.name
+        );
 
         for (let i = 0; i < 4; i++) {
-            visibilityConditionTasks[i] = await tasksService.createStandaloneTaskWithForm(StringUtil.generateRandomString(),
-                simpleApp, tabVisibilityFieldsId);
+            visibilityConditionTasks[i] = await tasksService.createStandaloneTaskWithForm(
+                StringUtil.generateRandomString(),
+                simpleApp,
+                tabVisibilityFieldsId
+            );
             await tasksService.claimTask(visibilityConditionTasks[i].entry.id, simpleApp);
         }
 
         for (let i = 4; i < 7; i++) {
-            visibilityConditionTasks[i] = await tasksService.createStandaloneTaskWithForm(StringUtil.generateRandomString(),
-                simpleApp, tabVisibilityVarsId);
+            visibilityConditionTasks[i] = await tasksService.createStandaloneTaskWithForm(
+                StringUtil.generateRandomString(),
+                simpleApp,
+                tabVisibilityVarsId
+            );
             await tasksService.claimTask(visibilityConditionTasks[i].entry.id, simpleApp);
         }
 
-        const formToTestValidationsKey = await formCloudService.getIdByFormName(browser.params.resources.ACTIVITI_CLOUD_APPS.CANDIDATE_BASE_APP.name,
-            browser.params.resources.ACTIVITI_CLOUD_APPS.CANDIDATE_BASE_APP.forms.formtotestvalidations);
+        const formToTestValidationsKey = await formCloudService.getIdByFormName(
+            browser.params.resources.ACTIVITI_CLOUD_APPS.CANDIDATE_BASE_APP.name,
+            browser.params.resources.ACTIVITI_CLOUD_APPS.CANDIDATE_BASE_APP.forms.formtotestvalidations
+        );
 
-        formValidationsTask = await tasksService.createStandaloneTaskWithForm(StringUtil.generateRandomString(), candidateBaseApp, formToTestValidationsKey);
+        formValidationsTask = await tasksService.createStandaloneTaskWithForm(
+            StringUtil.generateRandomString(),
+            candidateBaseApp,
+            formToTestValidationsKey
+        );
         await tasksService.claimTask(formValidationsTask.entry.id, candidateBaseApp);
 
         toBeCompletedTask = await tasksService.createStandaloneTask(StringUtil.generateRandomString(), candidateBaseApp);
@@ -134,14 +160,15 @@ describe('Task form cloud component', () => {
 
         processDefinitionService = new ProcessDefinitionsService(apiServiceHrUser);
 
-        const processDefinition = await processDefinitionService
-            .getProcessDefinitionByName(browser.params.resources.ACTIVITI_CLOUD_APPS.CANDIDATE_BASE_APP.processes.candidateUserProcess, candidateBaseApp);
+        const processDefinition = await processDefinitionService.getProcessDefinitionByName(
+            browser.params.resources.ACTIVITI_CLOUD_APPS.CANDIDATE_BASE_APP.processes.candidateUserProcess,
+            candidateBaseApp
+        );
 
         processInstancesService = new ProcessInstancesService(apiServiceHrUser);
         await processInstancesService.createProcessInstance(processDefinition.entry.key, candidateBaseApp);
 
         await loginSSOPage.login(testUser.username, testUser.password);
-
     }, 5 * 60 * 1000);
 
     beforeEach(async () => {
@@ -154,8 +181,7 @@ describe('Task form cloud component', () => {
         try {
             await apiService.loginWithProfile('identityAdmin');
             await identityService.deleteIdentityUser(testUser.idIdentityService);
-        } catch (error) {
-        }
+        } catch (error) {}
         await browser.executeScript('window.sessionStorage.clear();');
         await browser.executeScript('window.localStorage.clear();');
     });
@@ -175,7 +201,7 @@ describe('Task form cloud component', () => {
 
             await taskFormCloudComponent.clickCompleteButton();
 
-            await expect(await taskFilter.getActiveFilterName()).toBe(myTasksFilterTitle);
+            expect(await taskFilter.getActiveFilterName()).toBe(myTasksFilterTitle);
             await taskList.checkContentIsNotDisplayedByName(visibilityConditionTasks[0].entry.name);
 
             await chooseFilterAndSelectTaskByName(completedTasksFilter, visibilityConditionTasks[0].entry.name);
@@ -206,7 +232,7 @@ describe('Task form cloud component', () => {
 
             await taskFormCloudComponent.clickCompleteButton();
 
-            await expect(await taskFilter.getActiveFilterName()).toBe(myTasksFilterTitle);
+            expect(await taskFilter.getActiveFilterName()).toBe(myTasksFilterTitle);
             await taskList.checkContentIsNotDisplayedByName(visibilityConditionTasks[1].entry.name);
 
             await chooseFilterAndSelectTaskByName(completedTasksFilter, visibilityConditionTasks[1].entry.name);
@@ -234,7 +260,7 @@ describe('Task form cloud component', () => {
             await widget.tab().checkTabIsNotDisplayedByLabel(tab.tabFieldVar);
             await taskFormCloudComponent.clickCompleteButton();
 
-            await expect(await taskFilter.getActiveFilterName()).toBe(myTasksFilterTitle);
+            expect(await taskFilter.getActiveFilterName()).toBe(myTasksFilterTitle);
 
             await taskList.checkContentIsNotDisplayedByName(visibilityConditionTasks[2].entry.name);
 
@@ -254,7 +280,7 @@ describe('Task form cloud component', () => {
 
             await taskFormCloudComponent.clickCompleteButton();
 
-            await expect(await taskFilter.getActiveFilterName()).toBe(myTasksFilterTitle);
+            expect(await taskFilter.getActiveFilterName()).toBe(myTasksFilterTitle);
             await taskList.checkContentIsNotDisplayedByName(visibilityConditionTasks[4].entry.name);
 
             await chooseFilterAndSelectTaskByName(completedTasksFilter, visibilityConditionTasks[4].entry.name);
@@ -277,7 +303,7 @@ describe('Task form cloud component', () => {
             await widget.tab().clickTabByLabel(tab.tabVarField);
             await widget.textWidget().setValue(widgets.numberOneId, value.displayTab);
 
-            await expect(await taskFormCloudComponent.isCompleteButtonEnabled()).toEqual(false);
+            expect(await taskFormCloudComponent.isCompleteButtonEnabled()).toEqual(false);
         });
 
         it('[C315179] Should be able to complete a standalone task with visible tab with valid value for field', async () => {
@@ -293,7 +319,7 @@ describe('Task form cloud component', () => {
 
             await taskFormCloudComponent.clickCompleteButton();
 
-            await expect(await taskFilter.getActiveFilterName()).toBe(myTasksFilterTitle);
+            expect(await taskFilter.getActiveFilterName()).toBe(myTasksFilterTitle);
             await taskList.checkContentIsNotDisplayedByName(visibilityConditionTasks[6].entry.name);
 
             await chooseFilterAndSelectTaskByName(completedTasksFilter, visibilityConditionTasks[6].entry.name);
@@ -318,7 +344,7 @@ describe('Task form cloud component', () => {
             await widget.tab().checkTabIsDisplayedByLabel(tab.tabMultipleConditions);
             await taskFormCloudComponent.clickCompleteButton();
 
-            await expect(await taskFilter.getActiveFilterName()).toBe(myTasksFilterTitle);
+            expect(await taskFilter.getActiveFilterName()).toBe(myTasksFilterTitle);
             await taskList.checkContentIsNotDisplayedByName(visibilityConditionTasks[3].entry.name);
 
             await chooseFilterAndSelectTaskByName(completedTasksFilter, visibilityConditionTasks[3].entry.name);
@@ -326,6 +352,12 @@ describe('Task form cloud component', () => {
             await widget.tab().checkTabIsDisplayedByLabel(tab.tabMultipleConditions);
         });
 
+        /**
+         * Choose a filter and select a task by name
+         *
+         * @param filterName Filter name
+         * @param taskName Task name
+         */
         async function chooseFilterAndSelectTaskByName(filterName: string, taskName: string): Promise<void> {
             await taskFilter.clickTaskFilter(filterName);
             await taskList.getDataTable().waitTillContentLoaded();
@@ -333,16 +365,27 @@ describe('Task form cloud component', () => {
             await taskList.selectRow(taskName);
         }
 
+        /**
+         * Select a task by name
+         *
+         * @param taskName Task name
+         */
         async function selectTaskByName(taskName: string): Promise<void> {
             await taskList.checkContentIsDisplayedByName(taskName);
             await taskList.selectRow(taskName);
             await taskHeaderCloudPage.checkTaskPropertyListIsDisplayed();
         }
 
+        /**
+         * Choose a filter
+         *
+         * @param filterName Filter name
+         * @param filterTitle Filter title
+         */
         async function chooseFilter(filterName: string, filterTitle: string): Promise<void> {
             await taskFilter.clickTaskFilter(filterName);
             await taskList.getDataTable().waitTillContentLoaded();
-            await expect(await taskFilter.getActiveFilterName()).toBe(filterTitle);
+            expect(await taskFilter.getActiveFilterName()).toBe(filterTitle);
         }
-   });
+    });
 });

--- a/e2e/process-services-cloud/task-list/task-form-cloud-component.e2e.ts
+++ b/e2e/process-services-cloud/task-list/task-form-cloud-component.e2e.ts
@@ -16,7 +16,8 @@
  */
 
 import { browser, protractor } from 'protractor';
-import { createApiService,
+import {
+    createApiService,
     AppListCloudPage,
     LoginPage,
     ProcessCloudWidgetPage,
@@ -34,7 +35,6 @@ import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
 import { TasksCloudDemoPage } from './../pages/tasks-cloud-demo.page';
 
 describe('Task form cloud component', () => {
-
     const candidateBaseApp = browser.params.resources.ACTIVITI_CLOUD_APPS.CANDIDATE_BASE_APP.name;
     const candidateBaseAppProcesses = browser.params.resources.ACTIVITI_CLOUD_APPS.CANDIDATE_BASE_APP.processes;
     const simpleApp = browser.params.resources.ACTIVITI_CLOUD_APPS.SIMPLE_APP.name;
@@ -61,7 +61,8 @@ describe('Task form cloud component', () => {
     const processInstancesService = new ProcessInstancesService(apiService);
     const formCloudService = new FormCloudService(apiService);
 
-    const completedTaskName = StringUtil.generateRandomString(); const assignedTaskName = StringUtil.generateRandomString();
+    const completedTaskName = StringUtil.generateRandomString();
+    const assignedTaskName = StringUtil.generateRandomString();
     const myTasksFilter = 'my-tasks';
     const completedTasksFilter = 'completed-tasks';
     const dateFieldId = 'Date0rzbb6';
@@ -69,8 +70,20 @@ describe('Task form cloud component', () => {
     const changedDate = '2020-07-10';
     const dropdownFieldId = 'DropdownOptions';
 
-    let completedTask; let createdTask; let assigneeTask; let toBeCompletedTask; let formValidationsTask; let formTaskId; let assigneeTaskId; let assigneeReleaseTask; let candidateUsersTask ;
-    let dateTimerTaskId; let dateTimerTask; let dateTimerChangedTaskId; let dateTimerChangedTask; let dropdownOptionsTask;
+    let completedTask;
+    let createdTask;
+    let assigneeTask;
+    let toBeCompletedTask;
+    let formValidationsTask;
+    let formTaskId;
+    let assigneeTaskId;
+    let assigneeReleaseTask;
+    let candidateUsersTask;
+    let dateTimerTaskId;
+    let dateTimerTask;
+    let dateTimerChangedTaskId;
+    let dateTimerChangedTask;
+    let dropdownOptionsTask;
 
     beforeAll(async () => {
         try {
@@ -80,10 +93,16 @@ describe('Task form cloud component', () => {
             assigneeTask = await tasksService.createStandaloneTask(StringUtil.generateRandomString(), candidateBaseApp);
             await tasksService.claimTask(assigneeTask.entry.id, candidateBaseApp);
 
-            const formToTestValidationsKey = await formCloudService.getIdByFormName(candidateBaseApp,
-                    browser.params.resources.ACTIVITI_CLOUD_APPS.CANDIDATE_BASE_APP.forms.formtotestvalidations);
+            const formToTestValidationsKey = await formCloudService.getIdByFormName(
+                candidateBaseApp,
+                browser.params.resources.ACTIVITI_CLOUD_APPS.CANDIDATE_BASE_APP.forms.formtotestvalidations
+            );
 
-            formValidationsTask = await tasksService.createStandaloneTaskWithForm(StringUtil.generateRandomString(), candidateBaseApp, formToTestValidationsKey);
+            formValidationsTask = await tasksService.createStandaloneTaskWithForm(
+                StringUtil.generateRandomString(),
+                candidateBaseApp,
+                formToTestValidationsKey
+            );
             await tasksService.claimTask(formValidationsTask.entry.id, candidateBaseApp);
 
             toBeCompletedTask = await tasksService.createStandaloneTask(StringUtil.generateRandomString(), candidateBaseApp);
@@ -93,8 +112,10 @@ describe('Task form cloud component', () => {
             await tasksService.claimTask(completedTask.entry.id, candidateBaseApp);
             await tasksService.createAndCompleteTask(completedTaskName, candidateBaseApp);
 
-            let processDefinition = await processDefinitionService
-                    .getProcessDefinitionByName(candidateBaseAppProcesses.candidateUserProcess, candidateBaseApp);
+            let processDefinition = await processDefinitionService.getProcessDefinitionByName(
+                candidateBaseAppProcesses.candidateUserProcess,
+                candidateBaseApp
+            );
 
             const candidateUsersProcessInstance = await processInstancesService.createProcessInstance(processDefinition.entry.key, candidateBaseApp);
 
@@ -102,26 +123,31 @@ describe('Task form cloud component', () => {
             candidateUsersTask = processInstanceTasks.list.entries[0];
             await tasksService.claimTask(candidateUsersTask.entry.id, candidateBaseApp);
 
-            processDefinition = await processDefinitionService
-                    .getProcessDefinitionByName(candidateBaseAppProcesses.candidateUserProcess, candidateBaseApp);
+            processDefinition = await processDefinitionService.getProcessDefinitionByName(
+                candidateBaseAppProcesses.candidateUserProcess,
+                candidateBaseApp
+            );
 
             const formProcess = await processInstancesService.createProcessInstance(processDefinition.entry.key, candidateBaseApp);
             const formTasks = await queryService.getProcessInstanceTasks(formProcess.entry.id, candidateBaseApp);
             formTaskId = formTasks.list.entries[0].entry.id;
 
             const dropdownOptionsId = await formCloudService.getIdByFormName(simpleApp, simpleAppForm.dropdownWithOptions.name);
-            dropdownOptionsTask = await tasksService.createStandaloneTaskWithForm(StringUtil.generateRandomString(),
-                simpleApp, dropdownOptionsId);
+            dropdownOptionsTask = await tasksService.createStandaloneTaskWithForm(StringUtil.generateRandomString(), simpleApp, dropdownOptionsId);
             await tasksService.claimTask(dropdownOptionsTask.entry.id, simpleApp);
 
-            const timerProcessDefinition = await processDefinitionService
-                .getProcessDefinitionByName(simpleAppProcess.intermediateDateProcessVarTimer, simpleApp);
+            const timerProcessDefinition = await processDefinitionService.getProcessDefinitionByName(
+                simpleAppProcess.intermediateDateProcessVarTimer,
+                simpleApp
+            );
             const dateTimerProcess = await processInstancesService.createProcessInstance(timerProcessDefinition.entry.key, simpleApp);
             dateTimerTask = await queryService.getProcessInstanceTasks(dateTimerProcess.entry.id, simpleApp);
             dateTimerTaskId = dateTimerTask.list.entries[0].entry.id;
 
-            const timerChangedProcessDefinition = await processDefinitionService
-                .getProcessDefinitionByName(simpleAppProcess.intermediateDateProcessVarTimer, simpleApp);
+            const timerChangedProcessDefinition = await processDefinitionService.getProcessDefinitionByName(
+                simpleAppProcess.intermediateDateProcessVarTimer,
+                simpleApp
+            );
             const dateTimerChangedProcess = await processInstancesService.createProcessInstance(timerChangedProcessDefinition.entry.key, simpleApp);
             dateTimerChangedTask = await queryService.getProcessInstanceTasks(dateTimerChangedProcess.entry.id, simpleApp);
             dateTimerChangedTaskId = dateTimerChangedTask.list.entries[0].entry.id;
@@ -136,7 +162,6 @@ describe('Task form cloud component', () => {
         } catch (error) {
             Logger.error('Error in beforeAll: ', error);
         }
-
     }, 5 * 60 * 1000);
 
     beforeEach(async () => {
@@ -154,7 +179,7 @@ describe('Task form cloud component', () => {
         await taskFilter.clickTaskFilter(myTasksFilter);
         await taskList.getDataTable().waitTillContentLoaded();
 
-        await expect(taskFilter.getActiveFilterName()).toBe('My Tasks');
+        expect(taskFilter.getActiveFilterName()).toBe('My Tasks');
         await editTaskFilter.openFilter();
         await editTaskFilter.clearAssignee();
         await editTaskFilter.setStatusFilterDropDown('Created');
@@ -189,8 +214,8 @@ describe('Task form cloud component', () => {
         await appListCloudComponent.goToApp(simpleApp);
         await openTaskByIdFromFilters(myTasksFilter, assigneeTaskId);
 
-        await expect(await taskHeaderCloudPage.getAssignee()).toEqual(assigneeReleaseTask.list.entries[0].entry.assignee);
-        await expect(await taskHeaderCloudPage.getStatus()).toEqual('ASSIGNED');
+        expect(await taskHeaderCloudPage.getAssignee()).toEqual(assigneeReleaseTask.list.entries[0].entry.assignee);
+        expect(await taskHeaderCloudPage.getStatus()).toEqual('ASSIGNED');
         await taskFormCloudComponent.checkReleaseButtonIsNotDisplayed();
     });
 
@@ -200,7 +225,7 @@ describe('Task form cloud component', () => {
 
         await goToAppOpenDropdownTaskByNameFromFilters(myTasksFilter, dropdownOptionsTask.entry.name);
         await widget.dropdown().openDropdown(dropdownId);
-        await widget.dropdown().selectOption(selectedOption, dropdownId );
+        await widget.dropdown().selectOption(selectedOption, dropdownId);
         await taskFormCloudComponent.checkSaveButtonIsDisplayed();
         await taskFormCloudComponent.clickSaveButton();
 
@@ -208,7 +233,7 @@ describe('Task form cloud component', () => {
         await appListCloudComponent.checkApsContainer();
         await goToAppOpenDropdownTaskByNameFromFilters(myTasksFilter, dropdownOptionsTask.entry.name);
 
-        await expect(await widget.dropdown().getSelectedOptionText(dropdownFieldId)).toBe(selectedOption);
+        expect(await widget.dropdown().getSelectedOptionText(dropdownFieldId)).toBe(selectedOption);
     });
 
     it('[C313200] Should be able to complete a Task form with process date variable mapped to a Date widget in the form', async () => {
@@ -218,10 +243,10 @@ describe('Task form cloud component', () => {
         await completeTask();
         await verifyDateCompletedTask(dateTimerTaskId, defaultDate);
 
-        await openTaskByIdFromFilters(myTasksFilter, dateTimerChangedTaskId );
+        await openTaskByIdFromFilters(myTasksFilter, dateTimerChangedTaskId);
         await verifyDateInput(dateFieldId, defaultDate);
         await widget.dateWidget().clearDateInput(dateFieldId);
-        await widget.dateWidget().setDateInput(dateFieldId, changedDate );
+        await widget.dateWidget().setDateInput(dateFieldId, changedDate);
         await completeTask();
 
         await verifyDateCompletedTask(dateTimerChangedTaskId, changedDate);
@@ -234,7 +259,7 @@ describe('Task form cloud component', () => {
 
         it('[C307032] Should display the appropriate title for the unclaim option of a Task', async () => {
             await openTaskByIdFromFilters(myTasksFilter, candidateUsersTask.entry.id);
-            await expect(await taskFormCloudComponent.getReleaseButtonText()).toBe('RELEASE');
+            expect(await taskFormCloudComponent.getReleaseButtonText()).toBe('RELEASE');
         });
 
         it('[C310142] Empty content is displayed when having a task without form', async () => {
@@ -244,10 +269,10 @@ describe('Task form cloud component', () => {
             await taskList.checkContentIsDisplayedByName(assigneeTask.entry.name);
             await taskList.selectRow(assigneeTask.entry.name);
             await taskFormCloudComponent.checkFormIsNotDisplayed();
-            await expect(await taskFormCloudComponent.getFormTitle()).toBe(assigneeTask.entry.name);
+            expect(await taskFormCloudComponent.getFormTitle()).toBe(assigneeTask.entry.name);
             await taskFormCloudComponent.checkFormContentIsEmpty();
-            await expect(await taskFormCloudComponent.getEmptyFormContentTitle()).toBe(`No form available`);
-            await expect(await taskFormCloudComponent.getEmptyFormContentSubtitle()).toBe(`Attach a form that can be viewed later`);
+            expect(await taskFormCloudComponent.getEmptyFormContentTitle()).toBe(`No form available`);
+            expect(await taskFormCloudComponent.getEmptyFormContentSubtitle()).toBe(`Attach a form that can be viewed later`);
         });
 
         it('[C310199] Should not be able to complete a task when required field is empty or invalid data is added to a field', async () => {
@@ -261,36 +286,36 @@ describe('Task form cloud component', () => {
             await taskFormCloudComponent.formFields().checkWidgetIsVisible('Number0klykr');
             await taskFormCloudComponent.formFields().checkWidgetIsVisible('Amount0mtp1h');
 
-            await expect(await taskFormCloudComponent.isCompleteButtonEnabled()).toBe(false);
+            expect(await taskFormCloudComponent.isCompleteButtonEnabled()).toBe(false);
             await widget.textWidget().setValue('Text0tma8h', 'Some random text');
-            await expect(await taskFormCloudComponent.isCompleteButtonEnabled()).toBe(true);
+            expect(await taskFormCloudComponent.isCompleteButtonEnabled()).toBe(true);
 
             await widget.dateWidget().setDateInput('Date0m1moq', 'invalid date');
             await browser.actions().sendKeys(protractor.Key.ENTER).perform();
-            await expect(await taskFormCloudComponent.isCompleteButtonEnabled()).toBe(false);
+            expect(await taskFormCloudComponent.isCompleteButtonEnabled()).toBe(false);
 
             await widget.dateWidget().setDateInput('Date0m1moq', '20-10-2018');
             await browser.actions().sendKeys(protractor.Key.ENTER).perform();
-            await expect(await taskFormCloudComponent.isCompleteButtonEnabled()).toBe(true);
+            expect(await taskFormCloudComponent.isCompleteButtonEnabled()).toBe(true);
 
             await widget.numberWidget().setFieldValue('Number0klykr', 'invalid number');
-            await expect(await taskFormCloudComponent.isCompleteButtonEnabled()).toBe(false);
+            expect(await taskFormCloudComponent.isCompleteButtonEnabled()).toBe(false);
 
             await widget.numberWidget().setFieldValue('Number0klykr', '26');
-            await expect(await taskFormCloudComponent.isCompleteButtonEnabled()).toBe(true);
+            expect(await taskFormCloudComponent.isCompleteButtonEnabled()).toBe(true);
 
             await widget.amountWidget().setFieldValue('Amount0mtp1h', 'invalid amount');
-            await expect(await taskFormCloudComponent.isCompleteButtonEnabled()).toBe(false);
+            expect(await taskFormCloudComponent.isCompleteButtonEnabled()).toBe(false);
 
             await widget.amountWidget().setFieldValue('Amount0mtp1h', '660');
-            await expect(await taskFormCloudComponent.isCompleteButtonEnabled()).toBe(true);
+            expect(await taskFormCloudComponent.isCompleteButtonEnabled()).toBe(true);
         });
 
         it('[C307093] Complete button is not displayed when the task is already completed', async () => {
             await taskFilter.clickTaskFilter(completedTasksFilter);
             await taskList.getDataTable().waitTillContentLoaded();
 
-            await expect(await taskFilter.getActiveFilterName()).toBe('Completed Tasks');
+            expect(await taskFilter.getActiveFilterName()).toBe('Completed Tasks');
             await taskList.checkContentIsDisplayedByName(completedTaskName);
             await taskList.selectRow(completedTaskName);
             await taskHeaderCloudPage.checkTaskPropertyListIsDisplayed();
@@ -301,7 +326,7 @@ describe('Task form cloud component', () => {
             await taskFilter.clickTaskFilter(myTasksFilter);
             await taskList.getDataTable().waitTillContentLoaded();
 
-            await expect(await taskFilter.getActiveFilterName()).toBe('My Tasks');
+            expect(await taskFilter.getActiveFilterName()).toBe('My Tasks');
             await editTaskFilter.openFilter();
 
             await editTaskFilter.clearAssignee();
@@ -315,12 +340,12 @@ describe('Task form cloud component', () => {
             await taskFilter.clickTaskFilter(myTasksFilter);
             await taskList.getDataTable().waitTillContentLoaded();
 
-            await expect(await taskFilter.getActiveFilterName()).toBe('My Tasks');
+            expect(await taskFilter.getActiveFilterName()).toBe('My Tasks');
 
             await selectTaskByName(assigneeTask.entry.name);
             await taskFormCloudComponent.clickCancelButton();
 
-            await expect(await taskFilter.getActiveFilterName()).toBe('My Tasks');
+            expect(await taskFilter.getActiveFilterName()).toBe('My Tasks');
             await taskList.checkContentIsDisplayedByName(assigneeTask.entry.name);
         });
 
@@ -328,7 +353,7 @@ describe('Task form cloud component', () => {
             await taskFilter.clickTaskFilter(myTasksFilter);
             await taskList.getDataTable().waitTillContentLoaded();
 
-            await expect(await taskFilter.getActiveFilterName()).toBe('My Tasks');
+            expect(await taskFilter.getActiveFilterName()).toBe('My Tasks');
 
             await selectTaskByName(toBeCompletedTask.entry.name);
             await completeTask();
@@ -345,7 +370,7 @@ describe('Task form cloud component', () => {
             await taskFilter.clickTaskFilter(myTasksFilter);
             await taskList.getDataTable().waitTillContentLoaded();
 
-            await expect(await taskFilter.getActiveFilterName()).toBe('My Tasks');
+            expect(await taskFilter.getActiveFilterName()).toBe('My Tasks');
 
             await selectTaskByName(completedTask.entry.name);
             await completeTask();
@@ -359,6 +384,12 @@ describe('Task form cloud component', () => {
         });
     });
 
+    /**
+     * Open task by id from filters
+     *
+     * @param filterName Filter name
+     * @param taskId Task id
+     */
     async function openTaskByIdFromFilters(filterName: string, taskId: string): Promise<void> {
         await taskFilter.clickTaskFilter(filterName);
         await taskList.getDataTable().waitTillContentLoaded();
@@ -367,24 +398,47 @@ describe('Task form cloud component', () => {
         await taskList.selectRowByTaskId(taskId);
     }
 
+    /**
+     * Verify date input
+     *
+     * @param widgetId Widget id
+     * @param input input value
+     */
     async function verifyDateInput(widgetId: string, input: string): Promise<void> {
         await widget.dateWidget().checkWidgetIsVisible(widgetId);
-        await expect(await widget.dateWidget().getDateInput(widgetId)).toBe(input);
+        expect(await widget.dateWidget().getDateInput(widgetId)).toBe(input);
     }
 
+    /**
+     * Select task by name
+     *
+     * @param taskName Task name
+     */
     async function selectTaskByName(taskName: string): Promise<void> {
         await taskList.checkContentIsDisplayedByName(taskName);
         await taskList.selectRow(taskName);
         await taskHeaderCloudPage.checkTaskPropertyListIsDisplayed();
     }
 
+    /**
+     * Verify date completed task
+     *
+     * @param taskId Task id
+     * @param input input value
+     */
     async function verifyDateCompletedTask(taskId: string, input: string): Promise<void> {
-        await openTaskByIdFromFilters(completedTasksFilter, taskId );
+        await openTaskByIdFromFilters(completedTasksFilter, taskId);
         await taskFormCloudComponent.checkFormIsReadOnly();
         await verifyDateInput(dateFieldId, input);
         await taskFormCloudComponent.clickCancelButton();
     }
 
+    /**
+     * Go to app open dropdown task by name from filters
+     *
+     * @param filterName Filter name
+     * @param taskName Task name
+     */
     async function goToAppOpenDropdownTaskByNameFromFilters(filterName: string, taskName: string): Promise<void> {
         await appListCloudComponent.goToApp(simpleApp);
         await taskFilter.clickTaskFilter(filterName);
@@ -396,6 +450,9 @@ describe('Task form cloud component', () => {
         await widget.dropdown().isWidgetVisible(dropdownFieldId);
     }
 
+    /**
+     * Complete task
+     */
     async function completeTask(): Promise<void> {
         await taskFormCloudComponent.checkCompleteButtonIsDisplayed();
         await taskFormCloudComponent.clickCompleteButton();

--- a/e2e/process-services-cloud/task-list/task-header-cloud.e2e.ts
+++ b/e2e/process-services-cloud/task-list/task-header-cloud.e2e.ts
@@ -16,7 +16,8 @@
  */
 
 import CONSTANTS = require('../../util/constants');
-import { createApiService,
+import {
+    createApiService,
     AppListCloudPage,
     GroupIdentityService,
     IdentityService,
@@ -34,7 +35,6 @@ import { DateFnsUtils } from '../../../lib/core/src/lib/common/utils/date-fns-ut
 const isValueInvalid = (value: any): boolean => value === null || value === undefined;
 
 describe('Task Header cloud component', () => {
-
     const simpleApp = browser.params.resources.ACTIVITI_CLOUD_APPS.SIMPLE_APP.name;
 
     const loginSSOPage = new LoginPage();
@@ -73,21 +73,24 @@ describe('Task Header cloud component', () => {
     const formatDate = 'MMM D, YYYY';
     const dateTimeFormat = 'MMM D, Y, H:mm';
 
-    const createCompletedTask = async function() {
-        const completedTaskId = await tasksService.createStandaloneTask(completedTaskName,
-            simpleApp, { priority, description, dueDate: basicCreatedTask.entry.createdDate });
+    const createCompletedTask = async () => {
+        const completedTaskId = await tasksService.createStandaloneTask(completedTaskName, simpleApp, {
+            priority,
+            description,
+            dueDate: basicCreatedTask.entry.createdDate
+        });
         await tasksService.claimTask(completedTaskId.entry.id, simpleApp);
         await tasksService.completeTask(completedTaskId.entry.id, simpleApp);
         return tasksService.getTask(completedTaskId.entry.id, simpleApp);
     };
 
-    const createSubTask = async function(createdTaskId) {
+    const createSubTask = async (createdTaskId) => {
         const subTaskId = await tasksService.createStandaloneSubtask(createdTaskId.entry.id, simpleApp, StringUtil.generateRandomString());
         await tasksService.claimTask(subTaskId.entry.id, simpleApp);
-        return  tasksService.getTask(subTaskId.entry.id, simpleApp);
+        return tasksService.getTask(subTaskId.entry.id, simpleApp);
     };
 
-    const createTask = async function() {
+    const createTask = async () => {
         const createdTaskId = await tasksService.createStandaloneTask(basicCreatedTaskName, simpleApp);
         await tasksService.claimTask(createdTaskId.entry.id, simpleApp);
         basicCreatedTask = await tasksService.getTask(createdTaskId.entry.id, simpleApp);
@@ -98,7 +101,7 @@ describe('Task Header cloud component', () => {
     beforeAll(async () => {
         await apiService.loginWithProfile('identityAdmin');
 
-        testUser = await identityService.createIdentityUserWithRole( [identityService.ROLES.ACTIVITI_USER]);
+        testUser = await identityService.createIdentityUserWithRole([identityService.ROLES.ACTIVITI_USER]);
         groupInfo = await groupIdentityService.getGroupInfoByGroupName('hr');
         await identityService.addUserToGroup(testUser.idIdentityService, groupInfo.id);
         await apiService.login(testUser.username, testUser.password);
@@ -140,19 +143,24 @@ describe('Task Header cloud component', () => {
         await tasksCloudDemoPage.waitTillContentLoaded();
         await taskHeaderCloudPage.checkTaskPropertyListIsDisplayed();
 
-        await expect(await taskHeaderCloudPage.getId()).toEqual(basicCreatedTask.entry.id);
-        await expect(await taskHeaderCloudPage.getDescription())
-            .toEqual(isValueInvalid(basicCreatedTask.entry.description) ? CONSTANTS.TASK_DETAILS.NO_DESCRIPTION : basicCreatedTask.entry.description);
-        await expect(await taskHeaderCloudPage.getStatus()).toEqual('ASSIGNED');
-        await expect(await taskHeaderCloudPage.getPriority()).toEqual('None');
-        await expect(await taskHeaderCloudPage.getCategory()).toEqual(!basicCreatedTask.entry.category ?
-            CONSTANTS.TASK_DETAILS.NO_CATEGORY : basicCreatedTask.entry.category);
-        await expect(await taskHeaderCloudPage.getDueDate()).toEqual(isValueInvalid(basicCreatedTask.entry.dueDate) ?
-            CONSTANTS.TASK_DETAILS.NO_DATE : basicCreatedDate);
-        await expect(await taskHeaderCloudPage.getEndDate()).toEqual('');
-        await expect(await taskHeaderCloudPage.getCreated()).toEqual(basicCreatedDate);
-        await expect(await taskHeaderCloudPage.getAssignee()).toEqual(isValueInvalid(basicCreatedTask.entry.assignee) ? '' : basicCreatedTask.entry.assignee);
-        await expect(await taskHeaderCloudPage.getParentName()).toEqual(CONSTANTS.TASK_DETAILS.NO_PARENT);
+        expect(await taskHeaderCloudPage.getId()).toEqual(basicCreatedTask.entry.id);
+        expect(await taskHeaderCloudPage.getDescription()).toEqual(
+            isValueInvalid(basicCreatedTask.entry.description) ? CONSTANTS.TASK_DETAILS.NO_DESCRIPTION : basicCreatedTask.entry.description
+        );
+        expect(await taskHeaderCloudPage.getStatus()).toEqual('ASSIGNED');
+        expect(await taskHeaderCloudPage.getPriority()).toEqual('None');
+        expect(await taskHeaderCloudPage.getCategory()).toEqual(
+            !basicCreatedTask.entry.category ? CONSTANTS.TASK_DETAILS.NO_CATEGORY : basicCreatedTask.entry.category
+        );
+        expect(await taskHeaderCloudPage.getDueDate()).toEqual(
+            isValueInvalid(basicCreatedTask.entry.dueDate) ? CONSTANTS.TASK_DETAILS.NO_DATE : basicCreatedDate
+        );
+        expect(await taskHeaderCloudPage.getEndDate()).toEqual('');
+        expect(await taskHeaderCloudPage.getCreated()).toEqual(basicCreatedDate);
+        expect(await taskHeaderCloudPage.getAssignee()).toEqual(
+            isValueInvalid(basicCreatedTask.entry.assignee) ? '' : basicCreatedTask.entry.assignee
+        );
+        expect(await taskHeaderCloudPage.getParentName()).toEqual(CONSTANTS.TASK_DETAILS.NO_PARENT);
     });
 
     it('[C291944] Should display task details for completed task', async () => {
@@ -164,19 +172,22 @@ describe('Task Header cloud component', () => {
         await tasksCloudDemoPage.waitTillContentLoaded();
         await taskHeaderCloudPage.checkTaskPropertyListIsDisplayed();
 
-        await expect(await taskHeaderCloudPage.getId()).toEqual(completedTask.entry.id);
-        await expect(await taskHeaderCloudPage.getDescription())
-            .toEqual(isValueInvalid(completedTask.entry.description) ? CONSTANTS.TASK_DETAILS.NO_DESCRIPTION : completedTask.entry.description);
-        await expect(await taskHeaderCloudPage.getStatus()).toEqual('COMPLETED');
-        await expect(await taskHeaderCloudPage.getReadonlyPriority()).toEqual('None');
-        await expect(await taskHeaderCloudPage.getCategory()).toEqual(!completedTask.entry.category ?
-            CONSTANTS.TASK_DETAILS.NO_CATEGORY : completedTask.entry.category);
-        await expect(await taskHeaderCloudPage.getDueDate()).toEqual(isValueInvalid(completedTask.entry.dueDate) ?
-            CONSTANTS.TASK_DETAILS.NO_DATE : dueDate);
-        await expect(await taskHeaderCloudPage.getEndDate()).toEqual(completedEndDate);
-        await expect(await taskHeaderCloudPage.getCreated()).toEqual(completedCreatedDate);
-        await expect(await taskHeaderCloudPage.getAssignee()).toEqual(isValueInvalid(completedTask.entry.assignee) ? '' : completedTask.entry.assignee);
-        await expect(await taskHeaderCloudPage.getParentName()).toEqual(CONSTANTS.TASK_DETAILS.NO_PARENT);
+        expect(await taskHeaderCloudPage.getId()).toEqual(completedTask.entry.id);
+        expect(await taskHeaderCloudPage.getDescription()).toEqual(
+            isValueInvalid(completedTask.entry.description) ? CONSTANTS.TASK_DETAILS.NO_DESCRIPTION : completedTask.entry.description
+        );
+        expect(await taskHeaderCloudPage.getStatus()).toEqual('COMPLETED');
+        expect(await taskHeaderCloudPage.getReadonlyPriority()).toEqual('None');
+        expect(await taskHeaderCloudPage.getCategory()).toEqual(
+            !completedTask.entry.category ? CONSTANTS.TASK_DETAILS.NO_CATEGORY : completedTask.entry.category
+        );
+        expect(await taskHeaderCloudPage.getDueDate()).toEqual(
+            isValueInvalid(completedTask.entry.dueDate) ? CONSTANTS.TASK_DETAILS.NO_DATE : dueDate
+        );
+        expect(await taskHeaderCloudPage.getEndDate()).toEqual(completedEndDate);
+        expect(await taskHeaderCloudPage.getCreated()).toEqual(completedCreatedDate);
+        expect(await taskHeaderCloudPage.getAssignee()).toEqual(isValueInvalid(completedTask.entry.assignee) ? '' : completedTask.entry.assignee);
+        expect(await taskHeaderCloudPage.getParentName()).toEqual(CONSTANTS.TASK_DETAILS.NO_PARENT);
     });
 
     it('[C291945] Should Parent Name and Parent Id not be empty in task details for sub task', async () => {
@@ -188,20 +199,23 @@ describe('Task Header cloud component', () => {
         await tasksCloudDemoPage.waitTillContentLoaded();
         await taskHeaderCloudPage.checkTaskPropertyListIsDisplayed();
 
-        await expect(await taskHeaderCloudPage.getId()).toEqual(subTask.entry.id);
-        await expect(await taskHeaderCloudPage.getDescription())
-            .toEqual(isValueInvalid(subTask.entry.description) ? CONSTANTS.TASK_DETAILS.NO_DESCRIPTION : subTask.entry.description);
-        await expect(await taskHeaderCloudPage.getStatus()).toEqual('ASSIGNED');
-        await expect(await taskHeaderCloudPage.getPriority()).toEqual('None');
-        await expect(await taskHeaderCloudPage.getCategory()).toEqual(!subTask.entry.category ?
-            CONSTANTS.TASK_DETAILS.NO_CATEGORY : subTask.entry.category);
-        await expect(await taskHeaderCloudPage.getDueDate()).toEqual(isValueInvalid(subTask.entry.dueDate) ? CONSTANTS.TASK_DETAILS.NO_DATE : subTaskCreatedDate);
-        await expect(await taskHeaderCloudPage.getEndDate()).toEqual('');
-        await expect(await taskHeaderCloudPage.getCreated()).toEqual(subTaskCreatedDate);
-        await expect(await taskHeaderCloudPage.getAssignee()).toEqual(isValueInvalid(subTask.entry.assignee) ? '' : subTask.entry.assignee);
-        await expect(await taskHeaderCloudPage.getParentName()).toEqual(basicCreatedTask.entry.name);
-        await expect(await taskHeaderCloudPage.getParentTaskId())
-            .toEqual(isValueInvalid(subTask.entry.parentTaskId) ? '' : subTask.entry.parentTaskId);
+        expect(await taskHeaderCloudPage.getId()).toEqual(subTask.entry.id);
+        expect(await taskHeaderCloudPage.getDescription()).toEqual(
+            isValueInvalid(subTask.entry.description) ? CONSTANTS.TASK_DETAILS.NO_DESCRIPTION : subTask.entry.description
+        );
+        expect(await taskHeaderCloudPage.getStatus()).toEqual('ASSIGNED');
+        expect(await taskHeaderCloudPage.getPriority()).toEqual('None');
+        expect(await taskHeaderCloudPage.getCategory()).toEqual(
+            !subTask.entry.category ? CONSTANTS.TASK_DETAILS.NO_CATEGORY : subTask.entry.category
+        );
+        expect(await taskHeaderCloudPage.getDueDate()).toEqual(
+            isValueInvalid(subTask.entry.dueDate) ? CONSTANTS.TASK_DETAILS.NO_DATE : subTaskCreatedDate
+        );
+        expect(await taskHeaderCloudPage.getEndDate()).toEqual('');
+        expect(await taskHeaderCloudPage.getCreated()).toEqual(subTaskCreatedDate);
+        expect(await taskHeaderCloudPage.getAssignee()).toEqual(isValueInvalid(subTask.entry.assignee) ? '' : subTask.entry.assignee);
+        expect(await taskHeaderCloudPage.getParentName()).toEqual(basicCreatedTask.entry.name);
+        expect(await taskHeaderCloudPage.getParentTaskId()).toEqual(isValueInvalid(subTask.entry.parentTaskId) ? '' : subTask.entry.parentTaskId);
     });
 
     it('[C309698] Should validate the Priority field', async () => {
@@ -216,7 +230,7 @@ describe('Task Header cloud component', () => {
         await taskHeaderCloudPage.checkTaskPropertyListIsDisplayed();
 
         const currentAssignee = await taskHeaderCloudPage.assigneeCardTextItem.getFieldValue();
-        await expect(currentAssignee).toBe('No assignee');
+        expect(currentAssignee).toBe('No assignee');
 
         await taskHeaderCloudPage.priorityCardSelectItem.checkElementIsReadonly();
         await taskHeaderCloudPage.statusCardTextItem.checkElementIsReadonly();
@@ -225,8 +239,8 @@ describe('Task Header cloud component', () => {
     it('[C291991] Should be able to assign a task only to the users that have access to the selected app', async () => {
         await tasksCloudDemoPage.clickStartNewTaskButton();
         const currentAssignee = await peopleCloudComponentPage.getChipAssignee();
-        await expect(currentAssignee).toContain(testUser.firstName);
-        await expect(currentAssignee).toContain(testUser.lastName);
+        expect(currentAssignee).toContain(testUser.firstName);
+        expect(currentAssignee).toContain(testUser.lastName);
 
         await peopleCloudComponentPage.searchAssignee('hrUser');
         await peopleCloudComponentPage.selectAssigneeFromList('HR User');

--- a/e2e/process-services-cloud/task-list/task-list-properties-sort.e2e.ts
+++ b/e2e/process-services-cloud/task-list/task-list-properties-sort.e2e.ts
@@ -17,9 +17,14 @@
 
 import { browser } from 'protractor';
 import {
-    StringUtil, TasksService,
-    LoginPage, createApiService,
-    AppListCloudPage, LocalStorageUtil, IdentityService, GroupIdentityService
+    StringUtil,
+    TasksService,
+    LoginPage,
+    createApiService,
+    AppListCloudPage,
+    LocalStorageUtil,
+    IdentityService,
+    GroupIdentityService
 } from '@alfresco/adf-testing';
 import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
 import { TasksCloudDemoPage } from './../pages/tasks-cloud-demo.page';
@@ -47,13 +52,21 @@ describe('Edit task filters and task list properties', () => {
 
     const simpleApp = browser.params.resources.ACTIVITI_CLOUD_APPS.SIMPLE_APP.name;
     const candidateBaseApp = browser.params.resources.ACTIVITI_CLOUD_APPS.CANDIDATE_BASE_APP.name;
-    let createdTask; let notDisplayedTask; let noPriorityTask; let lowPriorityTask; let normalPriorityTask; let hightPriorityTask; let subTask;
-        let otherOwnerTask; let testUser; let groupInfo;
+    let createdTask;
+    let notDisplayedTask;
+    let noPriorityTask;
+    let lowPriorityTask;
+    let normalPriorityTask;
+    let hightPriorityTask;
+    let subTask;
+    let otherOwnerTask;
+    let testUser;
+    let groupInfo;
 
     beforeAll(async () => {
         await apiService.loginWithProfile('identityAdmin');
 
-        testUser = await identityService.createIdentityUserWithRole( [identityService.ROLES.ACTIVITI_USER]);
+        testUser = await identityService.createIdentityUserWithRole([identityService.ROLES.ACTIVITI_USER]);
 
         groupInfo = await groupIdentityService.getGroupInfoByGroupName('hr');
         await identityService.addUserToGroup(testUser.idIdentityService, groupInfo.id);
@@ -85,42 +98,41 @@ describe('Edit task filters and task list properties', () => {
 
         await loginSSOPage.login(testUser.username, testUser.password);
         await LocalStorageUtil.setConfigField('adf-cloud-task-list', JSON.stringify(jsonFile));
-        await LocalStorageUtil.setConfigField('adf-edit-task-filter', JSON.stringify({
-            filterProperties: [
-                'taskId',
-                'appName',
-                'status',
-                'assignee',
-                'taskName',
-                'parentTaskId',
-                'priority',
-                'standalone',
-                'owner',
-                'processDefinitionId',
-                'processInstanceId',
-                'lastModified',
-                'sort',
-                'order'
-            ],
-            sortProperties: [
-                'id',
-                'name',
-                'createdDate',
-                'priority',
-                'processDefinitionId',
-                'processInstanceId',
-                'parentTaskId',
-                'priority',
-                'standalone',
-                'owner',
-                'assignee'
-            ],
-            actions: [
-                'save',
-                'saveAs',
-                'delete'
-            ]
-        }));
+        await LocalStorageUtil.setConfigField(
+            'adf-edit-task-filter',
+            JSON.stringify({
+                filterProperties: [
+                    'taskId',
+                    'appName',
+                    'status',
+                    'assignee',
+                    'taskName',
+                    'parentTaskId',
+                    'priority',
+                    'standalone',
+                    'owner',
+                    'processDefinitionId',
+                    'processInstanceId',
+                    'lastModified',
+                    'sort',
+                    'order'
+                ],
+                sortProperties: [
+                    'id',
+                    'name',
+                    'createdDate',
+                    'priority',
+                    'processDefinitionId',
+                    'processInstanceId',
+                    'parentTaskId',
+                    'priority',
+                    'standalone',
+                    'owner',
+                    'assignee'
+                ],
+                actions: ['save', 'saveAs', 'delete']
+            })
+        );
     }, 5 * 60 * 1000);
 
     afterAll(async () => {
@@ -142,10 +154,10 @@ describe('Edit task filters and task list properties', () => {
             await editTaskFilter.setSortFilterDropDown('name');
             await editTaskFilter.setOrderFilterDropDown(SORT_ORDER.ASC);
 
-            await expect(await taskList.getDataTable().checkListIsSorted(SORT_ORDER.ASC, 'Task Name')).toBe(true);
+            expect(await taskList.getDataTable().checkListIsSorted(SORT_ORDER.ASC, 'Task Name')).toBe(true);
 
             await editTaskFilter.setOrderFilterDropDown(SORT_ORDER.DESC);
-            await expect(await taskList.getDataTable().checkListIsSorted(SORT_ORDER.DESC, 'Task Name')).toBe(true);
+            expect(await taskList.getDataTable().checkListIsSorted(SORT_ORDER.DESC, 'Task Name')).toBe(true);
         });
 
         it('[C290156] Should display tasks ordered by id when Id is selected from sort dropdown', async () => {
@@ -153,20 +165,20 @@ describe('Edit task filters and task list properties', () => {
             await editTaskFilter.setSortFilterDropDown('id');
             await editTaskFilter.setOrderFilterDropDown(SORT_ORDER.ASC);
 
-            await expect(await taskList.getDataTable().checkListIsSorted(SORT_ORDER.ASC, 'Id')).toBe(true);
+            expect(await taskList.getDataTable().checkListIsSorted(SORT_ORDER.ASC, 'Id')).toBe(true);
 
             await editTaskFilter.setOrderFilterDropDown(SORT_ORDER.DESC);
-            await expect(await taskList.getDataTable().checkListIsSorted(SORT_ORDER.DESC, 'Id')).toBe(true);
+            expect(await taskList.getDataTable().checkListIsSorted(SORT_ORDER.DESC, 'Id')).toBe(true);
         });
 
         it('[C306903] Should display tasks sorted by processDefinitionId when processDefinitionId is selected from sort dropdown', async () => {
             await editTaskFilter.setStatusFilterDropDown('Assigned');
             await editTaskFilter.setSortFilterDropDown('processDefinitionId');
             await editTaskFilter.setOrderFilterDropDown(SORT_ORDER.ASC);
-            await expect(await taskList.getDataTable().checkListIsSorted(SORT_ORDER.ASC, 'ProcessDefinitionId')).toBe(true);
+            expect(await taskList.getDataTable().checkListIsSorted(SORT_ORDER.ASC, 'ProcessDefinitionId')).toBe(true);
 
             await editTaskFilter.setOrderFilterDropDown(SORT_ORDER.DESC);
-            await expect(await taskList.getDataTable().checkListIsSorted(SORT_ORDER.DESC, 'ProcessDefinitionId')).toBe(true);
+            expect(await taskList.getDataTable().checkListIsSorted(SORT_ORDER.DESC, 'ProcessDefinitionId')).toBe(true);
         });
 
         it('[C306905] Should display tasks sorted by processInstanceId when processInstanceId is selected from sort dropdown', async () => {
@@ -174,10 +186,10 @@ describe('Edit task filters and task list properties', () => {
             await editTaskFilter.setSortFilterDropDown('processInstanceId');
             await editTaskFilter.setOrderFilterDropDown(SORT_ORDER.ASC);
 
-            await expect(await taskList.getDataTable().checkListIsSorted(SORT_ORDER.ASC, 'ProcessInstanceId')).toBe(true);
+            expect(await taskList.getDataTable().checkListIsSorted(SORT_ORDER.ASC, 'ProcessInstanceId')).toBe(true);
 
             await editTaskFilter.setOrderFilterDropDown(SORT_ORDER.DESC);
-            await expect(await taskList.getDataTable().checkListIsSorted(SORT_ORDER.DESC, 'ProcessInstanceId')).toBe(true);
+            expect(await taskList.getDataTable().checkListIsSorted(SORT_ORDER.DESC, 'ProcessInstanceId')).toBe(true);
         });
 
         it('[C306907] Should display tasks sorted by assignee when assignee is selected from sort dropdown', async () => {
@@ -186,10 +198,10 @@ describe('Edit task filters and task list properties', () => {
             await editTaskFilter.setSortFilterDropDown('assignee');
             await editTaskFilter.setOrderFilterDropDown(SORT_ORDER.ASC);
 
-            await expect(await taskList.getDataTable().checkListIsSorted(SORT_ORDER.ASC, 'Assignee')).toBe(true);
+            expect(await taskList.getDataTable().checkListIsSorted(SORT_ORDER.ASC, 'Assignee')).toBe(true);
 
             await editTaskFilter.setOrderFilterDropDown(SORT_ORDER.DESC);
-            await expect(await taskList.getDataTable().checkListIsSorted(SORT_ORDER.DESC, 'Assignee')).toBe(true);
+            expect(await taskList.getDataTable().checkListIsSorted(SORT_ORDER.DESC, 'Assignee')).toBe(true);
         });
 
         it('[C306911] Should display tasks sorted by parentTaskId when parentTaskId is selected from sort dropdown', async () => {
@@ -198,10 +210,10 @@ describe('Edit task filters and task list properties', () => {
             await editTaskFilter.setSortFilterDropDown('parentTaskId');
             await editTaskFilter.setOrderFilterDropDown(SORT_ORDER.ASC);
 
-            await expect(await taskList.getDataTable().checkListIsSorted(SORT_ORDER.ASC, 'ParentTaskId')).toBe(true);
+            expect(await taskList.getDataTable().checkListIsSorted(SORT_ORDER.ASC, 'ParentTaskId')).toBe(true);
 
             await editTaskFilter.setOrderFilterDropDown(SORT_ORDER.DESC);
-            await expect(await taskList.getDataTable().checkListIsSorted(SORT_ORDER.DESC, 'ParentTaskId')).toBe(true);
+            expect(await taskList.getDataTable().checkListIsSorted(SORT_ORDER.DESC, 'ParentTaskId')).toBe(true);
         });
 
         it('[C290087] Should display tasks ordered by priority when Priority is selected from sort dropdown', async () => {
@@ -209,10 +221,10 @@ describe('Edit task filters and task list properties', () => {
             await editTaskFilter.setSortFilterDropDown('priority');
             await editTaskFilter.setOrderFilterDropDown(SORT_ORDER.ASC);
 
-            await expect(await taskList.getDataTable().checkListIsSorted(SORT_ORDER.ASC, 'Priority', 'PRIORITY')).toBe(true);
+            expect(await taskList.getDataTable().checkListIsSorted(SORT_ORDER.ASC, 'Priority', 'PRIORITY')).toBe(true);
 
             await editTaskFilter.setOrderFilterDropDown(SORT_ORDER.DESC);
-            await expect(await taskList.getDataTable().checkListIsSorted(SORT_ORDER.DESC, 'Priority', 'PRIORITY')).toBe(true);
+            expect(await taskList.getDataTable().checkListIsSorted(SORT_ORDER.DESC, 'Priority', 'PRIORITY')).toBe(true);
         });
 
         it('[C307115] Should display tasks sorted by owner when owner is selected from sort dropdown', async () => {
@@ -221,10 +233,10 @@ describe('Edit task filters and task list properties', () => {
             await editTaskFilter.setSortFilterDropDown('owner');
             await editTaskFilter.setOrderFilterDropDown(SORT_ORDER.ASC);
 
-            await expect(await taskList.getDataTable().checkListIsSorted(SORT_ORDER.ASC, 'Owner')).toBe(true);
+            expect(await taskList.getDataTable().checkListIsSorted(SORT_ORDER.ASC, 'Owner')).toBe(true);
 
             await editTaskFilter.setOrderFilterDropDown(SORT_ORDER.DESC);
-            await expect(await taskList.getDataTable().checkListIsSorted(SORT_ORDER.DESC, 'Owner')).toBe(true);
+            expect(await taskList.getDataTable().checkListIsSorted(SORT_ORDER.DESC, 'Owner')).toBe(true);
         });
     });
 });

--- a/e2e/process-services-cloud/task-list/task-list-properties.e2e.ts
+++ b/e2e/process-services-cloud/task-list/task-list-properties.e2e.ts
@@ -17,10 +17,16 @@
 
 import { browser } from 'protractor';
 import {
-    StringUtil, TasksService,
-    ProcessDefinitionsService, ProcessInstancesService,
-    LoginPage, createApiService,
-    AppListCloudPage, LocalStorageUtil, IdentityService, GroupIdentityService
+    StringUtil,
+    TasksService,
+    ProcessDefinitionsService,
+    ProcessInstancesService,
+    LoginPage,
+    createApiService,
+    AppListCloudPage,
+    LocalStorageUtil,
+    IdentityService,
+    GroupIdentityService
 } from '@alfresco/adf-testing';
 import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
 import { TasksCloudDemoPage } from './../pages/tasks-cloud-demo.page';
@@ -29,7 +35,6 @@ import { taskFilterConfiguration } from './../config/task-filter.config';
 import { addDays, format, subDays } from 'date-fns';
 
 describe('Edit task filters and task list properties', () => {
-
     const simpleApp = browser.params.resources.ACTIVITI_CLOUD_APPS.SIMPLE_APP.name;
     const candidateBaseApp = browser.params.resources.ACTIVITI_CLOUD_APPS.CANDIDATE_BASE_APP.name;
 
@@ -91,8 +96,10 @@ describe('Edit task filters and task list properties', () => {
         notDisplayedTask = await tasksService.createStandaloneTask(StringUtil.generateRandomString(), candidateBaseApp);
         await tasksService.claimTask(notDisplayedTask.entry.id, candidateBaseApp);
 
-        processDefinition = await processDefinitionService
-            .getProcessDefinitionByName(browser.params.resources.ACTIVITI_CLOUD_APPS.SIMPLE_APP.processes.candidateUsersGroup, simpleApp);
+        processDefinition = await processDefinitionService.getProcessDefinitionByName(
+            browser.params.resources.ACTIVITI_CLOUD_APPS.SIMPLE_APP.processes.candidateUsersGroup,
+            simpleApp
+        );
 
         processInstance = await processInstancesService.createProcessInstance(processDefinition.entry.key, simpleApp);
 
@@ -112,7 +119,6 @@ describe('Edit task filters and task list properties', () => {
     });
 
     describe('Edit task filters and task list properties - filter properties', () => {
-
         beforeEach(async () => {
             await navigationBarPage.navigateToProcessServicesCloudPage();
             await appListCloudComponent.checkApsContainer();
@@ -122,7 +128,7 @@ describe('Edit task filters and task list properties', () => {
         });
 
         it('[C292004] Filter by appName', async () => {
-            await expect(await editTaskFilter.getAppNameDropDownValue()).toEqual(simpleApp);
+            expect(await editTaskFilter.getAppNameDropDownValue()).toEqual(simpleApp);
             await editTaskFilter.closeFilter();
 
             await taskList.checkContentIsDisplayedByName(createdTask.entry.name);
@@ -130,7 +136,7 @@ describe('Edit task filters and task list properties', () => {
 
             await editTaskFilter.openFilter();
             await editTaskFilter.setAppNameDropDown(candidateBaseApp);
-            await expect(await editTaskFilter.getAppNameDropDownValue()).toEqual(candidateBaseApp);
+            expect(await editTaskFilter.getAppNameDropDownValue()).toEqual(candidateBaseApp);
 
             await editTaskFilter.closeFilter();
             await taskList.checkContentIsDisplayedByName(notDisplayedTask.entry.name);
@@ -139,36 +145,36 @@ describe('Edit task filters and task list properties', () => {
 
         it('[C291906] Should be able to see only the task with specific taskId when typing it in the task Id field', async () => {
             await editTaskFilter.setId(createdTask.entry.id);
-            await expect(await editTaskFilter.getId()).toEqual(createdTask.entry.id);
+            expect(await editTaskFilter.getId()).toEqual(createdTask.entry.id);
             await editTaskFilter.closeFilter();
             await taskList.checkContentIsDisplayedById(createdTask.entry.id);
             await taskList.getRowsWithSameId(createdTask.entry.id).then(async (list) => {
-                await expect(list.length).toEqual(1);
+                expect(list.length).toEqual(1);
             });
         });
 
         it('[C291907] Should be able to see No tasks found when typing an invalid task id', async () => {
             await editTaskFilter.setId('invalidId');
-            await expect(await editTaskFilter.getId()).toEqual('invalidId');
+            expect(await editTaskFilter.getId()).toEqual('invalidId');
 
             await editTaskFilter.closeFilter();
-            await expect(await taskList.getNoTasksFoundMessage()).toEqual(noTasksFoundMessage);
+            expect(await taskList.getNoTasksFoundMessage()).toEqual(noTasksFoundMessage);
         });
 
         it('[C297476] Filter by taskName', async () => {
             await editTaskFilter.setTaskName(createdTask.entry.name);
-            await expect(await editTaskFilter.getTaskName()).toEqual(createdTask.entry.name);
+            expect(await editTaskFilter.getTaskName()).toEqual(createdTask.entry.name);
             await editTaskFilter.closeFilter();
             await taskList.getRowsWithSameName(createdTask.entry.name).then(async (list) => {
-                await expect(list.length).toEqual(1);
+                expect(list.length).toEqual(1);
             });
         });
 
         it('[C297613] Should be able to see No tasks found when typing a task name that does not exist', async () => {
             await editTaskFilter.setTaskName('invalidName');
-            await expect(await editTaskFilter.getTaskName()).toEqual('invalidName');
+            expect(await editTaskFilter.getTaskName()).toEqual('invalidName');
             await editTaskFilter.closeFilter();
-            await expect(await taskList.getNoTasksFoundMessage()).toEqual(noTasksFoundMessage);
+            expect(await taskList.getNoTasksFoundMessage()).toEqual(noTasksFoundMessage);
         });
 
         it('[C297480] Should be able to see only tasks that are part of a specific process when processInstanceId is set', async () => {
@@ -177,7 +183,7 @@ describe('Edit task filters and task list properties', () => {
             await editTaskFilter.clearAssignee();
             await editTaskFilter.closeFilter();
 
-            await expect(await taskList.getDataTable().getNumberOfRows()).toBe(1);
+            expect(await taskList.getDataTable().getNumberOfRows()).toBe(1);
 
             await taskList.checkContentIsDisplayedByProcessInstanceId(processInstance.entry.id);
         });
@@ -185,7 +191,7 @@ describe('Edit task filters and task list properties', () => {
         it('[C297684] Should be able to see No tasks found when typing an invalid processInstanceId', async () => {
             await editTaskFilter.setProcessInstanceId('invalidTaskId');
             await editTaskFilter.closeFilter();
-            await expect(await taskList.getNoTasksFoundMessage()).toEqual(noTasksFoundMessage);
+            expect(await taskList.getNoTasksFoundMessage()).toEqual(noTasksFoundMessage);
         });
 
         it('[C297478] Should be able to see only tasks that are assigned to a specific user when assignee is set', async () => {
@@ -198,7 +204,7 @@ describe('Edit task filters and task list properties', () => {
         it('[C297686] Should be able to see No tasks found when typing an invalid user to assignee field', async () => {
             await editTaskFilter.setAssignee('invalid');
             await editTaskFilter.closeFilter();
-            await expect(await taskList.getNoTasksFoundMessage()).toEqual(noTasksFoundMessage);
+            expect(await taskList.getNoTasksFoundMessage()).toEqual(noTasksFoundMessage);
         });
 
         it('[C297482] Should be able to see only tasks with specific priority when priority is set', async () => {
@@ -211,7 +217,7 @@ describe('Edit task filters and task list properties', () => {
         it('[C297687] Should be able to see No tasks found when typing unused value for priority field', async () => {
             await editTaskFilter.setPriority('Normal');
             await editTaskFilter.closeFilter();
-            await expect(await taskList.getNoTasksFoundMessage()).toEqual(noTasksFoundMessage);
+            expect(await taskList.getNoTasksFoundMessage()).toEqual(noTasksFoundMessage);
         });
 
         it('[C297481] Should be able to see only tasks with specific parentTaskId when parentTaskId is set', async () => {
@@ -232,7 +238,7 @@ describe('Edit task filters and task list properties', () => {
             await editTaskFilter.setOwner('invalid');
             await editTaskFilter.closeFilter();
 
-            await expect(await taskList.getNoTasksFoundMessage()).toEqual(noTasksFoundMessage);
+            expect(await taskList.getNoTasksFoundMessage()).toEqual(noTasksFoundMessage);
         });
 
         it('[C297484] Task is displayed when typing into lastModifiedFrom field a date before the task CreatedDate', async () => {
@@ -271,30 +277,39 @@ describe('Edit task filters and task list properties', () => {
             await taskList.checkContentIsNotDisplayedByName(simpleTask.entry.name);
         });
 
-        it('[C297691] Task is not displayed when typing into lastModifiedFrom field a date before the task due date  ' +
-            'and into lastModifiedTo a date before task due date', async () => {
-            await editTaskFilter.setLastModifiedFrom(beforeDate);
-            await editTaskFilter.setLastModifiedTo(beforeDate);
-            await editTaskFilter.setTaskName(createdTask.entry.name);
-            await editTaskFilter.closeFilter();
-            await expect(await taskList.getNoTasksFoundMessage()).toEqual(noTasksFoundMessage);
-        });
+        it(
+            '[C297691] Task is not displayed when typing into lastModifiedFrom field a date before the task due date  ' +
+                'and into lastModifiedTo a date before task due date',
+            async () => {
+                await editTaskFilter.setLastModifiedFrom(beforeDate);
+                await editTaskFilter.setLastModifiedTo(beforeDate);
+                await editTaskFilter.setTaskName(createdTask.entry.name);
+                await editTaskFilter.closeFilter();
+                expect(await taskList.getNoTasksFoundMessage()).toEqual(noTasksFoundMessage);
+            }
+        );
 
-        it('[C297692] Task is displayed when typing into lastModifiedFrom field a date before the tasks due date ' +
-            'and into lastModifiedTo a date after', async () => {
-            await editTaskFilter.setLastModifiedFrom(beforeDate);
-            await editTaskFilter.setLastModifiedTo(afterDate);
-            await editTaskFilter.setTaskName(createdTask.entry.name);
-            await editTaskFilter.closeFilter();
-            await taskList.checkContentIsDisplayedByName(createdTask.entry.name);
-        });
+        it(
+            '[C297692] Task is displayed when typing into lastModifiedFrom field a date before the tasks due date ' +
+                'and into lastModifiedTo a date after',
+            async () => {
+                await editTaskFilter.setLastModifiedFrom(beforeDate);
+                await editTaskFilter.setLastModifiedTo(afterDate);
+                await editTaskFilter.setTaskName(createdTask.entry.name);
+                await editTaskFilter.closeFilter();
+                await taskList.checkContentIsDisplayedByName(createdTask.entry.name);
+            }
+        );
 
-        it('[C297693] Task is not displayed when typing into lastModifiedFrom field a date after the tasks due date ' +
-            'and into lastModifiedTo a date after', async () => {
-            await editTaskFilter.setLastModifiedFrom(afterDate);
-            await editTaskFilter.setLastModifiedTo(afterDate);
-            await editTaskFilter.closeFilter();
-            await expect(await taskList.getNoTasksFoundMessage()).toEqual(noTasksFoundMessage);
-        });
+        it(
+            '[C297693] Task is not displayed when typing into lastModifiedFrom field a date after the tasks due date ' +
+                'and into lastModifiedTo a date after',
+            async () => {
+                await editTaskFilter.setLastModifiedFrom(afterDate);
+                await editTaskFilter.setLastModifiedTo(afterDate);
+                await editTaskFilter.closeFilter();
+                expect(await taskList.getNoTasksFoundMessage()).toEqual(noTasksFoundMessage);
+            }
+        );
     });
 });

--- a/e2e/process-services-cloud/task-list/tasks-claim-release.e2e.ts
+++ b/e2e/process-services-cloud/task-list/tasks-claim-release.e2e.ts
@@ -16,7 +16,8 @@
  */
 
 import { browser } from 'protractor';
-import { createApiService,
+import {
+    createApiService,
     AppListCloudPage,
     GroupIdentityService,
     IdentityService,
@@ -34,7 +35,6 @@ import { ProcessInstanceCloud } from '@alfresco/adf-process-services-cloud';
 import { taskFilterConfiguration } from './../config/task-filter.config';
 
 describe('Task claim/release', () => {
-
     const candidateApp = browser.params.resources.ACTIVITI_CLOUD_APPS.CANDIDATE_BASE_APP;
 
     const loginSSOPage = new LoginPage();
@@ -59,7 +59,10 @@ describe('Task claim/release', () => {
     describe('candidate user', () => {
         beforeAll(async () => {
             await apiService.login(browser.params.testConfig.users.hrUser.username, browser.params.testConfig.users.hrUser.password);
-            const processDefinition = await processDefinitionService.getProcessDefinitionByName(candidateApp.processes.candidateUserProcess, candidateApp.name);
+            const processDefinition = await processDefinitionService.getProcessDefinitionByName(
+                candidateApp.processes.candidateUserProcess,
+                candidateApp.name
+            );
             processInstance = (await processInstancesService.createProcessInstance(processDefinition.entry.key, candidateApp.name)).entry;
         });
 
@@ -81,7 +84,7 @@ describe('Task claim/release', () => {
             await taskHeaderCloudPage.checkTaskPropertyListIsDisplayed();
 
             await taskFormCloudComponent.checkClaimButtonIsDisplayed();
-            await expect(await taskHeaderCloudPage.getAssignee()).toEqual('No assignee');
+            expect(await taskHeaderCloudPage.getAssignee()).toEqual('No assignee');
 
             await taskFormCloudComponent.clickClaimButton();
             await browser.refresh();
@@ -89,18 +92,17 @@ describe('Task claim/release', () => {
 
             await taskFormCloudComponent.checkReleaseButtonIsDisplayed();
 
-            await expect(await taskHeaderCloudPage.getStatus()).toEqual('ASSIGNED');
-            await expect(await taskHeaderCloudPage.getAssignee()).toEqual(browser.params.testConfig.users.hrUser.username);
+            expect(await taskHeaderCloudPage.getStatus()).toEqual('ASSIGNED');
+            expect(await taskHeaderCloudPage.getAssignee()).toEqual(browser.params.testConfig.users.hrUser.username);
 
             await taskFormCloudComponent.clickReleaseButton();
             await browser.refresh();
             await taskHeaderCloudPage.checkTaskPropertyListIsDisplayed();
 
             await taskFormCloudComponent.checkClaimButtonIsDisplayed();
-            await expect(await taskHeaderCloudPage.getStatus()).toEqual('CREATED');
-            await expect(await taskHeaderCloudPage.getAssignee()).toEqual('No assignee');
+            expect(await taskHeaderCloudPage.getStatus()).toEqual('CREATED');
+            expect(await taskHeaderCloudPage.getAssignee()).toEqual('No assignee');
         });
-
     });
 
     describe('candidate group', () => {
@@ -113,7 +115,10 @@ describe('Task claim/release', () => {
             await identityService.addUserToGroup(candidate.idIdentityService, groupInfo.id);
 
             await apiService.login(browser.params.testConfig.users.hrUser.username, browser.params.testConfig.users.hrUser.password);
-            const processDefinition = await processDefinitionService.getProcessDefinitionByName(candidateApp.processes.uploadFileProcess, candidateApp.name);
+            const processDefinition = await processDefinitionService.getProcessDefinitionByName(
+                candidateApp.processes.uploadFileProcess,
+                candidateApp.name
+            );
             processInstance = (await processInstancesService.createProcessInstance(processDefinition.entry.key, candidateApp.name)).entry;
         });
 
@@ -135,24 +140,24 @@ describe('Task claim/release', () => {
             await taskHeaderCloudPage.checkTaskPropertyListIsDisplayed();
 
             await taskFormCloudComponent.checkClaimButtonIsDisplayed();
-            await expect(await taskHeaderCloudPage.getStatus()).toEqual('CREATED');
-            await expect(await taskHeaderCloudPage.getAssignee()).toEqual('No assignee');
+            expect(await taskHeaderCloudPage.getStatus()).toEqual('CREATED');
+            expect(await taskHeaderCloudPage.getAssignee()).toEqual('No assignee');
 
             await taskFormCloudComponent.clickClaimButton();
             await browser.refresh();
             await taskHeaderCloudPage.checkTaskPropertyListIsDisplayed();
 
             await taskFormCloudComponent.checkReleaseButtonIsDisplayed();
-            await expect(await taskHeaderCloudPage.getStatus()).toEqual('ASSIGNED');
-            await expect(await taskHeaderCloudPage.getAssignee()).toEqual(browser.params.testConfig.users.hrUser.username);
+            expect(await taskHeaderCloudPage.getStatus()).toEqual('ASSIGNED');
+            expect(await taskHeaderCloudPage.getAssignee()).toEqual(browser.params.testConfig.users.hrUser.username);
 
             await taskFormCloudComponent.clickReleaseButton();
             await browser.refresh();
             await taskHeaderCloudPage.checkTaskPropertyListIsDisplayed();
 
             await taskFormCloudComponent.checkClaimButtonIsDisplayed();
-            await expect(await taskHeaderCloudPage.getStatus()).toEqual('CREATED');
-            await expect(await taskHeaderCloudPage.getAssignee()).toEqual('No assignee');
+            expect(await taskHeaderCloudPage.getStatus()).toEqual('CREATED');
+            expect(await taskHeaderCloudPage.getAssignee()).toEqual('No assignee');
 
             await navigationBarPage.clickLogoutButton();
             await navigateToApp(candidate);
@@ -163,29 +168,38 @@ describe('Task claim/release', () => {
             await taskHeaderCloudPage.checkTaskPropertyListIsDisplayed();
 
             await taskFormCloudComponent.checkClaimButtonIsDisplayed();
-            await expect(await taskHeaderCloudPage.getStatus()).toEqual('CREATED');
-            await expect(await taskHeaderCloudPage.getAssignee()).toEqual('No assignee');
+            expect(await taskHeaderCloudPage.getStatus()).toEqual('CREATED');
+            expect(await taskHeaderCloudPage.getAssignee()).toEqual('No assignee');
 
             await taskFormCloudComponent.clickClaimButton();
             await browser.refresh();
             await taskHeaderCloudPage.checkTaskPropertyListIsDisplayed();
 
             await taskFormCloudComponent.checkReleaseButtonIsDisplayed();
-            await expect(await taskHeaderCloudPage.getStatus()).toEqual('ASSIGNED');
-            await expect(await taskHeaderCloudPage.getAssignee()).toEqual(candidate.username);
+            expect(await taskHeaderCloudPage.getStatus()).toEqual('ASSIGNED');
+            expect(await taskHeaderCloudPage.getAssignee()).toEqual(candidate.username);
 
             await taskFormCloudComponent.clickReleaseButton();
             await browser.refresh();
             await taskHeaderCloudPage.checkTaskPropertyListIsDisplayed();
 
             await taskFormCloudComponent.checkClaimButtonIsDisplayed();
-            await expect(await taskHeaderCloudPage.getStatus()).toEqual('CREATED');
-            await expect(await taskHeaderCloudPage.getAssignee()).toEqual('No assignee');
+            expect(await taskHeaderCloudPage.getStatus()).toEqual('CREATED');
+            expect(await taskHeaderCloudPage.getAssignee()).toEqual('No assignee');
         });
-
     });
 
-    async function navigateToApp(user: { username: string; password: string }) {
+    interface UserType {
+        username: string;
+        password: string;
+    }
+
+    /**
+     * Navigate to the app
+     *
+     * @param user user
+     */
+    async function navigateToApp(user: UserType) {
         await loginSSOPage.login(user.username, user.password);
         await LocalStorageUtil.setConfigField('adf-edit-task-filter', JSON.stringify(taskFilterConfiguration));
         await navigationBarPage.navigateToProcessServicesCloudPage();
@@ -196,6 +210,12 @@ describe('Task claim/release', () => {
         await taskList.getDataTable().waitForTableBody();
     }
 
+    /**
+     * Set status task filter
+     *
+     * @param status status type
+     * @param processInstanceId process instance id
+     */
     async function setStatusTaskFilter(status: StatusType, processInstanceId: string) {
         await editTaskFilter.openFilter();
         await editTaskFilter.clearAssignee();

--- a/e2e/process-services/form/apps-section.e2e.ts
+++ b/e2e/process-services/form/apps-section.e2e.ts
@@ -23,7 +23,6 @@ import CONSTANTS = require('../../util/constants');
 import { AppDefinitionRepresentation, AppDefinitionsApi } from '@alfresco/js-api';
 
 describe('Modify applications', () => {
-
     const app = browser.params.resources.Files.APP_WITH_PROCESSES;
     const appToBeDeleted = browser.params.resources.Files.SIMPLE_APP_WITH_USER_FORM;
     const replacingApp = browser.params.resources.Files.WIDGETS_SMOKE_TEST;
@@ -61,15 +60,15 @@ describe('Modify applications', () => {
     });
 
     it('[C260198] Should the app be displayed on dashboard when is deployed on APS', async () => {
-        await expect(await processServicesPage.getAppIconType(app.title)).toEqual(CONSTANTS.APP_ICON.UNIT);
-        await expect(await processServicesPage.getBackgroundColor(app.title)).toEqual(CONSTANTS.APP_COLOR.BLUE);
-        await expect(await processServicesPage.getDescription(app.title)).toEqual(app.description);
+        expect(await processServicesPage.getAppIconType(app.title)).toEqual(CONSTANTS.APP_ICON.UNIT);
+        expect(await processServicesPage.getBackgroundColor(app.title)).toEqual(CONSTANTS.APP_COLOR.BLUE);
+        expect(await processServicesPage.getDescription(app.title)).toEqual(app.description);
     });
 
     it('[C260213] Should a new version of the app be displayed on dashboard when is replaced by importing another app in APS', async () => {
-        await expect(await processServicesPage.getAppIconType(app.title)).toEqual(CONSTANTS.APP_ICON.UNIT);
-        await expect(await processServicesPage.getBackgroundColor(app.title)).toEqual(CONSTANTS.APP_COLOR.BLUE);
-        await expect(await processServicesPage.getDescription(app.title)).toEqual(app.description);
+        expect(await processServicesPage.getAppIconType(app.title)).toEqual(CONSTANTS.APP_ICON.UNIT);
+        expect(await processServicesPage.getBackgroundColor(app.title)).toEqual(CONSTANTS.APP_COLOR.BLUE);
+        expect(await processServicesPage.getDescription(app.title)).toEqual(app.description);
 
         await apps.importNewVersionAppDefinitionPublishDeployApp(replacingApp.file_location, firstApp.id);
 
@@ -78,9 +77,9 @@ describe('Modify applications', () => {
 
         await processServicesPage.checkApsContainer();
 
-        await expect(await processServicesPage.getAppIconType(app.title)).toEqual(CONSTANTS.APP_ICON.FAVORITE);
-        await expect(await processServicesPage.getBackgroundColor(app.title)).toEqual(CONSTANTS.APP_COLOR.GREY);
-        await expect(await processServicesPage.getDescription(app.title)).toEqual(app.description);
+        expect(await processServicesPage.getAppIconType(app.title)).toEqual(CONSTANTS.APP_ICON.FAVORITE);
+        expect(await processServicesPage.getBackgroundColor(app.title)).toEqual(CONSTANTS.APP_COLOR.GREY);
+        expect(await processServicesPage.getDescription(app.title)).toEqual(app.description);
     });
 
     it('[C260220] Should the app not be displayed on dashboard after it was deleted in APS', async () => {
@@ -96,7 +95,7 @@ describe('Modify applications', () => {
 
     it('[C260215] Should the penultimate version of an app be displayed on dashboard when the last version is deleted in APS', async () => {
         await processServicesPage.checkAppIsDisplayed(appToBeDeleted.title);
-        await expect(await processServicesPage.getBackgroundColor(appToBeDeleted.title)).toEqual(CONSTANTS.APP_COLOR.ORANGE);
+        expect(await processServicesPage.getBackgroundColor(appToBeDeleted.title)).toEqual(CONSTANTS.APP_COLOR.ORANGE);
 
         await apps.importNewVersionAppDefinitionPublishDeployApp(replacingApp.file_location, appVersionToBeDeleted.id);
 
@@ -105,7 +104,7 @@ describe('Modify applications', () => {
 
         await processServicesPage.getBackgroundColor(appToBeDeleted.title);
 
-        await expect(await processServicesPage.getBackgroundColor(appToBeDeleted.title)).toEqual(CONSTANTS.APP_COLOR.GREY);
+        expect(await processServicesPage.getBackgroundColor(appToBeDeleted.title)).toEqual(CONSTANTS.APP_COLOR.GREY);
 
         await modelActions.deleteModel(appVersionToBeDeleted.id);
         await modelActions.deleteModel(appVersionToBeDeleted.id);
@@ -116,15 +115,15 @@ describe('Modify applications', () => {
 
         await processServicesPage.checkApsContainer();
         await processServicesPage.checkAppIsDisplayed(appToBeDeleted.title);
-        await expect(await processServicesPage.getBackgroundColor(appToBeDeleted.title)).toEqual(CONSTANTS.APP_COLOR.ORANGE);
+        expect(await processServicesPage.getBackgroundColor(appToBeDeleted.title)).toEqual(CONSTANTS.APP_COLOR.ORANGE);
     });
 
     it('[C260207] Should the app be updated when is edited in APS', async () => {
         const newDescription = 'new description';
 
-        await expect(await processServicesPage.getAppIconType(appToBeDeleted.title)).toEqual(CONSTANTS.APP_ICON.USER);
-        await expect(await processServicesPage.getBackgroundColor(appToBeDeleted.title)).toEqual(CONSTANTS.APP_COLOR.ORANGE);
-        await expect(await processServicesPage.getDescription(appToBeDeleted.title)).toEqual(appToBeDeleted.description);
+        expect(await processServicesPage.getAppIconType(appToBeDeleted.title)).toEqual(CONSTANTS.APP_ICON.USER);
+        expect(await processServicesPage.getBackgroundColor(appToBeDeleted.title)).toEqual(CONSTANTS.APP_COLOR.ORANGE);
+        expect(await processServicesPage.getDescription(appToBeDeleted.title)).toEqual(appToBeDeleted.description);
 
         const appDefinition = {
             appDefinition: {
@@ -146,8 +145,8 @@ describe('Modify applications', () => {
         await navigationBarPage.clickHomeButton();
         await navigationBarPage.navigateToProcessServicesPage();
 
-        await expect(await processServicesPage.getDescription(appToBeDeleted.title)).toEqual(newDescription);
-        await expect(await processServicesPage.getBackgroundColor(appToBeDeleted.title)).toEqual(CONSTANTS.APP_COLOR.RED);
-        await expect(await processServicesPage.getAppIconType(appToBeDeleted.title)).toEqual(CONSTANTS.APP_ICON.USER);
+        expect(await processServicesPage.getDescription(appToBeDeleted.title)).toEqual(newDescription);
+        expect(await processServicesPage.getBackgroundColor(appToBeDeleted.title)).toEqual(CONSTANTS.APP_COLOR.RED);
+        expect(await processServicesPage.getAppIconType(appToBeDeleted.title)).toEqual(CONSTANTS.APP_ICON.USER);
     });
 });

--- a/e2e/process-services/form/attach-folder.e2e.ts
+++ b/e2e/process-services/form/attach-folder.e2e.ts
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 
-import { createApiService,
+import {
+    createApiService,
     ApplicationsUtil,
     ContentNodeSelectorDialogPage,
     IntegrationService,
@@ -84,13 +85,13 @@ describe('Attach Folder', () => {
 
         await searchService.isSearchable(folderName);
         await contentNodeSelector.searchAndSelectResult(folderName, folderName);
-        await expect(await contentNodeSelector.checkCancelButtonIsEnabled()).toBe(true);
-        await expect(await contentNodeSelector.checkCopyMoveButtonIsEnabled()).toBe(true);
+        expect(await contentNodeSelector.checkCancelButtonIsEnabled()).toBe(true);
+        expect(await contentNodeSelector.checkCopyMoveButtonIsEnabled()).toBe(true);
 
         await searchService.isSearchable('Meeting Notes');
         await contentNodeSelector.searchAndSelectResult('Meeting Notes', 'Meeting Notes');
-        await expect(await contentNodeSelector.checkCancelButtonIsEnabled()).toBe(true);
-        await expect(await contentNodeSelector.checkCopyMoveButtonIsEnabled()).toBe(false);
+        expect(await contentNodeSelector.checkCancelButtonIsEnabled()).toBe(true);
+        expect(await contentNodeSelector.checkCopyMoveButtonIsEnabled()).toBe(false);
 
         await contentNodeSelector.clickCancelButton();
         await widget.attachFolderWidget().checkFolderIsNotAttached(app.UPLOAD_FOLDER_FORM_CS.FIELD.widget_id, folderName);
@@ -99,8 +100,8 @@ describe('Attach Folder', () => {
         await contentNodeSelector.checkDialogIsDisplayed();
 
         await contentNodeSelector.searchAndSelectResult(folderName, folderName);
-        await expect(await contentNodeSelector.checkCancelButtonIsEnabled()).toBe(true);
-        await expect(await contentNodeSelector.checkCopyMoveButtonIsEnabled()).toBe(true);
+        expect(await contentNodeSelector.checkCancelButtonIsEnabled()).toBe(true);
+        expect(await contentNodeSelector.checkCopyMoveButtonIsEnabled()).toBe(true);
 
         await contentNodeSelector.clickMoveCopyButton();
         await widget.attachFolderWidget().checkFolderIsAttached(app.UPLOAD_FOLDER_FORM_CS.FIELD.widget_id, folderName);

--- a/e2e/process-services/form/attach-form-component.e2e.ts
+++ b/e2e/process-services/form/attach-form-component.e2e.ts
@@ -15,14 +15,7 @@
  * limitations under the License.
  */
 
-import { createApiService,
-    ApplicationsUtil,
-    FormFields,
-    LoginPage,
-    ModelsActions,
-    TaskUtil,
-    UsersActions
-} from '@alfresco/adf-testing';
+import { createApiService, ApplicationsUtil, FormFields, LoginPage, ModelsActions, TaskUtil, UsersActions } from '@alfresco/adf-testing';
 import { browser } from 'protractor';
 import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
 import { AttachFormPage } from './../pages/attach-form.page';
@@ -47,7 +40,9 @@ describe('Attach Form Component', () => {
     const modelsActions = new ModelsActions(apiService);
 
     const formTextField = app.form_fields.form_fieldId;
-    let user; let tenantId; let appModel;
+    let user;
+    let tenantId;
+    let appModel;
 
     const testNames = {
         taskName: 'Test Task',
@@ -78,13 +73,13 @@ describe('Attach Form Component', () => {
         await taskUtil.createStandaloneTask(testNames.taskName);
         await taskUtil.createStandaloneTask(standaloneTask.taskName);
         await loginPage.login(user.username, user.password);
-   });
+    });
 
     afterAll(async () => {
         await modelsActions.deleteModel(appModel.id);
         await apiService.loginWithProfile('admin');
         await usersActions.deleteTenant(tenantId);
-   });
+    });
 
     it('[C280047] Should be able to view the attach-form component after creating a standalone task', async () => {
         await (await (await navigationBarPage.navigateToProcessServicesPage()).goToTaskApp()).clickTasksButton();
@@ -132,7 +127,7 @@ describe('Attach Form Component', () => {
         await taskPage.filtersPage().goToFilter(CONSTANTS.TASK_FILTERS.COMPLETED_TASKS);
         await taskPage.tasksListPage().selectRow(testNames.taskName);
 
-        await expect(await formFields.getFieldValue(formTextField)).toEqual(testNames.formFieldValue);
+        expect(await formFields.getFieldValue(formTextField)).toEqual(testNames.formFieldValue);
     });
 
     it('[C329804] Attach form from standalone task with no form template', async () => {

--- a/e2e/process-services/form/checklist-component.e2e.ts
+++ b/e2e/process-services/form/checklist-component.e2e.ts
@@ -78,7 +78,7 @@ describe('Checklist component', () => {
         await (await taskPage.clickOnAddChecklistButton()).clickCreateChecklistButton();
         await taskPage.checkChecklistDialogIsNotDisplayed();
         await taskPage.checkNoChecklistIsDisplayed();
-        await expect(await taskPage.getNumberOfChecklists()).toEqual('0');
+        expect(await taskPage.getNumberOfChecklists()).toEqual('0');
     });
 
     it('[C279975] Should no checklist be created when clicking on Cancel button on checklist dialog', async () => {
@@ -89,7 +89,7 @@ describe('Checklist component', () => {
         await checklistDialog.clickCancelButton();
         await taskPage.checkChecklistDialogIsNotDisplayed();
         await taskPage.checkNoChecklistIsDisplayed();
-        await expect(await taskPage.getNumberOfChecklists()).toEqual('0');
+        expect(await taskPage.getNumberOfChecklists()).toEqual('0');
     });
 
     it('[C261025] Should Checklist dialog be displayed when clicking on add checklist button', async () => {
@@ -98,8 +98,8 @@ describe('Checklist component', () => {
 
         await taskPage.clickOnAddChecklistButton();
         await taskPage.checkChecklistDialogIsDisplayed();
-        await expect(await taskPage.usingCheckListDialog().getDialogTitle()).toEqual('New Check');
-        await expect(await taskPage.usingCheckListDialog().getNameFieldPlaceholder()).toEqual('Name');
+        expect(await taskPage.usingCheckListDialog().getDialogTitle()).toEqual('New Check');
+        expect(await taskPage.usingCheckListDialog().getNameFieldPlaceholder()).toEqual('Name');
         await taskPage.usingCheckListDialog().checkAddChecklistButtonIsEnabled();
         await checklistDialog.checkCancelButtonIsEnabled();
         await taskPage.usingCheckListDialog().clickCancelButton();
@@ -112,13 +112,13 @@ describe('Checklist component', () => {
         await (await taskPage.clickOnAddChecklistButton()).addName(checklists[2]);
         await checklistDialog.clickCreateChecklistButton();
         await taskPage.checkChecklistIsDisplayed(checklists[2]);
-        await expect(await taskPage.getNumberOfChecklists()).toEqual('1');
+        expect(await taskPage.getNumberOfChecklists()).toEqual('1');
 
         await (await taskPage.clickOnAddChecklistButton()).addName(checklists[3]);
         await checklistDialog.clickCreateChecklistButton();
         await taskPage.checkChecklistIsDisplayed(checklists[3]);
         await taskPage.checkChecklistIsDisplayed(checklists[2]);
-        await expect(await taskPage.getNumberOfChecklists()).toEqual('2');
+        expect(await taskPage.getNumberOfChecklists()).toEqual('2');
     });
 
     it('[C279980] Should checklist be removed when clicking on remove button', async () => {
@@ -159,7 +159,7 @@ describe('Checklist component', () => {
         await taskPage.tasksListPage().selectRow(tasks[3]);
         await taskPage.checkChecklistIsDisplayed(removeChecklist[2]);
         await taskPage.checkChecklistIsDisplayed(removeChecklist[3]);
-        await expect(await taskPage.getNumberOfChecklists()).toEqual('2');
+        expect(await taskPage.getNumberOfChecklists()).toEqual('2');
 
         await taskPage.checkChecklistsRemoveButtonIsNotDisplayed(removeChecklist[3]);
     });

--- a/e2e/process-services/form/form-people-widget.e2e.ts
+++ b/e2e/process-services/form/form-people-widget.e2e.ts
@@ -15,13 +15,7 @@
  * limitations under the License.
  */
 
-import { createApiService,
-    ApplicationsUtil,
-    LoginPage,
-    StartProcessPage,
-    UsersActions,
-    Widget
-} from '@alfresco/adf-testing';
+import { createApiService, ApplicationsUtil, LoginPage, StartProcessPage, UsersActions, Widget } from '@alfresco/adf-testing';
 import { ProcessFiltersPage } from './../pages/process-filters.page';
 import { ProcessDetailsPage } from './../pages/process-details.page';
 import { TaskDetailsPage } from './../pages/task-details.page';
@@ -31,7 +25,6 @@ import { ProcessServiceTabBarPage } from './../pages/process-service-tab-bar.pag
 import { TaskFormsApi } from '@alfresco/js-api';
 
 describe('Form widgets - People ', () => {
-
     const app = browser.params.resources.Files.APP_WITH_USER_WIDGET;
 
     const loginPage = new LoginPage();
@@ -86,7 +79,7 @@ describe('Form widgets - People ', () => {
         const taskId = await taskDetails.getId();
         const taskForm: any = await taskFormsApi.getTaskForm(taskId);
         const userEmail = taskForm['fields'][0].fields['1'][0].value.email;
-        await expect(userEmail).toEqual(processUserModel.email);
+        expect(userEmail).toEqual(processUserModel.email);
     });
 
     it('[C286576] Should be able to see user in completed task', async () => {
@@ -106,6 +99,6 @@ describe('Form widgets - People ', () => {
         const taskId = await taskDetails.getId();
         const taskForm: any = await taskFormsApi.getTaskForm(taskId);
         const userEmail = taskForm['fields'][0].fields['1'][0].value.email;
-        await expect(userEmail).toEqual(processUserModel.email);
+        expect(userEmail).toEqual(processUserModel.email);
     });
 });

--- a/e2e/process-services/form/form-widgets-component.e2e.ts
+++ b/e2e/process-services/form/form-widgets-component.e2e.ts
@@ -145,15 +145,13 @@ describe('Form widgets', () => {
         });
 
         it('[C272783] Should display displayText and displayValue in form', async () => {
-            expect(await widget.displayTextWidget().getFieldLabel(appFields.displayText_id)).toEqual(
-                formInstance.getWidgetBy('id', appFields.displayText_id).value
-            );
-            expect(await widget.displayValueWidget().getFieldLabel(appFields.displayValue_id)).toEqual(
-                formInstance.getWidgetBy('id', appFields.displayValue_id).value || 'Display value' || ''
-            );
-            expect(await widget.displayValueWidget().getFieldValue(appFields.displayValue_id)).toEqual(
-                formInstance.getWidgetBy('id', appFields.displayValue_id).value || ''
-            );
+            const expected0 = formInstance.getWidgetBy('id', appFields.displayText_id).value;
+            const expected1 = (formInstance.getWidgetBy('id', appFields.displayValue_id).value as string) || 'Display value' || '';
+            const expected2 = (formInstance.getWidgetBy('id', appFields.displayValue_id).value as string) || '';
+
+            expect(await widget.displayTextWidget().getFieldLabel(appFields.displayText_id)).toEqual(expected0);
+            expect(await widget.displayValueWidget().getFieldLabel(appFields.displayValue_id)).toEqual(expected1);
+            expect(await widget.displayValueWidget().getFieldValue(appFields.displayValue_id)).toEqual(expected2);
         });
 
         it('[C272784] Should display typeahead and header in form', async () => {

--- a/e2e/process-services/form/form-widgets-component.e2e.ts
+++ b/e2e/process-services/form/form-widgets-component.e2e.ts
@@ -146,7 +146,7 @@ describe('Form widgets', () => {
 
         it('[C272783] Should display displayText and displayValue in form', async () => {
             const expected0 = formInstance.getWidgetBy('id', appFields.displayText_id).value;
-            const expected1 = (formInstance.getWidgetBy('id', appFields.displayValue_id).value as string) || 'Display value' || '';
+            const expected1 = (formInstance.getWidgetBy('id', appFields.displayValue_id).value as string) || 'Display value';
             const expected2 = (formInstance.getWidgetBy('id', appFields.displayValue_id).value as string) || '';
 
             expect(await widget.displayTextWidget().getFieldLabel(appFields.displayText_id)).toEqual(expected0);

--- a/e2e/process-services/form/form-widgets-component.e2e.ts
+++ b/e2e/process-services/form/form-widgets-component.e2e.ts
@@ -15,13 +15,7 @@
  * limitations under the License.
  */
 
-import { createApiService,
-    ApplicationsUtil,
-    LoginPage,
-    ProcessUtil,
-    UsersActions,
-    Widget
-} from '@alfresco/adf-testing';
+import { createApiService, ApplicationsUtil, LoginPage, ProcessUtil, UsersActions, Widget } from '@alfresco/adf-testing';
 import { TasksPage } from './../pages/tasks.page';
 import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
 import { browser } from 'protractor';
@@ -32,7 +26,6 @@ import { TaskFormsApi } from '@alfresco/js-api';
 const formInstance = new FormDefinitionModel();
 
 describe('Form widgets', () => {
-
     const taskPage = new TasksPage();
     const loginPage = new LoginPage();
     const widget = new Widget();
@@ -48,7 +41,6 @@ describe('Form widgets', () => {
     let appModelWidget;
 
     describe('Form widgets', () => {
-
         const appWidget = browser.params.resources.Files.WIDGETS_SMOKE_TEST;
         const appFields = appWidget.form_fields;
 
@@ -74,7 +66,7 @@ describe('Form widgets', () => {
 
             await taskPage.tasksListPage().checkContentIsDisplayed(newTask);
             await taskPage.formFields().checkFormIsDisplayed();
-            await expect(await taskPage.taskDetails().getTitle()).toEqual('Activities');
+            expect(await taskPage.taskDetails().getTitle()).toEqual('Activities');
 
             const response = await taskPage.taskDetails().getId();
 
@@ -92,107 +84,126 @@ describe('Form widgets', () => {
         });
 
         it('[C272778] Should display text and multi-line in form', async () => {
-            await expect(await taskPage.formFields().getFieldLabel(appFields.text_id))
-                .toEqual(formInstance.getWidgetBy('id', appFields.text_id).name);
-            await expect(await taskPage.formFields().getFieldValue(appFields.text_id))
-                .toEqual(formInstance.getWidgetBy('id', appFields.text_id).value || '');
+            expect(await taskPage.formFields().getFieldLabel(appFields.text_id)).toEqual(formInstance.getWidgetBy('id', appFields.text_id).name);
+            expect(await taskPage.formFields().getFieldValue(appFields.text_id)).toEqual(
+                formInstance.getWidgetBy('id', appFields.text_id).value || ''
+            );
 
-            await expect(await widget.multilineTextWidget().getFieldValue(appFields.multiline_id))
-                .toEqual(formInstance.getWidgetBy('id', appFields.multiline_id).value || '');
-            await expect(await taskPage.formFields().getFieldLabel(appFields.multiline_id))
-                .toEqual(formInstance.getWidgetBy('id', appFields.multiline_id).name);
+            expect(await widget.multilineTextWidget().getFieldValue(appFields.multiline_id)).toEqual(
+                formInstance.getWidgetBy('id', appFields.multiline_id).value || ''
+            );
+            expect(await taskPage.formFields().getFieldLabel(appFields.multiline_id)).toEqual(
+                formInstance.getWidgetBy('id', appFields.multiline_id).name
+            );
         });
 
         it('[C272779] Should display number and amount in form', async () => {
-            await expect(await taskPage.formFields().getFieldValue(appFields.number_id))
-                .toEqual(formInstance.getWidgetBy('id', appFields.number_id).value || '');
-            await expect(await taskPage.formFields().getFieldLabel(appFields.number_id))
-                .toEqual(formInstance.getWidgetBy('id', appFields.number_id).name);
+            expect(await taskPage.formFields().getFieldValue(appFields.number_id)).toEqual(
+                formInstance.getWidgetBy('id', appFields.number_id).value || ''
+            );
+            expect(await taskPage.formFields().getFieldLabel(appFields.number_id)).toEqual(formInstance.getWidgetBy('id', appFields.number_id).name);
 
-            await expect(await taskPage.formFields().getFieldValue(appFields.amount_id))
-                .toEqual(formInstance.getWidgetBy('id', appFields.amount_id).value || '');
-            await expect(await taskPage.formFields().getFieldLabel(appFields.amount_id))
-                .toEqual(formInstance.getWidgetBy('id', appFields.amount_id).name);
+            expect(await taskPage.formFields().getFieldValue(appFields.amount_id)).toEqual(
+                formInstance.getWidgetBy('id', appFields.amount_id).value || ''
+            );
+            expect(await taskPage.formFields().getFieldLabel(appFields.amount_id)).toEqual(formInstance.getWidgetBy('id', appFields.amount_id).name);
         });
 
         it('[C272780] Should display attach file and attach folder in form', async () => {
-            await expect(await taskPage.formFields().getFieldLabel(appFields.attachFolder_id))
-                .toEqual(formInstance.getWidgetBy('id', appFields.attachFolder_id).name);
-            await expect(await taskPage.formFields().getFieldLabel(appFields.attachFile_id))
-                .toEqual(formInstance.getWidgetBy('id', appFields.attachFile_id).name);
+            expect(await taskPage.formFields().getFieldLabel(appFields.attachFolder_id)).toEqual(
+                formInstance.getWidgetBy('id', appFields.attachFolder_id).name
+            );
+            expect(await taskPage.formFields().getFieldLabel(appFields.attachFile_id)).toEqual(
+                formInstance.getWidgetBy('id', appFields.attachFile_id).name
+            );
         });
 
         it('[C272781] Should display date and date & time in form', async () => {
-            await expect(await taskPage.formFields().getFieldLabel(appFields.date_id))
-                .toContain(formInstance.getWidgetBy('id', appFields.date_id).name);
-            await expect(await taskPage.formFields().getFieldValue(appFields.date_id))
-                .toEqual(formInstance.getWidgetBy('id', appFields.date_id).value || '');
+            expect(await taskPage.formFields().getFieldLabel(appFields.date_id)).toContain(formInstance.getWidgetBy('id', appFields.date_id).name);
+            expect(await taskPage.formFields().getFieldValue(appFields.date_id)).toEqual(
+                formInstance.getWidgetBy('id', appFields.date_id).value || ''
+            );
 
-            await expect(await taskPage.formFields().getFieldLabel(appFields.dateTime_id))
-                .toContain(formInstance.getWidgetBy('id', appFields.dateTime_id).name);
-            await expect(await taskPage.formFields().getFieldValue(appFields.dateTime_id))
-                .toEqual(formInstance.getWidgetBy('id', appFields.dateTime_id).value || '');
+            expect(await taskPage.formFields().getFieldLabel(appFields.dateTime_id)).toContain(
+                formInstance.getWidgetBy('id', appFields.dateTime_id).name
+            );
+            expect(await taskPage.formFields().getFieldValue(appFields.dateTime_id)).toEqual(
+                formInstance.getWidgetBy('id', appFields.dateTime_id).value || ''
+            );
         });
 
         it('[C272782] Should display people and group in form', async () => {
-            await expect(await taskPage.formFields().getFieldValue(appFields.people_id))
-                .toEqual(formInstance.getWidgetBy('id', appFields.people_id).value || '');
-            await expect(await taskPage.formFields().getFieldLabel(appFields.people_id))
-                .toEqual(formInstance.getWidgetBy('id', appFields.people_id).name);
+            expect(await taskPage.formFields().getFieldValue(appFields.people_id)).toEqual(
+                formInstance.getWidgetBy('id', appFields.people_id).value || ''
+            );
+            expect(await taskPage.formFields().getFieldLabel(appFields.people_id)).toEqual(formInstance.getWidgetBy('id', appFields.people_id).name);
 
-            await expect(await taskPage.formFields().getFieldValue(appFields.group_id))
-                .toEqual(formInstance.getWidgetBy('id', appFields.group_id).value || '');
-            await expect(await taskPage.formFields().getFieldLabel(appFields.group_id))
-                .toEqual(formInstance.getWidgetBy('id', appFields.group_id).name);
+            expect(await taskPage.formFields().getFieldValue(appFields.group_id)).toEqual(
+                formInstance.getWidgetBy('id', appFields.group_id).value || ''
+            );
+            expect(await taskPage.formFields().getFieldLabel(appFields.group_id)).toEqual(formInstance.getWidgetBy('id', appFields.group_id).name);
         });
 
         it('[C272783] Should display displayText and displayValue in form', async () => {
-        await expect(await widget.displayTextWidget().getFieldLabel(appFields.displayText_id))
-                .toEqual(formInstance.getWidgetBy('id', appFields.displayText_id).value);
-        await expect(await widget.displayValueWidget().getFieldLabel(appFields.displayValue_id))
-                .toEqual(formInstance.getWidgetBy('id', appFields.displayValue_id).value || 'Display value' || '');
-        await expect(await widget.displayValueWidget().getFieldValue(appFields.displayValue_id))
-                .toEqual(formInstance.getWidgetBy('id', appFields.displayValue_id).value || '');
+            expect(await widget.displayTextWidget().getFieldLabel(appFields.displayText_id)).toEqual(
+                formInstance.getWidgetBy('id', appFields.displayText_id).value
+            );
+            expect(await widget.displayValueWidget().getFieldLabel(appFields.displayValue_id)).toEqual(
+                formInstance.getWidgetBy('id', appFields.displayValue_id).value || 'Display value' || ''
+            );
+            expect(await widget.displayValueWidget().getFieldValue(appFields.displayValue_id)).toEqual(
+                formInstance.getWidgetBy('id', appFields.displayValue_id).value || ''
+            );
         });
 
         it('[C272784] Should display typeahead and header in form', async () => {
-            await expect(await widget.headerWidget().getFieldLabel(appFields.header_id))
-                .toEqual(formInstance.getWidgetBy('id', appFields.header_id).name);
-            await expect(await taskPage.formFields().getFieldValue(appFields.typeAhead_id))
-                .toEqual(formInstance.getWidgetBy('id', appFields.typeAhead_id).value || '');
-            await expect(await taskPage.formFields().getFieldLabel(appFields.typeAhead_id))
-                .toEqual(formInstance.getWidgetBy('id', appFields.typeAhead_id).name);
+            expect(await widget.headerWidget().getFieldLabel(appFields.header_id)).toEqual(formInstance.getWidgetBy('id', appFields.header_id).name);
+            expect(await taskPage.formFields().getFieldValue(appFields.typeAhead_id)).toEqual(
+                formInstance.getWidgetBy('id', appFields.typeAhead_id).value || ''
+            );
+            expect(await taskPage.formFields().getFieldLabel(appFields.typeAhead_id)).toEqual(
+                formInstance.getWidgetBy('id', appFields.typeAhead_id).name
+            );
         });
 
         it('[C272785] Should display checkbox and radio button in form', async () => {
             const radioOption = 1;
 
-            await expect(await taskPage.formFields().getFieldLabel(appFields.checkbox_id))
-                .toContain(formInstance.getWidgetBy('id', appFields.checkbox_id).name);
+            expect(await taskPage.formFields().getFieldLabel(appFields.checkbox_id)).toContain(
+                formInstance.getWidgetBy('id', appFields.checkbox_id).name
+            );
 
-            await expect(await taskPage.formFields().getFieldLabel(appFields.radioButtons_id))
-                .toContain(formInstance.getWidgetBy('id', appFields.radioButtons_id).name);
-            await expect(await widget.radioWidget().getSpecificOptionLabel(appFields.radioButtons_id, radioOption))
-                .toContain(formInstance.getWidgetBy('id', appFields.radioButtons_id).options[radioOption - 1].name);
+            expect(await taskPage.formFields().getFieldLabel(appFields.radioButtons_id)).toContain(
+                formInstance.getWidgetBy('id', appFields.radioButtons_id).name
+            );
+            expect(await widget.radioWidget().getSpecificOptionLabel(appFields.radioButtons_id, radioOption)).toContain(
+                formInstance.getWidgetBy('id', appFields.radioButtons_id).options[radioOption - 1].name
+            );
         });
 
         it('[C268149] Should display hyperlink, dropdown and dynamic table in form', async () => {
-        await expect(await widget.hyperlink().getFieldText(appFields.hyperlink_id))
-                .toEqual(formInstance.getWidgetBy('id', appFields.hyperlink_id).hyperlinkUrl || '');
-        await expect(await taskPage.formFields().getFieldLabel(appFields.hyperlink_id))
-                .toEqual(formInstance.getWidgetBy('id', appFields.hyperlink_id).name);
+            expect(await widget.hyperlink().getFieldText(appFields.hyperlink_id)).toEqual(
+                formInstance.getWidgetBy('id', appFields.hyperlink_id).hyperlinkUrl || ''
+            );
+            expect(await taskPage.formFields().getFieldLabel(appFields.hyperlink_id)).toEqual(
+                formInstance.getWidgetBy('id', appFields.hyperlink_id).name
+            );
 
-        await expect(await taskPage.formFields().getFieldLabel(appFields.dropdown_id))
-                .toContain(formInstance.getWidgetBy('id', appFields.dropdown_id).name);
-        await expect(widget.dropdown().getSelectedOptionText(appFields.dropdown_id))
-                .toContain(formInstance.getWidgetBy('id', appFields.dropdown_id).value);
+            expect(await taskPage.formFields().getFieldLabel(appFields.dropdown_id)).toContain(
+                formInstance.getWidgetBy('id', appFields.dropdown_id).name
+            );
+            expect(widget.dropdown().getSelectedOptionText(appFields.dropdown_id)).toContain(
+                formInstance.getWidgetBy('id', appFields.dropdown_id).value
+            );
 
-        await expect(await widget.dynamicTable().getFieldLabel(appFields.dynamicTable_id))
-                .toContain(formInstance.getWidgetBy('id', appFields.dynamicTable_id).name);
-        await expect(await widget.dynamicTable().getColumnName(appFields.dynamicTable_id))
-                .toContain(formInstance.getWidgetBy('id', appFields.dynamicTable_id).columnDefinitions[0].name);
+            expect(await widget.dynamicTable().getFieldLabel(appFields.dynamicTable_id)).toContain(
+                formInstance.getWidgetBy('id', appFields.dynamicTable_id).name
+            );
+            expect(await widget.dynamicTable().getColumnName(appFields.dynamicTable_id)).toContain(
+                formInstance.getWidgetBy('id', appFields.dynamicTable_id).columnDefinitions[0].name
+            );
         });
-   });
+    });
 
     describe('with fields involving other people', () => {
         const app = browser.params.resources.Files.FORM_ADF;
@@ -227,19 +238,16 @@ describe('Form widgets', () => {
 
         it('[C260405] Value fields configured with process variables', async () => {
             await taskPage.formFields().checkFormIsDisplayed();
-            await expect(await taskPage.taskDetails().getTitle()).toEqual('Activities');
+            expect(await taskPage.taskDetails().getTitle()).toEqual('Activities');
 
             await taskPage.formFields().setValueInInputById('label', 'value 1');
             await taskPage.formFields().completeForm();
             /* cspell:disable-next-line */
             await taskPage.filtersPage().goToFilter(CONSTANTS.TASK_FILTERS.COMPLETED_TASKS);
 
-            await expect(await widget.displayTextWidget().getFieldText(appFields.displayText_id))
-                .toContain('value 1');
-            await expect(await widget.textWidget().getFieldValue(appFields.text_id))
-                .toEqual('value 1');
-            await expect(await widget.displayValueWidget().getFieldValue(appFields.displayValue_id))
-                .toEqual('value 1');
+            expect(await widget.displayTextWidget().getFieldText(appFields.displayText_id)).toContain('value 1');
+            expect(await widget.textWidget().getFieldValue(appFields.text_id)).toEqual('value 1');
+            expect(await widget.displayValueWidget().getFieldValue(appFields.displayValue_id)).toEqual('value 1');
         });
     });
 });

--- a/e2e/process-services/form/people-component.e2e.ts
+++ b/e2e/process-services/form/people-component.e2e.ts
@@ -23,7 +23,6 @@ import { browser } from 'protractor';
 import CONSTANTS = require('../../util/constants');
 
 describe('People component', () => {
-
     const app = browser.params.resources.Files.SIMPLE_APP_WITH_USER_FORM;
 
     const loginPage = new LoginPage();
@@ -36,7 +35,9 @@ describe('People component', () => {
     const taskUtil = new TaskUtil(apiService);
     const applicationUtil = new ApplicationsUtil(apiService);
 
-    let processUserModel; let assigneeUserModel; let secondAssigneeUserModel;
+    let processUserModel;
+    let assigneeUserModel;
+    let secondAssigneeUserModel;
     const peopleTitle = 'People this task is shared with ';
 
     const tasks = ['no people involved task', 'remove people task', 'can not complete task', 'multiple users', 'completed filter'];
@@ -102,8 +103,8 @@ describe('People component', () => {
         const taskDetails = taskPage.taskDetails();
 
         await taskDetails.clickInvolvePeopleButton();
-        await expect(await taskPage.taskDetails().getInvolvePeopleHeader()).toEqual('Add people and groups');
-        await expect(await taskPage.taskDetails().getInvolvePeoplePlaceholder()).toEqual('Search user');
+        expect(await taskPage.taskDetails().getInvolvePeopleHeader()).toEqual('Add people and groups');
+        expect(await taskPage.taskDetails().getInvolvePeoplePlaceholder()).toEqual('Search user');
 
         await taskDetails.checkAddPeopleButtonIsEnabled();
         await taskDetails.checkCancelButtonIsEnabled();
@@ -134,8 +135,9 @@ describe('People component', () => {
 
         await taskPage.taskDetails().clickAddInvolvedUserButton();
 
-        await expect(await taskPage.taskDetails().getInvolvedUserEmail(assigneeUserModel.firstName + ' ' + assigneeUserModel.lastName))
-            .toEqual(assigneeUserModel.email);
+        expect(await taskPage.taskDetails().getInvolvedUserEmail(assigneeUserModel.firstName + ' ' + assigneeUserModel.lastName)).toEqual(
+            assigneeUserModel.email
+        );
         await taskPage.taskDetails().removeInvolvedUser(assigneeUserModel.firstName + ' ' + assigneeUserModel.lastName);
         await taskPage.taskDetails().checkNoPeopleIsInvolved();
     });
@@ -151,8 +153,9 @@ describe('People component', () => {
         await taskDetails.checkUserIsSelected(assigneeUserModel.firstName + ' ' + assigneeUserModel.lastName);
         await taskPage.taskDetails().clickAddInvolvedUserButton();
 
-        await expect(await taskPage.taskDetails().getInvolvedUserEmail(assigneeUserModel.firstName + ' ' + assigneeUserModel.lastName))
-            .toEqual(assigneeUserModel.email);
+        expect(await taskPage.taskDetails().getInvolvedUserEmail(assigneeUserModel.firstName + ' ' + assigneeUserModel.lastName)).toEqual(
+            assigneeUserModel.email
+        );
 
         await navigationBarPage.clickLogoutButton();
         await loginPage.login(assigneeUserModel.username, assigneeUserModel.password);
@@ -175,9 +178,10 @@ describe('People component', () => {
         await taskDetails.checkUserIsSelected(assigneeUserModel.firstName + ' ' + assigneeUserModel.lastName);
         await taskPage.taskDetails().clickAddInvolvedUserButton();
 
-        await expect(await taskPage.taskDetails().getInvolvedUserEmail(assigneeUserModel.firstName + ' ' + assigneeUserModel.lastName))
-            .toEqual(assigneeUserModel.email);
-        await expect(await taskPage.taskDetails().getInvolvedPeopleTitle()).toEqual(peopleTitle + '(1)');
+        expect(await taskPage.taskDetails().getInvolvedUserEmail(assigneeUserModel.firstName + ' ' + assigneeUserModel.lastName)).toEqual(
+            assigneeUserModel.email
+        );
+        expect(await taskPage.taskDetails().getInvolvedPeopleTitle()).toEqual(peopleTitle + '(1)');
 
         const taskDetails2 = taskPage.taskDetails();
         await taskDetails2.clickInvolvePeopleButton();
@@ -187,9 +191,10 @@ describe('People component', () => {
 
         await taskPage.taskDetails().clickAddInvolvedUserButton();
 
-        await expect(await taskPage.taskDetails().getInvolvedUserEmail(secondAssigneeUserModel.firstName + ' ' + secondAssigneeUserModel.lastName))
-            .toEqual(secondAssigneeUserModel.email);
-        await expect(await taskPage.taskDetails().getInvolvedPeopleTitle()).toEqual(peopleTitle + '(2)');
+        expect(await taskPage.taskDetails().getInvolvedUserEmail(secondAssigneeUserModel.firstName + ' ' + secondAssigneeUserModel.lastName)).toEqual(
+            secondAssigneeUserModel.email
+        );
+        expect(await taskPage.taskDetails().getInvolvedPeopleTitle()).toEqual(peopleTitle + '(2)');
     });
 
     it('[C280014] Should involved user see the task in completed filters when the task is completed', async () => {
@@ -204,14 +209,16 @@ describe('People component', () => {
 
         await taskPage.taskDetails().clickAddInvolvedUserButton();
 
-        await expect(await taskPage.taskDetails().getInvolvedUserEmail(assigneeUserModel.firstName + ' ' + assigneeUserModel.lastName))
-            .toEqual(assigneeUserModel.email);
+        expect(await taskPage.taskDetails().getInvolvedUserEmail(assigneeUserModel.firstName + ' ' + assigneeUserModel.lastName)).toEqual(
+            assigneeUserModel.email
+        );
 
         await taskPage.completeTaskNoForm();
         await taskPage.filtersPage().goToFilter(CONSTANTS.TASK_FILTERS.COMPLETED_TASKS);
         await taskPage.tasksListPage().selectRow(tasks[3]);
-        await expect(await taskPage.taskDetails().getInvolvedUserEmail(assigneeUserModel.firstName + ' ' + assigneeUserModel.lastName))
-            .toEqual(assigneeUserModel.email);
+        expect(await taskPage.taskDetails().getInvolvedUserEmail(assigneeUserModel.firstName + ' ' + assigneeUserModel.lastName)).toEqual(
+            assigneeUserModel.email
+        );
 
         await navigationBarPage.clickLogoutButton();
         await loginPage.login(assigneeUserModel.username, assigneeUserModel.password);

--- a/e2e/process-services/form/stencil.e2e.ts
+++ b/e2e/process-services/form/stencil.e2e.ts
@@ -15,13 +15,7 @@
  * limitations under the License.
  */
 
-import { createApiService,
-    ApplicationsUtil,
-    LoginPage,
-    StartProcessPage,
-    UserModel,
-    UsersActions
-} from '@alfresco/adf-testing';
+import { createApiService, ApplicationsUtil, LoginPage, StartProcessPage, UserModel, UsersActions } from '@alfresco/adf-testing';
 import { TasksPage } from './../pages/tasks.page';
 import { browser } from 'protractor';
 import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
@@ -33,7 +27,6 @@ import { ProcessListPage } from './../pages/process-list.page';
 import CONSTANTS = require('../../util/constants');
 
 describe('Stencil', () => {
-
     const app = browser.params.resources.Files.STENCIL_PROCESS;
 
     const loginPage = new LoginPage();
@@ -74,7 +67,7 @@ describe('Stencil', () => {
     it('[C245648] Can start an app with custom stencil included', async () => {
         const name = 'test stencil process';
         await processServiceTabBarPage.clickProcessButton();
-        await expect(await processListPage.isProcessListDisplayed()).toEqual(true);
+        expect(await processListPage.isProcessListDisplayed()).toEqual(true);
         await processFiltersPage.clickCreateProcessButton();
         await processFiltersPage.clickNewProcessDropdown();
 

--- a/e2e/process-services/pages/attach-form.page.ts
+++ b/e2e/process-services/pages/attach-form.page.ts
@@ -19,7 +19,6 @@ import { $ } from 'protractor';
 import { BrowserVisibility, BrowserActions, DropdownPage, materialLocators } from '@alfresco/adf-testing';
 
 export class AttachFormPage {
-
     noFormMessage = $('.adf-empty-content__title');
     attachFormButton = $('#adf-attach-form-attach-button');
     completeButton = $('#adf-attach-form-complete-button');
@@ -38,11 +37,11 @@ export class AttachFormPage {
 
     async checkDefaultFormTitleIsDisplayed(formTitle: string): Promise<void> {
         const result = await BrowserActions.getText(this.defaultTitle);
-        await expect(result).toEqual(formTitle);
+        expect(result).toEqual(formTitle);
     }
 
     async openDropDownForms(): Promise<void> {
-       await BrowserActions.click(this.formDropdown);
+        await BrowserActions.click(this.formDropdown);
     }
 
     async checkFormDropdownIsDisplayed(): Promise<void> {

--- a/e2e/process-services/pages/process-filters.page.ts
+++ b/e2e/process-services/pages/process-filters.page.ts
@@ -43,13 +43,13 @@ export class ProcessFiltersPage {
     async clickCompletedFilterButton(): Promise<void> {
         const completedFilterButtonLocator = await this.getButtonFilterLocatorByName('Completed');
         await BrowserActions.click(completedFilterButtonLocator);
-        await expect(await completedFilterButtonLocator.isEnabled()).toBe(true);
+        expect(await completedFilterButtonLocator.isEnabled()).toBe(true);
     }
 
     async clickAllFilterButton(): Promise<void> {
         const allFilterButtonLocator = await this.getButtonFilterLocatorByName('All');
         await BrowserActions.click(allFilterButtonLocator);
-        await expect(await allFilterButtonLocator.isEnabled()).toBe(true);
+        expect(await allFilterButtonLocator.isEnabled()).toBe(true);
     }
 
     async clickCreateProcessButton(): Promise<void> {

--- a/e2e/process-services/process/comment-component-processes.e2e.ts
+++ b/e2e/process-services/process/comment-component-processes.e2e.ts
@@ -77,11 +77,9 @@ describe('Comment component for Processes', () => {
         await commentsPage.checkUserIconIsDisplayed();
 
         await commentsPage.getTotalNumberOfComments('Comments (' + addedComment.total + ')');
-        await expect(await commentsPage.getMessage(0)).toEqual(addedComment.data[0].message);
-        await expect(await commentsPage.getUserName(0)).toEqual(
-            addedComment.data[0].createdBy.firstName + ' ' + addedComment.data[0].createdBy.lastName
-        );
-        await expect(await commentsPage.getTime(0)).toMatch(/(ago|few)/);
+        expect(await commentsPage.getMessage(0)).toEqual(addedComment.data[0].message);
+        expect(await commentsPage.getUserName(0)).toEqual(addedComment.data[0].createdBy.firstName + ' ' + addedComment.data[0].createdBy.lastName);
+        expect(await commentsPage.getTime(0)).toMatch(/(ago|few)/);
     });
 
     it('[C260465] Should not be able to view process comment on included task', async () => {
@@ -97,7 +95,7 @@ describe('Comment component for Processes', () => {
         const taskId = taskQuery.data[0].id;
 
         const taskComments = await commentsApi.getTaskComments(taskId, { latestFirst: true });
-        await expect(taskComments.total).toEqual(0);
+        expect(taskComments.total).toEqual(0);
     });
 
     it('[C260466] Should be able to display comments from Task on the related Process', async () => {
@@ -117,10 +115,10 @@ describe('Comment component for Processes', () => {
         await commentsPage.checkUserIconIsDisplayed();
 
         await commentsPage.getTotalNumberOfComments('Comments (' + addedTaskComment.total + ')');
-        await expect(await commentsPage.getMessage(0)).toEqual(addedTaskComment.data[0].message);
-        await expect(await commentsPage.getUserName(0)).toEqual(
+        expect(await commentsPage.getMessage(0)).toEqual(addedTaskComment.data[0].message);
+        expect(await commentsPage.getUserName(0)).toEqual(
             addedTaskComment.data[0].createdBy.firstName + ' ' + addedTaskComment.data[0].createdBy.lastName
         );
-        await expect(await commentsPage.getTime(0)).toMatch(/(ago|few)/);
+        expect(await commentsPage.getTime(0)).toMatch(/(ago|few)/);
     });
 });

--- a/e2e/process-services/process/custom-process-filters-sorting.e2e.ts
+++ b/e2e/process-services/process/custom-process-filters-sorting.e2e.ts
@@ -107,9 +107,9 @@ describe('Sorting for process filters', () => {
             state: 'running',
             sort: 'created-asc'
         });
-        await expect(processesQuery.data[0].name).toEqual(firstProc.name);
-        await expect(processesQuery.data[1].name).toEqual(secondProc.name);
-        await expect(processesQuery.data[2].name).toEqual(thirdProc.name);
+        expect(processesQuery.data[0].name).toEqual(firstProc.name);
+        expect(processesQuery.data[1].name).toEqual(secondProc.name);
+        expect(processesQuery.data[2].name).toEqual(thirdProc.name);
     });
 
     it('[C260477] Should be able to create a filter on APS for completed processes - Oldest first and check on ADF', async () => {
@@ -141,9 +141,9 @@ describe('Sorting for process filters', () => {
             state: 'completed',
             sort: 'created-asc'
         });
-        await expect(processesQuery.data[0].name).toEqual(firstProc.name);
-        await expect(processesQuery.data[1].name).toEqual(secondProc.name);
-        await expect(processesQuery.data[2].name).toEqual(thirdProc.name);
+        expect(processesQuery.data[0].name).toEqual(firstProc.name);
+        expect(processesQuery.data[1].name).toEqual(secondProc.name);
+        expect(processesQuery.data[2].name).toEqual(thirdProc.name);
     });
 
     it('[C260478] Should be able to create a filter on APS for all processes - Oldest first and check on ADF', async () => {
@@ -179,12 +179,12 @@ describe('Sorting for process filters', () => {
             state: 'all',
             sort: 'created-asc'
         });
-        await expect(processesQuery.data[0].name).toEqual(firstProc.name);
-        await expect(processesQuery.data[1].name).toEqual(secondProc.name);
-        await expect(processesQuery.data[2].name).toEqual(thirdProc.name);
-        await expect(processesQuery.data[3].name).toEqual(deleteFirstProc.name);
-        await expect(processesQuery.data[4].name).toEqual(deleteSecondProc.name);
-        await expect(processesQuery.data[5].name).toEqual(deleteThirdProc.name);
+        expect(processesQuery.data[0].name).toEqual(firstProc.name);
+        expect(processesQuery.data[1].name).toEqual(secondProc.name);
+        expect(processesQuery.data[2].name).toEqual(thirdProc.name);
+        expect(processesQuery.data[3].name).toEqual(deleteFirstProc.name);
+        expect(processesQuery.data[4].name).toEqual(deleteSecondProc.name);
+        expect(processesQuery.data[5].name).toEqual(deleteThirdProc.name);
     });
 
     it('[C260479] Should be able to create a filter on APS for running processes - Newest first and check on ADF', async () => {
@@ -212,9 +212,9 @@ describe('Sorting for process filters', () => {
             state: 'running',
             sort: 'created-desc'
         });
-        await expect(processesQuery.data[0].name).toEqual(thirdProc.name);
-        await expect(processesQuery.data[1].name).toEqual(secondProc.name);
-        await expect(processesQuery.data[2].name).toEqual(firstProc.name);
+        expect(processesQuery.data[0].name).toEqual(thirdProc.name);
+        expect(processesQuery.data[1].name).toEqual(secondProc.name);
+        expect(processesQuery.data[2].name).toEqual(firstProc.name);
     });
 
     it('[C260480] Should be able to create a filter on APS for completed processes - Newest first and check on ADF', async () => {
@@ -245,9 +245,9 @@ describe('Sorting for process filters', () => {
             state: 'completed',
             sort: 'created-desc'
         });
-        await expect(processesQuery.data[0].name).toEqual(thirdProc.name);
-        await expect(processesQuery.data[1].name).toEqual(secondProc.name);
-        await expect(processesQuery.data[2].name).toEqual(firstProc.name);
+        expect(processesQuery.data[0].name).toEqual(thirdProc.name);
+        expect(processesQuery.data[1].name).toEqual(secondProc.name);
+        expect(processesQuery.data[2].name).toEqual(firstProc.name);
     });
 
     it('[C260481] Should be able to create a filter on APS for all processes - Newest first and check on ADF', async () => {
@@ -283,12 +283,12 @@ describe('Sorting for process filters', () => {
             state: 'all',
             sort: 'created-desc'
         });
-        await expect(processesQuery.data[0].name).toEqual(deleteThirdProc.name);
-        await expect(processesQuery.data[1].name).toEqual(deleteSecondProc.name);
-        await expect(processesQuery.data[2].name).toEqual(deleteFirstProc.name);
-        await expect(processesQuery.data[3].name).toEqual(thirdProc.name);
-        await expect(processesQuery.data[4].name).toEqual(secondProc.name);
-        await expect(processesQuery.data[5].name).toEqual(firstProc.name);
+        expect(processesQuery.data[0].name).toEqual(deleteThirdProc.name);
+        expect(processesQuery.data[1].name).toEqual(deleteSecondProc.name);
+        expect(processesQuery.data[2].name).toEqual(deleteFirstProc.name);
+        expect(processesQuery.data[3].name).toEqual(thirdProc.name);
+        expect(processesQuery.data[4].name).toEqual(secondProc.name);
+        expect(processesQuery.data[5].name).toEqual(firstProc.name);
     });
 
     it('[C272815] Should be able to create a filter on APS for completed processes - Completed most recently and check on ADF', async () => {
@@ -320,9 +320,9 @@ describe('Sorting for process filters', () => {
             state: 'completed',
             sort: 'ended-asc'
         });
-        await expect(processesQuery.data[0].name).toEqual(secondProc.name);
-        await expect(processesQuery.data[1].name).toEqual(firstProc.name);
-        await expect(processesQuery.data[2].name).toEqual(thirdProc.name);
+        expect(processesQuery.data[0].name).toEqual(secondProc.name);
+        expect(processesQuery.data[1].name).toEqual(firstProc.name);
+        expect(processesQuery.data[2].name).toEqual(thirdProc.name);
     });
 
     it('[C272816] Should be able to create a filter on APS for completed processes - Completed least recently and check on ADF', async () => {
@@ -354,8 +354,8 @@ describe('Sorting for process filters', () => {
             state: 'completed',
             sort: 'ended-desc'
         });
-        await expect(processesQuery.data[0].name).toEqual(thirdProc.name);
-        await expect(processesQuery.data[1].name).toEqual(firstProc.name);
-        await expect(processesQuery.data[2].name).toEqual(secondProc.name);
+        expect(processesQuery.data[0].name).toEqual(thirdProc.name);
+        expect(processesQuery.data[1].name).toEqual(firstProc.name);
+        expect(processesQuery.data[2].name).toEqual(secondProc.name);
     });
 });

--- a/e2e/process-services/process/empty-process-list-component.e2e.ts
+++ b/e2e/process-services/process/empty-process-list-component.e2e.ts
@@ -59,8 +59,8 @@ describe('Empty Process List Test', () => {
         await navigationBarPage.navigateToProcessServicesPage();
         await processServicesPage.checkApsContainer();
         await (await processServicesPage.goToApp(appWithProcess.title)).clickProcessButton();
-        await expect(await processListPage.getDisplayedProcessListTitle()).toEqual('No Processes Found');
-        await expect(await processDetailsPage.checkProcessDetailsMessage()).toEqual('No process details found');
+        expect(await processListPage.getDisplayedProcessListTitle()).toEqual('No Processes Found');
+        expect(await processDetailsPage.checkProcessDetailsMessage()).toEqual('No process details found');
 
         await processFiltersPage.clickCreateProcessButton();
         await processFiltersPage.clickNewProcessDropdown();
@@ -68,14 +68,14 @@ describe('Empty Process List Test', () => {
         await startProcessPage.selectFromProcessDropdown(appWithProcess.process_wse_name);
         await startProcessPage.clickStartProcessButton();
 
-        await expect(await processFiltersPage.numberOfProcessRows()).toEqual(1);
+        expect(await processFiltersPage.numberOfProcessRows()).toEqual(1);
 
         await processDetailsPage.propertiesList.waitVisible();
         await navigationBarPage.navigateToProcessServicesPage();
         await processServicesPage.checkApsContainer();
         await (await processServicesPage.goToApp(simpleAppWithUserForm.title)).clickProcessButton();
-        await expect(await processListPage.getDisplayedProcessListTitle()).toEqual('No Processes Found');
-        await expect(await processDetailsPage.checkProcessDetailsMessage()).toEqual('No process details found');
+        expect(await processListPage.getDisplayedProcessListTitle()).toEqual('No Processes Found');
+        expect(await processDetailsPage.checkProcessDetailsMessage()).toEqual('No process details found');
 
         await processFiltersPage.clickCreateProcessButton();
         await processFiltersPage.clickNewProcessDropdown();
@@ -83,7 +83,7 @@ describe('Empty Process List Test', () => {
         await startProcessPage.selectFromProcessDropdown(simpleAppWithUserForm.processName);
         await startProcessPage.clickStartProcessButton();
 
-        await expect(await processFiltersPage.numberOfProcessRows()).toEqual(1);
+        expect(await processFiltersPage.numberOfProcessRows()).toEqual(1);
 
         await processDetailsPage.propertiesList.waitVisible();
     });

--- a/e2e/process-services/process/pagination-processlist-adding-processes.e2e.ts
+++ b/e2e/process-services/process/pagination-processlist-adding-processes.e2e.ts
@@ -71,11 +71,11 @@ describe('Process List - Pagination when adding processes', () => {
         await processFiltersPage.dataTable.waitTillContentLoaded();
         await processDetailsPage.checkProcessTitleIsDisplayed();
 
-        await expect(await paginationPage.getCurrentPage()).toEqual('Page ' + page);
-        await expect(await paginationPage.getTotalPages()).toEqual('of ' + totalPages);
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.fifteen);
-        await expect(await paginationPage.getPaginationRange()).toEqual('Showing 1-' + itemsPerPage.fifteenValue * page + ' of 20');
-        await expect(await processFiltersPage.numberOfProcessRows()).toBe(itemsPerPage.fifteenValue);
+        expect(await paginationPage.getCurrentPage()).toEqual('Page ' + page);
+        expect(await paginationPage.getTotalPages()).toEqual('of ' + totalPages);
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.fifteen);
+        expect(await paginationPage.getPaginationRange()).toEqual('Showing 1-' + itemsPerPage.fifteenValue * page + ' of 20');
+        expect(await processFiltersPage.numberOfProcessRows()).toBe(itemsPerPage.fifteenValue);
         await paginationPage.checkNextPageButtonIsEnabled();
         await paginationPage.checkPreviousPageButtonIsDisabled();
 
@@ -87,11 +87,11 @@ describe('Process List - Pagination when adding processes', () => {
         await paginationPage.clickOnNextPage();
         await processDetailsPage.checkProcessTitleIsDisplayed();
         await processFiltersPage.waitForTableBody();
-        await expect(await paginationPage.getCurrentPage()).toEqual('Page ' + page);
-        await expect(await paginationPage.getTotalPages()).toEqual('of ' + totalPages);
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.fifteen);
-        await expect(await paginationPage.getPaginationRange()).toEqual('Showing 16-25 of 25');
-        await expect(await processFiltersPage.numberOfProcessRows()).toBe(10);
+        expect(await paginationPage.getCurrentPage()).toEqual('Page ' + page);
+        expect(await paginationPage.getTotalPages()).toEqual('of ' + totalPages);
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.fifteen);
+        expect(await paginationPage.getPaginationRange()).toEqual('Showing 16-25 of 25');
+        expect(await processFiltersPage.numberOfProcessRows()).toBe(10);
         await paginationPage.checkNextPageButtonIsDisabled();
         await paginationPage.checkPreviousPageButtonIsEnabled();
     });

--- a/e2e/process-services/process/process-filters-component.e2e.ts
+++ b/e2e/process-services/process/process-filters-component.e2e.ts
@@ -66,7 +66,7 @@ describe('Process Filters Test', () => {
     it('[C260387] Should the running process be displayed when clicking on Running filter', async () => {
         await processServicesPage.goToApp(app.title);
         await processServiceTabBarPage.clickProcessButton();
-        await expect(await processListPage.isProcessListDisplayed()).toEqual(true);
+        expect(await processListPage.isProcessListDisplayed()).toEqual(true);
 
         await processFiltersPage.clickCreateProcessButton();
         await processFiltersPage.clickNewProcessDropdown();
@@ -96,7 +96,7 @@ describe('Process Filters Test', () => {
     it('[C280063] Should both the new created process and a completed one to be displayed when clicking on All filter', async () => {
         await processServicesPage.goToApp(app.title);
         await processServiceTabBarPage.clickProcessButton();
-        await expect(await processListPage.isProcessListDisplayed()).toEqual(true);
+        expect(await processListPage.isProcessListDisplayed()).toEqual(true);
 
         await processFiltersPage.clickAllFilterButton();
         await processFiltersPage.selectFromProcessList(processTitle.running);
@@ -107,7 +107,7 @@ describe('Process Filters Test', () => {
     it('[C280064] Should the completed process be displayed when clicking on Completed filter', async () => {
         await processServicesPage.goToApp(app.title);
         await processServiceTabBarPage.clickProcessButton();
-        await expect(await processListPage.isProcessListDisplayed()).toEqual(true);
+        expect(await processListPage.isProcessListDisplayed()).toEqual(true);
 
         await processFiltersPage.clickCompletedFilterButton();
         await processFiltersPage.selectFromProcessList(processTitle.completed);
@@ -117,7 +117,7 @@ describe('Process Filters Test', () => {
     it('[C260463] Should Cancel process be displayed in Completed process filters', async () => {
         await processServicesPage.goToApp(app.title);
         await processServiceTabBarPage.clickProcessButton();
-        await expect(await processListPage.isProcessListDisplayed()).toEqual(true);
+        expect(await processListPage.isProcessListDisplayed()).toEqual(true);
 
         await processFiltersPage.clickCreateProcessButton();
         await processFiltersPage.clickNewProcessDropdown();

--- a/e2e/process-services/process/process-instance-details.e2e.ts
+++ b/e2e/process-services/process/process-instance-details.e2e.ts
@@ -61,7 +61,7 @@ describe('Process Instance Details', () => {
         await processServicesPage.checkApsContainer();
         await processServicesPage.goToApp(app.title);
         await processServiceTabBarPage.clickProcessButton();
-        await expect(await processListPage.isProcessListDisplayed()).toEqual(true);
+        expect(await processListPage.isProcessListDisplayed()).toEqual(true);
 
         process = await processApi.getProcessInstance(processModel.id);
     });

--- a/e2e/process-services/process/process-list-component.e2e.ts
+++ b/e2e/process-services/process/process-list-component.e2e.ts
@@ -191,12 +191,12 @@ describe('Process List Test', () => {
 
         const sortedProcessListNamesAsc = await processListDemoPage.getDisplayedProcessesNames();
 
-        await expect(JSON.stringify(processList) === JSON.stringify(sortedProcessListNamesAsc)).toBe(true);
+        expect(JSON.stringify(processList) === JSON.stringify(sortedProcessListNamesAsc)).toBe(true);
 
         await processListDemoPage.selectSorting('desc');
         await processListDemoPage.dataTable.waitTillContentLoaded();
 
         const sortedProcessListNamesDesc = await processListDemoPage.getDisplayedProcessesNames();
-        await expect(JSON.stringify(processList.reverse()) === JSON.stringify(sortedProcessListNamesDesc)).toBe(true);
+        expect(JSON.stringify(processList.reverse()) === JSON.stringify(sortedProcessListNamesDesc)).toBe(true);
     });
 });

--- a/e2e/process-services/process/start-process-component.e2e.ts
+++ b/e2e/process-services/process/start-process-component.e2e.ts
@@ -16,10 +16,12 @@
  */
 
 import CONSTANTS = require('../../util/constants');
-import { createApiService,
+import {
+    createApiService,
     ApplicationsUtil,
     FileBrowserUtil,
-    LoginPage, ModelsActions,
+    LoginPage,
+    ModelsActions,
     ProcessInstanceTasksPage,
     StartProcessPage,
     StringUtil,
@@ -137,7 +139,7 @@ describe('Start Process Component', () => {
                 await processFiltersPage.clickCreateProcessButton();
                 await processFiltersPage.clickNewProcessDropdown();
                 await startProcessPage.selectFromProcessDropdown(browser.params.resources.Files.APP_WITH_PROCESSES.process_wse_name);
-                await expect(await startProcessPage.getDefaultName()).toEqual('My Default Name');
+                expect(await startProcessPage.getDefaultName()).toEqual('My Default Name');
             });
 
             it('[C260445] Should require process definition and be possible to click cancel button', async () => {
@@ -179,12 +181,12 @@ describe('Start Process Component', () => {
                 await processFiltersPage.clickCreateProcessButton();
                 await processFiltersPage.clickNewProcessDropdown();
 
-                await expect(await startProcessPage.checkSelectProcessPlaceholderIsDisplayed()).toBe('');
+                expect(await startProcessPage.checkSelectProcessPlaceholderIsDisplayed()).toBe('');
 
                 await startProcessPage.selectFromProcessDropdown(browser.params.resources.Files.APP_WITH_PROCESSES.process_wse_name);
 
-                await expect(await startProcessPage.getDefaultName()).toEqual('My Default Name');
-                await expect(await startProcessPage.isStartProcessButtonEnabled()).toEqual(true);
+                expect(await startProcessPage.getDefaultName()).toEqual('My Default Name');
+                expect(await startProcessPage.isStartProcessButtonEnabled()).toEqual(true);
             });
 
             it('[C260449] Should be possible to start a process with start event', async () => {
@@ -201,14 +203,14 @@ describe('Start Process Component', () => {
                 const processId = await processDetailsPage.getId();
                 const response = await processApi.getProcessInstance(processId);
 
-                await expect(await processDetailsPage.getProcessStatus()).toEqual(CONSTANTS.PROCESS_STATUS.RUNNING);
-                await expect(await processDetailsPage.getEndDate()).toEqual(CONSTANTS.PROCESS_END_DATE);
-                await expect(await processDetailsPage.getProcessCategory()).toEqual(CONSTANTS.PROCESS_CATEGORY);
-                await expect(await processDetailsPage.getBusinessKey()).toEqual(CONSTANTS.PROCESS_BUSINESS_KEY);
-                await expect(await processDetailsPage.getCreatedBy()).toEqual(`${response.startedBy.firstName} ${response.startedBy.lastName}`);
-                await expect(await processDetailsPage.getId()).toEqual(response.id);
-                await expect(await processDetailsPage.getProcessDescription()).toEqual(CONSTANTS.PROCESS_DESCRIPTION);
-                await expect(await processDetailsPage.checkProcessTitleIsDisplayed()).toEqual(response.name);
+                expect(await processDetailsPage.getProcessStatus()).toEqual(CONSTANTS.PROCESS_STATUS.RUNNING);
+                expect(await processDetailsPage.getEndDate()).toEqual(CONSTANTS.PROCESS_END_DATE);
+                expect(await processDetailsPage.getProcessCategory()).toEqual(CONSTANTS.PROCESS_CATEGORY);
+                expect(await processDetailsPage.getBusinessKey()).toEqual(CONSTANTS.PROCESS_BUSINESS_KEY);
+                expect(await processDetailsPage.getCreatedBy()).toEqual(`${response.startedBy.firstName} ${response.startedBy.lastName}`);
+                expect(await processDetailsPage.getId()).toEqual(response.id);
+                expect(await processDetailsPage.getProcessDescription()).toEqual(CONSTANTS.PROCESS_DESCRIPTION);
+                expect(await processDetailsPage.checkProcessTitleIsDisplayed()).toEqual(response.name);
             });
 
             it('[C286503] Should NOT display any process definition when typing a non-existent one', async () => {
@@ -230,7 +232,7 @@ describe('Start Process Component', () => {
                 await startProcessPage.checkProcessOptionIsDisplayed(browser.params.resources.Files.APP_WITH_PROCESSES.process_wse_name);
                 await startProcessPage.checkProcessOptionIsDisplayed(browser.params.resources.Files.APP_WITH_PROCESSES.process_se_name);
                 await startProcessPage.selectProcessOption(browser.params.resources.Files.APP_WITH_PROCESSES.process_wse_name);
-                await expect(await startProcessPage.isStartProcessButtonEnabled()).toEqual(true);
+                expect(await startProcessPage.isStartProcessButtonEnabled()).toEqual(true);
             });
 
             it('[C286508] Should display only one option when typing an existent process definition', async () => {
@@ -242,7 +244,7 @@ describe('Start Process Component', () => {
                 await startProcessPage.checkProcessOptionIsDisplayed(browser.params.resources.Files.APP_WITH_PROCESSES.process_wse_name);
                 await startProcessPage.checkProcessOptionIsNotDisplayed(browser.params.resources.Files.APP_WITH_PROCESSES.process_se_name);
                 await startProcessPage.selectProcessOption(browser.params.resources.Files.APP_WITH_PROCESSES.process_wse_name);
-                await expect(await startProcessPage.isStartProcessButtonEnabled()).toEqual(true);
+                expect(await startProcessPage.isStartProcessButtonEnabled()).toEqual(true);
             });
 
             it('[C286509] Should select automatically the processDefinition when the app contains only one', async () => {
@@ -250,8 +252,8 @@ describe('Start Process Component', () => {
                 await processServiceTabBarPage.clickProcessButton();
                 await processFiltersPage.clickCreateProcessButton();
                 await processFiltersPage.clickNewProcessDropdown();
-                await expect(await startProcessPage.getProcessDefinitionValue()).toBe(simpleApp.title);
-                await expect(await startProcessPage.isStartProcessButtonEnabled()).toEqual(true);
+                expect(await startProcessPage.getProcessDefinitionValue()).toBe(simpleApp.title);
+                expect(await startProcessPage.isStartProcessButtonEnabled()).toEqual(true);
             });
 
             it('[C286511] Should be able to type the process definition and start a process', async () => {
@@ -262,10 +264,8 @@ describe('Start Process Component', () => {
                 await startProcessPage.typeProcessDefinition(browser.params.resources.Files.APP_WITH_PROCESSES.process_wse_name);
                 await startProcessPage.selectProcessOption(browser.params.resources.Files.APP_WITH_PROCESSES.process_wse_name);
                 await startProcessPage.enterProcessName('Type');
-                await expect(await startProcessPage.isStartProcessButtonEnabled()).toEqual(true);
-                await expect(await startProcessPage.getProcessDefinitionValue()).toBe(
-                    browser.params.resources.Files.APP_WITH_PROCESSES.process_wse_name
-                );
+                expect(await startProcessPage.isStartProcessButtonEnabled()).toEqual(true);
+                expect(await startProcessPage.getProcessDefinitionValue()).toBe(browser.params.resources.Files.APP_WITH_PROCESSES.process_wse_name);
                 await startProcessPage.clickStartProcessButton();
                 await processFiltersPage.clickRunningFilterButton();
                 await processFiltersPage.selectFromProcessList('Type');
@@ -279,9 +279,7 @@ describe('Start Process Component', () => {
                 await startProcessPage.typeProcessDefinition('process');
 
                 await startProcessPage.pressDownArrowAndEnter();
-                await expect(await startProcessPage.getProcessDefinitionValue()).toBe(
-                    browser.params.resources.Files.APP_WITH_PROCESSES.process_wse_name
-                );
+                expect(await startProcessPage.getProcessDefinitionValue()).toBe(browser.params.resources.Files.APP_WITH_PROCESSES.process_wse_name);
             });
 
             it('[C286514] Should the process definition input be cleared when clicking on options drop down ', async () => {
@@ -291,12 +289,10 @@ describe('Start Process Component', () => {
                 await processFiltersPage.clickNewProcessDropdown();
                 await startProcessPage.typeProcessDefinition('process');
                 await startProcessPage.selectProcessOption(browser.params.resources.Files.APP_WITH_PROCESSES.process_wse_name);
-                await expect(await startProcessPage.getProcessDefinitionValue()).toBe(
-                    browser.params.resources.Files.APP_WITH_PROCESSES.process_wse_name
-                );
+                expect(await startProcessPage.getProcessDefinitionValue()).toBe(browser.params.resources.Files.APP_WITH_PROCESSES.process_wse_name);
                 await startProcessPage.clickProcessDropdownArrow();
 
-                await expect(await startProcessPage.getProcessDefinitionValue()).toBe('');
+                expect(await startProcessPage.getProcessDefinitionValue()).toBe('');
             });
 
             it('[C260453] Should be possible to add a comment on an active process', async () => {
@@ -440,7 +436,7 @@ describe('Start Process Component', () => {
 
                 await startProcessPage.enterProcessName(processName255Characters);
                 await startProcessPage.selectFromProcessDropdown(browser.params.resources.Files.APP_WITH_PROCESSES.process_wse_name);
-                await expect(await startProcessPage.isStartProcessButtonEnabled()).toEqual(true);
+                expect(await startProcessPage.isStartProcessButtonEnabled()).toEqual(true);
 
                 await startProcessPage.enterProcessName(processNameBiggerThen255Characters);
                 await startProcessPage.checkValidationErrorIsDisplayed(lengthValidationError);
@@ -455,15 +451,15 @@ describe('Start Process Component', () => {
                 await startProcessPage.enterProcessName('DateFormProcess');
                 await startProcessPage.formFields().checkWidgetIsVisible('testdate');
                 await widget.dateWidget().setDateInput('testdate', '15-7-2019');
-                await expect(await startProcessPage.isStartFormProcessButtonEnabled()).toEqual(true);
+                expect(await startProcessPage.isStartFormProcessButtonEnabled()).toEqual(true);
                 await startProcessPage.clickFormStartProcessButton();
 
                 await processFiltersPage.clickRunningFilterButton();
                 await processFiltersPage.selectFromProcessList('DateFormProcess');
                 await processInstanceTasksPage.clickOnStartForm();
                 await processInstanceTasksPage.checkStartProcessDialogIsDisplayed();
-                await expect(await processInstanceTasksPage.getTitle()).toBe('Start Form');
-                await expect(await widget.dateWidget().getDateInput('testdate')).toBe('15-7-2019');
+                expect(await processInstanceTasksPage.getTitle()).toBe('Start Form');
+                expect(await widget.dateWidget().getDateInput('testdate')).toBe('15-7-2019');
                 await processInstanceTasksPage.clickCloseButton();
                 await processInstanceTasksPage.checkStartProcessDialogIsNotDisplayed();
             });

--- a/e2e/process-services/tasks/comment-component-tasks.e2e.ts
+++ b/e2e/process-services/tasks/comment-component-tasks.e2e.ts
@@ -17,14 +17,7 @@
 
 import { browser } from 'protractor';
 
-import { createApiService,
-    ApplicationsUtil,
-    LoginPage,
-    ModelsActions,
-    TaskUtil,
-    UserModel,
-    UsersActions
-} from '@alfresco/adf-testing';
+import { createApiService, ApplicationsUtil, LoginPage, ModelsActions, TaskUtil, UserModel, UsersActions } from '@alfresco/adf-testing';
 import { TasksPage } from '../pages/tasks.page';
 import { CommentsPage } from '../../core/pages/comments.page';
 import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
@@ -32,7 +25,6 @@ import { ActivitiCommentsApi, TaskActionsApi } from '@alfresco/js-api';
 import CONSTANTS = require('../../util/constants');
 
 describe('Comment component for Processes', () => {
-
     const app = browser.params.resources.Files.SIMPLE_APP_WITH_USER_FORM;
 
     const loginPage = new LoginPage();
@@ -92,7 +84,7 @@ describe('Comment component for Processes', () => {
     });
 
     it('[C212864] Should be able to add multiple comments on a single task using different users', async () => {
-        const newTask =  await taskUtil.createStandaloneTask(taskName.multiple_users);
+        const newTask = await taskUtil.createStandaloneTask(taskName.multiple_users);
 
         await taskActionsApi.involveUser(newTask.id, { email: secondUser.email });
 
@@ -117,14 +109,18 @@ describe('Comment component for Processes', () => {
 
         await commentsPage.getTotalNumberOfComments('Comments (' + totalCommentsLatest.total + ')');
 
-        await expect(await commentsPage.getMessage(0)).toEqual(totalCommentsLatest.data[0].message);
-        await expect(await commentsPage.getMessage(1)).toEqual(totalCommentsLatest.data[1].message);
+        expect(await commentsPage.getMessage(0)).toEqual(totalCommentsLatest.data[0].message);
+        expect(await commentsPage.getMessage(1)).toEqual(totalCommentsLatest.data[1].message);
 
-        await expect(await commentsPage.getUserName(0)).toEqual(totalCommentsLatest.data[0].createdBy.firstName + ' ' + totalCommentsLatest.data[0].createdBy.lastName);
-        await expect(await commentsPage.getUserName(1)).toEqual(totalCommentsLatest.data[1].createdBy.firstName + ' ' + totalCommentsLatest.data[1].createdBy.lastName);
+        expect(await commentsPage.getUserName(0)).toEqual(
+            totalCommentsLatest.data[0].createdBy.firstName + ' ' + totalCommentsLatest.data[0].createdBy.lastName
+        );
+        expect(await commentsPage.getUserName(1)).toEqual(
+            totalCommentsLatest.data[1].createdBy.firstName + ' ' + totalCommentsLatest.data[1].createdBy.lastName
+        );
 
-        await expect(await commentsPage.getTime(0)).toMatch(/(ago|few)/);
-        await expect(await commentsPage.getTime(1)).toMatch(/(ago|few)/);
+        expect(await commentsPage.getTime(0)).toMatch(/(ago|few)/);
+        expect(await commentsPage.getTime(1)).toMatch(/(ago|few)/);
 
         await navigationBarPage.clickLogoutButton();
         await loginPage.login(secondUser.username, secondUser.password);
@@ -145,16 +141,16 @@ describe('Comment component for Processes', () => {
 
         await commentsPage.getTotalNumberOfComments('Comments (' + totalComments.total + ')');
 
-        await expect(await commentsPage.getMessage(0)).toEqual(totalComments.data[0].message);
-        await expect(await commentsPage.getMessage(1)).toEqual(totalComments.data[1].message);
-        await expect(await commentsPage.getMessage(2)).toEqual(totalComments.data[2].message);
+        expect(await commentsPage.getMessage(0)).toEqual(totalComments.data[0].message);
+        expect(await commentsPage.getMessage(1)).toEqual(totalComments.data[1].message);
+        expect(await commentsPage.getMessage(2)).toEqual(totalComments.data[2].message);
 
-        await expect(await commentsPage.getUserName(0)).toEqual(totalComments.data[0].createdBy.firstName + ' ' + totalComments.data[0].createdBy.lastName);
-        await expect(await commentsPage.getUserName(1)).toEqual(totalComments.data[1].createdBy.firstName + ' ' + totalComments.data[1].createdBy.lastName);
-        await expect(await commentsPage.getUserName(2)).toEqual(totalComments.data[2].createdBy.firstName + ' ' + totalComments.data[2].createdBy.lastName);
+        expect(await commentsPage.getUserName(0)).toEqual(totalComments.data[0].createdBy.firstName + ' ' + totalComments.data[0].createdBy.lastName);
+        expect(await commentsPage.getUserName(1)).toEqual(totalComments.data[1].createdBy.firstName + ' ' + totalComments.data[1].createdBy.lastName);
+        expect(await commentsPage.getUserName(2)).toEqual(totalComments.data[2].createdBy.firstName + ' ' + totalComments.data[2].createdBy.lastName);
 
-        await expect(await commentsPage.getTime(0)).toMatch(/(ago|few)/);
-        await expect(await commentsPage.getTime(1)).toMatch(/(ago|few)/);
-        await expect(await commentsPage.getTime(2)).toMatch(/(ago|few)/);
+        expect(await commentsPage.getTime(0)).toMatch(/(ago|few)/);
+        expect(await commentsPage.getTime(1)).toMatch(/(ago|few)/);
+        expect(await commentsPage.getTime(2)).toMatch(/(ago|few)/);
     });
 });

--- a/e2e/process-services/tasks/custom-tasks-filters.e2e.ts
+++ b/e2e/process-services/tasks/custom-tasks-filters.e2e.ts
@@ -175,19 +175,19 @@ describe('Start Task - Custom App', () => {
         });
 
         it('[C286362] Default pagination settings on task list', async () => {
-            await expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.twenty);
-            await expect(await paginationPage.getPaginationRange()).toEqual('Showing 1-' + nrOfTasks + ' of ' + nrOfTasks);
-            await expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(nrOfTasks);
+            expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.twenty);
+            expect(await paginationPage.getPaginationRange()).toEqual('Showing 1-' + nrOfTasks + ' of ' + nrOfTasks);
+            expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(nrOfTasks);
 
             await taskListSinglePage
                 .taskList()
                 .getAllRowsNameColumn('Name')
                 .then(async (list) => {
-                    await expect(ArrayUtil.arrayContainsArray(list, allTasksName)).toEqual(true);
+                    expect(ArrayUtil.arrayContainsArray(list, allTasksName)).toEqual(true);
                 });
 
-            await expect(await paginationPage.getCurrentPage()).toEqual('Page 1');
-            await expect(await paginationPage.getTotalPages()).toEqual('of 1');
+            expect(await paginationPage.getCurrentPage()).toEqual('Page 1');
+            expect(await paginationPage.getTotalPages()).toEqual('of 1');
             await paginationPage.checkPageSelectorIsNotDisplayed();
             await paginationPage.checkNextPageButtonIsDisabled();
             await paginationPage.checkPreviousPageButtonIsDisabled();
@@ -196,15 +196,15 @@ describe('Start Task - Custom App', () => {
         it('[C286367] 20 Items per page', async () => {
             await taskListSinglePage.typeItemsPerPage(itemsPerPage.twentyValue);
             await taskListSinglePage.taskList().getDataTable().waitTillContentLoaded();
-            await expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.twenty);
-            await expect(await paginationPage.getPaginationRange()).toEqual('Showing 1-' + nrOfTasks + ' of ' + nrOfTasks);
-            await expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(nrOfTasks);
+            expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.twenty);
+            expect(await paginationPage.getPaginationRange()).toEqual('Showing 1-' + nrOfTasks + ' of ' + nrOfTasks);
+            expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(nrOfTasks);
 
             await taskListSinglePage
                 .taskList()
                 .getAllRowsNameColumn('Name')
                 .then(async (list) => {
-                    await expect(ArrayUtil.arrayContainsArray(list, allTasksName)).toEqual(true);
+                    expect(ArrayUtil.arrayContainsArray(list, allTasksName)).toEqual(true);
                 });
             await paginationPage.checkNextPageButtonIsDisabled();
             await paginationPage.checkPreviousPageButtonIsDisabled();
@@ -213,61 +213,57 @@ describe('Start Task - Custom App', () => {
         it('[C286365] 5 Items per page', async () => {
             await taskListSinglePage.typeItemsPerPage(itemsPerPage.fiveValue);
             await taskListSinglePage.taskList().getDataTable().waitTillContentLoaded();
-            await expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.five);
-            await expect(await paginationPage.getPaginationRange()).toEqual('Showing 1-' + itemsPerPage.fiveValue * currentPage + ' of ' + nrOfTasks);
-            await expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(itemsPerPage.fiveValue);
+            expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.five);
+            expect(await paginationPage.getPaginationRange()).toEqual('Showing 1-' + itemsPerPage.fiveValue * currentPage + ' of ' + nrOfTasks);
+            expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(itemsPerPage.fiveValue);
 
             await taskListSinglePage
                 .taskList()
                 .getAllRowsNameColumn('Name')
                 .then(async (list) => {
-                    await expect(ArrayUtil.arrayContainsArray(list, allTasksName.slice(0, 5))).toEqual(true);
+                    expect(ArrayUtil.arrayContainsArray(list, allTasksName.slice(0, 5))).toEqual(true);
                 });
 
             await paginationPage.clickOnNextPage();
 
             currentPage++;
             await taskListSinglePage.taskList().getDataTable().waitTillContentLoaded();
-            await expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.five);
-            await expect(await paginationPage.getPaginationRange()).toEqual('Showing 6-' + itemsPerPage.fiveValue * currentPage + ' of ' + nrOfTasks);
-            await expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(itemsPerPage.fiveValue);
+            expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.five);
+            expect(await paginationPage.getPaginationRange()).toEqual('Showing 6-' + itemsPerPage.fiveValue * currentPage + ' of ' + nrOfTasks);
+            expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(itemsPerPage.fiveValue);
 
             await taskListSinglePage
                 .taskList()
                 .getAllRowsNameColumn('Name')
                 .then(async (list) => {
-                    await expect(ArrayUtil.arrayContainsArray(list, allTasksName.slice(5, 10))).toEqual(true);
+                    expect(ArrayUtil.arrayContainsArray(list, allTasksName.slice(5, 10))).toEqual(true);
                 });
 
             await paginationPage.clickOnNextPage();
             currentPage++;
             await taskListSinglePage.taskList().getDataTable().waitTillContentLoaded();
-            await expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.five);
-            await expect(await paginationPage.getPaginationRange()).toEqual(
-                'Showing 11-' + itemsPerPage.fiveValue * currentPage + ' of ' + nrOfTasks
-            );
-            await expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(itemsPerPage.fiveValue);
+            expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.five);
+            expect(await paginationPage.getPaginationRange()).toEqual('Showing 11-' + itemsPerPage.fiveValue * currentPage + ' of ' + nrOfTasks);
+            expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(itemsPerPage.fiveValue);
 
             await taskListSinglePage
                 .taskList()
                 .getAllRowsNameColumn('Name')
                 .then(async (list) => {
-                    await expect(ArrayUtil.arrayContainsArray(list, allTasksName.slice(10, 15))).toEqual(true);
+                    expect(ArrayUtil.arrayContainsArray(list, allTasksName.slice(10, 15))).toEqual(true);
                 });
 
             await paginationPage.clickOnNextPage();
             currentPage++;
             await taskListSinglePage.taskList().getDataTable().waitTillContentLoaded();
-            await expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.five);
-            await expect(await paginationPage.getPaginationRange()).toEqual(
-                'Showing 16-' + itemsPerPage.fiveValue * currentPage + ' of ' + nrOfTasks
-            );
-            await expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(itemsPerPage.fiveValue);
+            expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.five);
+            expect(await paginationPage.getPaginationRange()).toEqual('Showing 16-' + itemsPerPage.fiveValue * currentPage + ' of ' + nrOfTasks);
+            expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(itemsPerPage.fiveValue);
             await taskListSinglePage
                 .taskList()
                 .getAllRowsNameColumn('Name')
                 .then(async (list) => {
-                    await expect(ArrayUtil.arrayContainsArray(list, allTasksName.slice(15, 20))).toEqual(true);
+                    expect(ArrayUtil.arrayContainsArray(list, allTasksName.slice(15, 20))).toEqual(true);
                 });
         });
 
@@ -275,26 +271,26 @@ describe('Start Task - Custom App', () => {
             currentPage = 1;
             await taskListSinglePage.typeItemsPerPage(itemsPerPage.tenValue);
             await taskListSinglePage.taskList().getDataTable().waitTillContentLoaded();
-            await expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.ten);
-            await expect(await paginationPage.getPaginationRange()).toEqual('Showing 1-' + itemsPerPage.tenValue * currentPage + ' of ' + nrOfTasks);
-            await expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(itemsPerPage.tenValue);
+            expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.ten);
+            expect(await paginationPage.getPaginationRange()).toEqual('Showing 1-' + itemsPerPage.tenValue * currentPage + ' of ' + nrOfTasks);
+            expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(itemsPerPage.tenValue);
             await taskListSinglePage
                 .taskList()
                 .getAllRowsNameColumn('Name')
                 .then(async (list) => {
-                    await expect(ArrayUtil.arrayContainsArray(list, allTasksName.slice(0, 10))).toEqual(true);
+                    expect(ArrayUtil.arrayContainsArray(list, allTasksName.slice(0, 10))).toEqual(true);
                 });
             await paginationPage.clickOnNextPage();
             currentPage++;
             await taskListSinglePage.taskList().getDataTable().waitTillContentLoaded();
-            await expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.ten);
-            await expect(await paginationPage.getPaginationRange()).toEqual('Showing 11-' + itemsPerPage.tenValue * currentPage + ' of ' + nrOfTasks);
-            await expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(itemsPerPage.tenValue);
+            expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.ten);
+            expect(await paginationPage.getPaginationRange()).toEqual('Showing 11-' + itemsPerPage.tenValue * currentPage + ' of ' + nrOfTasks);
+            expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(itemsPerPage.tenValue);
             await taskListSinglePage
                 .taskList()
                 .getAllRowsNameColumn('Name')
                 .then(async (list) => {
-                    await expect(ArrayUtil.arrayContainsArray(list, allTasksName.slice(10, 20))).toEqual(true);
+                    expect(ArrayUtil.arrayContainsArray(list, allTasksName.slice(10, 20))).toEqual(true);
                 });
         });
 
@@ -302,34 +298,32 @@ describe('Start Task - Custom App', () => {
             currentPage = 1;
             await taskListSinglePage.typeItemsPerPage(itemsPerPage.fifteenValue);
             await taskListSinglePage.taskList().getDataTable().waitTillContentLoaded();
-            await expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.fifteen);
-            await expect(await paginationPage.getPaginationRange()).toEqual(
-                'Showing 1-' + itemsPerPage.fifteenValue * currentPage + ' of ' + nrOfTasks
-            );
-            await expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(itemsPerPage.fifteenValue);
+            expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.fifteen);
+            expect(await paginationPage.getPaginationRange()).toEqual('Showing 1-' + itemsPerPage.fifteenValue * currentPage + ' of ' + nrOfTasks);
+            expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(itemsPerPage.fifteenValue);
             await taskListSinglePage
                 .taskList()
                 .getAllRowsNameColumn('Name')
                 .then(async (list) => {
-                    await expect(ArrayUtil.arrayContainsArray(list, allTasksName.slice(0, 15))).toEqual(true);
+                    expect(ArrayUtil.arrayContainsArray(list, allTasksName.slice(0, 15))).toEqual(true);
                 });
             currentPage++;
             await paginationPage.clickOnNextPage();
             await taskListSinglePage.taskList().getDataTable().waitTillContentLoaded();
-            await expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.fifteen);
-            await expect(await paginationPage.getPaginationRange()).toEqual('Showing 16-' + nrOfTasks + ' of ' + nrOfTasks);
-            await expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(nrOfTasks - itemsPerPage.fifteenValue);
+            expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.fifteen);
+            expect(await paginationPage.getPaginationRange()).toEqual('Showing 16-' + nrOfTasks + ' of ' + nrOfTasks);
+            expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(nrOfTasks - itemsPerPage.fifteenValue);
             await taskListSinglePage
                 .taskList()
                 .getAllRowsNameColumn('Name')
                 .then(async (list) => {
-                    await expect(ArrayUtil.arrayContainsArray(list, allTasksName.slice(15, 20))).toEqual(true);
+                    expect(ArrayUtil.arrayContainsArray(list, allTasksName.slice(15, 20))).toEqual(true);
                 });
         });
 
         it('[C286366] Pagination is not displayed when no task is displayed', async () => {
             await taskListSinglePage.typeAppId(secondAppRuntime.id.toString());
-            await expect(await taskListSinglePage.getAppId()).toEqual(secondAppRuntime.id.toString());
+            expect(await taskListSinglePage.getAppId()).toEqual(secondAppRuntime.id.toString());
 
             await taskListSinglePage.paginationPage().checkPaginationIsNotDisplayed();
         });
@@ -337,7 +331,7 @@ describe('Start Task - Custom App', () => {
         it('[C286406] Invalid values for items per page', async () => {
             await taskListSinglePage.typeItemsPerPage(0);
             await taskListSinglePage.clickAppId();
-            await expect(await taskListSinglePage.getItemsPerPageFieldErrorMessage()).toEqual('Value must be greater than or equal to 1');
+            expect(await taskListSinglePage.getItemsPerPageFieldErrorMessage()).toEqual('Value must be greater than or equal to 1');
         });
 
         it('[C286404] Navigate using page field', async () => {
@@ -348,18 +342,18 @@ describe('Start Task - Custom App', () => {
             await taskListSinglePage.typePage(currentPage);
             await taskListSinglePage.taskList().getDataTable().waitTillContentLoaded();
 
-            await expect(await paginationPage.getCurrentPage()).toEqual('Page ' + currentPage);
-            await expect(await paginationPage.getTotalPages()).toEqual(totalNrOfPages);
+            expect(await paginationPage.getCurrentPage()).toEqual('Page ' + currentPage);
+            expect(await paginationPage.getTotalPages()).toEqual(totalNrOfPages);
 
             await paginationPage.checkPageSelectorIsDisplayed();
 
-            await expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(itemsPerPage.fiveValue);
+            expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(itemsPerPage.fiveValue);
 
             await taskListSinglePage
                 .taskList()
                 .getAllRowsNameColumn('Name')
                 .then(async (list) => {
-                    await expect(ArrayUtil.arrayContainsArray(list, allTasksName.slice(0, 5))).toEqual(true);
+                    expect(ArrayUtil.arrayContainsArray(list, allTasksName.slice(0, 5))).toEqual(true);
                 });
 
             currentPage++;
@@ -367,60 +361,60 @@ describe('Start Task - Custom App', () => {
             await taskListSinglePage.typePage(currentPage);
             await taskListSinglePage.taskList().getDataTable().waitTillContentLoaded();
 
-            await expect(await paginationPage.getCurrentPage()).toEqual('Page ' + currentPage);
-            await expect(await paginationPage.getTotalPages()).toEqual(totalNrOfPages);
+            expect(await paginationPage.getCurrentPage()).toEqual('Page ' + currentPage);
+            expect(await paginationPage.getTotalPages()).toEqual(totalNrOfPages);
 
             await paginationPage.checkPageSelectorIsDisplayed();
 
-            await expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(itemsPerPage.fiveValue);
+            expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(itemsPerPage.fiveValue);
 
             await taskListSinglePage
                 .taskList()
                 .getAllRowsNameColumn('Name')
                 .then(async (list) => {
-                    await expect(ArrayUtil.arrayContainsArray(list, allTasksName.slice(5, 10))).toEqual(true);
+                    expect(ArrayUtil.arrayContainsArray(list, allTasksName.slice(5, 10))).toEqual(true);
                 });
 
             currentPage++;
             await taskListSinglePage.typePage(currentPage);
             await taskListSinglePage.taskList().getDataTable().waitTillContentLoaded();
 
-            await expect(await paginationPage.getCurrentPage()).toEqual('Page ' + currentPage);
-            await expect(await paginationPage.getTotalPages()).toEqual(totalNrOfPages);
+            expect(await paginationPage.getCurrentPage()).toEqual('Page ' + currentPage);
+            expect(await paginationPage.getTotalPages()).toEqual(totalNrOfPages);
 
             await paginationPage.checkPageSelectorIsDisplayed();
 
-            await expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(itemsPerPage.fiveValue);
+            expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(itemsPerPage.fiveValue);
             await taskListSinglePage
                 .taskList()
                 .getAllRowsNameColumn('Name')
                 .then(async (list) => {
-                    await expect(ArrayUtil.arrayContainsArray(list, allTasksName.slice(10, 15))).toEqual(true);
+                    expect(ArrayUtil.arrayContainsArray(list, allTasksName.slice(10, 15))).toEqual(true);
                 });
 
             currentPage++;
             await taskListSinglePage.typePage(currentPage);
             await taskListSinglePage.taskList().getDataTable().waitTillContentLoaded();
 
-            await expect(await paginationPage.getCurrentPage()).toEqual('Page ' + currentPage);
-            await expect(await paginationPage.getTotalPages()).toEqual(totalNrOfPages);
+            expect(await paginationPage.getCurrentPage()).toEqual('Page ' + currentPage);
+            expect(await paginationPage.getTotalPages()).toEqual(totalNrOfPages);
 
             await paginationPage.checkPageSelectorIsDisplayed();
 
-            await expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(itemsPerPage.fiveValue);
+            expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(itemsPerPage.fiveValue);
 
             await taskListSinglePage
                 .taskList()
                 .getAllRowsNameColumn('Name')
                 .then(async (list) => {
-                    await expect(ArrayUtil.arrayContainsArray(list, allTasksName.slice(15, 20))).toEqual(true);
+                    expect(ArrayUtil.arrayContainsArray(list, allTasksName.slice(15, 20))).toEqual(true);
                 });
         });
 
         it('[C286405] Type invalid values to page field', async () => {
             await taskListSinglePage.typePage(0);
             await taskListSinglePage.clickAppId();
-            await expect(await taskListSinglePage.getPageFieldErrorMessage()).toEqual('Value must be greater than or equal to 1');
+            expect(await taskListSinglePage.getPageFieldErrorMessage()).toEqual('Value must be greater than or equal to 1');
 
             await taskListSinglePage.clickResetButton();
             await taskListSinglePage.typePage(2);
@@ -430,7 +424,7 @@ describe('Start Task - Custom App', () => {
         it('[C286413] Task is displayed when typing into dueAfter field a date before the tasks due date', async () => {
             await taskListSinglePage.typeDueAfter(beforeDate);
             await taskListSinglePage.taskList().getDataTable().waitTillContentLoaded();
-            await expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(1);
+            expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(1);
         });
 
         it('[C286414] Task is not displayed when typing into dueAfter field a date after the task due date', async () => {
@@ -451,7 +445,7 @@ describe('Start Task - Custom App', () => {
         it('[C286425] Task is displayed when typing into dueBefore field a date after the task due date', async () => {
             await taskListSinglePage.typeDueBefore(afterDate);
             await taskListSinglePage.taskList().getDataTable().waitTillContentLoaded();
-            await expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(1);
+            expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(1);
         });
 
         it('[C286426] Task is not displayed when typing into dueBefore field the same date as tasks due date', async () => {
@@ -469,19 +463,19 @@ describe('Start Task - Custom App', () => {
             await taskListSinglePage.typeDueBefore(afterDate);
             await taskListSinglePage.typeDueAfter(beforeDate);
             await taskListSinglePage.taskList().getDataTable().waitTillContentLoaded();
-            await expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(1);
+            expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(1);
         });
 
         it('[C286429] Task is not displayed when typing into dueAfter field a date after the tasks due date and into dueBefore a date after', async () => {
             await taskListSinglePage.typeDueBefore(afterDate);
             await taskListSinglePage.typeDueAfter(afterDate);
             await taskListSinglePage.paginationPage().checkPaginationIsNotDisplayed();
-            await expect(await taskListSinglePage.taskList().getNoTasksFoundMessage()).toEqual(noTasksFoundMessage);
+            expect(await taskListSinglePage.taskList().getNoTasksFoundMessage()).toEqual(noTasksFoundMessage);
         });
 
         it('[C280515] Should be able to see only the tasks of a specific app when typing the apps id in the appId field', async () => {
             await taskListSinglePage.typeAppId(appRuntime.id.toString());
-            await expect(await taskListSinglePage.getAppId()).toEqual(appRuntime.id.toString());
+            expect(await taskListSinglePage.getAppId()).toEqual(appRuntime.id.toString());
 
             await taskListSinglePage.taskList().checkContentIsDisplayed(app.taskName, 'Name');
             await taskListSinglePage.taskList().checkContentIsDisplayed(app.taskName, 'Name');
@@ -490,41 +484,41 @@ describe('Start Task - Custom App', () => {
 
         it('[C280569] Should be able to see No tasks found when typing an invalid appId', async () => {
             await taskListSinglePage.typeAppId(invalidAppId);
-            await expect(await taskListSinglePage.getAppId()).toEqual(invalidAppId.toString());
+            expect(await taskListSinglePage.getAppId()).toEqual(invalidAppId.toString());
 
-            await expect(await taskListSinglePage.taskList().getNoTasksFoundMessage()).toEqual(noTasksFoundMessage);
+            expect(await taskListSinglePage.taskList().getNoTasksFoundMessage()).toEqual(noTasksFoundMessage);
         });
 
         it('[C280570] Should be able to see only the tasks with specific name when typing the name in the task name field', async () => {
             await taskListSinglePage.typeTaskName(paginationTasksName[13]);
-            await expect(await taskListSinglePage.getTaskName()).toEqual(paginationTasksName[13]);
+            expect(await taskListSinglePage.getTaskName()).toEqual(paginationTasksName[13]);
 
             await taskListSinglePage.taskList().checkContentIsDisplayed(paginationTasksName[13], 'Name');
-            await expect((await taskListSinglePage.taskList().getRowsDisplayedWithSameName(paginationTasksName[13], 'Name')).length).toBe(2);
+            expect((await taskListSinglePage.taskList().getRowsDisplayedWithSameName(paginationTasksName[13], 'Name')).length).toBe(2);
         });
 
         it('[C280571] Should be able to see No tasks found when typing a task name that does not exist', async () => {
             await taskListSinglePage.typeTaskName(invalidName);
-            await expect(await taskListSinglePage.getTaskName()).toEqual(invalidName);
+            expect(await taskListSinglePage.getTaskName()).toEqual(invalidName);
 
-            await expect(await taskListSinglePage.taskList().getNoTasksFoundMessage()).toEqual(noTasksFoundMessage);
+            expect(await taskListSinglePage.taskList().getNoTasksFoundMessage()).toEqual(noTasksFoundMessage);
         });
 
         it('[C280629] Should be able to see only the task with specific taskId when typing it in the task Id field', async () => {
             await taskListSinglePage.typeTaskId(taskWithDueDate.id);
             await taskListSinglePage.taskList().getDataTable().waitTillContentLoaded();
-            await expect(await taskListSinglePage.getTaskId()).toEqual(taskWithDueDate.id);
+            expect(await taskListSinglePage.getTaskId()).toEqual(taskWithDueDate.id);
 
             await taskListSinglePage.taskList().checkContentIsDisplayed(taskWithDueDate.name, 'Name');
-            await expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(1);
+            expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(1);
         });
 
         it('[C280630] Should be able to see No tasks found when typing an invalid taskId', async () => {
             await taskListSinglePage.typeTaskId(invalidTaskId);
 
-            await expect(await taskListSinglePage.getTaskId()).toEqual(invalidTaskId);
+            expect(await taskListSinglePage.getTaskId()).toEqual(invalidTaskId);
 
-            await expect(await taskListSinglePage.taskList().getNoTasksFoundMessage()).toEqual(noTasksFoundMessage);
+            expect(await taskListSinglePage.taskList().getNoTasksFoundMessage()).toEqual(noTasksFoundMessage);
         });
 
         it('[C286589] Should be able to see only completed tasks when choosing Completed from state drop down', async () => {
@@ -534,7 +528,7 @@ describe('Start Task - Custom App', () => {
             await taskListSinglePage.taskList().checkContentIsDisplayed(completedTasks[0].name, 'Name');
             await taskListSinglePage.taskList().checkContentIsDisplayed(completedTasks[1].name, 'Name');
             await taskListSinglePage.taskList().checkContentIsDisplayed(completedTasks[2].name, 'Name');
-            await expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(3);
+            expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(3);
         });
 
         it('[C286597] Should be able to see only running tasks when choosing Active from state drop down', async () => {
@@ -547,8 +541,8 @@ describe('Start Task - Custom App', () => {
 
             const list = await taskListSinglePage.taskList().getAllRowsNameColumn('Name');
 
-            await expect(ArrayUtil.arrayContainsArray(list, allTasksName)).toEqual(true);
-            await expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(20);
+            expect(ArrayUtil.arrayContainsArray(list, allTasksName)).toEqual(true);
+            expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(20);
         });
 
         it('[C286598] Should be able to see all tasks when choosing All from state drop down', async () => {
@@ -561,9 +555,9 @@ describe('Start Task - Custom App', () => {
             await taskListSinglePage.taskList().checkContentIsDisplayed(completedTasks[2].name, 'Name');
 
             const list = await taskListSinglePage.taskList().getAllRowsNameColumn('Name');
-            await expect(ArrayUtil.arrayContainsArray(list, allTasksName)).toEqual(true);
+            expect(ArrayUtil.arrayContainsArray(list, allTasksName)).toEqual(true);
 
-            await expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(23);
+            expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(23);
         });
     });
 
@@ -579,10 +573,10 @@ describe('Start Task - Custom App', () => {
         await taskListSinglePage.clickResetButton();
 
         await taskListSinglePage.typeProcessDefinitionId(processDefinitionId.processDefinitionId);
-        await expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(4);
+        expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(4);
 
         const list = await taskListSinglePage.getAllProcessDefinitionIds();
-        await expect(ArrayUtil.arrayContainsArray(list, processDefinitionIds)).toEqual(true);
+        expect(ArrayUtil.arrayContainsArray(list, processDefinitionIds)).toEqual(true);
     });
 
     it('[C286623] Should be able to see No tasks found when typing an invalid processDefinitionId', async () => {
@@ -591,7 +585,7 @@ describe('Start Task - Custom App', () => {
 
         await taskListSinglePage.typeProcessDefinitionId(invalidTaskId);
 
-        await expect(await taskListSinglePage.taskList().getNoTasksFoundMessage()).toEqual(noTasksFoundMessage);
+        expect(await taskListSinglePage.taskList().getNoTasksFoundMessage()).toEqual(noTasksFoundMessage);
     });
 
     it('[C286622] Should be able to see only tasks that are part of a specific process when processInstanceId is set', async () => {
@@ -602,11 +596,11 @@ describe('Start Task - Custom App', () => {
 
         await taskListSinglePage.typeProcessInstanceId(processDefinitionId.id);
         await taskListSinglePage.taskList().getDataTable().waitTillContentLoaded();
-        await expect(await taskListSinglePage.getProcessInstanceId()).toEqual(processDefinitionId.id);
+        expect(await taskListSinglePage.getProcessInstanceId()).toEqual(processDefinitionId.id);
 
-        await expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(1);
+        expect(await taskListSinglePage.taskList().getDataTable().numberOfRows()).toBe(1);
         const list = await taskListSinglePage.getAllProcessInstanceIds();
-        await expect(ArrayUtil.arrayContainsArray(list, processInstanceIds)).toEqual(true);
+        expect(ArrayUtil.arrayContainsArray(list, processInstanceIds)).toEqual(true);
     });
 
     it('[C286623] Should be able to see No tasks found when typing an invalid processInstanceId', async () => {
@@ -614,8 +608,8 @@ describe('Start Task - Custom App', () => {
         await taskListSinglePage.clickResetButton();
 
         await taskListSinglePage.typeProcessInstanceId(invalidTaskId);
-        await expect(await taskListSinglePage.getProcessInstanceId()).toEqual(invalidTaskId);
+        expect(await taskListSinglePage.getProcessInstanceId()).toEqual(invalidTaskId);
 
-        await expect(await taskListSinglePage.taskList().getNoTasksFoundMessage()).toEqual(noTasksFoundMessage);
+        expect(await taskListSinglePage.taskList().getNoTasksFoundMessage()).toEqual(noTasksFoundMessage);
     });
 });

--- a/e2e/process-services/tasks/info-drawer.e2e.ts
+++ b/e2e/process-services/tasks/info-drawer.e2e.ts
@@ -15,12 +15,14 @@
  * limitations under the License.
  */
 
-import { createApiService,
+import {
+    createApiService,
     ApplicationsUtil,
     BrowserActions,
     BrowserVisibility,
     LocalStorageUtil,
-    LoginPage, ModelsActions,
+    LoginPage,
+    ModelsActions,
     StringUtil,
     UserModel,
     UsersActions
@@ -36,7 +38,6 @@ import CONSTANTS = require('../../util/constants');
 import { DateFnsUtils } from '../../../lib/core/src/lib/common/utils/date-fns-utils';
 
 describe('Info Drawer', () => {
-
     const app = browser.params.resources.Files.SIMPLE_APP_WITH_USER_FORM;
     const loginPage = new LoginPage();
     const navigationBarPage = new NavigationBarPage();
@@ -107,7 +108,7 @@ describe('Info Drawer', () => {
         await taskPage.tasksListPage().selectRow(name);
 
         await taskPage.checkTaskTitle(name);
-        await expect(await taskPage.taskDetails().isAssigneeClickable()).toBeTruthy();
+        expect(await taskPage.taskDetails().isAssigneeClickable()).toBeTruthy();
         await shouldHaveInfoDrawerDetails({
             ...taskDetails,
             dueDate: date.header,
@@ -132,13 +133,13 @@ describe('Info Drawer', () => {
         await taskPage.tasksListPage().selectRow(name);
 
         await taskPage.checkTaskTitle(name);
-        await expect(await taskPage.taskDetails().getPriority()).toEqual(taskDetails.priority);
+        expect(await taskPage.taskDetails().getPriority()).toEqual(taskDetails.priority);
         await taskPage.taskDetails().updatePriority('40');
         await taskPage.taskDetails().checkTaskDetailsDisplayed();
-        await expect(await taskPage.taskDetails().getPriority()).toEqual('40');
+        expect(await taskPage.taskDetails().getPriority()).toEqual('40');
         await taskPage.taskDetails().updatePriority();
         await taskPage.taskDetails().checkTaskDetailsDisplayed();
-        await expect(await taskPage.taskDetails().getPriority()).toEqual('');
+        expect(await taskPage.taskDetails().getPriority()).toEqual('');
 
         await taskPage.taskDetails().clickCompleteFormTask();
     });
@@ -152,7 +153,7 @@ describe('Info Drawer', () => {
         await taskPage.tasksListPage().selectRow(name);
 
         await taskPage.checkTaskTitle(name);
-        await expect(await taskPage.taskDetails().isAssigneeClickable()).toBeTruthy();
+        expect(await taskPage.taskDetails().isAssigneeClickable()).toBeTruthy();
         await shouldHaveInfoDrawerDetails({
             ...taskDetails,
             dueDate: date.header,
@@ -161,7 +162,7 @@ describe('Info Drawer', () => {
         });
 
         await taskPage.taskDetails().updateDueDate();
-        await expect(await taskPage.taskDetails().getDueDate()).toEqual(DateFnsUtils.formatDate(new Date('Aug 1, 2017'), taskDetails.dateFormat));
+        expect(await taskPage.taskDetails().getDueDate()).toEqual(DateFnsUtils.formatDate(new Date('Aug 1, 2017'), taskDetails.dateFormat));
 
         await taskPage.taskDetails().clickCompleteFormTask();
 
@@ -218,7 +219,7 @@ describe('Info Drawer', () => {
             formName: app.formName
         });
 
-        await expect(await taskPage.taskDetails().isAssigneeClickable()).toBeTruthy();
+        expect(await taskPage.taskDetails().isAssigneeClickable()).toBeTruthy();
         await BrowserActions.click(taskPage.taskDetails().assigneeButton);
         const cancelSearch = element(by.css('button[id="close-people-search"]'));
         await BrowserVisibility.waitUntilElementIsPresent(cancelSearch);
@@ -231,7 +232,7 @@ describe('Info Drawer', () => {
             formName: app.formName
         });
 
-        await expect(await taskPage.taskDetails().isAssigneeClickable()).toBeTruthy();
+        expect(await taskPage.taskDetails().isAssigneeClickable()).toBeTruthy();
         await BrowserActions.click(taskPage.taskDetails().assigneeButton);
         const addPeople = element(by.css('button[id="add-people"]'));
         await BrowserVisibility.waitUntilElementIsPresent(addPeople);
@@ -301,7 +302,7 @@ describe('Info Drawer', () => {
         await taskPage.checkTaskTitle(name);
         await taskPage.taskDetails().checkTaskDetailsDisplayed();
         await browser.sleep(2000);
-        await expect(await taskPage.taskDetails().isAssigneeClickable()).toBeTruthy();
+        expect(await taskPage.taskDetails().isAssigneeClickable()).toBeTruthy();
         await shouldHaveInfoDrawerDetails({
             ...taskDetails,
             dueDate: 'Aug 12, 2017',
@@ -310,9 +311,9 @@ describe('Info Drawer', () => {
         });
 
         await taskPage.taskDetails().updateDescription('');
-        await expect(await taskPage.taskDetails().getDescriptionPlaceholder()).toEqual('No description');
+        expect(await taskPage.taskDetails().getDescriptionPlaceholder()).toEqual('No description');
         await taskPage.taskDetails().updateDescription('Good Bye');
-        await expect(await taskPage.taskDetails().getDescription()).toEqual('Good Bye');
+        expect(await taskPage.taskDetails().getDescription()).toEqual('Good Bye');
 
         await taskPage.taskDetails().clickCompleteFormTask();
     });
@@ -328,10 +329,10 @@ describe('Info Drawer', () => {
         await taskPage.tasksListPage().selectRow(name);
 
         await taskPage.checkTaskTitle(name);
-        await expect(await taskPage.taskDetails().getAssignee()).toEqual(processUserModelFullName);
-        await expect(await taskPage.taskDetails().getStatus()).toEqual(taskDetails.status);
-        await expect(await taskPage.taskDetails().getPriority()).toEqual(taskDetails.priority);
-        await expect(await taskPage.taskDetails().getParentName()).toEqual(taskDetails.parentName);
+        expect(await taskPage.taskDetails().getAssignee()).toEqual(processUserModelFullName);
+        expect(await taskPage.taskDetails().getStatus()).toEqual(taskDetails.status);
+        expect(await taskPage.taskDetails().getPriority()).toEqual(taskDetails.priority);
+        expect(await taskPage.taskDetails().getParentName()).toEqual(taskDetails.parentName);
         await taskPage.taskDetails().checkDueDatePickerButtonIsNotDisplayed();
 
         await taskPage.taskDetails().clickCompleteFormTask();
@@ -355,14 +356,16 @@ describe('Info Drawer', () => {
      * @param props task details properties to validate
      */
     async function shouldHaveInfoDrawerDetails(props: TaskDetailsProps) {
-        await expect(await taskPage.taskDetails().getAssignee()).toEqual(props.fullName);
-        await expect(await taskPage.taskDetails().getDescription()).toEqual(props.description);
-        await expect(await taskPage.taskDetails().getStatus()).toEqual(props.status);
-        await expect(await taskPage.taskDetails().getPriority()).toEqual(props.priority);
-        await expect(await taskPage.taskDetails().getDueDate()).toEqual(props.dueDate !== 'No date' ? DateFnsUtils.formatDate(new Date(props.dueDate), props.dateFormat) : 'No date');
-        await expect(await taskPage.taskDetails().getCategory()).toEqual(props.category);
-        await expect(await taskPage.taskDetails().getParentName()).toEqual(props.parentName);
-        await expect(await taskPage.taskDetails().getCreated()).toEqual(DateFnsUtils.formatDate(new Date().getTime(), props.dateFormat));
+        expect(await taskPage.taskDetails().getAssignee()).toEqual(props.fullName);
+        expect(await taskPage.taskDetails().getDescription()).toEqual(props.description);
+        expect(await taskPage.taskDetails().getStatus()).toEqual(props.status);
+        expect(await taskPage.taskDetails().getPriority()).toEqual(props.priority);
+        expect(await taskPage.taskDetails().getDueDate()).toEqual(
+            props.dueDate !== 'No date' ? DateFnsUtils.formatDate(new Date(props.dueDate), props.dateFormat) : 'No date'
+        );
+        expect(await taskPage.taskDetails().getCategory()).toEqual(props.category);
+        expect(await taskPage.taskDetails().getParentName()).toEqual(props.parentName);
+        expect(await taskPage.taskDetails().getCreated()).toEqual(DateFnsUtils.formatDate(new Date().getTime(), props.dateFormat));
         await taskPage.taskDetails().waitFormNameEqual(props.formName);
     }
 });

--- a/e2e/process-services/tasks/pagination-tasklist-adding-tasks.e2e.ts
+++ b/e2e/process-services/tasks/pagination-tasklist-adding-tasks.e2e.ts
@@ -15,20 +15,13 @@
  * limitations under the License.
  */
 
-import { createApiService,
-    ApplicationsUtil,
-    LoginPage,
-    PaginationPage,
-    ProcessUtil,
-    UsersActions
-} from '@alfresco/adf-testing';
+import { createApiService, ApplicationsUtil, LoginPage, PaginationPage, ProcessUtil, UsersActions } from '@alfresco/adf-testing';
 import { browser } from 'protractor';
 import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
 import { TasksPage } from './../pages/tasks.page';
 import CONSTANTS = require('../../util/constants');
 
 describe('Items per page set to 15 and adding of tasks', () => {
-
     const app = browser.params.resources.Files.SIMPLE_APP_WITH_USER_FORM;
 
     const loginPage = new LoginPage();
@@ -61,12 +54,12 @@ describe('Items per page set to 15 and adding of tasks', () => {
         resultApp = await applicationsService.importPublishDeployApp(app.file_path);
 
         const processUtil = new ProcessUtil(apiService);
-        for (i = 0; i < (nrOfTasks - 5); i++) {
+        for (i = 0; i < nrOfTasks - 5; i++) {
             await processUtil.startProcessOfApp(resultApp.name);
         }
 
         await loginPage.login(processUserModel.username, processUserModel.password);
-   });
+    });
 
     it('[C260306] Items per page set to 15 and adding of tasks', async () => {
         await (await new NavigationBarPage().navigateToProcessServicesPage()).goToTaskApp();
@@ -75,11 +68,11 @@ describe('Items per page set to 15 and adding of tasks', () => {
         await paginationPage.selectItemsPerPage(itemsPerPage.fifteen);
         await taskPage.tasksListPage().getDataTable().waitTillContentLoaded();
 
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.fifteen);
-        await expect(await paginationPage.getCurrentPage()).toEqual('Page ' + currentPage);
-        await expect(await paginationPage.getTotalPages()).toEqual('of ' + totalPages);
-        await expect(await paginationPage.getPaginationRange()).toEqual('Showing 1-' + itemsPerPage.fifteenValue + ' of ' + (nrOfTasks - 5));
-        await expect(await taskPage.tasksListPage().getDataTable().numberOfRows()).toBe(itemsPerPage.fifteenValue);
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.fifteen);
+        expect(await paginationPage.getCurrentPage()).toEqual('Page ' + currentPage);
+        expect(await paginationPage.getTotalPages()).toEqual('of ' + totalPages);
+        expect(await paginationPage.getPaginationRange()).toEqual('Showing 1-' + itemsPerPage.fifteenValue + ' of ' + (nrOfTasks - 5));
+        expect(await taskPage.tasksListPage().getDataTable().numberOfRows()).toBe(itemsPerPage.fifteenValue);
 
         const processUtil = new ProcessUtil(apiService);
         for (i; i < nrOfTasks; i++) {
@@ -90,11 +83,11 @@ describe('Items per page set to 15 and adding of tasks', () => {
         await paginationPage.clickOnNextPage();
         await taskPage.tasksListPage().getDataTable().waitTillContentLoaded();
 
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.fifteen);
-        await expect(await paginationPage.getCurrentPage()).toEqual('Page ' + currentPage);
-        await expect(await paginationPage.getTotalPages()).toEqual('of ' + totalPages);
-        await expect(await paginationPage.getPaginationRange()).toEqual('Showing 16-' + nrOfTasks + ' of ' + nrOfTasks);
-        await expect(await taskPage.tasksListPage().getDataTable().numberOfRows()).toBe(nrOfTasks - itemsPerPage.fifteenValue);
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.fifteen);
+        expect(await paginationPage.getCurrentPage()).toEqual('Page ' + currentPage);
+        expect(await paginationPage.getTotalPages()).toEqual('of ' + totalPages);
+        expect(await paginationPage.getPaginationRange()).toEqual('Showing 16-' + nrOfTasks + ' of ' + nrOfTasks);
+        expect(await taskPage.tasksListPage().getDataTable().numberOfRows()).toBe(nrOfTasks - itemsPerPage.fifteenValue);
         await paginationPage.checkNextPageButtonIsDisabled();
         await paginationPage.checkPreviousPageButtonIsEnabled();
     });

--- a/e2e/process-services/tasks/sort-tasklist-pagination.e2e.ts
+++ b/e2e/process-services/tasks/sort-tasklist-pagination.e2e.ts
@@ -71,11 +71,11 @@ describe('Task List Pagination - Sorting', () => {
         await taskPage.filtersPage().sortByName('ASC');
         await taskPage.tasksListPage().getDataTable().waitForTableBody();
         const listAsc = await taskPage.filtersPage().getAllRowsNameColumn();
-        await expect(JSON.stringify(listAsc) === JSON.stringify(taskNames)).toEqual(true);
+        expect(JSON.stringify(listAsc) === JSON.stringify(taskNames)).toEqual(true);
         await taskPage.filtersPage().sortByName('DESC');
         const listDesc = await taskPage.filtersPage().getAllRowsNameColumn();
 
         taskNames.reverse();
-        await expect(JSON.stringify(listDesc) === JSON.stringify(taskNames)).toEqual(true);
+        expect(JSON.stringify(listDesc) === JSON.stringify(taskNames)).toEqual(true);
     });
 });

--- a/e2e/process-services/tasks/standalone-task.e2e.ts
+++ b/e2e/process-services/tasks/standalone-task.e2e.ts
@@ -17,14 +17,7 @@
 
 import { browser } from 'protractor';
 
-import {
-    ApplicationsUtil,
-    BrowserVisibility,
-    createApiService,
-    LoginPage, UserModel,
-    UsersActions,
-    Widget
-} from '@alfresco/adf-testing';
+import { ApplicationsUtil, BrowserVisibility, createApiService, LoginPage, UserModel, UsersActions, Widget } from '@alfresco/adf-testing';
 import { TasksPage } from '../pages/tasks.page';
 import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
 import { TaskActionsApi, TasksApi } from '@alfresco/js-api';
@@ -32,7 +25,6 @@ import CONSTANTS = require('../../util/constants');
 import Task = require('../../models/APS/Task');
 
 describe('Start Task - Task App', () => {
-
     const app = browser.params.resources.Files.SIMPLE_APP_WITH_USER_FORM;
 
     const loginPage = new LoginPage();
@@ -64,7 +56,7 @@ describe('Start Task - Task App', () => {
         await taskPage.filtersPage().goToFilter(CONSTANTS.TASK_FILTERS.MY_TASKS);
     });
 
-    afterEach( async () => {
+    afterEach(async () => {
         await navigationBarPage.clickLogoutButton();
     });
 
@@ -81,7 +73,7 @@ describe('Start Task - Task App', () => {
         await taskPage.taskDetails().checkAttachFormButtonIsDisplayed();
         await taskPage.taskDetails().checkAttachFormButtonIsEnabled();
         await taskPage.taskDetails().waitFormNameEqual(CONSTANTS.TASK_DETAILS.NO_FORM);
-        await expect(await taskDetails.getNoFormMessage()).toEqual('No forms attached');
+        expect(await taskDetails.getNoFormMessage()).toEqual('No forms attached');
     });
 
     it('[C268910] Should a standalone task be displayed in completed tasks when completing it', async () => {
@@ -95,7 +87,7 @@ describe('Start Task - Task App', () => {
         await taskPage.completeTaskNoForm();
         await taskPage.filtersPage().goToFilter(CONSTANTS.TASK_FILTERS.COMPLETED_TASKS);
         await taskPage.tasksListPage().selectRow('Completed standalone task');
-        await expect(await taskPage.formFields().getCompletedTaskNoFormMessage()).toEqual('Task ' + 'Completed standalone task' + ' completed');
+        expect(await taskPage.formFields().getCompletedTaskNoFormMessage()).toEqual('Task ' + 'Completed standalone task' + ' completed');
 
         await taskPage.formFields().noFormIsDisplayed();
         await taskPage.taskDetails().waitFormNameEqual(CONSTANTS.TASK_DETAILS.NO_FORM);
@@ -139,7 +131,7 @@ describe('Start Task - Task App', () => {
 
         await taskPage.formFields().noFormIsDisplayed();
         await taskPage.taskDetails().waitFormNameEqual(CONSTANTS.TASK_DETAILS.NO_FORM);
-        await expect(await taskDetails.getNoFormMessage()).toEqual('No forms attached');
+        expect(await taskDetails.getNoFormMessage()).toEqual('No forms attached');
     });
 
     it('[C329799] Form actions are enabled in assigned task', async () => {
@@ -164,8 +156,8 @@ describe('Start Task - Task App', () => {
         await widget.textWidget().isWidgetVisible(app.form_fields.form_fieldId);
         await widget.textWidget().setValue(app.form_fields.form_fieldId, 'value');
 
-        await expect(await taskPage.formFields().isSaveFormButtonEnabled()).toEqual(true);
-        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
+        expect(await taskPage.formFields().isSaveFormButtonEnabled()).toEqual(true);
+        expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
         await taskPage.formFields().completeForm();
 
         await taskPage.filtersPage().goToFilter(CONSTANTS.TASK_FILTERS.COMPLETED_TASKS);
@@ -173,9 +165,9 @@ describe('Start Task - Task App', () => {
         await taskPage.tasksListPage().selectRow(taskName);
         await taskPage.formFields().checkFormIsDisplayed();
 
-        await expect(await widget.textWidget().getFieldValue(app.form_fields.form_fieldId)).toEqual('value');
+        expect(await widget.textWidget().getFieldValue(app.form_fields.form_fieldId)).toEqual('value');
 
         await BrowserVisibility.waitUntilElementIsNotVisible(await taskPage.formFields().saveButton);
-        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
+        expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
     });
 });

--- a/e2e/process-services/tasks/start-task-custom-app.e2e.ts
+++ b/e2e/process-services/tasks/start-task-custom-app.e2e.ts
@@ -83,7 +83,7 @@ describe('Start Task - Custom App', () => {
 
         await taskDetails.clickAddInvolvedUserButton();
 
-        await expect(await taskPage.taskDetails().getInvolvedUserEmail(assigneeUserModel.firstName + ' ' + assigneeUserModel.lastName)).toEqual(
+        expect(await taskPage.taskDetails().getInvolvedUserEmail(assigneeUserModel.firstName + ' ' + assigneeUserModel.lastName)).toEqual(
             assigneeUserModel.email
         );
 
@@ -135,7 +135,7 @@ describe('Start Task - Custom App', () => {
 
         await taskPage.tasksListPage().checkContentIsNotDisplayed(tasks[3]);
 
-        await expect(await taskPage.filtersPage().getActiveFilter()).toEqual(CONSTANTS.TASK_FILTERS.MY_TASKS);
+        expect(await taskPage.filtersPage().getActiveFilter()).toEqual(CONSTANTS.TASK_FILTERS.MY_TASKS);
     });
 
     it('[C263949] Should be possible to save filled form', async () => {
@@ -182,7 +182,7 @@ describe('Start Task - Custom App', () => {
 
         await taskPage.checkTaskTitle(tasks[5]);
 
-        await expect(await taskPage.taskDetails().getAssignee()).toEqual(assigneeUserModel.firstName + ' ' + assigneeUserModel.lastName);
+        expect(await taskPage.taskDetails().getAssignee()).toEqual(assigneeUserModel.firstName + ' ' + assigneeUserModel.lastName);
     });
 
     it('Attach a file', async () => {

--- a/e2e/process-services/tasks/start-task-task-app.e2e.ts
+++ b/e2e/process-services/tasks/start-task-task-app.e2e.ts
@@ -15,14 +15,7 @@
  * limitations under the License.
  */
 
-import { createApiService,
-    ApplicationsUtil,
-    LoginPage,
-    StringUtil,
-    TaskUtil,
-    UserModel,
-    UsersActions
-} from '@alfresco/adf-testing';
+import { createApiService, ApplicationsUtil, LoginPage, StringUtil, TaskUtil, UserModel, UsersActions } from '@alfresco/adf-testing';
 import { browser } from 'protractor';
 import { FileModel } from '../../models/ACS/file.model';
 import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
@@ -89,8 +82,9 @@ describe('Start Task - Task App', () => {
 
         await taskPage.taskDetails().clickAddInvolvedUserButton();
 
-        await expect(await taskPage.taskDetails().getInvolvedUserEmail(assigneeUserModel.firstName + ' ' + assigneeUserModel.lastName))
-            .toEqual(assigneeUserModel.email);
+        expect(await taskPage.taskDetails().getInvolvedUserEmail(assigneeUserModel.firstName + ' ' + assigneeUserModel.lastName)).toEqual(
+            assigneeUserModel.email
+        );
 
         await taskDetails.selectActivityTab();
         const firstComment = 'comm1';
@@ -115,7 +109,7 @@ describe('Start Task - Task App', () => {
         await task.clickCancelButton();
 
         await taskPage.tasksListPage().checkContentIsNotDisplayed(tasks[3]);
-        await expect(await taskPage.filtersPage().getActiveFilter()).toEqual(CONSTANTS.TASK_FILTERS.MY_TASKS);
+        expect(await taskPage.filtersPage().getActiveFilter()).toEqual(CONSTANTS.TASK_FILTERS.MY_TASKS);
     });
 
     it('[C260423] Should be possible to save filled form', async () => {
@@ -153,7 +147,7 @@ describe('Start Task - Task App', () => {
         await taskPage.tasksListPage().checkContentIsDisplayed(tasks[5]);
         await taskPage.tasksListPage().selectRow(tasks[5]);
         await taskPage.checkTaskTitle(tasks[5]);
-        await expect(await taskPage.taskDetails().getAssignee()).toEqual(assigneeUserModel.firstName + ' ' + assigneeUserModel.lastName);
+        expect(await taskPage.taskDetails().getAssignee()).toEqual(assigneeUserModel.firstName + ' ' + assigneeUserModel.lastName);
     });
 
     it('Attach a file', async () => {

--- a/e2e/process-services/tasks/task-assignee.e2e.ts
+++ b/e2e/process-services/tasks/task-assignee.e2e.ts
@@ -15,14 +15,7 @@
  * limitations under the License.
  */
 
-import { createApiService,
-    ApplicationsUtil,
-    LoginPage,
-    ProcessUtil,
-    StartProcessPage,
-    UserModel,
-    UsersActions
-} from '@alfresco/adf-testing';
+import { createApiService, ApplicationsUtil, LoginPage, ProcessUtil, StartProcessPage, UserModel, UsersActions } from '@alfresco/adf-testing';
 import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
 import { ProcessServicesPage } from './../pages/process-services.page';
 import { ProcessFiltersPage } from './../pages/process-filters.page';
@@ -35,7 +28,6 @@ import CONSTANTS = require('../../util/constants');
 import { AdminGroupsApi } from '@alfresco/js-api';
 
 describe('Task Assignee', () => {
-
     const app = browser.params.resources.Files.TEST_ASSIGNEE;
 
     const loginPage = new LoginPage();
@@ -54,18 +46,20 @@ describe('Task Assignee', () => {
     const adminGroupsApi = new AdminGroupsApi(apiService.getInstance());
 
     describe('Candidate User Assignee', () => {
-
         let user: UserModel;
 
         beforeAll(async () => {
             await apiService.loginWithProfile('admin');
 
-            user = await usersActions.createUser(new UserModel({
-                firstName: app.candidate.firstName,
-                lastName: app.candidate.lastName
-            }));
+            user = await usersActions.createUser(
+                new UserModel({
+                    firstName: app.candidate.firstName,
+                    lastName: app.candidate.lastName
+                })
+            );
 
-            try {// creates group if not available
+            try {
+                // creates group if not available
                 await adminGroupsApi.createNewGroup({
                     name: app.candidateGroup,
                     tenantId: user.tenantId,
@@ -94,7 +88,7 @@ describe('Task Assignee', () => {
             const name = 'sample-process-one';
             await processServicesPage.goToApp(app.title);
             await processServiceTabBarPage.clickProcessButton();
-            await expect(await processListPage.isProcessListDisplayed()).toEqual(true);
+            expect(await processListPage.isProcessListDisplayed()).toEqual(true);
             await processFiltersPage.clickCreateProcessButton();
             await processFiltersPage.clickNewProcessDropdown();
             await startProcessPage.startProcess(name, app.processNames[0]);
@@ -132,30 +126,28 @@ describe('Task Assignee', () => {
             candidate1 = await usersActions.createUser(new UserModel({ tenantId: user.tenantId }));
             candidate2 = await usersActions.createUser(new UserModel({ tenantId: user.tenantId }));
 
-            const adminGroup = await adminGroupsApi.createNewGroup(
-                { name: app.adminGroup, tenantId: user.tenantId }
-            );
+            const adminGroup = await adminGroupsApi.createNewGroup({ name: app.adminGroup, tenantId: user.tenantId });
 
             await adminGroupsApi.addGroupMember(adminGroup.id, user.id);
 
             await adminGroupsApi.addGroupCapabilities(adminGroup.id, { capabilities: app.adminCapabilities });
 
-            const candidateGroup = await adminGroupsApi.createNewGroup(
-                { name: app.candidateGroup, tenantId: user.tenantId, type: 1 }
-            );
+            const candidateGroup = await adminGroupsApi.createNewGroup({ name: app.candidateGroup, tenantId: user.tenantId, type: 1 });
 
             await adminGroupsApi.addGroupMember(candidateGroup.id, candidate1.id);
             await adminGroupsApi.addGroupMember(candidateGroup.id, candidate2.id);
             await adminGroupsApi.addGroupMember(candidateGroup.id, user.id);
 
-            try {// for creates user if not available
-                await usersActions.createUser(new UserModel({
-                    tenantId: user.tenantId,
-                    firstName: app.candidate.firstName,
-                    lastName: app.candidate.lastName
-                }));
-            } catch (e) {
-            }
+            try {
+                // for creates user if not available
+                await usersActions.createUser(
+                    new UserModel({
+                        tenantId: user.tenantId,
+                        firstName: app.candidate.firstName,
+                        lastName: app.candidate.lastName
+                    })
+                );
+            } catch (e) {}
 
             await apiService.login(user.username, user.password);
             const appModel = await applicationsService.importPublishDeployApp(app.file_path, { renewIdmEntries: true });

--- a/e2e/process-services/tasks/task-audit.e2e.ts
+++ b/e2e/process-services/tasks/task-audit.e2e.ts
@@ -87,7 +87,7 @@ describe('Task Audit', () => {
         await taskPage.completeTaskNoForm();
         await taskPage.filtersPage().goToFilter(CONSTANTS.TASK_FILTERS.COMPLETED_TASKS);
         await taskPage.tasksListPage().selectRow(taskTaskApp);
-        await expect(await taskPage.formFields().getCompletedTaskNoFormMessage()).toEqual('Task ' + taskTaskApp + ' completed');
+        expect(await taskPage.formFields().getCompletedTaskNoFormMessage()).toEqual('Task ' + taskTaskApp + ' completed');
 
         await taskPage.taskDetails().clickAuditLogButton();
         await FileBrowserUtil.isFileDownloaded(auditLogFile);
@@ -105,7 +105,7 @@ describe('Task Audit', () => {
         await taskPage.completeTaskNoForm();
         await taskPage.filtersPage().goToFilter(CONSTANTS.TASK_FILTERS.COMPLETED_TASKS);
         await taskPage.tasksListPage().selectRow(taskCompleteCustomApp);
-        await expect(await taskPage.formFields().getCompletedTaskNoFormMessage()).toEqual('Task ' + taskCompleteCustomApp + ' completed');
+        expect(await taskPage.formFields().getCompletedTaskNoFormMessage()).toEqual('Task ' + taskCompleteCustomApp + ' completed');
 
         await taskPage.taskDetails().clickAuditLogButton();
         await FileBrowserUtil.isFileDownloaded(auditLogFile);

--- a/e2e/process-services/tasks/task-details-form.e2e.ts
+++ b/e2e/process-services/tasks/task-details-form.e2e.ts
@@ -272,7 +272,7 @@ describe('Task Details - Form', () => {
             await widget.tab().clickTabByLabel(tab.tabFieldField);
             await widget.textWidget().setValue(widgets.numberOneId, value.displayTab);
 
-            await expect(await taskDetailsPage.isCompleteButtonWithFormEnabled()).toEqual(false);
+            expect(await taskDetailsPage.isCompleteButtonWithFormEnabled()).toEqual(false);
         });
 
         it('[C315193] Should be able to complete a standalone task with invisible tab with invalid value for field', async () => {
@@ -371,7 +371,7 @@ describe('Task Details - Form', () => {
             await tasksListPage.checkTaskListIsLoaded();
 
             await tasksListPage.selectRow(app.visibilityProcess.taskName);
-            await expect(await taskDetailsPage.getParentName()).toEqual(app.visibilityProcess.name);
+            expect(await taskDetailsPage.getParentName()).toEqual(app.visibilityProcess.name);
 
             await widget.tab().checkTabIsDisplayedByLabel(tab.tabWithFields);
             await widget.tab().checkTabIsDisplayedByLabel(tab.tabFieldField);
@@ -405,7 +405,7 @@ describe('Task Details - Form', () => {
             await tasksListPage.checkTaskListIsLoaded();
 
             await tasksListPage.selectRow(app.taskName);
-            await expect(await taskDetailsPage.getParentName()).toEqual(app.processName);
+            expect(await taskDetailsPage.getParentName()).toEqual(app.processName);
 
             await widget.textWidget().isWidgetVisible(app.form_fields.form_fieldId);
             await widget.textWidget().setValue(app.form_fields.form_fieldId, 'value');
@@ -413,7 +413,7 @@ describe('Task Details - Form', () => {
             await taskPage.formFields().refreshForm();
 
             await widget.textWidget().isWidgetVisible(app.form_fields.form_fieldId);
-            await expect(await widget.textWidget().getFieldValue(app.form_fields.form_fieldId)).toEqual('');
+            expect(await widget.textWidget().getFieldValue(app.form_fields.form_fieldId)).toEqual('');
 
             await widget.textWidget().setValue(app.form_fields.form_fieldId, 'value');
             await taskPage.taskDetails().saveTaskForm();
@@ -423,7 +423,7 @@ describe('Task Details - Form', () => {
 
             await filtersPage.goToFilter(CONSTANTS.TASK_FILTERS.MY_TASKS);
             await tasksListPage.checkTaskListIsLoaded();
-            await expect(await widget.textWidget().getFieldValue(app.form_fields.form_fieldId)).toEqual('value');
+            expect(await widget.textWidget().getFieldValue(app.form_fields.form_fieldId)).toEqual('value');
 
             await taskDetailsPage.clickCompleteFormTask();
         });

--- a/e2e/process-services/tasks/task-details-no-form.e2e.ts
+++ b/e2e/process-services/tasks/task-details-no-form.e2e.ts
@@ -64,6 +64,6 @@ describe('Task Details - No form', () => {
         await taskPage.taskDetails().waitFormNameEqual(CONSTANTS.TASK_DETAILS.NO_FORM);
 
         const noFormMessage = 'No forms attached';
-        await expect(await taskPage.formFields().getNoFormMessage()).toEqual(noFormMessage);
+        expect(await taskPage.formFields().getNoFormMessage()).toEqual(noFormMessage);
     });
 });

--- a/e2e/process-services/tasks/task-details.e2e.ts
+++ b/e2e/process-services/tasks/task-details.e2e.ts
@@ -90,23 +90,23 @@ describe('Task Details component', () => {
         await taskPage.filtersPage().goToFilter(CONSTANTS.TASK_FILTERS.MY_TASKS);
 
         await taskPage.createTask({ name: tasks[1], description: 'Description', formName: app.formName });
-        await expect(await taskPage.taskDetails().getTitle()).toEqual('Activities');
+        expect(await taskPage.taskDetails().getTitle()).toEqual('Activities');
 
         const allTasks = await tasksApi.listTasks(new Task({ sort: 'created-desc' }));
 
         const taskModel = new TaskModel(allTasks.data[0]);
         await taskPage.tasksListPage().checkContentIsDisplayed(taskModel.getName());
-        await expect(await taskPage.taskDetails().getCreated()).toEqual(format(new Date(taskModel.getCreated()), TASK_DATE_FORMAT));
-        await expect(await taskPage.taskDetails().getId()).toEqual(taskModel.getId());
-        await expect(await taskPage.taskDetails().getDescription()).toEqual(taskModel.getDescription());
-        await expect(await taskPage.taskDetails().getAssignee()).toEqual(taskModel.getAssignee().getEntireName());
-        await expect(await taskPage.taskDetails().getCategory()).toEqual(CONSTANTS.TASK_DETAILS.NO_CATEGORY);
-        await expect(await taskPage.taskDetails().getDueDate()).toEqual(CONSTANTS.TASK_DETAILS.NO_DATE);
-        await expect(await taskPage.taskDetails().getParentName()).toEqual(CONSTANTS.TASK_DETAILS.NO_PARENT);
-        await expect(await taskPage.taskDetails().getParentTaskId()).toEqual('');
-        await expect(await taskPage.taskDetails().getDuration()).toEqual('');
-        await expect(await taskPage.taskDetails().getEndDate()).toEqual('');
-        await expect(await taskPage.taskDetails().getStatus()).toEqual(CONSTANTS.TASK_STATUS.RUNNING);
+        expect(await taskPage.taskDetails().getCreated()).toEqual(format(new Date(taskModel.getCreated()), TASK_DATE_FORMAT));
+        expect(await taskPage.taskDetails().getId()).toEqual(taskModel.getId());
+        expect(await taskPage.taskDetails().getDescription()).toEqual(taskModel.getDescription());
+        expect(await taskPage.taskDetails().getAssignee()).toEqual(taskModel.getAssignee().getEntireName());
+        expect(await taskPage.taskDetails().getCategory()).toEqual(CONSTANTS.TASK_DETAILS.NO_CATEGORY);
+        expect(await taskPage.taskDetails().getDueDate()).toEqual(CONSTANTS.TASK_DETAILS.NO_DATE);
+        expect(await taskPage.taskDetails().getParentName()).toEqual(CONSTANTS.TASK_DETAILS.NO_PARENT);
+        expect(await taskPage.taskDetails().getParentTaskId()).toEqual('');
+        expect(await taskPage.taskDetails().getDuration()).toEqual('');
+        expect(await taskPage.taskDetails().getEndDate()).toEqual('');
+        expect(await taskPage.taskDetails().getStatus()).toEqual(CONSTANTS.TASK_STATUS.RUNNING);
 
         const taskForm = await taskFormsApi.getTaskForm(allTasks.data[0].id);
         formModel = new FormModel(taskForm);
@@ -119,25 +119,25 @@ describe('Task Details component', () => {
 
         await taskPage.filtersPage().goToFilter(CONSTANTS.TASK_FILTERS.MY_TASKS);
         await taskPage.createTask({ name: tasks[1], description: 'Description', formName: app.formName });
-        await expect(await taskPage.taskDetails().getTitle()).toEqual('Activities');
+        expect(await taskPage.taskDetails().getTitle()).toEqual('Activities');
 
         const allTasks = await tasksApi.listTasks(new Task({ sort: 'created-desc' }));
 
         const taskModel = new TaskModel(allTasks.data[0]);
         await taskPage.tasksListPage().checkContentIsDisplayed(taskModel.getName());
 
-        await expect(await taskPage.taskDetails().getCreated()).toEqual(format(new Date(taskModel.getCreated()), TASK_DATE_FORMAT));
-        await expect(await taskPage.taskDetails().getId()).toEqual(taskModel.getId());
-        await expect(await taskPage.taskDetails().getDescription()).toEqual(taskModel.getDescription());
-        await expect(await taskPage.taskDetails().getAssignee()).toEqual(taskModel.getAssignee().getEntireName());
+        expect(await taskPage.taskDetails().getCreated()).toEqual(format(new Date(taskModel.getCreated()), TASK_DATE_FORMAT));
+        expect(await taskPage.taskDetails().getId()).toEqual(taskModel.getId());
+        expect(await taskPage.taskDetails().getDescription()).toEqual(taskModel.getDescription());
+        expect(await taskPage.taskDetails().getAssignee()).toEqual(taskModel.getAssignee().getEntireName());
 
-        await expect(await taskPage.taskDetails().getCategory()).toEqual(CONSTANTS.TASK_DETAILS.NO_CATEGORY);
-        await expect(await taskPage.taskDetails().getDueDate()).toEqual(CONSTANTS.TASK_DETAILS.NO_DATE);
-        await expect(await taskPage.taskDetails().getParentName()).toEqual(CONSTANTS.TASK_DETAILS.NO_PARENT);
-        await expect(await taskPage.taskDetails().getDuration()).toEqual('');
-        await expect(await taskPage.taskDetails().getEndDate()).toEqual('');
-        await expect(await taskPage.taskDetails().getParentTaskId()).toEqual('');
-        await expect(await taskPage.taskDetails().getStatus()).toEqual(CONSTANTS.TASK_STATUS.RUNNING);
+        expect(await taskPage.taskDetails().getCategory()).toEqual(CONSTANTS.TASK_DETAILS.NO_CATEGORY);
+        expect(await taskPage.taskDetails().getDueDate()).toEqual(CONSTANTS.TASK_DETAILS.NO_DATE);
+        expect(await taskPage.taskDetails().getParentName()).toEqual(CONSTANTS.TASK_DETAILS.NO_PARENT);
+        expect(await taskPage.taskDetails().getDuration()).toEqual('');
+        expect(await taskPage.taskDetails().getEndDate()).toEqual('');
+        expect(await taskPage.taskDetails().getParentTaskId()).toEqual('');
+        expect(await taskPage.taskDetails().getStatus()).toEqual(CONSTANTS.TASK_STATUS.RUNNING);
 
         const taskForm = await taskFormsApi.getTaskForm(allTasks.data[0].id);
 
@@ -153,24 +153,24 @@ describe('Task Details component', () => {
 
         await taskPage.filtersPage().goToFilter(CONSTANTS.TASK_FILTERS.MY_TASKS);
 
-        await expect(await taskPage.taskDetails().getTitle()).toEqual('Activities');
+        expect(await taskPage.taskDetails().getTitle()).toEqual('Activities');
 
         const allTasks = await tasksApi.listTasks(new Task({ sort: 'created-desc' }));
 
         const taskModel = new TaskModel(allTasks.data[0]);
 
         await taskPage.tasksListPage().checkContentIsDisplayed(taskModel.getName());
-        await expect(await taskPage.taskDetails().getCreated()).toEqual(format(new Date(taskModel.getCreated()), TASK_DATE_FORMAT));
-        await expect(await taskPage.taskDetails().getId()).toEqual(taskModel.getId());
-        await expect(await taskPage.taskDetails().getDescription()).toEqual(CONSTANTS.TASK_DETAILS.NO_DESCRIPTION);
-        await expect(await taskPage.taskDetails().getAssignee()).toEqual(taskModel.getAssignee().getEntireName());
-        await expect(await taskPage.taskDetails().getCategory()).toEqual(CONSTANTS.TASK_DETAILS.NO_CATEGORY);
-        await expect(await taskPage.taskDetails().getDueDate()).toEqual(CONSTANTS.TASK_DETAILS.NO_DATE);
-        await expect(await taskPage.taskDetails().getParentName()).toEqual(appModel['definition'].models[1].name);
-        await expect(await taskPage.taskDetails().getDuration()).toEqual('');
-        await expect(await taskPage.taskDetails().getEndDate()).toEqual('');
-        await expect(await taskPage.taskDetails().getParentTaskId()).toEqual('');
-        await expect(await taskPage.taskDetails().getStatus()).toEqual(CONSTANTS.TASK_STATUS.RUNNING);
+        expect(await taskPage.taskDetails().getCreated()).toEqual(format(new Date(taskModel.getCreated()), TASK_DATE_FORMAT));
+        expect(await taskPage.taskDetails().getId()).toEqual(taskModel.getId());
+        expect(await taskPage.taskDetails().getDescription()).toEqual(CONSTANTS.TASK_DETAILS.NO_DESCRIPTION);
+        expect(await taskPage.taskDetails().getAssignee()).toEqual(taskModel.getAssignee().getEntireName());
+        expect(await taskPage.taskDetails().getCategory()).toEqual(CONSTANTS.TASK_DETAILS.NO_CATEGORY);
+        expect(await taskPage.taskDetails().getDueDate()).toEqual(CONSTANTS.TASK_DETAILS.NO_DATE);
+        expect(await taskPage.taskDetails().getParentName()).toEqual(appModel['definition'].models[1].name);
+        expect(await taskPage.taskDetails().getDuration()).toEqual('');
+        expect(await taskPage.taskDetails().getEndDate()).toEqual('');
+        expect(await taskPage.taskDetails().getParentTaskId()).toEqual('');
+        expect(await taskPage.taskDetails().getStatus()).toEqual(CONSTANTS.TASK_STATUS.RUNNING);
 
         const taskForm = await taskFormsApi.getTaskForm(allTasks.data[0].id);
 
@@ -185,23 +185,23 @@ describe('Task Details component', () => {
         await (await processServices.goToTaskApp()).clickTasksButton();
         await taskPage.filtersPage().goToFilter(CONSTANTS.TASK_FILTERS.MY_TASKS);
 
-        await expect(await taskPage.taskDetails().getTitle()).toEqual('Activities');
+        expect(await taskPage.taskDetails().getTitle()).toEqual('Activities');
 
         const allTasks = await tasksApi.listTasks(new Task({ sort: 'created-desc' }));
         const taskModel = new TaskModel(allTasks.data[0]);
 
         await taskPage.tasksListPage().checkContentIsDisplayed(taskModel.getName());
-        await expect(await taskPage.taskDetails().getCreated()).toEqual(format(new Date(taskModel.getCreated()), TASK_DATE_FORMAT));
-        await expect(await taskPage.taskDetails().getId()).toEqual(taskModel.getId());
-        await expect(await taskPage.taskDetails().getDescription()).toEqual(CONSTANTS.TASK_DETAILS.NO_DESCRIPTION);
-        await expect(await taskPage.taskDetails().getAssignee()).toEqual(taskModel.getAssignee().getEntireName());
-        await expect(await taskPage.taskDetails().getCategory()).toEqual(CONSTANTS.TASK_DETAILS.NO_CATEGORY);
-        await expect(await taskPage.taskDetails().getDueDate()).toEqual(CONSTANTS.TASK_DETAILS.NO_DATE);
-        await expect(await taskPage.taskDetails().getParentName()).toEqual(appModel['definition'].models[1].name);
-        await expect(await taskPage.taskDetails().getDuration()).toEqual('');
-        await expect(await taskPage.taskDetails().getEndDate()).toEqual('');
-        await expect(await taskPage.taskDetails().getParentTaskId()).toEqual('');
-        await expect(await taskPage.taskDetails().getStatus()).toEqual(CONSTANTS.TASK_STATUS.RUNNING);
+        expect(await taskPage.taskDetails().getCreated()).toEqual(format(new Date(taskModel.getCreated()), TASK_DATE_FORMAT));
+        expect(await taskPage.taskDetails().getId()).toEqual(taskModel.getId());
+        expect(await taskPage.taskDetails().getDescription()).toEqual(CONSTANTS.TASK_DETAILS.NO_DESCRIPTION);
+        expect(await taskPage.taskDetails().getAssignee()).toEqual(taskModel.getAssignee().getEntireName());
+        expect(await taskPage.taskDetails().getCategory()).toEqual(CONSTANTS.TASK_DETAILS.NO_CATEGORY);
+        expect(await taskPage.taskDetails().getDueDate()).toEqual(CONSTANTS.TASK_DETAILS.NO_DATE);
+        expect(await taskPage.taskDetails().getParentName()).toEqual(appModel['definition'].models[1].name);
+        expect(await taskPage.taskDetails().getDuration()).toEqual('');
+        expect(await taskPage.taskDetails().getEndDate()).toEqual('');
+        expect(await taskPage.taskDetails().getParentTaskId()).toEqual('');
+        expect(await taskPage.taskDetails().getStatus()).toEqual(CONSTANTS.TASK_STATUS.RUNNING);
 
         const taskForm = await taskFormsApi.getTaskForm(allTasks.data[0].id);
 
@@ -233,17 +233,17 @@ describe('Task Details component', () => {
 
         const taskModel = new TaskModel(allTasks.data[0]);
         await taskPage.tasksListPage().checkContentIsDisplayed(taskModel.getName());
-        await expect(await taskPage.taskDetails().getCreated()).toEqual(format(new Date(taskModel.getCreated()), TASK_DATE_FORMAT));
-        await expect(await taskPage.taskDetails().getId()).toEqual(taskModel.getId());
-        await expect(await taskPage.taskDetails().getDescription()).toEqual(CONSTANTS.TASK_DETAILS.NO_DESCRIPTION);
-        await expect(await taskPage.taskDetails().getAssignee()).toEqual(taskModel.getAssignee().getEntireName());
-        await expect(await taskPage.taskDetails().getCategory()).toEqual(CONSTANTS.TASK_DETAILS.NO_CATEGORY);
-        await expect(await taskPage.taskDetails().getDueDate()).toEqual(CONSTANTS.TASK_DETAILS.NO_DATE);
-        await expect(await taskPage.taskDetails().getParentName()).toEqual(CONSTANTS.TASK_DETAILS.NO_PARENT);
-        await expect(await taskPage.taskDetails().getDuration()).toEqual('');
-        await expect(await taskPage.taskDetails().getEndDate()).toEqual('');
-        await expect(await taskPage.taskDetails().getParentTaskId()).toEqual(taskModel.getParentTaskId());
-        await expect(await taskPage.taskDetails().getStatus()).toEqual(CONSTANTS.TASK_STATUS.RUNNING);
+        expect(await taskPage.taskDetails().getCreated()).toEqual(format(new Date(taskModel.getCreated()), TASK_DATE_FORMAT));
+        expect(await taskPage.taskDetails().getId()).toEqual(taskModel.getId());
+        expect(await taskPage.taskDetails().getDescription()).toEqual(CONSTANTS.TASK_DETAILS.NO_DESCRIPTION);
+        expect(await taskPage.taskDetails().getAssignee()).toEqual(taskModel.getAssignee().getEntireName());
+        expect(await taskPage.taskDetails().getCategory()).toEqual(CONSTANTS.TASK_DETAILS.NO_CATEGORY);
+        expect(await taskPage.taskDetails().getDueDate()).toEqual(CONSTANTS.TASK_DETAILS.NO_DATE);
+        expect(await taskPage.taskDetails().getParentName()).toEqual(CONSTANTS.TASK_DETAILS.NO_PARENT);
+        expect(await taskPage.taskDetails().getDuration()).toEqual('');
+        expect(await taskPage.taskDetails().getEndDate()).toEqual('');
+        expect(await taskPage.taskDetails().getParentTaskId()).toEqual(taskModel.getParentTaskId());
+        expect(await taskPage.taskDetails().getStatus()).toEqual(CONSTANTS.TASK_STATUS.RUNNING);
     });
 
     it('[C286707] Should display task details for subtask - Custom App', async () => {
@@ -255,7 +255,7 @@ describe('Task Details component', () => {
 
         await taskPage.filtersPage().goToFilter(CONSTANTS.TASK_FILTERS.MY_TASKS);
 
-        await expect(await taskPage.taskDetails().getTitle()).toEqual('Activities');
+        expect(await taskPage.taskDetails().getTitle()).toEqual('Activities');
 
         const dialog = await taskPage.clickOnAddChecklistButton();
         await dialog.addName(checklistName);
@@ -270,17 +270,17 @@ describe('Task Details component', () => {
 
         const taskModel = new TaskModel(allTasks.data[0]);
         await taskPage.tasksListPage().checkContentIsDisplayed(taskModel.getName());
-        await expect(await taskPage.taskDetails().getCreated()).toEqual(format(new Date(taskModel.getCreated()), TASK_DATE_FORMAT));
-        await expect(await taskPage.taskDetails().getId()).toEqual(taskModel.getId());
-        await expect(await taskPage.taskDetails().getDescription()).toEqual(CONSTANTS.TASK_DETAILS.NO_DESCRIPTION);
-        await expect(await taskPage.taskDetails().getAssignee()).toEqual(taskModel.getAssignee().getEntireName());
-        await expect(await taskPage.taskDetails().getCategory()).toEqual(taskModel.getCategory());
-        await expect(await taskPage.taskDetails().getDueDate()).toEqual(CONSTANTS.TASK_DETAILS.NO_DATE);
-        await expect(await taskPage.taskDetails().getParentName()).toEqual(CONSTANTS.TASK_DETAILS.NO_PARENT);
-        await expect(await taskPage.taskDetails().getDuration()).toEqual('');
-        await expect(await taskPage.taskDetails().getEndDate()).toEqual('');
-        await expect(await taskPage.taskDetails().getParentTaskId()).toEqual(taskModel.getParentTaskId());
-        await expect(await taskPage.taskDetails().getStatus()).toEqual(CONSTANTS.TASK_STATUS.RUNNING);
+        expect(await taskPage.taskDetails().getCreated()).toEqual(format(new Date(taskModel.getCreated()), TASK_DATE_FORMAT));
+        expect(await taskPage.taskDetails().getId()).toEqual(taskModel.getId());
+        expect(await taskPage.taskDetails().getDescription()).toEqual(CONSTANTS.TASK_DETAILS.NO_DESCRIPTION);
+        expect(await taskPage.taskDetails().getAssignee()).toEqual(taskModel.getAssignee().getEntireName());
+        expect(await taskPage.taskDetails().getCategory()).toEqual(taskModel.getCategory());
+        expect(await taskPage.taskDetails().getDueDate()).toEqual(CONSTANTS.TASK_DETAILS.NO_DATE);
+        expect(await taskPage.taskDetails().getParentName()).toEqual(CONSTANTS.TASK_DETAILS.NO_PARENT);
+        expect(await taskPage.taskDetails().getDuration()).toEqual('');
+        expect(await taskPage.taskDetails().getEndDate()).toEqual('');
+        expect(await taskPage.taskDetails().getParentTaskId()).toEqual(taskModel.getParentTaskId());
+        expect(await taskPage.taskDetails().getStatus()).toEqual(CONSTANTS.TASK_STATUS.RUNNING);
     });
 
     it('[C286709] Should display task details for completed task - Task App', async () => {
@@ -301,17 +301,17 @@ describe('Task Details component', () => {
 
         const taskModel = new TaskModel(getTaskResponse);
         await taskPage.tasksListPage().checkContentIsDisplayed(taskModel.getName());
-        await expect(await taskPage.taskDetails().getCreated()).toEqual(format(new Date(taskModel.getCreated()), TASK_DATE_FORMAT));
-        await expect(await taskPage.taskDetails().getId()).toEqual(taskModel.getId());
-        await expect(await taskPage.taskDetails().getDescription()).toEqual(CONSTANTS.TASK_DETAILS.NO_DESCRIPTION);
-        await expect(await taskPage.taskDetails().getAssignee()).toEqual(taskModel.getAssignee().getEntireName());
-        await expect(await taskPage.taskDetails().getCategory()).toEqual(CONSTANTS.TASK_DETAILS.NO_CATEGORY);
-        await expect(await taskPage.taskDetails().getDueDate()).toEqual(CONSTANTS.TASK_DETAILS.NO_DATE);
-        await expect(await taskPage.taskDetails().getParentName()).toEqual(CONSTANTS.TASK_DETAILS.NO_PARENT);
-        await expect(await taskPage.taskDetails().getDuration()).toEqual(await taskPage.taskDetails().getDuration());
-        await expect(await taskPage.taskDetails().getEndDate()).toEqual(await taskPage.taskDetails().getEndDate());
-        await expect(await taskPage.taskDetails().getParentTaskId()).toEqual('');
-        await expect(await taskPage.taskDetails().getStatus()).toEqual(CONSTANTS.TASK_STATUS.COMPLETED);
+        expect(await taskPage.taskDetails().getCreated()).toEqual(format(new Date(taskModel.getCreated()), TASK_DATE_FORMAT));
+        expect(await taskPage.taskDetails().getId()).toEqual(taskModel.getId());
+        expect(await taskPage.taskDetails().getDescription()).toEqual(CONSTANTS.TASK_DETAILS.NO_DESCRIPTION);
+        expect(await taskPage.taskDetails().getAssignee()).toEqual(taskModel.getAssignee().getEntireName());
+        expect(await taskPage.taskDetails().getCategory()).toEqual(CONSTANTS.TASK_DETAILS.NO_CATEGORY);
+        expect(await taskPage.taskDetails().getDueDate()).toEqual(CONSTANTS.TASK_DETAILS.NO_DATE);
+        expect(await taskPage.taskDetails().getParentName()).toEqual(CONSTANTS.TASK_DETAILS.NO_PARENT);
+        expect(await taskPage.taskDetails().getDuration()).toEqual(await taskPage.taskDetails().getDuration());
+        expect(await taskPage.taskDetails().getEndDate()).toEqual(await taskPage.taskDetails().getEndDate());
+        expect(await taskPage.taskDetails().getParentTaskId()).toEqual('');
+        expect(await taskPage.taskDetails().getStatus()).toEqual(CONSTANTS.TASK_STATUS.COMPLETED);
     });
 
     it('[C260321] Should not be able to edit a completed task details', async () => {

--- a/e2e/process-services/tasks/task-filters-component.e2e.ts
+++ b/e2e/process-services/tasks/task-filters-component.e2e.ts
@@ -15,12 +15,7 @@
  * limitations under the License.
  */
 
-import { createApiService,
-    ApplicationsUtil,
-    LoginPage, ModelsActions,
-    UserModel,
-    UsersActions
-} from '@alfresco/adf-testing';
+import { createApiService, ApplicationsUtil, LoginPage, ModelsActions, UserModel, UsersActions } from '@alfresco/adf-testing';
 import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
 import { ProcessServicesPage } from '../pages/process-services.page';
 import { TasksPage } from '../pages/tasks.page';
@@ -80,23 +75,23 @@ describe('Task', () => {
         await tasksPage.createTask({ name: 'Test' });
         await taskFiltersDemoPage.myTasksFilter().clickTaskFilter();
         await tasksListPage.checkContentIsDisplayed('Test');
-        await expect(await taskFiltersDemoPage.checkActiveFilterActive()).toBe('My Tasks');
-        await expect(await taskDetailsPage.checkTaskDetailsDisplayed()).toBeDefined();
+        expect(await taskFiltersDemoPage.checkActiveFilterActive()).toBe('My Tasks');
+        expect(await taskDetailsPage.checkTaskDetailsDisplayed()).toBeDefined();
 
         await taskFiltersDemoPage.queuedTasksFilter().clickTaskFilter();
-        await expect(await taskFiltersDemoPage.checkActiveFilterActive()).toBe('Queued Tasks');
+        expect(await taskFiltersDemoPage.checkActiveFilterActive()).toBe('Queued Tasks');
         await tasksListPage.checkContentIsNotDisplayed('Test');
-        await expect(await taskDetailsPage.checkTaskDetailsEmpty()).toBeDefined();
+        expect(await taskDetailsPage.checkTaskDetailsEmpty()).toBeDefined();
 
         await taskFiltersDemoPage.involvedTasksFilter().clickTaskFilter();
-        await expect(await taskFiltersDemoPage.checkActiveFilterActive()).toBe('Involved Tasks');
+        expect(await taskFiltersDemoPage.checkActiveFilterActive()).toBe('Involved Tasks');
         await tasksListPage.checkContentIsDisplayed('Test');
-        await expect(await taskDetailsPage.checkTaskDetailsDisplayed()).toBeDefined();
+        expect(await taskDetailsPage.checkTaskDetailsDisplayed()).toBeDefined();
 
         await taskFiltersDemoPage.completedTasksFilter().clickTaskFilter();
-        await expect(await taskFiltersDemoPage.checkActiveFilterActive()).toBe('Completed Tasks');
+        expect(await taskFiltersDemoPage.checkActiveFilterActive()).toBe('Completed Tasks');
         await tasksListPage.checkContentIsNotDisplayed('Test');
-        await expect(await taskDetailsPage.checkTaskDetailsEmpty()).toBeDefined();
+        expect(await taskDetailsPage.checkTaskDetailsEmpty()).toBeDefined();
     });
 
     it('[C260348] Should display task in Complete Tasks List when task is completed', async () => {
@@ -110,23 +105,23 @@ describe('Task', () => {
         await task.clickStartButton();
         await taskFiltersDemoPage.myTasksFilter().clickTaskFilter();
         await tasksListPage.checkContentIsDisplayed('Test');
-        await expect(await taskFiltersDemoPage.checkActiveFilterActive()).toBe('My Tasks');
-        await expect(await taskDetailsPage.checkTaskDetailsDisplayed()).toBeDefined();
+        expect(await taskFiltersDemoPage.checkActiveFilterActive()).toBe('My Tasks');
+        expect(await taskDetailsPage.checkTaskDetailsDisplayed()).toBeDefined();
 
         await taskFiltersDemoPage.queuedTasksFilter().clickTaskFilter();
-        await expect(await taskFiltersDemoPage.checkActiveFilterActive()).toBe('Queued Tasks');
-        await expect(await tasksListPage.getNoTasksFoundMessage()).toBe('No Tasks Found');
-        await expect(await taskDetailsPage.getEmptyTaskDetailsMessage()).toBe('No task details found');
+        expect(await taskFiltersDemoPage.checkActiveFilterActive()).toBe('Queued Tasks');
+        expect(await tasksListPage.getNoTasksFoundMessage()).toBe('No Tasks Found');
+        expect(await taskDetailsPage.getEmptyTaskDetailsMessage()).toBe('No task details found');
 
         await taskFiltersDemoPage.involvedTasksFilter().clickTaskFilter();
-        await expect(await taskFiltersDemoPage.checkActiveFilterActive()).toBe('Involved Tasks');
+        expect(await taskFiltersDemoPage.checkActiveFilterActive()).toBe('Involved Tasks');
         await tasksListPage.checkContentIsDisplayed('Test');
-        await expect(await taskDetailsPage.checkTaskDetailsDisplayed()).toBeDefined();
+        expect(await taskDetailsPage.checkTaskDetailsDisplayed()).toBeDefined();
 
         await taskFiltersDemoPage.completedTasksFilter().clickTaskFilter();
-        await expect(await taskFiltersDemoPage.checkActiveFilterActive()).toBe('Completed Tasks');
-        await expect(await tasksListPage.getNoTasksFoundMessage()).toBe('No Tasks Found');
-        await expect(await taskDetailsPage.getEmptyTaskDetailsMessage()).toBe('No task details found');
+        expect(await taskFiltersDemoPage.checkActiveFilterActive()).toBe('Completed Tasks');
+        expect(await tasksListPage.getNoTasksFoundMessage()).toBe('No Tasks Found');
+        expect(await taskDetailsPage.getEmptyTaskDetailsMessage()).toBe('No task details found');
     });
 
     it('[C260349] Should sort task by name when Name sorting is clicked', async () => {
@@ -145,17 +140,17 @@ describe('Task', () => {
         await taskDetailsPage.checkTaskDetailsDisplayed();
 
         await tasksPage.clickSortByNameAsc();
-        await expect(await tasksListPage.getDataTable().contentInPosition(1)).toBe('Test3');
+        expect(await tasksListPage.getDataTable().contentInPosition(1)).toBe('Test3');
         await tasksPage.clickSortByNameDesc();
-        await expect(await tasksListPage.getDataTable().contentInPosition(1)).toBe('Test4');
+        expect(await tasksListPage.getDataTable().contentInPosition(1)).toBe('Test4');
 
         await taskFiltersDemoPage.completedTasksFilter().clickTaskFilter();
         await tasksListPage.checkContentIsDisplayed('Test1');
         await tasksListPage.checkContentIsDisplayed('Test2');
-        await expect(await tasksListPage.getDataTable().contentInPosition(1)).toBe('Test2');
+        expect(await tasksListPage.getDataTable().contentInPosition(1)).toBe('Test2');
 
         await tasksPage.clickSortByNameAsc();
-        await expect(await tasksListPage.getDataTable().contentInPosition(1)).toBe('Test1');
+        expect(await tasksListPage.getDataTable().contentInPosition(1)).toBe('Test1');
 
         await taskFiltersDemoPage.involvedTasksFilter().clickTaskFilter();
         await tasksListPage.checkContentIsDisplayed('Test3');
@@ -167,6 +162,6 @@ describe('Task', () => {
 
         await taskFiltersDemoPage.myTasksFilter().clickTaskFilter();
         await tasksListPage.checkContentIsDisplayed('Test');
-        await expect(await taskDetailsPage.getTaskDetailsTitle()).toBe('Test');
+        expect(await taskDetailsPage.getTaskDetailsTitle()).toBe('Test');
     });
 });

--- a/e2e/process-services/tasks/task-filters-sorting.e2e.ts
+++ b/e2e/process-services/tasks/task-filters-sorting.e2e.ts
@@ -97,9 +97,9 @@ describe('Task Filters Sorting', () => {
         await browser.refresh();
         await taskFiltersDemoPage.customTaskFilter(newFilter.name).clickTaskFilter();
 
-        await expect(await tasksListPage.getDataTable().contentInPosition(1)).toBe(tasks[2].name);
-        await expect(await tasksListPage.getDataTable().contentInPosition(2)).toBe(tasks[1].name);
-        await expect(await tasksListPage.getDataTable().contentInPosition(3)).toBe(tasks[0].name);
+        expect(await tasksListPage.getDataTable().contentInPosition(1)).toBe(tasks[2].name);
+        expect(await tasksListPage.getDataTable().contentInPosition(2)).toBe(tasks[1].name);
+        expect(await tasksListPage.getDataTable().contentInPosition(3)).toBe(tasks[0].name);
     });
 
     it('[C277255] Should display tasks under new filter from oldest to newest when they are completed', async () => {
@@ -114,9 +114,9 @@ describe('Task Filters Sorting', () => {
         await browser.refresh();
         await taskFiltersDemoPage.customTaskFilter(newFilter.name).clickTaskFilter();
 
-        await expect(await tasksListPage.getDataTable().contentInPosition(1)).toBe(tasks[0].name);
-        await expect(await tasksListPage.getDataTable().contentInPosition(2)).toBe(tasks[1].name);
-        await expect(await tasksListPage.getDataTable().contentInPosition(3)).toBe(tasks[2].name);
+        expect(await tasksListPage.getDataTable().contentInPosition(1)).toBe(tasks[0].name);
+        expect(await tasksListPage.getDataTable().contentInPosition(2)).toBe(tasks[1].name);
+        expect(await tasksListPage.getDataTable().contentInPosition(3)).toBe(tasks[2].name);
     });
 
     it('[C277256] Should display tasks under new filter from closest due date to farthest when they are completed', async () => {
@@ -131,9 +131,9 @@ describe('Task Filters Sorting', () => {
         await browser.refresh();
         await taskFiltersDemoPage.customTaskFilter(newFilter.name).clickTaskFilter();
 
-        await expect(await tasksListPage.getDataTable().contentInPosition(1)).toBe(tasks[2].name);
-        await expect(await tasksListPage.getDataTable().contentInPosition(2)).toBe(tasks[1].name);
-        await expect(await tasksListPage.getDataTable().contentInPosition(3)).toBe(tasks[0].name);
+        expect(await tasksListPage.getDataTable().contentInPosition(1)).toBe(tasks[2].name);
+        expect(await tasksListPage.getDataTable().contentInPosition(2)).toBe(tasks[1].name);
+        expect(await tasksListPage.getDataTable().contentInPosition(3)).toBe(tasks[0].name);
     });
 
     it('[C277257] Should display tasks under new filter from farthest due date to closest when they are completed', async () => {
@@ -148,9 +148,9 @@ describe('Task Filters Sorting', () => {
         await browser.refresh();
         await taskFiltersDemoPage.customTaskFilter(newFilter.name).clickTaskFilter();
 
-        await expect(await tasksListPage.getDataTable().contentInPosition(1)).toBe(tasks[0].name);
-        await expect(await tasksListPage.getDataTable().contentInPosition(2)).toBe(tasks[1].name);
-        await expect(await tasksListPage.getDataTable().contentInPosition(3)).toBe(tasks[2].name);
+        expect(await tasksListPage.getDataTable().contentInPosition(1)).toBe(tasks[0].name);
+        expect(await tasksListPage.getDataTable().contentInPosition(2)).toBe(tasks[1].name);
+        expect(await tasksListPage.getDataTable().contentInPosition(3)).toBe(tasks[2].name);
     });
 
     it('[C277258] Should display tasks under new filter from newest to oldest when they are open  ', async () => {
@@ -165,9 +165,9 @@ describe('Task Filters Sorting', () => {
         await browser.refresh();
         await taskFiltersDemoPage.customTaskFilter(newFilter.name).clickTaskFilter();
 
-        await expect(await tasksListPage.getDataTable().contentInPosition(1)).toBe(tasks[5].name);
-        await expect(await tasksListPage.getDataTable().contentInPosition(2)).toBe(tasks[4].name);
-        await expect(await tasksListPage.getDataTable().contentInPosition(3)).toBe(tasks[3].name);
+        expect(await tasksListPage.getDataTable().contentInPosition(1)).toBe(tasks[5].name);
+        expect(await tasksListPage.getDataTable().contentInPosition(2)).toBe(tasks[4].name);
+        expect(await tasksListPage.getDataTable().contentInPosition(3)).toBe(tasks[3].name);
     });
 
     it('[C277259] Should display tasks under new filter from oldest to newest when they are open', async () => {
@@ -182,9 +182,9 @@ describe('Task Filters Sorting', () => {
         await browser.refresh();
         await taskFiltersDemoPage.customTaskFilter(newFilter.name).clickTaskFilter();
 
-        await expect(await tasksListPage.getDataTable().contentInPosition(1)).toBe(tasks[3].name);
-        await expect(await tasksListPage.getDataTable().contentInPosition(2)).toBe(tasks[4].name);
-        await expect(await tasksListPage.getDataTable().contentInPosition(3)).toBe(tasks[5].name);
+        expect(await tasksListPage.getDataTable().contentInPosition(1)).toBe(tasks[3].name);
+        expect(await tasksListPage.getDataTable().contentInPosition(2)).toBe(tasks[4].name);
+        expect(await tasksListPage.getDataTable().contentInPosition(3)).toBe(tasks[5].name);
     });
 
     it('[C277260] Should display tasks under new filter from closest due date to farthest when they are open', async () => {
@@ -199,9 +199,9 @@ describe('Task Filters Sorting', () => {
         await browser.refresh();
         await taskFiltersDemoPage.customTaskFilter(newFilter.name).clickTaskFilter();
 
-        await expect(await tasksListPage.getDataTable().contentInPosition(1)).toBe(tasks[5].name);
-        await expect(await tasksListPage.getDataTable().contentInPosition(2)).toBe(tasks[4].name);
-        await expect(await tasksListPage.getDataTable().contentInPosition(3)).toBe(tasks[3].name);
+        expect(await tasksListPage.getDataTable().contentInPosition(1)).toBe(tasks[5].name);
+        expect(await tasksListPage.getDataTable().contentInPosition(2)).toBe(tasks[4].name);
+        expect(await tasksListPage.getDataTable().contentInPosition(3)).toBe(tasks[3].name);
     });
 
     it('[C277261] Should display tasks under new filter from farthest due date to closest when they are open', async () => {
@@ -216,8 +216,8 @@ describe('Task Filters Sorting', () => {
         await browser.refresh();
         await taskFiltersDemoPage.customTaskFilter(newFilter.name).clickTaskFilter();
 
-        await expect(await tasksListPage.getDataTable().contentInPosition(1)).toBe(tasks[3].name);
-        await expect(await tasksListPage.getDataTable().contentInPosition(2)).toBe(tasks[4].name);
-        await expect(await tasksListPage.getDataTable().contentInPosition(3)).toBe(tasks[5].name);
+        expect(await tasksListPage.getDataTable().contentInPosition(1)).toBe(tasks[3].name);
+        expect(await tasksListPage.getDataTable().contentInPosition(2)).toBe(tasks[4].name);
+        expect(await tasksListPage.getDataTable().contentInPosition(3)).toBe(tasks[5].name);
     });
 });

--- a/e2e/process-services/tasks/task-list-pagination.e2e.ts
+++ b/e2e/process-services/tasks/task-list-pagination.e2e.ts
@@ -15,21 +15,13 @@
  * limitations under the License.
  */
 
-import { createApiService,
-    ApplicationsUtil,
-    LoginPage,
-    PaginationPage,
-    ProcessUtil,
-    UserModel,
-    UsersActions
-} from '@alfresco/adf-testing';
+import { createApiService, ApplicationsUtil, LoginPage, PaginationPage, ProcessUtil, UserModel, UsersActions } from '@alfresco/adf-testing';
 import { browser } from 'protractor';
 import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
 import { TasksPage } from '../pages/tasks.page';
 import CONSTANTS = require('../../util/constants');
 
 describe('Task List Pagination', () => {
-
     const loginPage = new LoginPage();
     const navigationBarPage = new NavigationBarPage();
     const taskPage = new TasksPage();
@@ -71,86 +63,86 @@ describe('Task List Pagination', () => {
         await loginPage.login(processUserModel.username, processUserModel.password);
     });
 
-    afterAll( async () => {
+    afterAll(async () => {
         await apiService.loginWithProfile('admin');
         await usersActions.deleteTenant(processUserModel.tenantId);
     });
 
     it('[C260301] Should display default pagination', async () => {
         await (await navigationBarPage.navigateToProcessServicesPage()).goToTaskApp();
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.default);
-        await expect(await paginationPage.getPaginationRange()).toEqual('Showing 1-' + nrOfTasks + ' of ' + nrOfTasks);
-        await expect(await taskPage.tasksListPage().getDataTable().numberOfRows()).toBe(nrOfTasks);
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.default);
+        expect(await paginationPage.getPaginationRange()).toEqual('Showing 1-' + nrOfTasks + ' of ' + nrOfTasks);
+        expect(await taskPage.tasksListPage().getDataTable().numberOfRows()).toBe(nrOfTasks);
         await paginationPage.checkNextPageButtonIsDisabled();
         await paginationPage.checkPreviousPageButtonIsDisabled();
         await paginationPage.selectItemsPerPage(itemsPerPage.twenty);
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.twenty);
-        await expect(await paginationPage.getPaginationRange()).toEqual('Showing 1-' + nrOfTasks + ' of ' + nrOfTasks);
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.twenty);
+        expect(await paginationPage.getPaginationRange()).toEqual('Showing 1-' + nrOfTasks + ' of ' + nrOfTasks);
     });
 
     it('[C260304] Should be possible to set Items per page to 5', async () => {
         await (await navigationBarPage.navigateToProcessServicesPage()).goToTaskApp();
         await taskPage.filtersPage().goToFilter(CONSTANTS.TASK_FILTERS.INV_TASKS);
         await paginationPage.selectItemsPerPage(itemsPerPage.five);
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.five);
-        await expect(await paginationPage.getPaginationRange()).toEqual('Showing 1-' + itemsPerPage.fiveValue + ' of ' + nrOfTasks);
-        await expect(await taskPage.tasksListPage().getDataTable().numberOfRows()).toBe(itemsPerPage.fiveValue);
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.five);
+        expect(await paginationPage.getPaginationRange()).toEqual('Showing 1-' + itemsPerPage.fiveValue + ' of ' + nrOfTasks);
+        expect(await taskPage.tasksListPage().getDataTable().numberOfRows()).toBe(itemsPerPage.fiveValue);
 
         await paginationPage.clickOnNextPage();
         currentPage++;
 
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.five);
-        await expect(await paginationPage.getPaginationRange()).toEqual('Showing 6-' + itemsPerPage.fiveValue * currentPage + ' of ' + nrOfTasks);
-        await expect(await taskPage.tasksListPage().getDataTable().numberOfRows()).toBe(itemsPerPage.fiveValue);
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.five);
+        expect(await paginationPage.getPaginationRange()).toEqual('Showing 6-' + itemsPerPage.fiveValue * currentPage + ' of ' + nrOfTasks);
+        expect(await taskPage.tasksListPage().getDataTable().numberOfRows()).toBe(itemsPerPage.fiveValue);
         await paginationPage.clickOnNextPage();
         currentPage++;
 
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.five);
-        await expect(await paginationPage.getPaginationRange()).toEqual('Showing 11-' + itemsPerPage.fiveValue * currentPage + ' of ' + nrOfTasks);
-        await expect(await taskPage.tasksListPage().getDataTable().numberOfRows()).toBe(itemsPerPage.fiveValue);
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.five);
+        expect(await paginationPage.getPaginationRange()).toEqual('Showing 11-' + itemsPerPage.fiveValue * currentPage + ' of ' + nrOfTasks);
+        expect(await taskPage.tasksListPage().getDataTable().numberOfRows()).toBe(itemsPerPage.fiveValue);
         await paginationPage.clickOnNextPage();
         currentPage++;
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.five);
-        await expect(await paginationPage.getPaginationRange()).toEqual('Showing 16-' + itemsPerPage.fiveValue * currentPage + ' of ' + nrOfTasks);
-        await expect(await taskPage.tasksListPage().getDataTable().numberOfRows()).toBe(itemsPerPage.fiveValue);
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.five);
+        expect(await paginationPage.getPaginationRange()).toEqual('Showing 16-' + itemsPerPage.fiveValue * currentPage + ' of ' + nrOfTasks);
+        expect(await taskPage.tasksListPage().getDataTable().numberOfRows()).toBe(itemsPerPage.fiveValue);
 
         await (await navigationBarPage.navigateToProcessServicesPage()).goToTaskApp();
         await taskPage.filtersPage().goToFilter(CONSTANTS.TASK_FILTERS.INV_TASKS);
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.five);
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.five);
     });
 
     it('[C260303] Should be possible to set Items per page to 10', async () => {
         await (await navigationBarPage.navigateToProcessServicesPage()).goToTaskApp();
         await taskPage.filtersPage().goToFilter(CONSTANTS.TASK_FILTERS.INV_TASKS);
         await paginationPage.selectItemsPerPage(itemsPerPage.ten);
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.ten);
-        await expect(await paginationPage.getPaginationRange()).toEqual('Showing 1-' + itemsPerPage.tenValue + ' of ' + nrOfTasks);
-        await expect(await taskPage.tasksListPage().getDataTable().numberOfRows()).toBe(itemsPerPage.tenValue);
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.ten);
+        expect(await paginationPage.getPaginationRange()).toEqual('Showing 1-' + itemsPerPage.tenValue + ' of ' + nrOfTasks);
+        expect(await taskPage.tasksListPage().getDataTable().numberOfRows()).toBe(itemsPerPage.tenValue);
         await paginationPage.clickOnNextPage();
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.ten);
-        await expect(await paginationPage.getPaginationRange()).toEqual('Showing 11-' + itemsPerPage.twentyValue + ' of ' + nrOfTasks);
-        await expect(await taskPage.tasksListPage().getDataTable().numberOfRows()).toBe(itemsPerPage.tenValue);
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.ten);
+        expect(await paginationPage.getPaginationRange()).toEqual('Showing 11-' + itemsPerPage.twentyValue + ' of ' + nrOfTasks);
+        expect(await taskPage.tasksListPage().getDataTable().numberOfRows()).toBe(itemsPerPage.tenValue);
 
         await (await navigationBarPage.navigateToProcessServicesPage()).goToTaskApp();
         await taskPage.filtersPage().goToFilter(CONSTANTS.TASK_FILTERS.INV_TASKS);
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.ten);
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.ten);
     });
 
     it('[C260302] Should be possible to set Items per page to 15', async () => {
         await (await navigationBarPage.navigateToProcessServicesPage()).goToTaskApp();
         await taskPage.filtersPage().goToFilter(CONSTANTS.TASK_FILTERS.INV_TASKS);
         await paginationPage.selectItemsPerPage(itemsPerPage.fifteen);
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.fifteen);
-        await expect(await paginationPage.getPaginationRange()).toEqual('Showing 1-' + itemsPerPage.fifteenValue + ' of ' + nrOfTasks);
-        await expect(await taskPage.tasksListPage().getDataTable().numberOfRows()).toBe(itemsPerPage.fifteenValue);
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.fifteen);
+        expect(await paginationPage.getPaginationRange()).toEqual('Showing 1-' + itemsPerPage.fifteenValue + ' of ' + nrOfTasks);
+        expect(await taskPage.tasksListPage().getDataTable().numberOfRows()).toBe(itemsPerPage.fifteenValue);
         await paginationPage.clickOnNextPage();
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.fifteen);
-        await expect(await paginationPage.getPaginationRange()).toEqual('Showing 16-' + itemsPerPage.twentyValue + ' of ' + nrOfTasks);
-        await expect(await taskPage.tasksListPage().getDataTable().numberOfRows()).toBe(itemsPerPage.fiveValue);
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.fifteen);
+        expect(await paginationPage.getPaginationRange()).toEqual('Showing 16-' + itemsPerPage.twentyValue + ' of ' + nrOfTasks);
+        expect(await taskPage.tasksListPage().getDataTable().numberOfRows()).toBe(itemsPerPage.fiveValue);
 
         await (await navigationBarPage.navigateToProcessServicesPage()).goToTaskApp();
         await taskPage.filtersPage().goToFilter(CONSTANTS.TASK_FILTERS.INV_TASKS);
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.fifteen);
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.fifteen);
     });
 
     it('[C261006] Should be possible to navigate to a page with page number dropdown', async () => {
@@ -161,37 +153,37 @@ describe('Task List Pagination', () => {
         await taskPage.tasksListPage().getDataTable().waitForTableBody();
         await paginationPage.selectItemsPerPage(itemsPerPage.ten);
         await taskPage.tasksListPage().getDataTable().waitForTableBody();
-        await expect(await paginationPage.getCurrentPage()).toEqual('Page ' + currentPage);
-        await expect(await paginationPage.getTotalPages()).toEqual('of ' + totalPages);
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.ten);
-        await expect(await paginationPage.getPaginationRange()).toEqual('Showing 1-' + itemsPerPage.tenValue * currentPage + ' of ' + nrOfTasks);
-        await expect(await taskPage.tasksListPage().getDataTable().numberOfRows()).toBe(itemsPerPage.tenValue);
+        expect(await paginationPage.getCurrentPage()).toEqual('Page ' + currentPage);
+        expect(await paginationPage.getTotalPages()).toEqual('of ' + totalPages);
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.ten);
+        expect(await paginationPage.getPaginationRange()).toEqual('Showing 1-' + itemsPerPage.tenValue * currentPage + ' of ' + nrOfTasks);
+        expect(await taskPage.tasksListPage().getDataTable().numberOfRows()).toBe(itemsPerPage.tenValue);
         await paginationPage.checkNextPageButtonIsEnabled();
         await paginationPage.checkPreviousPageButtonIsDisabled();
 
         await paginationPage.clickOnPageDropdown();
-        await expect(await paginationPage.getPageDropdownOptions()).toEqual(['1', '2']);
+        expect(await paginationPage.getPageDropdownOptions()).toEqual(['1', '2']);
         currentPage = 2;
         await paginationPage.clickOnPageDropdownOption('2');
         await taskPage.tasksListPage().getDataTable().waitForTableBody();
-        await expect(await paginationPage.getCurrentPage()).toEqual('Page ' + currentPage);
-        await expect(await paginationPage.getTotalPages()).toEqual('of ' + totalPages);
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.ten);
-        await expect(await paginationPage.getPaginationRange()).toEqual('Showing 11-' + itemsPerPage.tenValue * currentPage + ' of ' + nrOfTasks);
-        await expect(await taskPage.tasksListPage().getDataTable().numberOfRows()).toBe(itemsPerPage.tenValue);
+        expect(await paginationPage.getCurrentPage()).toEqual('Page ' + currentPage);
+        expect(await paginationPage.getTotalPages()).toEqual('of ' + totalPages);
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.ten);
+        expect(await paginationPage.getPaginationRange()).toEqual('Showing 11-' + itemsPerPage.tenValue * currentPage + ' of ' + nrOfTasks);
+        expect(await taskPage.tasksListPage().getDataTable().numberOfRows()).toBe(itemsPerPage.tenValue);
         await paginationPage.checkNextPageButtonIsDisabled();
         await paginationPage.checkPreviousPageButtonIsEnabled();
 
         await paginationPage.clickOnPageDropdown();
-        await expect(await paginationPage.getPageDropdownOptions()).toEqual(['1', '2']);
+        expect(await paginationPage.getPageDropdownOptions()).toEqual(['1', '2']);
         currentPage = 1;
         await paginationPage.clickOnPageDropdownOption('1');
         await taskPage.tasksListPage().getDataTable().waitForTableBody();
-        await expect(await paginationPage.getCurrentPage()).toEqual('Page ' + currentPage);
-        await expect(await paginationPage.getTotalPages()).toEqual('of ' + totalPages);
-        await expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.ten);
-        await expect(await paginationPage.getPaginationRange()).toEqual('Showing 1-' + itemsPerPage.tenValue * currentPage + ' of ' + nrOfTasks);
-        await expect(await taskPage.tasksListPage().getDataTable().numberOfRows()).toBe(itemsPerPage.tenValue);
+        expect(await paginationPage.getCurrentPage()).toEqual('Page ' + currentPage);
+        expect(await paginationPage.getTotalPages()).toEqual('of ' + totalPages);
+        expect(await paginationPage.getCurrentItemsPerPage()).toEqual(itemsPerPage.ten);
+        expect(await paginationPage.getPaginationRange()).toEqual('Showing 1-' + itemsPerPage.tenValue * currentPage + ' of ' + nrOfTasks);
+        expect(await taskPage.tasksListPage().getDataTable().numberOfRows()).toBe(itemsPerPage.tenValue);
         await paginationPage.checkNextPageButtonIsEnabled();
         await paginationPage.checkPreviousPageButtonIsDisabled();
     });

--- a/e2e/process-services/widgets/amount-widget.e2e.ts
+++ b/e2e/process-services/widgets/amount-widget.e2e.ts
@@ -72,23 +72,23 @@ describe('Amount Widget', () => {
         await widget.checkboxWidget().clickCheckboxInput(app.FIELD.checkbox_id);
         await taskPage.formFields().checkWidgetIsVisible(app.FIELD.amount_input_id);
 
-        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
-        await expect(await widget.amountWidget().getAmountFieldLabel(app.FIELD.amount_input_id)).toContain('Amount');
-        await expect(await widget.amountWidget().getPlaceholder(app.FIELD.amount_input_id)).toContain('Type amount');
+        expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
+        expect(await widget.amountWidget().getAmountFieldLabel(app.FIELD.amount_input_id)).toContain('Amount');
+        expect(await widget.amountWidget().getPlaceholder(app.FIELD.amount_input_id)).toContain('Type amount');
         const fieldCurrency = await widget.amountWidget().getAmountFieldCurrency(app.FIELD.amount_input_id);
-        await expect(fieldCurrency.trim()).toBe('$');
+        expect(fieldCurrency.trim()).toBe('$');
 
         await widget.amountWidget().setFieldValue(app.FIELD.amount_input_id, 4);
-        await expect(await widget.amountWidget().getErrorMessage(app.FIELD.amount_input_id)).toBe(`Can't be less than 5`);
-        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
+        expect(await widget.amountWidget().getErrorMessage(app.FIELD.amount_input_id)).toBe(`Can't be less than 5`);
+        expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
         await widget.amountWidget().clearFieldValue(app.FIELD.amount_input_id);
 
         await widget.amountWidget().setFieldValue(app.FIELD.amount_input_id, 101);
-        await expect(await widget.amountWidget().getErrorMessage(app.FIELD.amount_input_id)).toBe(`Can't be greater than 100`);
-        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
+        expect(await widget.amountWidget().getErrorMessage(app.FIELD.amount_input_id)).toBe(`Can't be greater than 100`);
+        expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
         await widget.amountWidget().clearFieldValue(app.FIELD.amount_input_id);
 
         await widget.amountWidget().setFieldValue(app.FIELD.amount_input_id, 6);
-        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
+        expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
     });
 });

--- a/e2e/process-services/widgets/attach-folder-widget.e2e.ts
+++ b/e2e/process-services/widgets/attach-folder-widget.e2e.ts
@@ -71,6 +71,6 @@ describe('Attach Folder widget', () => {
         await widget.checkboxWidget().clickCheckboxInput(app.FIELD.checkbox_id);
         await taskPage.formFields().checkWidgetIsVisible(app.FIELD.upload_button_id);
 
-        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
+        expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
     });
 });

--- a/e2e/process-services/widgets/checkbox-widget.e2e.ts
+++ b/e2e/process-services/widgets/checkbox-widget.e2e.ts
@@ -67,10 +67,10 @@ describe('Checkbox Widget', () => {
 
     it('[C268554] Should be able to set general settings for Checkbox widget ', async () => {
         await taskPage.formFields().setValueInInputById(app.FIELD.number_input_id, '2');
-        await expect(await widget.checkboxWidget().getCheckboxLabel()).toContain(app.FIELD.checkbox_label);
-        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
+        expect(await widget.checkboxWidget().getCheckboxLabel()).toContain(app.FIELD.checkbox_label);
+        expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
         await widget.checkboxWidget().clickCheckboxInput(app.FIELD.checkbox_input_id);
-        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
+        expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
     });
 
     it('[C272812] Should be able to set visibility settings for Checkbox widget', async () => {

--- a/e2e/process-services/widgets/document-template-widget.e2e.ts
+++ b/e2e/process-services/widgets/document-template-widget.e2e.ts
@@ -67,6 +67,6 @@ describe('Document Template widget', () => {
     });
 
     it('[C260406] should check that the template contains assigned file ', async () => {
-        await expect(await widget.containerWidget().getFieldText(app.form_fields.container_id)).toEqual(app.attached_file);
+        expect(await widget.containerWidget().getFieldText(app.form_fields.container_id)).toEqual(app.attached_file);
     });
 });

--- a/e2e/process-services/widgets/dropdown-widget.e2e.ts
+++ b/e2e/process-services/widgets/dropdown-widget.e2e.ts
@@ -15,14 +15,7 @@
  * limitations under the License.
  */
 
-import {
-  createApiService,
-  ApplicationsUtil,
-  LoginPage,
-  ProcessUtil,
-  UsersActions,
-  Widget, UserModel
-} from '@alfresco/adf-testing';
+import { createApiService, ApplicationsUtil, LoginPage, ProcessUtil, UsersActions, Widget, UserModel } from '@alfresco/adf-testing';
 import { TasksPage } from '../pages/tasks.page';
 import { browser } from 'protractor';
 import CONSTANTS = require('../../util/constants');
@@ -74,19 +67,19 @@ describe('Dropdown widget', () => {
     });
 
     it('[C269051] Should be possible to set general and options properties for Dropdown widget ', async () => {
-        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
+        expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
 
         await widget.dropdown().selectOption('Happy');
-        await expect(await widget.dropdown().getSelectedOptionText(app.FIELD.general_dropdown)).toContain('Happy');
-        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
+        expect(await widget.dropdown().getSelectedOptionText(app.FIELD.general_dropdown)).toContain('Happy');
+        expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
 
         await widget.dropdown().selectOption('Choose one');
-        await expect(await widget.dropdown().getSelectedOptionText(app.FIELD.general_dropdown)).toContain('Choose one');
-        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
+        expect(await widget.dropdown().getSelectedOptionText(app.FIELD.general_dropdown)).toContain('Choose one');
+        expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
 
         await widget.dropdown().selectOption('Sad');
-        await expect(await widget.dropdown().getSelectedOptionText(app.FIELD.general_dropdown)).toContain('Sad');
-        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
+        expect(await widget.dropdown().getSelectedOptionText(app.FIELD.general_dropdown)).toContain('Sad');
+        expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
     });
 
     it('[C269052] Should be possible to set visibility properties for Dropdown widget', async () => {

--- a/e2e/process-services/widgets/dynamic-table-widget.e2e.ts
+++ b/e2e/process-services/widgets/dynamic-table-widget.e2e.ts
@@ -15,14 +15,7 @@
  * limitations under the License.
  */
 
-import {
-    createApiService,
-    ApplicationsUtil,
-    LoginPage,
-    ProcessUtil,
-    UsersActions,
-    Widget, UserModel
-} from '@alfresco/adf-testing';
+import { createApiService, ApplicationsUtil, LoginPage, ProcessUtil, UsersActions, Widget, UserModel } from '@alfresco/adf-testing';
 import { TasksPage } from '../pages/tasks.page';
 import { browser } from 'protractor';
 import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
@@ -129,18 +122,18 @@ describe('Dynamic Table widget ', () => {
             await widget.dynamicTable().clickAddRow(app.FIELD.dynamic_table_id);
             await widget.dynamicTable().setDatatableInput('User1');
             await widget.dynamicTable().clickSaveButton();
-            await expect(await widget.dynamicTable().getTableRowText(0)).toEqual('User1');
+            expect(await widget.dynamicTable().getTableRowText(0)).toEqual('User1');
 
             await widget.dynamicTable().clickTableRow(0);
             await widget.dynamicTable().clickEditButton();
             await widget.dynamicTable().setDatatableInput('User2');
             await widget.dynamicTable().clickCancelButton();
-            await expect(await widget.dynamicTable().getTableRowText(0)).toEqual('User1');
+            expect(await widget.dynamicTable().getTableRowText(0)).toEqual('User1');
 
             await widget.dynamicTable().clickEditButton();
             await widget.dynamicTable().setDatatableInput('User2');
             await widget.dynamicTable().clickSaveButton();
-            await expect(await widget.dynamicTable().getTableRowText(0)).toEqual('User2');
+            expect(await widget.dynamicTable().getTableRowText(0)).toEqual('User2');
 
             await widget.dynamicTable().clickAddRow(app.FIELD.dynamic_table_id);
             await widget.dynamicTable().setDatatableInput('User3');
@@ -184,19 +177,19 @@ describe('Dynamic Table widget ', () => {
             await widget.dynamicTable().clickAddRow();
             await widget.dynamicTable().setDatatableInput('admin', app.CUSTOM_VALIDATOR.FIELD.NAME);
             await widget.dynamicTable().clickSaveButton();
-            await expect(await widget.dynamicTable().checkErrorMessage()).toBe('Sorry, wrong value. You cannot use "admin".');
+            expect(await widget.dynamicTable().checkErrorMessage()).toBe('Sorry, wrong value. You cannot use "admin".');
 
             await widget.dynamicTable().setDatatableInput('name', app.CUSTOM_VALIDATOR.FIELD.NAME);
             await widget.dynamicTable().clickSaveButton();
-            await expect(await widget.dynamicTable().checkErrorMessage()).toBe(`Field 'Id' is required.`);
+            expect(await widget.dynamicTable().checkErrorMessage()).toBe(`Field 'Id' is required.`);
 
             await widget.dynamicTable().setDatatableInput('id', app.CUSTOM_VALIDATOR.FIELD.ID);
             await widget.dynamicTable().clickSaveButton();
-            await expect(await widget.dynamicTable().checkErrorMessage()).toBe(`Field 'Number' is required.`);
+            expect(await widget.dynamicTable().checkErrorMessage()).toBe(`Field 'Number' is required.`);
 
             await widget.dynamicTable().setDatatableInput('12', app.CUSTOM_VALIDATOR.FIELD.NUM);
             await widget.dynamicTable().clickSaveButton();
-            await expect(await widget.dynamicTable().checkErrorMessage()).toBe(`Field 'Address' is required.`);
+            expect(await widget.dynamicTable().checkErrorMessage()).toBe(`Field 'Address' is required.`);
 
             await widget.dynamicTable().setDatatableInput('address', app.CUSTOM_VALIDATOR.FIELD.ADDRESS);
             await widget.dynamicTable().clickSaveButton();

--- a/e2e/process-services/widgets/header-widget.e2e.ts
+++ b/e2e/process-services/widgets/header-widget.e2e.ts
@@ -71,7 +71,7 @@ describe('Header widget', async () => {
         await widget.checkboxWidget().clickCheckboxInput(app.FIELD.checkbox_id);
         await taskPage.formFields().checkWidgetIsVisible(app.FIELD.header_id);
 
-        await expect(await widget.headerWidget().getFieldLabel(app.FIELD.header_id)).toBe('Header');
-        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
+        expect(await widget.headerWidget().getFieldLabel(app.FIELD.header_id)).toBe('Header');
+        expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
     });
 });

--- a/e2e/process-services/widgets/hyperlink-widget.e2e.ts
+++ b/e2e/process-services/widgets/hyperlink-widget.e2e.ts
@@ -71,7 +71,7 @@ describe('Hyperlink widget', () => {
         await widget.checkboxWidget().clickCheckboxInput(app.FIELD.checkbox_id);
         await taskPage.formFields().checkWidgetIsVisible(app.FIELD.hyperlink_id);
 
-        await expect(await widget.hyperlink().getFieldLabel(app.FIELD.hyperlink_id)).toBe('Hyperlink');
-        await expect(await widget.hyperlink().getFieldText(app.FIELD.hyperlink_id)).toBe('https://www.google.com/');
+        expect(await widget.hyperlink().getFieldLabel(app.FIELD.hyperlink_id)).toBe('Hyperlink');
+        expect(await widget.hyperlink().getFieldText(app.FIELD.hyperlink_id)).toBe('https://www.google.com/');
     });
 });

--- a/e2e/process-services/widgets/multi-line-widget.e2e.ts
+++ b/e2e/process-services/widgets/multi-line-widget.e2e.ts
@@ -68,29 +68,29 @@ describe('Multi-line Widget', () => {
 
     it('[C268182] Should be able to set general properties for Multi-line Text Widget', async () => {
         const label = await widget.multilineTextWidget().getFieldLabel(app.FIELD.multiSimple);
-        await expect(label).toBe('multiSimple*');
-        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
+        expect(label).toBe('multiSimple*');
+        expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
         const placeHolder = await widget.multilineTextWidget().getFieldPlaceHolder(app.FIELD.multiSimple);
-        await expect(placeHolder).toBe('Type something...');
+        expect(placeHolder).toBe('Type something...');
         await widget.multilineTextWidget().setValue(app.FIELD.multiSimple, 'TEST');
-        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
+        expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
     });
 
     it('[C268184] Should be able to set advanced properties for Multi-line Text Widget', async () => {
         await widget.multilineTextWidget().setValue(app.FIELD.multiMinMax, 'A');
-        await expect(await widget.multilineTextWidget().getErrorMessage(app.FIELD.multiMinMax)).toContain('Enter at least 4 characters');
-        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
+        expect(await widget.multilineTextWidget().getErrorMessage(app.FIELD.multiMinMax)).toContain('Enter at least 4 characters');
+        expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
         await widget.multilineTextWidget().setValue(app.FIELD.multiMinMax, 'AAAAAAAAAAA');
-        await expect(await widget.multilineTextWidget().getErrorMessage(app.FIELD.multiMinMax)).toContain('Enter no more than 10 characters');
-        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
+        expect(await widget.multilineTextWidget().getErrorMessage(app.FIELD.multiMinMax)).toContain('Enter no more than 10 characters');
+        expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
         await widget.multilineTextWidget().setValue(app.FIELD.multiMinMax, 'AAAA');
 
         await widget.multilineTextWidget().setValue(app.FIELD.multiSimple, 'TEST');
         await widget.multilineTextWidget().setValue(app.FIELD.multiRegexp, '3');
-        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
-        await expect(await widget.multilineTextWidget().getErrorMessage(app.FIELD.multiRegexp)).toContain('Enter a different value');
+        expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
+        expect(await widget.multilineTextWidget().getErrorMessage(app.FIELD.multiRegexp)).toContain('Enter a different value');
         await widget.multilineTextWidget().setValue(app.FIELD.multiRegexp, 'TE');
-        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
+        expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
     });
 
     it('[C268232] Should be able to set visibility properties for Multi-line Text Widget', async () => {

--- a/e2e/process-services/widgets/number-widget.e2e.ts
+++ b/e2e/process-services/widgets/number-widget.e2e.ts
@@ -67,12 +67,12 @@ describe('Number widget', () => {
     });
 
     it('[C269111] Should be able to set general properties for Number Widget', async () => {
-        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
-        await expect(await widget.numberWidget().getNumberFieldLabel(app.FIELD.number_general)).toContain('Number General');
-        await expect(await widget.numberWidget().getPlaceholder(app.FIELD.number_general)).toContain('Type a number');
+        expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
+        expect(await widget.numberWidget().getNumberFieldLabel(app.FIELD.number_general)).toContain('Number General');
+        expect(await widget.numberWidget().getPlaceholder(app.FIELD.number_general)).toContain('Type a number');
 
         await widget.numberWidget().setFieldValue(app.FIELD.number_general, 2);
-        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
+        expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
     });
 
     it('[C274702] Should be able to set advanced and visibility properties for Number Widget', async () => {
@@ -83,16 +83,16 @@ describe('Number widget', () => {
         await taskPage.formFields().checkWidgetIsVisible(app.FIELD.number_visible);
 
         await widget.numberWidget().setFieldValue(app.FIELD.number_visible, 2);
-        await expect(await widget.numberWidget().getErrorMessage(app.FIELD.number_visible)).toBe(`Can't be less than 3`);
-        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
+        expect(await widget.numberWidget().getErrorMessage(app.FIELD.number_visible)).toBe(`Can't be less than 3`);
+        expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
         await widget.numberWidget().clearFieldValue(app.FIELD.number_visible);
 
         await widget.numberWidget().setFieldValue(app.FIELD.number_visible, 101);
-        await expect(await widget.numberWidget().getErrorMessage(app.FIELD.number_visible)).toBe(`Can't be greater than 100`);
-        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
+        expect(await widget.numberWidget().getErrorMessage(app.FIELD.number_visible)).toBe(`Can't be greater than 100`);
+        expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
         await widget.numberWidget().clearFieldValue(app.FIELD.number_visible);
 
         await widget.numberWidget().setFieldValue(app.FIELD.number_visible, 4);
-        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
+        expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
     });
 });

--- a/e2e/process-services/widgets/people-group-widget.e2e.ts
+++ b/e2e/process-services/widgets/people-group-widget.e2e.ts
@@ -119,7 +119,7 @@ describe('People and Group widget', () => {
         await widget.peopleWidget().insertUser(peopleWidget.FIELD.widget_id, peopleWidget.searchTerm);
         await widget.peopleWidget().checkDropDownListIsDisplayed();
         const suggestions = (await widget.peopleWidget().getDropDownList()).sort((a, b) => a.localeCompare(b));
-        expect(suggestions).toEqual(getGroupMembers().sort());
+        expect(suggestions).toEqual(getGroupMembers());
         await widget.peopleWidget().selectUserFromDropDown(getGroupMembers()[0]);
         await taskPage.taskDetails().clickCompleteFormTask();
     });
@@ -189,6 +189,8 @@ describe('People and Group widget', () => {
      * @returns list of group member full names
      */
     function getGroupMembers(): string[] {
-        return app.groupUser.map((groupUser: AppGroupUser) => `${groupUser.firstName} ${groupUser.lastName}`);
+        return app.groupUser
+            .map((groupUser: AppGroupUser) => `${groupUser.firstName} ${groupUser.lastName}`)
+            .sort((a: string, b: string) => a.localeCompare(b));
     }
 });

--- a/e2e/process-services/widgets/people-group-widget.e2e.ts
+++ b/e2e/process-services/widgets/people-group-widget.e2e.ts
@@ -22,6 +22,15 @@ import { NavigationBarPage } from '../../core/pages/navigation-bar.page';
 import CONSTANTS = require('../../util/constants');
 import { AdminGroupsApi } from '@alfresco/js-api';
 
+interface AppGroupUser {
+    firstName: string;
+    lastName: string;
+}
+
+interface AppSubGroup {
+    name: string;
+}
+
 describe('People and Group widget', () => {
     const app = browser.params.resources.Files.MORE_WIDGETS;
 
@@ -124,7 +133,7 @@ describe('People and Group widget', () => {
         await apiService.loginWithProfile('admin');
 
         const userCreated = await Promise.all(
-            app.groupUser.map((usersToCreate) =>
+            app.groupUser.map((usersToCreate: AppGroupUser) =>
                 usersActions.createUser(
                     new UserModel({
                         tenantId,
@@ -151,7 +160,7 @@ describe('People and Group widget', () => {
 
         await Promise.all(userCreated.map((userToAddGroup: UserModel) => adminGroupsApi.addGroupMember(group.id, userToAddGroup.id)));
 
-        const subgroups: any[] = await Promise.all(
+        const subgroups = await Promise.all(
             getSubGroupsName().map((name) =>
                 adminGroupsApi.createNewGroup({
                     name,
@@ -171,7 +180,7 @@ describe('People and Group widget', () => {
      * @returns list of subgroup names
      */
     function getSubGroupsName(): string[] {
-        return app.group.subgroup.map((subgroup) => subgroup.name);
+        return app.group.subgroup.map((subgroup: AppSubGroup) => subgroup.name);
     }
 
     /**
@@ -180,6 +189,6 @@ describe('People and Group widget', () => {
      * @returns list of group member full names
      */
     function getGroupMembers(): string[] {
-        return app.groupUser.map((groupUser) => `${groupUser.firstName} ${groupUser.lastName}`);
+        return app.groupUser.map((groupUser: AppGroupUser) => `${groupUser.firstName} ${groupUser.lastName}`);
     }
 });

--- a/e2e/process-services/widgets/people-group-widget.e2e.ts
+++ b/e2e/process-services/widgets/people-group-widget.e2e.ts
@@ -76,7 +76,7 @@ describe('People and Group widget', () => {
         await widget.groupWidget().insertGroup(groupVisibilityForm.FIELD.widget_id, groupVisibilityForm.searchTerm);
         await widget.groupWidget().checkDropDownListIsDisplayed();
         const suggestions = await widget.groupWidget().getDropDownList();
-        expect(suggestions.sort()).toEqual(['Heros', 'Users']);
+        expect(suggestions.sort((a, b) => a.localeCompare(b))).toEqual(['Heros', 'Users']);
         await widget.groupWidget().selectGroupFromDropDown('Users');
         await taskPage.taskDetails().clickCompleteFormTask();
     });
@@ -93,8 +93,8 @@ describe('People and Group widget', () => {
 
         await widget.groupWidget().insertGroup(subgroupFrom.FIELD.widget_id, subgroupFrom.searchTerm);
         await widget.groupWidget().checkDropDownListIsDisplayed();
-        const suggestions = await widget.groupWidget().getDropDownList();
-        expect(suggestions.sort()).toEqual(getSubGroupsName().sort());
+        const suggestions = (await widget.groupWidget().getDropDownList()).sort((a, b) => a.localeCompare(b));
+        expect(suggestions).toEqual(getSubGroupsName());
         await widget.groupWidget().selectGroupFromDropDown(getSubGroupsName()[0]);
         await taskPage.taskDetails().clickCompleteFormTask();
 
@@ -180,7 +180,7 @@ describe('People and Group widget', () => {
      * @returns list of subgroup names
      */
     function getSubGroupsName(): string[] {
-        return app.group.subgroup.map((subgroup: AppSubGroup) => subgroup.name);
+        return app.group.subgroup.map((subgroup: AppSubGroup) => subgroup.name).sort((a: string, b: string) => a.localeCompare(b));
     }
 
     /**

--- a/e2e/process-services/widgets/people-group-widget.e2e.ts
+++ b/e2e/process-services/widgets/people-group-widget.e2e.ts
@@ -75,8 +75,8 @@ describe('People and Group widget', () => {
 
         await widget.groupWidget().insertGroup(groupVisibilityForm.FIELD.widget_id, groupVisibilityForm.searchTerm);
         await widget.groupWidget().checkDropDownListIsDisplayed();
-        const suggestions = await widget.groupWidget().getDropDownList();
-        expect(suggestions.sort((a, b) => a.localeCompare(b))).toEqual(['Heros', 'Users']);
+        const suggestions = (await widget.groupWidget().getDropDownList()).sort((a, b) => a.localeCompare(b));
+        expect(suggestions).toEqual(['Heros', 'Users']);
         await widget.groupWidget().selectGroupFromDropDown('Users');
         await taskPage.taskDetails().clickCompleteFormTask();
     });
@@ -118,8 +118,8 @@ describe('People and Group widget', () => {
 
         await widget.peopleWidget().insertUser(peopleWidget.FIELD.widget_id, peopleWidget.searchTerm);
         await widget.peopleWidget().checkDropDownListIsDisplayed();
-        const suggestions = await widget.peopleWidget().getDropDownList();
-        expect(suggestions.sort()).toEqual(getGroupMembers().sort());
+        const suggestions = (await widget.peopleWidget().getDropDownList()).sort((a, b) => a.localeCompare(b));
+        expect(suggestions).toEqual(getGroupMembers().sort());
         await widget.peopleWidget().selectUserFromDropDown(getGroupMembers()[0]);
         await taskPage.taskDetails().clickCompleteFormTask();
     });

--- a/e2e/process-services/widgets/radio-buttons-widget.e2e.ts
+++ b/e2e/process-services/widgets/radio-buttons-widget.e2e.ts
@@ -72,11 +72,11 @@ describe('Radio Buttons Widget', () => {
 
     it('[C274704] Should be able to set visibility properties for Radio Button widget', async () => {
         await taskPage.formFields().checkWidgetIsHidden(app.FIELD.radio_buttons_id);
-        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
+        expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
 
         await widget.checkboxWidget().clickCheckboxInput(app.FIELD.checkbox_id);
-        await expect(await widget.radioWidget().getRadioWidgetLabel(app.FIELD.radio_buttons_id)).toContain('Radio posts');
+        expect(await widget.radioWidget().getRadioWidgetLabel(app.FIELD.radio_buttons_id)).toContain('Radio posts');
         await widget.radioWidget().selectOption(app.FIELD.radio_buttons_id, 1);
-        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
+        expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
     });
 });

--- a/e2e/process-services/widgets/text-widget.e2e.ts
+++ b/e2e/process-services/widgets/text-widget.e2e.ts
@@ -68,43 +68,43 @@ describe('Text widget', () => {
 
     it('[C268157] Should be able to set general properties for Text widget', async () => {
         const label = await widget.textWidget().getFieldLabel(app.FIELD.simpleText);
-        await expect(label).toBe('textSimple*');
-        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
+        expect(label).toBe('textSimple*');
+        expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
         const placeHolder = await widget.textWidget().getFieldPlaceHolder(app.FIELD.simpleText);
-        await expect(placeHolder).toBe('Type something...');
+        expect(placeHolder).toBe('Type something...');
         await widget.textWidget().setValue(app.FIELD.simpleText, 'TEST');
-        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
+        expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
     });
 
     it('[C268170] Min-max length properties', async () => {
         await widget.textWidget().setValue(app.FIELD.simpleText, 'TEST');
         await widget.textWidget().setValue(app.FIELD.textMinMax, 'A');
-        await expect(await widget.textWidget().getErrorMessage(app.FIELD.textMinMax)).toContain('Enter at least 4 characters');
-        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
+        expect(await widget.textWidget().getErrorMessage(app.FIELD.textMinMax)).toContain('Enter at least 4 characters');
+        expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
         await widget.textWidget().setValue(app.FIELD.textMinMax, '01234567890');
-        await expect(await widget.textWidget().getErrorMessage(app.FIELD.textMinMax)).toContain('Enter no more than 10 characters');
-        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
+        expect(await widget.textWidget().getErrorMessage(app.FIELD.textMinMax)).toContain('Enter no more than 10 characters');
+        expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
         await widget.textWidget().setValue(app.FIELD.textMinMax, '123456789');
-        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
+        expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
     });
 
     it('[C268171] Input mask reversed checkbox properties', async () => {
         await widget.textWidget().setValue(app.FIELD.textMask, '18951523');
-        await expect(await widget.textWidget().getFieldValue(app.FIELD.textMask)).toBe('1895-1523');
+        expect(await widget.textWidget().getFieldValue(app.FIELD.textMask)).toBe('1895-1523');
     });
 
     it('[C268171] Input mask reversed checkbox properties', async () => {
         await widget.textWidget().setValue(app.FIELD.textMaskReversed, '1234567899');
-        await expect(await widget.textWidget().getFieldValue(app.FIELD.textMaskReversed)).toBe('3456-7899');
+        expect(await widget.textWidget().getFieldValue(app.FIELD.textMaskReversed)).toBe('3456-7899');
     });
 
     it('[C268177] Should be able to set Regex Pattern property for Text widget', async () => {
         await widget.textWidget().setValue(app.FIELD.simpleText, 'TEST');
         await widget.textWidget().setValue(app.FIELD.textRegexp, 'T');
-        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
-        await expect(await widget.textWidget().getErrorMessage(app.FIELD.textRegexp)).toContain('Enter a different value');
+        expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(false);
+        expect(await widget.textWidget().getErrorMessage(app.FIELD.textRegexp)).toContain('Enter a different value');
         await widget.textWidget().setValue(app.FIELD.textRegexp, 'TE');
-        await expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
+        expect(await taskPage.formFields().isCompleteFormButtonEnabled()).toEqual(true);
     });
 
     it('[C274712] Should be able to set visibility properties for Text widget ', async () => {

--- a/e2e/search/components/search-check-list.e2e.ts
+++ b/e2e/search/components/search-check-list.e2e.ts
@@ -15,14 +15,7 @@
  * limitations under the License.
  */
 
-import { createApiService,
-    LocalStorageUtil,
-    LoginPage,
-    StringUtil,
-    UploadActions,
-    UserModel,
-    UsersActions
-} from '@alfresco/adf-testing';
+import { createApiService, LocalStorageUtil, LoginPage, StringUtil, UploadActions, UserModel, UsersActions } from '@alfresco/adf-testing';
 import { SearchResultsPage } from '../pages/search-results.page';
 import { SearchFiltersPage } from '../pages/search-filters.page';
 import { SearchBarPage } from '../pages/search-bar.page';
@@ -32,7 +25,6 @@ import { browser } from 'protractor';
 import { NodesApi } from '@alfresco/js-api';
 
 describe('Search Checklist Component', () => {
-
     const loginPage = new LoginPage();
     const searchFiltersPage = new SearchFiltersPage();
     const searchBarPage = new SearchBarPage();
@@ -58,7 +50,8 @@ describe('Search Checklist Component', () => {
         folder: `${randomName}Folder`
     };
 
-    let createdFile; let createdFolder;
+    let createdFile;
+    let createdFolder;
 
     beforeAll(async () => {
         await apiService.loginWithProfile('admin');
@@ -153,7 +146,7 @@ describe('Search Checklist Component', () => {
             for (let numberOfOptions = 0; numberOfOptions < 8; numberOfOptions++) {
                 jsonFile.categories[1].component.settings.options.push({
                     name: 'Folder',
-                    value: 'TYPE:\'cm:folder\''
+                    value: `TYPE:'cm:folder'`
                 });
             }
 
@@ -165,21 +158,21 @@ describe('Search Checklist Component', () => {
 
             await searchFiltersPage.clickCheckListFilter();
 
-            await expect(await searchFiltersPage.checkListFiltersPage().getCheckListOptionsNumberOnPage()).toBe(5);
+            expect(await searchFiltersPage.checkListFiltersPage().getCheckListOptionsNumberOnPage()).toBe(5);
 
             await searchFiltersPage.checkListFiltersPage().checkShowMoreButtonIsDisplayed();
             await searchFiltersPage.checkListFiltersPage().checkShowLessButtonIsNotDisplayed();
 
             await searchFiltersPage.checkListFiltersPage().clickShowMoreButton();
 
-            await expect(await searchFiltersPage.checkListFiltersPage().getCheckListOptionsNumberOnPage()).toBe(10);
+            expect(await searchFiltersPage.checkListFiltersPage().getCheckListOptionsNumberOnPage()).toBe(10);
 
             await searchFiltersPage.checkListFiltersPage().checkShowMoreButtonIsNotDisplayed();
             await searchFiltersPage.checkListFiltersPage().checkShowLessButtonIsDisplayed();
 
             await searchFiltersPage.checkListFiltersPage().clickShowLessButton();
 
-            await expect(await searchFiltersPage.checkListFiltersPage().getCheckListOptionsNumberOnPage()).toBe(5);
+            expect(await searchFiltersPage.checkListFiltersPage().getCheckListOptionsNumberOnPage()).toBe(5);
 
             await searchFiltersPage.checkListFiltersPage().checkShowMoreButtonIsDisplayed();
             await searchFiltersPage.checkListFiltersPage().checkShowLessButtonIsNotDisplayed();
@@ -193,7 +186,7 @@ describe('Search Checklist Component', () => {
             for (let numberOfOptions = 0; numberOfOptions < 8; numberOfOptions++) {
                 jsonFile.categories[1].component.settings.options.push({
                     name: 'Folder',
-                    value: 'TYPE:\'cm:folder\''
+                    value: `TYPE:'cm:folder'`
                 });
             }
 
@@ -206,7 +199,7 @@ describe('Search Checklist Component', () => {
 
             await searchFiltersPage.clickCheckListFilter();
 
-            await expect(await searchFiltersPage.checkListFiltersPage().getCheckListOptionsNumberOnPage()).toBe(10);
+            expect(await searchFiltersPage.checkListFiltersPage().getCheckListOptionsNumberOnPage()).toBe(10);
 
             await searchFiltersPage.checkListFiltersPage().checkShowMoreButtonIsNotDisplayed();
 
@@ -222,7 +215,7 @@ describe('Search Checklist Component', () => {
 
             await searchFiltersPage.clickCheckListFilter();
 
-            await expect(await searchFiltersPage.checkListFiltersPage().getCheckListOptionsNumberOnPage()).toBe(10);
+            expect(await searchFiltersPage.checkListFiltersPage().getCheckListOptionsNumberOnPage()).toBe(10);
 
             await searchFiltersPage.checkListFiltersPage().checkShowMoreButtonIsNotDisplayed();
 
@@ -237,7 +230,7 @@ describe('Search Checklist Component', () => {
             await searchBarPage.enterTextAndPressEnter(randomName);
             await searchFiltersPage.clickCheckListFilter();
 
-            await expect(await searchFiltersPage.checkListFiltersPage().getCheckListOptionsNumberOnPage()).toBe(9);
+            expect(await searchFiltersPage.checkListFiltersPage().getCheckListOptionsNumberOnPage()).toBe(9);
 
             await searchFiltersPage.checkListFiltersPage().checkShowMoreButtonIsDisplayed();
         });
@@ -250,7 +243,7 @@ describe('Search Checklist Component', () => {
             for (let numberOfOptions = 0; numberOfOptions < 8; numberOfOptions++) {
                 jsonFile.categories[1].component.settings.options.push({
                     name: 'Folder',
-                    value: 'TYPE:\'cm:folder\''
+                    value: `TYPE:'cm:folder'`
                 });
             }
 
@@ -265,14 +258,14 @@ describe('Search Checklist Component', () => {
 
             await searchFiltersPage.clickCheckListFilter();
 
-            await expect(await searchFiltersPage.checkListFiltersPage().getCheckListOptionsNumberOnPage()).toBe(5);
+            expect(await searchFiltersPage.checkListFiltersPage().getCheckListOptionsNumberOnPage()).toBe(5);
 
             await searchFiltersPage.checkListFiltersPage().checkShowMoreButtonIsDisplayed();
             await searchFiltersPage.checkListFiltersPage().checkShowLessButtonIsNotDisplayed();
 
             await searchFiltersPage.checkListFiltersPage().clickShowMoreButton();
 
-            await expect(await searchFiltersPage.checkListFiltersPage().getCheckListOptionsNumberOnPage()).toBe(10);
+            expect(await searchFiltersPage.checkListFiltersPage().getCheckListOptionsNumberOnPage()).toBe(10);
 
             await searchFiltersPage.checkListFiltersPage().checkShowMoreButtonIsNotDisplayed();
             await searchFiltersPage.checkListFiltersPage().checkShowLessButtonIsDisplayed();
@@ -290,14 +283,14 @@ describe('Search Checklist Component', () => {
 
             await searchFiltersPage.clickCheckListFilter();
 
-            await expect(await searchFiltersPage.checkListFiltersPage().getCheckListOptionsNumberOnPage()).toBe(5);
+            expect(await searchFiltersPage.checkListFiltersPage().getCheckListOptionsNumberOnPage()).toBe(5);
 
             await searchFiltersPage.checkListFiltersPage().checkShowMoreButtonIsDisplayed();
             await searchFiltersPage.checkListFiltersPage().checkShowLessButtonIsNotDisplayed();
 
             await searchFiltersPage.checkListFiltersPage().clickShowMoreButton();
 
-            await expect(await searchFiltersPage.checkListFiltersPage().getCheckListOptionsNumberOnPage()).toBe(10);
+            expect(await searchFiltersPage.checkListFiltersPage().getCheckListOptionsNumberOnPage()).toBe(10);
 
             await searchFiltersPage.checkListFiltersPage().checkShowMoreButtonIsNotDisplayed();
             await searchFiltersPage.checkListFiltersPage().checkShowLessButtonIsDisplayed();
@@ -340,7 +333,7 @@ describe('Search Checklist Component', () => {
         it('[C277019] Should be able to add new properties with different types', async () => {
             jsonFile.categories[1].component.settings.options.push({
                 name: filterType.custom,
-                value: 'TYPE:\'cm:auditable\''
+                value: `TYPE:'cm:auditable'`
             });
 
             await LocalStorageUtil.setConfigField('search', JSON.stringify(jsonFile));

--- a/e2e/search/components/search-number-range.e2e.ts
+++ b/e2e/search/components/search-number-range.e2e.ts
@@ -106,7 +106,7 @@ describe('Search Number Range Filter', () => {
         await sizeRangeFilter.checkApplyButtonIsDisplayed();
         await sizeRangeFilter.checkClearButtonIsDisplayed();
 
-        await expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(false);
+        expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(false);
     });
 
     it('[C276922] Should be keep value when Number Range widget is collapsed', async () => {
@@ -117,8 +117,8 @@ describe('Search Number Range Filter', () => {
         await searchFilters.checkSizeRangeFilterIsCollapsed();
         await searchFilters.clickSizeRangeFilterHeader();
         await searchFilters.checkSizeRangeFilterIsExpanded();
-        await expect(await sizeRangeFilter.getFromNumber()).toEqual(`${size}`);
-        await expect(await sizeRangeFilter.getToNumber()).toEqual(`${size}`);
+        expect(await sizeRangeFilter.getFromNumber()).toEqual(`${size}`);
+        expect(await sizeRangeFilter.getToNumber()).toEqual(`${size}`);
     });
 
     it('[C276924] Should display error message when input had an invalid format', async () => {
@@ -128,39 +128,39 @@ describe('Search Number Range Filter', () => {
         await sizeRangeFilter.checkFromErrorInvalidIsDisplayed();
         await sizeRangeFilter.checkToErrorInvalidIsDisplayed();
 
-        await expect(await sizeRangeFilter.getFromErrorInvalid()).toEqual('Invalid Format');
-        await expect(await sizeRangeFilter.getToErrorInvalid()).toEqual('Invalid Format');
-        await expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(false);
+        expect(await sizeRangeFilter.getFromErrorInvalid()).toEqual('Invalid Format');
+        expect(await sizeRangeFilter.getToErrorInvalid()).toEqual('Invalid Format');
+        expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(false);
 
         await sizeRangeFilter.putFromNumber('@');
         await sizeRangeFilter.putToNumber('£');
         await sizeRangeFilter.checkFromErrorInvalidIsDisplayed();
         await sizeRangeFilter.checkToErrorInvalidIsDisplayed();
-        await expect(await sizeRangeFilter.getFromErrorInvalid()).toEqual('Invalid Format');
-        await expect(await sizeRangeFilter.getToErrorInvalid()).toEqual('Invalid Format');
-        await expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(false);
+        expect(await sizeRangeFilter.getFromErrorInvalid()).toEqual('Invalid Format');
+        expect(await sizeRangeFilter.getToErrorInvalid()).toEqual('Invalid Format');
+        expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(false);
 
         await sizeRangeFilter.putFromNumber('4.5');
         await sizeRangeFilter.putToNumber('4,5');
         await sizeRangeFilter.checkFromErrorInvalidIsDisplayed();
         await sizeRangeFilter.checkToErrorInvalidIsDisplayed();
-        await expect(await sizeRangeFilter.getFromErrorInvalid()).toEqual('Invalid Format');
-        await expect(await sizeRangeFilter.getToErrorInvalid()).toEqual('Invalid Format');
-        await expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(false);
+        expect(await sizeRangeFilter.getFromErrorInvalid()).toEqual('Invalid Format');
+        expect(await sizeRangeFilter.getToErrorInvalid()).toEqual('Invalid Format');
+        expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(false);
 
         await sizeRangeFilter.putFromNumber('01');
         await sizeRangeFilter.putToNumber('-1');
-        await expect(await sizeRangeFilter.getFromErrorInvalid()).toEqual('Invalid Format');
-        await expect(await sizeRangeFilter.getToErrorInvalid()).toEqual('Invalid Format');
-        await expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(false);
+        expect(await sizeRangeFilter.getFromErrorInvalid()).toEqual('Invalid Format');
+        expect(await sizeRangeFilter.getToErrorInvalid()).toEqual('Invalid Format');
+        expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(false);
 
         await sizeRangeFilter.clearFromField();
         await sizeRangeFilter.clearToField();
         await sizeRangeFilter.checkFromErrorRequiredIsDisplayed();
         await sizeRangeFilter.checkToErrorRequiredIsDisplayed();
-        await expect(await sizeRangeFilter.getFromErrorRequired()).toEqual('Required value');
-        await expect(await sizeRangeFilter.getToErrorRequired()).toEqual('Required value');
-        await expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(false);
+        expect(await sizeRangeFilter.getFromErrorRequired()).toEqual('Required value');
+        expect(await sizeRangeFilter.getToErrorRequired()).toEqual('Required value');
+        expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(false);
     });
 
     it('[C276943] Should be able to put a big value in To field', async () => {
@@ -170,7 +170,7 @@ describe('Search Number Range Filter', () => {
         await sizeRangeFilter.putToNumber(toSize);
         await sizeRangeFilter.putFromNumber(fromSize);
 
-        await expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(true);
+        expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(true);
 
         await sizeRangeFilter.clickApplyButton();
         await searchResults.dataTable.waitTillContentLoaded();
@@ -181,7 +181,7 @@ describe('Search Number Range Filter', () => {
             const currentSize = await BrowserActions.getAttribute(currentResult, 'title');
 
             if (currentSize && currentSize.trim() !== '') {
-                await expect(parseInt(currentSize, 10) <= toSize).toBe(true);
+                expect(parseInt(currentSize, 10) <= toSize).toBe(true);
             }
         }
     });
@@ -199,7 +199,7 @@ describe('Search Number Range Filter', () => {
         await sizeRangeFilter.putFromNumber(fromSize);
         await sizeRangeFilter.putToNumber(toSize);
 
-        await expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(true);
+        expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(true);
 
         await sizeRangeFilter.clickApplyButton();
         await searchResults.dataTable.waitTillContentLoaded();
@@ -210,7 +210,7 @@ describe('Search Number Range Filter', () => {
         for (const currentResult of results) {
             const currentSize = await BrowserActions.getAttribute(currentResult, 'title');
             if (currentSize && currentSize.trim() !== '') {
-                await expect(parseInt(currentSize, 10) <= toSize).toBe(true);
+                expect(parseInt(currentSize, 10) <= toSize).toBe(true);
             }
         }
 
@@ -224,7 +224,7 @@ describe('Search Number Range Filter', () => {
         for (const currentResult of resultsSize) {
             const currentSize = await BrowserActions.getAttribute(currentResult, 'title');
             if (currentSize && currentSize.trim() !== '') {
-                await expect(parseInt(currentSize, 10) <= toSize).toBe(true);
+                expect(parseInt(currentSize, 10) <= toSize).toBe(true);
             }
         }
 
@@ -232,7 +232,7 @@ describe('Search Number Range Filter', () => {
         for (const currentResult of resultsDisplay) {
             const name = await BrowserActions.getAttribute(currentResult, 'title');
             if (name && name.trim() !== '') {
-                await expect(/z*/i.test(name)).toBe(true);
+                expect(/z*/i.test(name)).toBe(true);
             }
         }
     });
@@ -241,7 +241,7 @@ describe('Search Number Range Filter', () => {
         await sizeRangeFilter.checkToFieldIsDisplayed();
         await sizeRangeFilter.putToNumber(99999999);
         await sizeRangeFilter.putFromNumber(0);
-        await expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(true);
+        expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(true);
 
         await sizeRangeFilter.clickApplyButton();
         await searchResults.dataTable.waitTillContentLoaded();
@@ -259,7 +259,7 @@ describe('Search Number Range Filter', () => {
         await sizeRangeFilter.checkToFieldIsDisplayed();
         await sizeRangeFilter.putToNumber(1);
         await sizeRangeFilter.putFromNumber(0);
-        await expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(true);
+        expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(true);
 
         await sizeRangeFilter.clickApplyButton();
         await searchResults.dataTable.waitTillContentLoaded();
@@ -270,7 +270,7 @@ describe('Search Number Range Filter', () => {
         for (const currentResult of results) {
             const currentSize = await BrowserActions.getAttribute(currentResult, 'title');
             if (currentSize && currentSize.trim() !== '') {
-                await expect((currentSize === '0' || currentSize === '1')).toBe(true);
+                expect(currentSize === '0' || currentSize === '1').toBe(true);
             }
         }
     });
@@ -278,13 +278,13 @@ describe('Search Number Range Filter', () => {
     it('[C277092] Should disable apply button when from field value equal/is bigger than to field value', async () => {
         await sizeRangeFilter.checkFromFieldIsDisplayed();
         await sizeRangeFilter.putFromNumber(10);
-        await expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(false);
+        expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(false);
 
         await sizeRangeFilter.putToNumber('5');
-        await expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(false);
+        expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(false);
 
         await sizeRangeFilter.putToNumber('10');
-        await expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(false);
+        expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(false);
     });
 
     it('[C289930] Should be able to clear values in number range fields', async () => {
@@ -297,8 +297,8 @@ describe('Search Number Range Filter', () => {
         await sizeRangeFilter.putToNumber(1);
         await sizeRangeFilter.clickClearButton();
 
-        await expect(await sizeRangeFilter.getFromNumber()).toEqual('');
-        await expect(await sizeRangeFilter.getToNumber()).toEqual('');
+        expect(await sizeRangeFilter.getFromNumber()).toEqual('');
+        expect(await sizeRangeFilter.getToNumber()).toEqual('');
 
         await sizeRangeFilter.putFromNumber(0);
         await sizeRangeFilter.putToNumber(1);
@@ -309,20 +309,20 @@ describe('Search Number Range Filter', () => {
         for (const currentResult of results) {
             const currentSize = await BrowserActions.getAttribute(currentResult, 'title');
             if (currentSize && currentSize.trim() !== '') {
-                await expect(parseInt(currentSize, 10) <= 1000).toBe(true);
+                expect(parseInt(currentSize, 10) <= 1000).toBe(true);
             }
         }
 
         await sizeRangeFilter.clickClearButton();
 
-        await expect(await sizeRangeFilter.getFromNumber()).toEqual('');
-        await expect(await sizeRangeFilter.getToNumber()).toEqual('');
+        expect(await sizeRangeFilter.getFromNumber()).toEqual('');
+        expect(await sizeRangeFilter.getToNumber()).toEqual('');
 
         const resultsSize = (await dataTable.geCellElementDetail('Size')) as ElementFinder[];
         for (const currentResult of resultsSize) {
             const currentSize = await BrowserActions.getAttribute(currentResult, 'title');
             if (currentSize && currentSize.trim() !== '') {
-                await expect(parseInt(currentSize, 10) >= 1000).toBe(true);
+                expect(parseInt(currentSize, 10) >= 1000).toBe(true);
             }
         }
     });
@@ -331,7 +331,7 @@ describe('Search Number Range Filter', () => {
         await sizeRangeFilter.checkToFieldIsDisplayed();
         await sizeRangeFilter.putToNumber(2);
         await sizeRangeFilter.putFromNumber(1);
-        await expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(true);
+        expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(true);
 
         await sizeRangeFilter.clickApplyButton();
 
@@ -342,7 +342,7 @@ describe('Search Number Range Filter', () => {
         await sizeRangeFilter.checkToFieldIsDisplayed();
         await sizeRangeFilter.putToNumber(1);
         await sizeRangeFilter.putFromNumber(0);
-        await expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(true);
+        expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(true);
 
         await sizeRangeFilter.clickApplyButton();
 
@@ -353,7 +353,7 @@ describe('Search Number Range Filter', () => {
         await sizeRangeFilter.checkToFieldIsDisplayed();
         await sizeRangeFilter.putToNumber(3);
         await sizeRangeFilter.putFromNumber(2);
-        await expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(true);
+        expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(true);
 
         await sizeRangeFilter.clickApplyButton();
 
@@ -364,7 +364,7 @@ describe('Search Number Range Filter', () => {
         await sizeRangeFilter.checkToFieldIsDisplayed();
         await sizeRangeFilter.putToNumber(4);
         await sizeRangeFilter.putFromNumber(3);
-        await expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(true);
+        expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(true);
 
         await sizeRangeFilter.clickApplyButton();
 
@@ -402,7 +402,7 @@ describe('Search Number Range Filter', () => {
             await sizeRangeFilter.checkToFieldIsDisplayed();
             await sizeRangeFilter.putToNumber(toYear);
             await sizeRangeFilter.putFromNumber(fromYear);
-            await expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(true);
+            expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(true);
 
             await sizeRangeFilter.clickApplyButton();
             await searchResults.dataTable.waitTillContentLoaded();
@@ -414,8 +414,8 @@ describe('Search Number Range Filter', () => {
                 const currentDate = await BrowserActions.getAttribute(currentResult, 'title');
                 const currentDateFormatted = parse(currentDate, 'MMM dd, yyyy, h:mm:ss a', new Date());
 
-                await expect(currentDateFormatted.getFullYear() <= toYear).toBe(true);
-                await expect(currentDateFormatted.getFullYear() >= fromYear).toBe(true);
+                expect(currentDateFormatted.getFullYear() <= toYear).toBe(true);
+                expect(currentDateFormatted.getFullYear() >= fromYear).toBe(true);
             }
         });
 
@@ -438,7 +438,7 @@ describe('Search Number Range Filter', () => {
             await sizeRangeFilter.checkToFieldIsDisplayed();
             await sizeRangeFilter.putToNumber(2);
             await sizeRangeFilter.putFromNumber(1);
-            await expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(true);
+            expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(true);
 
             await sizeRangeFilter.clickApplyButton();
 
@@ -449,7 +449,7 @@ describe('Search Number Range Filter', () => {
             await sizeRangeFilter.checkToFieldIsDisplayed();
             await sizeRangeFilter.putToNumber(3);
             await sizeRangeFilter.putFromNumber(1);
-            await expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(true);
+            expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(true);
 
             await sizeRangeFilter.clickApplyButton();
 
@@ -477,7 +477,7 @@ describe('Search Number Range Filter', () => {
             await sizeRangeFilter.checkToFieldIsDisplayed();
             await sizeRangeFilter.putToNumber(3);
             await sizeRangeFilter.putFromNumber(1);
-            await expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(true);
+            expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(true);
 
             await sizeRangeFilter.clickApplyButton();
 
@@ -488,7 +488,7 @@ describe('Search Number Range Filter', () => {
             await sizeRangeFilter.checkToFieldIsDisplayed();
             await sizeRangeFilter.putToNumber(3);
             await sizeRangeFilter.putFromNumber(2);
-            await expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(true);
+            expect(await sizeRangeFilter.checkApplyButtonIsEnabled()).toBe(true);
 
             await sizeRangeFilter.clickApplyButton();
 

--- a/e2e/search/components/search-radio.e2e.ts
+++ b/e2e/search/components/search-radio.e2e.ts
@@ -15,7 +15,8 @@
  * limitations under the License.
  */
 
-import { createApiService,
+import {
+    createApiService,
     BrowserActions,
     LocalStorageUtil,
     LoginPage,
@@ -33,7 +34,6 @@ import { browser } from 'protractor';
 import { NodesApi } from '@alfresco/js-api';
 
 describe('Search Radio Component', () => {
-
     const loginPage = new LoginPage();
     const searchFiltersPage = new SearchFiltersPage();
     const navigationBarPage = new NavigationBarPage();
@@ -60,7 +60,8 @@ describe('Search Radio Component', () => {
         folder: `${randomName}Folder`
     };
 
-    let createdFile; let createdFolder;
+    let createdFile;
+    let createdFolder;
 
     beforeAll(async () => {
         await apiService.loginWithProfile('admin');
@@ -82,7 +83,7 @@ describe('Search Radio Component', () => {
         await loginPage.login(acsUser.username, acsUser.password);
 
         await BrowserActions.getUrl(browser.baseUrl + '/search;q=' + randomName);
-   });
+    });
 
     afterAll(async () => {
         await apiService.loginWithProfile('admin');
@@ -91,7 +92,7 @@ describe('Search Radio Component', () => {
         await uploadActions.deleteFileOrFolder(createdFolder.entry.id);
 
         await navigationBarPage.clickLogoutButton();
-   });
+    });
 
     it('[C277039] Should be able to choose only one option at a time', async () => {
         await searchFiltersPage.checkTypeFilterIsDisplayed();
@@ -142,7 +143,7 @@ describe('Search Radio Component', () => {
             for (let numberOfOptions = 0; numberOfOptions < 6; numberOfOptions++) {
                 jsonFile.categories[5].component.settings.options.push({
                     name: 'Folder',
-                    value: 'TYPE:\'cm:folder\''
+                    value: `TYPE:'cm:folder'`
                 });
             }
 
@@ -155,7 +156,7 @@ describe('Search Radio Component', () => {
 
             await searchFiltersPage.clickTypeFilterHeader();
 
-            await expect(await searchFiltersPage.typeFiltersPage().getRadioButtonsNumberOnPage()).toBe(16);
+            expect(await searchFiltersPage.typeFiltersPage().getRadioButtonsNumberOnPage()).toBe(16);
 
             await navigationBarPage.navigateToContentServices();
 
@@ -170,7 +171,7 @@ describe('Search Radio Component', () => {
 
             await searchFiltersPage.clickTypeFilterHeader();
 
-            await expect(await searchFiltersPage.typeFiltersPage().getRadioButtonsNumberOnPage()).toBe(16);
+            expect(await searchFiltersPage.typeFiltersPage().getRadioButtonsNumberOnPage()).toBe(16);
 
             await navigationBarPage.navigateToContentServices();
             jsonFile.categories[5].component.settings.pageSize = 9;
@@ -184,7 +185,7 @@ describe('Search Radio Component', () => {
 
             await searchFiltersPage.clickTypeFilterHeader();
 
-            await expect(await searchFiltersPage.typeFiltersPage().getRadioButtonsNumberOnPage()).toBe(15);
+            expect(await searchFiltersPage.typeFiltersPage().getRadioButtonsNumberOnPage()).toBe(15);
 
             await searchFiltersPage.typeFiltersPage().checkShowMoreButtonIsDisplayed();
             await searchFiltersPage.typeFiltersPage().checkShowLessButtonIsNotDisplayed();
@@ -200,7 +201,7 @@ describe('Search Radio Component', () => {
             for (let numberOfOptions = 0; numberOfOptions < 6; numberOfOptions++) {
                 jsonFile.categories[5].component.settings.options.push({
                     name: 'Folder',
-                    value: 'TYPE:\'cm:folder\''
+                    value: `TYPE:'cm:folder'`
                 });
             }
 
@@ -213,21 +214,21 @@ describe('Search Radio Component', () => {
 
             await searchFiltersPage.clickTypeFilterHeader();
 
-            await expect(await searchFiltersPage.typeFiltersPage().getRadioButtonsNumberOnPage()).toBe(11);
+            expect(await searchFiltersPage.typeFiltersPage().getRadioButtonsNumberOnPage()).toBe(11);
 
             await searchFiltersPage.typeFiltersPage().checkShowMoreButtonIsDisplayed();
             await searchFiltersPage.typeFiltersPage().checkShowLessButtonIsNotDisplayed();
 
             await searchFiltersPage.typeFiltersPage().clickShowMoreButton();
 
-            await expect(await searchFiltersPage.typeFiltersPage().getRadioButtonsNumberOnPage()).toBe(16);
+            expect(await searchFiltersPage.typeFiltersPage().getRadioButtonsNumberOnPage()).toBe(16);
 
             await searchFiltersPage.typeFiltersPage().checkShowMoreButtonIsNotDisplayed();
             await searchFiltersPage.typeFiltersPage().checkShowLessButtonIsDisplayed();
 
             await searchFiltersPage.typeFiltersPage().clickShowLessButton();
 
-            await expect(await searchFiltersPage.typeFiltersPage().getRadioButtonsNumberOnPage()).toBe(11);
+            expect(await searchFiltersPage.typeFiltersPage().getRadioButtonsNumberOnPage()).toBe(11);
 
             await searchFiltersPage.typeFiltersPage().checkShowMoreButtonIsDisplayed();
             await searchFiltersPage.typeFiltersPage().checkShowLessButtonIsNotDisplayed();
@@ -244,26 +245,26 @@ describe('Search Radio Component', () => {
 
             await searchFiltersPage.clickTypeFilterHeader();
 
-            await expect(await searchFiltersPage.typeFiltersPage().getRadioButtonsNumberOnPage()).toBe(11);
+            expect(await searchFiltersPage.typeFiltersPage().getRadioButtonsNumberOnPage()).toBe(11);
 
             await searchFiltersPage.typeFiltersPage().checkShowMoreButtonIsDisplayed();
             await searchFiltersPage.typeFiltersPage().checkShowLessButtonIsNotDisplayed();
 
             await searchFiltersPage.typeFiltersPage().clickShowMoreButton();
 
-            await expect(await searchFiltersPage.typeFiltersPage().getRadioButtonsNumberOnPage()).toBe(16);
+            expect(await searchFiltersPage.typeFiltersPage().getRadioButtonsNumberOnPage()).toBe(16);
 
             await searchFiltersPage.typeFiltersPage().checkShowMoreButtonIsNotDisplayed();
             await searchFiltersPage.typeFiltersPage().checkShowLessButtonIsDisplayed();
 
             await searchFiltersPage.typeFiltersPage().clickShowLessButton();
 
-            await expect(await searchFiltersPage.typeFiltersPage().getRadioButtonsNumberOnPage()).toBe(11);
+            expect(await searchFiltersPage.typeFiltersPage().getRadioButtonsNumberOnPage()).toBe(11);
 
             await searchFiltersPage.typeFiltersPage().checkShowMoreButtonIsDisplayed();
             await searchFiltersPage.typeFiltersPage().checkShowLessButtonIsNotDisplayed();
         });
-   });
+    });
 
     describe('Properties', () => {
         let jsonFile;
@@ -282,7 +283,7 @@ describe('Search Radio Component', () => {
 
             jsonFile.categories[5].component.settings.options.push({
                 name: filterType.custom,
-                value: 'TYPE:\'cm:content\''
+                value: `TYPE:'cm:content'`
             });
 
             await LocalStorageUtil.setConfigField('search', JSON.stringify(jsonFile));
@@ -306,5 +307,5 @@ describe('Search Radio Component', () => {
             await searchResults.checkContentIsDisplayed(nodeNames.document);
             await searchResults.checkContentIsNotDisplayed(nodeNames.folder);
         });
-   });
+    });
 });

--- a/e2e/search/components/search-slider.e2e.ts
+++ b/e2e/search/components/search-slider.e2e.ts
@@ -15,7 +15,9 @@
  * limitations under the License.
  */
 
-import { createApiService, BrowserActions,
+import {
+    createApiService,
+    BrowserActions,
     DataTableComponentPage,
     LocalStorageUtil,
     LoginPage,
@@ -32,7 +34,6 @@ import { browser, ElementFinder } from 'protractor';
 import { SearchConfiguration } from '../search.config';
 
 describe('Search Slider Filter', () => {
-
     const loginPage = new LoginPage();
     const searchBarPage = new SearchBarPage();
     const searchFilters = new SearchFiltersPage();
@@ -70,18 +71,16 @@ describe('Search Slider Filter', () => {
         await searchBarPage.clickOnSearchIcon();
         await searchBarPage.enterTextAndPressEnter('*');
         await searchResults.dataTable.waitTillContentLoaded();
-
     });
 
     afterAll(async () => {
         try {
             await apiService.login(acsUser.username, acsUser.password);
             await uploadActions.deleteFileOrFolder(file2Bytes.entry.id);
-        } catch (error) {
-        }
+        } catch (error) {}
 
         await navigationBarPage.clickLogoutButton();
-   });
+    });
 
     afterEach(async () => {
         await browser.refresh();
@@ -112,7 +111,7 @@ describe('Search Slider Filter', () => {
         await searchFilters.checkSizeSliderFilterIsExpanded();
         await searchFilters.checkSizeSliderFilterIsDisplayed();
 
-        await expect(await sizeSliderFilter.getValue()).toEqual(`${size}`);
+        expect(await sizeSliderFilter.getValue()).toEqual(`${size}`);
     });
 
     it('[C276981] Should be able to clear value in Search Size Slider', async () => {
@@ -124,12 +123,12 @@ describe('Search Slider Filter', () => {
         await sizeSliderFilter.setValue(size);
         await searchResults.sortBySize('DESC');
 
-        const results = await dataTable.geCellElementDetail('Size') as ElementFinder[];
+        const results = (await dataTable.geCellElementDetail('Size')) as ElementFinder[];
         for (const currentResult of results) {
             const currentSize = await BrowserActions.getAttribute(currentResult, 'title');
 
             if (currentSize && currentSize.trim() !== '') {
-                await expect(parseInt(currentSize, 10) <= 5000).toBe(true);
+                expect(parseInt(currentSize, 10) <= 5000).toBe(true);
             }
         }
 
@@ -138,12 +137,12 @@ describe('Search Slider Filter', () => {
 
         await searchResults.sortBySize('DESC');
 
-        const resultsSize = await dataTable.geCellElementDetail('Size') as ElementFinder[];
+        const resultsSize = (await dataTable.geCellElementDetail('Size')) as ElementFinder[];
         for (const currentResult of resultsSize) {
             const currentSize = await BrowserActions.getAttribute(currentResult, 'title');
 
             if (currentSize && currentSize.trim() !== '') {
-                await expect(parseInt(currentSize, 10) >= 5000).toBe(true);
+                expect(parseInt(currentSize, 10) >= 5000).toBe(true);
             }
         }
     });
@@ -190,7 +189,7 @@ describe('Search Slider Filter', () => {
 
             await sizeSliderFilter.checkSliderIsDisplayed();
 
-            await expect(await sizeSliderFilter.getMinValue()).toEqual(`${minSize}`);
+            expect(await sizeSliderFilter.getMinValue()).toEqual(`${minSize}`);
         });
 
         it('[C276986] Should be able to set max value for Search Size Slider', async () => {
@@ -210,7 +209,7 @@ describe('Search Slider Filter', () => {
 
             await sizeSliderFilter.checkSliderIsDisplayed();
 
-            await expect(await sizeSliderFilter.getMaxValue()).toEqual(`${maxSize}`);
+            expect(await sizeSliderFilter.getMaxValue()).toEqual(`${maxSize}`);
         });
 
         it('[C276987] Should be able to set steps for Search Size Slider', async () => {
@@ -232,9 +231,9 @@ describe('Search Slider Filter', () => {
             await sizeSliderFilter.checkSliderIsDisplayed();
             await sizeSliderFilter.setValue(randomValue);
 
-            await expect(await sizeSliderFilter.getValue()).toEqual(`0`);
+            expect(await sizeSliderFilter.getValue()).toEqual(`0`);
             await sizeSliderFilter.setValue(step);
-            await expect(await sizeSliderFilter.getValue()).toEqual(`${step}`);
+            expect(await sizeSliderFilter.getValue()).toEqual(`${step}`);
         });
     });
 });

--- a/e2e/search/search-component.e2e.ts
+++ b/e2e/search/search-component.e2e.ts
@@ -161,20 +161,20 @@ describe('Search component - Search Bar', () => {
 
         await searchBarPage.resultTableContainsRow(firstFolderModel.name);
 
-        await expect(await searchBarPage.getSpecificRowsHighlightName(firstFolderModel.name)).toEqual(firstFolderModel.shortName);
-        await expect(await searchBarPage.getSpecificRowsAuthor(firstFolderModel.name)).toContain(acsUser.firstName);
-        await expect(await searchBarPage.getSpecificRowsAuthor(firstFolderModel.name)).toContain(acsUser.lastName);
-        await expect(await searchBarPage.getSpecificRowsCompleteName(firstFolderModel.name)).toEqual(firstFolderModel.name);
+        expect(await searchBarPage.getSpecificRowsHighlightName(firstFolderModel.name)).toEqual(firstFolderModel.shortName);
+        expect(await searchBarPage.getSpecificRowsAuthor(firstFolderModel.name)).toContain(acsUser.firstName);
+        expect(await searchBarPage.getSpecificRowsAuthor(firstFolderModel.name)).toContain(acsUser.lastName);
+        expect(await searchBarPage.getSpecificRowsCompleteName(firstFolderModel.name)).toEqual(firstFolderModel.name);
 
         await searchBarPage.clearText();
         await searchBarPage.clickOnSearchIcon();
         await searchBarPage.enterText(firstFileModel.shortName);
         await searchBarPage.resultTableContainsRow(firstFileModel.name);
 
-        await expect(await searchBarPage.getSpecificRowsHighlightName(firstFileModel.name)).toEqual(firstFileModel.shortName);
-        await expect(await searchBarPage.getSpecificRowsAuthor(firstFileModel.name)).toContain(acsUser.firstName);
-        await expect(await searchBarPage.getSpecificRowsAuthor(firstFileModel.name)).toContain(acsUser.lastName);
-        await expect(await searchBarPage.getSpecificRowsCompleteName(firstFileModel.name)).toEqual(firstFileModel.name);
+        expect(await searchBarPage.getSpecificRowsHighlightName(firstFileModel.name)).toEqual(firstFileModel.shortName);
+        expect(await searchBarPage.getSpecificRowsAuthor(firstFileModel.name)).toContain(acsUser.firstName);
+        expect(await searchBarPage.getSpecificRowsAuthor(firstFileModel.name)).toContain(acsUser.lastName);
+        expect(await searchBarPage.getSpecificRowsCompleteName(firstFileModel.name)).toEqual(firstFileModel.name);
     });
 
     it('[C272800] Should display file/folder in search suggestion when typing name', async () => {
@@ -184,10 +184,10 @@ describe('Search component - Search Bar', () => {
 
         await searchBarPage.resultTableContainsRow(firstFolderModel.name);
 
-        await expect(await searchBarPage.getSpecificRowsHighlightName(firstFolderModel.name)).toEqual(firstFolderModel.name);
-        await expect(await searchBarPage.getSpecificRowsAuthor(firstFolderModel.name)).toContain(acsUser.firstName);
-        await expect(await searchBarPage.getSpecificRowsAuthor(firstFolderModel.name)).toContain(acsUser.lastName);
-        await expect(await searchBarPage.getSpecificRowsCompleteName(firstFolderModel.name)).toEqual(firstFolderModel.name);
+        expect(await searchBarPage.getSpecificRowsHighlightName(firstFolderModel.name)).toEqual(firstFolderModel.name);
+        expect(await searchBarPage.getSpecificRowsAuthor(firstFolderModel.name)).toContain(acsUser.firstName);
+        expect(await searchBarPage.getSpecificRowsAuthor(firstFolderModel.name)).toContain(acsUser.lastName);
+        expect(await searchBarPage.getSpecificRowsCompleteName(firstFolderModel.name)).toEqual(firstFolderModel.name);
 
         await searchBarPage.clearText();
 
@@ -195,10 +195,10 @@ describe('Search component - Search Bar', () => {
         await searchBarPage.enterText(firstFileModel.name);
         await searchBarPage.resultTableContainsRow(firstFileModel.name);
 
-        await expect(await searchBarPage.getSpecificRowsHighlightName(firstFileModel.name)).toEqual(firstFileModel.name);
-        await expect(await searchBarPage.getSpecificRowsAuthor(firstFileModel.name)).toContain(acsUser.firstName);
-        await expect(await searchBarPage.getSpecificRowsAuthor(firstFileModel.name)).toContain(acsUser.lastName);
-        await expect(await searchBarPage.getSpecificRowsCompleteName(firstFileModel.name)).toEqual(firstFileModel.name);
+        expect(await searchBarPage.getSpecificRowsHighlightName(firstFileModel.name)).toEqual(firstFileModel.name);
+        expect(await searchBarPage.getSpecificRowsAuthor(firstFileModel.name)).toContain(acsUser.firstName);
+        expect(await searchBarPage.getSpecificRowsAuthor(firstFileModel.name)).toContain(acsUser.lastName);
+        expect(await searchBarPage.getSpecificRowsCompleteName(firstFileModel.name)).toEqual(firstFileModel.name);
     });
 
     it('[C260257] Should display content when clicking on folder from search suggestions', async () => {
@@ -210,7 +210,7 @@ describe('Search component - Search Bar', () => {
         await searchBarPage.clickOnSpecificRow(firstFolderModel.name);
         await searchResultPage.dataTable.waitTillContentLoaded();
 
-        await expect(await contentServicesPage.currentFolderName()).toEqual(firstFolderModel.name);
+        expect(await contentServicesPage.currentFolderName()).toEqual(firstFolderModel.name);
 
         await searchBarPage.checkSearchIconIsVisible();
         await searchBarPage.clickOnSearchIcon();
@@ -220,7 +220,7 @@ describe('Search component - Search Bar', () => {
 
         await searchBarPage.clickOnSpecificRow(firstFileModel.name);
 
-        await expect(await viewerPage.getDisplayedFileName()).toEqual(firstFileModel.name);
+        expect(await viewerPage.getDisplayedFileName()).toEqual(firstFileModel.name);
 
         await viewerPage.clickCloseButton();
     });
@@ -252,7 +252,7 @@ describe('Search component - Search Bar', () => {
         await searchResultPage.checkContentIsDisplayed(firstFileModel.name);
     });
 
-    it("[C290137] Should be able to search by '%'", async () => {
+    it(`[C290137] Should be able to search by '%'`, async () => {
         await openSearchBar();
 
         await searchBarPage.enterTextAndPressEnter('%');
@@ -275,11 +275,14 @@ describe('Search component - Search Bar', () => {
 
         it('[C299212] Should be able to configure the highlight option for search results', async () => {
             const text = await searchResultPage.getNodeHighlight(fileHighlightUploaded.entry.name).getText();
-            await expect(text.includes(`¿${term}?`)).toBe(true);
-            await expect(text.includes(`(${term})`)).toBe(true);
+            expect(text.includes(`¿${term}?`)).toBe(true);
+            expect(text.includes(`(${term})`)).toBe(true);
         });
     });
 
+    /**
+     * Open the search bar
+     */
     async function openSearchBar(): Promise<void> {
         if (await searchBarPage.searchBarExpanded.isDisplayed()) {
             await searchBarPage.clearText();

--- a/e2e/search/search-filters.e2e.ts
+++ b/e2e/search/search-filters.e2e.ts
@@ -204,11 +204,11 @@ describe('Search Filters', () => {
         const bucketNumberForFilter = await searchFiltersPage.fileTypeCheckListFiltersPage().getBucketNumberOfFilterType(filter.type);
         const resultFileNames: any = await contentList.getAllRowsColumnValues('Display name');
 
-        await expect(bucketNumberForFilter).not.toEqual('0');
-        await expect(await paginationPage.getTotalNumberOfFiles()).toEqual(bucketNumberForFilter);
+        expect(bucketNumberForFilter).not.toEqual('0');
+        expect(await paginationPage.getTotalNumberOfFiles()).toEqual(bucketNumberForFilter);
 
         resultFileNames.map(async (nameOfResultFiles) => {
-            await expect(nameOfResultFiles.toLowerCase()).toContain('.png');
+            expect(nameOfResultFiles.toLowerCase()).toContain('.png');
         });
     });
 
@@ -282,8 +282,8 @@ describe('Search Filters', () => {
             await searchResults.dataTable.waitTillContentLoaded();
 
             await searchFiltersPage.checkDefaultFacetQueryGroupIsDisplayed();
-            await expect(await searchFiltersPage.isTypeFacetQueryGroupPresent()).toBe(false);
-            await expect(await searchFiltersPage.isSizeFacetQueryGroupPresent()).toBe(false);
+            expect(await searchFiltersPage.isTypeFacetQueryGroupPresent()).toBe(false);
+            expect(await searchFiltersPage.isSizeFacetQueryGroupPresent()).toBe(false);
         });
 
         it('[C299124] Should be able to parse escaped empty spaced labels inside facetFields', async () => {

--- a/e2e/search/search-multiselect.e2e.ts
+++ b/e2e/search/search-multiselect.e2e.ts
@@ -117,14 +117,14 @@ describe('Search Component - Multi-Select Facet', () => {
             await searchFiltersPage.fileTypeCheckListFiltersPage().filterBy('Plain Text');
             await searchResultsPage.dataTable.waitTillContentLoaded();
 
-            await expect(searchResultsPage.numberOfResultsDisplayed()).toBe(2);
+            expect(searchResultsPage.numberOfResultsDisplayed()).toBe(2);
             await searchResultsPage.checkContentIsDisplayed(txtFile.entry.name);
             await searchResultsPage.checkContentIsDisplayed(txtFileSite.entry.name);
 
             await searchFiltersPage.fileTypeCheckListFiltersPage().filterBy('JPEG Image');
             await searchResultsPage.dataTable.waitTillContentLoaded();
 
-            await expect(await searchResultsPage.numberOfResultsDisplayed()).toBe(4);
+            expect(await searchResultsPage.numberOfResultsDisplayed()).toBe(4);
             await searchResultsPage.checkContentIsDisplayed(txtFile.entry.name);
             await searchResultsPage.checkContentIsDisplayed(txtFileSite.entry.name);
             await searchResultsPage.checkContentIsDisplayed(jpgFile.entry.name);
@@ -190,7 +190,7 @@ describe('Search Component - Multi-Select Facet', () => {
             await searchFiltersPage.fileTypeCheckListFiltersPage().filterBy('JPEG Image');
             await searchResultsPage.dataTable.waitTillContentLoaded();
 
-            await expect(await searchResultsPage.numberOfResultsDisplayed()).toBe(2);
+            expect(await searchResultsPage.numberOfResultsDisplayed()).toBe(2);
             await searchResultsPage.checkContentIsDisplayed(txtFile.entry.name);
             await searchResultsPage.checkContentIsDisplayed(jpgFile.entry.name);
         });
@@ -234,7 +234,7 @@ describe('Search Component - Multi-Select Facet', () => {
             await searchFiltersPage.creatorCheckListFiltersPage().enterFilterInputValue(`${acsUser.firstName} ${acsUser.lastName}`);
             await searchResultsPage.dataTable.waitTillContentLoaded();
 
-            await expect(await searchResultsPage.numberOfResultsDisplayed()).toBe(1);
+            expect(await searchResultsPage.numberOfResultsDisplayed()).toBe(1);
             await searchResultsPage.checkContentIsDisplayed(txtFile.entry.name);
         });
     });

--- a/lib/cli/.eslintrc.json
+++ b/lib/cli/.eslintrc.json
@@ -17,7 +17,6 @@
         "@typescript-eslint/prefer-for-of": "off",
         "@typescript-eslint/consistent-type-definitions": "error",
         "@typescript-eslint/dot-notation": "off",
-        "@typescript-eslint/no-floating-promises": "off",
         "@typescript-eslint/no-inferrable-types": "off",
         "@typescript-eslint/no-require-imports": "off",
         "default-case": "error",

--- a/lib/content-services/.eslintrc.json
+++ b/lib/content-services/.eslintrc.json
@@ -46,7 +46,6 @@
             "accessibility": "explicit"
           }
         ],
-        "@typescript-eslint/no-floating-promises": "off",
         "@typescript-eslint/no-inferrable-types": "off",
         "@typescript-eslint/no-require-imports": "off",
         "@typescript-eslint/no-var-requires": "error",

--- a/lib/core/.eslintrc.json
+++ b/lib/core/.eslintrc.json
@@ -47,7 +47,6 @@
             "accessibility": "explicit"
           }
         ],
-        "@typescript-eslint/no-floating-promises": "off",
         "@typescript-eslint/no-inferrable-types": "off",
         "@typescript-eslint/no-require-imports": "off",
         "@typescript-eslint/no-var-requires": "error",

--- a/lib/extensions/.eslintrc.json
+++ b/lib/extensions/.eslintrc.json
@@ -34,7 +34,6 @@
             "accessibility": "explicit"
           }
         ],
-        "@typescript-eslint/no-floating-promises": "off",
         "@typescript-eslint/no-inferrable-types": "off",
         "@typescript-eslint/no-require-imports": "off",
         "@typescript-eslint/no-var-requires": "error",

--- a/lib/insights/.eslintrc.json
+++ b/lib/insights/.eslintrc.json
@@ -47,7 +47,6 @@
             "accessibility": "explicit"
           }
         ],
-        "@typescript-eslint/no-floating-promises": "off",
         "@typescript-eslint/no-inferrable-types": "off",
         "@typescript-eslint/no-require-imports": "off",
         "@typescript-eslint/no-var-requires": "error",

--- a/lib/js-api/.eslintrc.json
+++ b/lib/js-api/.eslintrc.json
@@ -14,7 +14,6 @@
             "accessibility": "explicit"
           }
         ],
-        "@typescript-eslint/no-floating-promises": "off",
         "@typescript-eslint/no-inferrable-types": "off",
         "@typescript-eslint/no-require-imports": "off",
         "@typescript-eslint/no-var-requires": "error",

--- a/lib/process-services-cloud/.eslintrc.json
+++ b/lib/process-services-cloud/.eslintrc.json
@@ -48,7 +48,6 @@
             "accessibility": "explicit"
           }
         ],
-        "@typescript-eslint/no-floating-promises": "off",
         "@typescript-eslint/no-inferrable-types": "off",
         "@typescript-eslint/no-require-imports": "off",
         "@typescript-eslint/no-var-requires": "error",

--- a/lib/process-services/.eslintrc.json
+++ b/lib/process-services/.eslintrc.json
@@ -45,7 +45,6 @@
             "accessibility": "explicit"
           }
         ],
-        "@typescript-eslint/no-floating-promises": "off",
         "@typescript-eslint/no-inferrable-types": "off",
         "@typescript-eslint/no-require-imports": "off",
         "@typescript-eslint/no-var-requires": "error",

--- a/lib/process-services/src/lib/form/services/index.ts
+++ b/lib/process-services/src/lib/form/services/index.ts
@@ -15,18 +15,12 @@
  * limitations under the License.
  */
 
-export * from './widgets/index';
-export * from './services';
-
-export * from './process-form-rendering.service';
-
-export * from './events/validate-dynamic-table-row.event';
-
-export * from './model/form-definition.model';
-
-export * from './form-list/form-list.component';
-export * from './form.component';
-export * from './start-form.component';
-export * from './form-custom-outcomes.component';
-
-export * from './form.module';
+export * from './activiti-alfresco.service';
+export * from './ecm-model.service';
+export * from './editor.service';
+export * from './external-alfresco-api.service';
+export * from './model.service';
+export * from './process-content.service';
+export * from './process-definition.service';
+export * from './task.service';
+export * from './task-form.service';

--- a/lib/testing/.eslintrc.json
+++ b/lib/testing/.eslintrc.json
@@ -32,7 +32,7 @@
             "accessibility": "explicit"
           }
         ],
-        "@typescript-eslint/no-floating-promises": "error",
+        "@typescript-eslint/no-floating-promises": "off",
         "@typescript-eslint/no-inferrable-types": "off",
         "@typescript-eslint/no-require-imports": "off",
         "@typescript-eslint/no-var-requires": "error",

--- a/lib/testing/.eslintrc.json
+++ b/lib/testing/.eslintrc.json
@@ -32,7 +32,6 @@
             "accessibility": "explicit"
           }
         ],
-        "@typescript-eslint/no-floating-promises": "off",
         "@typescript-eslint/no-inferrable-types": "off",
         "@typescript-eslint/no-require-imports": "off",
         "@typescript-eslint/no-var-requires": "error",

--- a/lib/testing/src/lib/protractor/content-services/pages/search/search-categories.page.ts
+++ b/lib/testing/src/lib/protractor/content-services/pages/search/search-categories.page.ts
@@ -25,7 +25,6 @@ import { BrowserActions } from '../../../core/utils/browser-actions';
 import { BrowserVisibility } from '../../../core/utils/browser-visibility';
 
 export class SearchCategoriesPage {
-
     static checkListFiltersPage(filter: ElementFinder): SearchCheckListPage {
         return new SearchCheckListPage(filter);
     }
@@ -59,14 +58,13 @@ export class SearchCategoriesPage {
         await BrowserActions.click(fileSizeFilterHeader);
     }
 
-    async checkFilterIsCollapsed(filter: ElementFinder): Promise<void> {
+    async checkFilterIsCollapsed(filter: ElementFinder) {
         const elementClass = await BrowserActions.getAttribute(filter, 'class');
-        await expect(elementClass).not.toContain('mat-expanded');
+        expect(elementClass).not.toContain('mat-expanded');
     }
 
-    async checkFilterIsExpanded(filter: ElementFinder): Promise<void> {
+    async checkFilterIsExpanded(filter: ElementFinder) {
         const elementClass = await BrowserActions.getAttribute(filter, 'class');
-        await expect(elementClass).toContain('mat-expanded');
+        expect(elementClass).toContain('mat-expanded');
     }
-
 }

--- a/lib/testing/src/lib/protractor/core/pages/form/widgets/dynamic-table-widget.page.ts
+++ b/lib/testing/src/lib/protractor/core/pages/form/widgets/dynamic-table-widget.page.ts
@@ -66,7 +66,7 @@ export class DynamicTableWidgetPage {
         const dataTableInput = $(`#${id}`);
         await BrowserVisibility.waitUntilElementIsVisible(dataTableInput);
         await BrowserActions.clearSendKeys(dataTableInput, text);
-     }
+    }
 
     async getTableRowText(rowNumber): Promise<string> {
         const tableRowByIndex = this.getTableRowByIndex(rowNumber);
@@ -121,7 +121,7 @@ export class DynamicTableWidgetPage {
     async checkItemIsPresent(item): Promise<void> {
         const row = element(by.cssContainingText('table tbody tr td span', item));
         const present = await BrowserVisibility.waitUntilElementIsVisible(row);
-        await expect(present).toBe(true);
+        expect(present).toBe(true);
     }
 
     private getTableRowByIndex = (idx: string) => $(`#dynamictable-row-${idx}`);

--- a/lib/testing/src/lib/protractor/core/pages/form/widgets/group-widget.page.ts
+++ b/lib/testing/src/lib/protractor/core/pages/form/widgets/group-widget.page.ts
@@ -21,7 +21,6 @@ import { BrowserVisibility, BrowserActions } from '../../../utils/public-api';
 import { materialLocators } from '../../public-api';
 
 export class GroupWidgetPage {
-
     groupField = $('input[data-automation-id="adf-group-search-input"]');
     firstResult = $('#adf-group-widget-user-0');
     formFields = new FormFields();
@@ -39,7 +38,7 @@ export class GroupWidgetPage {
         return this.formFields.getFieldText(fieldId);
     }
 
-    insertGroup(fieldId, value): Promise<void> {
+    insertGroup(fieldId: string, value: string): Promise<void> {
         return this.formFields.setValueInInputById(fieldId, value);
     }
 
@@ -52,13 +51,13 @@ export class GroupWidgetPage {
         await BrowserVisibility.waitUntilElementIsVisible(groupElement);
     }
 
-    async getDropDownList(): Promise<any[]> {
+    async getDropDownList(): Promise<string[]> {
         const user: Locator = by.css('[id="adf-group-label-name"]');
         await BrowserVisibility.waitUntilElementIsVisible(element(user));
         return element.all(user).map((elementFinder) => elementFinder.getText());
     }
 
-    async selectGroupFromDropDown(groupName): Promise<void> {
+    async selectGroupFromDropDown(groupName: string): Promise<void> {
         const group = element(by.cssContainingText('[id="adf-group-label-name"]', groupName));
         await BrowserActions.click(group);
     }

--- a/lib/testing/src/lib/protractor/core/pages/material/date-picker-calendar.page.ts
+++ b/lib/testing/src/lib/protractor/core/pages/material/date-picker-calendar.page.ts
@@ -40,10 +40,10 @@ export class DatePickerCalendarPage {
         const afterCalendar = $(`td[class*="${materialLocators.Calendar.body.cell.root}"][aria-label="${afterDate}"]`);
         if (await afterCalendar.isPresent()) {
             const aria = await BrowserActions.getAttribute(afterCalendar, 'aria-disabled');
-            await expect(aria).toBe('true');
+            expect(aria).toBe('true');
         }
         const isEnabled = await this.nextMonthButton.isEnabled();
-        await expect(isEnabled).toBe(false);
+        expect(isEnabled).toBe(false);
     }
 
     async checkDatesBeforeDateAreDisabled(date: Date): Promise<void> {
@@ -51,10 +51,10 @@ export class DatePickerCalendarPage {
         const beforeCalendar = $(`td[class*="${materialLocators.Calendar.body.cell.root}"][aria-label="${beforeDate}"]`);
         if (await beforeCalendar.isPresent()) {
             const aria = await BrowserActions.getAttribute(beforeCalendar, 'aria-disabled');
-            await expect(aria).toBe('true');
+            expect(aria).toBe('true');
         }
         const isEnabled = await this.previousMonthButton.isEnabled();
-        await expect(isEnabled).toBe(false);
+        expect(isEnabled).toBe(false);
     }
 
     async selectTodayDate(): Promise<void> {

--- a/lib/testing/src/lib/protractor/core/pages/material/tabs.page.ts
+++ b/lib/testing/src/lib/protractor/core/pages/material/tabs.page.ts
@@ -21,7 +21,6 @@ import { BrowserVisibility } from '../../utils/browser-visibility';
 import { materialLocators } from './material-locators';
 
 export class TabsPage {
-
     tabs = $$(`div[id*='${materialLocators.Tab.label.root}']`);
 
     async clickTabByTitle(tabTitle): Promise<void> {
@@ -31,8 +30,8 @@ export class TabsPage {
 
     async checkTabIsSelectedByTitle(tabTitle): Promise<void> {
         const tab = element(by.cssContainingText(`div[id*='${materialLocators.Tab.label.root}']`, tabTitle));
-        const result = await BrowserActions.getAttribute(tab, 'aria-selected');
-        await expect(result).toBe('true');
+        const result: string = await BrowserActions.getAttribute(tab, 'aria-selected');
+        expect(result).toBe('true');
     }
 
     async getNoOfTabs(): Promise<number> {

--- a/lib/testing/src/lib/protractor/core/pages/viewer.page.ts
+++ b/lib/testing/src/lib/protractor/core/pages/viewer.page.ts
@@ -115,7 +115,7 @@ export class ViewerPage {
 
     async checkAllThumbnailsDisplayed(nbPages): Promise<void> {
         const defaultThumbnailHeight = 143;
-        await expect(await BrowserActions.getAttribute(this.thumbnailsContent, 'style')).toEqual(
+        expect(await BrowserActions.getAttribute(this.thumbnailsContent, 'style')).toEqual(
             'height: ' + nbPages * defaultThumbnailHeight + 'px; transform: translate(-50%, 0px);'
         );
     }
@@ -124,7 +124,7 @@ export class ViewerPage {
         const selectedThumbnail = $('adf-pdf-thumb.adf-pdf-thumbnails__thumb.adf-pdf-thumbnails__thumb--selected > img');
         const pageNumber = await BrowserActions.getInputValue(this.pageSelectorInput);
 
-        await expect('Page ' + pageNumber).toEqual(await BrowserActions.getAttribute(selectedThumbnail, 'title'));
+        expect('Page ' + pageNumber).toEqual(await BrowserActions.getAttribute(selectedThumbnail, 'title'));
     }
 
     async checkThumbnailsCloseIsDisplayed(): Promise<void> {
@@ -193,7 +193,7 @@ export class ViewerPage {
     }
 
     async checkPageSelectorInputIsDisplayed(checkNumber: string): Promise<void> {
-        await expect(await BrowserActions.getInputValue(this.pageSelectorInput)).toEqual(checkNumber);
+        expect(await BrowserActions.getInputValue(this.pageSelectorInput)).toEqual(checkNumber);
     }
 
     async checkImgContainerIsDisplayed(): Promise<void> {
@@ -225,11 +225,11 @@ export class ViewerPage {
     }
 
     async checkZoomedIn(zoom): Promise<void> {
-        await expect(await BrowserActions.getText(this.percentage)).toBeGreaterThan(zoom);
+        expect(await BrowserActions.getText(this.percentage)).toBeGreaterThan(zoom);
     }
 
     async checkZoomedOut(zoom): Promise<void> {
-        await expect(await BrowserActions.getText(this.percentage)).toBeLessThan(zoom);
+        expect(await BrowserActions.getText(this.percentage)).toBeLessThan(zoom);
     }
 
     async checkScaleImgButtonIsDisplayed(): Promise<void> {
@@ -254,9 +254,7 @@ export class ViewerPage {
 
     async checkTabIsActive(tabName: string): Promise<void> {
         const materialLocatorPart = `div${materialLocators.Tab.labels.class} div${materialLocators.Tab.label.active.class} ${materialLocators.Tab.label.content.class}`;
-        const tab = element(
-            by.cssContainingText(`.adf-info-drawer-layout-content ${materialLocatorPart}`, tabName)
-        );
+        const tab = element(by.cssContainingText(`.adf-info-drawer-layout-content ${materialLocatorPart}`, tabName));
         await BrowserVisibility.waitUntilElementIsVisible(tab);
     }
 
@@ -330,7 +328,7 @@ export class ViewerPage {
     }
 
     async expectUrlToContain(text: string): Promise<void> {
-        await expect(browser.getCurrentUrl()).toContain(text);
+        expect(browser.getCurrentUrl()).toContain(text);
     }
 
     private async isSpinnerPresent(): Promise<boolean> {

--- a/lib/testing/src/lib/protractor/core/utils/file-browser.util.ts
+++ b/lib/testing/src/lib/protractor/core/utils/file-browser.util.ts
@@ -20,14 +20,15 @@ import * as fs from 'fs';
 import { browser } from 'protractor';
 
 export class FileBrowserUtil {
-
     static async isFileDownloaded(fileName: string): Promise<boolean> {
         const DEFAULT_ROOT_PATH = browser.params.testConfig ? browser.params.testConfig.main.rootPath : __dirname;
-        const file = await browser.driver.wait(() => fs.existsSync(path.join(DEFAULT_ROOT_PATH, 'downloads', fileName)), 30000,`${fileName} not downloaded`);
+        const file: boolean = await browser.driver.wait(
+            () => fs.existsSync(path.join(DEFAULT_ROOT_PATH, 'downloads', fileName)),
+            30000,
+            `${fileName} not downloaded`
+        );
 
-        await expect(file).toBe(true, `${fileName} not downloaded`);
-
+        expect(file).toBe(true);
         return !!file;
     }
-
 }

--- a/lib/testing/src/lib/protractor/process-services/pages/start-process.page.ts
+++ b/lib/testing/src/lib/protractor/process-services/pages/start-process.page.ts
@@ -24,7 +24,6 @@ import { Logger } from '../../core/utils/logger';
 import { materialLocators } from '../../public-api';
 
 export class StartProcessPage {
-
     defaultProcessName = $('input[id="processName"]');
     processNameInput = $('#processName');
     disabledSelectProcessDropdown = $('input[id="processDefinitionName"][disabled]');
@@ -82,7 +81,6 @@ export class StartProcessPage {
         } catch (error) {
             Logger.log(`No start form on process`);
         }
-
     }
 
     async selectFromApplicationDropdown(name): Promise<void> {
@@ -138,7 +136,7 @@ export class StartProcessPage {
     }
 
     async checkStartProcessButtonIsDisabled() {
-        await expect(await this.startProcessButton.isEnabled()).toBe(false);
+        expect(await this.startProcessButton.isEnabled()).toBe(false);
     }
 
     async clickStartProcessButton(): Promise<void> {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

the `@typescript-eslint/await-thenable` prevents modified e2e files to be checked in unless all the `expect await` errors are fixed

**What is the new behaviour?**

- cleanup old protractor tests to respect the `@typescript-eslint/await-thenable` eslint rule
- fix errors with double quotes in strings (e2e)
- fix code formatting in various old e2e files
- fix missing documentation tags in e2e utility functions

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
