### PR TITLE
Fix date-fns related exports for Core lib

### DIFF
--- a/demo-shell/src/app/app.module.ts
+++ b/demo-shell/src/app/app.module.ts
@@ -27,7 +27,6 @@ import { AppComponent } from './app.component';
 import { appRoutes } from './app.routes';
 import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
 import { ContentModule } from '@alfresco/adf-content-services';
-import { InsightsModule } from '@alfresco/adf-insights';
 import { ProcessModule } from '@alfresco/adf-process-services';
 import { environment } from '../environments/environment';
 import { ProcessServicesCloudModule } from '@alfresco/adf-process-services-cloud';
@@ -44,7 +43,6 @@ import { CoreAutomationService } from '../testing/automation.service';
         TranslateModule.forRoot(),
         CoreModule.forRoot(),
         ContentModule.forRoot(),
-        InsightsModule.forRoot(),
         ProcessModule.forRoot(),
         ProcessServicesCloudModule.forRoot(),
         ExtensionsModule.forRoot(),
@@ -54,7 +52,8 @@ import { CoreAutomationService } from '../testing/automation.service';
     declarations: [AppComponent],
     providers: [
         { provide: AppConfigService, useClass: DebugAppConfigService }, // not use this service in production
-        provideTranslations('app', 'resources')
+        provideTranslations('app', 'resources'),
+        provideTranslations('adf-insights', 'assets/adf-insights')
     ],
     bootstrap: [AppComponent]
 })

--- a/lib/core/src/lib/common/utils/date-fns-adapter.ts
+++ b/lib/core/src/lib/common/utils/date-fns-adapter.ts
@@ -65,7 +65,7 @@ export const ADF_DATE_FORMATS: MatDateFormats = {
     }
 };
 
