### PR TITLE
[ACS-8634] Change saved searches config file name

### DIFF
--- a/docs/core/services/saved-searches.service.md
+++ b/docs/core/services/saved-searches.service.md
@@ -58,7 +58,7 @@ When the saved searches file does not exist, it will be created:
 
 ```typescript
 this.savedSearchService.createSavedSearchesNode('parent-node-id').subscribe((node) => {
-    console.log('Created saved-searches.json node:', node);
+    console.log('Created config.json node:', node);
 });
 ```
 

--- a/lib/content-services/src/lib/common/services/saved-searches.service.spec.ts
+++ b/lib/content-services/src/lib/common/services/saved-searches.service.spec.ts
@@ -69,7 +69,7 @@ describe('SavedSearchesService', () => {
         localStorage.removeItem(SAVED_SEARCHES_NODE_ID + testUserName);
     });
 
-    it('should retrieve saved searches from the saved-searches.json file', (done) => {
+    it('should retrieve saved searches from the config.json file', (done) => {
         spyOn(authService, 'getUsername').and.callFake(() => testUserName);
         spyOn(localStorage, 'getItem').and.callFake(() => testNodeId);
         service.innit();
@@ -84,7 +84,7 @@ describe('SavedSearchesService', () => {
         });
     });
 
-    it('should create saved-searches.json file if it does not exist', (done) => {
+    it('should create config.json file if it does not exist', (done) => {
         spyOn(authService, 'getUsername').and.callFake(() => testUserName);
         getNodeContentSpy.and.callFake(() => Promise.resolve(new Blob([''])));
         service.innit();
@@ -92,7 +92,7 @@ describe('SavedSearchesService', () => {
         service.getSavedSearches().subscribe((searches) => {
             expect(service.nodesApi.getNode).toHaveBeenCalledWith('-my-');
             expect(service.searchApi.search).toHaveBeenCalled();
-            expect(service.nodesApi.createNode).toHaveBeenCalledWith(testNodeId, jasmine.objectContaining({ name: 'saved-searches.json' }));
+            expect(service.nodesApi.createNode).toHaveBeenCalledWith(testNodeId, jasmine.objectContaining({ name: 'config.json' }));
             expect(searches.length).toBe(0);
             done();
         });

--- a/lib/content-services/src/lib/common/services/saved-searches.service.ts
+++ b/lib/content-services/src/lib/common/services/saved-searches.service.ts
@@ -217,7 +217,7 @@ export class SavedSearchesService {
                         this.searchApi.search({
                             query: {
                                 language: SEARCH_LANGUAGE.AFTS,
-                                query: `cm:name:"saved-searches.json" AND PARENT:"${parentNodeId}"`
+                                query: `cm:name:"config.json" AND PARENT:"${parentNodeId}"`
                             }
                         })
                     ).pipe(
@@ -247,7 +247,7 @@ export class SavedSearchesService {
         }
     }
     private createSavedSearchesNode(parentNodeId: string): Observable<NodeEntry> {
-        return from(this.nodesApi.createNode(parentNodeId, { name: 'saved-searches.json', nodeType: 'cm:content' }));
+        return from(this.nodesApi.createNode(parentNodeId, { name: 'config.json', nodeType: 'cm:content' }));
     }
 
     private async mapFileContentToSavedSearches(blob: Blob): Promise<Array<SavedSearch>> {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://hyland.atlassian.net/browse/ACS-8634

**What is the new behaviour?**

Name of saved searches config file has been changed to `config.json`

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
