### PR TITLE
[ACS-8451] Fixed arrow position for select dropdowns in create/edit rules dialog

### DIFF
--- a/lib/core/src/lib/card-view/components/card-view-selectitem/card-view-selectitem.component.scss
+++ b/lib/core/src/lib/card-view/components/card-view-selectitem/card-view-selectitem.component.scss
@@ -25,15 +25,16 @@
             background-color: initial;
         }
 
-        /* TODO(mdc-migration): The following rule targets internal classes of select that may no longer apply for the MDC version. */
-        mat-select {
-            padding: 6px 0 8px 12px;
+        #{$mat-select} {
             margin-top: 0;
             border-radius: 6px;
-            width: 90%;
 
             #{$mat-select-value} {
                 color: var(--adf-metadata-action-button-clear-color);
+            }
+
+            #{$mat-select-trigger} {
+                padding: 6px 12px 6px 6px;
             }
         }
     }

--- a/lib/core/src/lib/styles/_mat-selectors.scss
+++ b/lib/core/src/lib/styles/_mat-selectors.scss
@@ -62,6 +62,7 @@ $mat-button-toggle: '.mat-button-toggle';
 $mat-button-toggle-checked: '.mat-button-toggle-checked';
 $mat-button-toggle-disabled: '.mat-button-toggle-disabled';
 $mat-button-toggle-focus-overlay: '.mat-button-toggle-focus-overlay';
+$mat-button-touch-target: '.mat-mdc-button-touch-target';
 $mat-input-element: '.mat-mdc-input-element';
 $mat-card: '.mat-mdc-card';
 $mat-card-actions: '.mat-mdc-card-actions';


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Dropdown arrows were too far to the left in create/edit rule window


**What is the new behaviour?**
Fixed position of dropdown arrow


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://hyland.atlassian.net/browse/ACS-8451