### PR TITLE
[Acs 8432] Sending all file types to hx instead of only the text file types

### DIFF
--- a/lib/content-services/src/lib/i18n/en.json
+++ b/lib/content-services/src/lib/i18n/en.json
@@ -705,7 +705,6 @@
     "SEARCH": {
       "WARNINGS": {
         "TOO_MANY_FILES_SELECTED": "Please select no more than {{ maxFiles }} files.",
-        "NON_TEXT_FILE_SELECTED": "Only text related files are compatible with AI Agents.",
         "FOLDER_SELECTED": "Folders are not compatible with AI Agents."
       }
     }

--- a/lib/content-services/src/lib/search-ai/services/search-ai.service.spec.ts
+++ b/lib/content-services/src/lib/search-ai/services/search-ai.service.spec.ts
@@ -120,9 +120,7 @@ describe('SearchAiService', () => {
     describe('checkSearchAvailability', () => {
         let translateService: TranslateService;
 
-        const noFilesSelectedError = 'Please select some file.';
         const tooManyFilesSelectedError = 'Please select no more than 100 files.';
-        const nonTextFileSelectedError = 'Only text related files are compatible with AI Agents.';
         const folderSelectedError = 'Folders are not compatible with AI Agents.';
 
         beforeEach(() => {
@@ -131,8 +129,6 @@ describe('SearchAiService', () => {
                 switch (key) {
                     case 'KNOWLEDGE_RETRIEVAL.SEARCH.WARNINGS.TOO_MANY_FILES_SELECTED':
                         return tooManyFilesSelectedError;
-                    case 'KNOWLEDGE_RETRIEVAL.SEARCH.WARNINGS.NON_TEXT_FILE_SELECTED':
-                        return nonTextFileSelectedError;
                     case 'KNOWLEDGE_RETRIEVAL.SEARCH.WARNINGS.FOLDER_SELECTED':
                         return folderSelectedError;
                     default:
@@ -141,7 +137,7 @@ describe('SearchAiService', () => {
             });
         });
 
-        it('should return error for no selected nodes', () => {
+        it('should not return error if user did not select any files', () => {
             expect(
                 service.checkSearchAvailability({
                     count: 0,
@@ -149,7 +145,7 @@ describe('SearchAiService', () => {
                     libraries: [],
                     isEmpty: true
                 })
-            ).toBe(noFilesSelectedError);
+            ).toEqual('');
         });
 
         it('should return error for too many files selected', () => {
@@ -167,29 +163,24 @@ describe('SearchAiService', () => {
             });
         });
 
-        it('should return error for non text file selected if non text file is selected and it is not a folder', () => {
+        it('should return error for folder selected', () => {
             expect(
                 service.checkSearchAvailability({
                     count: 1,
                     nodes: [
                         {
                             entry: {
-                                isFolder: false,
-                                content: {
-                                    mimeType: 'image/jpeg',
-                                    mimeTypeName: 'image/jpeg',
-                                    sizeInBytes: 100
-                                }
+                                isFolder: true
                             } as Node
                         }
                     ],
                     libraries: [],
                     isEmpty: false
                 })
-            ).toBe(nonTextFileSelectedError);
+            ).toBe(folderSelectedError);
         });
 
-        it('should not return error for non text file selected if non text mime type node is selected and it is a folder', () => {
+        it('should return error for folder and if non text mime type node is selected', () => {
             expect(
                 service.checkSearchAvailability({
                     count: 1,
@@ -208,23 +199,6 @@ describe('SearchAiService', () => {
                     libraries: [],
                     isEmpty: false
                 })
-            ).not.toBe(nonTextFileSelectedError);
-        });
-
-        it('should return error for folder selected if', () => {
-            expect(
-                service.checkSearchAvailability({
-                    count: 1,
-                    nodes: [
-                        {
-                            entry: {
-                                isFolder: true
-                            } as Node
-                        }
-                    ],
-                    libraries: [],
-                    isEmpty: false
-                })
             ).toBe(folderSelectedError);
         });
 
@@ -235,7 +209,7 @@ describe('SearchAiService', () => {
                     nodes: [
                         {
                             entry: {
-                                isFolder: false,
+                                isFolder: true,
                                 content: {
                                     mimeType: 'image/jpeg',
                                     mimeTypeName: 'image/jpeg',
@@ -247,7 +221,7 @@ describe('SearchAiService', () => {
                     libraries: [],
                     isEmpty: false
                 })
-            ).toBe(`${tooManyFilesSelectedError} ${nonTextFileSelectedError}`);
+            ).toBe(`${tooManyFilesSelectedError} ${folderSelectedError}`);
         });
     });
 });

--- a/lib/content-services/src/lib/search-ai/services/search-ai.service.ts
+++ b/lib/content-services/src/lib/search-ai/services/search-ai.service.ts
@@ -28,15 +28,6 @@ import { SearchAiInputState } from '../models/search-ai-input-state';
     providedIn: 'root'
 })
 export class SearchAiService {
-    private readonly textFileMimeTypes = [
-        'application/msword',
-        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-        'application/vnd.oasis.opendocument.text',
-        'application/rtf',
-        'text/plain',
-        'application/pdf'
-    ];
-
     private toggleSearchAiInput = new BehaviorSubject<SearchAiInputState>({
         active: false
     });
@@ -137,11 +128,6 @@ export class SearchAiService {
             messages.push({
                 key: 'KNOWLEDGE_RETRIEVAL.SEARCH.WARNINGS.TOO_MANY_FILES_SELECTED',
                 maxFiles: maxSelectedNodes
-            });
-        }
-        if (selectedNodesState.nodes.some((node) => !node.entry.isFolder && !this.textFileMimeTypes.includes(node.entry.content.mimeType))) {
-            messages.push({
-                key: 'KNOWLEDGE_RETRIEVAL.SEARCH.WARNINGS.NON_TEXT_FILE_SELECTED'
             });
         }
         if (selectedNodesState.nodes.some((node) => node.entry.isFolder)) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/ACS-8432


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
