### PR TITLE
AAE-23666 Make Datetime timezone aware

### DIFF
--- a/lib/core/src/lib/common/utils/date-fns-utils.spec.ts
+++ b/lib/core/src/lib/common/utils/date-fns-utils.spec.ts
@@ -138,4 +138,37 @@ describe('DateFnsUtils', () => {
         expect(forceLocalDateJapan.getMonth()).toBe(0);
         expect(forceLocalDateJapan.getFullYear()).toBe(2020);
     });
+
+    it('should detect if a formatted string contains a timezone', () => {
+        let result = DateFnsUtils.stringDateContainsTimeZone('2021-06-09T14:10');
+        expect(result).toEqual(false);
+
+        result = DateFnsUtils.stringDateContainsTimeZone('2021-06-09T14:10:00');
+        expect(result).toEqual(false);
+
+        result = DateFnsUtils.stringDateContainsTimeZone('2021-06-09T14:10:00Z');
+        expect(result).toEqual(true);
+
+        result = DateFnsUtils.stringDateContainsTimeZone('2021-06-09T14:10:00+00:00');
+        expect(result).toEqual(true);
+
+        result = DateFnsUtils.stringDateContainsTimeZone('2021-06-09T14:10:00-00:00');
+        expect(result).toEqual(true);
+    });
+
+    it('should get the date from number', () => {
+        const spyUtcToLocal = spyOn(DateFnsUtils, 'utcToLocal').and.callThrough();
+
+        const date = DateFnsUtils.getDate(1623232200000);
+        expect(date.toISOString()).toBe('2021-06-09T09:50:00.000Z');
+        expect(spyUtcToLocal).not.toHaveBeenCalled();
+    });
+
+    it('should get transformed date when string date does not contain the timezone', () => {
+        const spyUtcToLocal = spyOn(DateFnsUtils, 'utcToLocal').and.callThrough();
+
+        DateFnsUtils.getDate('2021-06-09T14:10:00');
+
+        expect(spyUtcToLocal).toHaveBeenCalled();
+    });
 });

--- a/lib/core/src/lib/common/utils/date-fns-utils.ts
+++ b/lib/core/src/lib/common/utils/date-fns-utils.ts
@@ -225,4 +225,18 @@ export class DateFnsUtils {
         const utcDate = `${date.getFullYear()}-${panDate(date.getMonth() + 1)}-${panDate(date.getDate())}T00:00:00.000Z`;
         return new Date(utcDate);
     }
+
+    static stringDateContainsTimeZone(value: string): boolean {
+        return /(Z|([+|-]\d\d:?\d\d))$/.test(value);
+    }
+
+    static getDate(value: string | number | Date): Date {
+        let date = new Date(value);
+
+        if (typeof value === 'string' && !DateFnsUtils.stringDateContainsTimeZone(value)) {
+            date = this.utcToLocal(date);
+        }
+
+        return date;
+    }
 }