-@Injectable()
+@Injectable({ providedIn: 'root' })
 export class AdfDateFnsAdapter extends DateFnsAdapter {
     private _displayFormat?: string = null;
 

--- a/lib/core/src/lib/common/utils/datetime-fns-adapter.ts
+++ b/lib/core/src/lib/common/utils/datetime-fns-adapter.ts
@@ -58,7 +58,7 @@ function range<T>(length: number, valueFunction: (index: number) => T): T[] {
     return valuesArray;
 }
 
-@Injectable()
+@Injectable({ providedIn: 'root' })
 export class AdfDateTimeFnsAdapter extends DatetimeAdapter<Date> {
     private _displayFormat?: string = null;
 

--- a/lib/core/src/lib/core.module.ts
+++ b/lib/core/src/lib/core.module.ts
@@ -51,9 +51,7 @@ import { loadAppConfig } from './app-config/app-config.loader';
 import { AppConfigService } from './app-config/app-config.service';
 import { StorageService } from './common/services/storage.service';
 import { AlfrescoApiLoaderService, createAlfrescoApiInstance } from './api-factories/alfresco-api-v2-loader.service';
-import { AdfDateFnsAdapter } from './common/utils/date-fns-adapter';
 import { MomentDateAdapter } from './common/utils/moment-date-adapter';
-import { AdfDateTimeFnsAdapter } from './common/utils/datetime-fns-adapter';
 import { AppConfigPipe, StoragePrefixFactory } from './app-config';
 import { IconComponent } from './icon';
 import { SortingPickerComponent } from './sorting-picker';
@@ -139,8 +137,6 @@ export class CoreModule {
                 TranslateStore,
                 TranslateService,
                 { provide: TranslateLoader, useClass: TranslateLoaderService },
-                AdfDateFnsAdapter,
-                AdfDateTimeFnsAdapter,
                 MomentDateAdapter,
                 StoragePrefixFactory,
                 {

--- a/lib/insights/src/lib/analytics-process/components/analytics-report-parameters.component.ts
+++ b/lib/insights/src/lib/analytics-process/components/analytics-report-parameters.component.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { AdfDateFnsAdapter, DownloadService, ToolbarComponent, ToolbarTitleComponent } from '@alfresco/adf-core';
+import { ADF_DATE_FORMATS, AdfDateFnsAdapter, DownloadService, ToolbarComponent, ToolbarTitleComponent } from '@alfresco/adf-core';
 import {
     AfterContentChecked,
     Component,
@@ -46,6 +46,7 @@ import { MatMenuModule } from '@angular/material/menu';
 import { WIDGET_DIRECTIVES } from './widgets';
 import { MatButtonModule } from '@angular/material/button';
 import { ButtonsMenuComponent } from './buttons-menu/buttons-menu.component';
+import { DateAdapter, MAT_DATE_FORMATS } from '@angular/material/core';
 
 const FORMAT_DATE_ACTIVITI = 'YYYY-MM-DD';
 
@@ -123,6 +124,10 @@ export interface ReportFormValues {
         FormsModule,
         MatButtonModule,
         ButtonsMenuComponent
+    ],
+    providers: [
+        { provide: MAT_DATE_FORMATS, useValue: ADF_DATE_FORMATS },
+        { provide: DateAdapter, useClass: AdfDateFnsAdapter }
     ],
     templateUrl: './analytics-report-parameters.component.html',
     styleUrls: ['./analytics-report-parameters.component.scss'],

--- a/lib/insights/src/lib/insights.module.ts
+++ b/lib/insights/src/lib/insights.module.ts
@@ -20,6 +20,7 @@ import { provideTranslations } from '@alfresco/adf-core';
 import { ANALYTICS_PROCESS_DIRECTIVES } from './analytics-process/public-api';
 import { DIAGRAM_DIRECTIVES } from './diagram/public-api';
 
+/** @deprecated This module is deprecated and will be removed in a future release. */
 @NgModule({
     imports: [...ANALYTICS_PROCESS_DIRECTIVES, ...DIAGRAM_DIRECTIVES],
     exports: [...ANALYTICS_PROCESS_DIRECTIVES, ...DIAGRAM_DIRECTIVES]

--- a/lib/insights/src/lib/testing/insights.testing.module.ts
+++ b/lib/insights/src/lib/testing/insights.testing.module.ts
@@ -18,7 +18,6 @@
 import { NgModule } from '@angular/core';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TranslateModule } from '@ngx-translate/core';
-import { InsightsModule } from '../insights.module';
 import {
     AlfrescoApiService,
     AlfrescoApiServiceMock,
@@ -31,12 +30,12 @@ import {
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 @NgModule({
-    imports: [AuthModule.forRoot({ useHash: true }), NoopAnimationsModule, HttpClientTestingModule, TranslateModule.forRoot(), InsightsModule],
+    imports: [AuthModule.forRoot({ useHash: true }), NoopAnimationsModule, HttpClientTestingModule, TranslateModule.forRoot()],
     providers: [
         { provide: AlfrescoApiService, useClass: AlfrescoApiServiceMock },
         { provide: AppConfigService, useClass: AppConfigServiceMock },
         { provide: TranslationService, useClass: TranslationMock }
     ],
-    exports: [NoopAnimationsModule, TranslateModule, InsightsModule]
+    exports: [NoopAnimationsModule, TranslateModule]
 })
 export class InsightsTestingModule {}

--- a/lib/insights/src/lib/testing/insights.testing.module.ts
+++ b/lib/insights/src/lib/testing/insights.testing.module.ts
@@ -26,17 +26,17 @@ import {
     AppConfigServiceMock,
     TranslationService,
     TranslationMock,
-    CoreModule,
     AuthModule
 } from '@alfresco/adf-core';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 @NgModule({
-    imports: [AuthModule.forRoot({ useHash: true }), NoopAnimationsModule, TranslateModule.forRoot(), InsightsModule],
+    imports: [AuthModule.forRoot({ useHash: true }), NoopAnimationsModule, HttpClientTestingModule, TranslateModule.forRoot(), InsightsModule],
     providers: [
         { provide: AlfrescoApiService, useClass: AlfrescoApiServiceMock },
         { provide: AppConfigService, useClass: AppConfigServiceMock },
         { provide: TranslationService, useClass: TranslationMock }
     ],
-    exports: [NoopAnimationsModule, TranslateModule, CoreModule, InsightsModule]
+    exports: [NoopAnimationsModule, TranslateModule, InsightsModule]
 })
 export class InsightsTestingModule {}

--- a/lib/insights/src/lib/testing/insights.testing.module.ts
+++ b/lib/insights/src/lib/testing/insights.testing.module.ts
@@ -31,7 +31,7 @@ import {
 } from '@alfresco/adf-core';
 
 @NgModule({
-    imports: [AuthModule.forRoot({ useHash: true }), NoopAnimationsModule, TranslateModule.forRoot(), CoreModule.forRoot(), InsightsModule],
+    imports: [AuthModule.forRoot({ useHash: true }), NoopAnimationsModule, TranslateModule.forRoot(), InsightsModule],
     providers: [
         { provide: AlfrescoApiService, useClass: AlfrescoApiServiceMock },
         { provide: AppConfigService, useClass: AppConfigServiceMock },


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

- property export the date-fns related services, without requiring `CoreModule.forRoot()` calls
- break `Insights` testing dependency on Core
- break Demo Shell dependency on `Insights.forRoot` as insights is a standalone components now, and does not need root imports besides the translations (configured on the demo shell level)

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
