### PR TITLE
[ACS-7769] Fixed UI issue where Tasks and Processes filters had different spacing than the rest of side-nav

### DIFF
--- a/lib/process-services/src/lib/process-list/components/process-filters.component.scss
+++ b/lib/process-services/src/lib/process-list/components/process-filters.component.scss
@@ -12,9 +12,14 @@ adf-process-instance-filters {
                 width: 100%;
             }
 
-            .adf-filter-action-button .adf-filter-action-button__label {
-                padding-left: 20px;
-                margin: 0 8px;
+            .adf-filter-action-button {
+                align-items: center;
+                height: 32px;
+
+                .adf-filter-action-button__label {
+                    padding-left: 20px;
+                    margin: 0 8px;
+                }
             }
         }
     }

--- a/lib/process-services/src/lib/process-list/components/process-filters.component.scss
+++ b/lib/process-services/src/lib/process-list/components/process-filters.component.scss
@@ -1,27 +1,21 @@
-.adf {
-    &-filters__entry:has(.adf-filter-action-button) {
-        padding: 12px 0;
-        height: 24px;
-        width: 100%;
-        cursor: pointer;
-        font-size: var(--theme-body-1-font-size);
-        font-weight: bold;
-        opacity: 0.54;
-
-        .adf-full-width {
-            display: flex;
+adf-process-instance-filters {
+    .adf {
+        &-filters__entry:has(.adf-filter-action-button) {
+            padding: 0;
             width: 100%;
-        }
+            cursor: pointer;
+            font-size: var(--theme-body-1-font-size);
+            font-weight: bold;
 
-        .adf-filter-action-button .adf-filter-action-button__label {
-            padding-left: 20px;
-            margin: 0 8px;
-        }
+            .adf-full-width {
+                display: flex;
+                width: 100%;
+            }
 
-        &.adf-active,
-        &:hover {
-            color: var(--theme-primary-color);
-            opacity: 1;
+            .adf-filter-action-button .adf-filter-action-button__label {
+                padding-left: 20px;
+                margin: 0 8px;
+            }
         }
     }
 }

--- a/lib/process-services/src/lib/task-list/components/task-filters.component.scss
+++ b/lib/process-services/src/lib/task-list/components/task-filters.component.scss
@@ -1,27 +1,21 @@
-.adf {
-    &-filters__entry:has(.adf-filter-action-button) {
-        padding: 12px 0;
-        height: 24px;
-        width: 100%;
-        cursor: pointer;
-        font-size: var(--theme-body-1-font-size);
-        font-weight: bold;
-        opacity: 0.54;
-
-        .adf-full-width {
-            display: flex;
+adf-task-filters {
+    .adf {
+        &-filters__entry:has(.adf-filter-action-button) {
+            padding: 0;
             width: 100%;
-        }
+            cursor: pointer;
+            font-size: var(--theme-body-1-font-size);
+            font-weight: bold;
 
-        .adf-filter-action-button .adf-filter-action-button__label {
-            padding-left: 20px;
-            margin: 0 8px;
-        }
+            .adf-full-width {
+                display: flex;
+                width: 100%;
+            }
 
-        &.adf-active,
-        &:hover {
-            color: var(--theme-primary-color);
-            opacity: 1;
+            .adf-filter-action-button .adf-filter-action-button__label {
+                padding-left: 20px;
+                margin: 0 8px;
+            }
         }
     }
 }

--- a/lib/process-services/src/lib/task-list/components/task-filters.component.scss
+++ b/lib/process-services/src/lib/task-list/components/task-filters.component.scss
@@ -12,9 +12,14 @@ adf-task-filters {
                 width: 100%;
             }
 
-            .adf-filter-action-button .adf-filter-action-button__label {
-                padding-left: 20px;
-                margin: 0 8px;
+            .adf-filter-action-button {
+                align-items: center;
+                height: 32px;
+
+                .adf-filter-action-button__label {
+                    padding-left: 20px;
+                    margin: 0 8px;
+                }
             }
         }
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Tasks and processes filter had different spacing from rest of side nav
![image](https://github.com/Alfresco/alfresco-ng2-components/assets/92505353/2eeac3a6-3627-4c0a-b29c-2964937d6756)



**What is the new behaviour?**
Spacing is even in sidenav
![image](https://github.com/Alfresco/alfresco-ng2-components/assets/92505353/5142f884-a214-45d0-b89c-a37a466c4bfe)


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
JIRA Link - https://hyland.atlassian.net/browse/ACS-7769