### PR TITLE
ACS-8661: fix regression with metadata tags layout after Angular 15 upgrade

### DIFF
--- a/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.scss
+++ b/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.scss
@@ -65,11 +65,15 @@ $panel-properties-height: 56px !default;
         }
 
         #{$mat-chip} {
-            background: var(--adf-metadata-buttons-background-color);
-            padding: 6px;
-
             &.metadata-properties-tag-chip {
-                overflow-wrap: anywhere;
+                // TODO: bug open https://github.com/angular/components/issues/26584
+                /* stylelint-disable selector-class-pattern */
+                .mdc-evolution-chip__cell--primary,
+                .mdc-evolution-chip__action--primary,
+                .mat-mdc-chip-action-label {
+                    overflow: hidden;
+                }
+                /* stylelint-enable selector-class-pattern */
             }
         }
 

--- a/lib/content-services/src/lib/tag/tags-creator/tags-creator.component.html
+++ b/lib/content-services/src/lib/tag/tags-creator/tags-creator.component.html
@@ -16,7 +16,7 @@
         {{ 'TAG.TAGS_CREATOR.NO_TAGS_CREATED' | translate }}
     </p>
     <div class="adf-tags-list" [class.adf-tags-list-fixed]="!tagNameControlVisible" #tagsList>
-        <mat-chip-listbox *ngIf="tags.length > 0" class="adf-tags-chips-container">
+        <mat-chip-listbox *ngIf="tags.length > 0">
             <mat-chip-option *ngFor="let tag of tags" [disableRipple]="true" [title]="tag" class="adf-tags-chip">
                 {{ tag }}
                 <button

--- a/lib/content-services/src/lib/tag/tags-creator/tags-creator.component.scss
+++ b/lib/content-services/src/lib/tag/tags-creator/tags-creator.component.scss
@@ -42,19 +42,7 @@ adf-tags-creator {
     }
 
     .adf-tags-list {
-        padding-right: 0;
-        display: flex;
-        flex-wrap: wrap;
-        gap: 8px;
-    }
-
-    .adf-tags-chips-container {
         margin-top: 8px;
-
-        .adf-tags-chip {
-            background: var(--adf-metadata-buttons-background-color);
-            height: unset;
-        }
     }
 
     .adf-existing-tags-panel {
@@ -106,6 +94,17 @@ adf-tags-creator {
             }
         }
     }
+
+    // TODO: bug open https://github.com/angular/components/issues/26584
+    /* stylelint-disable selector-class-pattern */
+    .mdc-evolution-chip-set .mat-mdc-standard-chip {
+        .mdc-evolution-chip__cell--primary,
+        .mdc-evolution-chip__action--primary,
+        .mat-mdc-chip-action-label {
+            overflow: hidden;
+        }
+    }
+    /* stylelint-enable selector-class-pattern */
 
     [hidden] {
         visibility: hidden;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

- introduce the 

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://hyland.atlassian.net/browse/ACS-8661