### PR TITLE
AAE-22443 disable insecure eval support for pdf viewer

### DIFF
--- a/lib/core/src/lib/viewer/components/pdf-viewer/pdf-viewer.component.ts
+++ b/lib/core/src/lib/viewer/components/pdf-viewer/pdf-viewer.component.ts
@@ -181,7 +181,8 @@ export class PdfViewerComponent implements OnChanges, OnDestroy {
                 const pdfOptions = {
                     ...this.pdfjsDefaultOptions,
                     data: reader.result,
-                    withCredentials: this.appConfigService.get<boolean>('auth.withCredentials', undefined)
+                    withCredentials: this.appConfigService.get<boolean>('auth.withCredentials', undefined),
+                    isEvalSupported: false
                 };
                 this.executePdf(pdfOptions);
             };
@@ -193,7 +194,8 @@ export class PdfViewerComponent implements OnChanges, OnDestroy {
             const pdfOptions: any = {
                 ...this.pdfjsDefaultOptions,
                 url: urlFile.currentValue,
-                withCredentials: this.appConfigService.get<boolean>('auth.withCredentials', undefined)
+                withCredentials: this.appConfigService.get<boolean>('auth.withCredentials', undefined),
+                isEvalSupported: false
             };
             if (this.cacheType) {
                 pdfOptions.httpHeaders = {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://hyland.atlassian.net/browse/AAE-22443
https://hyland.atlassian.net/browse/MNT-24444

**What is the new behaviour?**

Setting `isEvalSupported` to `false` disables insecure evaluation of strings as JavaScript in `adf-pdf-viewer` component

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
