### PR TITLE
[ACS-8556] Resolved issue where UI for type to narrow field in the add aspect dropdown was broken

### DIFF
--- a/lib/core/src/lib/card-view/components/card-view-selectitem/select-filter-input/select-filter-input.component.html
+++ b/lib/core/src/lib/card-view/components/card-view-selectitem/select-filter-input/select-filter-input.component.html
@@ -15,6 +15,7 @@
         <button
             matSuffix
             mat-icon-button
+            class="adf-select-filter-clear-button"
             [attr.aria-label]="'SELECT_FILTER.BUTTON.ARIA_LABEL' | translate"
             *ngIf="term"
             (keydown.enter)="reset($event)"

--- a/lib/core/src/lib/card-view/components/card-view-selectitem/select-filter-input/select-filter-input.component.scss
+++ b/lib/core/src/lib/card-view/components/card-view-selectitem/select-filter-input/select-filter-input.component.scss
@@ -8,7 +8,6 @@ $select-filter-height: 4em !default;
 
     .adf-select-filter-input-container {
         width: 100%;
-        display: flex;
         z-index: 100;
         font-size: var(--theme-body-1-font-size);
         color: var(--adf-theme-foreground-text-color-087);
@@ -21,10 +20,14 @@ $select-filter-height: 4em !default;
     #{$mat-form-field} {
         width: 100%;
     }
+
+    .adf-select-filter-clear-button {
+        padding: 0;
+    }
 }
 
 #{$mat-select-panel}.adf-select-filter {
-    transform: none !important;
-    overflow-x: hidden !important;
+    transform: none;
+    overflow-x: hidden;
     max-height: calc(256px + #{$select-filter-height});
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
UI for Type To Narrow field was broken. Clear 'X' button was overlapping with the form field underline


**What is the new behaviour?**
Fixed UI issues


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://hyland.atlassian.net/browse/ACS-8556