### PR TITLE
[ACS-8555] Name filter clear icon now no longer gets cut off

### DIFF
--- a/lib/content-services/src/lib/search/components/search-text/search-text.component.html
+++ b/lib/content-services/src/lib/search/components/search-text/search-text.component.html
@@ -7,7 +7,7 @@
         [(ngModel)]="value"
         (change)="onChangedHandler($event)">
     <button
-        mat-button
+        mat-icon-button
         *ngIf="value"
         matSuffix
         (click)="clear()"

--- a/lib/content-services/src/lib/search/components/search-text/search-text.component.scss
+++ b/lib/content-services/src/lib/search/components/search-text/search-text.component.scss
@@ -46,13 +46,6 @@
         &-clear-button {
             min-width: unset;
             border-radius: 50%;
-            height: 1.5em;
-            width: 1.5em;
-            margin-right: 8px;
-
-            mat-icon {
-                margin-right: 0;
-            }
         }
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Clear Filter (X) button was getting cut off in name filter overlay


**What is the new behaviour?**
Clear Filter (X) button no longer gets cut off


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://hyland.atlassian.net/browse/ACS-8555