### PR TITLE
[ACS-8476] ADW - on localhost attach file widget is opening login page instead of node selector

### DIFF
--- a/lib/process-services/src/lib/form/widgets/content-widget/attach-file-widget.component.spec.ts
+++ b/lib/process-services/src/lib/form/widgets/content-widget/attach-file-widget.component.spec.ts
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import * as angularCore from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { AttachFileWidgetComponent } from './attach-file-widget.component';
@@ -607,5 +608,12 @@ describe('AttachFileWidgetComponent', () => {
         await fixture.whenStable();
 
         expect(openLoginSpy).toHaveBeenCalledWith(fakeRepositoryListAnswer[2], undefined, 'alfresco-2000-external');
+    });
+
+    it('should open fileBrowserDialog if devMode flag is on', async () => {
+        spyOn(angularCore, 'isDevMode').and.returnValue(true);
+        widget.openSelectDialog({});
+        await fixture.whenStable();
+        expect(contentNodeDialogService.openFileBrowseDialogByDefaultLocation).toHaveBeenCalled();
     });
 });

--- a/lib/process-services/src/lib/form/widgets/content-widget/attach-file-widget.component.spec.ts
+++ b/lib/process-services/src/lib/form/widgets/content-widget/attach-file-widget.component.spec.ts
@@ -18,7 +18,16 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { AttachFileWidgetComponent } from './attach-file-widget.component';
-import { FormFieldModel, FormModel, FormFieldTypes, FormService, FormFieldMetadata, DownloadService } from '@alfresco/adf-core';
+import {
+    FormFieldModel,
+    FormModel,
+    FormFieldTypes,
+    FormService,
+    FormFieldMetadata,
+    DownloadService,
+    AppConfigService,
+    AppConfigValues
+} from '@alfresco/adf-core';
 import { ContentNodeDialogService, ContentModule } from '@alfresco/adf-content-services';
 import { of } from 'rxjs';
 import { Node } from '@alfresco/js-api';
