### PR TITLE
[MNT-24553] Allow custom viewer extension components to obtain node id

### DIFF
--- a/docs/core/components/viewer-render.component.md
+++ b/docs/core/components/viewer-render.component.md
@@ -63,6 +63,7 @@ Using with file [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob):
 | tracks | [`Track`](../../../lib/core/src/lib/viewer/models/viewer.model.ts)`[]` | \[] | media subtitles for the media player |
 | urlFile | `string` | "" | If you want to load an external file that does not come from ACS you can use this URL to specify where to load the file from. |
 | viewerTemplateExtensions | [`TemplateRef`](https://angular.io/api/core/TemplateRef)`<any>` | null | Template containing ViewerExtensionDirective instances providing different viewer extensions based on supported file extension. |
+| nodeId | `string` | null | Identifier of a node opened by a viewer. |
 
 ### Events
 

--- a/docs/core/components/viewer.component.md
+++ b/docs/core/components/viewer.component.md
@@ -89,6 +89,7 @@ See the [Custom layout](#custom-layout) section for full details of all availabl
 | tracks | [`Track`](../../../lib/core/src/lib/viewer/models/viewer.model.ts)`[]` | \[] | media subtitles for the media player |
 | urlFile | `string` | "" | If you want to load an external file that does not come from ACS you can use this URL to specify where to load the file from. |
 | viewerExtensions | [`TemplateRef`](https://angular.io/api/core/TemplateRef)`<any>` | null | Template containing ViewerExtensionDirective instances providing different viewer extensions based on supported file extension. |
+| nodeId | `string` | null | Identifier of a node opened by a viewer. |
 
 ### Events
 

--- a/docs/extensions/components/preview-extension.component.md
+++ b/docs/extensions/components/preview-extension.component.md
@@ -20,6 +20,7 @@ an example of a real working viewer extension project.
 | ---- | ---- | ------------- | ----------- |
 | extension | `string` |  | File extension (.jpg, .png, etc) for the viewer. |
 | id | `string` |  | ID string of the component to preview. |
+| nodeId | `string` | null | Identifier of a node opened by a viewer. |
 | url | `string` |  | URL of the content in the repository. |
 
 ## Details

--- a/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.html
+++ b/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.html
@@ -26,6 +26,7 @@
     [readOnly]="readOnly"
     [allowedEditActions]="allowedEditActions"
     [viewerExtensions]="viewerExtensions"
+    [nodeId]="nodeId"
     (downloadFile)="onDownloadFile()"
     (navigateBefore)="onNavigateBeforeClick($event)"
     (navigateNext)="onNavigateNextClick($event)"

--- a/lib/core/src/lib/viewer/components/viewer-render/viewer-render.component.html
+++ b/lib/core/src/lib/viewer/components/viewer-render/viewer-render.component.html
@@ -24,6 +24,7 @@
                                        [id]="externalViewer.component"
                                        [url]="urlFile"
                                        [extension]="externalViewer.fileExtension"
+                                       [nodeId]="nodeId"
                                        [attr.data-automation-id]="externalViewer.component">
                 </adf-preview-extension>
             </ng-container>
@@ -75,6 +76,7 @@
                                            [id]="ext.component"
                                            [url]="urlFile"
                                            [extension]="extension"
+                                           [nodeId]="nodeId"
                                            [attr.data-automation-id]="ext.component">
                     </adf-preview-extension>
                 </ng-container>

--- a/lib/core/src/lib/viewer/components/viewer-render/viewer-render.component.ts
+++ b/lib/core/src/lib/viewer/components/viewer-render/viewer-render.component.ts
@@ -110,6 +110,10 @@ export class ViewerRenderComponent implements OnChanges, OnInit, OnDestroy {
     @Input()
     tracks: Track[] = [];
 
+    /** Identifier of a node that is opened by the viewer. */
+    @Input()
+    nodeId: string = null;
+
     /** Template containing ViewerExtensionDirective instances providing different viewer extensions based on supported file extension. */
     @Input()
     viewerTemplateExtensions: TemplateRef<any>;

--- a/lib/core/src/lib/viewer/components/viewer.component.html
+++ b/lib/core/src/lib/viewer/components/viewer.component.html
@@ -171,7 +171,8 @@
                                [urlFile]="urlFile"
                                (isSaving)="allowNavigate = !$event"
                                [tracks]="tracks"
-                               [viewerTemplateExtensions]="viewerExtensions ?? viewerTemplateExtensions">
+                               [viewerTemplateExtensions]="viewerExtensions ?? viewerTemplateExtensions"
+                               [nodeId]="nodeId">
             </adf-viewer-render>
 
         </div>

--- a/lib/core/src/lib/viewer/components/viewer.component.ts
+++ b/lib/core/src/lib/viewer/components/viewer.component.ts
@@ -238,6 +238,10 @@ export class ViewerComponent<T> implements OnDestroy, OnInit, OnChanges {
     @Input()
     viewerExtensions: TemplateRef<any>;
 
+    /** Identifier of a node that is opened by the viewer. */
+    @Input()
+    nodeId: string = null;
+
     /**
      * Enable dialog box to allow user to download the previewed file, in case the preview is not responding for a set period of time.
      */

--- a/lib/extensions/src/lib/components/viewer/preview-extension.component.ts
+++ b/lib/extensions/src/lib/components/viewer/preview-extension.component.ts
@@ -31,6 +31,10 @@ export class PreviewExtensionComponent implements OnInit, OnChanges, OnDestroy {
     @Input()
     id: string;
 
+    /** Identifier of a node that is opened by the viewer. */
+    @Input()
+    nodeId: string = null;
+
     /** URL of the content in the repository. */
     @Input()
     url: string;
@@ -73,6 +77,7 @@ export class PreviewExtensionComponent implements OnInit, OnChanges, OnDestroy {
 
             instance.url = this.url;
             instance.extension = this.extension;
+            instance.nodeId = this.nodeId;
         }
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://hyland.atlassian.net/browse/MNT-24553

**What is the new behaviour?**

It's possible to pass down node id to `PreviewExtensionComponent` that renders custom viewer extension components, node id will be added to an instance of the custom component. 

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
