### PR TITLE
ACS-8586: Remove internal dependency on PipeModule

### DIFF
--- a/lib/content-services/src/lib/content-metadata/components/content-metadata-card/content-metadata-card.component.spec.ts
+++ b/lib/content-services/src/lib/content-metadata/components/content-metadata-card/content-metadata-card.component.spec.ts
@@ -26,14 +26,13 @@ import { NodeAspectService } from '../../../aspect-list/services/node-aspect.ser
 import { ContentMetadataService } from '../../services/content-metadata.service';
 import { AllowableOperationsEnum } from '../../../common/models/allowable-operations.enum';
 import { of } from 'rxjs';
-import { AlfrescoApiService, AlfrescoApiServiceMock, AuthModule, PipeModule, TranslationMock, TranslationService } from '@alfresco/adf-core';
+import { AlfrescoApiService, AlfrescoApiServiceMock, AuthModule, TranslationMock, TranslationService } from '@alfresco/adf-core';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { HttpClientModule } from '@angular/common/http';
 import { versionCompatibilityFactory } from '../../../version-compatibility/version-compatibility-factory';
 import { VersionCompatibilityService } from '../../../version-compatibility';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
-import { MatTooltipModule } from '@angular/material/tooltip';
 import { CategoryService } from '../../../category';
 import { TagService } from '../../../tag';
 import { PropertyDescriptorsService } from '../../public-api';
