### PR TITLE
[ACS-8865] Viewer / DOCX files could not load preview for the first 20 seconds - error 409 for renditions

### DIFF
--- a/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.spec.ts
+++ b/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.spec.ts
@@ -147,10 +147,19 @@ class ViewerWithCustomOpenWithComponent {}
 })
 class ViewerWithCustomMoreActionsComponent {}
 
-const getSimpleChanges = (currentValue: string, previousValue?: string): SimpleChanges => {
-    return {
-        nodeId: new SimpleChange(previousValue || null, currentValue, false)
-    };
+const getSimpleChanges = (currentValue: string, previousValue?: string): SimpleChanges => ({
+    nodeId: new SimpleChange(previousValue || null, currentValue, false)
+});
+
+const verifyCustomElement = (component: any, selector: string, done: DoneFn) => {
+    const customFixture = TestBed.createComponent(component);
+    const customElement: HTMLElement = customFixture.nativeElement;
+
+    customFixture.detectChanges();
+    customFixture.whenStable().then(() => {
+        expect(customElement.querySelector(selector)).toBeDefined();
+        done();
+    });
 };
 
 describe('AlfrescoViewerComponent', () => {
@@ -365,61 +374,23 @@ describe('AlfrescoViewerComponent', () => {
 
     describe('Viewer Example Component Rendering', () => {
         it('should use custom toolbar', (done) => {
-            const customFixture = TestBed.createComponent(ViewerWithCustomToolbarComponent);
-            const customElement: HTMLElement = customFixture.nativeElement;
-
-            customFixture.detectChanges();
-            fixture.whenStable().then(() => {
-                expect(customElement.querySelector('.custom-toolbar-element')).toBeDefined();
-                done();
-            });
+            verifyCustomElement(ViewerWithCustomToolbarComponent, '.custom-toolbar-element', done);
         });
 
         it('should use custom toolbar actions', (done) => {
-            const customFixture = TestBed.createComponent(ViewerWithCustomToolbarActionsComponent);
-            const customElement: HTMLElement = customFixture.nativeElement;
-
-            customFixture.detectChanges();
-            fixture.whenStable().then(() => {
-                expect(customElement.querySelector('#custom-button')).toBeDefined();
-                done();
-            });
+            verifyCustomElement(ViewerWithCustomToolbarActionsComponent, '#custom-button', done);
         });
 
         it('should use custom info drawer', (done) => {
-            const customFixture = TestBed.createComponent(ViewerWithCustomSidebarComponent);
-            const customElement: HTMLElement = customFixture.nativeElement;
-
-            customFixture.detectChanges();
-
-            fixture.whenStable().then(() => {
-                expect(customElement.querySelector('.custom-info-drawer-element')).toBeDefined();
-                done();
-            });
+            verifyCustomElement(ViewerWithCustomSidebarComponent, '.custom-info-drawer-element', done);
         });
 
         it('should use custom open with menu', (done) => {
-            const customFixture = TestBed.createComponent(ViewerWithCustomOpenWithComponent);
-            const customElement: HTMLElement = customFixture.nativeElement;
-
-            customFixture.detectChanges();
-
-            fixture.whenStable().then(() => {
-                expect(customElement.querySelector('.adf-viewer-container-open-with')).toBeDefined();
-                done();
-            });
+            verifyCustomElement(ViewerWithCustomOpenWithComponent, '.adf-viewer-container-open-with', done);
         });
 
         it('should use custom more actions menu', (done) => {
-            const customFixture = TestBed.createComponent(ViewerWithCustomMoreActionsComponent);
-            const customElement: HTMLElement = customFixture.nativeElement;
-
-            customFixture.detectChanges();
-
-            fixture.whenStable().then(() => {
-                expect(customElement.querySelector('.adf-viewer-container-more-actions')).toBeDefined();
-                done();
-            });
+            verifyCustomElement(ViewerWithCustomMoreActionsComponent, '.adf-viewer-container-more-actions', done);
         });
 
         it('should stop propagation on sidebar keydown event [keydown]', async () => {

--- a/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.spec.ts
+++ b/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.spec.ts
@@ -722,52 +722,47 @@ describe('AlfrescoViewerComponent', () => {
         });
 
         describe('SideBar Test', () => {
-            it('should NOT display sidebar if is not allowed', (done) => {
-                component.showRightSidebar = true;
-                component.allowRightSidebar = false;
+            const verifySidebarDisplay = (
+                sidebarId: string,
+                showSidebar: boolean,
+                allowSidebar: boolean,
+                expectedOrder: string | null,
+                done: DoneFn
+            ) => {
+                if (sidebarId === '#adf-right-sidebar') {
+                    component.showRightSidebar = showSidebar;
+                    component.allowRightSidebar = allowSidebar;
+                } else if (sidebarId === '#adf-left-sidebar') {
+                    component.showLeftSidebar = showSidebar;
+                    component.allowLeftSidebar = allowSidebar;
+                }
                 fixture.detectChanges();
 
                 fixture.whenStable().then(() => {
-                    const sidebar = element.querySelector('#adf-right-sidebar');
-                    expect(sidebar).toBeNull();
+                    const sidebar = element.querySelector(sidebarId);
+                    if (expectedOrder === null) {
+                        expect(sidebar).toBeNull();
+                    } else {
+                        expect(getComputedStyle(sidebar).order).toEqual(expectedOrder);
+                    }
                     done();
                 });
+            };
+
+            it('should NOT display sidebar if is not allowed', (done) => {
+                verifySidebarDisplay('#adf-right-sidebar', true, false, null, done);
             });
 
             it('should display sidebar on the right side', (done) => {
-                component.allowRightSidebar = true;
-                component.showRightSidebar = true;
-                fixture.detectChanges();
-
-                fixture.whenStable().then(() => {
-                    const sidebar = element.querySelector('#adf-right-sidebar');
-                    expect(getComputedStyle(sidebar).order).toEqual('4');
-                    done();
-                });
+                verifySidebarDisplay('#adf-right-sidebar', true, true, '4', done);
             });
 
             it('should NOT display left sidebar if is not allowed', (done) => {
-                component.showLeftSidebar = true;
-                component.allowLeftSidebar = false;
-                fixture.detectChanges();
-
-                fixture.whenStable().then(() => {
-                    const sidebar = element.querySelector('#adf-left-sidebar');
-                    expect(sidebar).toBeNull();
-                    done();
-                });
+                verifySidebarDisplay('#adf-left-sidebar', true, false, null, done);
             });
 
             it('should display sidebar on the left side', (done) => {
-                component.allowLeftSidebar = true;
-                component.showLeftSidebar = true;
-                fixture.detectChanges();
-
-                fixture.whenStable().then(() => {
-                    const sidebar = element.querySelector('#adf-left-sidebar');
-                    expect(getComputedStyle(sidebar).order).toEqual('1');
-                    done();
-                });
+                verifySidebarDisplay('#adf-left-sidebar', true, true, '1', done);
             });
         });
 

--- a/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.spec.ts
+++ b/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.spec.ts
@@ -296,21 +296,13 @@ describe('AlfrescoViewerComponent', () => {
     }));
 
     it('should not setup the node twice if the node id is not changed', fakeAsync(() => {
-        spyOn(component['nodesApi'], 'getNode').and.returnValues(
-            Promise.resolve(new NodeEntry({ entry: new Node({ name: 'file1', content: new ContentInfo() }) })),
-            Promise.resolve(new NodeEntry({ entry: new Node({ name: 'file2', content: new ContentInfo() }) }))
-        );
-
+        spyOn(component['nodesApi'], 'getNode').and.stub();
         component.showViewer = true;
         component.nodeId = 'id1';
-        component.ngOnChanges(getSimpleChanges('id1'));
+        component.ngOnChanges(getSimpleChanges('id0', 'id1'));
         tick();
-
-        expect(component.fileName).toBe('file1');
         component.ngOnChanges(getSimpleChanges('id1', 'id1'));
         tick();
-
-        expect(component.fileName).toBe('file1');
         expect(component['nodesApi'].getNode).toHaveBeenCalledTimes(1);
     }));
 

--- a/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.spec.ts
+++ b/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.spec.ts
@@ -298,8 +298,6 @@ describe('AlfrescoViewerComponent', () => {
         tick();
 
         expect(component.fileName).toBe('file1');
-
-        component.nodeId = 'id1';
         component.ngOnChanges(getSimpleChanges('id1', 'id1'));
         tick();
 

--- a/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.ts
+++ b/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.ts
@@ -25,6 +25,7 @@ import {
     OnDestroy,
     OnInit,
     Output,
+    SimpleChanges,
     TemplateRef,
     ViewChild,
     ViewEncapsulation
@@ -443,13 +444,13 @@ export class AlfrescoViewerComponent implements OnChanges, OnInit, OnDestroy {
         return !!(this.nodeId || this.sharedLinkId);
     }
 
-    ngOnChanges() {
+    ngOnChanges(changes: SimpleChanges) {
         if (this.showViewer) {
             if (!this.isSourceDefined()) {
                 throw new Error('A content source attribute value is missing.');
             }
 
-            if (this.nodeId) {
+            if (changes.nodeId?.currentValue !== changes.nodeId?.previousValue) {
                 this.setupNode();
             } else if (this.sharedLinkId) {
                 this.setupSharedLink();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://hyland.atlassian.net/browse/ACS-8865
DOCX files could not load preview for the first 20 second, error 409 for renditions and null/ appear in the network tab.

**What is the new behaviour?**

DOCX files can be opened in viewer without errors.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
