### PR TITLE
[ACS-8037] Add new endpoint to confirm/reject prediction

### DIFF
--- a/lib/content-services/src/lib/prediction/services/prediction.service.spec.ts
+++ b/lib/content-services/src/lib/prediction/services/prediction.service.spec.ts
@@ -18,7 +18,7 @@
 import { PredictionService } from './prediction.service';
 import { TestBed } from '@angular/core/testing';
 import { ContentTestingModule } from '../../testing/content.testing.module';
-import { Prediction, PredictionEntry, PredictionPaging, PredictionPagingList } from '@alfresco/js-api';
+import { Prediction, PredictionEntry, PredictionPaging, PredictionPagingList, ReviewStatus } from '@alfresco/js-api';
 
 describe('PredictionService', () => {
     let service: PredictionService;
@@ -43,5 +43,12 @@ describe('PredictionService', () => {
 
         service.getPredictions('test id');
         expect(service.predictionsApi.getPredictions).toHaveBeenCalledWith('test id');
+    });
+
+    it('should call reviewPrediction on PredictionsApi with predictionId and reviewStatus', () => {
+        spyOn(service.predictionsApi, 'reviewPrediction').and.returnValue(Promise.resolve());
+
+        service.reviewPrediction('test id', ReviewStatus.CONFIRMED);
+        expect(service.predictionsApi.reviewPrediction).toHaveBeenCalledWith('test id', ReviewStatus.CONFIRMED);
     });
 });

--- a/lib/content-services/src/lib/prediction/services/prediction.service.ts
+++ b/lib/content-services/src/lib/prediction/services/prediction.service.ts
@@ -17,7 +17,7 @@
 
 import { Injectable } from '@angular/core';
 import { AlfrescoApiService } from '@alfresco/adf-core';
-import { PredictionsApi, PredictionPaging } from '@alfresco/js-api';
+import { PredictionsApi, PredictionPaging, ReviewStatus } from '@alfresco/js-api';
 import { from, Observable } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
@@ -39,5 +39,16 @@ export class PredictionService {
      */
     getPredictions(nodeId: string): Observable<PredictionPaging> {
         return from(this.predictionsApi.getPredictions(nodeId));
+    }
+
+    /**
+     * Review a prediction
+     *
+     * @param predictionId The identifier of prediction.
+     * @param reviewStatus Review status to apply.
+     * @returns Observable<void>
+     */
+    reviewPrediction(predictionId: string, reviewStatus: ReviewStatus): Observable<void> {
+        return from(this.predictionsApi.reviewPrediction(predictionId, reviewStatus));
     }
 }

--- a/lib/js-api/src/api/hxi-connector-api/api/predictions.api.ts
+++ b/lib/js-api/src/api/hxi-connector-api/api/predictions.api.ts
@@ -17,7 +17,7 @@
 
 import { BaseApi } from './base.api';
 import { throwIfNotDefined } from '../../../assert';
-import { PredictionPaging } from '../model';
+import { PredictionPaging, ReviewStatus } from '../model';
 
 export class PredictionsApi extends BaseApi {
     /**
@@ -37,6 +37,29 @@ export class PredictionsApi extends BaseApi {
             path: '/nodes/{nodeId}/predictions',
             pathParams,
             returnType: PredictionPaging
+        });
+    }
+
+    /**
+     * Confirm or reject a prediction
+     *
+     * @param predictionId The identifier of a prediction.
+     * @param reviewStatus New status to apply for prediction. Can be either 'confirmed' or 'rejected'.
+     * @returns Promise<void>
+     */
+    reviewPrediction(predictionId: string, reviewStatus: ReviewStatus): Promise<void> {
+        throwIfNotDefined(predictionId, 'predictionId');
+        throwIfNotDefined(reviewStatus, 'reviewStatus');
+
+        const pathParams = {
+            predictionId,
+            reviewStatus
+        };
+
+        return this.post({
+            path: '/predictions/{predictionId}/review',
+            pathParams,
+            returnType: Promise<void>
         });
     }
 }

--- a/lib/js-api/src/api/hxi-connector-api/docs/PredictionsApi.md
+++ b/lib/js-api/src/api/hxi-connector-api/docs/PredictionsApi.md
@@ -26,7 +26,7 @@ Name | Type | Description  | Notes
 
 <a name="reviewPrediction"></a>
 # **reviewPrediction**
-> Promise<void> reviewPrediction(predictionId, reviewStatus)
+> Promise\<void\> reviewPrediction(predictionId, reviewStatus)
 
 Confirm or reject a prediction.
 
@@ -39,4 +39,4 @@ Name | Type | Description  | Notes
 
 ### Return type
 
-**Promise<void>**
+**Promise\<void\>**

--- a/lib/js-api/src/api/hxi-connector-api/docs/PredictionsApi.md
+++ b/lib/js-api/src/api/hxi-connector-api/docs/PredictionsApi.md
@@ -5,6 +5,7 @@ All URIs are relative to *https://localhost/alfresco/api/-default-/private/hxi/v
 Method | HTTP request | Description
 ------------- | ------------- | -------------
 [**getPredictions**](PredictionsApi.md#getPredictions) | **GET** /nodes/{nodeId}/predictions | Get predictions for node.
+[**reviewPrediction**](PredictionsApi.md#reviewPrediction) | **POST** /predictions/{predictionId}/review | Reject or confirm prediction.
 
 <a name="getPredictions"></a>
 # **getPredictions**
@@ -16,8 +17,26 @@ Get predictions for a node.
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
- **nodeId** | **string**| The identifier of a node. |
+ **nodeId** | **string** | The identifier of a node. |
 
 ### Return type
 
 [**PredictionPaging**](PredictionPaging.md)
+
+
+<a name="reviewPrediction"></a>
+# **reviewPrediction**
+> Promise<void> reviewPrediction(predictionId, reviewStatus)
+
+Confirm or reject a prediction.
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **predictionId** | **string** | The identifier of a prediction. |
+ **reviewStatus** | **ReviewStatus** | Review status for prediction. Can be confirmed or rejected. |
+
+### Return type
+
+**Promise<void>**


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

New endpoint for confirming/rejecting predictions has been added. https://hyland.atlassian.net/browse/ACS-8037

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
