### PR TITLE
[ACS-8497] Resolved issue where icons in file upload overlay were not displaying properly

### DIFF
--- a/lib/content-services/src/lib/upload/components/file-uploading-list-row.component.html
+++ b/lib/content-services/src/lib/upload/components/file-uploading-list-row.component.html
@@ -1,5 +1,5 @@
 <div class="adf-file-uploading-row">
-    <mat-icon *ngIf="mimeType === 'default'" matListItemLine class="adf-file-uploading-row__type">
+    <mat-icon *ngIf="mimeType === 'default'" matListItemIcon class="adf-file-uploading-row__type">
         insert_drive_file
     </mat-icon>
 
@@ -12,10 +12,10 @@
     </span>
 
     <span *ngIf="isUploadVersion()" class="adf-file-uploading-row__version" tabindex="0" >
-        <mat-chip-option color="primary"
+        <mat-chip color="primary"
             [attr.aria-label]="'ADF_FILE_UPLOAD.ARIA-LABEL.VERSION' | translate: { version:  versionNumber }"
-            [title]="'version' + versionNumber" [disabled]="true"
-        >{{ versionNumber }}</mat-chip-option>
+            [title]="'version' + versionNumber"
+        >{{ versionNumber }}</mat-chip>
     </span>
 
     <div
@@ -61,7 +61,7 @@
         [attr.aria-label]="'ADF_FILE_UPLOAD.STATUS.FILE_DONE_STATUS' | translate"
         >
         <mat-icon
-            matListItemLine
+            matListItemIcon
             class="adf-file-uploading-row__status--done">
             check_circle
         </mat-icon>
@@ -94,7 +94,7 @@
         role="status"
         *ngIf="isUploadError()"
         class="adf-file-uploading-row__block adf-file-uploading-row__status--error">
-        <mat-icon matListItemLine
+        <mat-icon matListItemIcon
             [attr.aria-label]="'ADF_FILE_UPLOAD.ARIA-LABEL.UPLOAD_FILE_ERROR' | translate: { error: file.errorCode | adfFileUploadError }"
             [title]="file.errorCode | adfFileUploadError">
             report_problem

--- a/lib/content-services/src/lib/upload/components/file-uploading-list-row.component.scss
+++ b/lib/content-services/src/lib/upload/components/file-uploading-list-row.component.scss
@@ -32,6 +32,7 @@ adf-file-uploading-list-row:not(:first-child) {
         line-height: 40px;
         height: 40px;
         align-items: center;
+        padding: 0 12px;
     }
 
     &__group--toggle {
@@ -48,6 +49,7 @@ adf-file-uploading-list-row:not(:first-child) {
 
     &__status--error {
         color: var(--theme-warn-color);
+        padding: 0 12px;
     }
 
     &__action--cancel {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Icons in the file upload overlay were getting cut off after ng16 upgrade


**What is the new behaviour?**
Icons now display properly


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://hyland.atlassian.net/browse/ACS-8497