### PR TITLE
[ACS-8841] Fix viewer rendering for doc files

### DIFF
--- a/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.spec.ts
+++ b/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.spec.ts
@@ -510,7 +510,7 @@ describe('AlfrescoViewerComponent', () => {
             } as Node);
 
             await fixture.whenStable();
-            expect(component.mimeType).toEqual('application/msWord');
+            expect(component.mimeType).toEqual('application/pdf');
         });
     });
 

--- a/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.spec.ts
+++ b/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.spec.ts
@@ -478,7 +478,7 @@ describe('AlfrescoViewerComponent', () => {
     });
 
     describe('mimeType', () => {
-        it('should set mime type based on nodeData content', async () => {
+        it('should set mime type based on renditionMimeType rather then nodeData', async () => {
             const defaultNode: Node = {
                 id: 'mock-id',
                 name: 'Mock Node',
@@ -496,7 +496,7 @@ describe('AlfrescoViewerComponent', () => {
             spyOn(renditionService, 'getNodeRendition').and.returnValue(
                 Promise.resolve({
                     url: '',
-                    mimeType: ''
+                    mimeType: 'application/pdf'
                 })
             );
 

--- a/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.ts
+++ b/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.ts
@@ -346,7 +346,7 @@ export class AlfrescoViewerComponent implements OnChanges, OnInit, OnDestroy {
 
                 const nodeMimeType = nodeData?.content?.mimeType;
                 const renditionMimeType = nodeRendition.mimeType;
-                mimeType = nodeMimeType || renditionMimeType;
+                mimeType = renditionMimeType || nodeMimeType;
             }
         } else if (viewerType === 'media') {
             this.tracks = await this.renditionService.generateMediaTracksRendition(this.nodeId);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Doc files can not be rendered in the viewer
https://hyland.atlassian.net/browse/ACS-8841

**What is the new behaviour?**

Doc files can be rendered in the viewer as expected 

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
