### PR TITLE
[ACS-8749] View More tags button no longer shows when all tags are removed from a node

### DIFF
--- a/lib/core/src/lib/dynamic-chip-list/dynamic-chip-list.component.html
+++ b/lib/core/src/lib/dynamic-chip-list/dynamic-chip-list.component.html
@@ -26,7 +26,7 @@
     <button
         data-automation-id="adf-dynamic-chip-list-view-more-button"
         mat-button
-        [hidden]="!limitChipsDisplayed"
+        [hidden]="chipsToDisplay.length === 0 || !limitChipsDisplayed"
         [style.left.px]="viewMoreButtonLeftOffset"
         [style.top.px]="viewMoreButtonTop"
         class="adf-dynamic-chip-list-view-more-button"

--- a/lib/core/src/lib/dynamic-chip-list/dynamic-chip-list.component.spec.ts
+++ b/lib/core/src/lib/dynamic-chip-list/dynamic-chip-list.component.spec.ts
@@ -182,7 +182,7 @@ describe('DynamicChipListComponent', () => {
             element.style.maxWidth = '309px';
         });
 
-        afterEach(() =>{
+        afterEach(() => {
             fixture.destroy();
         });
 
@@ -316,6 +316,16 @@ describe('DynamicChipListComponent', () => {
             resizeCallback([], null);
             fixture.detectChanges();
             expect(viewMoreButton.hidden).toBeTrue();
+        }));
+
+        it('should not render View more button if there are no chips', fakeAsync(() => {
+            renderChips();
+            component.chips = [];
+            tick();
+            fixture.detectChanges();
+
+            expect(component.chipsToDisplay).toEqual([]);
+            expect(findViewMoreButton().hidden).toBeTrue();
         }));
     });
 });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
View more button was not getting hidden when all tags on a node were removed.


**What is the new behaviour?**
View more button now gets hidden


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://hyland.atlassian.net/browse/ACS-8749
Also, take a loot at #10200, #10221. This PR is a duplicate of those, and was again created due to unsuccessful rebase to the latest ng16-migration branch