--- a/lib/core/src/lib/form/components/widgets/core/error-message.model.ts
+++ b/lib/core/src/lib/form/components/widgets/core/error-message.model.ts
@@ -33,11 +33,9 @@ export class ErrorMessageModel {
     getAttributesAsJsonObj() {
         let result = {};
         if (this.attributes.size > 0) {
-            const obj = Object.create(null);
             this.attributes.forEach((value, key) => {
-                obj[key] = value;
+                result[key] = typeof value === 'string' ? value : JSON.stringify(value);
             });
-            result = JSON.stringify(obj);
         }
         return result;
     }

--- a/lib/core/src/lib/form/components/widgets/core/form-field-validator.ts
+++ b/lib/core/src/lib/form/components/widgets/core/form-field-validator.ts
@@ -280,7 +280,7 @@ export class MinDateTimeFieldValidator implements FormFieldValidator {
 
         if (isBefore(fieldValueDate, min)) {
             field.validationSummary.message = `FORM.FIELD.VALIDATOR.NOT_LESS_THAN`;
-            field.validationSummary.attributes.set('minValue', DateFnsUtils.formatDate(min, field.dateDisplayFormat).replace(':', '-'));
+            field.validationSummary.attributes.set('minValue', DateFnsUtils.formatDate(DateFnsUtils.utcToLocal(min), field.dateDisplayFormat));
             isValid = false;
         }
         return isValid;
@@ -322,7 +322,7 @@ export class MaxDateTimeFieldValidator implements FormFieldValidator {
 
         if (isAfter(fieldValueDate, max)) {
             field.validationSummary.message = `FORM.FIELD.VALIDATOR.NOT_GREATER_THAN`;
-            field.validationSummary.attributes.set('maxValue', DateFnsUtils.formatDate(max, field.dateDisplayFormat).replace(':', '-'));
+            field.validationSummary.attributes.set('maxValue', DateFnsUtils.formatDate(DateFnsUtils.utcToLocal(max), field.dateDisplayFormat));
             isValid = false;
         }
         return isValid;

--- a/lib/core/src/lib/form/components/widgets/core/form-field-validator.ts
+++ b/lib/core/src/lib/form/components/widgets/core/form-field-validator.ts
@@ -245,15 +245,7 @@ export class MaxDateFieldValidator extends BoundaryDateFieldValidator {
     }
 }
 
-/**
- * Validates the min constraint for the datetime value.
- *
- * Notes for developers:
- * the format of the min/max values is always the ISO datetime: i.e. 2023-10-01T15:21:00.000Z.
- * Min/Max values can be parsed with standard `new Date(value)` calls.
- *
- */
-export class MinDateTimeFieldValidator implements FormFieldValidator {
+export abstract class BoundaryDateTimeFieldValidator implements FormFieldValidator {
     private supportedTypes = [FormFieldTypes.DATETIME];
 
     isSupported(field: FormFieldModel): boolean {
@@ -276,14 +268,42 @@ export class MinDateTimeFieldValidator implements FormFieldValidator {
     private checkDateTime(field: FormFieldModel): boolean {
         let isValid = true;
         const fieldValueDate = DateFnsUtils.getDate(field.value);
-        const min = DateFnsUtils.getDate(field.minValue);
+        const subjectFieldDate = DateFnsUtils.getDate(field[this.getSubjectField()]);
 
-        if (isBefore(fieldValueDate, min)) {
-            field.validationSummary.message = `FORM.FIELD.VALIDATOR.NOT_LESS_THAN`;
-            field.validationSummary.attributes.set('minValue', DateFnsUtils.formatDate(min, field.dateDisplayFormat));
+        if (this.compareDates(fieldValueDate, subjectFieldDate)) {
+            field.validationSummary.message = this.getErrorMessage();
+            field.validationSummary.attributes.set(this.getSubjectField(), DateFnsUtils.formatDate(subjectFieldDate, field.dateDisplayFormat));
             isValid = false;
         }
         return isValid;
+    }
+
+    protected abstract compareDates(fieldValueDate: Date, subjectFieldDate: Date): boolean;
+
+    protected abstract getSubjectField(): string;
+
+    protected abstract getErrorMessage(): string;
+}
+
+/**
+ * Validates the min constraint for the datetime value.
+ *
+ * Notes for developers:
+ * the format of the min/max values is always the ISO datetime: i.e. 2023-10-01T15:21:00.000Z.
+ * Min/Max values can be parsed with standard `new Date(value)` calls.
+ *
+ */
+export class MinDateTimeFieldValidator extends BoundaryDateTimeFieldValidator {
+    protected compareDates(fieldValueDate: Date, subjectFieldDate: Date): boolean {
+        return isBefore(fieldValueDate, subjectFieldDate);
+    }
+
+    protected getSubjectField(): string {
+        return 'minValue';
+    }
+
+    protected getErrorMessage(): string {
+        return `FORM.FIELD.VALIDATOR.NOT_LESS_THAN`;
     }
 }
 
@@ -295,37 +315,17 @@ export class MinDateTimeFieldValidator implements FormFieldValidator {
  * Min/Max values can be parsed with standard `new Date(value)` calls.
  *
  */
-export class MaxDateTimeFieldValidator implements FormFieldValidator {
-    private supportedTypes = [FormFieldTypes.DATETIME];
-
-    isSupported(field: FormFieldModel): boolean {
-        return field && this.supportedTypes.indexOf(field.type) > -1 && !!field.maxValue;
+export class MaxDateTimeFieldValidator extends BoundaryDateTimeFieldValidator {
+    protected compareDates(fieldValueDate: Date, subjectFieldDate: Date): boolean {
+        return isAfter(fieldValueDate, subjectFieldDate);
     }
 
-    validate(field: FormFieldModel): boolean {
-        let isValid = true;
-        if (this.isSupported(field) && field.value && field.isVisible) {
-            if (!DateTimeFieldValidator.isValidDateTime(field.value)) {
-                field.validationSummary.message = 'FORM.FIELD.VALIDATOR.INVALID_DATE';
-                isValid = false;
-            } else {
-                isValid = this.checkDateTime(field);
-            }
-        }
-        return isValid;
+    protected getSubjectField(): string {
+        return 'maxValue';
     }
 
-    private checkDateTime(field: FormFieldModel): boolean {
-        let isValid = true;
-        const fieldValueDate = DateFnsUtils.getDate(field.value);
-        const max = DateFnsUtils.getDate(field.maxValue);
-
-        if (isAfter(fieldValueDate, max)) {
-            field.validationSummary.message = `FORM.FIELD.VALIDATOR.NOT_GREATER_THAN`;
-            field.validationSummary.attributes.set('maxValue', DateFnsUtils.formatDate(max, field.dateDisplayFormat));
-            isValid = false;
-        }
-        return isValid;
+    protected getErrorMessage(): string {
+        return `FORM.FIELD.VALIDATOR.NOT_GREATER_THAN`;
     }
 }
 

--- a/lib/core/src/lib/form/components/widgets/core/form-field-validator.ts
+++ b/lib/core/src/lib/form/components/widgets/core/form-field-validator.ts
@@ -159,7 +159,7 @@ export class DateTimeFieldValidator implements FormFieldValidator {
     }
 
     static isValidDateTime(input: string): boolean {
-        const date = new Date(input);
+        const date = DateFnsUtils.getDate(input);
         return isDateValid(date);
     }
 
@@ -275,12 +275,12 @@ export class MinDateTimeFieldValidator implements FormFieldValidator {
 
     private checkDateTime(field: FormFieldModel): boolean {
         let isValid = true;
-        const fieldValueDate = new Date(field.value);
-        const min = new Date(field.minValue);
+        const fieldValueDate = DateFnsUtils.getDate(field.value);
+        const min = DateFnsUtils.getDate(field.minValue);
 
         if (isBefore(fieldValueDate, min)) {
             field.validationSummary.message = `FORM.FIELD.VALIDATOR.NOT_LESS_THAN`;
-            field.validationSummary.attributes.set('minValue', DateFnsUtils.formatDate(DateFnsUtils.utcToLocal(min), field.dateDisplayFormat));
+            field.validationSummary.attributes.set('minValue', DateFnsUtils.formatDate(min, field.dateDisplayFormat));
             isValid = false;
         }
         return isValid;
@@ -317,12 +317,12 @@ export class MaxDateTimeFieldValidator implements FormFieldValidator {
 
     private checkDateTime(field: FormFieldModel): boolean {
         let isValid = true;
-        const fieldValueDate = new Date(field.value);
-        const max = new Date(field.maxValue);
+        const fieldValueDate = DateFnsUtils.getDate(field.value);
+        const max = DateFnsUtils.getDate(field.maxValue);
 
         if (isAfter(fieldValueDate, max)) {
             field.validationSummary.message = `FORM.FIELD.VALIDATOR.NOT_GREATER_THAN`;
-            field.validationSummary.attributes.set('maxValue', DateFnsUtils.formatDate(DateFnsUtils.utcToLocal(max), field.dateDisplayFormat));
+            field.validationSummary.attributes.set('maxValue', DateFnsUtils.formatDate(max, field.dateDisplayFormat));
             isValid = false;
         }
         return isValid;

--- a/lib/core/src/lib/form/components/widgets/core/form-field-validator.ts
+++ b/lib/core/src/lib/form/components/widgets/core/form-field-validator.ts
@@ -249,7 +249,7 @@ export abstract class BoundaryDateTimeFieldValidator implements FormFieldValidat
     private supportedTypes = [FormFieldTypes.DATETIME];
 
     isSupported(field: FormFieldModel): boolean {
-        return field && this.supportedTypes.indexOf(field.type) > -1 && !!field.minValue;
+        return field && this.supportedTypes.indexOf(field.type) > -1 && !!field[this.getSubjectField()];
     }
 
     validate(field: FormFieldModel): boolean {

--- a/lib/core/src/lib/form/components/widgets/core/form-field.model.ts
+++ b/lib/core/src/lib/form/components/widgets/core/form-field.model.ts
@@ -299,7 +299,7 @@ export class FormFieldModel extends FormWidgetModel {
     }
 
     parseValue(json: any): any {
-        let value = Object.prototype.hasOwnProperty.call(json, 'value') && json.value !== undefined ? json.value : null;
+        const value = Object.prototype.hasOwnProperty.call(json, 'value') && json.value !== undefined ? json.value : null;
 
         /*
          This is needed due to Activiti issue related to reading dropdown values as value string
@@ -440,7 +440,12 @@ export class FormFieldModel extends FormWidgetModel {
                     this.value = new Date();
                 }
 
-                const dateValue = DateFnsUtils.parseDate(this.value, this.dateDisplayFormat);
+                let dateValue;
+                try {
+                    dateValue = DateFnsUtils.parseDate(this.value, this.dateDisplayFormat);
+                } catch (e) {
+                    dateValue = new Date('error');
+                }
 
                 if (isValidDate(dateValue)) {
                     const datePart = DateFnsUtils.formatDate(dateValue, 'yyyy-MM-dd');

--- a/lib/core/src/lib/form/components/widgets/core/form-field.model.ts
+++ b/lib/core/src/lib/form/components/widgets/core/form-field.model.ts
@@ -461,7 +461,7 @@ export class FormFieldModel extends FormWidgetModel {
                     this.value = new Date();
                 }
 
-                const dateTimeValue = this.value !== null ? new Date(this.value) : null;
+                const dateTimeValue = this.value !== null ? DateFnsUtils.getDate(this.value) : null;
 
                 if (isValidDate(dateTimeValue)) {
                     this.form.values[this.id] = dateTimeValue.toISOString();

--- a/lib/core/src/lib/form/components/widgets/date-time/date-time.widget.ts
+++ b/lib/core/src/lib/form/components/widgets/date-time/date-time.widget.ts
@@ -67,15 +67,15 @@ export class DateTimeWidgetComponent extends WidgetComponent implements OnInit {
 
         if (this.field) {
             if (this.field.minValue) {
-                this.minDate = DateFnsUtils.localToUtc(new Date(this.field.minValue));
+                this.minDate = DateFnsUtils.utcToLocal(new Date(this.field.minValue));
             }
 
             if (this.field.maxValue) {
-                this.maxDate = DateFnsUtils.localToUtc(new Date(this.field.maxValue));
+                this.maxDate = DateFnsUtils.utcToLocal(new Date(this.field.maxValue));
             }
 
             if (this.field.value) {
-                this.value = DateFnsUtils.localToUtc(new Date(this.field.value));
+                this.value = new Date(this.field.value);
             }
         }
     }
@@ -85,7 +85,7 @@ export class DateTimeWidgetComponent extends WidgetComponent implements OnInit {
         const newValue = this.dateTimeAdapter.parse(input.value, this.field.dateDisplayFormat);
 
         if (isValid(newValue)) {
-            this.field.value = DateFnsUtils.utcToLocal(newValue).toISOString();
+            this.field.value = DateFnsUtils.localToUtc(newValue).toISOString();
         } else {
             this.field.value = input.value;
         }
@@ -98,7 +98,7 @@ export class DateTimeWidgetComponent extends WidgetComponent implements OnInit {
         const input = event.targetElement as HTMLInputElement;
 
         if (newValue && isValid(newValue)) {
-            this.field.value = DateFnsUtils.utcToLocal(newValue).toISOString();
+            this.field.value = DateFnsUtils.localToUtc(newValue).toISOString();
         } else {
             this.field.value = input.value;
         }

--- a/lib/core/src/lib/form/components/widgets/date-time/date-time.widget.ts
+++ b/lib/core/src/lib/form/components/widgets/date-time/date-time.widget.ts
@@ -67,15 +67,15 @@ export class DateTimeWidgetComponent extends WidgetComponent implements OnInit {
 
         if (this.field) {
             if (this.field.minValue) {
-                this.minDate = DateFnsUtils.utcToLocal(new Date(this.field.minValue));
+                this.minDate = DateFnsUtils.getDate(this.field.minValue);
             }
 
             if (this.field.maxValue) {
-                this.maxDate = DateFnsUtils.utcToLocal(new Date(this.field.maxValue));
+                this.maxDate = DateFnsUtils.getDate(this.field.maxValue);
             }
 
             if (this.field.value) {
-                this.value = new Date(this.field.value);
+                this.value = DateFnsUtils.getDate(this.field.value);
             }
         }
     }
@@ -85,11 +85,12 @@ export class DateTimeWidgetComponent extends WidgetComponent implements OnInit {
         const newValue = this.dateTimeAdapter.parse(input.value, this.field.dateDisplayFormat);
 
         if (isValid(newValue)) {
-            this.field.value = DateFnsUtils.localToUtc(newValue).toISOString();
+            this.field.value = newValue.toISOString();
         } else {
             this.field.value = input.value;
         }
 
+        this.value = DateFnsUtils.getDate(this.field.value);
         this.onFieldChanged(this.field);
     }
 
@@ -98,7 +99,7 @@ export class DateTimeWidgetComponent extends WidgetComponent implements OnInit {
         const input = event.targetElement as HTMLInputElement;
 
         if (newValue && isValid(newValue)) {
-            this.field.value = DateFnsUtils.localToUtc(newValue).toISOString();
+            this.field.value = newValue.toISOString();
         } else {
             this.field.value = input.value;
         }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [X] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
The datetime is always interpreted as local time, but this is not true when the datetime was introduced by another user in a different time zone


**What is the new behaviour?**
Datetime includes now the time zone offset


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
