### PR TITLE
ACS-8639 - [ACC ]Adding a space to the front/end of a tag name during tag creation removes the 'Tag already exists' validation message

### DIFF
--- a/lib/content-services/src/lib/tag/tags-creator/tags-creator.component.spec.ts
+++ b/lib/content-services/src/lib/tag/tags-creator/tags-creator.component.spec.ts
@@ -28,7 +28,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatProgressSpinnerHarness } from '@angular/material/progress-spinner/testing';
-import { MatChipOptionHarness } from '@angular/material/chips/testing';
+import { MatChipHarness } from '@angular/material/chips/testing';
 
 describe('TagsCreatorComponent', () => {
     let fixture: ComponentFixture<TagsCreatorComponent>;
@@ -105,7 +105,7 @@ describe('TagsCreatorComponent', () => {
      * @returns list of tags
      */
     async function getAddedTags(): Promise<string[]> {
-        const matChipHarness = await loader.getAllHarnesses(MatChipOptionHarness.with({ selector: '.adf-tags-chip' }));
+        const matChipHarness = await loader.getAllHarnesses(MatChipHarness.with({ selector: '.adf-tags-chip' }));
         const tagElements = [];
         for (const matChip of matChipHarness) {
             tagElements.push(await matChip.getText());
@@ -395,6 +395,23 @@ describe('TagsCreatorComponent', () => {
                     })
                 );
                 typeTag(tag);
+
+                const error = getFirstError();
+                expect(error).toBe('TAG.TAGS_CREATOR.ERRORS.EXISTING_TAG');
+            }));
+
+            it('should show error when duplicated already existing tag with spaces', fakeAsync(() => {
+                const tag = 'Some tag';
+
+                spyOn(tagService, 'findTagByName').and.returnValue(
+                    of({
+                        entry: {
+                            tag,
+                            id: 'tag-1'
+                        }
+                    })
+                );
+                typeTag(tag + ' ');
 
                 const error = getFirstError();
                 expect(error).toBe('TAG.TAGS_CREATOR.ERRORS.EXISTING_TAG');

--- a/lib/content-services/src/lib/tag/tags-creator/tags-creator.component.ts
+++ b/lib/content-services/src/lib/tag/tags-creator/tags-creator.component.ts
@@ -182,7 +182,13 @@ export class TagsCreatorComponent implements OnInit, OnDestroy {
         this.tagNameControl.valueChanges
             .pipe(
                 map((name: string) => name.trim()),
-                distinctUntilChanged(),
+                distinctUntilChanged((previous, current) => {
+                    const valueNotChanged = previous === current;
+                    if (valueNotChanged) {
+                        this.exactTagSet$.next();
+                    }
+                    return valueNotChanged;
+                }),
                 tap((name: string) => {
                     this._typing = true;
                     if (name) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/ACS-8639


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
