### PR TITLE
[ACS-8663] Fixed issue where datatable selection was not getting reset completely in some cases

### DIFF
--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.spec.ts
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.spec.ts
@@ -423,6 +423,7 @@ describe('DataTable', () => {
     describe('Selection reset', () => {
         beforeEach(() => {
             spyOn(dataTable, 'resetSelection').and.callThrough();
+            spyOn(dataTable.selectedItemsCountChanged, 'emit');
 
             dataTable.data = new ObjectDataTableAdapter([{ name: '1' }, { name: '2' }], [new ObjectDataColumn({ key: 'name' })]);
             const rows = dataTable.data.getRows();
@@ -440,6 +441,9 @@ describe('DataTable', () => {
             });
 
             expect(dataTable.selection).toEqual([]);
+            expect(dataTable.selectedItemsCountChanged.emit).toHaveBeenCalledWith(0);
+            expect(dataTable.isSelectAllIndeterminate).toBe(false);
+            expect(dataTable.isSelectAllChecked).toBe(false);
         });
 
         it('should reset selection on multiselect change', () => {
@@ -448,6 +452,9 @@ describe('DataTable', () => {
             });
 
             expect(dataTable.selection).toEqual([]);
+            expect(dataTable.selectedItemsCountChanged.emit).toHaveBeenCalledWith(0);
+            expect(dataTable.isSelectAllIndeterminate).toBe(false);
+            expect(dataTable.isSelectAllChecked).toBe(false);
         });
     });
 
@@ -930,7 +937,7 @@ describe('DataTable', () => {
         );
         const rows = dataTable.data.getRows();
         const event = new MouseEvent('click');
-        Object.defineProperty(event, 'target', { value: { hasAttribute: () => null, closest: () => null} });
+        Object.defineProperty(event, 'target', { value: { hasAttribute: () => null, closest: () => null } });
         spyOn(dataTable, 'onRowClick');
 
         dataTable.onCheckboxLabelClick(rows[0], event);
@@ -943,7 +950,7 @@ describe('DataTable', () => {
         const event = new MouseEvent('click');
         Object.defineProperty(event, 'target', {
             value: {
-                getAttribute: (attr: string) => attr === 'data-adf-datatable-row-checkbox' ? 'data-adf-datatable-row-checkbox' : null,
+                getAttribute: (attr: string) => (attr === 'data-adf-datatable-row-checkbox' ? 'data-adf-datatable-row-checkbox' : null),
                 hasAttribute: (attr: string) => attr === 'data-adf-datatable-row-checkbox',
                 closest: () => null
             }
@@ -958,7 +965,7 @@ describe('DataTable', () => {
         const data = new ObjectDataTableAdapter([{}, {}], []);
         const rows = data.getRows();
         const event = new MouseEvent('click');
-        Object.defineProperty(event, 'target', { value: { hasAttribute: () => null, closest: () => 'element'} });
+        Object.defineProperty(event, 'target', { value: { hasAttribute: () => null, closest: () => 'element' } });
         spyOn(dataTable, 'onRowClick');
 
         dataTable.onCheckboxLabelClick(rows[0], event);

--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.ts
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.ts
@@ -619,6 +619,8 @@ export class DataTableComponent implements OnInit, AfterContentInit, OnChanges, 
             this.selection = [];
         }
         this.isSelectAllChecked = false;
+        this.isSelectAllIndeterminate = false;
+        this.selectedItemsCountChanged.emit(0);
     }
 
     onRowDblClick(row: DataRow, event?: Event) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Selection state on document list was not getting reset when selected document was no longer available on the page. This can happen via file delete, file move, folder navigation, breadcrumb navigation etc


**What is the new behaviour?**
Selection state is now reset completely


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://hyland.atlassian.net/browse/ACS-8663