### PR TITLE
[ACS-8823] Viewer - do not show non responsive dialog if blobFile was provided

### DIFF
--- a/lib/core/src/lib/viewer/components/viewer.component.spec.ts
+++ b/lib/core/src/lib/viewer/components/viewer.component.spec.ts
@@ -611,6 +611,14 @@ describe('ViewerComponent', () => {
             expect(dialogOpenSpy).toHaveBeenCalled();
         }));
 
+        it('should not show non responsive dialog if blobFile was provided', fakeAsync(() => {
+            component.blobFile = new Blob(['mock content'], { type: 'text/plain' });
+            fixture.detectChanges();
+            tick(3000);
+            fixture.detectChanges();
+            expect(dialogOpenSpy).not.toHaveBeenCalled();
+        }));
+
         it('should show reminder non responsive dialog after initial dialog', fakeAsync(() => {
             dialogOpenSpy.and.returnValue({ afterClosed: () => of(DownloadPromptActions.WAIT) } as any);
             fixture.detectChanges();

--- a/lib/core/src/lib/viewer/components/viewer.component.ts
+++ b/lib/core/src/lib/viewer/components/viewer.component.ts
@@ -456,7 +456,7 @@ export class ViewerComponent<T> implements OnDestroy, OnInit, OnChanges {
     }
 
     private showOrClearDownloadPrompt() {
-        if (!this.urlFile) {
+        if (!this.urlFile && !this.blobFile) {
             this.showDownloadPrompt();
         } else {
             this.clearDownloadPromptTimeouts();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Non responsive download prompt dialog will pop up even if the viewer was rendered properly using blobFile, in case if urlFile was not provided. 

**What is the new behaviour?**

The "Download Prompt Dialog" will only appear if neither blobFile nor urlFile were specified.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
