### PR TITLE
AAE-25190 Retrieve start process cloud customisation

### DIFF
--- a/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.html
+++ b/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.html
@@ -100,7 +100,7 @@
 <ng-template #taskFormCloudButtons>
     <div class="adf-start-process-cloud-actions">
         <button
-            *ngIf="showCancelButton && displayCancelButton"
+            *ngIf="showCancelButton"
             mat-button
             (click)="cancelStartProcess()"
             id="cancel_process"
@@ -108,7 +108,7 @@
             {{ cancelButtonLabel }}
         </button>
         <button
-            *ngIf="displayStartProcessButton"
+            *ngIf="showStartProcessButton"
             color="primary"
             mat-raised-button
             [disabled]="disableStartButton || !isProcessFormValid"

--- a/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.html
+++ b/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.html
@@ -100,14 +100,15 @@
 <ng-template #taskFormCloudButtons>
     <div class="adf-start-process-cloud-actions">
         <button
-            *ngIf="showCancelButton"
+            *ngIf="showCancelButton && displayCancelButton"
             mat-button
             (click)="cancelStartProcess()"
             id="cancel_process"
         >
-            {{ 'ADF_CLOUD_PROCESS_LIST.ADF_CLOUD_START_PROCESS.FORM.ACTION.CANCEL' | translate | uppercase}}
+            {{ cancelButtonLabel }}
         </button>
         <button
+            *ngIf="displayStartProcessButton"
             color="primary"
             mat-raised-button
             [disabled]="disableStartButton || !isProcessFormValid"
@@ -116,7 +117,7 @@
             id="button-start"
             class="adf-btn-start"
         >
-                {{'ADF_CLOUD_PROCESS_LIST.ADF_CLOUD_START_PROCESS.FORM.ACTION.START' | translate | uppercase}}
+                {{ startProcessButtonLabel }}
         </button>
     </div>
 </ng-template>

--- a/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.ts
@@ -131,8 +131,7 @@ export class StartProcessCloudComponent implements OnChanges, OnInit, OnDestroy 
     isFormCloudLoading = false;
     processDefinitionLoaded = false;
 
-    displayStartProcessButton = true;
-    displayCancelButton = true;
+    showStartProcessButton = true;
     startProcessButtonLabel: string;
     cancelButtonLabel: string;
 
