### PR TITLE
AAE-26181 Fix layout container overflowing screen

### DIFF
--- a/lib/core/src/lib/layout/components/layout-container/layout-container.component.scss
+++ b/lib/core/src/lib/layout/components/layout-container/layout-container.component.scss
@@ -9,6 +9,7 @@ adf-layout-container {
 
 .adf-container-full-width {
     width: inherit;
+    overflow: hidden;
 }
 
 /* query for Microsoft IE 11 */


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Layout container was allowing content to overflow screen. In this case, scroll logic was handled at the layout container level. This resulted in every child component being scrollable, even if only one component was indeed required to do so.

https://hyland.atlassian.net/browse/AAE-26181


**What is the new behaviour?**
Layout container now prevents content from overflowing screen. Larger content in width, within this layout container, is responsible for implementing its own overflow logic.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
