### PR TITLE
[ACS-8751] Rework search filters to allow initial state and query encoding

### DIFF
--- a/docs/content-services/services/search-query-builder.service.md
+++ b/docs/content-services/services/search-query-builder.service.md
@@ -23,6 +23,8 @@ Stores information from all the custom search and faceted search widgets, compil
 -   **buildQuery**(): `SearchRequest`<br/>
     Builds the current query.
     -   **Returns** `SearchRequest` - The finished query
+-   **encodeQuery**()<br/>
+    Encodes query shards stored in `filterRawParams` property.    
 -   **execute**(queryBody?: `SearchRequest`)<br/>
     Builds and executes the current query.
     -   _queryBody:_ `SearchRequest`  - (Optional)
@@ -70,7 +72,12 @@ Stores information from all the custom search and faceted search widgets, compil
 
 -   **loadConfiguration**(): [`SearchConfiguration`](../../../lib/content-services/src/lib/search/models/search-configuration.interface.ts)<br/>
 
-    -   **Returns** [`SearchConfiguration`](../../../lib/content-services/src/lib/search/models/search-configuration.interface.ts) - 
+    -   **Returns** [`SearchConfiguration`](../../../lib/content-services/src/lib/search/models/search-configuration.interface.ts) -
+
+-   **navigateToSearch**(query: `string`, searchUrl: `string`) <br/>
+    Updates user query, executes existing search configuration, encodes the query and navigates to searchUrl.
+    -   _query:_ `string`  - The query to use as user query
+    -   _searchUrl:_ `string`  - Search url to navigate to
 
 -   **removeFilterQuery**(query: `string`)<br/>
     Removes an existing filter query.
@@ -93,6 +100,8 @@ Stores information from all the custom search and faceted search widgets, compil
 -   **update**(queryBody?: `SearchRequest`)<br/>
     Builds the current query and triggers the `updated` event.
     -   _queryBody:_ `SearchRequest`  - (Optional)
