### PR TITLE
[MNT-24317]Audit app creates multiple entries on document preview in ADW

### DIFF
--- a/lib/core/src/lib/viewer/components/img-viewer/img-viewer.component.ts
+++ b/lib/core/src/lib/viewer/components/img-viewer/img-viewer.component.ts
@@ -81,46 +81,7 @@ export class ImgViewerComponent implements AfterViewInit, OnChanges, OnDestroy {
     isSaving = new EventEmitter<boolean>();
 
     @ViewChild('image', { static: false })
-    public imageElement: ElementRef;
-
-    public scale: number = 1.0;
-    public cropper: Cropper;
-    public isEditing: boolean = false;
-
-    get currentScaleText(): string {
-        return Math.round(this.scale * 100) + '%';
-    }
-
-    constructor(private appConfigService: AppConfigService, private urlService: UrlService) {
-        this.initializeScaling();
-    }
-
-    initializeScaling() {
-        const scaling = this.appConfigService.get<number>('adf-viewer-render.image-viewer-scaling', undefined) / 100;
-        if (scaling) {
-            this.scale = scaling;
-        }
-    }
-
-    ngAfterViewInit() {
-        this.cropper = new Cropper(this.imageElement.nativeElement, {
-            autoCrop: false,
-            dragMode: 'move',
-            background: false,
-            scalable: true,
-            zoomOnWheel: true,
-            toggleDragModeOnDblclick: false,
-            viewMode: 1,
-            checkCrossOrigin: false,
-            ready: () => {
-                this.updateCanvasContainer();
-            }
-        });
-    }
-
-    ngOnDestroy() {
-        this.cropper.destroy();
-    }
+    imageElement: ElementRef;
 
     @HostListener('document:keydown', ['$event'])
     onKeyDown(event: KeyboardEvent) {
@@ -161,6 +122,18 @@ export class ImgViewerComponent implements AfterViewInit, OnChanges, OnDestroy {
         }
     }
 
+    scale: number = 1.0;
+    cropper: Cropper;
+    isEditing: boolean = false;
+
+    get currentScaleText(): string {
+        return Math.round(this.scale * 100) + '%';
+    }
+
+    constructor(private appConfigService: AppConfigService, private urlService: UrlService) {
+        this.initializeScaling();
+    }
+
     ngOnChanges(changes: SimpleChanges) {
         const blobFile = changes['blobFile'];
         if (blobFile?.currentValue) {
@@ -176,6 +149,34 @@ export class ImgViewerComponent implements AfterViewInit, OnChanges, OnDestroy {
 
         if (!this.urlFile && !this.blobFile) {
             throw new Error('Attribute urlFile or blobFile is required');
+        }
+    }
+
+    ngAfterViewInit() {
+        this.cropper = new Cropper(this.imageElement.nativeElement, {
+            autoCrop: false,
+            checkOrientation: false,
+            dragMode: 'move',
+            background: false,
+            scalable: true,
+            zoomOnWheel: true,
+            toggleDragModeOnDblclick: false,
+            viewMode: 1,
+            checkCrossOrigin: false,
+            ready: () => {
+                this.updateCanvasContainer();
+            }
+        });
+    }
+
+    ngOnDestroy() {
+        this.cropper.destroy();
+    }
+
+    initializeScaling() {
+        const scaling = this.appConfigService.get<number>('adf-viewer-render.image-viewer-scaling', undefined) / 100;
+        if (scaling) {
+            this.scale = scaling;
         }
     }
 


### PR DESCRIPTION
ACS-24317 fix src double call
First part 
https://hyland.atlassian.net/browse/MNT-24317

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
double call when opening image
<img width="1282" alt="image" src="https://github.com/user-attachments/assets/5eea614e-a642-48db-b207-5a92d8f0344f">


**What is the new behaviour?**
single call when opening image
added `checkOrientation: false,`
<img width="1721" alt="image" src="https://github.com/user-attachments/assets/a642ef83-f2cb-4e80-8d77-872479180624">



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
