### PR TITLE
[ACS-7974] Adding material selectors for assign security marks dialog

### DIFF
--- a/lib/core/src/lib/styles/_mat-selectors.scss
+++ b/lib/core/src/lib/styles/_mat-selectors.scss
@@ -140,5 +140,4 @@ $mat-text-field-disabled: '.mdc-text-field--disabled';
 $mat-form-field-focus-overlay: '.mat-mdc-form-field-focus-overlay';
 $mat-form-field-error-wrapper: '.mat-mdc-form-field-error-wrapper';
 $mat-text-field-textarea: '.mdc-text-field--textarea';
-$mat-list-item-disabled: '.mdc-list-item--disabled';
 $mat-chip-focus-overlay: '.mat-mdc-chip-focus-overlay';


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe:
Adding material selectors for use in user assign security marks dialog

**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://hyland.atlassian.net/browse/ACS-7974