### PR TITLE
AAE-23099 Reset datatable selection on multiselect change to false

### DIFF
--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.spec.ts
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.spec.ts
@@ -397,40 +397,35 @@ describe('DataTable', () => {
         expect(dataSort).toEqual(dataSortObj);
     });
 
-    it('should reset selection on mode change', () => {
-        spyOn(dataTable, 'resetSelection').and.callThrough();
+    describe('Selection reset', () => {
+        beforeEach(() => {
+            spyOn(dataTable, 'resetSelection').and.callThrough();
 
-        dataTable.data = new ObjectDataTableAdapter([{ name: '1' }, { name: '2' }], [new ObjectDataColumn({ key: 'name' })]);
-        const rows = dataTable.data.getRows();
-        rows[0].isSelected = true;
-        rows[1].isSelected = true;
+            dataTable.data = new ObjectDataTableAdapter([{ name: '1' }, { name: '2' }], [new ObjectDataColumn({ key: 'name' })]);
+            const rows = dataTable.data.getRows();
 
-        expect(rows[0].isSelected).toBeTruthy();
-        expect(rows[1].isSelected).toBeTruthy();
+            rows[0].isSelected = true;
+            rows[1].isSelected = true;
 
-        dataTable.ngOnChanges({
-            selectionMode: new SimpleChange(null, 'multiple', false)
+            expect(rows[0].isSelected).toBeTruthy();
+            expect(rows[1].isSelected).toBeTruthy();
         });
 
-        expect(dataTable.resetSelection).toHaveBeenCalled();
-    });
+        it('should reset selection on mode change', () => {
+            dataTable.ngOnChanges({
+                selectionMode: new SimpleChange(null, 'multiple', false)
+            });
 
-    it('should reset selection on multiselect change', () => {
-        spyOn(dataTable, 'resetSelection').and.callThrough();
-
-        dataTable.data = new ObjectDataTableAdapter([{ name: '1' }, { name: '2' }], [new ObjectDataColumn({ key: 'name' })]);
-        const rows = dataTable.data.getRows();
-        rows[0].isSelected = true;
-        rows[1].isSelected = true;
-
-        expect(rows[0].isSelected).toBeTruthy();
-        expect(rows[1].isSelected).toBeTruthy();
-
-        dataTable.ngOnChanges({
-            multiselect: new SimpleChange(true, false, false)
+            expect(dataTable.selection).toEqual([]);
         });
 
-        expect(dataTable.selection).toEqual([]);
+        it('should reset selection on multiselect change', () => {
+            dataTable.ngOnChanges({
+                multiselect: new SimpleChange(true, false, false)
+            });
+
+            expect(dataTable.selection).toEqual([]);
+        });
     });
 
     it('should select the row where isSelected is true', () => {

--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.spec.ts
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.spec.ts
@@ -430,7 +430,7 @@ describe('DataTable', () => {
             multiselect: new SimpleChange(true, false, false)
         });
 
-        expect(dataTable.resetSelection).toHaveBeenCalled();
+        expect(dataTable.selection).toEqual([]);
     });
 
     it('should select the row where isSelected is true', () => {

--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.spec.ts
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.spec.ts
@@ -415,6 +415,24 @@ describe('DataTable', () => {
         expect(dataTable.resetSelection).toHaveBeenCalled();
     });
 
+    it('should reset selection on multiselect change', () => {
+        spyOn(dataTable, 'resetSelection').and.callThrough();
+
+        dataTable.data = new ObjectDataTableAdapter([{ name: '1' }, { name: '2' }], [new ObjectDataColumn({ key: 'name' })]);
+        const rows = dataTable.data.getRows();
+        rows[0].isSelected = true;
+        rows[1].isSelected = true;
+
+        expect(rows[0].isSelected).toBeTruthy();
+        expect(rows[1].isSelected).toBeTruthy();
+
+        dataTable.ngOnChanges({
+            multiselect: new SimpleChange(true, false, false)
+        });
+
+        expect(dataTable.resetSelection).toHaveBeenCalled();
+    });
+
     it('should select the row where isSelected is true', () => {
         dataTable.rows = [{ name: 'TEST1' }, { name: 'FAKE2' }, { name: 'TEST2', isSelected: true }, { name: 'FAKE2' }];
         dataTable.data = new ObjectDataTableAdapter([], [new ObjectDataColumn({ key: 'name' })]);

--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.ts
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.ts
@@ -302,6 +302,7 @@ export class DataTableComponent implements OnInit, AfterContentInit, OnChanges, 
         const dataChanges = changes['data'];
         const rowChanges = changes['rows'];
         const columnChanges = changes['columns'];
+        const multiselectChanges = changes['multiselect'];
 
         if (this.isPropertyChanged(dataChanges) || this.isPropertyChanged(rowChanges) || this.isPropertyChanged(columnChanges)) {
             if (this.isTableEmpty()) {
@@ -332,6 +333,10 @@ export class DataTableComponent implements OnInit, AfterContentInit, OnChanges, 
 
         if (this.isPropertyChanged(changes['sorting'])) {
             this.setTableSorting(changes['sorting'].currentValue);
+        }
+
+        if (multiselectChanges.currentValue === false) {
+            this.resetSelection();
         }
     }
 

--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.ts
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.ts
@@ -335,7 +335,7 @@ export class DataTableComponent implements OnInit, AfterContentInit, OnChanges, 
             this.setTableSorting(changes['sorting'].currentValue);
         }
 
-        if (multiselectChanges.currentValue === false) {
+        if (multiselectChanges?.currentValue === false) {
             this.resetSelection();
         }
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/AAE-23099


**What is the new behaviour?**
Datatable selection is reset when the `multiselect` input of `DataTableComponent` is changed to false.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
