### PR TITLE
HXCS-3181 Update translation label for viewer error

### DIFF
--- a/e2e/content-services/components/viewer-content-services-component.e2e.ts
+++ b/e2e/content-services/components/viewer-content-services-component.e2e.ts
@@ -290,7 +290,9 @@ describe('Content Services Viewer', () => {
 
             await viewerPage.checkZoomInButtonIsNotDisplayed();
             await viewerPage.checkUnknownFormatIsDisplayed();
-            expect(await viewerPage.getUnknownFormatMessage()).toBe(`Couldn't load preview. Unknown format.`);
+            expect(await viewerPage.getUnknownFormatMessage()).toBe(
+                `Couldn't load preview. Unsupported file type or loading error. Please try refreshing the page.`
+            );
 
             await viewerPage.clickCloseButton();
         });

--- a/lib/core/src/lib/i18n/en.json
+++ b/lib/core/src/lib/i18n/en.json
@@ -418,7 +418,7 @@
       "PAGE_SELECTOR_LABEL": "Page selector"
     },
     "LOADING": "Loading",
-    "UNKNOWN_FORMAT": "Couldn't load preview. Unknown format.",
+    "UNKNOWN_FORMAT": "Couldn't load preview. Unsupported file type or loading error. Please try refreshing the page.",
     "SIDEBAR": {
       "THUMBNAILS": {
         "PAGE": "Page {{ pageNum }}"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe:
Translation adjustment

**What is the current behaviour?** (You can also link to an open issue here)
Translation label for document viewer error was "Couldn't load preview. Unknown format."


**What is the new behaviour?**
Translation label for document viewer error is "Couldn't load preview. Unsupported file type or loading error. Please try refreshing the page."


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
