### PR TITLE
[ACS-6124] Mark tree view component for deprecation

### DIFF
--- a/docs/release-notes/RelNote-6.10.0.md
+++ b/docs/release-notes/RelNote-6.10.0.md
@@ -13,6 +13,7 @@ The following components have been removed:
 - Content Services: `WebScriptComponent`
 - Content Services: `RatingComponent` 
 - Content Services: `LikeComponent`
+- Content Services: `adf-create-folder`, `adf-edit-folder` directives
 
 ## Changelog
 

--- a/docs/release-notes/RelNote-6.10.0.md
+++ b/docs/release-notes/RelNote-6.10.0.md
@@ -10,10 +10,10 @@ The following components have been deprecated and will be removed in the next ma
 
 The following components have been removed:
 
-- Content Services: `WebScriptComponent`
-- Content Services: `RatingComponent` 
-- Content Services: `LikeComponent`
-- Content Services: `adf-create-folder`, `adf-edit-folder` directives
+- ACS-5571: Content Services: `WebScriptComponent`
+- ACS-5572: Content Services: `RatingComponent` 
+- ACS-5572: Content Services: `LikeComponent`
+- ACS-7577: Content Services: `adf-create-folder`, `adf-edit-folder` directives
 
 ## Changelog
 

--- a/docs/release-notes/RelNote-6.10.0.md
+++ b/docs/release-notes/RelNote-6.10.0.md
@@ -6,6 +6,14 @@ The following components have been deprecated and will be removed in the next ma
 
 - Content Services: `TreeViewComponent`
 
+## Removed Content
+
+The following components have been removed:
+
+- Content Services: `WebScriptComponent`
+- Content Services: `RatingComponent` 
+- Content Services: `LikeComponent`
+
 ## Changelog
 
 TBD

--- a/docs/release-notes/RelNote-6.10.0.md
+++ b/docs/release-notes/RelNote-6.10.0.md
@@ -1,0 +1,11 @@
+# Release Notes v6.10.0
+
+## Deprecated Content
+
+The following components have been deprecated and will be removed in the next major release:
+
+- Content Services: `TreeViewComponent`
+
+## Changelog
+
+TBD

--- a/lib/content-services/src/lib/tree-view/components/tree-view.component.spec.ts
+++ b/lib/content-services/src/lib/tree-view/components/tree-view.component.spec.ts
@@ -74,7 +74,7 @@ describe('TreeViewComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ContentTestingModule]
+            imports: [ContentTestingModule, TreeViewComponent]
         });
     });
 

--- a/lib/content-services/src/lib/tree-view/components/tree-view.component.ts
+++ b/lib/content-services/src/lib/tree-view/components/tree-view.component.ts
@@ -21,9 +21,16 @@ import { TreeBaseNode } from '../models/tree-view.model';
 import { TreeViewDataSource } from '../data/tree-view-datasource';
 import { TreeViewService } from '../services/tree-view.service';
 import { NodeEntry } from '@alfresco/js-api';
+import { CommonModule } from '@angular/common';
+import { MatTreeModule } from '@angular/material/tree';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { TranslateModule } from '@ngx-translate/core';
 
 @Component({
     selector: 'adf-tree-view-list',
+    standalone: true,
+    imports: [CommonModule, MatTreeModule, MatButtonModule, MatIconModule, TranslateModule],
     templateUrl: './tree-view.component.html',
     styleUrls: ['./tree-view.component.scss']
 })

--- a/lib/content-services/src/lib/tree-view/services/tree-view.service.ts
+++ b/lib/content-services/src/lib/tree-view/services/tree-view.service.ts
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-import { NodesApiService } from  '../../common/services/nodes-api.service';
-import { Injectable } from '@angular/core';
+import { NodesApiService } from '../../common/services/nodes-api.service';
+import { inject, Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { TreeBaseNode } from '../models/tree-view.model';
 import { NodePaging, NodeEntry } from '@alfresco/js-api';
@@ -26,16 +26,12 @@ import { map } from 'rxjs/operators';
     providedIn: 'root'
 })
 export class TreeViewService {
+    private nodeApi = inject(NodesApiService);
 
-    constructor(private nodeApi: NodesApiService) {
+    getTreeNodes(nodeId: string): Observable<TreeBaseNode[]> {
+        return this.nodeApi.getNodeChildren(nodeId).pipe(
+            map((nodePage: NodePaging) => nodePage.list.entries.filter((node) => (node.entry.isFolder ? node : null))),
+            map((nodes: NodeEntry[]) => nodes.map((node) => new TreeBaseNode(node)))
+        );
     }
-
-    getTreeNodes(nodeId): Observable<TreeBaseNode[]> {
-        return this.nodeApi.getNodeChildren(nodeId)
-            .pipe(
-                map((nodePage: NodePaging) => nodePage.list.entries.filter((node) => node.entry.isFolder ? node : null)),
-                map((nodes: NodeEntry[]) => nodes.map((node) => new TreeBaseNode(node)))
-            );
-    }
-
 }

--- a/lib/content-services/src/lib/tree-view/tree-view.module.ts
+++ b/lib/content-services/src/lib/tree-view/tree-view.module.ts
@@ -15,24 +15,12 @@
  * limitations under the License.
  */
 
-import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { TranslateModule } from '@ngx-translate/core';
-import { MaterialModule } from '../material.module';
 import { TreeViewComponent } from './components/tree-view.component';
 
+/** @deprecated this module is deprecated and will be removed in future versions */
 @NgModule({
-    imports: [
-        CommonModule,
-        MaterialModule,
-        TranslateModule
-    ],
-    declarations: [
-        TreeViewComponent
-    ],
-    exports: [
-        TreeViewComponent
-    ]
+    imports: [TreeViewComponent],
+    exports: [TreeViewComponent]
 })
-export class TreeViewModule {
-}
+export class TreeViewModule {}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

ACS-6124

the tree view component is not used in any internal applicaiton, not being tested and/or maintained properly

**What is the new behaviour?**

- mark the tree view for deprecation
- update the upcoming release notes 
- break tree view dependency on the `MaterialModule`, convert to standalone component

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
