### PR TITLE
[MNT-24660] version list action cannot be disabled using app conf

### DIFF
--- a/docs/content-services/components/version-list.component.md
+++ b/docs/content-services/components/version-list.component.md
@@ -19,21 +19,22 @@ Displays the version history of a node in a [Version Manager component](version-
 
 ### Properties
 
-| Name | Type | Default value | Description |
-| ---- | ---- | ------------- | ----------- |
-| allowDownload | `boolean` | true | Enable/disable downloading a version of the current node. |
-| allowViewVersions | `boolean` | true | Enable/disable viewing a version of the current node. |
-| node | `Node` |  | The target node. |
-| showActions | `boolean` | true | Toggles showing/hiding of version actions |
-| showComments | `boolean` | true | Toggles showing/hiding of comments |
+| Name               | Type      | Default value | Description                                               |
+|--------------------|-----------|---------------|-----------------------------------------------------------|
+| allowDownload      | `boolean` | true          | Enable/disable downloading a version of the current node. |
+| allowViewVersions  | `boolean` | true          | Enable/disable viewing a version of the current node.     |
+| node               | `Node`    |               | The target node.                                          |
+| showActions        | `boolean` | true          | Toggles showing/hiding of version actions                 |
+| showComments       | `boolean` | true          | Toggles showing/hiding of comments                        |
+| allowVersionDelete | `boolean` | true          | Enable/disable deletion of version                        |
 
 ### Events
 
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| deleted | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<Node>` | Emitted when a version is deleted |
-| restored | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<Node>` | Emitted when a version is restored |
-| viewVersion | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<string>` | Emitted when viewing a version |
+| Name        | Type                            |  Description                       |
+|-------------|---------------------------------|------------------------------------|
+| deleted     | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<Node>`   | Emitted when a version is deleted  |
+| restored    | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<Node>`   | Emitted when a version is restored |
+| viewVersion | [`EventEmitter`](https://angular.io/api/core/EventEmitter)`<string>` | Emitted when viewing a version     |
 
 ## Details
 

--- a/lib/content-services/src/lib/new-version-uploader/models/new-version-uploader.model.ts
+++ b/lib/content-services/src/lib/new-version-uploader/models/new-version-uploader.model.ts
@@ -26,6 +26,7 @@ export interface NewVersionUploaderDialogData {
     showVersionsOnly?: boolean;
     showComments?: boolean;
     allowDownload?: boolean;
+    allowViewVersions?: boolean;
 }
 
 export type NewVersionUploaderData = VersionManagerUploadData | ViewVersion | RefreshData;

--- a/lib/content-services/src/lib/new-version-uploader/models/new-version-uploader.model.ts
+++ b/lib/content-services/src/lib/new-version-uploader/models/new-version-uploader.model.ts
@@ -25,8 +25,10 @@ export interface NewVersionUploaderDialogData {
     currentVersion?: Version;
     showVersionsOnly?: boolean;
     showComments?: boolean;
+    showActions?: boolean;
     allowDownload?: boolean;
     allowViewVersions?: boolean;
+    allowVersionDelete?: boolean;
 }
 
 export type NewVersionUploaderData = VersionManagerUploadData | ViewVersion | RefreshData;

--- a/lib/content-services/src/lib/new-version-uploader/new-version-uploader.dialog.html
+++ b/lib/content-services/src/lib/new-version-uploader/new-version-uploader.dialog.html
@@ -19,8 +19,10 @@
         <adf-version-list
           [node]="data.node"
           [showComments]="data.showComments"
+          [showActions]="data.showActions"
           [allowDownload]="data.allowDownload"
           [allowViewVersions]="data.allowViewVersions"
+          [allowVersionDelete]="data.allowVersionDelete"
           (deleted)="refresh($event)"
           (restored)="refresh($event)"
           (viewVersion)="onViewingVersion($event)"

--- a/lib/content-services/src/lib/new-version-uploader/new-version-uploader.dialog.html
+++ b/lib/content-services/src/lib/new-version-uploader/new-version-uploader.dialog.html
@@ -20,6 +20,7 @@
           [node]="data.node"
           [showComments]="data.showComments"
           [allowDownload]="data.allowDownload"
+          [allowViewVersions]="data.allowViewVersions"
           (deleted)="refresh($event)"
           (restored)="refresh($event)"
           (viewVersion)="onViewingVersion($event)"

--- a/lib/content-services/src/lib/new-version-uploader/new-version-uploader.dialog.spec.ts
+++ b/lib/content-services/src/lib/new-version-uploader/new-version-uploader.dialog.spec.ts
@@ -22,6 +22,7 @@ import { ContentTestingModule } from '../testing/content.testing.module';
 import { NewVersionUploaderDataAction } from './models';
 import { NewVersionUploaderDialogComponent } from './new-version-uploader.dialog';
 import { By } from '@angular/platform-browser';
+import { VersionListComponent } from '../version-manager/version-list.component';
 
 describe('NewVersionUploaderDialog', () => {
     let component: NewVersionUploaderDialogComponent;
@@ -139,6 +140,8 @@ describe('NewVersionUploaderDialog', () => {
     describe('Manage Versions', () => {
         const expectedManageVersionsTitle = 'ADF-NEW-VERSION-UPLOADER.DIALOG_LIST.TITLE';
 
+        const getVersionListComponent = (): VersionListComponent => fixture.debugElement.query(By.css(cssSelectors.adfVersionList)).componentInstance;
+
         it('should display adf version list if showVersionsOnly is passed as true from parent component', () => {
             component.data.showVersionsOnly = true;
             fixture.detectChanges();
@@ -184,13 +187,52 @@ describe('NewVersionUploaderDialog', () => {
             expect(matDialogTitle.innerHTML).toEqual('TEST_TITLE');
         });
 
-        it('should have assigned allowViewVersions based on allowViewVersions from data', () => {
+        it('should have assigned allowViewVersions to true if allowViewVersions from data is true', () => {
             component.data.showVersionsOnly = true;
             component.data.allowViewVersions = true;
 
             fixture.detectChanges();
-            const adfVersionListComponent = fixture.debugElement.query(By.css(cssSelectors.adfVersionList));
-            expect(adfVersionListComponent.componentInstance.allowViewVersions).toBeTrue();
+            expect(getVersionListComponent().allowViewVersions).toBeTrue();
+        });
+
+        it('should have assigned allowViewVersions to false if allowViewVersions from data is false', () => {
+            component.data.showVersionsOnly = true;
+            component.data.allowViewVersions = false;
+
+            fixture.detectChanges();
+            expect(getVersionListComponent().allowViewVersions).toBeFalse();
+        });
+
+        it('should have assigned showActions to true if showActions from data is true', () => {
+            component.data.showVersionsOnly = true;
+            component.data.showActions = true;
+
+            fixture.detectChanges();
+            expect(getVersionListComponent().showActions).toBeTrue();
+        });
+
+        it('should have assigned showActions to false if showActions from data is false', () => {
+            component.data.showVersionsOnly = true;
+            component.data.showActions = false;
+
+            fixture.detectChanges();
+            expect(getVersionListComponent().showActions).toBeFalse();
+        });
+
+        it('should have assigned allowVersionDelete to true if allowVersionDelete from data is true', () => {
+            component.data.showVersionsOnly = true;
+            component.data.allowVersionDelete = true;
+
+            fixture.detectChanges();
+            expect(getVersionListComponent().allowVersionDelete).toBeTrue();
+        });
+
+        it('should have assigned allowVersionDelete to false if allowVersionDelete from data is false', () => {
+            component.data.showVersionsOnly = true;
+            component.data.allowVersionDelete = false;
+
+            fixture.detectChanges();
+            expect(getVersionListComponent().allowVersionDelete).toBeFalse();
         });
     });
 });

--- a/lib/content-services/src/lib/new-version-uploader/new-version-uploader.dialog.spec.ts
+++ b/lib/content-services/src/lib/new-version-uploader/new-version-uploader.dialog.spec.ts
@@ -21,6 +21,7 @@ import { mockFile, mockNode } from '../mock';
 import { ContentTestingModule } from '../testing/content.testing.module';
 import { NewVersionUploaderDataAction } from './models';
 import { NewVersionUploaderDialogComponent } from './new-version-uploader.dialog';
+import { By } from '@angular/platform-browser';
 
 describe('NewVersionUploaderDialog', () => {
     let component: NewVersionUploaderDialogComponent;
@@ -181,6 +182,15 @@ describe('NewVersionUploaderDialog', () => {
             fixture.detectChanges();
             const matDialogTitle = nativeElement.querySelector(cssSelectors.title);
             expect(matDialogTitle.innerHTML).toEqual('TEST_TITLE');
+        });
+
+        it('should have assigned allowViewVersions based on allowViewVersions from data', () => {
+            component.data.showVersionsOnly = true;
+            component.data.allowViewVersions = true;
+
+            fixture.detectChanges();
+            const adfVersionListComponent = fixture.debugElement.query(By.css(cssSelectors.adfVersionList));
+            expect(adfVersionListComponent.componentInstance.allowViewVersions).toBeTrue();
         });
     });
 });

--- a/lib/content-services/src/lib/new-version-uploader/new-version-uploader.service.spec.ts
+++ b/lib/content-services/src/lib/new-version-uploader/new-version-uploader.service.spec.ts
@@ -101,7 +101,8 @@ describe('NewVersionUploaderService', () => {
                         currentVersion: '2',
                         showComments: true,
                         allowDownload: true,
-                        showVersionsOnly: undefined
+                        showVersionsOnly: undefined,
+                        allowViewVersions: true
                     },
                     panelClass: ['adf-new-version-uploader-dialog', 'adf-new-version-uploader-dialog-upload'],
                     width: '630px'
@@ -122,7 +123,8 @@ describe('NewVersionUploaderService', () => {
                         currentVersion: '2',
                         showComments: true,
                         allowDownload: true,
-                        showVersionsOnly: undefined
+                        showVersionsOnly: undefined,
+                        allowViewVersions: true
                     },
                     panelClass: 'adf-custom-class',
                     width: '500px'
@@ -142,7 +144,8 @@ describe('NewVersionUploaderService', () => {
                         currentVersion: '2',
                         showComments: true,
                         allowDownload: true,
-                        showVersionsOnly: undefined
+                        showVersionsOnly: undefined,
+                        allowViewVersions: true
                     },
                     panelClass: ['adf-new-version-uploader-dialog', 'adf-new-version-uploader-dialog-upload'],
                     width: '630px',
@@ -161,7 +164,8 @@ describe('NewVersionUploaderService', () => {
                         currentVersion: '2',
                         showComments: true,
                         allowDownload: true,
-                        showVersionsOnly: undefined
+                        showVersionsOnly: undefined,
+                        allowViewVersions: true
                     },
                     panelClass: ['adf-new-version-uploader-dialog', 'adf-new-version-uploader-dialog-upload'],
                     width: '630px'
@@ -185,12 +189,57 @@ describe('NewVersionUploaderService', () => {
                         currentVersion: '2',
                         showComments: true,
                         allowDownload: true,
-                        showVersionsOnly: true
+                        showVersionsOnly: true,
+                        allowViewVersions: true
                     },
                     panelClass: ['adf-new-version-uploader-dialog', 'adf-new-version-uploader-dialog-list'],
                     width: '630px'
                 } as any);
             }));
+
+            it('should open dialog with correct configuration when allowViewVersions is true', (done) => {
+                dialogRefSpyObj.componentInstance.dialogAction = new BehaviorSubject<NewVersionUploaderData>(mockNewVersionUploaderData);
+                mockNewVersionUploaderDialogData.allowViewVersions = true;
+
+                service.openUploadNewVersionDialog(mockNewVersionUploaderDialogData).subscribe(() => {
+                    expect(spyOnDialogOpen).toHaveBeenCalledWith(NewVersionUploaderDialogComponent, {
+                        data: {
+                            file: mockFile,
+                            node: mockNode,
+                            currentVersion: '2',
+                            showComments: true,
+                            allowDownload: true,
+                            showVersionsOnly: undefined,
+                            allowViewVersions: true
+                        },
+                        panelClass: ['adf-new-version-uploader-dialog', 'adf-new-version-uploader-dialog-upload'],
+                        width: '630px'
+                    });
+                    done();
+                });
+            });
+
+            it('should open dialog with correct configuration when allowViewVersions is false', (done) => {
+                dialogRefSpyObj.componentInstance.dialogAction = new BehaviorSubject<NewVersionUploaderData>(mockNewVersionUploaderData);
+                mockNewVersionUploaderDialogData.allowViewVersions = false;
+
+                service.openUploadNewVersionDialog(mockNewVersionUploaderDialogData).subscribe(() => {
+                    expect(spyOnDialogOpen).toHaveBeenCalledWith(NewVersionUploaderDialogComponent, {
+                        data: {
+                            file: mockFile,
+                            node: mockNode,
+                            currentVersion: '2',
+                            showComments: true,
+                            allowDownload: true,
+                            showVersionsOnly: undefined,
+                            allowViewVersions: false
+                        },
+                        panelClass: ['adf-new-version-uploader-dialog', 'adf-new-version-uploader-dialog-upload'],
+                        width: '630px'
+                    });
+                    done();
+                });
+            });
         });
 
         describe('Subscribe events from Dialog', () => {

--- a/lib/content-services/src/lib/new-version-uploader/new-version-uploader.service.spec.ts
+++ b/lib/content-services/src/lib/new-version-uploader/new-version-uploader.service.spec.ts
@@ -31,6 +31,7 @@ import {
 } from './models';
 import { NewVersionUploaderDialogComponent } from './new-version-uploader.dialog';
 import { NewVersionUploaderService } from './new-version-uploader.service';
+import { Version, VersionPaging } from '@alfresco/js-api';
 
 @Component({
     template: ''
@@ -77,11 +78,21 @@ describe('NewVersionUploaderService', () => {
     describe('openUploadNewVersionDialog', () => {
         describe('Mat Dialog configuration', () => {
             let mockNewVersionUploaderDialogData: NewVersionUploaderDialogData;
+            let expectedConfig: MatDialogConfig<NewVersionUploaderDialogData>;
+
             beforeEach(() => {
                 spyOn(service.versionsApi, 'listVersionHistory').and.returnValue(
                     Promise.resolve({
-                        list: { entries: [{ entry: '2' }] }
-                    } as any)
+                        list: {
+                            entries: [
+                                {
+                                    entry: {
+                                        id: '2'
+                                    }
+                                }
+                            ]
+                        }
+                    } as VersionPaging)
                 );
                 mockNewVersionUploaderDialogData = {
                     node: mockNode,
@@ -89,90 +100,61 @@ describe('NewVersionUploaderService', () => {
                     showComments: true,
                     allowDownload: true
                 };
-            });
-
-            it('Should open dialog with default configuration', fakeAsync(() => {
-                service.openUploadNewVersionDialog(mockNewVersionUploaderDialogData).toPromise();
-                tick();
-                expect(spyOnDialogOpen).toHaveBeenCalledWith(NewVersionUploaderDialogComponent, {
+                expectedConfig = {
                     data: {
                         file: mockFile,
                         node: mockNode,
-                        currentVersion: '2',
+                        currentVersion: {
+                            id: '2'
+                        } as Version,
                         showComments: true,
                         allowDownload: true,
                         showVersionsOnly: undefined,
-                        allowViewVersions: true
+                        allowViewVersions: true,
+                        allowVersionDelete: true,
+                        showActions: true
                     },
                     panelClass: ['adf-new-version-uploader-dialog', 'adf-new-version-uploader-dialog-upload'],
                     width: '630px'
-                } as any);
+                };
+            });
+
+            it('should open dialog with default configuration', fakeAsync(() => {
+                service.openUploadNewVersionDialog(mockNewVersionUploaderDialogData).toPromise();
+                tick();
+                expect(spyOnDialogOpen).toHaveBeenCalledWith(NewVersionUploaderDialogComponent, expectedConfig);
             }));
 
-            it('Should override default dialog panelClass', fakeAsync(() => {
+            it('should override default dialog panelClass', fakeAsync(() => {
                 const mockDialogConfiguration: MatDialogConfig = {
                     panelClass: 'adf-custom-class',
                     width: '500px'
                 };
                 service.openUploadNewVersionDialog(mockNewVersionUploaderDialogData, mockDialogConfiguration).toPromise();
                 tick();
-                expect(spyOnDialogOpen).toHaveBeenCalledWith(NewVersionUploaderDialogComponent, {
-                    data: {
-                        file: mockFile,
-                        node: mockNode,
-                        currentVersion: '2',
-                        showComments: true,
-                        allowDownload: true,
-                        showVersionsOnly: undefined,
-                        allowViewVersions: true
-                    },
-                    panelClass: 'adf-custom-class',
-                    width: '500px'
-                } as any);
+                expectedConfig.panelClass = 'adf-custom-class';
+                expectedConfig.width = '500px';
+                expect(spyOnDialogOpen).toHaveBeenCalledWith(NewVersionUploaderDialogComponent, expectedConfig);
             }));
 
-            it('Should set dialog height', fakeAsync(() => {
+            it('should set dialog height', fakeAsync(() => {
                 const mockDialogConfiguration: MatDialogConfig = {
                     height: '600px'
                 };
                 service.openUploadNewVersionDialog(mockNewVersionUploaderDialogData, mockDialogConfiguration).toPromise();
                 tick();
-                expect(spyOnDialogOpen).toHaveBeenCalledWith(NewVersionUploaderDialogComponent, {
-                    data: {
-                        file: mockFile,
-                        node: mockNode,
-                        currentVersion: '2',
-                        showComments: true,
-                        allowDownload: true,
-                        showVersionsOnly: undefined,
-                        allowViewVersions: true
-                    },
-                    panelClass: ['adf-new-version-uploader-dialog', 'adf-new-version-uploader-dialog-upload'],
-                    width: '630px',
-                    height: '600px'
-                } as any);
+                expectedConfig.height = '600px';
+                expect(spyOnDialogOpen).toHaveBeenCalledWith(NewVersionUploaderDialogComponent, expectedConfig);
             }));
 
-            it('Should not override dialog configuration, if dialog configuration is empty', fakeAsync(() => {
+            it('should not override dialog configuration, if dialog configuration is empty', fakeAsync(() => {
                 const mockDialogConfiguration: MatDialogConfig = {};
                 service.openUploadNewVersionDialog(mockNewVersionUploaderDialogData, mockDialogConfiguration).toPromise();
                 tick();
-                expect(spyOnDialogOpen).toHaveBeenCalledWith(NewVersionUploaderDialogComponent, {
-                    data: {
-                        file: mockFile,
-                        node: mockNode,
-                        currentVersion: '2',
-                        showComments: true,
-                        allowDownload: true,
-                        showVersionsOnly: undefined,
-                        allowViewVersions: true
-                    },
-                    panelClass: ['adf-new-version-uploader-dialog', 'adf-new-version-uploader-dialog-upload'],
-                    width: '630px'
-                } as any);
+                expect(spyOnDialogOpen).toHaveBeenCalledWith(NewVersionUploaderDialogComponent, expectedConfig);
             }));
 
-            it('Should dialog add list css class if showVersionsOnly is true', fakeAsync(() => {
+            it('should dialog add list css class if showVersionsOnly is true', fakeAsync(() => {
                 const mockNewVersionUploaderDialogDataWithVersionsOnly = {
                     node: mockNode,
                     file: mockFile,
@@ -182,19 +164,9 @@ describe('NewVersionUploaderService', () => {
                 };
                 service.openUploadNewVersionDialog(mockNewVersionUploaderDialogDataWithVersionsOnly).toPromise();
                 tick();
-                expect(spyOnDialogOpen).toHaveBeenCalledWith(NewVersionUploaderDialogComponent, {
-                    data: {
-                        file: mockFile,
-                        node: mockNode,
-                        currentVersion: '2',
-                        showComments: true,
-                        allowDownload: true,
-                        showVersionsOnly: true,
-                        allowViewVersions: true
-                    },
-                    panelClass: ['adf-new-version-uploader-dialog', 'adf-new-version-uploader-dialog-list'],
-                    width: '630px'
-                } as any);
+                expectedConfig.data.showVersionsOnly = true;
+                expectedConfig.panelClass = ['adf-new-version-uploader-dialog', 'adf-new-version-uploader-dialog-list'];
+                expect(spyOnDialogOpen).toHaveBeenCalledWith(NewVersionUploaderDialogComponent, expectedConfig);
             }));
 
             it('should open dialog with correct configuration when allowViewVersions is true', (done) => {
@@ -202,19 +174,7 @@ describe('NewVersionUploaderService', () => {
                 mockNewVersionUploaderDialogData.allowViewVersions = true;
 
                 service.openUploadNewVersionDialog(mockNewVersionUploaderDialogData).subscribe(() => {
-                    expect(spyOnDialogOpen).toHaveBeenCalledWith(NewVersionUploaderDialogComponent, {
-                        data: {
-                            file: mockFile,
-                            node: mockNode,
-                            currentVersion: '2',
-                            showComments: true,
-                            allowDownload: true,
-                            showVersionsOnly: undefined,
-                            allowViewVersions: true
-                        },
-                        panelClass: ['adf-new-version-uploader-dialog', 'adf-new-version-uploader-dialog-upload'],
-                        width: '630px'
-                    });
+                    expect(spyOnDialogOpen).toHaveBeenCalledWith(NewVersionUploaderDialogComponent, expectedConfig);
                     done();
                 });
             });
@@ -224,19 +184,50 @@ describe('NewVersionUploaderService', () => {
                 mockNewVersionUploaderDialogData.allowViewVersions = false;
 
                 service.openUploadNewVersionDialog(mockNewVersionUploaderDialogData).subscribe(() => {
-                    expect(spyOnDialogOpen).toHaveBeenCalledWith(NewVersionUploaderDialogComponent, {
-                        data: {
-                            file: mockFile,
-                            node: mockNode,
-                            currentVersion: '2',
-                            showComments: true,
-                            allowDownload: true,
-                            showVersionsOnly: undefined,
-                            allowViewVersions: false
-                        },
-                        panelClass: ['adf-new-version-uploader-dialog', 'adf-new-version-uploader-dialog-upload'],
-                        width: '630px'
-                    });
+                    expectedConfig.data.allowViewVersions = false;
+                    expect(spyOnDialogOpen).toHaveBeenCalledWith(NewVersionUploaderDialogComponent, expectedConfig);
+                    done();
+                });
+            });
+
+            it('should open dialog with correct configuration when allowVersionDelete is true', (done) => {
+                dialogRefSpyObj.componentInstance.dialogAction = new BehaviorSubject<NewVersionUploaderData>(mockNewVersionUploaderData);
+                mockNewVersionUploaderDialogData.allowVersionDelete = true;
+
+                service.openUploadNewVersionDialog(mockNewVersionUploaderDialogData).subscribe(() => {
+                    expect(spyOnDialogOpen).toHaveBeenCalledWith(NewVersionUploaderDialogComponent, expectedConfig);
+                    done();
+                });
+            });
+
+            it('should open dialog with correct configuration when allowVersionDelete is false', (done) => {
+                dialogRefSpyObj.componentInstance.dialogAction = new BehaviorSubject<NewVersionUploaderData>(mockNewVersionUploaderData);
+                mockNewVersionUploaderDialogData.allowVersionDelete = false;
+
+                service.openUploadNewVersionDialog(mockNewVersionUploaderDialogData).subscribe(() => {
+                    expectedConfig.data.allowVersionDelete = false;
+                    expect(spyOnDialogOpen).toHaveBeenCalledWith(NewVersionUploaderDialogComponent, expectedConfig);
+                    done();
+                });
+            });
+
+            it('should open dialog with correct configuration when showActions is true', (done) => {
+                dialogRefSpyObj.componentInstance.dialogAction = new BehaviorSubject<NewVersionUploaderData>(mockNewVersionUploaderData);
+                mockNewVersionUploaderDialogData.showActions = true;
+
+                service.openUploadNewVersionDialog(mockNewVersionUploaderDialogData).subscribe(() => {
+                    expect(spyOnDialogOpen).toHaveBeenCalledWith(NewVersionUploaderDialogComponent, expectedConfig);
+                    done();
+                });
+            });
+
+            it('should open dialog with correct configuration when showActions is false', (done) => {
+                dialogRefSpyObj.componentInstance.dialogAction = new BehaviorSubject<NewVersionUploaderData>(mockNewVersionUploaderData);
+                mockNewVersionUploaderDialogData.showActions = false;
+
+                service.openUploadNewVersionDialog(mockNewVersionUploaderDialogData).subscribe(() => {
+                    expectedConfig.data.showActions = false;
+                    expect(spyOnDialogOpen).toHaveBeenCalledWith(NewVersionUploaderDialogComponent, expectedConfig);
                     done();
                 });
             });

--- a/lib/content-services/src/lib/new-version-uploader/new-version-uploader.service.ts
+++ b/lib/content-services/src/lib/new-version-uploader/new-version-uploader.service.ts
@@ -62,7 +62,15 @@ export class NewVersionUploaderService {
                 const dialogRef = this.dialog.open<NewVersionUploaderDialogComponent, NewVersionUploaderDialogData>(
                     NewVersionUploaderDialogComponent,
                     {
-                        data: { file, node, currentVersion: versionPaging.list.entries[0].entry, showComments, allowDownload, showVersionsOnly },
+                        data: {
+                            file,
+                            node,
+                            currentVersion: versionPaging.list.entries[0].entry,
+                            showComments,
+                            allowDownload,
+                            showVersionsOnly,
+                            allowViewVersions: data.allowViewVersions ?? true
+                        },
                         panelClass: this.composePanelClass(showVersionsOnly),
                         width: '630px',
                         ...(config && Object.keys(config).length > 0 && config)

--- a/lib/content-services/src/lib/new-version-uploader/new-version-uploader.service.ts
+++ b/lib/content-services/src/lib/new-version-uploader/new-version-uploader.service.ts
@@ -69,7 +69,9 @@ export class NewVersionUploaderService {
                             showComments,
                             allowDownload,
                             showVersionsOnly,
-                            allowViewVersions: data.allowViewVersions ?? true
+                            allowViewVersions: data.allowViewVersions ?? true,
+                            allowVersionDelete: data.allowVersionDelete ?? true,
+                            showActions: data.showActions ?? true
                         },
                         panelClass: this.composePanelClass(showVersionsOnly),
                         width: '630px',

--- a/lib/content-services/src/lib/version-manager/version-list.component.html
+++ b/lib/content-services/src/lib/version-manager/version-list.component.html
@@ -50,6 +50,7 @@
                         {{ 'ADF_VERSION_LIST.ACTIONS.DOWNLOAD' | translate }}
                     </button>
                     <button
+                        *ngIf="allowVersionDelete"
                         [disabled]="!canDelete()"
                         [id]="'adf-version-list-action-delete-' + version.entry.id"
                         (click)="deleteVersion(version.entry.id)"

--- a/lib/content-services/src/lib/version-manager/version-list.component.spec.ts
+++ b/lib/content-services/src/lib/version-manager/version-list.component.spec.ts
@@ -267,6 +267,8 @@ describe('VersionListComponent', () => {
             return fixture.debugElement.query(By.css(`[id="adf-version-list-action-restore-${version}"]`))?.nativeElement;
         };
 
+        const getDeleteButton = (version = '1.1') => fixture.debugElement.query(By.css(`[id="adf-version-list-action-delete-${version}"]`));
+
         beforeEach(() => {
             fixture.detectChanges();
             versionTest[1].entry.id = '1.1';
@@ -351,6 +353,41 @@ describe('VersionListComponent', () => {
             it('should enable restore action if is allowed', (done) => {
                 fixture.whenStable().then(() => {
                     expect(getRestoreButton('1.1').disabled).toBeFalse();
+                    done();
+                });
+            });
+        });
+
+        describe('Delete action', () => {
+            beforeEach(() => {
+                component.node = { id: nodeId, allowableOperations: ['update', 'delete'] } as Node;
+            });
+
+            it('should show delete action by default', (done) => {
+                fixture.detectChanges();
+                fixture.whenStable().then(() => {
+                    getActionMenuButton('1.1').click();
+                    expect(getDeleteButton()).not.toBeNull();
+                    done();
+                });
+            });
+
+            it('should show delete action if allowVersionDelete is true', (done) => {
+                component.allowVersionDelete = true;
+                fixture.detectChanges();
+                fixture.whenStable().then(() => {
+                    getActionMenuButton('1.1').click();
+                    expect(getDeleteButton()).not.toBeNull();
+                    done();
+                });
+            });
+
+            it('should hide delete action if allowVersionDelete is false', (done) => {
+                component.allowVersionDelete = false;
+                fixture.detectChanges();
+                fixture.whenStable().then(() => {
+                    getActionMenuButton('1.1').click();
+                    expect(getDeleteButton()).toBeNull();
                     done();
                 });
             });

--- a/lib/content-services/src/lib/version-manager/version-list.component.ts
+++ b/lib/content-services/src/lib/version-manager/version-list.component.ts
@@ -113,6 +113,10 @@ export class VersionListComponent implements OnChanges, OnInit, OnDestroy {
     @Input()
     showActions = true;
 
+    /** Enable/disable deletion of version */
+    @Input()
+    allowVersionDelete = true;
+
     /** Emitted when a version is restored */
     @Output()
     restored = new EventEmitter<Node>();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/MNT-24660


**What is the new behaviour?**
Properties of versions list can be properly configured. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
