### PR TITLE
[ACS-8741] Sidenav text for Process and Task filters is now grey

### DIFF
--- a/lib/process-services/src/lib/process-list/components/process-filters/process-filters.component.scss
+++ b/lib/process-services/src/lib/process-list/components/process-filters/process-filters.component.scss
@@ -20,6 +20,7 @@ adf-process-instance-filters {
                 .adf-filter-action-button__label {
                     padding-left: 20px;
                     margin: 0 8px;
+                    color: var(--theme-action-button-text-color);
                 }
             }
         }

--- a/lib/process-services/src/lib/task-list/components/task-filters/task-filters.component.scss
+++ b/lib/process-services/src/lib/task-list/components/task-filters/task-filters.component.scss
@@ -20,6 +20,7 @@ adf-task-filters {
                 .adf-filter-action-button__label {
                     padding-left: 20px;
                     margin: 0 8px;
+                    color: var(--theme-action-button-text-color);
                 }
             }
         }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Sidnav text for processes and tasks filter was black


**What is the new behaviour?**
Sidenav text for processes and tasks filter is now grey


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://hyland.atlassian.net/browse/ACS-8741