### PR TITLE
Revert "[Acs 8095] Share modal link text is too low, making the underlining overlap with the text, Print button in the viewer does not open the print window"

### DIFF
--- a/lib/content-services/src/lib/common/services/rendition.service.ts
+++ b/lib/content-services/src/lib/common/services/rendition.service.ts
@@ -257,14 +257,17 @@ export class RenditionService {
     printFile(url: string, type: string): void {
         const pwa = window.open(url, RenditionService.TARGET);
         if (pwa) {
-            pwa.onload = () => {
-                pwa.print();
-                if (type === RenditionService.ContentGroup.IMAGE) {
-                    // Because of the way chrome focus and close image window vs. pdf preview window
+            // Because of the way chrome focus and close image window vs. pdf preview window
+            if (type === RenditionService.ContentGroup.IMAGE) {
+                pwa.onfocus = () => {
                     setTimeout(() => {
                         pwa.close();
                     }, 500);
-                }
+                };
+            }
+
+            pwa.onload = () => {
+                pwa.print();
             };
         }
     }

--- a/lib/content-services/src/lib/content-node-share/content-node-share.dialog.scss
+++ b/lib/content-services/src/lib/content-node-share/content-node-share.dialog.scss
@@ -37,7 +37,6 @@
 
             #{$mat-form-field-infix}:has(.adf-share-link__input) {
                 border-top: 0.9375em solid transparent;
-                border-bottom: 0.9375em solid transparent;
                 height: 16px;
             }
 


### PR DESCRIPTION
Reverts Alfresco/alfresco-ng2-components#9776