### PR TITLE
[ACS-8635] ADW: View button not working on create process

### DIFF
--- a/lib/process-services/src/lib/form/widgets/content-widget/attach-file-widget.component.spec.ts
+++ b/lib/process-services/src/lib/form/widgets/content-widget/attach-file-widget.component.spec.ts
@@ -517,6 +517,19 @@ describe('AttachFileWidgetComponent', () => {
             await fixture.whenStable();
         });
 
+        it('should raise formContentClicked event when file has sourceId', async () => {
+            const testFile = {
+                sourceId: '12345',
+                id: '12345',
+                contentAvailable: true
+            };
+            formService.formContentClicked.subscribe((file) => {
+                expect(file).not.toBeNull();
+                expect(file).toBe(testFile);
+            });
+            fixture.componentInstance.onAttachFileClicked(testFile);
+        });
+
         it('should not display the show button file when is an external file', async () => {
             fakePngAnswer.isExternal = true;
             spyOn(processContentService, 'getFileRawContent').and.returnValue(of(fakePngAnswer));

--- a/lib/process-services/src/lib/form/widgets/content-widget/attach-file-widget.component.ts
+++ b/lib/process-services/src/lib/form/widgets/content-widget/attach-file-widget.component.ts
@@ -170,7 +170,7 @@ export class AttachFileWidgetComponent extends UploadWidgetComponent implements 
         if (file.isExternal || !file.contentAvailable) {
             return;
         }
-        if (this.isTemporaryFile(file)) {
+        if (this.isTemporaryFile(file) || file.sourceId) {
             this.formService.formContentClicked.next(file);
         } else {
             this.fileClicked(file);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/ACS-8648


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
