### PR TITLE
AAE-23115 Display key of the user attribute in external property preview

### DIFF
--- a/lib/process-services-cloud/src/lib/form/components/widgets/display-external-property/display-external-property.widget.html
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/display-external-property/display-external-property.widget.html
@@ -27,7 +27,7 @@
                 <span class="adf-display-external-property-widget-preview"
                        data-automation-id="adf-display-external-property-widget-preview"
                 >
-                    {{ field.externalProperty }}
+                    {{ field.params.externalPropertyLabel }}
                 </span>
             </ng-container>
         </mat-form-field>

--- a/lib/process-services-cloud/src/lib/form/components/widgets/display-external-property/display-external-property.widget.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/display-external-property/display-external-property.widget.spec.ts
@@ -97,6 +97,7 @@ describe('DisplayExternalPropertyWidgetComponent', () => {
             widget.field = new FormFieldModel(new FormModel({ taskId: '<id>' }), {
                 type: FormFieldTypes.DISPLAY_EXTERNAL_PROPERTY,
                 externalProperty: 'fruitName',
+                params: { externalPropertyLabel: 'Fruit Name' },
                 value: null
             });
 
@@ -111,7 +112,7 @@ describe('DisplayExternalPropertyWidgetComponent', () => {
 
         it('should display external property name', () => {
             const externalPropertyPreview = fixture.debugElement.query(By.css('[data-automation-id="adf-display-external-property-widget-preview"]'));
-            expect(externalPropertyPreview.nativeElement.textContent.trim()).toBe('fruitName');
+            expect(externalPropertyPreview.nativeElement.textContent.trim()).toBe('Fruit Name');
         });
     });
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/issues/AAE-23115


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
