### PR TITLE
AAE-23369 Feature flag override dialog missing the label in header

### DIFF
--- a/lib/core/feature-flags/src/lib/components/flags/flags.component.html
+++ b/lib/core/feature-flags/src/lib/components/flags/flags.component.html
@@ -1,7 +1,10 @@
 <mat-toolbar class="adf-feature-flags-overrides-header">
   <div class="adf-feature-flags-overrides-header-text">
-    <adf-feature-flags-override-indicator></adf-feature-flags-override-indicator>
-    <span>{{ "CORE.FEATURE-FLAGS.OVERRIDE" | translate }}</span>
+    <adf-feature-flags-override-indicator
+      class="adf-activity-indicator"
+      size='large'>
+    </adf-feature-flags-override-indicator>
+    <span>{{ "CORE.FEATURE-FLAGS.OVERRIDES" | translate }}</span>
   </div>
   <mat-slide-toggle
     color="warning"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/AAE-23369
<img width=550 src="https://github.com/Alfresco/alfresco-ng2-components/assets/63188869/164a2f7e-2228-48fb-a89f-ae451c1034dd" />

**What is the new behaviour?**
<img width=550 src="https://github.com/Alfresco/alfresco-ng2-components/assets/63188869/9faf1d1c-873b-40ae-b792-47459c9a1b29" />

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
