### PR TITLE
[ACS-8452] Fixed UI for folder select input fields in create/edit rules

### DIFF
--- a/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.html
+++ b/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.html
@@ -111,11 +111,12 @@
         (keyup.enter)="clicked()"
         (click)="clicked()"
     >
-        <mat-form-field class="adf-property-field adf-card-textitem-field">
+        <mat-form-field class="adf-property-field adf-card-textitem-field" [floatLabel]="'always'">
             <mat-label
                 *ngIf="showProperty || isEditable"
                 [attr.data-automation-id]="'card-textitem-label-' + property.key"
                 class="adf-property-label"
+                [ngClass]="{ 'adf-property-value-editable': editable }"
             >
                 {{ property.label | translate }}
             </mat-label>

--- a/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.scss
+++ b/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.scss
@@ -18,8 +18,9 @@
     }
 
     .adf-textitem-action {
-        width: 20px;
-        height: 20px;
+        width: 30px;
+        height: 30px;
+        padding: 0;
         line-height: 20px;
         color: var(--adf-theme-foreground-text-color-025);
 
@@ -27,6 +28,15 @@
         &:focus {
             color: var(--adf-theme-foreground-text-color);
         }
+
+        #{$mat-button-touch-target} {
+            width: 30px;
+            height: 30px;
+        }
+    }
+
+    #{$mat-form-field-icon-suffix} {
+        align-self: baseline;
     }
 
     .adf-textitem-chip-list-container {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Folder select input fields had broken UI after ng15 upgrade


**What is the new behaviour?**
Fixed UI for input fields


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://hyland.atlassian.net/browse/ACS-8452
Also see old PR - https://github.com/Alfresco/alfresco-ng2-components/pull/9990