### PR TITLE
[ACS-7740] Removed ADF code to apply saved extensions management config on app init

### DIFF
--- a/lib/extensions/src/lib/services/app-extension.service.ts
+++ b/lib/extensions/src/lib/services/app-extension.service.ts
@@ -18,10 +18,9 @@
 import { Injectable } from '@angular/core';
 import { ExtensionConfig, ExtensionRef } from '../config/extension.config';
 import { ExtensionService } from '../services/extension.service';
-import { Observable, BehaviorSubject, from } from 'rxjs';
+import { Observable, BehaviorSubject } from 'rxjs';
 import { ViewerExtensionRef } from '../config/viewer.extensions';
 import { DocumentListPresetRef } from '../config/document-list.extensions';
-import { AlfrescoApiService, AppConfigService, AuthenticationService } from '@alfresco/adf-core';
 
 @Injectable({
     providedIn: 'root'
@@ -30,17 +29,8 @@ export class AppExtensionService {
     references$: Observable<ExtensionRef[]>;
     private _references = new BehaviorSubject<ExtensionRef[]>([]);
 
-    constructor(protected extensionService: ExtensionService, authenticationService: AuthenticationService, appConfigService: AppConfigService, apiService: AlfrescoApiService) {
+    constructor(protected extensionService: ExtensionService) {
         this.references$ = this._references.asObservable();
-
-        authenticationService.onLogin.subscribe(() => {
-            const instanceId = appConfigService.get('instanceId', '1234');
-
-            const requestParams = [{}, {}, {}, {}, {}, ['application/json'], ['application/json']];
-            from(apiService.getInstance().contentClient.callApi(`/settings/${instanceId}`, 'GET', ...requestParams)).subscribe((pluginConfig) => {
-                extensionService.appendConfig(pluginConfig.entry);
-            });
-        });
     }
 
     async load() {
@@ -53,9 +43,7 @@ export class AppExtensionService {
             return;
         }
 
-        const references = (config.$references || [])
-            .filter((entry) => typeof entry === 'object')
-            .map((entry) => entry as ExtensionRef);
+        const references = (config.$references || []).filter((entry) => typeof entry === 'object').map((entry) => entry as ExtensionRef);
         this._references.next(references);
     }
 
@@ -67,11 +55,7 @@ export class AppExtensionService {
      * @returns list of document list presets
      */
     getDocumentListPreset(key: string): DocumentListPresetRef[] {
-        return this.extensionService
-          .getElements<DocumentListPresetRef>(
-            `features.documentList.${key}`
-          )
-          .filter((entry) => !entry.disabled);
+        return this.extensionService.getElements<DocumentListPresetRef>(`features.documentList.${key}`).filter((entry) => !entry.disabled);
     }
 
     /**
@@ -88,13 +72,13 @@ export class AppExtensionService {
 
     protected isViewerExtensionDisabled(extension: ViewerExtensionRef): boolean {
         if (extension) {
-          if (extension.disabled) {
-            return true;
-          }
+            if (extension.disabled) {
+                return true;
+            }
 
-          if (extension.rules?.disabled) {
-            return this.extensionService.evaluateRule(extension.rules.disabled);
-          }
+            if (extension.rules?.disabled) {
+                return this.extensionService.evaluateRule(extension.rules.disabled);
+            }
         }
 
         return false;


### PR DESCRIPTION
…n app init (now to be done in ADW)

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
App Extension service had code to apply extension state saved in ACC extensions manager on app init. This was causing various issues such as circular dependency, unnecessary API call in cases where there was no extensions manager etc


**What is the new behaviour?**
Removed the code to apply the extension state. This code will now be placed in ADW. ([PR link here](https://github.com/Alfresco/alfresco-applications/pull/577)). So API call is only made when ADW is init


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
JIRA link  - https://hyland.atlassian.net/browse/ACS-7740
