### PR TITLE
[ACS-8602] [Legal Hold] The tabs names in "Manage Legal Holds" window are not matching the design

### DIFF
--- a/lib/core/src/lib/dialogs/dialog/dialog.component.html
+++ b/lib/core/src/lib/dialogs/dialog/dialog.component.html
@@ -45,8 +45,7 @@
         class="adf-dialog-actions"
         [ngClass]="{ 'adf-additional-actions': data.actionsTemplate || additionalActionButtons }"
     >
-        <div>
-
+        <div class="adf-additional-actions-container">
             <ng-container *ngIf="!additionalActionButtons && data.actionsTemplate">
                 <ng-container [ngTemplateOutlet]="data.actionsTemplate"></ng-container>
             </ng-container>
@@ -64,7 +63,7 @@
             </ng-container>
         </div>
 
-        <div>
+        <div class="adf-main-actions-container">
             <button
                 *ngIf="!isCancelButtonHidden"
                 mat-stroked-button

--- a/lib/core/src/lib/dialogs/dialog/dialog.component.scss
+++ b/lib/core/src/lib/dialogs/dialog/dialog.component.scss
@@ -114,14 +114,22 @@ $dialog-padding: 24px;
     }
 
     .adf-dialog-header {
-        position: relative;
         display: flex;
-        justify-content: space-between;
         align-items: center;
         padding-bottom: $dialog-padding;
 
         &.adf-centered-header {
             align-items: flex-start;
+        }
+
+        .adf-dialog-title-container {
+            flex: 1;
+
+            &.adf-centered-title {
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+            }
         }
 
         .adf-dialog-title {
@@ -168,10 +176,6 @@ $dialog-padding: 24px;
 
     .adf-dialog-header::after {
         bottom: 0;
-    }
-
-    #{$mat-dialog-title}::before {
-        display: none;
     }
 
     .adf-dialog-actions {
@@ -277,14 +281,10 @@ $dialog-padding: 24px;
     color: var(--theme-primary-color);
 }
 
-// TODO: Update after migration to Angular 15
-/* stylelint-disable-next-line selector-class-pattern */
-.mat-dialog-actions .mat-button-base + .mat-button-base {
+#{$mat-dialog-actions} #{$mat-button-base} + #{$mat-button-base} {
     margin-left: 16px;
 }
 
-// TODO: Update after migration to Angular 15
-/* stylelint-disable-next-line selector-class-pattern */
-.mat-dialog-container {
+#{$mat-dialog-container} #{$mat-dialog-surface} {
     border-radius: 8px;
 }

--- a/lib/core/src/lib/dialogs/dialog/dialog.component.scss
+++ b/lib/core/src/lib/dialogs/dialog/dialog.component.scss
@@ -1,3 +1,5 @@
+@import 'styles/mat-selectors';
+
 $dialog-large-l-width: 1075px;
 $dialog-large-l-height: 907px;
 
@@ -166,6 +168,10 @@ $dialog-padding: 24px;
 
     .adf-dialog-header::after {
         bottom: 0;
+    }
+
+    #{$mat-dialog-title}::before {
+        display: none;
     }
 
     .adf-dialog-actions {

--- a/lib/core/src/lib/dialogs/dialog/dialog.component.scss
+++ b/lib/core/src/lib/dialogs/dialog/dialog.component.scss
@@ -1,5 +1,3 @@
-@import 'styles/mat-selectors';
-
 $dialog-large-l-width: 1075px;
 $dialog-large-l-height: 907px;
 
@@ -28,6 +26,8 @@ $dialog-padding: 24px;
 .adf-medium-dialog-panel,
 .adf-alert-dialog-panel {
     min-width: calc(269px - $dialog-padding * 2);
+    border-radius: 8px;
+    overflow: hidden;
 
     @media screen and (max-width: $xxs-screen) {
         .adf-additional-actions {
@@ -185,6 +185,12 @@ $dialog-padding: 24px;
         padding-top: $dialog-padding;
         text-transform: capitalize;
         min-height: auto;
+
+        .adf-main-actions-container,
+        .adf-additional-actions-container {
+            display: flex;
+            column-gap: 8px;
+        }
     }
 
     &.adf-large {
@@ -279,12 +285,4 @@ $dialog-padding: 24px;
 
 .adf-additional-actions {
     color: var(--theme-primary-color);
-}
-
-#{$mat-dialog-actions} #{$mat-button-base} + #{$mat-button-base} {
-    margin-left: 16px;
-}
-
-#{$mat-dialog-container} #{$mat-dialog-surface} {
-    border-radius: 8px;
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

https://hyland.atlassian.net/browse/ACS-8602

the issue accrues after angular migration. because of `::before` space above title was too big.

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
title is centered


**What is the new behaviour?**
title aligned to the left


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
