### PR TITLE
[ACS-8042] Fixed styles for inputs in library creation

### DIFF
--- a/lib/content-services/src/lib/dialogs/library/library.dialog.html
+++ b/lib/content-services/src/lib/dialogs/library/library.dialog.html
@@ -2,7 +2,7 @@
 
 <mat-dialog-content class="adf-library-dialog-content">
   <form novalidate [formGroup]="form" (submit)="submit()">
-    <mat-form-field class="adf-library-dialog-form-field" appearance="outline">
+    <mat-form-field class="adf-library-dialog-form-field">
       <mat-label>{{ 'LIBRARY.DIALOG.FORM.NAME' | translate }}</mat-label>
       <input
         required
@@ -28,7 +28,7 @@
       </mat-error>
     </mat-form-field>
 
-    <mat-form-field class="adf-library-dialog-form-field" appearance="outline">
+    <mat-form-field class="adf-library-dialog-form-field">
       <mat-label>{{ 'LIBRARY.DIALOG.FORM.SITE_ID' | translate }}</mat-label>
       <input
         required
@@ -46,7 +46,7 @@
       </mat-error>
     </mat-form-field>
 
-    <mat-form-field class="adf-library-dialog-form-field" appearance="outline">
+    <mat-form-field class="adf-library-dialog-form-field adf-library-dialog-form-field-description">
       <mat-label>{{ 'LIBRARY.DIALOG.FORM.DESCRIPTION' | translate }}</mat-label>
       <textarea
         matInput

--- a/lib/content-services/src/lib/dialogs/library/library.dialog.scss
+++ b/lib/content-services/src/lib/dialogs/library/library.dialog.scss
@@ -1,3 +1,5 @@
+@import 'styles/mat-selectors';
+
 .adf-library-dialog {
     .adf-library-dialog-content {
         padding: 0;
@@ -16,7 +18,47 @@
 
     .adf-library-dialog-form-field {
         width: 100%;
-        padding-top: 20px;
+        padding-top: 9.5px;
+
+        &:first-of-type {
+            padding-top: 13.5px;
+        }
+
+        &:last-of-type {
+            padding-top: 4.5px;
+        }
+
+        #{$mat-floating-label} {
+            -webkit-font-smoothing: subpixel-antialiased;
+        }
+
+        &#{$mat-form-field-hide-placeholder} {
+            #{$mat-floating-label} {
+                padding-top: 11px;
+            }
+        }
+
+        &-description {
+            &#{$mat-form-field-hide-placeholder} {
+                #{$mat-floating-label} {
+                    padding-top: 20px;
+                }
+            }
+        }
+
+        #{$mat-form-field-infix} {
+            padding-bottom: 3.5px;
+        }
+
+        #{$mat-form-field-error-wrapper} {
+            margin-left: -2px;
+            font-size: 10.5px;
+            -webkit-font-smoothing: subpixel-antialiased;
+
+            #{$mat-form-field-error} {
+                height: 13.125px;
+            }
+        }
     }
 
     .adf-action-buttons {

--- a/lib/core/src/lib/styles/_mat-selectors.scss
+++ b/lib/core/src/lib/styles/_mat-selectors.scss
@@ -99,6 +99,8 @@ $mat-text-field--no-label: '.mdc-text-field--no-label';
 $mat-form-field-infix: '.mat-mdc-form-field-infix';
 $mat-form-field-hide-placeholder: '.mat-form-field-hide-placeholder';
 $mat-form-field-hint-wrapper: '.mat-mdc-form-field-hint-wrapper';
+$mat-form-field-error-wrapper: '.mat-mdc-form-field-error-wrapper';
+$mat-form-field-error: '.mat-mdc-form-field-error';
 $mat-checkbox-background: '.mdc-checkbox__background';
 $mat-dialog-content: '.mdc-dialog__content';
 $mat-floating-label: '.mdc-floating-label';


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/ACS-8042


**What is the new behaviour?**
Inputs for library creation dialog are styled properly. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
