### PR TITLE
ACS-8572: Support for reloading document list from outside

### DIFF
--- a/docs/content-services/services/document-list.service.md
+++ b/docs/content-services/services/document-list.service.md
@@ -5,57 +5,71 @@ Status: Active
 Last reviewed: 2019-01-16
 ---
 
-# [Document List service](../../../lib/content-services/src/lib/document-list/services/document-list.service.ts "Defined in document-list.service.ts")
+# Document List Service
 
-Implements node operations used by the [Document List component](../components/document-list.component.md).
+`service`
 
-## Class members
+Implements operations used by the [Document List component](../components/document-list.component.md).
+
+## Usage
+
+```typescript
+import { DocumentListService } from '@alfresco/adf-core';
+```
+
+## API
+
+### Events
+
+| Name      | Description                                     |
+|-----------|-------------------------------------------------|
+| `reload$` | Emits when the document list should be reloaded |
 
 ### Methods
 
--   **copyNode**(nodeId: `string`, targetParentId: `string`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`NodeEntry`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/NodeEntry.md)`>`<br/>
+-   **copyNode**(nodeId: `string`, targetParentId: `string`): `Observable<NodeEntry>`<br/>
     Copy a node to destination node
     -   _nodeId:_ `string`  - The id of the node to be copied
     -   _targetParentId:_ `string`  - The id of the folder where the node will be copied
