### PR TITLE
[MNT-24449] Validate ticket on config initialization

### DIFF
--- a/lib/js-api/src/alfrescoApi.ts
+++ b/lib/js-api/src/alfrescoApi.ts
@@ -93,14 +93,18 @@ export class AlfrescoApi implements Emitter, AlfrescoApiType {
             if (!this.contentAuth) {
                 this.contentAuth = new ContentAuth(this.config, this, this.httpClient);
             }
-
-            this.contentAuth.validateTicket().then((ticket) => {
-                config.ticketEcm = ticket;
-            })
-            .catch(() => {
-                config.ticketEcm = null;
-                this.initConfig(config);
-            });
+            this.contentAuth
+                .validateTicket()
+                .then((ticket) => {
+                    config.ticketEcm = ticket;
+                })
+                .catch((error) => {
+                    if (error.status === 401) {
+                        config.ticketEcm = null;
+                        this.initConfig(config);
+                        this.emitBuffer('ticket_invalidated');
+                    }
+                });
         }
     }
 

--- a/lib/js-api/src/alfrescoApi.ts
+++ b/lib/js-api/src/alfrescoApi.ts
@@ -69,6 +69,11 @@ export class AlfrescoApi implements Emitter, AlfrescoApiType {
         this.storage = Storage.getInstance();
         this.storage.setDomainPrefix(config.domainPrefix);
 
+        this.initConfig(config);
+        this.validateTicket(config);
+    }
+
+    private initConfig(config: AlfrescoApiConfig) {
         this.config = new AlfrescoApiConfig(config);
 
         this.clientsFactory();
@@ -81,8 +86,22 @@ export class AlfrescoApi implements Emitter, AlfrescoApiType {
                 this.emitBuffer('logged-in');
             }
         }
+    }
 
-        return config;
+    private validateTicket(config: AlfrescoApiConfig) {
+        if (config.ticketEcm && !this.isOauthConfiguration()) {
+            if (!this.contentAuth) {
+                this.contentAuth = new ContentAuth(this.config, this, this.httpClient);
+            }
+
+            this.contentAuth.validateTicket().then((ticket) => {
+                config.ticketEcm = ticket;
+            })
+            .catch(() => {
+                config.ticketEcm = null;
+                this.initConfig(config);
+            });
+        }
     }
 
     private initAuth(config: AlfrescoApiConfig): void {

--- a/lib/js-api/test/alfrescoApi.spec.ts
+++ b/lib/js-api/test/alfrescoApi.spec.ts
@@ -40,6 +40,26 @@ describe('Basic configuration test', () => {
                 'https://testServer.com:1616/strangeContextRoot/api/-default-/public/alfresco/versions/1'
             );
         });
+
+        it('should detect invalid ticket and unset it', (done) => {
+            const hostEcm = 'https://127.0.0.1:8080';
+            const authEcmMock = new EcmAuthMock(hostEcm);
+
+            const config = {
+                hostEcm,
+                authType: 'BASIC',
+                ticketEcm: 'wrong-ticket'
+            };
+
+            authEcmMock.get401InvalidTicket();
+
+            const alfrescoApi = new AlfrescoApi(config);
+
+            alfrescoApi.on('ticket_invalidated', () => {
+                assert.equal(alfrescoApi.config.ticketEcm, null);
+                done();
+            });
+        });
     });
 
     describe('setconfig parameter ', () => {

--- a/lib/js-api/test/mockObjects/content-services/ecm-auth.mock.ts
+++ b/lib/js-api/test/mockObjects/content-services/ecm-auth.mock.ts
@@ -47,6 +47,20 @@ export class EcmAuthMock extends BaseMock {
             .reply(200, { entry: { id: returnMockTicket } });
     }
 
+    get401InvalidTicket(): void {
+        nock(this.host, { encodedQueryParams: true })
+            .get('/alfresco/api/-default-/public/authentication/versions/1/tickets/-me-')
+            .reply(401, {
+                error: {
+                    errorKey: 'framework.exception.ApiDefault',
+                    statusCode: 401,
+                    briefSummary: '05210059 Authentication failed for Web Script org/alfresco/api/ResourceWebScript.get',
+                    stackTrace: 'For security reasons the stack trace is no longer displayed, but the property is kept for previous versions.',
+                    descriptionURL: 'https://api-explorer.alfresco.com'
+                }
+            });
+    }
+
     get403Response(): void {
         nock(this.host, { encodedQueryParams: true })
             .post('/alfresco/api/-default-/public/authentication/versions/1/tickets', {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

The config object is initialized with the ticket from browser local storage which can be invalid, making subsequent requests to fail, e.g, the document viewer.

**What is the new behaviour?**

The ticket is now validated during config initialization, if invalid, the ticket is not set at the config object at that stage.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
