### PR TITLE
[ACS-8081] People facet - update the query on apply hit

### DIFF
--- a/lib/content-services/src/lib/search/components/search-filter-chips/search-facet-chip-tabbed/search-facet-chip-tabbed.component.ts
+++ b/lib/content-services/src/lib/search/components/search-filter-chips/search-facet-chip-tabbed/search-facet-chip-tabbed.component.ts
@@ -87,7 +87,8 @@ export class SearchFacetChipTabbedComponent {
             this.menuTrigger.closeMenu();
         }
     }
-    onIsPopulatedEventChange(isPopulated: boolean): void {
+
+    onIsPopulatedEventChange(isPopulated: boolean) {
         this.isPopulated = isPopulated;
         this.changeDetectorRef.detectChanges();
     }

--- a/lib/content-services/src/lib/search/components/search-filter-chips/search-facet-chip-tabbed/search-facet-tabbed-content.component.spec.ts
+++ b/lib/content-services/src/lib/search/components/search-filter-chips/search-facet-chip-tabbed/search-facet-tabbed-content.component.spec.ts
@@ -23,7 +23,6 @@ import { FacetField } from '../../../models/facet-field.interface';
 import { SearchFacetFiltersService } from '../../../services/search-facet-filters.service';
 import { NO_ERRORS_SCHEMA, SimpleChange } from '@angular/core';
 import { SearchFacetTabbedContentComponent } from './search-facet-tabbed-content.component';
-import { of } from 'rxjs';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatTabGroupHarness, MatTabHarness } from '@angular/material/tabs/testing';
@@ -59,9 +58,6 @@ describe('SearchFacetTabbedContentComponent', () => {
                 field2: facet2
             }
         };
-
-        component.onReset$ = of(void 0);
-        component.onApply$ = of(void 0);
 
         fixture.detectChanges();
     });
@@ -203,8 +199,7 @@ describe('SearchFacetTabbedContentComponent', () => {
     });
 
     it('should not call queryBuilder.update on options change', () => {
-        expect(queryBuilderUpdateSpy.calls.count()).toBe(2);
         component.onOptionsChange([{ value: 'test' }], 'field');
-        expect(queryBuilderUpdateSpy.calls.count()).toBe(2);
+        expect(queryBuilderUpdateSpy).not.toHaveBeenCalled();
     });
 });

--- a/lib/content-services/src/lib/search/components/search-filter-chips/search-facet-chip-tabbed/search-facet-tabbed-content.component.spec.ts
+++ b/lib/content-services/src/lib/search/components/search-filter-chips/search-facet-chip-tabbed/search-facet-tabbed-content.component.spec.ts
@@ -34,6 +34,7 @@ describe('SearchFacetTabbedContentComponent', () => {
     let queryBuilder: SearchQueryBuilderService;
     let searchFacetService: SearchFacetFiltersService;
     let loader: HarnessLoader;
+    let queryBuilderUpdateSpy: jasmine.Spy;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -45,7 +46,7 @@ describe('SearchFacetTabbedContentComponent', () => {
         component = fixture.componentInstance;
         queryBuilder = TestBed.inject(SearchQueryBuilderService);
         searchFacetService = TestBed.inject(SearchFacetFiltersService);
-        spyOn(queryBuilder, 'update').and.stub();
+        queryBuilderUpdateSpy = spyOn(queryBuilder, 'update').and.stub();
 
         const facet1: FacetField = { type: 'field', label: 'field', field: 'field', buckets: new SearchFilterList() };
         const facet2: FacetField = { type: 'field', label: 'field2', field: 'field2', buckets: new SearchFilterList() };
@@ -189,7 +190,7 @@ describe('SearchFacetTabbedContentComponent', () => {
         spyOn(searchFacetService, 'updateSelectedBuckets').and.callThrough();
         component.submitValues();
         expect(component.submitValues).toHaveBeenCalled();
-        expect(queryBuilder.update).toHaveBeenCalled();
+        expect(queryBuilderUpdateSpy).toHaveBeenCalled();
         expect(component.updateDisplayValue).toHaveBeenCalled();
         expect(searchFacetService.updateSelectedBuckets).toHaveBeenCalled();
     });
@@ -197,7 +198,13 @@ describe('SearchFacetTabbedContentComponent', () => {
     it('should update search query and display value on reset', () => {
         spyOn(component, 'updateDisplayValue').and.callThrough();
         component.reset();
-        expect(queryBuilder.update).toHaveBeenCalled();
+        expect(queryBuilderUpdateSpy).toHaveBeenCalled();
         expect(component.updateDisplayValue).toHaveBeenCalled();
+    });
+
+    it('should not call queryBuilder.update on options change', () => {
+        expect(queryBuilderUpdateSpy.calls.count()).toBe(2);
+        component.onOptionsChange([{ value: 'test' }], 'field');
+        expect(queryBuilderUpdateSpy.calls.count()).toBe(2);
     });
 });

--- a/lib/content-services/src/lib/search/components/search-filter-chips/search-facet-chip-tabbed/search-facet-tabbed-content.component.ts
+++ b/lib/content-services/src/lib/search/components/search-filter-chips/search-facet-chip-tabbed/search-facet-tabbed-content.component.ts
@@ -93,7 +93,6 @@ export class SearchFacetTabbedContentComponent implements OnInit, OnDestroy, OnC
         this.isPopulated.emit(this.tabbedFacet.fields.some((facetField) => this.selectedOptions[facetField].length > 0));
         this.updateDisplayValue();
         this.updateUserFacetBuckets();
-        this.queryBuilder.update();
     }
 
     updateDisplayValue() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://hyland.atlassian.net/browse/ACS-8081
The search query is updated when options are selected, causing the list of options to be updated based on the results.

**What is the new behaviour?**

The search query is updated when you click the Apply button, allowing you to select multiple options before returning the result.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