+-   **updateSearchQueryParams**() <br/>
+    Encodes the query and navigates to existing search route adding encoded query as a search param.
 -   **updateSelectedConfiguration**(index: `number`)<br/>
 
     -   _index:_ `number`  -

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel/content-node-selector-panel.component-search.spec.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel/content-node-selector-panel.component-search.spec.ts
@@ -174,7 +174,7 @@ describe('ContentNodeSelectorPanelComponent', () => {
                 tick(debounceSearch);
                 fixture.detectChanges();
 
-                expect(searchSpy).toHaveBeenCalledWith(mockSearchRequest);
+                expect(searchSpy).toHaveBeenCalledWith(false, mockSearchRequest);
             }));
 
             it('should NOT perform a search and clear the results when the search request gets updated and it is NOT defined', async () => {
@@ -212,7 +212,7 @@ describe('ContentNodeSelectorPanelComponent', () => {
                 tick(debounceSearch);
                 fixture.detectChanges();
 
-                expect(searchSpy).toHaveBeenCalledWith(mockSearchRequest);
+                expect(searchSpy).toHaveBeenCalledWith(false, mockSearchRequest);
             }));
 
             it('should the query include the show files filterQuery', fakeAsync(() => {
@@ -227,7 +227,7 @@ describe('ContentNodeSelectorPanelComponent', () => {
                 tick(debounceSearch);
                 fixture.detectChanges();
 
-                expect(searchSpy).toHaveBeenCalledWith(expectedRequest);
+                expect(searchSpy).toHaveBeenCalledWith(false, expectedRequest);
             }));
 
             it('should reset the currently chosen node in case of starting a new search', fakeAsync(() => {
@@ -261,7 +261,7 @@ describe('ContentNodeSelectorPanelComponent', () => {
                 expectedRequest.filterQueries = [{ query: `ANCESTOR:'workspace://SpacesStore/namek'` }];
 
                 expect(searchSpy.calls.count()).toBe(2);
-                expect(searchSpy).toHaveBeenCalledWith(expectedRequest);
+                expect(searchSpy).toHaveBeenCalledWith(false, expectedRequest);
             }));
 
             it('should create the query with the right parameters on changing the site selectBox value from a custom dropdown menu', fakeAsync(() => {
@@ -286,8 +286,8 @@ describe('ContentNodeSelectorPanelComponent', () => {
 
                 expect(searchSpy).toHaveBeenCalled();
                 expect(searchSpy.calls.count()).toBe(2);
-                expect(searchSpy).toHaveBeenCalledWith(mockSearchRequest);
-                expect(searchSpy).toHaveBeenCalledWith(expectedRequest);
+                expect(searchSpy).toHaveBeenCalledWith(false, mockSearchRequest);
+                expect(searchSpy).toHaveBeenCalledWith(false, expectedRequest);
             }));
 
             it('should get the corresponding node ids on search when a known alias is selected from dropdown', fakeAsync(() => {
@@ -407,7 +407,7 @@ describe('ContentNodeSelectorPanelComponent', () => {
                 const expectedRequest = mockSearchRequest;
                 expectedRequest.filterQueries = [{ query: `ANCESTOR:'workspace://SpacesStore/my-root-id'` }];
 
-                expect(searchSpy).toHaveBeenCalledWith(expectedRequest);
+                expect(searchSpy).toHaveBeenCalledWith(false, expectedRequest);
             }));
 
             it('should emit showingSearch event with true while searching', async () => {
@@ -416,7 +416,7 @@ describe('ContentNodeSelectorPanelComponent', () => {
                 spyOn(customResourcesService, 'hasCorrespondingNodeIds').and.returnValue(true);
                 const showingSearchSpy = spyOn(component.showingSearch, 'emit');
 
-                await searchQueryBuilderService.execute({ query: { query: 'search' } });
+                await searchQueryBuilderService.execute(true, { query: { query: 'search' } });
 
                 triggerSearchResults(fakeResultSetPaging);
                 fixture.detectChanges();
@@ -460,7 +460,7 @@ describe('ContentNodeSelectorPanelComponent', () => {
                 searchQueryBuilderService.update();
                 getCorrespondingNodeIdsSpy.and.throwError('Failed');
                 const showingSearchSpy = spyOn(component.showingSearch, 'emit');
-                await searchQueryBuilderService.execute({ query: { query: 'search' } });
+                await searchQueryBuilderService.execute(true, { query: { query: 'search' } });
 
                 triggerSearchResults(fakeResultSetPaging);
                 fixture.detectChanges();
@@ -479,7 +479,7 @@ describe('ContentNodeSelectorPanelComponent', () => {
                 const expectedRequest = mockSearchRequest;
                 expectedRequest.filterQueries = [{ query: `ANCESTOR:'workspace://SpacesStore/my-site-id'` }];
 
-                expect(searchSpy).toHaveBeenCalledWith(expectedRequest);
+                expect(searchSpy).toHaveBeenCalledWith(false, expectedRequest);
             });
 
             it('should restrict the breadcrumb to the currentFolderId in case restrictedRoot is true', async () => {

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel/content-node-selector-panel.component.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel/content-node-selector-panel.component.ts
@@ -343,7 +343,7 @@ export class ContentNodeSelectorPanelComponent implements OnInit, OnDestroy {
             if (searchRequest) {
                 this.hasValidQuery = true;
                 this.prepareDialogForNewSearch(searchRequest);
-                this.queryBuilderService.execute(searchRequest);
+                this.queryBuilderService.execute(false, searchRequest);
             } else {
                 this.hasValidQuery = false;
                 this.resetFolderToShow();

--- a/lib/content-services/src/lib/search/components/search-chip-autocomplete-input/search-chip-autocomplete-input.component.spec.ts
+++ b/lib/content-services/src/lib/search/components/search-chip-autocomplete-input/search-chip-autocomplete-input.component.spec.ts
@@ -122,6 +122,12 @@ describe('SearchChipAutocompleteInputComponent', () => {
         return fixture.debugElement.queryAll(By.css('.adf-autocomplete-added-option'));
     }
 
+    it('should assign preselected values to selected options on init', () => {
+        component.preselectedOptions = [{ value: 'option1' }];
+        component.ngOnInit();
+        expect(component.selectedOptions).toEqual([{ value: 'option1' }]);
+    });
+
     it('should add new option only if value is predefined when allowOnlyPredefinedValues = true', async () => {
         addNewOption('test');
         addNewOption('option1');

--- a/lib/content-services/src/lib/search/components/search-chip-autocomplete-input/search-chip-autocomplete-input.component.ts
+++ b/lib/content-services/src/lib/search/components/search-chip-autocomplete-input/search-chip-autocomplete-input.component.ts
@@ -56,6 +56,9 @@ export class SearchChipAutocompleteInputComponent implements OnInit, OnDestroy, 
     autocompleteOptions: AutocompleteOption[] = [];
 
     @Input()
+    preselectedOptions: AutocompleteOption[] = [];
+
+    @Input()
     onReset$: Observable<void>;
 
     @Input()
@@ -106,6 +109,7 @@ export class SearchChipAutocompleteInputComponent implements OnInit, OnDestroy, 
                 this.inputChanged.emit(value);
             });
         this.onReset$?.pipe(takeUntil(this.onDestroy$)).subscribe(() => this.reset());
+        this.selectedOptions = this.preselectedOptions ?? [];
     }
 
     ngOnChanges(changes: SimpleChanges) {

--- a/lib/content-services/src/lib/search/components/search-date-range-tabbed/search-date-range-tabbed.component.html
+++ b/lib/content-services/src/lib/search/components/search-date-range-tabbed/search-date-range-tabbed.component.html
@@ -5,7 +5,7 @@
             [dateFormat]="settings.dateFormat"
             [maxDate]="settings.maxDate"
             [field]="field"
-            [initialValue]="startValue"
+            [initialValue]="preselectedValues[field]"
             (changed)="onDateRangedValueChanged($event, field)"
             (valid)="tabsValidity[field]=$event">
         </adf-search-date-range>

--- a/lib/content-services/src/lib/search/components/search-filter-autocomplete-chips/search-filter-autocomplete-chips.component.html
+++ b/lib/content-services/src/lib/search/components/search-filter-autocomplete-chips/search-filter-autocomplete-chips.component.html
@@ -1,5 +1,6 @@
 <adf-search-chip-autocomplete-input
     [autocompleteOptions]="autocompleteOptions$ | async"
+    [preselectedOptions]="selectedOptions"
     [onReset$]="reset$"
     [allowOnlyPredefinedValues]="settings.allowOnlyPredefinedValues"
     (inputChanged)="onInputChange($event)"

--- a/lib/content-services/src/lib/search/components/search-filter-chips/search-widget-chip/search-widget-chip.component.ts
+++ b/lib/content-services/src/lib/search/components/search-filter-chips/search-widget-chip/search-widget-chip.component.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Component, ElementRef, Input, ViewChild, ViewEncapsulation } from '@angular/core';
+import { AfterViewInit, ChangeDetectorRef, Component, ElementRef, Input, ViewChild, ViewEncapsulation } from '@angular/core';
 import { SearchCategory } from '../../../models/search-category.interface';
 import { ConfigurableFocusTrap, ConfigurableFocusTrapFactory } from '@angular/cdk/a11y';
 import { MatMenuModule, MatMenuTrigger } from '@angular/material/menu';
@@ -26,6 +26,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import { MatIconModule } from '@angular/material/icon';
 import { SearchFilterMenuCardComponent } from '../search-filter-menu-card/search-filter-menu-card.component';
 import { MatButtonModule } from '@angular/material/button';
+import { first } from 'rxjs/operators';
 
 @Component({
     selector: 'adf-search-widget-chip',
@@ -50,7 +51,7 @@ import { MatButtonModule } from '@angular/material/button';
     ],
     encapsulation: ViewEncapsulation.None
 })
-export class SearchWidgetChipComponent {
+export class SearchWidgetChipComponent implements AfterViewInit {
     @Input()
     category: SearchCategory;
 
@@ -66,7 +67,16 @@ export class SearchWidgetChipComponent {
     focusTrap: ConfigurableFocusTrap;
     chipIcon = 'keyboard_arrow_down';
 
-    constructor(private focusTrapFactory: ConfigurableFocusTrapFactory) {}
+    constructor(private cd: ChangeDetectorRef, private focusTrapFactory: ConfigurableFocusTrapFactory) {}
+
+    ngAfterViewInit(): void {
+        this.widgetContainerComponent
+            ?.getDisplayValue()
+            .pipe(first())
+            .subscribe(() => {
+                this.cd.detectChanges();
+            });
+    }
 
     onMenuOpen() {
         if (this.menuContainer && !this.focusTrap) {

--- a/lib/content-services/src/lib/search/components/search-panel/search-panel.component.spec.ts
+++ b/lib/content-services/src/lib/search/components/search-panel/search-panel.component.spec.ts
@@ -15,194 +15,44 @@
  * limitations under the License.
  */
 
-import { SearchCheckListComponent, SearchListOption } from '../search-check-list/search-check-list.component';
-import { SearchFilterList } from '../../models/search-filter-list.model';
 import { ContentTestingModule } from '../../../testing/content.testing.module';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { sizeOptions, stepOne, stepThree } from '../../../mock';
-import { HarnessLoader, TestKey } from '@angular/cdk/testing';
-import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { MatCheckboxHarness } from '@angular/material/checkbox/testing';
+import { SearchPanelComponent } from './search-panel.component';
 import { By } from '@angular/platform-browser';
+import { ContentNodeSelectorPanelService } from '../../../content-node-selector';
+import { SearchCategory } from '../../models';
 
-describe('SearchCheckListComponent', () => {
-    let loader: HarnessLoader;
-    let fixture: ComponentFixture<SearchCheckListComponent>;
-    let component: SearchCheckListComponent;
+describe('SearchPanelComponent', () => {
+    let fixture: ComponentFixture<SearchPanelComponent>;
+    let contentNodeSelectorPanelService: ContentNodeSelectorPanelService;
+
+    const getSearchFilter = () => fixture.debugElement.query(By.css('.app-search-settings'));
 
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [ContentTestingModule]
         });
-        fixture = TestBed.createComponent(SearchCheckListComponent);
-        component = fixture.componentInstance;
+        fixture = TestBed.createComponent(SearchPanelComponent);
+        contentNodeSelectorPanelService = TestBed.inject(ContentNodeSelectorPanelService);
 
         fixture.detectChanges();
-        loader = TestbedHarnessEnvironment.loader(fixture);
     });
 
-    it('should setup options from settings', () => {
-        const options: any = [
-            { name: 'Folder', value: `TYPE:'cm:folder'` },
-            { name: 'Document', value: `TYPE:'cm:content'` }
+    it('should not render search filter when no custom models are available', () => {
+        contentNodeSelectorPanelService.customModels = [];
+        spyOn(contentNodeSelectorPanelService, 'convertCustomModelPropertiesToSearchCategories').and.returnValue([]);
+        fixture.detectChanges();
+        expect(getSearchFilter()).toBeNull();
+    });
+
+    it('should render search filter when some custom models are available', () => {
+        const categoriesMock: SearchCategory[] = [
+            { id: 'model1', name: 'model1', enabled: true, expanded: false, component: { selector: 'test', settings: { field: 'test' } } },
+            { id: 'model2', name: 'model2', enabled: true, expanded: false, component: { selector: 'test2', settings: { field: 'test2' } } }
         ];
-        component.settings = { options } as any;
-        component.ngOnInit();
-
-        expect(component.options.items).toEqual(options);
-    });
-
-    it('should handle enter key as click on checkboxes', async () => {
-        component.options = new SearchFilterList<SearchListOption>([
-            { name: 'Folder', value: `TYPE:'cm:folder'`, checked: false },
-            { name: 'Document', value: `TYPE:'cm:content'`, checked: false }
-        ]);
-
-        component.ngOnInit();
+        contentNodeSelectorPanelService.customModels = ['model1', 'model2'];
+        spyOn(contentNodeSelectorPanelService, 'convertCustomModelPropertiesToSearchCategories').and.returnValue(categoriesMock);
         fixture.detectChanges();
-
-        const options = await loader.getAllHarnesses(MatCheckboxHarness);
-        await (await options[0].host()).sendKeys(TestKey.ENTER);
-        expect(await options[0].isChecked()).toBe(true);
-
-        await (await options[0].host()).sendKeys(TestKey.ENTER);
-        expect(await options[0].isChecked()).toBe(false);
-    });
-
-    it('should setup operator from the settings', () => {
-        component.settings = { operator: 'AND' } as any;
-        component.ngOnInit();
-        expect(component.operator).toBe('AND');
-    });
-
-    it('should use OR operator by default', () => {
-        component.settings = { operator: null } as any;
-        component.ngOnInit();
-        expect(component.operator).toBe('OR');
-    });
-
-    it('should update query builder on checkbox change', () => {
-        component.options = new SearchFilterList<SearchListOption>([
-            { name: 'Folder', value: `TYPE:'cm:folder'`, checked: false },
-            { name: 'Document', value: `TYPE:'cm:content'`, checked: false }
-        ]);
-
-        component.id = 'checklist';
-        component.context = {
-            queryFragments: {},
-            update: () => {}
-        } as any;
-
-        component.ngOnInit();
-
-        spyOn(component.context, 'update').and.stub();
-
-        component.changeHandler({ checked: true } as any, component.options.items[0]);
-
-        expect(component.context.queryFragments[component.id]).toEqual(`TYPE:'cm:folder'`);
-
-        component.changeHandler({ checked: true } as any, component.options.items[1]);
-
-        expect(component.context.queryFragments[component.id]).toEqual(`TYPE:'cm:folder' OR TYPE:'cm:content'`);
-    });
-
-    it('should reset selected boxes', () => {
-        component.options = new SearchFilterList<SearchListOption>([
-            { name: 'Folder', value: `TYPE:'cm:folder'`, checked: true },
-            { name: 'Document', value: `TYPE:'cm:content'`, checked: true }
-        ]);
-
-        component.reset();
-
-        expect(component.options.items[0].checked).toBeFalsy();
-        expect(component.options.items[1].checked).toBeFalsy();
-    });
-
-    it('should update query builder on reset', () => {
-        component.id = 'checklist';
-        component.context = {
-            queryFragments: {
-                checklist: 'query'
-            },
-            update: () => {}
-        } as any;
-        spyOn(component.context, 'update').and.stub();
-
-        component.ngOnInit();
-        component.options = new SearchFilterList<SearchListOption>([
-            { name: 'Folder', value: `TYPE:'cm:folder'`, checked: true },
-            { name: 'Document', value: `TYPE:'cm:content'`, checked: true }
-        ]);
-
-        component.reset();
-
-        expect(component.context.update).toHaveBeenCalled();
-        expect(component.context.queryFragments[component.id]).toBe('');
-    });
-
-    describe('Pagination', () => {
-        it('should show 5 items when pageSize not defined', async () => {
-            component.id = 'checklist';
-            component.context = {
-                queryFragments: {
-                    checklist: 'query'
-                },
-                update: () => {}
-            } as any;
-            component.settings = { options: sizeOptions } as any;
-
-            component.ngOnInit();
-            fixture.detectChanges();
-
-            const options = await loader.getAllHarnesses(MatCheckboxHarness);
-            expect(options.length).toEqual(5);
-
-            const labels = await Promise.all(Array.from(options).map(async (element) => element.getLabelText()));
-            expect(labels).toEqual(stepOne);
-        });
-
-        it('should show all items when pageSize is high', async () => {
-            component.id = 'checklist';
-            component.context = {
-                queryFragments: {
-                    checklist: 'query'
-                },
-                update: () => {}
-            } as any;
-            component.settings = { pageSize: 15, options: sizeOptions } as any;
-            component.ngOnInit();
-            fixture.detectChanges();
-
-            const options = await loader.getAllHarnesses(MatCheckboxHarness);
-            expect(options.length).toEqual(13);
-
-            const labels = await Promise.all(Array.from(options).map(async (element) => element.getLabelText()));
-            expect(labels).toEqual(stepThree);
-        });
-    });
-
-    it('should able to check/reset the checkbox', async () => {
-        component.id = 'checklist';
-        component.context = {
-            queryFragments: {
-                checklist: 'query'
-            },
-            update: () => {}
-        } as any;
-        component.settings = { options: sizeOptions } as any;
-        spyOn(component, 'submitValues').and.stub();
-        component.ngOnInit();
-        fixture.detectChanges();
-
-        const checkbox = await loader.getHarness(MatCheckboxHarness);
-        await checkbox.check();
-
-        expect(component.submitValues).toHaveBeenCalled();
-
-        const clearAllElement = fixture.debugElement.query(By.css('button[title="SEARCH.FILTER.ACTIONS.CLEAR-ALL"]'));
-        clearAllElement.triggerEventHandler('click', {});
-        fixture.detectChanges();
-
-        expect(await checkbox.isChecked()).toBe(false);
+        expect(getSearchFilter()).toBeDefined();
     });
 });

--- a/lib/content-services/src/lib/search/components/search-properties/search-properties.component.html
+++ b/lib/content-services/src/lib/search/components/search-properties/search-properties.component.html
@@ -46,6 +46,7 @@
     <p class="adf-search-properties-file-type-label">{{ 'SEARCH.SEARCH_PROPERTIES.FILE_TYPE' | translate }}</p>
     <adf-search-chip-autocomplete-input
         [autocompleteOptions]="autocompleteOptions"
+        [preselectedOptions]="preselectedOptions"
         (optionsChanged)="selectedExtensions = $event"
         [onReset$]="reset$"
         [allowOnlyPredefinedValues]="false"

--- a/lib/content-services/src/lib/search/components/search-radio/search-radio.component.ts
+++ b/lib/content-services/src/lib/search/components/search-radio/search-radio.component.ts
@@ -22,7 +22,8 @@ import { SearchWidget } from '../../models/search-widget.interface';
 import { SearchWidgetSettings } from '../../models/search-widget-settings.interface';
 import { SearchQueryBuilderService } from '../../services/search-query-builder.service';
 import { SearchFilterList } from '../../models/search-filter-list.model';
-import { Subject } from 'rxjs';
+import { ReplaySubject } from 'rxjs';
+import { first } from 'rxjs/operators';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
@@ -56,7 +57,7 @@ export class SearchRadioComponent implements SearchWidget, OnInit {
     isActive = false;
     startValue: any;
     enableChangeUpdate: boolean;
-    displayValue$: Subject<string> = new Subject<string>();
+    displayValue$: ReplaySubject<string> = new ReplaySubject<string>(1);
 
     constructor() {
         this.options = new SearchFilterList<SearchRadioOption>();
@@ -82,6 +83,16 @@ export class SearchRadioComponent implements SearchWidget, OnInit {
         }
         this.enableChangeUpdate = this.settings.allowUpdateOnChange ?? true;
         this.updateDisplayValue();
+        this.context.populateFilters
+            .asObservable()
+            .pipe(first())
+            .subscribe((filtersQueries) => {
+                if (filtersQueries[this.id]) {
+                    this.value = filtersQueries[this.id];
+                    this.submitValues(false);
+                    this.context.filterLoaded.next();
+                }
+            });
     }
 
     private getSelectedValue(): string {
@@ -98,10 +109,12 @@ export class SearchRadioComponent implements SearchWidget, OnInit {
         return null;
     }
 
-    submitValues() {
+    submitValues(updateContext = true) {
         this.setValue(this.value);
         this.updateDisplayValue();
-        this.context.update();
+        if (updateContext) {
+            this.context.update();
+        }
     }
 
     hasValidValue() {
@@ -112,6 +125,7 @@ export class SearchRadioComponent implements SearchWidget, OnInit {
     setValue(newValue: string) {
         this.value = newValue;
         this.context.queryFragments[this.id] = newValue;
+        this.context.filterRawParams[this.id] = newValue;
         if (this.enableChangeUpdate) {
             this.updateDisplayValue();
             this.context.update();

--- a/lib/content-services/src/lib/search/components/search-sorting-picker/search-sorting-picker.component.spec.ts
+++ b/lib/content-services/src/lib/search/components/search-sorting-picker/search-sorting-picker.component.spec.ts
@@ -17,42 +17,45 @@
 
 import { SearchSortingPickerComponent } from './search-sorting-picker.component';
 import { SearchQueryBuilderService } from '../../services/search-query-builder.service';
-import { AppConfigService } from '@alfresco/adf-core';
-import { SearchConfiguration } from '../../models/search-configuration.interface';
-import { TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ContentTestingModule } from '../../../testing/content.testing.module';
-import { AlfrescoApiService } from '../../../services/alfresco-api.service';
+import { SearchConfiguration } from '../../models';
 
 describe('SearchSortingPickerComponent', () => {
-    let queryBuilder: SearchQueryBuilderService;
+    let fixture: ComponentFixture<SearchSortingPickerComponent>;
     let component: SearchSortingPickerComponent;
 
-    const buildConfig = (searchSettings): AppConfigService => {
-        const config = TestBed.inject(AppConfigService);
-        config.config.search = searchSettings;
-        return config;
+    const config: SearchConfiguration = {
+        sorting: {
+            options: [
+                { key: 'name', label: 'Name', type: 'FIELD', field: 'cm:name', ascending: true },
+                { key: 'content.sizeInBytes', label: 'Size', type: 'FIELD', field: 'content.size', ascending: true },
+                { key: 'description', label: 'Description', type: 'FIELD', field: 'cm:description', ascending: true }
+            ],
+            defaults: [{ key: 'name', type: 'FIELD', field: 'cm:name', ascending: false } as any]
+        },
+        categories: [{ id: 'cat1', enabled: true } as any]
+    };
+
+    const queryBuilder = {
+        getSortingOptions: () => config.sorting.options,
+        getPrimarySorting: () => config.sorting.defaults[0],
+        sorting: config.sorting.options,
+        update: jasmine.createSpy('update')
     };
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [ContentTestingModule]
+            imports: [ContentTestingModule],
+            providers: [
+                {
+                    provide: SearchQueryBuilderService,
+                    useValue: queryBuilder
+                }
+            ]
         });
-
-        const config: SearchConfiguration = {
-            sorting: {
-                options: [
-                    { key: 'name', label: 'Name', type: 'FIELD', field: 'cm:name', ascending: true },
-                    { key: 'content.sizeInBytes', label: 'Size', type: 'FIELD', field: 'content.size', ascending: true },
-                    { key: 'description', label: 'Description', type: 'FIELD', field: 'cm:description', ascending: true }
-                ],
-                defaults: [{ key: 'name', type: 'FIELD', field: 'cm:name', ascending: false } as any]
-            },
-            categories: [{ id: 'cat1', enabled: true } as any]
-        };
-        const alfrescoApiService = TestBed.inject(AlfrescoApiService);
-
-        queryBuilder = new SearchQueryBuilderService(buildConfig(config), alfrescoApiService);
-        component = new SearchSortingPickerComponent(queryBuilder);
+        fixture = TestBed.createComponent(SearchSortingPickerComponent);
+        component = fixture.componentInstance;
     });
 
     it('should load options from query builder', () => {
@@ -72,8 +75,6 @@ describe('SearchSortingPickerComponent', () => {
     });
 
     it('should update query builder each time selection is changed', () => {
-        spyOn(queryBuilder, 'update').and.stub();
-
         component.ngOnInit();
         component.onValueChanged('description');
 
@@ -84,8 +85,6 @@ describe('SearchSortingPickerComponent', () => {
     });
 
     it('should update query builder each time sorting is changed', () => {
-        spyOn(queryBuilder, 'update').and.stub();
-
         component.ngOnInit();
         component.onSortingChanged(false);
 

--- a/lib/content-services/src/lib/search/models/search-widget.interface.ts
+++ b/lib/content-services/src/lib/search/models/search-widget.interface.ts
@@ -17,7 +17,7 @@
 
 import { SearchWidgetSettings } from './search-widget-settings.interface';
 import { SearchQueryBuilderService } from '../services/search-query-builder.service';
-import { Subject } from 'rxjs';
+import { ReplaySubject } from 'rxjs';
 
 export interface SearchWidget {
     id: string;
@@ -27,7 +27,7 @@ export interface SearchWidget {
     isActive?: boolean;
     startValue: any;
     /* stream emit value on changes */
-    displayValue$: Subject<string>;
+    displayValue$: ReplaySubject<string>;
     /* reset the value and update the search */
     reset(): void;
     /* update the search with field value */

--- a/lib/content-services/src/lib/search/services/search-facet-filters.service.ts
+++ b/lib/content-services/src/lib/search/services/search-facet-filters.service.ts
@@ -69,7 +69,7 @@ export class SearchFacetFiltersService implements OnDestroy {
             this.responseFacets = null;
         });
 
-        this.queryBuilder.updated.pipe(takeUntil(this.onDestroy$)).subscribe((query) => this.queryBuilder.execute(query));
+        this.queryBuilder.updated.pipe(takeUntil(this.onDestroy$)).subscribe((query) => this.queryBuilder.execute(true, query));
 
         this.queryBuilder.executed.pipe(takeUntil(this.onDestroy$)).subscribe((resultSetPaging: ResultSetPaging) => {
             this.onDataLoaded(resultSetPaging);

--- a/lib/content-services/src/lib/search/services/search-header-query-builder.service.spec.ts
+++ b/lib/content-services/src/lib/search/services/search-header-query-builder.service.spec.ts
@@ -23,7 +23,6 @@ import { ContentTestingModule } from '../../testing/content.testing.module';
 import { AlfrescoApiService } from '../../services/alfresco-api.service';
 
 describe('SearchHeaderQueryBuilderService', () => {
-
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [ContentTestingModule]
@@ -36,21 +35,22 @@ describe('SearchHeaderQueryBuilderService', () => {
         return config;
     };
 
+    const createQueryBuilder = (searchSettings): SearchHeaderQueryBuilderService => {
+        let builder: SearchHeaderQueryBuilderService;
+        TestBed.runInInjectionContext(() => {
+            const alfrescoApiService = TestBed.inject(AlfrescoApiService);
+            builder = new SearchHeaderQueryBuilderService(buildConfig(searchSettings), alfrescoApiService, null);
+        });
+        return builder;
+    };
+
     it('should load the configuration from app config', () => {
         const config: SearchConfiguration = {
-            categories: [
-                { id: 'cat1', enabled: true } as any,
-                { id: 'cat2', enabled: true } as any
-            ],
+            categories: [{ id: 'cat1', enabled: true } as any, { id: 'cat2', enabled: true } as any],
             filterQueries: [{ query: 'query1' }, { query: 'query2' }]
         };
 
-        const alfrescoApiService = TestBed.inject(AlfrescoApiService);
-        const builder = new SearchHeaderQueryBuilderService(
-            buildConfig(config),
-            alfrescoApiService,
-            null
-        );
+        const builder = createQueryBuilder(config);
 
         builder.categories = [];
         builder.filterQueries = [];
@@ -73,12 +73,7 @@ describe('SearchHeaderQueryBuilderService', () => {
             filterQueries: [{ query: 'query1' }, { query: 'query2' }]
         };
 
-        const alfrescoApiService = TestBed.inject(AlfrescoApiService);
-        const service = new SearchHeaderQueryBuilderService(
-            buildConfig(config),
-            alfrescoApiService,
-            null
-        );
+        const service = createQueryBuilder(config);
 
         const category = service.getCategoryForColumn('fake-key-1');
         expect(category).not.toBeNull();
@@ -87,34 +82,19 @@ describe('SearchHeaderQueryBuilderService', () => {
     });
 
     it('should have empty user query by default', () => {
-        const alfrescoApiService = TestBed.inject(AlfrescoApiService);
-        const builder = new SearchHeaderQueryBuilderService(
-            buildConfig({}),
-            alfrescoApiService,
-            null
-        );
+        const builder = createQueryBuilder({});
         expect(builder.userQuery).toBe('');
     });
 
     it('should add the extra filter for the parent node', () => {
         const config: SearchConfiguration = {
-            categories: [
-                { id: 'cat1', enabled: true } as any,
-                { id: 'cat2', enabled: true } as any
-            ],
+            categories: [{ id: 'cat1', enabled: true } as any, { id: 'cat2', enabled: true } as any],
             filterQueries: [{ query: 'query1' }, { query: 'query2' }]
         };
 
-        const expectedResult = [
-            { query: 'PARENT:"workspace://SpacesStore/fake-node-id"' }
-        ];
+        const expectedResult = [{ query: 'PARENT:"workspace://SpacesStore/fake-node-id"' }];
 
-        const alfrescoApiService = TestBed.inject(AlfrescoApiService);
-        const searchHeaderService = new SearchHeaderQueryBuilderService(
-            buildConfig(config),
-            alfrescoApiService,
-            null
-        );
+        const searchHeaderService = createQueryBuilder(config);
 
         searchHeaderService.setCurrentRootFolderId('fake-node-id');
 
@@ -122,52 +102,28 @@ describe('SearchHeaderQueryBuilderService', () => {
     });
 
     it('should not add again the parent filter if that node is already added', () => {
-
-        const expectedResult = [
-            { query: 'PARENT:"workspace://SpacesStore/fake-node-id"' }
-        ];
+        const expectedResult = [{ query: 'PARENT:"workspace://SpacesStore/fake-node-id"' }];
 
         const config: SearchConfiguration = {
-            categories: [
-                { id: 'cat1', enabled: true } as any,
-                { id: 'cat2', enabled: true } as any
-            ],
+            categories: [{ id: 'cat1', enabled: true } as any, { id: 'cat2', enabled: true } as any],
             filterQueries: expectedResult
         };
 
-        const alfrescoApiService = TestBed.inject(AlfrescoApiService);
-        const searchHeaderService = new SearchHeaderQueryBuilderService(
-            buildConfig(config),
-            alfrescoApiService,
-            null
-        );
-
+        const searchHeaderService = createQueryBuilder(config);
         searchHeaderService.setCurrentRootFolderId('fake-node-id');
 
-        expect(searchHeaderService.filterQueries).toEqual(
-            expectedResult,
-            'Filters are not as expected'
-        );
+        expect(searchHeaderService.filterQueries).toEqual(expectedResult, 'Filters are not as expected');
     });
 
     it('should not add duplicate column names in activeFilters', () => {
         const activeFilter = 'FakeColumn';
 
         const config: SearchConfiguration = {
-            categories: [
-                { id: 'cat1', enabled: true } as any
-            ],
-            filterQueries: [
-                { query: 'PARENT:"workspace://SpacesStore/fake-node-id' }
-            ]
+            categories: [{ id: 'cat1', enabled: true } as any],
+            filterQueries: [{ query: 'PARENT:"workspace://SpacesStore/fake-node-id' }]
         };
 
-        const alfrescoApiService = TestBed.inject(AlfrescoApiService);
-        const searchHeaderService = new SearchHeaderQueryBuilderService(
-            buildConfig(config),
-            alfrescoApiService,
-            null
-        );
+        const searchHeaderService = createQueryBuilder(config);
 
         expect(searchHeaderService.activeFilters.length).toBe(0);
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://hyland.atlassian.net/browse/ACS-8751

**What is the new behaviour?**

Query builder service now stores configuration per each configured and used filter including provided values, this configuration is then encoded and pushed to query params, this configuration is updated when any filter is interacted with and when query is executed, `userQuery` is also included. Additionally every filter during initialization now listens to `populateFilters` subject which pushes initial state for the filter when query param is populated and page is reloaded. Additionally when query is executed it updates existing path with new encoded state of filters.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