@@ -268,14 +267,14 @@ export class StartProcessCloudComponent implements OnChanges, OnInit, OnDestroy 
             const cancelLabel = constants?.find((constant) => constant.name === 'cancelLabel');
 
             if (displayStart) {
-                this.displayStartProcessButton = displayStart?.value === 'true';
+                this.showStartProcessButton = displayStart?.value === 'true';
             }
             if (startLabel) {
                 this.startProcessButtonLabel = startLabel?.value?.trim()?.length > 0 ? startLabel.value.trim() : this.defaultStartProcessButtonLabel;
             }
 
             if (displayCancel) {
-                this.displayCancelButton = displayCancel?.value === 'true';
+                this.showCancelButton = displayCancel?.value === 'true' && this.showCancelButton;
             }
             if (cancelLabel) {
                 this.cancelButtonLabel = cancelLabel?.value?.trim()?.length > 0 ? cancelLabel.value.trim() : this.defaultCancelProcessButtonLabel;

--- a/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.ts
@@ -186,10 +186,8 @@ export class StartProcessCloudComponent implements OnChanges, OnInit, OnDestroy 
     }
 
     constructor(private translateService: TranslationService) {
-        this.startProcessButtonLabel = this.translateService
-            .instant('ADF_CLOUD_PROCESS_LIST.ADF_CLOUD_START_PROCESS.FORM.ACTION.START')
-            .toUpperCase();
-        this.cancelButtonLabel = this.translateService.instant('ADF_CLOUD_PROCESS_LIST.ADF_CLOUD_START_PROCESS.FORM.ACTION.CANCEL').toUpperCase();
+        this.startProcessButtonLabel = this.defaultStartProcessButtonLabel;
+        this.cancelButtonLabel = this.defaultCancelProcessButtonLabel;
     }
 
     ngOnInit() {

--- a/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.ts
@@ -30,18 +30,18 @@ import {
     ViewEncapsulation
 } from '@angular/core';
 
-import { ContentLinkModel, FORM_FIELD_VALIDATORS, FormFieldValidator, FormModel } from '@alfresco/adf-core';
+import { ContentLinkModel, FORM_FIELD_VALIDATORS, FormFieldValidator, FormModel, TranslationService } from '@alfresco/adf-core';
 import { AbstractControl, FormControl, FormGroup, ValidatorFn, Validators } from '@angular/forms';
 import { MatAutocompleteTrigger } from '@angular/material/autocomplete';
-import { Subject } from 'rxjs';
-import { debounceTime, takeUntil } from 'rxjs/operators';
-import { TaskVariableCloud } from '../../../form/models/task-variable-cloud.model';
-import { ProcessDefinitionCloud } from '../../../models/process-definition-cloud.model';
-import { ProcessNameCloudPipe } from '../../../pipes/process-name-cloud.pipe';
+import { catchError, debounceTime, takeUntil } from 'rxjs/operators';
 import { ProcessInstanceCloud } from '../models/process-instance-cloud.model';
 import { ProcessPayloadCloud } from '../models/process-payload-cloud.model';
 import { ProcessWithFormPayloadCloud } from '../models/process-with-form-payload-cloud.model';
 import { StartProcessCloudService } from '../services/start-process-cloud.service';
+import { forkJoin, of, Subject } from 'rxjs';
+import { ProcessDefinitionCloud } from '../../../models/process-definition-cloud.model';
+import { TaskVariableCloud } from '../../../form/models/task-variable-cloud.model';
+import { ProcessNameCloudPipe } from '../../../pipes/process-name-cloud.pipe';
 
 const MAX_NAME_LENGTH: number = 255;
 const PROCESS_DEFINITION_DEBOUNCE: number = 300;
@@ -131,6 +131,11 @@ export class StartProcessCloudComponent implements OnChanges, OnInit, OnDestroy 
     isFormCloudLoading = false;
     processDefinitionLoaded = false;
 
+    displayStartProcessButton = true;
+    displayCancelButton = true;
+    startProcessButtonLabel: string;
+    cancelButtonLabel: string;
+
     formCloud?: FormModel;
     processForm = new FormGroup({
         processInstanceName: new FormControl('', [
@@ -170,6 +175,21 @@ export class StartProcessCloudComponent implements OnChanges, OnInit, OnDestroy 
 
     get hasForm(): boolean {
         return !!this.processDefinitionCurrent?.formKey;
+    }
+
+    get defaultStartProcessButtonLabel(): string {
+        return this.translateService.instant('ADF_CLOUD_PROCESS_LIST.ADF_CLOUD_START_PROCESS.FORM.ACTION.START').toUpperCase();
+    }
+
+    get defaultCancelProcessButtonLabel(): string {
+        return this.translateService.instant('ADF_CLOUD_PROCESS_LIST.ADF_CLOUD_START_PROCESS.FORM.ACTION.CANCEL').toUpperCase();
+    }
+
+    constructor(private translateService: TranslationService) {
+        this.startProcessButtonLabel = this.translateService
+            .instant('ADF_CLOUD_PROCESS_LIST.ADF_CLOUD_START_PROCESS.FORM.ACTION.START')
+            .toUpperCase();
+        this.cancelButtonLabel = this.translateService.instant('ADF_CLOUD_PROCESS_LIST.ADF_CLOUD_START_PROCESS.FORM.ACTION.CANCEL').toUpperCase();
     }
 
     ngOnInit() {
@@ -230,19 +250,39 @@ export class StartProcessCloudComponent implements OnChanges, OnInit, OnDestroy 
             (process: ProcessDefinitionCloud) => process.name === selectedProcessDefinitionName || process.key === selectedProcessDefinitionName
         );
 
-        this.startProcessCloudService.getStartEventFormStaticValuesMapping(this.appName, processDefinitionCurrent.id).subscribe(
-            (staticMappings) => {
-                this.staticMappings = staticMappings;
-                this.resolvedValues = this.staticMappings.concat(this.values || []);
-                this.processDefinitionCurrent = processDefinitionCurrent;
-                this.isFormCloudLoading = false;
-            },
-            () => {
-                this.resolvedValues = this.values;
-                this.processDefinitionCurrent = processDefinitionCurrent;
-                this.isFormCloudLoading = false;
+        forkJoin([
+            this.startProcessCloudService
+                .getStartEventFormStaticValuesMapping(this.appName, processDefinitionCurrent.id)
+                .pipe(catchError(() => of([] as TaskVariableCloud[]))),
+            this.startProcessCloudService
+                .getStartEventConstants(this.appName, processDefinitionCurrent.id)
+                .pipe(catchError(() => of([] as TaskVariableCloud[])))
+        ]).subscribe(([staticMappings, constants]) => {
+            this.staticMappings = staticMappings;
+            this.resolvedValues = this.staticMappings.concat(this.values || []);
+            this.processDefinitionCurrent = processDefinitionCurrent;
+            this.isFormCloudLoading = false;
+
+            const displayStart = constants?.find((constant) => constant.name === 'startEnabled');
+            const startLabel = constants?.find((constant) => constant.name === 'startLabel');
+
+            const displayCancel = constants?.find((constant) => constant.name === 'cancelEnabled');
+            const cancelLabel = constants?.find((constant) => constant.name === 'cancelLabel');
+
+            if (displayStart) {
+                this.displayStartProcessButton = displayStart?.value === 'true';
             }
-        );
+            if (startLabel) {
+                this.startProcessButtonLabel = startLabel?.value?.trim()?.length > 0 ? startLabel.value.trim() : this.defaultStartProcessButtonLabel;
+            }
+
+            if (displayCancel) {
+                this.displayCancelButton = displayCancel?.value === 'true';
+            }
+            if (cancelLabel) {
+                this.cancelButtonLabel = cancelLabel?.value?.trim()?.length > 0 ? cancelLabel.value.trim() : this.defaultCancelProcessButtonLabel;
+            }
+        });
 
         this.isFormCloudLoaded = false;
         this.processPayloadCloud.processDefinitionKey = processDefinitionCurrent.key;

--- a/lib/process-services-cloud/src/lib/process/start-process/services/start-process-cloud.service.spec.ts
+++ b/lib/process-services-cloud/src/lib/process/start-process/services/start-process-cloud.service.spec.ts
@@ -125,4 +125,29 @@ describe('StartProcessCloudService', () => {
         expect(requestSpy.calls.mostRecent().args[0]).toContain(`${appName}/rb/v1/process-definitions/${processDefinitionId}/static-values`);
         expect(requestSpy.calls.mostRecent().args[1].httpMethod).toBe('GET');
     });
+
+    it('should transform the response into task variables when retrieving the constant values for the start event', async () => {
+        const appName = 'test-app';
+        const processDefinitionId = 'processDefinitionId';
+        const requestSpy = spyOn(adfHttpClient, 'request');
+        requestSpy.and.returnValue(Promise.resolve({ constant1: 'value', constant2: '0', constant3: 'true' }));
+
+        const result = await service.getStartEventConstants(appName, processDefinitionId).toPromise();
+
+        expect(result.length).toEqual(3);
+        expect(result[0].name).toEqual('constant1');
+        expect(result[0].id).toEqual('constant1');
+        expect(result[0].value).toEqual('value');
+        expect(result[0].type).toEqual('string');
+        expect(result[1].name).toEqual('constant2');
+        expect(result[1].id).toEqual('constant2');
+        expect(result[1].value).toEqual('0');
+        expect(result[1].type).toEqual('string');
+        expect(result[2].name).toEqual('constant3');
+        expect(result[2].id).toEqual('constant3');
+        expect(result[2].value).toEqual('true');
+        expect(result[2].type).toEqual('string');
+        expect(requestSpy.calls.mostRecent().args[0]).toContain(`${appName}/rb/v1/process-definitions/${processDefinitionId}/constant-values`);
+        expect(requestSpy.calls.mostRecent().args[1].httpMethod).toBe('GET');
+    });
 });

--- a/lib/process-services-cloud/src/lib/process/start-process/services/start-process-cloud.service.ts
+++ b/lib/process-services-cloud/src/lib/process/start-process/services/start-process-cloud.service.ts
@@ -119,4 +119,26 @@ export class StartProcessCloudService extends BaseCloudService {
             })
         );
     }
+
+    /**
+     * Gets the constants mapped to the start form of a process definition.
+     *
+     * @param appName Name of the app
+     * @param processDefinitionId ID of the target process definition
+     * @returns Constants values for the start event
+     */
+    getStartEventConstants(appName: string, processDefinitionId: string): Observable<TaskVariableCloud[]> {
+        const apiUrl = `${this.getBasePath(appName)}/rb/v1/process-definitions/${processDefinitionId}/constant-values`;
+        return this.get(apiUrl).pipe(
+            map((res: { [key: string]: any }) => {
+                const result = [];
+                if (res) {
+                    Object.keys(res).forEach((constant) =>
+                        result.push(new TaskVariableCloud({ name: constant, value: res[constant], type: 'string' }))
+                    );
+                }
+                return result;
+            })
+        );
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [X] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
The start and cancel button labels can not be customised in process cloud


**What is the new behaviour?**
From the process extensions, the modeler user can set which are the labels for the start and cancel buttons, and also decide whether the buttons will be displayed or not


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
Related Activiti Cloud PR: https://github.com/Activiti/activiti-cloud/pull/1518