### PR TITLE
AAE-24018 Readonly dropdown with the rest config don't fetch options when form rule change it to not readonly

### DIFF
--- a/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.html
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.html
@@ -30,7 +30,7 @@
                 <mat-option id="readonlyOption" *ngIf="isReadOnlyType()" [value]="field.value">{{field.value}}</mat-option>
             </mat-select>
         </mat-form-field>
-        <div *ngIf="!previewState">
+        <div *ngIf="!previewState && !isReadOnlyField">
             <error-widget [error]="field.validationSummary"></error-widget>
             <error-widget class="adf-dropdown-required-message" *ngIf="showRequiredMessage()"
                         required="{{ 'FORM.FIELD.REQUIRED' | translate }}"></error-widget>

--- a/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.ts
@@ -393,7 +393,7 @@ export class DropdownCloudWidgetComponent extends WidgetComponent implements OnI
     }
 
     private isReadOnlyForm(): boolean {
-        return this.field?.form?.readOnly ?? false;
+        return !!this.field?.form?.readOnly;
     }
 
     get isReadOnlyField(): boolean {

--- a/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/dropdown/dropdown-cloud.widget.ts
@@ -84,7 +84,7 @@ export class DropdownCloudWidgetComponent extends WidgetComponent implements OnI
 
     private checkFieldOptionsSource(): void {
         switch (true) {
-            case this.isReadOnly():
+            case this.isReadOnlyForm():
                 break;
             case this.hasRestUrl() && !this.isLinkedWidget():
                 this.persistFieldOptionsFromRestApi();
@@ -392,7 +392,11 @@ export class DropdownCloudWidgetComponent extends WidgetComponent implements OnI
         }
     }
 
-    private isReadOnly(): boolean {
+    private isReadOnlyForm(): boolean {
+        return this.field?.form?.readOnly ?? false;
+    }
+
+    get isReadOnlyField(): boolean {
         return this.field.readOnly;
     }
 
@@ -410,7 +414,7 @@ export class DropdownCloudWidgetComponent extends WidgetComponent implements OnI
     }
 
     updateOptions(): void {
-        if (this.isReadOnly()) {
+        if (this.isReadOnlyForm()) {
             this.list$ = of(this.field.options);
         }
 

--- a/lib/process-services/src/lib/form/widgets/dropdown/dropdown.widget.html
+++ b/lib/process-services/src/lib/form/widgets/dropdown/dropdown.widget.html
@@ -15,7 +15,9 @@
             <mat-option id="readonlyOption" *ngIf="isReadOnlyType()" [value]="field.value">{{field.value}}</mat-option>
         </mat-select>
     </mat-form-field>
-    <error-widget [error]="field.validationSummary"></error-widget>
-    <error-widget class="adf-dropdown-required-message" *ngIf="showRequiredMessage()"
+    <ng-container *ngIf="!isReadOnlyField">
+        <error-widget [error]="field.validationSummary"></error-widget>
+        <error-widget class="adf-dropdown-required-message" *ngIf="showRequiredMessage()"
                   required="{{ 'FORM.FIELD.REQUIRED' | translate }}"></error-widget>
+    </ng-container>
 </div>

--- a/lib/process-services/src/lib/form/widgets/dropdown/dropdown.widget.ts
+++ b/lib/process-services/src/lib/form/widgets/dropdown/dropdown.widget.ts
@@ -52,7 +52,7 @@ export class DropdownWidgetComponent extends WidgetComponent implements OnInit {
     }
 
     ngOnInit() {
-        if (this.field?.restUrl) {
+        if (this.field?.restUrl && !this.field?.form?.readOnly) {
             if (this.field.form.taskId) {
                 this.getValuesByTaskId();
             } else {
@@ -101,5 +101,9 @@ export class DropdownWidgetComponent extends WidgetComponent implements OnInit {
 
     showRequiredMessage(): boolean {
         return (this.isInvalidFieldRequired() || this.field.value === 'empty') && this.isTouched();
+    }
+
+    get isReadOnlyField(): boolean {
+        return this.field.readOnly;
     }
 }

--- a/lib/process-services/src/lib/form/widgets/dropdown/dropdown.widget.ts
+++ b/lib/process-services/src/lib/form/widgets/dropdown/dropdown.widget.ts
@@ -52,7 +52,7 @@ export class DropdownWidgetComponent extends WidgetComponent implements OnInit {
     }
 
     ngOnInit() {
-        if (this.field?.restUrl && !this.field?.form?.readOnly) {
+        if (this.field?.restUrl && !this.isReadOnlyForm()) {
             if (this.field.form.taskId) {
                 this.getValuesByTaskId();
             } else {
@@ -105,5 +105,9 @@ export class DropdownWidgetComponent extends WidgetComponent implements OnInit {
 
     get isReadOnlyField(): boolean {
         return this.field.readOnly;
+    }
+
+    private isReadOnlyForm(): boolean {
+        return !!this.field?.form?.readOnly;
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
AAE-24018

https://github.com/user-attachments/assets/df688bc9-262e-476a-88a8-5abfb04dcb02

**Note:** We have form rule here: Enable dropdown when Text field has '1', otherwise is disabled. 

**What is the new behaviour?**

https://github.com/user-attachments/assets/9e7ae15c-a15c-44ae-b4f1-6c8615acd525

**Note:** We have form rule here: Enable dropdown when Text field has '1', otherwise is disabled. 

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
