### PR TITLE
[Acs 8095] Share modal link text is too low, making the underlining overlap with the text, Print button in the viewer does not open the print window

### DIFF
--- a/lib/content-services/src/lib/common/services/rendition.service.ts
+++ b/lib/content-services/src/lib/common/services/rendition.service.ts
@@ -257,17 +257,14 @@ export class RenditionService {
     printFile(url: string, type: string): void {
         const pwa = window.open(url, RenditionService.TARGET);
         if (pwa) {
-            // Because of the way chrome focus and close image window vs. pdf preview window
-            if (type === RenditionService.ContentGroup.IMAGE) {
-                pwa.onfocus = () => {
+            pwa.onload = () => {
+                pwa.print();
+                if (type === RenditionService.ContentGroup.IMAGE) {
+                    // Because of the way chrome focus and close image window vs. pdf preview window
                     setTimeout(() => {
                         pwa.close();
                     }, 500);
-                };
-            }
-
-            pwa.onload = () => {
-                pwa.print();
+                }
             };
         }
     }

--- a/lib/content-services/src/lib/content-node-share/content-node-share.dialog.scss
+++ b/lib/content-services/src/lib/content-node-share/content-node-share.dialog.scss
@@ -37,6 +37,7 @@
 
             #{$mat-form-field-infix}:has(.adf-share-link__input) {
                 border-top: 0.9375em solid transparent;
+                border-bottom: 0.9375em solid transparent;
                 height: 16px;
             }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/ACS-8096
https://hyland.atlassian.net/browse/ACS-8095


**What is the new behaviour?**
ACS-8096 - occurring only on bigger image files in file viewer, which triggered setTimeout that waited 500 ms for the image to load then closed the browser print action. If image didn't load in that time then the browser would cancel print action.

Now it should work as expected and the timeout should trigger after image loads, allowing browser to complete print action.

ACS-8095 - fixes the input in the share dialog
<img width="551" alt="image" src="https://github.com/Alfresco/alfresco-ng2-components/assets/73617938/25de455e-c683-4ba7-a22d-f36b266e62e6">


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
