### PR TITLE
[ACS-8666] Fixed issue where header filters were not getting reset when navigating between folders

### DIFF
--- a/lib/content-services/src/lib/search/components/search-check-list/search-check-list.component.spec.ts
+++ b/lib/content-services/src/lib/search/components/search-check-list/search-check-list.component.spec.ts
@@ -204,4 +204,40 @@ describe('SearchCheckListComponent', () => {
         const checkedElements = await loader.getAllHarnesses(MatCheckboxHarness.with({ checked: true }));
         expect(checkedElements.length).toBe(0);
     });
+
+    it('should update query with startValue on init, if provided', () => {
+        component.id = 'checkList';
+        component.options = new SearchFilterList<SearchListOption>([
+            { name: 'Folder', value: `TYPE:'cm:folder'`, checked: false },
+            { name: 'Document', value: `TYPE:'cm:content'`, checked: false }
+        ]);
+        component.startValue = `TYPE:'cm:folder'`;
+        component.context = {
+            queryFragments: {},
+            update: jasmine.createSpy()
+        } as any;
+        fixture.detectChanges();
+
+        expect(component.context.queryFragments[component.id]).toBe(`TYPE:'cm:folder'`);
+        expect(component.context.update).toHaveBeenCalled();
+    });
+
+    it('should set query context as blank and not call query update, if no start value was provided', () => {
+        component.id = 'checkList';
+        component.options = new SearchFilterList<SearchListOption>([
+            { name: 'Folder', value: `TYPE:'cm:folder'`, checked: true },
+            { name: 'Document', value: `TYPE:'cm:content'`, checked: false }
+        ]);
+        component.startValue = undefined;
+        component.context = {
+            queryFragments: {
+                checkList: `TYPE:'cm:folder'`
+            },
+            update: jasmine.createSpy()
+        } as any;
+        fixture.detectChanges();
+
+        expect(component.context.queryFragments[component.id]).toBe('');
+        expect(component.context.update).not.toHaveBeenCalled();
+    });
 });

--- a/lib/content-services/src/lib/search/components/search-check-list/search-check-list.component.ts
+++ b/lib/content-services/src/lib/search/components/search-check-list/search-check-list.component.ts
@@ -49,7 +49,7 @@ export class SearchCheckListComponent implements SearchWidget, OnInit {
     context?: SearchQueryBuilderService;
     options: SearchFilterList<SearchListOption>;
     operator: string = 'OR';
-    startValue: SearchListOption = null;
+    startValue: string;
     pageSize = 5;
     isActive = false;
     enableChangeUpdate = true;
@@ -72,6 +72,10 @@ export class SearchCheckListComponent implements SearchWidget, OnInit {
 
         if (this.startValue) {
             this.setValue(this.startValue);
+        } else {
+            if (this.id && this.context) {
+                this.context.queryFragments[this.id] = '';
+            }
         }
     }
 

--- a/lib/content-services/src/lib/search/components/search-text/search-text.component.spec.ts
+++ b/lib/content-services/src/lib/search/components/search-text/search-text.component.spec.ts
@@ -119,4 +119,25 @@ describe('SearchTextComponent', () => {
         expect(component.value).toBe('');
         expect(component.context.queryFragments[component.id]).toBe('');
     });
+
+    it('should update query with startValue on init, if provided', () => {
+        spyOn(component.context, 'update');
+        component.startValue = 'mock-start-value';
+        fixture.detectChanges();
+
+        expect(component.context.queryFragments[component.id]).toBe(`cm:name:'mock-start-value'`);
+        expect(component.value).toBe('mock-start-value');
+        expect(component.context.update).toHaveBeenCalled();
+    });
+
+    it('should parse value and set query context as blank, and not call query update, if no start value was provided', () => {
+        component.context.queryFragments[component.id] = `cm:name:'secret.pdf'`;
+        spyOn(component.context, 'update');
+        component.startValue = undefined;
+        fixture.detectChanges();
+
+        expect(component.context.queryFragments[component.id]).toBe('');
+        expect(component.value).toBe('secret.pdf');
+        expect(component.context.update).not.toHaveBeenCalled();
+    });
 });

--- a/lib/content-services/src/lib/search/components/search-text/search-text.component.ts
+++ b/lib/content-services/src/lib/search/components/search-text/search-text.component.ts
@@ -64,6 +64,10 @@ export class SearchTextComponent implements SearchWidget, OnInit {
 
             if (this.startValue) {
                 this.setValue(this.startValue);
+            } else {
+                if (this.context?.queryFragments) {
+                    this.context.queryFragments[this.id] = '';
+                }
             }
         }
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Filters in document list header were not getting reset when navigating between folders


**What is the new behaviour?**
Filters are now reset on folder navigation. Filters still display the value typed in the previous location, but users now need to click on the Apply button in order to apply those filters


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://hyland.atlassian.net/browse/ACS-8666