### PR TITLE
AAE-26163 Fix infinite loop when authentication error event occured

### DIFF
--- a/lib/core/src/lib/auth/guard/auth-guard-bpm.service.spec.ts
+++ b/lib/core/src/lib/auth/guard/auth-guard-bpm.service.spec.ts
@@ -51,7 +51,8 @@ describe('AuthGuardService BPM', () => {
                         ssoLogin: () => {},
                         isPublicUrl: () => false,
                         hasValidIdToken: () => false,
-                        isLoggedIn: () => false
+                        isLoggedIn: () => false,
+                        shouldPerformSsoLogin$: of(true)
                     }
                 }
             ]

--- a/lib/core/src/lib/auth/guard/auth-guard-ecm.service.spec.ts
+++ b/lib/core/src/lib/auth/guard/auth-guard-ecm.service.spec.ts
@@ -50,7 +50,8 @@ describe('AuthGuardService ECM', () => {
                         ssoLogin: () => {},
                         isPublicUrl: () => false,
                         hasValidIdToken: () => false,
-                        isLoggedIn: () => false
+                        isLoggedIn: () => false,
+                        shouldPerformSsoLogin$: of(true)
                     }
                 },
                 { provide: RedirectAuthService, useValue: { onLogin: EMPTY, onTokenReceived: of() } }

--- a/lib/core/src/lib/auth/guard/auth-guard.service.spec.ts
+++ b/lib/core/src/lib/auth/guard/auth-guard.service.spec.ts
@@ -52,7 +52,8 @@ describe('AuthGuardService', () => {
                     useValue: {
                         ssoLogin: () => {},
                         isPublicUrl: () => false,
-                        hasValidIdToken: () => false
+                        hasValidIdToken: () => false,
+                        shouldPerformSsoLogin$: of(true)
                     }
                 }
             ]
