### PR TITLE
AAE-25888 Offset SearchTextInput expansion based on search icon width

### DIFF
--- a/lib/content-services/src/lib/search/components/search-control.component.spec.ts
+++ b/lib/content-services/src/lib/search/components/search-control.component.spec.ts
@@ -415,13 +415,13 @@ describe('SearchControlComponent', () => {
             it('should have positive transform translation', () => {
                 userPreferencesService.setWithoutStore('textOrientation', 'ltr');
                 fixture.detectChanges();
-                expect(component.searchTextInput.subscriptAnimationState.params.transform).toBe('translateX(85%)');
+                expect(component.searchTextInput.subscriptAnimationState.params.transform).toBe('translateX(100%)');
             });
 
             it('should have negative transform translation ', () => {
                 userPreferencesService.setWithoutStore('textOrientation', 'rtl');
                 fixture.detectChanges();
-                expect(component.searchTextInput.subscriptAnimationState.params.transform).toBe('translateX(-85%)');
+                expect(component.searchTextInput.subscriptAnimationState.params.transform).toBe('translateX(-100%)');
             });
         });
     });

--- a/lib/core/src/lib/search-text/search-text-input.component.html
+++ b/lib/core/src/lib/search-text/search-text-input.component.html
@@ -6,6 +6,7 @@
                 *ngIf="expandable"
                 id="adf-search-button"
                 class="adf-search-button"
+                [ngClass]="{'adf-search-button-inactive': subscriptAnimationState.value === 'inactive'}"
                 [title]="'SEARCH.BUTTON.TOOLTIP' | translate"
                 (click)="toggleSearchBar()"
                 (keyup.enter)="toggleSearchBar()">

--- a/lib/core/src/lib/search-text/search-text-input.component.scss
+++ b/lib/core/src/lib/search-text/search-text-input.component.scss
@@ -1,7 +1,5 @@
 @import 'styles/mat-selectors';
 
