### PR TITLE
AAE-23734 Fix flaky unit test - should set the date value to todays D…

### DIFF
--- a/lib/core/src/lib/form/components/widgets/core/form-field.model.spec.ts
+++ b/lib/core/src/lib/form/components/widgets/core/form-field.model.spec.ts
@@ -277,7 +277,8 @@ describe('FormFieldModel', () => {
         const currentDate = new Date();
         const expectedDateFormat = `${DateFnsUtils.formatDate(currentDate, 'yyyy-MM-dd')}T00:00:00.000Z`;
 
-        expect(field.value).toEqual(currentDate);
+        expect(field.value.getDate()).toEqual(currentDate.getDate());
+        expect(field.value.getHours()).toEqual(currentDate.getHours());
         expect(form.values['ddmmyyy']).toEqual(expectedDateFormat);
     });
 


### PR DESCRIPTION
…ate object when value is today

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/AAE-23734


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
