### PR TITLE
ACS-8254 [ADF] Add functionality to pass data on confirmation in DialogComponent

### DIFF
--- a/docs/core/dialogs/dialog.md
+++ b/docs/core/dialogs/dialog.md
@@ -89,9 +89,12 @@ function openDialog() {
         title: 'Dialog title',
         contentComponent: ExampleDialogComponent,
         componentData: { nodeId: 'nodeId', name: 'node name' } // any data can be passed
+        dataOnConfirm$: of({ nodeId, data: {} })
     };
 
-    this.dialog.open(DialogComponent, { data });
+    const dialogInstance = this.dialog.open(DialogComponent, { data });
+
+    dialogInstance.afterClosed().subscribe((data) => data) // data = { nodeId, data: {} }
 }
 ```
 

--- a/docs/core/interfaces/dialog.interface.md
+++ b/docs/core/interfaces/dialog.interface.md
@@ -26,7 +26,8 @@ interface DialogData {
     descriptionTemplate?: TemplateRef<any>;
     headerIcon?: string;
     additionalActionButtons?: AdditionalDialogActionButton[];
-    componentData: any;
+    componentData?: any;
+    dataOnConfirm$?: Subject<any>
 }
 ```
 
@@ -50,6 +51,7 @@ interface DialogData {
 | descriptionTemplate | `TemplateRef<any>` |    | Inserts a description template. (optional) |
 | additionalActionButtons | `AdditionalDialogActionButton[]` |    | Inserts additional base-styled buttons into the action bar on the left. (optional) |
 | componentData | `any` |    | Data that injected in contentComponent. (optional) |
+| dataOnConfirm$ | `Subject<any>` |    | Data to be passed on confirm action after dialog closed. (optional) |
 
 ## See also
 

--- a/docs/core/models/dialog.model.md
+++ b/docs/core/models/dialog.model.md
@@ -50,4 +50,4 @@ function openDialog() {
 
 - [Dialog Component](../dialogs/dialog.md)
 - [Dialog Data Interface](../interfaces/dialog.interface.md)
-- [AdditionalDialogActionButton Interface](./additional-dialog-action-button.md)
+- [AdditionalDialogActionButton Interface](../interfaces/additional-dialog-action-button.interface.md)

--- a/lib/core/src/lib/dialogs/dialog/dialog-data.interface.ts
+++ b/lib/core/src/lib/dialogs/dialog/dialog-data.interface.ts
@@ -36,6 +36,7 @@ export interface DialogData {
     headerIcon?: string;
     additionalActionButtons?: AdditionalDialogActionButton[];
     componentData?: any;
+    dataOnConfirm$?: Subject<any>;
 }
 
 export interface AdditionalDialogActionButton {

--- a/lib/core/src/lib/dialogs/dialog/dialog.component.spec.ts
+++ b/lib/core/src/lib/dialogs/dialog/dialog.component.spec.ts
@@ -23,6 +23,7 @@ import { DialogData } from './dialog-data.interface';
 import { DialogSize } from './dialog.model';
 import { CoreTestingModule } from '../../testing';
 import { Component, DebugElement, inject } from '@angular/core';
+import { Subject } from 'rxjs';
 
 @Component({
     selector: 'adf-dummy-component'
@@ -38,6 +39,8 @@ describe('DialogComponent', () => {
     let cancelButton: HTMLButtonElement;
     let confirmButton: HTMLButtonElement;
     let dialogContainer: HTMLElement;
+    const mockId = 'mockId';
+    const mockDataOnConfirm$ = new Subject();
 
     const data: DialogData = {
         title: 'Title',
@@ -96,7 +99,7 @@ describe('DialogComponent', () => {
     describe('confirm action', () => {
         const mockButtonTitle = 'mockTitle';
         beforeEach(() => {
-            setupBeforeEach({ ...data, confirmButtonTitle: mockButtonTitle });
+            setupBeforeEach({ ...data, confirmButtonTitle: mockButtonTitle, dataOnConfirm$: mockDataOnConfirm$ });
             fixture.detectChanges();
         });
 
@@ -124,9 +127,17 @@ describe('DialogComponent', () => {
             expect(confirmButton.getAttribute('disabled')).toBeTruthy();
         });
 
-        it('should close dialog', () => {
+        it('should close dialog and pass default value', () => {
             component.onConfirm();
             expect(dialogRef.close).toHaveBeenCalledWith(true);
+        });
+
+        it('should close dialog and pass dataOnConfirm$', () => {
+            mockDataOnConfirm$.next(mockId);
+
+            component.onConfirm();
+
+            expect(dialogRef.close).toHaveBeenCalledWith(mockId);
         });
 
         it('should set correct button title', () => {

--- a/lib/core/src/lib/dialogs/dialog/dialog.component.ts
+++ b/lib/core/src/lib/dialogs/dialog/dialog.component.ts
@@ -73,7 +73,7 @@ export class DialogComponent implements OnDestroy {
 
     onConfirm() {
         this.isConfirmButtonDisabled$.next(true);
-        this.dialogRef.close(true);
+        this.dialogRef.close(this.data.dataOnConfirm$ || true);
     }
 
     ngOnDestroy() {

--- a/lib/core/src/lib/dialogs/dialog/dialog.component.ts
+++ b/lib/core/src/lib/dialogs/dialog/dialog.component.ts
@@ -43,6 +43,7 @@ export class DialogComponent implements OnDestroy {
     cancelButtonTitle: string;
     dialogSize: DialogSizes;
     additionalActionButtons: AdditionalDialogActionButton[];
+    dataOnConfirm: any;
 
     dataInjector: Injector;
 
@@ -68,12 +69,16 @@ export class DialogComponent implements OnDestroy {
             if (data.isConfirmButtonDisabled$) {
                 data.isConfirmButtonDisabled$.pipe(takeUntil(this.onDestroy$)).subscribe((value) => this.isConfirmButtonDisabled$.next(value));
             }
+
+            if (data.dataOnConfirm$) {
+                data.dataOnConfirm$.pipe(takeUntil(this.onDestroy$)).subscribe((value) => (this.dataOnConfirm = value));
+            }
         }
     }
 
     onConfirm() {
         this.isConfirmButtonDisabled$.next(true);
-        this.dialogRef.close(this.data.dataOnConfirm$ || true);
+        this.dialogRef.close(this.dataOnConfirm || true);
     }
 
     ngOnDestroy() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

https://hyland.atlassian.net/browse/ACS-8254

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
can't pass data on confirmation `dataOnConfirm$`


**What is the new behaviour?**
Able to pass data on confirmation with 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
