### PR TITLE
AAE-22577 Improve DataTable widget to support single object reference (e.g. only 1st element from array) - Case 3

### DIFF
--- a/lib/process-services-cloud/src/lib/form/components/widgets/data-table/data-table.widget.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/data-table/data-table.widget.spec.ts
@@ -196,18 +196,6 @@ describe('DataTableWidgetComponent', () => {
         assertData(mockCountryColumns, mockEuropeCountriesRows);
     });
 
-    it('should NOT display error if form is in preview state', () => {
-        widget.field = getDataVariable(mockVariableConfig, mockSchemaDefinition, [], mockJsonFormVariableWithIncorrectData);
-        spyOn(formCloudService, 'getPreviewState').and.returnValue(true);
-        fixture.detectChanges();
-
-        const failedErrorMsgElement = fixture.debugElement.query(By.css('.adf-data-table-widget-failed-message'));
-        const previewDataTable = getPreview();
-
-        expect(failedErrorMsgElement).toBeNull();
-        expect(previewDataTable).toBeTruthy();
-    });
-
     it('should NOT display data table with data source if form is in preview state', () => {
         widget.field = getDataVariable(mockVariableConfig, mockSchemaDefinition, [], mockJsonFormVariable);
         spyOn(formCloudService, 'getPreviewState').and.returnValue(true);
@@ -220,53 +208,85 @@ describe('DataTableWidgetComponent', () => {
         expect(dataTable).toBeNull();
     });
 
-    it('should display error if data source is not linked to every column', () => {
-        widget.field = getDataVariable(mockVariableConfig, mockSchemaDefinition, [], mockJsonFormVariableWithIncorrectData);
-        fixture.detectChanges();
+    describe('should NOT display error message if', () => {
+        it('form is in preview state', () => {
+            widget.field = getDataVariable(mockVariableConfig, mockSchemaDefinition, [], mockJsonFormVariableWithIncorrectData);
+            spyOn(formCloudService, 'getPreviewState').and.returnValue(true);
+            fixture.detectChanges();
 
-        checkDataTableErrorMessage();
-        expect(widget.dataSource.getRows()).toEqual([]);
+            const failedErrorMsgElement = fixture.debugElement.query(By.css('.adf-data-table-widget-failed-message'));
+            const previewDataTable = getPreview();
+
+            expect(failedErrorMsgElement).toBeNull();
+            expect(previewDataTable).toBeTruthy();
+        });
+
+        it('path points to single object with appropriate schema definition', () => {
+            widget.field = getDataVariable({ ...mockVariableConfig, optionsPath: 'response.single-object' }, mockSchemaDefinition, [], []);
+            widget.field.value = mockJsonNestedResponseEuropeCountriesData;
+            fixture.detectChanges();
+
+            const failedErrorMsgElement = fixture.debugElement.query(By.css('.adf-data-table-widget-failed-message'));
+
+            assertData(mockCountryColumns, [mockEuropeCountriesRows[1]]);
+            expect(failedErrorMsgElement).toBeNull();
+        });
     });
 
-    it('should display error if data source has invalid column structure', () => {
-        widget.field = getDataVariable(mockVariableConfig, mockInvalidSchemaDefinition, [], mockJsonFormVariableWithIncorrectData);
-        fixture.detectChanges();
+    describe('should display error message if', () => {
+        it('data source is NOT linked to every column', () => {
+            widget.field = getDataVariable(mockVariableConfig, mockSchemaDefinition, [], mockJsonFormVariableWithIncorrectData);
+            fixture.detectChanges();
 
-        checkDataTableErrorMessage();
-        expect(widget.dataSource.getRows()).toEqual([]);
-    });
+            checkDataTableErrorMessage();
+            expect(widget.dataSource.getRows()).toEqual([]);
+        });
 
-    it('should display error if data source is not found', () => {
-        widget.field = getDataVariable({ variableName: 'not-found-data-source' }, mockSchemaDefinition, [], mockJsonFormVariableWithIncorrectData);
-        fixture.detectChanges();
+        it('data source has invalid column structure', () => {
+            widget.field = getDataVariable(mockVariableConfig, mockInvalidSchemaDefinition, [], mockJsonFormVariableWithIncorrectData);
+            fixture.detectChanges();
 
-        checkDataTableErrorMessage();
-        expect(widget.dataSource).toBeUndefined();
-    });
+            checkDataTableErrorMessage();
+            expect(widget.dataSource.getRows()).toEqual([]);
+        });
 
-    it('should display error if path is incorrect', () => {
-        widget.field = getDataVariable(
-            { ...mockVariableConfig, optionsPath: 'wrong.path' },
-            mockSchemaDefinition,
-            mockJsonNestedResponseFormVariable,
-            []
-        );
-        fixture.detectChanges();
+        it('data source is NOT found', () => {
+            widget.field = getDataVariable(
+                { variableName: 'not-found-data-source' },
+                mockSchemaDefinition,
+                [],
+                mockJsonFormVariableWithIncorrectData
+            );
+            fixture.detectChanges();
 
-        checkDataTableErrorMessage();
-        expect(widget.dataSource).toBeUndefined();
-    });
+            checkDataTableErrorMessage();
+            expect(widget.dataSource).toBeUndefined();
+        });
 
-    it('should display error if provided data by path is not an array', () => {
-        widget.field = getDataVariable(
-            { ...mockVariableConfig, optionsPath: 'response.no-array' },
-            mockSchemaDefinition,
-            mockJsonNestedResponseFormVariable,
-            []
-        );
-        fixture.detectChanges();
+        it('path is incorrect', () => {
+            widget.field = getDataVariable(
+                { ...mockVariableConfig, optionsPath: 'wrong.path' },
+                mockSchemaDefinition,
+                mockJsonNestedResponseFormVariable,
+                []
+            );
+            fixture.detectChanges();
 
-        checkDataTableErrorMessage();
-        expect(widget.dataSource).toBeUndefined();
+            checkDataTableErrorMessage();
+            expect(widget.dataSource).toBeUndefined();
+        });
+
+        it('provided data by path is NOT an array or object', () => {
+            widget.field = getDataVariable(
+                { ...mockVariableConfig, optionsPath: 'response.no-array-or-object' },
+                mockSchemaDefinition,
+                mockJsonNestedResponseFormVariable,
+                []
+            );
+            fixture.detectChanges();
+
+            checkDataTableErrorMessage();
+            expect(widget.dataSource).toBeUndefined();
+        });
     });
 });

--- a/lib/process-services-cloud/src/lib/form/components/widgets/data-table/data-table.widget.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/data-table/data-table.widget.ts
@@ -83,7 +83,7 @@ export class DataTableWidgetComponent extends WidgetComponent implements OnInit 
                 this.handleError('Data source has corrupted model or structure');
             }
         } else {
-            this.handleError('Data source not found or it is not an array');
+            this.handleError('Data source not found or it is not an array/object');
         }
     }
 

--- a/lib/process-services-cloud/src/lib/form/components/widgets/data-table/helpers/data-table-path-parser.helper.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/data-table/helpers/data-table-path-parser.helper.spec.ts
@@ -16,7 +16,7 @@
  */
 
 import { DataTablePathParserHelper } from './data-table-path-parser.helper';
-import { mockResponseResultData, mockResponseResultDataWithNestedArray, mockResultData } from '../mocks/data-table-path-parser.helper.mock';
+import { mockResponseResultData, mockResponseResultDataWithArrayInsideArray, mockResultData } from '../mocks/data-table-path-parser.helper.mock';
 
 interface DataTablePathParserTestCase {
     description: string;
@@ -132,20 +132,32 @@ describe('DataTablePathParserHelper', () => {
                 description: 'with property followed by single index reference',
                 propertyName: 'users',
                 path: 'response.users[0].data',
-                data: mockResponseResultDataWithNestedArray('users')
+                data: mockResponseResultDataWithArrayInsideArray('users')
             },
             {
                 description: 'with property followed by multiple index references',
                 propertyName: 'users:Array',
                 path: 'response.[users:Array][0][1][12].data',
-                data: mockResponseResultDataWithNestedArray('users:Array'),
+                data: mockResponseResultDataWithArrayInsideArray('users:Array'),
                 expected: []
             },
             {
-                description: 'when path does NOT point to array',
+                description: 'when path points to array in the middle (incorrect path)',
                 propertyName: 'users',
-                path: 'response.users[0]',
-                data: mockResponseResultDataWithNestedArray('users'),
+                path: 'response.users.incorrectPath',
+                data: mockResponseResultDataWithArrayInsideArray('users'),
+                expected: []
+            },
+            {
+                description: 'when path points to the particular element of the array',
+                propertyName: 'users',
+                path: 'response.users[1]',
+                expected: [mockResultData[1]]
+            },
+            {
+                description: 'when path points to the particular element of the array which does NOT exist',
+                propertyName: 'users',
+                path: 'response.users[100]',
                 expected: []
             }
         ];

--- a/lib/process-services-cloud/src/lib/form/components/widgets/data-table/helpers/data-table-path-parser.helper.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/data-table/helpers/data-table-path-parser.helper.ts
@@ -38,11 +38,8 @@ export class DataTablePathParserHelper {
         const nestedData = isPropertyWithSingleIndexReference ? data[purePropertyName]?.[propertyIndexReferences[0]] : data[purePropertyName];
 
         if (nestedData && properties.length === 0) {
-            const isNestedDataArray = Array.isArray(nestedData);
-            const isNestedDataObject = typeof nestedData === 'object';
-
-            if (isNestedDataArray || isNestedDataObject) {
-                return isNestedDataArray ? nestedData : [nestedData];
+            if (this.isDataArrayOrObject(nestedData)) {
+                return Array.isArray(nestedData) ? nestedData : [nestedData];
             }
         }
 
@@ -131,5 +128,12 @@ export class DataTablePathParserHelper {
 
     private isPropertyExistsInData(data: any, property: string): boolean {
         return Object.prototype.hasOwnProperty.call(data, property);
+    }
+
+    private isDataArrayOrObject(data: any): boolean {
+        if (data == null) {
+            return false;
+        }
+        return Array.isArray(data) || typeof data === 'object';
     }
 }

--- a/lib/process-services-cloud/src/lib/form/components/widgets/data-table/helpers/data-table-path-parser.helper.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/data-table/helpers/data-table-path-parser.helper.ts
@@ -37,8 +37,13 @@ export class DataTablePathParserHelper {
         const isPropertyWithSingleIndexReference = propertyIndexReferences.length === 1;
         const nestedData = isPropertyWithSingleIndexReference ? data[purePropertyName]?.[propertyIndexReferences[0]] : data[purePropertyName];
 
-        if (Array.isArray(nestedData)) {
-            return nestedData;
+        if (nestedData && properties.length === 0) {
+            const isNestedDataArray = Array.isArray(nestedData);
+            const isNestedDataObject = typeof nestedData === 'object';
+
+            if (isNestedDataArray || isNestedDataObject) {
+                return isNestedDataArray ? nestedData : [nestedData];
+            }
         }
 
         return this.retrieveDataFromPath(nestedData, properties.join('.'));

--- a/lib/process-services-cloud/src/lib/form/components/widgets/data-table/mocks/data-table-path-parser.helper.mock.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/data-table/mocks/data-table-path-parser.helper.mock.ts
@@ -44,7 +44,7 @@ export const mockResponseResultData = (propertyName?: string) => ({
     }
 });
 
-export const mockResponseResultDataWithNestedArray = (propertyName?: string) => ({
+export const mockResponseResultDataWithArrayInsideArray = (propertyName?: string) => ({
     response: {
         [propertyName]: [
             {

--- a/lib/process-services-cloud/src/lib/form/components/widgets/data-table/mocks/data-table-widget.mock.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/data-table/mocks/data-table-widget.mock.ts
@@ -114,13 +114,14 @@ export const mockJsonNestedResponseEuropeCountriesData = {
     response: {
         empty: [],
         'my-data': mockEuropeCountriesData,
+        'single-object': mockEuropeCountriesData[0],
+        'no-array-or-object': 'string-value',
         data: [
             {
                 id: 'HR',
                 name: 'Croatia'
             }
-        ],
-        'no-array': {}
+        ]
     }
 };
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [X] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/AAE-22577


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