-    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`NodeEntry`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/NodeEntry.md)`>` - NodeEntry for the copied node
--   **deleteNode**(nodeId: `string`): [`Observable`](http://reactivex.io/documentation/observable.html)`<any>`<br/>
+    -   **Returns** `Observable<NodeEntry>` - NodeEntry for the copied node
+-   **deleteNode**(nodeId: `string`): `Observable<any>`<br/>
     Deletes a node.
     -   _nodeId:_ `string`  - ID of the node to delete
-    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<any>` - Empty response when the operation is complete
--   **getFolder**(folder: `string`, opts?: `any`, includeFields: `string[]` = `[]`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`NodePaging`](https://github.com/Alfresco/alfresco-js-api/blob/develop/src/api/content-rest-api/docs/NodePaging.md)`>`<br/>
+    -   **Returns** `Observable<any>` - Empty response when the operation is complete
+-   **getFolder**(folder: `string`, opts?: `any`, includeFields: `string[]` = `[]`): `Observable<NodePaging>`<br/>
     Gets the folder node with the specified relative name path below the root node.
     -   _folder:_ `string`  - Path to folder.
     -   _opts:_ `any`  - (Optional) Options.
     -   _includeFields:_ `string[]`  - Extra information to include (available options are "aspectNames", "isLink" and "association")
-    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`NodePaging`](https://github.com/Alfresco/alfresco-js-api/blob/develop/src/api/content-rest-api/docs/NodePaging.md)`>` - Details of the folder
--   **getFolderNode**(nodeId: `string`, includeFields: `string[]` = `[]`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`NodeEntry`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/NodeEntry.md)`>`<br/>
+    -   **Returns** `Observable<NodePaging>` - Details of the folder
+-   **getFolderNode**(nodeId: `string`, includeFields: `string[]` = `[]`): `Observable<NodeEntry>`<br/>
     Gets a folder node via its node ID.
     -   _nodeId:_ `string`  - ID of the folder node
     -   _includeFields:_ `string[]`  - Extra information to include (available options are "aspectNames", "isLink" and "association")
-    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`NodeEntry`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/NodeEntry.md)`>` - Details of the folder
--   **getNode**(nodeId: `string`, includeFields: `string[]` = `[]`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`MinimalNode`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/NodeMinimalEntry.md)`>`<br/>
+    -   **Returns** `Observable<NodeEntry>` - Details of the folder
+-   **getNode**(nodeId: `string`, includeFields: `string[]` = `[]`): `Observable<MinimalNode>`<br/>
     Gets a node via its node ID.
     -   _nodeId:_ `string`  - ID of the target node
     -   _includeFields:_ `string[]`  - Extra information to include (available options are "aspectNames", "isLink" and "association")
-    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`MinimalNode`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/NodeMinimalEntry.md)`>` - Details of the folder
+    -   **Returns** `Observable<MinimalNode>` - Details of the folder
 -   **isCustomSourceService**(nodeId: `any`): `boolean`<br/>
 
     -   _nodeId:_ `any`  - 
     -   **Returns** `boolean` - 
 
--   **loadFolderByNodeId**(nodeId: `string`, pagination: [`PaginationModel`](../../../lib/core/src/lib/models/pagination.model.ts), includeFields: `string[]`, where?: `string`, orderBy?: `string[]`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`DocumentLoaderNode`](../../../lib/content-services/src/lib/document-list/models/document-folder.model.ts)`>`<br/>
+-   **loadFolderByNodeId**(nodeId: `string`, pagination: `PaginationModel`, includeFields: `string[]`, where?: `string`, orderBy?: `string[]`): `Observable<DocumentLoaderNode>`<br/>
     Load a folder by Node Id.
     -   _nodeId:_ `string`  - ID of the folder node
-    -   _pagination:_ [`PaginationModel`](../../../lib/core/src/lib/models/pagination.model.ts)  - 
+    -   _pagination:_ `PaginationModel` - pagination model
     -   _includeFields:_ `string[]`  - List of data field names to include in the results
     -   _where:_ `string`  - (Optional) Optionally filter the list
     -   _orderBy:_ `string[]`  - (Optional) order by node property
-    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`DocumentLoaderNode`](../../../lib/content-services/src/lib/document-list/models/document-folder.model.ts)`>` - Details of the folder
--   **moveNode**(nodeId: `string`, targetParentId: `string`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`NodeEntry`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/NodeEntry.md)`>`<br/>
+    -   **Returns** `Observable<DocumentLoaderNode>` - Details of the folder
+-   **moveNode**(nodeId: `string`, targetParentId: `string`): `Observable<NodeEntry>`<br/>
     Moves a node to destination node.
     -   _nodeId:_ `string`  - The id of the node to be moved
     -   _targetParentId:_ `string`  - The id of the folder where the node will be moved
-    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`NodeEntry`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/NodeEntry.md)`>` - NodeEntry for the moved node
+    -   **Returns** `Observable<NodeEntry>` - NodeEntry for the moved node
 
 ## Details
 

--- a/docs/content-services/services/document-list.service.md
+++ b/docs/content-services/services/document-list.service.md
@@ -21,14 +21,17 @@ import { DocumentListService } from '@alfresco/adf-core';
 
 ### Events
 
-| Name      | Description                                     |
-|-----------|-------------------------------------------------|
-| `reload$` | Emits when the document list should be reloaded |
+| Name              | Description                                     |
+|-------------------|-------------------------------------------------|
+| `reload$`         | Emits when the document list should be reloaded |
+| `resetSelection$` | Emits when the selection should be reset        |
 
 ### Methods
 
 - **reload**(): `void`<br/>
     Reloads the document list.
+- **resetSelection**(): `void`<br/>
+    Resets the selection.
 -   **copyNode**(nodeId: `string`, targetParentId: `string`): `Observable<NodeEntry>`<br/>
     Copy a node to destination node
     -   _nodeId:_ `string`  - The id of the node to be copied

--- a/docs/content-services/services/document-list.service.md
+++ b/docs/content-services/services/document-list.service.md
@@ -27,6 +27,8 @@ import { DocumentListService } from '@alfresco/adf-core';
 
 ### Methods
 
+- **reload**(): `void`<br/>
+    Reloads the document list.
 -   **copyNode**(nodeId: `string`, targetParentId: `string`): `Observable<NodeEntry>`<br/>
     Copy a node to destination node
     -   _nodeId:_ `string`  - The id of the node to be copied

--- a/lib/content-services/src/lib/document-list/components/document-list.component.spec.ts
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.spec.ts
@@ -147,6 +147,23 @@ describe('DocumentList', () => {
         expect(documentList.reload).not.toHaveBeenCalled();
     });
 
+    it('should reset selection when resetSelection$ is emitted', () => {
+        spyOn(documentList, 'resetSelection').and.callThrough();
+
+        documentListService.resetSelection();
+
+        expect(documentList.resetSelection).toHaveBeenCalled();
+    });
+
+    it('should not reset selection after component is destroyed', () => {
+        spyOn(documentList, 'resetSelection').and.callThrough();
+
+        documentList.ngOnDestroy();
+        documentListService.resetSelection();
+
+        expect(documentList.resetSelection).not.toHaveBeenCalled();
+    });
+
     describe('presets', () => {
         const validatePreset = (keys: string[]) => {
             const columns = documentList.data.getColumns();

--- a/lib/content-services/src/lib/document-list/components/document-list.component.spec.ts
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.spec.ts
@@ -126,6 +126,27 @@ describe('DocumentList', () => {
         fixture.destroy();
     });
 
+    it('should reset selection and reload on documentListService reload$', () => {
+        spyOn(documentList, 'resetSelection').and.callThrough();
+        spyOn(documentList, 'reload').and.callThrough();
+
+        documentListService.reload();
+
+        expect(documentList.resetSelection).toHaveBeenCalled();
+        expect(documentList.reload).toHaveBeenCalled();
+    });
+
+    it('should not reset selection or reload after component is destroyed', () => {
+        spyOn(documentList, 'resetSelection').and.callThrough();
+        spyOn(documentList, 'reload').and.callThrough();
+
+        documentList.ngOnDestroy();
+        documentListService.reload();
+
+        expect(documentList.resetSelection).not.toHaveBeenCalled();
+        expect(documentList.reload).not.toHaveBeenCalled();
+    });
+
     describe('presets', () => {
         const validatePreset = (keys: string[]) => {
             const columns = documentList.data.getColumns();

--- a/lib/content-services/src/lib/document-list/components/document-list.component.ts
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.ts
@@ -517,6 +517,11 @@ export class DocumentListComponent extends DataTableSchema implements OnInit, On
         if (this.columnsPresetKey) {
             this.setPresetKey(this.columnsPresetKey);
         }
+
+        this.documentListService.reload$.pipe(takeUntil(this.onDestroy$)).subscribe(() => {
+            this.resetSelection();
+            this.reload();
+        });
     }
 
     ngAfterContentInit() {

--- a/lib/content-services/src/lib/document-list/components/document-list.component.ts
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.ts
@@ -522,6 +522,10 @@ export class DocumentListComponent extends DataTableSchema implements OnInit, On
             this.resetSelection();
             this.reload();
         });
+
+        this.documentListService.resetSelection$.pipe(takeUntil(this.onDestroy$)).subscribe(() => {
+            this.resetSelection();
+        });
     }
 
     ngAfterContentInit() {

--- a/lib/content-services/src/lib/document-list/services/document-list.service.spec.ts
+++ b/lib/content-services/src/lib/document-list/services/document-list.service.spec.ts
@@ -74,6 +74,20 @@ describe('DocumentListService', () => {
         jasmine.Ajax.install();
     });
 
+    it('should emit resetSelection$ when resetSelection is called', (done) => {
+        service.resetSelection$.subscribe(() => {
+            done();
+        });
+        service.resetSelection();
+    });
+
+    it('should emit reload$ when reload is called', (done) => {
+        service.reload$.subscribe(() => {
+            done();
+        });
+        service.reload();
+    });
+
     afterEach(() => {
         jasmine.Ajax.uninstall();
     });

--- a/lib/content-services/src/lib/document-list/services/document-list.service.ts
+++ b/lib/content-services/src/lib/document-list/services/document-list.service.ts
@@ -17,10 +17,10 @@
 
 import { AlfrescoApiService, PaginationModel } from '@alfresco/adf-core';
 import { NodesApiService } from '../../common/services/nodes-api.service';
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { Node, NodeEntry, NodePaging, NodesApi } from '@alfresco/js-api';
 import { DocumentLoaderNode } from '../models/document-folder.model';
-import { Observable, from, forkJoin } from 'rxjs';
+import { Observable, from, forkJoin, Subject } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { DocumentListLoader } from '../interfaces/document-list-loader.interface';
 import { CustomResourcesService } from './custom-resources.service';
@@ -31,17 +31,25 @@ const ROOT_ID = '-root-';
     providedIn: 'root'
 })
 export class DocumentListService implements DocumentListLoader {
+    private nodesApiService = inject(NodesApiService);
+    private apiService = inject(AlfrescoApiService);
+    private customResourcesService = inject(CustomResourcesService);
+
     private _nodesApi: NodesApi;
     get nodes(): NodesApi {
         this._nodesApi = this._nodesApi ?? new NodesApi(this.apiService.getInstance());
         return this._nodesApi;
     }
 
-    constructor(
-        private nodesApiService: NodesApiService,
-        private apiService: AlfrescoApiService,
-        private customResourcesService: CustomResourcesService
-    ) {}
+    private _reload = new Subject<void>();
+
+    /** Gets an observable that emits when the document list should be reloaded. */
+    reload$ = this._reload.asObservable();
+
+    /** Reloads the document list. */
+    reload() {
+        this._reload.next();
+    }
 
     /**
      * Deletes a node.

--- a/lib/content-services/src/lib/document-list/services/document-list.service.ts
+++ b/lib/content-services/src/lib/document-list/services/document-list.service.ts
@@ -42,13 +42,22 @@ export class DocumentListService implements DocumentListLoader {
     }
 
     private _reload = new Subject<void>();
+    private _resetSelection = new Subject<void>();
 
     /** Gets an observable that emits when the document list should be reloaded. */
     reload$ = this._reload.asObservable();
 
+    /** Gets an observable that emits when the selection should be reset. */
+    resetSelection$ = this._resetSelection.asObservable();
+
     /** Reloads the document list. */
     reload() {
         this._reload.next();
+    }
+
+    /** Resets the selection. */
+    resetSelection() {
+        this._resetSelection.next();
     }
 
     /**


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

- ACS-8572: port the document list reloading from the ACA/ADW (this feature is going to help cleaning up a lot of custom code in ACA/ADW)
- update the Document List Service docs, remove the direct code links where not relevant

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
