### PR TITLE
[ACS-8644] Fixed issue where download button and comments section was missing on manage versions dialog

### DIFF
--- a/lib/content-services/src/lib/new-version-uploader/new-version-uploader.service.ts
+++ b/lib/content-services/src/lib/new-version-uploader/new-version-uploader.service.ts
@@ -52,7 +52,9 @@ export class NewVersionUploaderService {
         config?: MatDialogConfig,
         selectorAutoFocusedOnClose?: string
     ): Observable<NewVersionUploaderData> {
-        const { file, node, showVersionsOnly, showComments, allowDownload } = data;
+        const { file, node, showVersionsOnly } = data;
+        const allowDownload = data.allowDownload ?? true;
+        const showComments = data.showComments ?? true;
 
         return new Observable((observer) => {
             this.versionsApi.listVersionHistory(node.id).then((versionPaging) => {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Download button and comments section from manage versions dialog was missing


**What is the new behaviour?**
Download button and comments section from manage versions dialog are now shown


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://hyland.atlassian.net/browse/ACS-8644
Root cause analysis - [comment](https://hyland.atlassian.net/browse/ACS-8644?focusedCommentId=1341112)