### PR TITLE
Fix/mnt 24682 kerberos do not add authorization header

### DIFF
--- a/lib/core/src/lib/auth/basic-auth/basic-alfresco-auth.service.ts
+++ b/lib/core/src/lib/auth/basic-auth/basic-alfresco-auth.service.ts
@@ -370,7 +370,7 @@ export class BasicAlfrescoAuthService extends BaseAuthenticationService {
      * @param requestUrl the request url
      * @returns The ticket or `null` if none was found
      */
-    private getTicketEcmBase64(requestUrl: string): string | null {
+    getTicketEcmBase64(requestUrl: string): string | null {
         let ticket = null;
 
         const contextRootBpm = this.appConfig.get<string>(AppConfigValues.CONTEXTROOTBPM) || 'activiti-app';

--- a/lib/core/src/lib/auth/basic-auth/basic-alfresco-auth.service.ts
+++ b/lib/core/src/lib/auth/basic-auth/basic-alfresco-auth.service.ts
@@ -347,6 +347,10 @@ export class BasicAlfrescoAuthService extends BaseAuthenticationService {
     }
 
     private addBasicAuth(requestUrl: string, header: HttpHeaders): HttpHeaders {
+        if (this.isKerberosEnabled()) {
+            return header;
+        }
+
         const ticket = this.getTicketEcmBase64(requestUrl);
 
         if (!ticket) {

--- a/lib/core/src/lib/auth/services/authentication.service.spec.ts
+++ b/lib/core/src/lib/auth/services/authentication.service.spec.ts
@@ -21,7 +21,7 @@ import { CookieService } from '../../common/services/cookie.service';
 import { AppConfigService } from '../../app-config/app-config.service';
 import { BasicAlfrescoAuthService } from '../basic-auth/basic-alfresco-auth.service';
 import { AuthModule } from '../oidc/auth.module';
-import { HttpClientModule } from '@angular/common/http';
+import { HttpClientModule, HttpHeaders } from '@angular/common/http';
 import { CookieServiceMock } from '../../mock';
 import { AppConfigServiceMock } from '../../common';
 import { OidcAuthenticationService } from '../oidc/oidc-authentication.service';
@@ -39,6 +39,7 @@ xdescribe('AuthenticationService', () => {
     let appConfigService: AppConfigService;
     let cookie: CookieService;
     let oidcAuthenticationService: OidcAuthenticationService;
+    let headers: HttpHeaders;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -80,6 +81,7 @@ xdescribe('AuthenticationService', () => {
         beforeEach(() => {
             appConfigService.config.providers = 'ALL';
             appConfigService.config.auth = { withCredentials: true };
+            headers = new HttpHeaders();
         });
 
         it('should emit login event for kerberos', (done) => {
@@ -106,6 +108,15 @@ xdescribe('AuthenticationService', () => {
             spyOn(authService, 'isOauth').and.returnValue(false);
             spyOn(basicAlfrescoAuthService, 'isKerberosEnabled').and.returnValue(true);
             expect(authService.isKerberosEnabled()).toEqual(true);
+        });
+
+        it('should not add Authorization header if kerberos is enabled', () => {
+            const url = 'some-url';
+            spyOn(basicAlfrescoAuthService, 'isKerberosEnabled').and.returnValue(true);
+            spyOn(basicAlfrescoAuthService, 'getTicketEcmBase64').and.returnValue('some-ticket');
+            headers = basicAlfrescoAuthService.getAuthHeaders(url, headers);
+            expect(headers.get('Authorization')).toBeNull();
+            expect(basicAlfrescoAuthService.getTicketEcmBase64).not.toHaveBeenCalled();
         });
     });
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

When Kerberos is enabled, the `Authorization` header is being sent with basic authentication making some requests to fail with `401` error.

Further information can be found in [MNT-24642](https://hyland.atlassian.net/browse/MNT-24642) namely the comparison between sending and not sending the header with Kerberos.

**What is the new behaviour?**

Prevent the header from being added to the request if Kerberos is enabled.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Two notes regarding the unit test I have added to `authentication.service.spec.ts`:

- Tests are not being executed since `xdescribe` is being used (I had to change to `describe` locally in order to run my test)
- I also had to change `BasicAlfrescoAuthService.getTicketEcmBase64` access modifier in order to mock/verify it in my test