-$search-text-input-search-icon-width: 48px;
-
 .adf-search-container {
     &:has(.adf-input-form-field-divider) {
         overflow: hidden;
@@ -16,17 +14,9 @@ $search-text-input-search-icon-width: 48px;
         align-items: center;
     }
 
-    &[state='inactive'] .adf-search-button {
-        margin-left: -$search-text-input-search-icon-width;
-    }
-
-    &[state='active'] .adf-search-button {
-        margin-left: 0;
-    }
-
     .adf {
         &-search-button-inactive {
-            margin-left: -$search-text-input-search-icon-width;
+            margin-left: -48px;
         }
 
         &-search-fixed-text {

--- a/lib/core/src/lib/search-text/search-text-input.component.scss
+++ b/lib/core/src/lib/search-text/search-text-input.component.scss
@@ -25,6 +25,10 @@ $search-text-input-search-icon-width: 48px;
     }
 
     .adf {
+        &-search-button-inactive {
+            margin-left: -$search-text-input-search-icon-width;
+        }
+
         &-search-fixed-text {
             line-height: normal;
         }

--- a/lib/core/src/lib/search-text/search-text-input.component.scss
+++ b/lib/core/src/lib/search-text/search-text-input.component.scss
@@ -1,5 +1,7 @@
 @import 'styles/mat-selectors';
 
+$search-text-input-search-icon-width: 48px;
+
 .adf-search-container {
     &:has(.adf-input-form-field-divider) {
         overflow: hidden;
@@ -12,6 +14,14 @@
     .adf-search-container-transition {
         display: flex;
         align-items: center;
+    }
+
+    &[state='inactive'] .adf-search-button {
+        margin-left: -$search-text-input-search-icon-width;
+    }
+
+    &[state='active'] .adf-search-button {
+        margin-left: 0;
     }
 
     .adf {

--- a/lib/core/src/lib/search-text/search-text-input.component.spec.ts
+++ b/lib/core/src/lib/search-text/search-text-input.component.spec.ts
@@ -223,6 +223,13 @@ describe('SearchTextInputComponent', () => {
             testTransformValue(false);
         }));
 
+        it('should have an inactive class when input is collapsed', fakeAsync(() => {
+            component.subscriptAnimationState.value = 'inactive';
+            fixture.detectChanges();
+            expect(component.subscriptAnimationState.value).toBe('inactive');
+            expect(element.querySelector('.adf-search-button-inactive')).toBeTruthy();
+        }));
+
         it('should set browser autocomplete to on when configured', async () => {
             component.autocomplete = true;
 

--- a/lib/core/src/lib/search-text/search-text-input.component.spec.ts
+++ b/lib/core/src/lib/search-text/search-text-input.component.spec.ts
@@ -210,7 +210,7 @@ describe('SearchTextInputComponent', () => {
             userPreferencesService.setWithoutStore('textOrientation', isLtr ? 'ltr' : 'rtl');
             component.subscriptAnimationState.value = 'active';
             clickSearchButton();
-            const expectedValue = isLtr ? 'translateX(85%)' : 'translateX(-85%)';
+            const expectedValue = isLtr ? 'translateX(100%)' : 'translateX(-100%)';
             expect(component.subscriptAnimationState.params).toEqual({ transform: expectedValue });
             discardPeriodicTasks();
         }

--- a/lib/core/src/lib/search-text/search-text-input.component.ts
+++ b/lib/core/src/lib/search-text/search-text-input.component.ts
@@ -16,7 +16,7 @@
  */
 
 import { Direction } from '@angular/cdk/bidi';
-import { NgIf } from '@angular/common';
+import { NgClass, NgIf } from '@angular/common';
 import { Component, ElementRef, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild, ViewEncapsulation } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
@@ -38,7 +38,17 @@ import { SearchTriggerDirective } from './search-trigger.directive';
     styleUrls: ['./search-text-input.component.scss'],
     animations: [searchAnimation],
     encapsulation: ViewEncapsulation.None,
-    imports: [MatButtonModule, MatIconModule, TranslateModule, MatFormFieldModule, MatInputModule, FormsModule, SearchTriggerDirective, NgIf],
+    imports: [
+        MatButtonModule,
+        MatIconModule,
+        TranslateModule,
+        MatFormFieldModule,
+        MatInputModule,
+        FormsModule,
+        SearchTriggerDirective,
+        NgIf,
+        NgClass
+    ],
     host: {
         class: 'adf-search-text-input'
     }

--- a/lib/core/src/lib/search-text/search-text-input.component.ts
+++ b/lib/core/src/lib/search-text/search-text-input.component.ts
@@ -143,11 +143,11 @@ export class SearchTextInputComponent implements OnInit, OnDestroy {
     animationStates: SearchAnimationDirection = {
         ltr: {
             active: { value: 'active', params: { 'margin-left': 13 } },
-            inactive: { value: 'inactive', params: { transform: 'translateX(85%)' } }
+            inactive: { value: 'inactive', params: { transform: 'translateX(100%)' } }
         },
         rtl: {
             active: { value: 'active', params: { 'margin-right': 13 } },
-            inactive: { value: 'inactive', params: { transform: 'translateX(-85%)' } }
+            inactive: { value: 'inactive', params: { transform: 'translateX(-100%)' } }
         }
     };
 
@@ -201,11 +201,11 @@ export class SearchTextInputComponent implements OnInit, OnDestroy {
         if (this.dir === 'ltr') {
             return this.subscriptAnimationState.value === 'inactive'
                 ? { value: 'active', params: { 'margin-left': 13 } }
-                : { value: 'inactive', params: { transform: 'translateX(85%)' } };
+                : { value: 'inactive', params: { transform: 'translateX(100%)' } };
         } else {
             return this.subscriptAnimationState.value === 'inactive'
                 ? { value: 'active', params: { 'margin-right': 13 } }
-                : { value: 'inactive', params: { transform: 'translateX(-85%)' } };
+                : { value: 'inactive', params: { transform: 'translateX(-100%)' } };
         }
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://hyland.atlassian.net/browse/AAE-25888

Expandable search text input offset by approximate not full value to compensate for the search icon's width.

**What is the new behaviour?**

Expandable search text input offset by 100% minus actual search icon width.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