@@ -142,6 +143,19 @@ describe('AuthGuardService', () => {
 
         expect(await authGuard).toBeFalsy();
         expect(oidcAuthenticationService.ssoLogin).toHaveBeenCalledTimes(1);
+    });
+
+    it('should NOT call ssoLogin if user is authenticated or discovery document is not loaded', async () => {
+        spyOn(oidcAuthenticationService, 'ssoLogin').and.stub();
+        spyOn(authService, 'isLoggedIn').and.returnValue(false);
+        spyOn(authService, 'isOauth').and.returnValue(true);
+        appConfigService.config.oauth2.silentLogin = true;
+        oidcAuthenticationService.shouldPerformSsoLogin$ = of(false);
+
+        authGuard = TestBed.runInInjectionContext(() => AuthGuard(route, state)) as Promise<boolean>;
+
+        expect(await authGuard).toBeFalsy();
+        expect(oidcAuthenticationService.ssoLogin).toHaveBeenCalledTimes(0);
     });
 
     it('should set redirect url', async () => {

--- a/lib/core/src/lib/auth/guard/auth-guard.service.ts
+++ b/lib/core/src/lib/auth/guard/auth-guard.service.ts
@@ -71,7 +71,10 @@ export class AuthGuardService {
             urlToRedirect = `${urlToRedirect}?redirectUrl=${url}`;
             return this.navigate(urlToRedirect);
         } else if (this.getOauthConfig().silentLogin && !this.oidcAuthenticationService.isPublicUrl()) {
-            if (!this.oidcAuthenticationService.hasValidIdToken() || !this.oidcAuthenticationService.hasValidAccessToken()) {
+            const shouldPerformSsoLogin = await new Promise((resolve) => {
+                this.oidcAuthenticationService.shouldPerformSsoLogin$.subscribe(value => resolve(value));
+            });
+            if (shouldPerformSsoLogin) {
                 this.oidcAuthenticationService.ssoLogin(url);
             }
         } else {

--- a/lib/core/src/lib/auth/oidc/auth.module.ts
+++ b/lib/core/src/lib/auth/oidc/auth.module.ts
@@ -25,6 +25,8 @@ import { AuthRoutingModule } from './auth-routing.module';
 import { AuthService } from './auth.service';
 import { RedirectAuthService } from './redirect-auth.service';
 import { AuthenticationConfirmationComponent } from './view/authentication-confirmation/authentication-confirmation.component';
+import { HTTP_INTERCEPTORS } from '@angular/common/http';
+import { TokenInterceptor } from './token.interceptor';
 
 /**
  * Create a Login Factory function
@@ -41,7 +43,7 @@ export function loginFactory(redirectService: RedirectAuthService): () => Promis
     imports: [AuthRoutingModule, OAuthModule.forRoot()],
     providers: [
         { provide: OAuthStorage, useExisting: StorageService },
-        { provide: AuthenticationService},
+        { provide: AuthenticationService },
         {
             provide: AUTH_CONFIG,
             useFactory: authConfigFactory,
@@ -53,6 +55,11 @@ export function loginFactory(redirectService: RedirectAuthService): () => Promis
             provide: APP_INITIALIZER,
             useFactory: loginFactory,
             deps: [RedirectAuthService],
+            multi: true
+        },
+        {
+            provide: HTTP_INTERCEPTORS,
+            useClass: TokenInterceptor,
             multi: true
         }
     ]

--- a/lib/core/src/lib/auth/oidc/auth.service.ts
+++ b/lib/core/src/lib/auth/oidc/auth.service.ts
@@ -26,6 +26,15 @@ export abstract class AuthService {
 
   abstract onTokenReceived: Observable<any>;
 
+  /**
+   * An abstract observable that emits a boolean value indicating whether the discovery document
+   * has been successfully loaded.
+   *
+   * @observable
+   * @type {Observable<boolean>}
+   */
+  abstract isDiscoveryDocumentLoaded$: Observable<boolean>;
+
   /** Subscribe to whether the user has valid Id/Access tokens.  */
   abstract authenticated$: Observable<boolean>;
 

--- a/lib/core/src/lib/auth/oidc/auth.service.ts
+++ b/lib/core/src/lib/auth/oidc/auth.service.ts
@@ -24,6 +24,15 @@ import { Observable } from 'rxjs';
 export abstract class AuthService {
   abstract onLogin: Observable<any>;
 
+  /**
+   * An observable that emits a value when a logout event occurs.
+   * Implement this observable to handle any necessary cleanup or state updates
+   * when a user logs out of the application.
+   *
+   * @type {Observable<void>}
+   */
+  abstract onLogout$: Observable<void>;
+
   abstract onTokenReceived: Observable<any>;
 
   /**

--- a/lib/core/src/lib/auth/oidc/auth.service.ts
+++ b/lib/core/src/lib/auth/oidc/auth.service.ts
@@ -30,7 +30,6 @@ export abstract class AuthService {
    * An abstract observable that emits a boolean value indicating whether the discovery document
    * has been successfully loaded.
    *
-   * @observable
    * @type {Observable<boolean>}
    */
   abstract isDiscoveryDocumentLoaded$: Observable<boolean>;

--- a/lib/core/src/lib/auth/oidc/oidc-auth.guard.spec.ts
+++ b/lib/core/src/lib/auth/oidc/oidc-auth.guard.spec.ts
@@ -40,16 +40,6 @@ describe('OidcAuthGuard', () => {
         authServiceSpy = TestBed.inject(AuthService) as jasmine.SpyObj<AuthService>;
     });
 
-    describe('canActivate', () => {
-        it('should return true if is authenticated', async () => {
-            authServiceSpy.authenticated = true;
-
-            const oidcAuthGuard = await TestBed.runInInjectionContext(() => OidcAuthGuard(route, state));
-
-            expect(oidcAuthGuard).toBe(true);
-        });
-    });
-
     describe('isAuthenticated', () => {
         it('should call loginCallback and navigateByUrl if not authenticated', async () => {
             authServiceSpy.authenticated = false;

--- a/lib/core/src/lib/auth/oidc/oidc-auth.guard.ts
+++ b/lib/core/src/lib/auth/oidc/oidc-auth.guard.ts
@@ -22,13 +22,21 @@ import { AuthService } from './auth.service';
 const ROUTE_DEFAULT = '/';
 
 export const OidcAuthGuard: CanActivateFn = async (): Promise<boolean> => {
+    let onLogoutEmitted = false;
+
     const authService = inject(AuthService);
     const router = inject(Router);
+
+    authService.onLogout$.subscribe(() => onLogoutEmitted = true);
 
     try {
         const route = await authService.loginCallback({ customHashFragment: window.location.search });
         return router.navigateByUrl(route, { replaceUrl: true });
     } catch (error) {
+        console.log('onLogoutEmitted: ', onLogoutEmitted);
+        if (onLogoutEmitted) {
+            throw error;
+        }
         return router.navigateByUrl(ROUTE_DEFAULT, { replaceUrl: true });
     }
 };

--- a/lib/core/src/lib/auth/oidc/oidc-auth.guard.ts
+++ b/lib/core/src/lib/auth/oidc/oidc-auth.guard.ts
@@ -27,13 +27,12 @@ export const OidcAuthGuard: CanActivateFn = async (): Promise<boolean> => {
     const authService = inject(AuthService);
     const router = inject(Router);
 
-    authService.onLogout$.subscribe(() => onLogoutEmitted = true);
+    authService.onLogout$.subscribe(() => (onLogoutEmitted = true));
 
     try {
         const route = await authService.loginCallback({ customHashFragment: window.location.search });
         return router.navigateByUrl(route, { replaceUrl: true });
     } catch (error) {
-        console.log('onLogoutEmitted: ', onLogoutEmitted);
         if (onLogoutEmitted) {
             throw error;
         }

--- a/lib/core/src/lib/auth/oidc/oidc-auth.guard.ts
+++ b/lib/core/src/lib/auth/oidc/oidc-auth.guard.ts
@@ -25,10 +25,6 @@ export const OidcAuthGuard: CanActivateFn = async (): Promise<boolean> => {
     const authService = inject(AuthService);
     const router = inject(Router);
 
-    if (authService.authenticated) {
-        return Promise.resolve(true);
-    }
-
     try {
         const route = await authService.loginCallback({ customHashFragment: window.location.search });
         return router.navigateByUrl(route, { replaceUrl: true });

--- a/lib/core/src/lib/auth/oidc/oidc-authentication.service.ts
+++ b/lib/core/src/lib/auth/oidc/oidc-authentication.service.ts
@@ -17,7 +17,7 @@
 
 import { Injectable } from '@angular/core';
 import { OAuthService, OAuthStorage } from 'angular-oauth2-oidc';
-import { Observable, defer, EMPTY } from 'rxjs';
+import { Observable, defer, EMPTY, combineLatest } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { AppConfigService, AppConfigValues } from '../../app-config/app-config.service';
 import { OauthConfigModel } from '../models/oauth-config.model';
@@ -44,6 +44,19 @@ export class OidcAuthenticationService extends BaseAuthenticationService {
     ) {
         super(appConfig, cookie);
     }
+
+    /**
+     * Observable that determines whether an SSO login should be performed.
+     *
+     * This observable combines the authentication status and the discovery document load status
+     * to decide if an SSO login is necessary. It emits `true` if the user is not authenticated
+     * and the discovery document is loaded, otherwise it emits `false`.
+     *
+     * @type {Observable<boolean>}
+     */
+    shouldPerformSsoLogin$: Observable<boolean> = combineLatest([this.auth.authenticated$, this.auth.isDiscoveryDocumentLoaded$]).pipe(
+        map(([authenticated, isDiscoveryDocumentLoaded]) => !authenticated && isDiscoveryDocumentLoaded)
+    );
 
     isEcmLoggedIn(): boolean {
         if (this.isECMProvider() || this.isALLProvider()) {

--- a/lib/core/src/lib/auth/oidc/redirect-auth.service.spec.ts
+++ b/lib/core/src/lib/auth/oidc/redirect-auth.service.spec.ts
@@ -16,7 +16,7 @@
  */
 
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
-import { OAuthService, OAuthEvent, OAuthStorage, AUTH_CONFIG, TokenResponse, AuthConfig, OAuthLogger, OAuthErrorEvent, OAuthSuccessEvent } from 'angular-oauth2-oidc';
+import { OAuthService, OAuthEvent, OAuthStorage, AUTH_CONFIG, TokenResponse, AuthConfig, OAuthLogger, OAuthErrorEvent, OAuthSuccessEvent, OAuthInfoEvent } from 'angular-oauth2-oidc';
 import { of, Subject, timeout } from 'rxjs';
 import { RedirectAuthService } from './redirect-auth.service';
 import { AUTH_MODULE_CONFIG } from './auth-config';
@@ -475,6 +475,15 @@ describe('RedirectAuthService', () => {
 
         expect(oauthServiceSpy.logOut).toHaveBeenCalledTimes(1);
         expect(oauthLoggerSpy.error).toHaveBeenCalledWith(expectedErrorMessage);
+    });
+
+    it('should onLogout$ be emitted when logout event occur', () => {
+        let expectedLogoutIsEmitted = false;
+        service.onLogout$.subscribe(() => expectedLogoutIsEmitted = true);
+
+        oauthEvents$.next(new OAuthInfoEvent('logout'));
+
+        expect(expectedLogoutIsEmitted).toBeTrue();
     });
 
 });

--- a/lib/core/src/lib/auth/oidc/redirect-auth.service.spec.ts
+++ b/lib/core/src/lib/auth/oidc/redirect-auth.service.spec.ts
@@ -54,7 +54,6 @@ describe('RedirectAuthService', () => {
 
         TestBed.inject(OAuthService);
         service = TestBed.inject(RedirectAuthService);
-        spyOn(service, 'reloadPage').and.callFake(() => {});
         spyOn(service, 'ensureDiscoveryDocument').and.resolveTo(true);
         mockOauthService.getAccessToken = () => 'access-token';
     });
@@ -94,26 +93,6 @@ describe('RedirectAuthService', () => {
 
         expect(refreshTokenCalled).toBe(true);
         expect(silentRefreshCalled).toBe(true);
-    });
-
-    it('should remove all auth items from the storage if access token is set and is not authenticated', () => {
-        mockOauthService.getAccessToken = () => 'access-token';
-        spyOnProperty(service, 'authenticated', 'get').and.returnValue(false);
-        (mockOauthService.events as Subject<OAuthEvent>).next({ type: 'discovery_document_loaded' } as OAuthEvent);
-
-        expect(mockOAuthStorage.removeItem).toHaveBeenCalledWith('access_token');
-        expect(mockOAuthStorage.removeItem).toHaveBeenCalledWith('access_token_stored_at');
-        expect(mockOAuthStorage.removeItem).toHaveBeenCalledWith('expires_at');
-        expect(mockOAuthStorage.removeItem).toHaveBeenCalledWith('granted_scopes');
-        expect(mockOAuthStorage.removeItem).toHaveBeenCalledWith('id_token');
-        expect(mockOAuthStorage.removeItem).toHaveBeenCalledWith('id_token_claims_obj');
-        expect(mockOAuthStorage.removeItem).toHaveBeenCalledWith('id_token_expires_at');
-        expect(mockOAuthStorage.removeItem).toHaveBeenCalledWith('id_token_stored_at');
-        expect(mockOAuthStorage.removeItem).toHaveBeenCalledWith('nonce');
-        expect(mockOAuthStorage.removeItem).toHaveBeenCalledWith('PKCE_verifier');
-        expect(mockOAuthStorage.removeItem).toHaveBeenCalledWith('refresh_token');
-        expect(mockOAuthStorage.removeItem).toHaveBeenCalledWith('session_state');
-        expect(service.reloadPage).toHaveBeenCalledOnceWith();
     });
 
 });

--- a/lib/core/src/lib/auth/oidc/redirect-auth.service.spec.ts
+++ b/lib/core/src/lib/auth/oidc/redirect-auth.service.spec.ts
@@ -396,4 +396,85 @@ describe('RedirectAuthService', () => {
         expect(oauthServiceSpy.logOut).toHaveBeenCalledTimes(1);
         expect(oauthLoggerSpy.error).toHaveBeenCalledWith(expectedErrorCausedBySecondTokenRefreshError);
     }));
+
+    it('should logout user if token_refresh_error is emitted because of clock out of sync', () => {
+        const expectedErrorMessage = new Error('OAuth error occurred due to local machine clock 2024-10-10T22:00:18.621Z being out of sync with server time 2024-10-10T22:10:53.000Z');
+        timeSyncServiceSpy.checkTimeSync.and.returnValue(of({ outOfSync: true, localDateTimeISO: '2024-10-10T22:00:18.621Z', serverDateTimeISO: '2024-10-10T22:10:53.000Z' } as TimeSync));
+
+        oauthEvents$.next(new OAuthErrorEvent('token_refresh_error', { reason: 'error' }, {}));
+
+        expect(oauthServiceSpy.logOut).toHaveBeenCalledTimes(1);
+        expect(oauthLoggerSpy.error).toHaveBeenCalledWith(expectedErrorMessage);
+    });
+
+    it('should logout user if discovery_document_load_error is emitted because of clock out of sync', () => {
+        const expectedErrorMessage = new Error('OAuth error occurred due to local machine clock 2024-10-10T22:00:18.621Z being out of sync with server time 2024-10-10T22:10:53.000Z');
+        timeSyncServiceSpy.checkTimeSync.and.returnValue(of({ outOfSync: true, localDateTimeISO: '2024-10-10T22:00:18.621Z', serverDateTimeISO: '2024-10-10T22:10:53.000Z' } as TimeSync));
+
+        oauthEvents$.next(new OAuthErrorEvent('discovery_document_load_error', { reason: 'error' }, {}));
+
+        expect(oauthServiceSpy.logOut).toHaveBeenCalledTimes(1);
+        expect(oauthLoggerSpy.error).toHaveBeenCalledWith(expectedErrorMessage);
+    });
+
+    it('should logout user if code_error is emitted because of clock out of sync', () => {
+        const expectedErrorMessage = new Error('OAuth error occurred due to local machine clock 2024-10-10T22:00:18.621Z being out of sync with server time 2024-10-10T22:10:53.000Z');
+        timeSyncServiceSpy.checkTimeSync.and.returnValue(of({ outOfSync: true, localDateTimeISO: '2024-10-10T22:00:18.621Z', serverDateTimeISO: '2024-10-10T22:10:53.000Z' } as TimeSync));
+
+        oauthEvents$.next(new OAuthErrorEvent('code_error', { reason: 'error' }, {}));
+
+        expect(oauthServiceSpy.logOut).toHaveBeenCalledTimes(1);
+        expect(oauthLoggerSpy.error).toHaveBeenCalledWith(expectedErrorMessage);
+    });
+
+    it('should logout user if discovery_document_validation_error is emitted because of clock out of sync', () => {
+        const expectedErrorMessage = new Error('OAuth error occurred due to local machine clock 2024-10-10T22:00:18.621Z being out of sync with server time 2024-10-10T22:10:53.000Z');
+        timeSyncServiceSpy.checkTimeSync.and.returnValue(of({ outOfSync: true, localDateTimeISO: '2024-10-10T22:00:18.621Z', serverDateTimeISO: '2024-10-10T22:10:53.000Z' } as TimeSync));
+
+        oauthEvents$.next(new OAuthErrorEvent('discovery_document_validation_error', { reason: 'error' }, {}));
+
+        expect(oauthServiceSpy.logOut).toHaveBeenCalledTimes(1);
+        expect(oauthLoggerSpy.error).toHaveBeenCalledWith(expectedErrorMessage);
+    });
+
+    it('should logout user if jwks_load_error is emitted because of clock out of sync', () => {
+        const expectedErrorMessage = new Error('OAuth error occurred due to local machine clock 2024-10-10T22:00:18.621Z being out of sync with server time 2024-10-10T22:10:53.000Z');
+        timeSyncServiceSpy.checkTimeSync.and.returnValue(of({ outOfSync: true, localDateTimeISO: '2024-10-10T22:00:18.621Z', serverDateTimeISO: '2024-10-10T22:10:53.000Z' } as TimeSync));
+
+        oauthEvents$.next(new OAuthErrorEvent('jwks_load_error', { reason: 'error' }, {}));
+
+        expect(oauthServiceSpy.logOut).toHaveBeenCalledTimes(1);
+        expect(oauthLoggerSpy.error).toHaveBeenCalledWith(expectedErrorMessage);
+    });
+
+    it('should logout user if silent_refresh_error is emitted because of clock out of sync', () => {
+        const expectedErrorMessage = new Error('OAuth error occurred due to local machine clock 2024-10-10T22:00:18.621Z being out of sync with server time 2024-10-10T22:10:53.000Z');
+        timeSyncServiceSpy.checkTimeSync.and.returnValue(of({ outOfSync: true, localDateTimeISO: '2024-10-10T22:00:18.621Z', serverDateTimeISO: '2024-10-10T22:10:53.000Z' } as TimeSync));
+
+        oauthEvents$.next(new OAuthErrorEvent('silent_refresh_error', { reason: 'error' }, {}));
+
+        expect(oauthServiceSpy.logOut).toHaveBeenCalledTimes(1);
+        expect(oauthLoggerSpy.error).toHaveBeenCalledWith(expectedErrorMessage);
+    });
+
+    it('should logout user if user_profile_load_error is emitted because of clock out of sync', () => {
+        const expectedErrorMessage = new Error('OAuth error occurred due to local machine clock 2024-10-10T22:00:18.621Z being out of sync with server time 2024-10-10T22:10:53.000Z');
+        timeSyncServiceSpy.checkTimeSync.and.returnValue(of({ outOfSync: true, localDateTimeISO: '2024-10-10T22:00:18.621Z', serverDateTimeISO: '2024-10-10T22:10:53.000Z' } as TimeSync));
+
+        oauthEvents$.next(new OAuthErrorEvent('user_profile_load_error', { reason: 'error' }, {}));
+
+        expect(oauthServiceSpy.logOut).toHaveBeenCalledTimes(1);
+        expect(oauthLoggerSpy.error).toHaveBeenCalledWith(expectedErrorMessage);
+    });
+
+    it('should logout user if token_error is emitted because of clock out of sync', () => {
+        const expectedErrorMessage = new Error('OAuth error occurred due to local machine clock 2024-10-10T22:00:18.621Z being out of sync with server time 2024-10-10T22:10:53.000Z');
+        timeSyncServiceSpy.checkTimeSync.and.returnValue(of({ outOfSync: true, localDateTimeISO: '2024-10-10T22:00:18.621Z', serverDateTimeISO: '2024-10-10T22:10:53.000Z' } as TimeSync));
+
+        oauthEvents$.next(new OAuthErrorEvent('token_error', { reason: 'error' }, {}));
+
+        expect(oauthServiceSpy.logOut).toHaveBeenCalledTimes(1);
+        expect(oauthLoggerSpy.error).toHaveBeenCalledWith(expectedErrorMessage);
+    });
+
 });

--- a/lib/core/src/lib/auth/oidc/redirect-auth.service.ts
+++ b/lib/core/src/lib/auth/oidc/redirect-auth.service.ts
@@ -67,7 +67,6 @@ export class RedirectAuthService extends AuthService {
    * Observable that emits an error when the token has expired due to
    * the local machine clock being out of sync with the server time.
    *
-   * @observable
    * @type {Observable<Error>}
    */
   tokenHasExpiredDueToClockOutOfSync$: Observable<Error>;

--- a/lib/core/src/lib/auth/oidc/redirect-auth.service.ts
+++ b/lib/core/src/lib/auth/oidc/redirect-auth.service.ts
@@ -45,6 +45,16 @@ export class RedirectAuthService extends AuthService {
   private _loadDiscoveryDocumentPromise = Promise.resolve(false);
 
   /**
+   * Observable stream that emits when the user logs out.
+   *
+   * This observable listens to the events emitted by the OAuth service and filters
+   * them to only include instances of OAuthSuccessEvent with the type `logout`.
+   *
+   * @type {Observable<void>}
+   */
+  onLogout$: Observable<void>;
+
+  /**
    * Observable stream that emits OAuthErrorEvent instances.
    *
    * This observable listens to the events emitted by the OAuth service and filters
@@ -183,6 +193,11 @@ export class RedirectAuthService extends AuthService {
         filter((timeSync) => timeSync?.outOfSync),
         map((timeSync) => new Error(`Token has expired due to local machine clock ${timeSync.localDateTimeISO} being out of sync with server time ${timeSync.serverDateTimeISO}`)),
         take(1)
+    );
+
+    this.onLogout$ = this.oauthService.events.pipe(
+        filter((event) => event.type === 'logout'),
+        map(() => undefined)
     );
 
     this.combinedOAuthErrorsStream$ = race([

--- a/lib/core/src/lib/auth/oidc/retry-login.service.spec.ts
+++ b/lib/core/src/lib/auth/oidc/retry-login.service.spec.ts
@@ -16,7 +16,7 @@
  */
 
 import { TestBed } from '@angular/core/testing';
-import { OAuthService } from 'angular-oauth2-oidc';
+import { OAuthErrorEvent, OAuthService } from 'angular-oauth2-oidc';
 import { RetryLoginService } from './retry-login.service';
 
 describe('RetryLoginService', () => {
@@ -64,7 +64,7 @@ describe('RetryLoginService', () => {
     });
 
     it('should fail after 2 attempts throwing an error', async () => {
-        oauthService.tryLogin.and.rejectWith({ reason: 'fake-error'});
+        oauthService.tryLogin.and.rejectWith({ reason: 'fake-error' } as unknown as OAuthErrorEvent);
 
         try {
             await service.tryToLoginTimes({}, 2);
@@ -75,8 +75,20 @@ describe('RetryLoginService', () => {
         }
     });
 
+    it('should fail after 2 attempts throwing an error if error is returned as string instead of object', async () => {
+        oauthService.tryLogin.and.rejectWith('fake-message-error');
+
+        try {
+            await service.tryToLoginTimes({}, 2);
+            fail('Expected to throw an error');
+        } catch (error) {
+            expect(error).toEqual(new Error('Login failed after 2 attempts. caused by: fake-message-error'));
+            expect(oauthService.tryLogin).toHaveBeenCalledTimes(2);
+        }
+    });
+
     it('should fail after default max logint attempts ', async () => {
-        oauthService.tryLogin.and.rejectWith({ reason: 'fake-error'});
+        oauthService.tryLogin.and.rejectWith({ reason: 'fake-error' } as unknown as OAuthErrorEvent);
 
         try {
             await service.tryToLoginTimes({});

--- a/lib/core/src/lib/auth/oidc/retry-login.service.spec.ts
+++ b/lib/core/src/lib/auth/oidc/retry-login.service.spec.ts
@@ -1,0 +1,85 @@
+/*!
+ * @license
+ * Copyright © 2005-2024 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { OAuthService } from 'angular-oauth2-oidc';
+import { RetryLoginService } from './retry-login.service';
+
+describe('RetryLoginService', () => {
+    let service: RetryLoginService;
+    let oauthService: jasmine.SpyObj<OAuthService>;
+
+    beforeEach(() => {
+        const oauthServiceSpy = jasmine.createSpyObj('OAuthService', ['tryLogin']);
+
+        TestBed.configureTestingModule({
+            providers: [
+                RetryLoginService,
+                { provide: OAuthService, useValue: oauthServiceSpy }
+            ]
+        });
+
+        service = TestBed.inject(RetryLoginService);
+        oauthService = TestBed.inject(OAuthService) as jasmine.SpyObj<OAuthService>;
+    });
+
+    it('should login successfully on the first attempt', async () => {
+        oauthService.tryLogin.and.returnValue(Promise.resolve(true));
+
+        const result = await service.tryToLoginTimes({});
+
+        expect(result).toBeTrue();
+        expect(oauthService.tryLogin).toHaveBeenCalledTimes(1);
+    });
+
+    it('should retry login up to maxRetries times', async () => {
+        oauthService.tryLogin.and.returnValues(
+            Promise.reject(new Error('error')),
+            Promise.reject(new Error('error')),
+            Promise.resolve(true)
+        );
+
+        const result = await service.tryToLoginTimes({}, 2);
+
+        expect(result).toBeTrue();
+        expect(oauthService.tryLogin).toHaveBeenCalledTimes(2);
+    });
+
+    it('should fail after maxRetries attempts providing maxRetries', async () => {
+        oauthService.tryLogin.and.rejectWith('error');
+
+        try {
+            await service.tryToLoginTimes({}, 2);
+            fail('Expected to throw an error');
+        } catch (error) {
+            expect(error).toBe('error');
+            expect(oauthService.tryLogin).toHaveBeenCalledTimes(2);
+        }
+    });
+
+    it('should fail after maxRetries attempts using default maxRetries value', async () => {
+        oauthService.tryLogin.and.rejectWith('error');
+
+        try {
+            await service.tryToLoginTimes({});
+            fail('Expected to throw an error');
+        } catch (error) {
+            expect(error).toBe('error');
+            expect(oauthService.tryLogin).toHaveBeenCalledTimes(3);
+        }
+    });
+});

--- a/lib/core/src/lib/auth/oidc/retry-login.service.ts
+++ b/lib/core/src/lib/auth/oidc/retry-login.service.ts
@@ -43,12 +43,23 @@ export class RetryLoginService {
                     retryCount++;
                     return attemptLogin();
                 } else {
-                    const errorReason = (error as OAuthErrorEvent)?.reason || error;
-                    throw new Error(`Login failed after ${maxLoginAttempts} attempts. caused by: ${errorReason}`);
+                    const errorMessage = this.getErrorMessage(error, maxLoginAttempts);
+                    throw new Error(errorMessage);
                 }
             });
 
         return attemptLogin();
     }
 
+    private getErrorMessage(error: any, maxLoginAttempts: number) {
+        const isOAuthErrorEvent = error instanceof OAuthErrorEvent;
+        let oAuthErrorMessage: string;
+        if (isOAuthErrorEvent) {
+            oAuthErrorMessage = (error.reason as any).reason || error.type.toString();
+        }
+        const errorDescription = oAuthErrorMessage || error;
+        const errorMessage = `Login failed after ${maxLoginAttempts} attempts. caused by: ${errorDescription}`;
+        return errorMessage;
+    }
 }
+

--- a/lib/core/src/lib/auth/oidc/retry-login.service.ts
+++ b/lib/core/src/lib/auth/oidc/retry-login.service.ts
@@ -37,13 +37,14 @@ export class RetryLoginService {
         const maxRetries = maxLoginAttempts - 1;
 
         const attemptLogin = (): Promise<boolean> => this.oauthService.tryLogin({ ...loginOptions })
-            .catch((error: OAuthErrorEvent) => {
+            .catch((error) => {
                 if (retryCount < maxRetries) {
                     console.error(`Login attempt ${retryCount + 1} of ${maxLoginAttempts} failed. ${retryCount < maxLoginAttempts - 1 ? 'Retrying...' : ''}`);
                     retryCount++;
                     return attemptLogin();
                 } else {
-                    throw new Error(`Login failed after ${maxLoginAttempts} attempts. caused by: ${error.reason}`);
+                    const errorReason = (error as OAuthErrorEvent)?.reason || error;
+                    throw new Error(`Login failed after ${maxLoginAttempts} attempts. caused by: ${errorReason}`);
                 }
             });
 

--- a/lib/core/src/lib/auth/oidc/retry-login.service.ts
+++ b/lib/core/src/lib/auth/oidc/retry-login.service.ts
@@ -16,7 +16,7 @@
  */
 
 import { inject, Injectable } from '@angular/core';
-import { LoginOptions, OAuthService } from 'angular-oauth2-oidc';
+import { LoginOptions, OAuthErrorEvent, OAuthService } from 'angular-oauth2-oidc';
 
 @Injectable({
     providedIn: 'root'
@@ -37,13 +37,13 @@ export class RetryLoginService {
         const maxRetries = maxLoginAttempts - 1;
 
         const attemptLogin = (): Promise<boolean> => this.oauthService.tryLogin({ ...loginOptions })
-            .catch((error) => {
+            .catch((error: OAuthErrorEvent) => {
                 if (retryCount < maxRetries) {
                     console.error(`Login attempt ${retryCount + 1} of ${maxLoginAttempts} failed. ${retryCount < maxLoginAttempts - 1 ? 'Retrying...' : ''}`);
                     retryCount++;
                     return attemptLogin();
                 } else {
-                    throw new Error(`Login failed after ${maxLoginAttempts} attempts. ${error.message}`);
+                    throw new Error(`Login failed after ${maxLoginAttempts} attempts. caused by: ${error.reason}`);
                 }
             });
 

--- a/lib/core/src/lib/auth/oidc/retry-login.service.ts
+++ b/lib/core/src/lib/auth/oidc/retry-login.service.ts
@@ -1,0 +1,53 @@
+/*!
+ * @license
+ * Copyright © 2005-2024 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { inject, Injectable } from '@angular/core';
+import { LoginOptions, OAuthService } from 'angular-oauth2-oidc';
+
+@Injectable({
+    providedIn: 'root'
+})
+export class RetryLoginService {
+
+    private oauthService = inject(OAuthService);
+
+    /**
+     * Attempts to log in a specified number of times if the initial login attempt fails.
+     *
+     * @param loginOptions - The options to be used for the login attempt.
+     * @param maxLoginAttempts - The maximum number of login attempts. Defaults to 3.
+     * @returns A promise that resolves to `true` if the login is successful, or rejects with an error if all attempts fail.
+     */
+    tryToLoginTimes(loginOptions: LoginOptions, maxLoginAttempts = 3): Promise<boolean> {
+        let retryCount = 0;
+        const maxRetries = maxLoginAttempts - 1;
+
+        const attemptLogin = (): Promise<boolean> => this.oauthService.tryLogin({ ...loginOptions })
+            .catch((error) => {
+                if (retryCount < maxRetries) {
+                    console.error(`Login attempt ${retryCount + 1} of ${maxLoginAttempts} failed. ${retryCount < maxLoginAttempts - 1 ? 'Retrying...' : ''}`);
+                    retryCount++;
+                    return attemptLogin();
+                } else {
+                    throw new Error(`Login failed after ${maxLoginAttempts} attempts. ${error.message}`);
+                }
+            });
+
+        return attemptLogin();
+    }
+
+}

--- a/lib/core/src/lib/auth/oidc/retry-login.service.ts
+++ b/lib/core/src/lib/auth/oidc/retry-login.service.ts
@@ -22,7 +22,6 @@ import { LoginOptions, OAuthErrorEvent, OAuthService } from 'angular-oauth2-oidc
     providedIn: 'root'
 })
 export class RetryLoginService {
-
     private oauthService = inject(OAuthService);
 
     /**
@@ -36,10 +35,12 @@ export class RetryLoginService {
         let retryCount = 0;
         const maxRetries = maxLoginAttempts - 1;
 
-        const attemptLogin = (): Promise<boolean> => this.oauthService.tryLogin({ ...loginOptions })
-            .catch((error) => {
+        const attemptLogin = (): Promise<boolean> =>
+            this.oauthService.tryLogin({ ...loginOptions }).catch((error) => {
                 if (retryCount < maxRetries) {
-                    console.error(`Login attempt ${retryCount + 1} of ${maxLoginAttempts} failed. ${retryCount < maxLoginAttempts - 1 ? 'Retrying...' : ''}`);
+                    console.error(
+                        `Login attempt ${retryCount + 1} of ${maxLoginAttempts} failed. ${retryCount < maxLoginAttempts - 1 ? 'Retrying...' : ''}`
+                    );
                     retryCount++;
                     return attemptLogin();
                 } else {
@@ -55,11 +56,10 @@ export class RetryLoginService {
         const isOAuthErrorEvent = error instanceof OAuthErrorEvent;
         let oAuthErrorMessage: string;
         if (isOAuthErrorEvent) {
-            oAuthErrorMessage = (error.reason as any).reason || error.type.toString();
+            oAuthErrorMessage = (error.reason as any)?.reason || error.type.toString();
         }
         const errorDescription = oAuthErrorMessage || error;
         const errorMessage = `Login failed after ${maxLoginAttempts} attempts. caused by: ${errorDescription}`;
         return errorMessage;
     }
 }
-

--- a/lib/core/src/lib/auth/oidc/token.interceptor.spec.ts
+++ b/lib/core/src/lib/auth/oidc/token.interceptor.spec.ts
@@ -1,0 +1,108 @@
+/*!
+ * @license
+ * Copyright © 2005-2024 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { HTTP_INTERCEPTORS, HttpClient } from '@angular/common/http';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { OAuthService, OAuthStorage } from 'angular-oauth2-oidc';
+import { TokenInterceptor } from './token.interceptor';
+
+describe('TokenInterceptor', () => {
+    let httpMock: HttpTestingController;
+    let httpClient: HttpClient;
+    let oauthService: OAuthService;
+    let oauthStorage: OAuthStorage;
+
+    beforeEach(() => {
+        const oauthServiceMock = {
+            tokenEndpoint: 'lv-426/token',
+            getIdToken: jasmine.createSpy('getIdToken').and.returnValue(null)
+        };
+
+        const oauthStorageMock = {
+            setItem: jasmine.createSpy('setItem')
+        };
+
+        TestBed.configureTestingModule({
+            imports: [HttpClientTestingModule],
+            providers: [
+                { provide: OAuthService, useValue: oauthServiceMock },
+                { provide: OAuthStorage, useValue: oauthStorageMock },
+                {
+                    provide: HTTP_INTERCEPTORS,
+                    useClass: TokenInterceptor,
+                    multi: true
+                }
+            ]
+        });
+
+        httpMock = TestBed.inject(HttpTestingController);
+        httpClient = TestBed.inject(HttpClient);
+        oauthService = TestBed.inject(OAuthService);
+        oauthStorage = TestBed.inject(OAuthStorage);
+    });
+
+    afterEach(() => {
+        httpMock.verify();
+    });
+
+    it('should store id_token in OAuthStorage if not already set', () => {
+        const mockResponse = { id_token: 'mock-id-token' };
+
+        httpClient.post('lv-426/token', {}).subscribe((response) => {
+            expect(response).toBeTruthy();
+        });
+
+        const req = httpMock.expectOne('lv-426/token');
+        expect(req.request.method).toBe('POST');
+
+        req.flush(mockResponse);
+
+        expect(oauthService.getIdToken).toHaveBeenCalled();
+        expect(oauthStorage.setItem).toHaveBeenCalledWith('id_token', 'mock-id-token');
+    });
+
+    it('should NOT store id_token if already set', () => {
+        (oauthService.getIdToken as jasmine.Spy).and.returnValue('existing-id-token');
+
+        httpClient.post('lv-426/token', {}).subscribe((response) => {
+            expect(response).toBeTruthy();
+        });
+
+        const req = httpMock.expectOne('lv-426/token');
+        expect(req.request.method).toBe('POST');
+
+        req.flush({ id_token: 'new-id-token' });
+
+        expect(oauthService.getIdToken).toHaveBeenCalled();
+        expect(oauthStorage.setItem).not.toHaveBeenCalled();
+    });
+
+    it('should NOT intercept requests to other URLs', () => {
+        httpClient.get('lv-426/other').subscribe((response) => {
+            expect(response).toBeTruthy();
+        });
+
+        const req = httpMock.expectOne('lv-426/other');
+        expect(req.request.method).toBe('GET');
+
+        req.flush({ data: 'test' });
+
+        expect(oauthService.getIdToken).not.toHaveBeenCalled();
+        expect(oauthStorage.setItem).not.toHaveBeenCalled();
+    });
+});

--- a/lib/core/src/lib/auth/oidc/token.interceptor.ts
+++ b/lib/core/src/lib/auth/oidc/token.interceptor.ts
@@ -1,0 +1,62 @@
+/*!
+ * @license
+ * Copyright © 2005-2024 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { inject, Injectable } from '@angular/core';
+import { HttpRequest, HttpHandler, HttpEvent, HttpInterceptor, HttpResponse } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import { OAuthService, OAuthStorage } from 'angular-oauth2-oidc';
+
+@Injectable()
+/**
+ * TokenInterceptor is an HTTP interceptor that processes HTTP requests and responses
+ * to handle the id_token. It checks if the request URL matches the token endpoint
+ * and processes the response to store the `id_token` in the OAuth storage if it is
+ * not already set.
+ * The purpose of this interceptor is to fix the missing `id_token_hint` required by the Idp to complete the logout.
+ * `id_token_hint` is set by the `angular-oauth2-oidc` library only when the `id_token` is set in the storage.
+ * https://github.com/manfredsteyer/angular-oauth2-oidc/blob/15.0.0/projects/lib/src/oauth-service.ts#L2555
+ *
+ * See the related issue: https://github.com/manfredsteyer/angular-oauth2-oidc/issues/1443
+ *
+ * @implements {HttpInterceptor}
+ * @class
+ * @function intercept
+ * @param {HttpRequest<unknown>} request - The outgoing HTTP request.
+ * @param {HttpHandler} next - The next handler in the HTTP request chain.
+ * @returns {Observable<HttpEvent<unknown>>} An observable of the HTTP event.
+ */
+export class TokenInterceptor implements HttpInterceptor {
+    private readonly _oauthStorage = inject(OAuthStorage);
+    private readonly _oauthService = inject(OAuthService);
+
+    intercept(request: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+        const tokenEndpoint = this._oauthService.tokenEndpoint;
+        if (tokenEndpoint && request.url === tokenEndpoint) {
+            return next.handle(request).pipe(
+                tap((event) => {
+                    if (event instanceof HttpResponse) {
+                        if (!this._oauthService.getIdToken() && event?.body?.id_token) {
+                            this._oauthStorage.setItem('id_token', event.body.id_token);
+                        }
+                    }
+                })
+            );
+        }
+        return next.handle(request);
+    }
+}

--- a/lib/core/src/lib/auth/services/time-sync.service.spec.ts
+++ b/lib/core/src/lib/auth/services/time-sync.service.spec.ts
@@ -1,0 +1,208 @@
+/*!
+ * @license
+ * Copyright © 2005-2024 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { AppConfigService } from '../../app-config/app-config.service';
+import { TimeSyncService } from './time-sync.service';
+
+describe('TimeSyncService', () => {
+    let service: TimeSyncService;
+    let httpMock: HttpTestingController;
+    let appConfigSpy: jasmine.SpyObj<AppConfigService>;
+
+    beforeEach(() => {
+        appConfigSpy = jasmine.createSpyObj('AppConfigService', ['get']);
+
+        TestBed.configureTestingModule({
+            imports: [HttpClientTestingModule],
+            providers: [
+                TimeSyncService,
+                { provide: AppConfigService, useValue: appConfigSpy }
+            ]
+        });
+
+        service = TestBed.inject(TimeSyncService);
+        httpMock = TestBed.inject(HttpTestingController);
+    });
+
+    afterEach(() => {
+        httpMock.verify();
+    });
+
+    describe('checkTimeSync', () => {
+
+        it('should check time sync and return outOfSync as false when time is within allowed skew', () => {
+            appConfigSpy.get.and.returnValue('http://fake-server-time-url');
+
+            const expectedServerTimeUrl = 'http://fake-server-time-url';
+
+            const timeBeforeCallingServerTimeEndpoint = 1728911579000; // (GMT): Monday, October 14, 2024 1:12:59 PM
+            const timeResponseReceivedFromServerTimeEndpoint = 1728911580000; // (GMT): Monday, October 14, 2024 1:13:00 PM
+
+            const localCurrentTime = 1728911580000; // (GMT): Monday, October 14, 2024 1:13:00 PM
+
+            const serverTime = 1728911640000; // (GMT): Monday, October 14, 2024 1:14:00 PM
+
+            spyOn(Date, 'now').and.returnValues(
+                timeBeforeCallingServerTimeEndpoint,
+                timeResponseReceivedFromServerTimeEndpoint,
+                localCurrentTime
+            );
+
+            // difference between localCurrentTime and serverTime is 60 seconds plus the round trip time of 1 second
+            const allowedClockSkewInSec = 61;
+            service.checkTimeSync(allowedClockSkewInSec).subscribe(sync => {
+                expect(sync.outOfSync).toBeFalse();
+                expect(sync.localDateTimeISO).toEqual('2024-10-14T13:13:00.000Z');
+                expect(sync.serverDateTimeISO).toEqual('2024-10-14T13:14:00.500Z');
+            });
+
+            const req = httpMock.expectOne(expectedServerTimeUrl);
+            expect(req.request.method).toBe('GET');
+            req.flush(serverTime);
+        });
+
+        it('should check time sync and return outOfSync as true when time is outside allowed skew', () => {
+            appConfigSpy.get.and.returnValue('http://fake-server-time-url');
+
+            const expectedServerTimeUrl = 'http://fake-server-time-url';
+
+            const timeBeforeCallingServerTimeEndpoint = 1728911579000; // (GMT): Monday, October 14, 2024 1:12:59 PM
+            const timeResponseReceivedFromServerTimeEndpoint = 1728911580000; // (GMT): Monday, October 14, 2024 1:13:00 PM
+
+            const localCurrentTime = 1728911580000; // (GMT): Monday, October 14, 2024 1:13:00 PM
+
+            const serverTime = 1728911640000; // (GMT): Monday, October 14, 2024 1:14:00 PM
+
+            spyOn(Date, 'now').and.returnValues(
+                timeBeforeCallingServerTimeEndpoint,
+                timeResponseReceivedFromServerTimeEndpoint,
+                localCurrentTime
+            );
+
+            // difference between localCurrentTime and serverTime is 60 seconds plus the round trip time of 1 second
+            // setting allowedClockSkewInSec to 60 seconds will make the local time out of sync
+            const allowedClockSkewInSec = 60;
+            service.checkTimeSync(allowedClockSkewInSec).subscribe(sync => {
+                expect(sync.outOfSync).toBeTrue();
+                expect(sync.localDateTimeISO).toEqual('2024-10-14T13:13:00.000Z');
+                expect(sync.serverDateTimeISO).toEqual('2024-10-14T13:14:00.500Z');
+            });
+
+            const req = httpMock.expectOne(expectedServerTimeUrl);
+            expect(req.request.method).toBe('GET');
+            req.flush(serverTime);
+        });
+
+        it('should throw an error if serverTimeUrl is not configured', async () => {
+            appConfigSpy.get.and.returnValue('');
+
+            try {
+                await service.checkTimeSync(60).toPromise();
+                fail('Expected to throw an error');
+            } catch (error) {
+                expect(error.message).toBe('serverTimeUrl is not configured.');
+            }
+
+        });
+
+        it('should throw an error if the server time endpoint returns an error', () => {
+            appConfigSpy.get.and.returnValue('http://fake-server-time-url');
+
+            const expectedServerTimeUrl = 'http://fake-server-time-url';
+
+            service.checkTimeSync(60).subscribe({
+                next: () => {
+                    fail('Expected to throw an error');
+                },
+                error: error => {
+                    expect(error.message).toBe('Error: Failed to get server time');
+                }
+            });
+
+            const req = httpMock.expectOne(expectedServerTimeUrl);
+            expect(req.request.method).toBe('GET');
+            req.error(new ProgressEvent(''));
+        });
+
+    });
+
+    describe('isLocalTimeOutOfSync', () => {
+        it('should return clock is out of sync', () => {
+
+            appConfigSpy.get.and.returnValue('http://fake-server-time-url');
+
+            const expectedServerTimeUrl = 'http://fake-server-time-url';
+
+            const timeBeforeCallingServerTimeEndpoint = 1728911579000; // (GMT): Monday, October 14, 2024 1:12:59 PM
+            const timeResponseReceivedFromServerTimeEndpoint = 1728911580000; // (GMT): Monday, October 14, 2024 1:13:00 PM
+
+            const localCurrentTime = 1728911580000; // (GMT): Monday, October 14, 2024 1:13:00 PM
+
+            const serverTime = 1728911640000; // (GMT): Monday, October 14, 2024 1:14:00 PM
+
+            spyOn(Date, 'now').and.returnValues(
+                timeBeforeCallingServerTimeEndpoint,
+                timeResponseReceivedFromServerTimeEndpoint,
+                localCurrentTime
+            );
+
+            // difference between localCurrentTime and serverTime is 60 seconds plus the round trip time of 1 second
+            // setting allowedClockSkewInSec to 60 seconds will make the local time out of sync
+            const allowedClockSkewInSec = 60;
+            service.isLocalTimeOutOfSync(allowedClockSkewInSec).subscribe(isOutOfSync => {
+                expect(isOutOfSync).toBeTrue();
+            });
+
+            const req = httpMock.expectOne(expectedServerTimeUrl);
+            expect(req.request.method).toBe('GET');
+            req.flush(serverTime);
+        });
+
+        it('should check time sync and return outOfSync as false when time is within allowed skew', () => {
+            appConfigSpy.get.and.returnValue('http://fake-server-time-url');
+
+            const expectedServerTimeUrl = 'http://fake-server-time-url';
+
+            const timeBeforeCallingServerTimeEndpoint = 1728911579000; // (GMT): Monday, October 14, 2024 1:12:59 PM
+            const timeResponseReceivedFromServerTimeEndpoint = 1728911580000; // (GMT): Monday, October 14, 2024 1:13:00 PM
+
+            const localCurrentTime = 1728911580000; // (GMT): Monday, October 14, 2024 1:13:00 PM
+
+            const serverTime = 1728911640000; // (GMT): Monday, October 14, 2024 1:14:00 PM
+
+            spyOn(Date, 'now').and.returnValues(
+                timeBeforeCallingServerTimeEndpoint,
+                timeResponseReceivedFromServerTimeEndpoint,
+                localCurrentTime
+            );
+
+            // difference between localCurrentTime and serverTime is 60 seconds plus the round trip time of 1 second
+            const allowedClockSkewInSec = 61;
+            service.isLocalTimeOutOfSync(allowedClockSkewInSec).subscribe(isOutOfSync => {
+                expect(isOutOfSync).toBeFalse();
+            });
+
+            const req = httpMock.expectOne(expectedServerTimeUrl);
+            expect(req.request.method).toBe('GET');
+            req.flush(serverTime);
+        });
+    });
+
+
+});

--- a/lib/core/src/lib/auth/services/time-sync.service.ts
+++ b/lib/core/src/lib/auth/services/time-sync.service.ts
@@ -45,7 +45,7 @@ export class TimeSyncService {
     checkTimeSync(maxAllowedClockSkewInSec: number): Observable<TimeSync> {
         const startTime = Date.now();
 
-        return this.getServiceTime().pipe(
+        return this.getServerTime().pipe(
             map((serverTimeResponse: number) => {
                 let serverTimeInMs: number;
 
@@ -87,7 +87,7 @@ export class TimeSyncService {
         );
     }
 
-    private getServiceTime(): Observable<number> {
+    private getServerTime(): Observable<number> {
         return from(this._http.get<number>(this.getServerTimeUrl())).pipe(
             timeout(5000),
             catchError(() => throwError(() => new Error('Failed to get server time')))

--- a/lib/core/src/lib/auth/services/time-sync.service.ts
+++ b/lib/core/src/lib/auth/services/time-sync.service.ts
@@ -1,0 +1,104 @@
+/*!
+ * @license
+ * Copyright © 2005-2024 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { HttpClient } from '@angular/common/http';
+import { Injectable, Injector } from '@angular/core';
+import { AppConfigService } from '../../app-config/app-config.service';
+import { from, Observable, throwError } from 'rxjs';
+import { catchError, map, timeout } from 'rxjs/operators';
+
+export interface TimeSync {
+    outOfSync: boolean;
+    timeOutOfSyncInSec?: number;
+    localDateTimeISO: string;
+    serverDateTimeISO: string;
+}
+
+@Injectable({
+    providedIn: 'root'
+})
+export class TimeSyncService {
+
+    private readonly _http: HttpClient;
+
+    constructor(
+        private _injector: Injector,
+        private _appConfigService: AppConfigService
+    ) {
+        this._http = this._injector.get(HttpClient);
+    }
+
+    checkTimeSync(maxAllowedClockSkewInSec: number): Observable<TimeSync> {
+        const startTime = Date.now();
+
+        return this.getServiceTime().pipe(
+            map((serverTimeResponse: number) => {
+                let serverTimeInMs: number;
+
+                const endTime = Date.now();
+                const roundTripTimeInMs = endTime - startTime;
+
+                const isServerTimeResponseInMs = serverTimeResponse.toString().length === 13;
+                if (!isServerTimeResponseInMs) {
+                    serverTimeInMs = serverTimeResponse * 1000;
+                } else {
+                    serverTimeInMs = serverTimeResponse;
+                }
+
+                const adjustedServerTimeInMs = serverTimeInMs + (roundTripTimeInMs / 2);
+                const localCurrentTimeInMs = Date.now();
+                const timeOffsetInMs = Math.abs(localCurrentTimeInMs - adjustedServerTimeInMs);
+                const maxAllowedClockSkewInMs = maxAllowedClockSkewInSec * 1000;
+
+                return {
+                    outOfSync: timeOffsetInMs > maxAllowedClockSkewInMs,
+                    timeOffsetInSec: timeOffsetInMs / 1000,
+                    localDateTimeISO: new Date(localCurrentTimeInMs).toISOString(),
+                    serverDateTimeISO: new Date(adjustedServerTimeInMs).toISOString()
+                };
+            }),
+            catchError(error => throwError(() => new Error(error)))
+        );
+    }
+
+    /**
+     * Checks if the local time is out of sync with the server time.
+     *
+     * @param maxAllowedClockSkewInSec - The maximum allowed clock skew in seconds.
+     * @returns An Observable that emits a boolean indicating whether the local time is out of sync.
+     */
+    isLocalTimeOutOfSync(maxAllowedClockSkewInSec: number): Observable<boolean> {
+        return this.checkTimeSync(maxAllowedClockSkewInSec).pipe(
+            map(sync => sync.outOfSync)
+        );
+    }
+
+    private getServiceTime(): Observable<number> {
+        return from(this._http.get<number>(this.getServerTimeUrl())).pipe(
+            timeout(5000),
+            catchError(() => throwError(() => new Error('Failed to get server time')))
+        );
+    }
+
+    private getServerTimeUrl(): string {
+        const serverTimeUrl = this._appConfigService.get('serverTimeUrl', '');
+        if (!serverTimeUrl) {
+            throw new Error('serverTimeUrl is not configured.');
+        }
+        return serverTimeUrl;
+    }
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/AAE-26163


**What is the new behaviour?**
- After 3 failed login attempts, the user is logged out to prevent an infinite loop.
- If `serverTimeUrl` is set in app configuration, in case of token expiration and an `OAuthErrorEvent` emitted, the local machine clock is compared with the server time to logout the user and throw a specific error.
- Fix the issue where the logout API call is canceled by the authorize call when login fails due to clock synchronization problems, causing an infinite loop.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
Verified ADF changes triggering CI on HFA 🟢  with versions released from this branch `7.0.0-alpha.4-11388985748`, js-api `8.0.0-alpha.4-11388985748`