### PR TITLE
[MNT-24351] Add missing array validation to card-view

### DIFF
--- a/lib/core/src/lib/card-view/validators/card-view-item-length.valiator.ts
+++ b/lib/core/src/lib/card-view/validators/card-view-item-length.valiator.ts
@@ -27,8 +27,16 @@ export class CardViewItemLengthValidator implements CardViewItemValidator {
 
     constructor(private minLength: number, private maxLength: number) {}
 
-    isValid(value: string = ''): boolean {
-        const stringLength = value.length;
-        return stringLength >= this.minLength && stringLength <= this.maxLength;
+    isValid(value: string | string[]): boolean {
+        if (Array.isArray(value)) {
+            return value.every((val) => this.isCorrectLength(val, this.minLength, this.maxLength));
+        }
+
+        return value === '' || this.isCorrectLength(value, this.minLength, this.maxLength);
+    }
+
+    private isCorrectLength(value: string, min: number, max: number): boolean {
+        const length = value.length;
+        return length >= min && length <= max;
     }
 }

--- a/lib/core/src/lib/card-view/validators/card-view-item-length.validator.spec.ts
+++ b/lib/core/src/lib/card-view/validators/card-view-item-length.validator.spec.ts
@@ -1,0 +1,43 @@
+/*!
+ * @license
+ * Copyright © 2005-2024 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CardViewItemLengthValidator } from './card-view-item-length.valiator';
+
+describe('CardViewItemPositiveIntValidator', () => {
+    const validator = new CardViewItemLengthValidator(2, 3);
+
+    it('should validate empty value', () => {
+        expect(validator.isValid('')).toBeTrue();
+    });
+
+    it('should validate correct value', () => {
+        expect(validator.isValid('12')).toBeTrue();
+    });
+
+    it('should not validate too short value', () => {
+        expect(validator.isValid('1')).toBeFalse();
+    });
+
+    it('should not validate too long value', () => {
+        expect(validator.isValid('1234')).toBeFalse();
+    });
+
+    it('should validate arrays', () => {
+        expect(validator.isValid(['12', '123'])).toBeTrue();
+        expect(validator.isValid(['12', '1234'])).toBeFalse();
+    });
+});

--- a/lib/core/src/lib/card-view/validators/card-view-item-match.valiator.ts
+++ b/lib/core/src/lib/card-view/validators/card-view-item-match.valiator.ts
@@ -26,11 +26,19 @@ export interface MatchValidatorParams {
 export class CardViewItemMatchValidator implements CardViewItemValidator {
     message = 'CORE.CARDVIEW.VALIDATORS.MATCH_VALIDATION_ERROR';
 
-    constructor(private expression: string, private flags?: string, private requiresMatch?: boolean) {
+    constructor(private expression: string, private flags?: string, private requiresMatch?: boolean) {}
+
+    isValid(value: string | string[]): boolean {
+        const regex = new RegExp(this.expression, this?.flags);
+
+        if (Array.isArray(value)) {
+            return value.every((val) => (this.requiresMatch ? this.matchRegex(val, regex) : !this.matchRegex(val, regex)));
+        }
+
+        return value === '' || (this.requiresMatch ? this.matchRegex(value, regex) : !this.matchRegex(value, regex));
     }
 
-    isValid(value: string): boolean {
-        const regex = new RegExp(this.expression, this.flags);
-        return value === '' || this.requiresMatch ? regex.test(value) : !regex.test(value);
+    private matchRegex(value: string, regex: RegExp): boolean {
+        return regex.test(value);
     }
 }

--- a/lib/core/src/lib/card-view/validators/card-view-item-match.validator.spec.ts
+++ b/lib/core/src/lib/card-view/validators/card-view-item-match.validator.spec.ts
@@ -1,0 +1,39 @@
+/*!
+ * @license
+ * Copyright © 2005-2024 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CardViewItemMatchValidator } from './card-view-item-match.valiator';
+
+describe('CardViewItemMatchValidator', () => {
+    const validator = new CardViewItemMatchValidator('^[a-zA-Z]+$', undefined, true);
+
+    it('should validate empty value', () => {
+        expect(validator.isValid('')).toBeTrue();
+    });
+
+    it('should validate correct value', () => {
+        expect(validator.isValid('aA')).toBeTrue();
+    });
+
+    it('should not validate incorrect value', () => {
+        expect(validator.isValid('1a')).toBeFalse();
+    });
+
+    it('should validate arrays', () => {
+        expect(validator.isValid(['aa', 'BB'])).toBeTrue();
+        expect(validator.isValid(['b2', 'aB'])).toBeFalse();
+    });
+});

--- a/lib/core/src/lib/card-view/validators/card-view-item-minmax.valiator.ts
+++ b/lib/core/src/lib/card-view/validators/card-view-item-minmax.valiator.ts
@@ -31,7 +31,15 @@ export class CardViewItemMinMaxValidator implements CardViewItemValidator {
         this.intValidator = new CardViewItemIntValidator();
     }
 
-    isValid(value: number): boolean {
-        return this.intValidator.isValid(value) && (value >= this.minValue && value <= this.maxValue);
+    isValid(value: number | number[] | ''): boolean {
+        if (Array.isArray(value)) {
+            return value.every((val) => this.isInRange(val, this.minValue, this.maxValue));
+        }
+
+        return value === '' || (this.intValidator.isValid(value) && this.isInRange(value, this.minValue, this.maxValue));
+    }
+
+    private isInRange(value: number, min: number, max: number): boolean {
+        return value >= min && value <= max;
     }
 }

--- a/lib/core/src/lib/card-view/validators/card-view-item-minmax.validator.spec.ts
+++ b/lib/core/src/lib/card-view/validators/card-view-item-minmax.validator.spec.ts
@@ -1,0 +1,43 @@
+/*!
+ * @license
+ * Copyright © 2005-2024 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CardViewItemMinMaxValidator } from './card-view-item-minmax.valiator';
+
+describe('CardViewItemMinMaxValidator', () => {
+    const validator = new CardViewItemMinMaxValidator(1, 3);
+
+    it('should validate empty value', () => {
+        expect(validator.isValid('')).toBeTrue();
+    });
+
+    it('should validate correct value', () => {
+        expect(validator.isValid(1)).toBeTrue();
+    });
+
+    it('should not validate value below min', () => {
+        expect(validator.isValid(-1)).toBeFalse();
+    });
+
+    it('should not validate value above max', () => {
+        expect(validator.isValid(4)).toBeFalse();
+    });
+
+    it('should validate arrays', () => {
+        expect(validator.isValid([2, 3])).toBeTrue();
+        expect(validator.isValid([1, 0])).toBeFalse();
+    });
+});

--- a/lib/core/src/lib/card-view/validators/card-view-item-only-positive-int.validator.spec.ts
+++ b/lib/core/src/lib/card-view/validators/card-view-item-only-positive-int.validator.spec.ts
@@ -18,11 +18,7 @@
 import { CardViewItemPositiveIntValidator } from './card-view-item-only-positive-int.validator';
 
 describe('CardViewItemPositiveIntValidator', () => {
-    let validator: CardViewItemPositiveIntValidator;
-
-    beforeEach(() => {
-        validator = new CardViewItemPositiveIntValidator();
-    });
+    const validator = new CardViewItemPositiveIntValidator();
 
     it('should return false for invalid integer value', () => {
         expect(validator.isValid('a')).toBeFalse();
@@ -46,5 +42,10 @@ describe('CardViewItemPositiveIntValidator', () => {
 
     it('should work for positive string value', () => {
         expect(validator.isValid('1')).toBeTrue();
+    });
+
+    it('should validate arrays', () => {
+        expect(validator.isValid(['-1', 1])).toBeFalse();
+        expect(validator.isValid(['1', 2])).toBeTrue();
     });
 });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/MNT-24351
Some of card-view validators don't have array validation. This causes validation error to be displayed for multivalued properties.


**What is the new behaviour?**
Added array and default value (empty string) validation.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