@@ -59,9 +58,7 @@ describe('ContentMetadataCardComponent', () => {
                 AuthModule.forRoot({ useHash: true }),
                 HttpClientModule,
                 MatDialogModule,
-                PipeModule,
                 MatSnackBarModule,
-                MatTooltipModule,
                 ContentMetadataCardComponent
             ],
             providers: [

--- a/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.spec.ts
+++ b/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.spec.ts
@@ -27,7 +27,6 @@ import {
     CardViewBaseItemModel,
     CardViewComponent,
     NotificationService,
-    PipeModule,
     TranslationMock,
     TranslationService,
     UpdateNotification
@@ -51,8 +50,6 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { HttpClientModule } from '@angular/common/http';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
-import { MatProgressBarModule } from '@angular/material/progress-bar';
-import { MatTooltipModule } from '@angular/material/tooltip';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatChipHarness } from '@angular/material/chips/testing';
 
@@ -193,9 +190,6 @@ describe('ContentMetadataComponent', () => {
                 HttpClientModule,
                 MatDialogModule,
                 MatSnackBarModule,
-                MatProgressBarModule,
-                MatTooltipModule,
-                PipeModule,
                 ContentMetadataComponent
             ],
             providers: [

--- a/lib/content-services/src/lib/content-metadata/services/basic-properties.service.ts
+++ b/lib/content-services/src/lib/content-metadata/services/basic-properties.service.ts
@@ -15,16 +15,15 @@
  * limitations under the License.
  */
 
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { Node } from '@alfresco/js-api';
-import { CardViewDateItemModel, CardViewTextItemModel, FileSizePipe } from '@alfresco/adf-core';
+import { CardViewDateItemModel, CardViewTextItemModel, FileSizePipe, TranslationService } from '@alfresco/adf-core';
+
 @Injectable({
     providedIn: 'root'
 })
 export class BasicPropertiesService {
-
-    constructor(private fileSizePipe: FileSizePipe) {
-    }
+    private translationService = inject(TranslationService);
 
     getProperties(node: Node) {
         const sizeInBytes = node.content ? node.content.sizeInBytes : '';
@@ -63,7 +62,7 @@ export class BasicPropertiesService {
                 label: 'CORE.METADATA.BASIC.SIZE',
                 value: sizeInBytes,
                 key: 'content.sizeInBytes',
-                pipes: [{ pipe: this.fileSizePipe }],
+                pipes: [{ pipe: new FileSizePipe(this.translationService) }],
                 editable: false
             }),
             new CardViewTextItemModel({

--- a/lib/content-services/src/lib/content-metadata/services/property-groups-translator.service.ts
+++ b/lib/content-services/src/lib/content-metadata/services/property-groups-translator.service.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import {
     CardViewItemProperties,
     CardViewItem,
@@ -30,7 +30,8 @@ import {
     MultiValuePipe,
     AppConfigService,
     DecimalNumberPipe,
-    LogService
+    LogService,
+    UserPreferencesService
 } from '@alfresco/adf-core';
 import { Property, CardViewGroup, OrganisedPropertyGroup } from '../interfaces/content-metadata.interfaces';
 import { of } from 'rxjs';
@@ -52,14 +53,13 @@ export const RECOGNISED_ECM_TYPES = [D_TEXT, D_MLTEXT, D_DATE, D_DATETIME, D_INT
     providedIn: 'root'
 })
 export class PropertyGroupTranslatorService {
+    private userPreferenceService = inject(UserPreferencesService);
+    private appConfig = inject(AppConfigService);
+    private logService = inject(LogService);
+
     valueSeparator: string;
 
-    constructor(
-        private multiValuePipe: MultiValuePipe,
-        private decimalNumberPipe: DecimalNumberPipe,
-        private appConfig: AppConfigService,
-        private logService: LogService
-    ) {
+    constructor() {
         this.valueSeparator = this.appConfig.get<string>('content-metadata.multi-value-pipe-separator');
     }
 
@@ -137,7 +137,7 @@ export class PropertyGroupTranslatorService {
                     cardViewItemProperty = new CardViewIntItemModel(
                         Object.assign(propertyDefinition, {
                             multivalued: isMultiValued,
-                            pipes: [{ pipe: this.multiValuePipe, params: [this.valueSeparator] }]
+                            pipes: [{ pipe: new MultiValuePipe(), params: [this.valueSeparator] }]
                         })
                     );
                     break;
@@ -146,7 +146,7 @@ export class PropertyGroupTranslatorService {
                     cardViewItemProperty = new CardViewLongItemModel(
                         Object.assign(propertyDefinition, {
                             multivalued: isMultiValued,
-                            pipes: [{ pipe: this.multiValuePipe, params: [this.valueSeparator] }]
+                            pipes: [{ pipe: new MultiValuePipe(), params: [this.valueSeparator] }]
                         })
                     );
                     break;
@@ -156,7 +156,10 @@ export class PropertyGroupTranslatorService {
                     cardViewItemProperty = new CardViewFloatItemModel(
                         Object.assign(propertyDefinition, {
                             multivalued: isMultiValued,
-                            pipes: [{ pipe: this.decimalNumberPipe }, { pipe: this.multiValuePipe, params: [this.valueSeparator] }]
+                            pipes: [
+                                { pipe: new DecimalNumberPipe(this.userPreferenceService, this.appConfig) },
+                                { pipe: new MultiValuePipe(), params: [this.valueSeparator] }
+                            ]
                         })
                     );
                     break;
@@ -165,7 +168,7 @@ export class PropertyGroupTranslatorService {
                     cardViewItemProperty = new CardViewDateItemModel(
                         Object.assign(propertyDefinition, {
                             multivalued: isMultiValued,
-                            pipes: [{ pipe: this.multiValuePipe, params: [this.valueSeparator] }]
+                            pipes: [{ pipe: new MultiValuePipe(), params: [this.valueSeparator] }]
                         })
                     );
                     break;
@@ -174,7 +177,7 @@ export class PropertyGroupTranslatorService {
                     cardViewItemProperty = new CardViewDatetimeItemModel(
                         Object.assign(propertyDefinition, {
                             multivalued: isMultiValued,
-                            pipes: [{ pipe: this.multiValuePipe, params: [this.valueSeparator] }]
+                            pipes: [{ pipe: new MultiValuePipe(), params: [this.valueSeparator] }]
                         })
                     );
                     break;
@@ -189,7 +192,7 @@ export class PropertyGroupTranslatorService {
                         Object.assign(propertyDefinition, {
                             multivalued: isMultiValued,
                             multiline: isMultiValued,
-                            pipes: [{ pipe: this.multiValuePipe, params: [this.valueSeparator] }]
+                            pipes: [{ pipe: new MultiValuePipe(), params: [this.valueSeparator] }]
                         })
                     );
             }

--- a/lib/content-services/src/lib/dialogs/download-zip/download-zip.dialog.module.ts
+++ b/lib/content-services/src/lib/dialogs/download-zip/download-zip.dialog.module.ts
@@ -17,7 +17,6 @@
 
 import { NgModule } from '@angular/core';
 import { DownloadZipDialogComponent } from './download-zip.dialog';
-import { PipeModule } from '@alfresco/adf-core';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatButtonModule } from '@angular/material/button';
@@ -26,14 +25,7 @@ import { CommonModule } from '@angular/common';
 
 @NgModule({
     declarations: [DownloadZipDialogComponent],
-    imports: [
-        CommonModule,
-        PipeModule,
-        MatDialogModule,
-        MatProgressBarModule,
-        MatButtonModule,
-        TranslateModule
-    ],
+    imports: [CommonModule, MatDialogModule, MatProgressBarModule, MatButtonModule, TranslateModule],
     exports: [DownloadZipDialogComponent]
 })
 export class DownloadZipDialogModule {}

--- a/lib/core/src/lib/card-view/components/card-view-arrayitem/card-view-arrayitem.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view-arrayitem/card-view-arrayitem.component.spec.ts
@@ -26,10 +26,7 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatChipHarness, MatChipListboxHarness } from '@angular/material/chips/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatIconHarness } from '@angular/material/icon/testing';
-import { MatChipsModule } from '@angular/material/chips';
-import { MatMenuModule } from '@angular/material/menu';
-import { MatButtonModule } from '@angular/material/button';
-import { TranslateModule } from '@ngx-translate/core';
+import { CoreTestingModule } from '@alfresco/adf-core';
 
 describe('CardViewArrayItemComponent', () => {
     let loader: HarnessLoader;
@@ -54,7 +51,7 @@ describe('CardViewArrayItemComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [TranslateModule.forRoot(), MatMenuModule, MatButtonModule, MatChipsModule]
+            imports: [CoreTestingModule, CardViewArrayItemComponent]
         });
         fixture = TestBed.createComponent(CardViewArrayItemComponent);
         service = TestBed.inject(CardViewUpdateService);

--- a/lib/core/src/lib/card-view/components/card-view-dateitem/card-view-dateitem.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view-dateitem/card-view-dateitem.component.spec.ts
@@ -22,20 +22,14 @@ import { CardViewUpdateService } from '../../services/card-view-update.service';
 import { CardViewDateItemComponent } from './card-view-dateitem.component';
 import { ClipboardService } from '../../../clipboard/clipboard.service';
 import { CardViewDatetimeItemModel } from '../../models/card-view-datetimeitem.model';
-import { TranslateModule } from '@ngx-translate/core';
 import { AppConfigService } from '../../../app-config/app-config.service';
 import { MatDatetimepickerInputEvent } from '@mat-datetimepicker/core';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatChipHarness } from '@angular/material/chips/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
-import { TranslationMock } from '../../../mock';
-import { TranslationService } from '../../../translation';
-import { MatDialogModule } from '@angular/material/dialog';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { MatDatepickerModule } from '@angular/material/datepicker';
 import { addMinutes } from 'date-fns';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { CoreTestingModule } from '@alfresco/adf-core';
 
 describe('CardViewDateItemComponent', () => {
     let loader: HarnessLoader;
@@ -45,16 +39,7 @@ describe('CardViewDateItemComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [
-                TranslateModule.forRoot(),
-                NoopAnimationsModule,
-                HttpClientTestingModule,
-                MatSnackBarModule,
-                MatDatepickerModule,
-                MatDialogModule,
-                CardViewDateItemComponent
-            ],
-            providers: [ClipboardService, { provide: TranslationService, useClass: TranslationMock }]
+            imports: [CoreTestingModule, MatSnackBarModule, CardViewDateItemComponent]
         });
         appConfigService = TestBed.inject(AppConfigService);
         appConfigService.config.dateValues = {

--- a/lib/core/src/lib/card-view/components/card-view-dateitem/card-view-dateitem.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view-dateitem/card-view-dateitem.component.spec.ts
@@ -32,7 +32,6 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { TranslationMock } from '../../../mock';
 import { TranslationService } from '../../../translation';
-import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatDialogModule } from '@angular/material/dialog';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatDatepickerModule } from '@angular/material/datepicker';
@@ -53,7 +52,7 @@ describe('CardViewDateItemComponent', () => {
                 MatSnackBarModule,
                 MatDatepickerModule,
                 MatDialogModule,
-                MatTooltipModule
+                CardViewDateItemComponent
             ],
             providers: [ClipboardService, { provide: TranslationService, useClass: TranslationMock }]
         });

--- a/lib/core/src/lib/card-view/components/card-view-keyvaluepairsitem/card-view-keyvaluepairsitem.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view-keyvaluepairsitem/card-view-keyvaluepairsitem.component.spec.ts
@@ -20,8 +20,7 @@ import { By } from '@angular/platform-browser';
 import { CardViewKeyValuePairsItemModel } from '../../models/card-view-keyvaluepairs.model';
 import { CardViewKeyValuePairsItemComponent } from './card-view-keyvaluepairsitem.component';
 import { CardViewUpdateService } from '../../services/card-view-update.service';
-import { TranslateModule } from '@ngx-translate/core';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { CoreTestingModule } from '@alfresco/adf-core';
 
 describe('CardViewKeyValuePairsItemComponent', () => {
     let fixture: ComponentFixture<CardViewKeyValuePairsItemComponent>;
@@ -32,8 +31,7 @@ describe('CardViewKeyValuePairsItemComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [NoopAnimationsModule, TranslateModule.forRoot(), CardViewKeyValuePairsItemComponent],
-            providers: [CardViewUpdateService]
+            imports: [CoreTestingModule, CardViewKeyValuePairsItemComponent]
         });
         fixture = TestBed.createComponent(CardViewKeyValuePairsItemComponent);
         cardViewUpdateService = TestBed.inject(CardViewUpdateService);

--- a/lib/core/src/lib/card-view/components/card-view-mapitem/card-view-mapitem.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view-mapitem/card-view-mapitem.component.spec.ts
@@ -21,7 +21,7 @@ import { By } from '@angular/platform-browser';
 import { CardViewMapItemModel } from '../../models/card-view-mapitem.model';
 import { CardViewUpdateService } from '../../services/card-view-update.service';
 import { CardViewMapItemComponent } from './card-view-mapitem.component';
-import { TranslateModule } from '@ngx-translate/core';
+import { CoreTestingModule } from '@alfresco/adf-core';
 
 describe('CardViewMapItemComponent', () => {
     let service: CardViewUpdateService;
@@ -33,7 +33,7 @@ describe('CardViewMapItemComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [TranslateModule.forRoot()]
+            imports: [CoreTestingModule, CardViewMapItemComponent]
         });
         fixture = TestBed.createComponent(CardViewMapItemComponent);
         service = TestBed.inject(CardViewUpdateService);

--- a/lib/core/src/lib/card-view/components/card-view-selectitem/card-view-selectitem.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view-selectitem/card-view-selectitem.component.spec.ts
@@ -25,10 +25,7 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatSelectHarness } from '@angular/material/select/testing';
 import { MatFormFieldHarness } from '@angular/material/form-field/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { MatSelectModule } from '@angular/material/select';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { TranslateModule } from '@ngx-translate/core';
+import { CoreTestingModule } from '@alfresco/adf-core';
 
 describe('CardViewSelectItemComponent', () => {
     let loader: HarnessLoader;
@@ -62,7 +59,7 @@ describe('CardViewSelectItemComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [NoopAnimationsModule, TranslateModule.forRoot(), HttpClientTestingModule, MatSelectModule]
+            imports: [CoreTestingModule, CardViewSelectItemComponent]
         });
         fixture = TestBed.createComponent(CardViewSelectItemComponent);
         component = fixture.componentInstance;

--- a/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
@@ -25,7 +25,7 @@ import { CardViewItemFloatValidator } from '../../validators/card-view-item-floa
 import { CardViewItemIntValidator } from '../../validators/card-view-item-int.validator';
 import { CardViewIntItemModel } from '../../models/card-view-intitem.model';
 import { CardViewFloatItemModel } from '../../models/card-view-floatitem.model';
-import { MatChipInputEvent, MatChipsModule } from '@angular/material/chips';
+import { MatChipInputEvent } from '@angular/material/chips';
 import { ClipboardService } from '../../../clipboard/clipboard.service';
 import { DebugElement, SimpleChange } from '@angular/core';
 import { CardViewItemValidator } from '../../interfaces/card-view-item-validator.interface';
@@ -111,7 +111,7 @@ describe('CardViewTextItemComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [CoreTestingModule, MatChipsModule]
+            imports: [CoreTestingModule, CardViewTextItemComponent]
         });
         fixture = TestBed.createComponent(CardViewTextItemComponent);
         component = fixture.componentInstance;

--- a/lib/core/src/lib/card-view/components/card-view/card-view.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view/card-view.component.spec.ts
@@ -33,11 +33,9 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { TranslationService } from '../../../translation';
 import { TranslationMock } from '../../../mock';
-import { MatTooltipModule } from '@angular/material/tooltip';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatDatepickerModule } from '@angular/material/datepicker';
-import { MatSelectModule } from '@angular/material/select';
 
 describe('CardViewComponent', () => {
     let loader: HarnessLoader;
@@ -50,10 +48,8 @@ describe('CardViewComponent', () => {
                 TranslateModule.forRoot(),
                 NoopAnimationsModule,
                 MatSnackBarModule,
-                MatTooltipModule,
                 MatDialogModule,
                 MatDatepickerModule,
-                MatSelectModule,
                 HttpClientTestingModule,
                 CardViewComponent
             ],

--- a/lib/core/src/lib/card-view/components/card-view/card-view.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view/card-view.component.spec.ts
@@ -20,7 +20,6 @@ import { By } from '@angular/platform-browser';
 import { CardViewDateItemModel } from '../../models/card-view-dateitem.model';
 import { CardViewTextItemModel } from '../../models/card-view-textitem.model';
 import { CardViewComponent } from './card-view.component';
-import { TranslateModule } from '@ngx-translate/core';
 import { CardViewSelectItemModel } from '../../models/card-view-selectitem.model';
 import { of } from 'rxjs';
 import { CardViewSelectItemOption } from '../../interfaces/card-view-selectitem-properties.interface';
@@ -29,32 +28,19 @@ import { CardViewItemDispatcherComponent } from '../card-view-item-dispatcher/ca
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatSelectHarness } from '@angular/material/select/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
-import { TranslationService } from '../../../translation';
-import { TranslationMock } from '../../../mock';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatDialogModule } from '@angular/material/dialog';
-import { MatDatepickerModule } from '@angular/material/datepicker';
+import { CoreTestingModule } from '@alfresco/adf-core';
 
 describe('CardViewComponent', () => {
     let loader: HarnessLoader;
     let fixture: ComponentFixture<CardViewComponent>;
     let component: CardViewComponent;
 
-    beforeEach(async () => {
-        await TestBed.configureTestingModule({
-            imports: [
-                TranslateModule.forRoot(),
-                NoopAnimationsModule,
-                MatSnackBarModule,
-                MatDialogModule,
-                MatDatepickerModule,
-                HttpClientTestingModule,
-                CardViewComponent
-            ],
-            providers: [{ provide: TranslationService, useClass: TranslationMock }]
-        }).compileComponents();
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [CoreTestingModule, MatSnackBarModule, MatDialogModule, CardViewComponent]
+        });
 
         fixture = TestBed.createComponent(CardViewComponent);
         component = fixture.componentInstance;

--- a/lib/core/src/lib/core.module.ts
+++ b/lib/core/src/lib/core.module.ts
@@ -99,7 +99,6 @@ import { MaterialModule } from './material.module';
         }),
         MaterialModule
     ],
-    providers: [...CORE_PIPES],
     exports: [
         ...ABOUT_DIRECTIVES,
         ...VIEWER_DIRECTIVES,

--- a/lib/core/src/lib/form/components/widgets/date-time/date-time.widget.spec.ts
+++ b/lib/core/src/lib/form/components/widgets/date-time/date-time.widget.spec.ts
@@ -20,17 +20,13 @@ import { FormFieldModel } from '../core/form-field.model';
 import { FormModel } from '../core/form.model';
 import { DateTimeWidgetComponent } from './date-time.widget';
 import { TranslateModule } from '@ngx-translate/core';
-import { MatTooltipModule } from '@angular/material/tooltip';
 import { FormFieldTypes } from '../core/form-field-types';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatInputHarness } from '@angular/material/input/testing';
 import { addMinutes } from 'date-fns';
 import { MatDialogModule } from '@angular/material/dialog';
-import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatDatetimepickerModule, MatNativeDatetimeModule } from '@mat-datetimepicker/core';
-import { MatMenuModule } from '@angular/material/menu';
-import { MatButtonModule } from '@angular/material/button';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
@@ -49,13 +45,10 @@ describe('DateTimeWidgetComponent', () => {
                 HttpClientTestingModule,
                 NoopAnimationsModule,
                 MatDialogModule,
-                MatMenuModule,
-                MatFormFieldModule,
                 MatNativeDatetimeModule,
                 MatDatepickerModule,
-                MatButtonModule,
                 MatDatetimepickerModule,
-                MatTooltipModule
+                DateTimeWidgetComponent
             ]
         });
         fixture = TestBed.createComponent(DateTimeWidgetComponent);

--- a/lib/core/src/lib/form/components/widgets/text/text.widget.spec.ts
+++ b/lib/core/src/lib/form/components/widgets/text/text.widget.spec.ts
@@ -20,15 +20,10 @@ import { FormFieldTypes } from '../core/form-field-types';
 import { FormFieldModel } from '../core/form-field.model';
 import { FormModel } from '../core/form.model';
 import { TextWidgetComponent } from './text.widget';
-import { FormsModule } from '@angular/forms';
-import { MatIconModule } from '@angular/material/icon';
-import { MatInputModule } from '@angular/material/input';
 import { TranslateModule } from '@ngx-translate/core';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatInputHarness } from '@angular/material/input/testing';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatTooltipModule } from '@angular/material/tooltip';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('TextWidgetComponent', () => {
@@ -42,15 +37,7 @@ describe('TextWidgetComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [
-                TranslateModule.forRoot(),
-                NoopAnimationsModule,
-                MatInputModule,
-                MatFormFieldModule,
-                MatTooltipModule,
-                FormsModule,
-                MatIconModule
-            ]
+            imports: [TranslateModule.forRoot(), NoopAnimationsModule, TextWidgetComponent]
         });
         fixture = TestBed.createComponent(TextWidgetComponent);
         widget = fixture.componentInstance;

--- a/lib/core/src/lib/pipes/pipe.module.ts
+++ b/lib/core/src/lib/pipes/pipe.module.ts
@@ -61,7 +61,6 @@ export const CORE_PIPES = [
  */
 @NgModule({
     imports: [...CORE_PIPES],
-    providers: [...CORE_PIPES],
     exports: [...CORE_PIPES]
 })
 export class PipeModule {}

--- a/lib/process-services-cloud/src/lib/form/components/widgets/date/date-cloud.widget.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/date/date-cloud.widget.ts
@@ -38,21 +38,11 @@ import { NgIf } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
-import { MatTooltipModule } from '@angular/material/tooltip';
 
 @Component({
     selector: 'date-widget',
     standalone: true,
-    imports: [
-        NgIf,
-        TranslateModule,
-        MatFormFieldModule,
-        MatInputModule,
-        MatDatepickerModule,
-        MatTooltipModule,
-        ReactiveFormsModule,
-        ErrorWidgetComponent
-    ],
+    imports: [NgIf, TranslateModule, MatFormFieldModule, MatInputModule, MatDatepickerModule, ReactiveFormsModule, ErrorWidgetComponent],
     providers: [
         { provide: MAT_DATE_FORMATS, useValue: ADF_DATE_FORMATS },
         { provide: DateAdapter, useClass: AdfDateFnsAdapter }

--- a/lib/process-services/src/lib/attachment/create-process-attachment/create-process-attachment.component.spec.ts
+++ b/lib/process-services/src/lib/attachment/create-process-attachment/create-process-attachment.component.spec.ts
@@ -18,12 +18,8 @@
 import { SimpleChange } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CreateProcessAttachmentComponent } from './create-process-attachment.component';
-import { TranslateModule } from '@ngx-translate/core';
-import { HttpClientModule } from '@angular/common/http';
-import { MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { AlfrescoApiService, AlfrescoApiServiceMock } from '@alfresco/adf-core';
+import { ProcessTestingModule } from '../../testing/process.testing.module';
 
 declare let jasmine: any;
 
@@ -52,13 +48,7 @@ describe('CreateProcessAttachmentComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [
-                TranslateModule.forRoot(),
-                NoopAnimationsModule,
-                HttpClientModule,
-                MatButtonModule,
-                MatIconModule
-            ],
+            imports: [ProcessTestingModule, CreateProcessAttachmentComponent],
             providers: [{ provide: AlfrescoApiService, useClass: AlfrescoApiServiceMock }]
         });
         fixture = TestBed.createComponent(CreateProcessAttachmentComponent);

--- a/lib/process-services/src/lib/attachment/task-attachment-list/task-attachment-list.component.spec.ts
+++ b/lib/process-services/src/lib/attachment/task-attachment-list/task-attachment-list.component.spec.ts
@@ -26,11 +26,6 @@ import { ProcessContentService } from '../../form/services/process-content.servi
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatMenuItemHarness } from '@angular/material/menu/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { MatMenuModule } from '@angular/material/menu';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { AlfrescoApiService, AlfrescoApiServiceMock } from '@alfresco/adf-core';
-import { TranslateModule } from '@ngx-translate/core';
 
 describe('TaskAttachmentList', () => {
     let component: TaskAttachmentListComponent;
@@ -45,8 +40,7 @@ describe('TaskAttachmentList', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [TranslateModule.forRoot(), HttpClientTestingModule, MatMenuModule, NoopAnimationsModule, TaskAttachmentListComponent],
-            providers: [{ provide: AlfrescoApiService, useClass: AlfrescoApiServiceMock }]
+            imports: [ProcessTestingModule, TaskAttachmentListComponent]
         });
         fixture = TestBed.createComponent(TaskAttachmentListComponent);
         component = fixture.componentInstance;

--- a/lib/process-services/src/lib/attachment/task-attachment-list/task-attachment-list.component.spec.ts
+++ b/lib/process-services/src/lib/attachment/task-attachment-list/task-attachment-list.component.spec.ts
@@ -29,8 +29,6 @@ import { MatMenuItemHarness } from '@angular/material/menu/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { MatMenuModule } from '@angular/material/menu';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { MatTooltipModule } from '@angular/material/tooltip';
 import { AlfrescoApiService, AlfrescoApiServiceMock } from '@alfresco/adf-core';
 import { TranslateModule } from '@ngx-translate/core';
 
@@ -47,14 +45,7 @@ describe('TaskAttachmentList', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [
-                TranslateModule.forRoot(),
-                HttpClientTestingModule,
-                MatMenuModule,
-                NoopAnimationsModule,
-                MatProgressSpinnerModule,
-                MatTooltipModule
-            ],
+            imports: [TranslateModule.forRoot(), HttpClientTestingModule, MatMenuModule, NoopAnimationsModule, TaskAttachmentListComponent],
             providers: [{ provide: AlfrescoApiService, useClass: AlfrescoApiServiceMock }]
         });
         fixture = TestBed.createComponent(TaskAttachmentListComponent);

--- a/lib/process-services/src/lib/process-list/components/start-process/start-process.component.spec.ts
+++ b/lib/process-services/src/lib/process-list/components/start-process/start-process.component.spec.ts
@@ -22,13 +22,11 @@ import {
     AppConfigServiceMock,
     FormRenderingService,
     LocalizedDatePipe,
-    PipeModule,
-    TemplateModule,
     TranslationMock,
     TranslationService
 } from '@alfresco/adf-core';
 import { of, throwError } from 'rxjs';
-import { MatSelectChange, MatSelectModule } from '@angular/material/select';
+import { MatSelectChange } from '@angular/material/select';
 import { ProcessService } from '../../services/process.service';
 import {
     newProcess,
@@ -45,11 +43,7 @@ import { MatFormFieldHarness } from '@angular/material/form-field/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatAutocompleteHarness } from '@angular/material/autocomplete/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { MatInputModule } from '@angular/material/input';
-import { MatIconModule } from '@angular/material/icon';
-import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { RestVariable } from '@alfresco/js-api';
 import { ActivitiContentService } from '../../../form/services/activiti-alfresco.service';
 import { AppsProcessService } from '../../../services/apps-process.service';
@@ -74,20 +68,7 @@ describe('StartProcessComponent', () => {
 
     beforeEach(() => {
         getTestBed().configureTestingModule({
-            imports: [
-                TranslateModule.forRoot(),
-                TemplateModule,
-                NoopAnimationsModule,
-                ReactiveFormsModule,
-                FormsModule,
-                HttpClientTestingModule,
-                MatInputModule,
-                MatIconModule,
-                MatSelectModule,
-                MatAutocompleteModule,
-                PipeModule,
-                StartProcessInstanceComponent
-            ],
+            imports: [TranslateModule.forRoot(), NoopAnimationsModule, HttpClientTestingModule, StartProcessInstanceComponent],
             providers: [
                 LocalizedDatePipe,
                 ActivitiContentService,

--- a/lib/process-services/src/lib/testing/process.testing.module.ts
+++ b/lib/process-services/src/lib/testing/process.testing.module.ts
@@ -32,11 +32,13 @@ import {
 import { TranslateModule } from '@ngx-translate/core';
 import { ProcessFormRenderingService } from '../form/process-form-rendering.service';
 import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 @NgModule({
     imports: [
         AuthModule.forRoot({ useHash: true }),
         NoopAnimationsModule,
+        HttpClientTestingModule,
         TranslateModule.forRoot(),
         CoreModule.forRoot(),
         ProcessModule.forRoot(),


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

- fix the usage of pipes in the Content Metadata services
- remove Pipe Module reference from within internal components- remove incorrect registration of core pipes as providers

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://hyland.atlassian.net/browse/ACS-8586