### PR TITLE
Allow for more customization of adf-cloud-people component

### DIFF
--- a/docs/process-services-cloud/components/people-cloud.component.md
+++ b/docs/process-services-cloud/components/people-cloud.component.md
@@ -35,6 +35,10 @@ Allows one or more users to be selected (with auto-suggestion) based on the inpu
 | roles | `string[]` |  | Role names of the users to be listed. |
 | searchUserCtrl | `FormControl<any>` |  | FormControl to search the user |
 | title | `string` |  | Placeholder translation key |
+| hideInputOnSingleSelection | `boolean` | false | Hide the input field when a user is selected in single selection mode. The input will be shown again when the user is removed using the icon on the chip. |
+| formFieldAppearance | [`MatFormFieldAppearance`](https://material.angular.io/components/form-field/api#MatFormFieldAppearance) | "fill" | Material form field appearance (fill / outline). |
+| formFieldSubscriptSizing | [`SubscriptSizing`](https://material.angular.io/components/form-field/api#SubscriptSizing) | "fixed" | Material form field subscript sizing (fixed / dynamic). |
+| showErrors | `boolean` | true | Show errors under the form field. |
 | userChipsCtrl | `UntypedFormControl` |  | FormControl to list of users |
 | validate | `boolean` | false | This flag enables the validation on the preSelectUsers passed as input. In case the flag is true the components call the identity service to verify the validity of the information passed as input. Otherwise, no check will be done. |
 

--- a/lib/process-services-cloud/src/lib/people/components/people-cloud.component.html
+++ b/lib/process-services-cloud/src/lib/people/components/people-cloud.component.html
@@ -1,5 +1,11 @@
 <form>
-    <mat-form-field [floatLabel]="'auto'" class="adf-people-cloud" [class.adf-invalid]="hasError() && isDirty()">
+    <mat-form-field
+        [appearance]="formFieldAppearance"
+        [subscriptSizing]="formFieldSubscriptSizing"
+        [floatLabel]="'auto'"
+        class="adf-people-cloud"
+        [class.adf-invalid]="hasError() && isDirty()"
+    >
         <ng-content select="[label]"></ng-content>
         <mat-chip-grid #userMultipleChipList [disabled]="isReadonly() || isValidationLoading()" data-automation-id="adf-cloud-people-chip-list">
             <mat-chip-row
@@ -58,7 +64,7 @@
         mode="indeterminate">
     </mat-progress-bar>
 
-    <div class="adf-error-container">
+    <div class="adf-error-container" *ngIf="showErrors">
         <mat-error *ngIf="hasPreselectError() && !isValidationLoading()" [@transitionMessages]="subscriptAnimationState" class="adf-error">
             <mat-icon class="adf-error-icon">error_outline</mat-icon>
             <div class="adf-error-text">{{ 'ADF_CLOUD_USERS.ERROR.NOT_FOUND' | translate : { userName : validateUsersMessage } }}</div>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
It's not possible to customize the `appearance` and `subscriptSizing` of the `mat-form-field` inside `adf-cloud-people` component. It's also not possible to hide the text input field after a user has been selected in single selection mode. 

**What is the new behaviour?**
Added the options described above.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