@@ -136,6 +145,7 @@ describe('AttachFileWidgetComponent', () => {
     let fixture: ComponentFixture<AttachFileWidgetComponent>;
     let element: HTMLInputElement;
     let activitiContentService: ActivitiContentService;
+    let appConfigService: AppConfigService;
     let contentNodeDialogService: ContentNodeDialogService;
     let processContentService: ProcessContentService;
     let downloadService: DownloadService;
@@ -153,6 +163,7 @@ describe('AttachFileWidgetComponent', () => {
         contentNodeDialogService = TestBed.inject(ContentNodeDialogService);
         processContentService = TestBed.inject(ProcessContentService);
         downloadService = TestBed.inject(DownloadService);
+        appConfigService = TestBed.inject(AppConfigService);
         formService = TestBed.inject(FormService);
         attachFileWidgetDialogService = TestBed.inject(AttachFileWidgetDialogService);
     });
@@ -610,6 +621,7 @@ describe('AttachFileWidgetComponent', () => {
     });
 
     it('should open fileBrowserDialog if devMode flag is on', async () => {
+        spyOn(appConfigService, 'get').withArgs(AppConfigValues.ECMHOST).and.returnValue('ECMHOST');
         widget.openSelectDialog({});
         await fixture.whenStable();
         expect(contentNodeDialogService.openFileBrowseDialogByDefaultLocation).toHaveBeenCalled();

--- a/lib/process-services/src/lib/form/widgets/content-widget/attach-file-widget.component.spec.ts
+++ b/lib/process-services/src/lib/form/widgets/content-widget/attach-file-widget.component.spec.ts
@@ -610,7 +610,6 @@ describe('AttachFileWidgetComponent', () => {
     });
 
     it('should open fileBrowserDialog if devMode flag is on', async () => {
-        global['ngDevMode'] = true;
         widget.openSelectDialog({});
         await fixture.whenStable();
         expect(contentNodeDialogService.openFileBrowseDialogByDefaultLocation).toHaveBeenCalled();

--- a/lib/process-services/src/lib/form/widgets/content-widget/attach-file-widget.component.spec.ts
+++ b/lib/process-services/src/lib/form/widgets/content-widget/attach-file-widget.component.spec.ts
@@ -622,7 +622,7 @@ describe('AttachFileWidgetComponent', () => {
 
     it('should open fileBrowserDialog if devMode flag is on', async () => {
         spyOn(appConfigService, 'get').withArgs(AppConfigValues.ECMHOST).and.returnValue('ECMHOST');
-        spyOn(contentNodeDialogService, 'openFileBrowseDialogByDefaultLocation');
+        spyOn(contentNodeDialogService, 'openFileBrowseDialogByDefaultLocation').and.returnValue(of([]));
         widget.openSelectDialog({ repositoryUrl: 'repositoryUrl' });
         await fixture.whenStable();
         expect(contentNodeDialogService.openFileBrowseDialogByDefaultLocation).toHaveBeenCalled();

--- a/lib/process-services/src/lib/form/widgets/content-widget/attach-file-widget.component.spec.ts
+++ b/lib/process-services/src/lib/form/widgets/content-widget/attach-file-widget.component.spec.ts
@@ -622,6 +622,7 @@ describe('AttachFileWidgetComponent', () => {
 
     it('should open fileBrowserDialog if devMode flag is on', async () => {
         spyOn(appConfigService, 'get').withArgs(AppConfigValues.ECMHOST).and.returnValue('ECMHOST');
+        spyOn(contentNodeDialogService, 'openFileBrowseDialogByDefaultLocation');
         widget.openSelectDialog({ repositoryUrl: 'repositoryUrl' });
         await fixture.whenStable();
         expect(contentNodeDialogService.openFileBrowseDialogByDefaultLocation).toHaveBeenCalled();

--- a/lib/process-services/src/lib/form/widgets/content-widget/attach-file-widget.component.spec.ts
+++ b/lib/process-services/src/lib/form/widgets/content-widget/attach-file-widget.component.spec.ts
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import * as angularCore from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { AttachFileWidgetComponent } from './attach-file-widget.component';
@@ -27,7 +26,6 @@ import { ProcessTestingModule } from '../../../testing/process.testing.module';
 import { AttachFileWidgetDialogService } from './attach-file-widget-dialog.service';
 import { ActivitiContentService } from '../../services/activiti-alfresco.service';
 import { ProcessContentService } from '../../services/process-content.service';
-import { isDevMode } from '@angular/core';
 
 const fakeRepositoryListAnswer = [
     {

--- a/lib/process-services/src/lib/form/widgets/content-widget/attach-file-widget.component.spec.ts
+++ b/lib/process-services/src/lib/form/widgets/content-widget/attach-file-widget.component.spec.ts
@@ -622,7 +622,7 @@ describe('AttachFileWidgetComponent', () => {
 
     it('should open fileBrowserDialog if devMode flag is on', async () => {
         spyOn(appConfigService, 'get').withArgs(AppConfigValues.ECMHOST).and.returnValue('ECMHOST');
-        widget.openSelectDialog({});
+        widget.openSelectDialog({ repositoryUrl: 'repositoryUrl' });
         await fixture.whenStable();
         expect(contentNodeDialogService.openFileBrowseDialogByDefaultLocation).toHaveBeenCalled();
     });

--- a/lib/process-services/src/lib/form/widgets/content-widget/attach-file-widget.component.spec.ts
+++ b/lib/process-services/src/lib/form/widgets/content-widget/attach-file-widget.component.spec.ts
@@ -27,6 +27,7 @@ import { ProcessTestingModule } from '../../../testing/process.testing.module';
 import { AttachFileWidgetDialogService } from './attach-file-widget-dialog.service';
 import { ActivitiContentService } from '../../services/activiti-alfresco.service';
 import { ProcessContentService } from '../../services/process-content.service';
+import { isDevMode } from '@angular/core';
 
 const fakeRepositoryListAnswer = [
     {
@@ -611,7 +612,7 @@ describe('AttachFileWidgetComponent', () => {
     });
 
     it('should open fileBrowserDialog if devMode flag is on', async () => {
-        spyOn(angularCore, 'isDevMode').and.returnValue(true);
+        global['ngDevMode'] = true;
         widget.openSelectDialog({});
         await fixture.whenStable();
         expect(contentNodeDialogService.openFileBrowseDialogByDefaultLocation).toHaveBeenCalled();

--- a/lib/process-services/src/lib/form/widgets/content-widget/attach-file-widget.component.ts
+++ b/lib/process-services/src/lib/form/widgets/content-widget/attach-file-widget.component.ts
@@ -204,8 +204,10 @@ export class AttachFileWidgetComponent extends UploadWidgetComponent implements 
             this.uploadFileFromExternalCS(repository);
         } else {
             this.contentDialog.openFileBrowseDialogByDefaultLocation().subscribe((selections: Node[]) => {
-                this.tempFilesList.push(...selections);
-                this.uploadFileFromCS(selections, `alfresco-${repository.id}-${repository.name}`);
+                if (selections.length) {
+                    this.tempFilesList.push(...selections);
+                    this.uploadFileFromCS(selections, `alfresco-${repository.id}-${repository.name}`);
+                }
             });
         }
     }

--- a/lib/process-services/src/lib/form/widgets/content-widget/attach-file-widget.component.ts
+++ b/lib/process-services/src/lib/form/widgets/content-widget/attach-file-widget.component.ts
@@ -17,7 +17,7 @@
 
 /* eslint-disable @angular-eslint/component-selector */
 
-import { Component, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, isDevMode, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
 import { AppConfigService, AppConfigValues, DownloadService, ErrorWidgetComponent, FormService, ThumbnailService } from '@alfresco/adf-core';
 import { ContentNodeDialogService, ContentService } from '@alfresco/adf-content-services';
 import { AlfrescoEndpointRepresentation, Node, NodeChildAssociation, RelatedContentRepresentation } from '@alfresco/js-api';
@@ -217,7 +217,7 @@ export class AttachFileWidgetComponent extends UploadWidgetComponent implements 
     private isExternalHost(repository: AlfrescoEndpointRepresentation): boolean {
         const currentECMHost = this.getDomainHost(this.appConfigService.get(AppConfigValues.ECMHOST));
         const chosenRepositoryHost = this.getDomainHost(repository.repositoryUrl);
-        return chosenRepositoryHost !== currentECMHost;
+        return chosenRepositoryHost !== currentECMHost && !isDevMode();
     }
 
     private findSource(sourceIdentifier: string): AlfrescoEndpointRepresentation {

--- a/lib/process-services/src/lib/form/widgets/content-widget/attach-file-widget.component.ts
+++ b/lib/process-services/src/lib/form/widgets/content-widget/attach-file-widget.component.ts
@@ -200,7 +200,7 @@ export class AttachFileWidgetComponent extends UploadWidgetComponent implements 
     }
 
     openSelectDialog(repository: AlfrescoEndpointRepresentation) {
-        if (this.isExternalHost(repository)) {
+        if (this.isExternalHost(repository) && !isDevMode()) {
             this.uploadFileFromExternalCS(repository);
         } else {
             this.contentDialog.openFileBrowseDialogByDefaultLocation().subscribe((selections: Node[]) => {
@@ -217,7 +217,7 @@ export class AttachFileWidgetComponent extends UploadWidgetComponent implements 
     private isExternalHost(repository: AlfrescoEndpointRepresentation): boolean {
         const currentECMHost = this.getDomainHost(this.appConfigService.get(AppConfigValues.ECMHOST));
         const chosenRepositoryHost = this.getDomainHost(repository.repositoryUrl);
-        return chosenRepositoryHost !== currentECMHost && !isDevMode();
+        return chosenRepositoryHost !== currentECMHost;
     }
 
     private findSource(sourceIdentifier: string): AlfrescoEndpointRepresentation {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/ACS-8476


**What is the new behaviour?**
Attach file window opens correctly on locahost.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
