### PR TITLE
[MNT-24698] Add aspect name to the title when there are duplicated aspect titles

### DIFF
--- a/lib/content-services/src/lib/content-metadata/services/content-metadata.service.spec.ts
+++ b/lib/content-services/src/lib/content-metadata/services/content-metadata.service.spec.ts
@@ -161,11 +161,25 @@ describe('ContentMetaDataService', () => {
 
     const aspect3Group: OrganisedPropertyGroup = {
         name: 'test:aspect3',
-        title: 'Test Aspect',
+        title: undefined,
         properties: [
             {
                 title: 'Property 3',
                 name: 'test:property3',
+                dataType: 'd:text',
+                mandatory: false,
+                multiValued: false
+            }
+        ]
+    };
+
+    const aspect4Group: OrganisedPropertyGroup = {
+        name: 'test:aspect4',
+        title: 'test:aspect3',
+        properties: [
+            {
+                title: 'Property 4',
+                name: 'test:property4',
                 dataType: 'd:text',
                 mandatory: false,
                 multiValued: false
@@ -219,12 +233,18 @@ describe('ContentMetaDataService', () => {
         });
     });
 
-    it('should distinguish aspects with same title by concatenating the aspect name', () => {
-        const groupedProperties = service.setTitleToNameIfNotSet([aspect1Group, aspect2Group, aspect3Group]);
-        expect(groupedProperties.length).toEqual(3);
+    it('should distinguish aspects with same title', () => {
+        const groupedProperties = service.setTitleToNameIfNotSet([aspect1Group, aspect2Group]);
+        expect(groupedProperties.length).toEqual(2);
         expect(groupedProperties[0].title).toEqual('Test Aspect');
         expect(groupedProperties[1].title).toEqual('Test Aspect (test:aspect2)');
-        expect(groupedProperties[2].title).toEqual('Test Aspect (test:aspect3)');
+    });
+
+    it('should distinguish aspect without title from other aspect with title equals to its name', () => {
+        const groupedProperties = service.setTitleToNameIfNotSet([aspect3Group, aspect4Group]);
+        expect(groupedProperties.length).toEqual(2);
+        expect(groupedProperties[0].title).toEqual('test:aspect3');
+        expect(groupedProperties[1].title).toEqual('test:aspect3 (test:aspect4)');
     });
 
     describe('AspectOriented preset', () => {

--- a/lib/content-services/src/lib/content-metadata/services/content-metadata.service.spec.ts
+++ b/lib/content-services/src/lib/content-metadata/services/content-metadata.service.spec.ts
@@ -18,11 +18,12 @@
 import { AppConfigService } from '@alfresco/adf-core';
 import { ClassesApi, Node } from '@alfresco/js-api';
 import { TestBed } from '@angular/core/testing';
-import { ContentMetadataService } from './content-metadata.service';
 import { of } from 'rxjs';
-import { PropertyGroup } from '../interfaces/property-group.interface';
-import { ContentTypePropertiesService } from './content-type-property.service';
 import { ContentTestingModule } from '../../testing/content.testing.module';
+import { OrganisedPropertyGroup } from '../interfaces/content-metadata.interfaces';
+import { PropertyGroup } from '../interfaces/property-group.interface';
+import { ContentMetadataService } from './content-metadata.service';
+import { ContentTypePropertiesService } from './content-type-property.service';
 import { PropertyDescriptorsService } from './property-descriptors.service';
 
 const fakeNode: Node = {
@@ -130,6 +131,48 @@ describe('ContentMetaDataService', () => {
         }
     };
 
+    const aspect1Group: OrganisedPropertyGroup = {
+        name: 'test:aspect1',
+        title: 'Test Aspect',
+        properties: [
+            {
+                title: 'Property 1',
+                name: 'test:property1',
+                dataType: 'd:text',
+                mandatory: false,
+                multiValued: false
+            }
+        ]
+    };
+
+    const aspect2Group: OrganisedPropertyGroup = {
+        name: 'test:aspect2',
+        title: 'Test Aspect',
+        properties: [
+            {
+                title: 'Property 2',
+                name: 'test:property2',
+                dataType: 'd:text',
+                mandatory: false,
+                multiValued: false
+            }
+        ]
+    };
+
+    const aspect3Group: OrganisedPropertyGroup = {
+        name: 'test:aspect3',
+        title: 'Test Aspect',
+        properties: [
+            {
+                title: 'Property 3',
+                name: 'test:property3',
+                dataType: 'd:text',
+                mandatory: false,
+                multiValued: false
+            }
+        ]
+    };
+
     const setConfig = (presetName, presetConfig) => {
         appConfig.config['content-metadata'] = {
             presets: {
@@ -174,6 +217,14 @@ describe('ContentMetaDataService', () => {
         service.openConfirmDialog(fakeNode).subscribe(() => {
             expect(contentPropertyService.openContentTypeDialogConfirm).toHaveBeenCalledWith('fn:fakenode');
         });
+    });
+
+    it('should distinguish aspects with same title by concatenating the aspect name', () => {
+        const groupedProperties = service.setTitleToNameIfNotSet([aspect1Group, aspect2Group, aspect3Group]);
+        expect(groupedProperties.length).toEqual(3);
+        expect(groupedProperties[0].title).toEqual('Test Aspect');
+        expect(groupedProperties[1].title).toEqual('Test Aspect (test:aspect2)');
+        expect(groupedProperties[2].title).toEqual('Test Aspect (test:aspect3)');
     });
 
     describe('AspectOriented preset', () => {

--- a/lib/content-services/src/lib/content-metadata/services/content-metadata.service.ts
+++ b/lib/content-services/src/lib/content-metadata/services/content-metadata.service.ts
@@ -91,7 +91,11 @@ export class ContentMetadataService {
             const title = propertyGroup.title;
             const name = propertyGroup.name;
             if (title) {
-                propertyGroup.title = propertyGroupsTitles[title] ? `${title} (${name})` : title;
+                if (propertyGroupsTitles[title]) {
+                    propertyGroup.title = name ? `${title} (${name})` : title;
+                } else {
+                    propertyGroup.title = title;
+                }
                 propertyGroupsTitles[title] = title;
             } else {
                 propertyGroup.title = name;

--- a/lib/content-services/src/lib/content-metadata/services/content-metadata.service.ts
+++ b/lib/content-services/src/lib/content-metadata/services/content-metadata.service.ts
@@ -86,19 +86,20 @@ export class ContentMetadataService {
     }
 
     setTitleToNameIfNotSet(propertyGroups: OrganisedPropertyGroup[]): OrganisedPropertyGroup[] {
-        const propertyGroupsTitles = {};
+        const propertyGroupsTitles = [];
         propertyGroups.map((propertyGroup) => {
             const title = propertyGroup.title;
             const name = propertyGroup.name;
             if (title) {
-                if (propertyGroupsTitles[title]) {
+                if (propertyGroupsTitles.includes(title)) {
                     propertyGroup.title = name ? `${title} (${name})` : title;
                 } else {
                     propertyGroup.title = title;
                 }
-                propertyGroupsTitles[title] = title;
+                propertyGroupsTitles.push(title);
             } else {
                 propertyGroup.title = name;
+                propertyGroupsTitles.push(name);
             }
         });
         return propertyGroups;

--- a/lib/content-services/src/lib/content-metadata/services/content-metadata.service.ts
+++ b/lib/content-services/src/lib/content-metadata/services/content-metadata.service.ts
@@ -30,15 +30,15 @@ import { ContentTypePropertiesService } from './content-type-property.service';
     providedIn: 'root'
 })
 export class ContentMetadataService {
-
     error = new Subject<{ statusCode: number; message: string }>();
 
-    constructor(private basicPropertiesService: BasicPropertiesService,
-                private contentMetadataConfigFactory: ContentMetadataConfigFactory,
-                private propertyGroupTranslatorService: PropertyGroupTranslatorService,
-                private propertyDescriptorsService: PropertyDescriptorsService,
-                private contentTypePropertyService: ContentTypePropertiesService) {
-    }
+    constructor(
+        private basicPropertiesService: BasicPropertiesService,
+        private contentMetadataConfigFactory: ContentMetadataConfigFactory,
+        private propertyGroupTranslatorService: PropertyGroupTranslatorService,
+        private propertyDescriptorsService: PropertyDescriptorsService,
+        private contentTypePropertyService: ContentTypePropertiesService
+    ) {}
 
     getBasicProperties(node: Node): Observable<CardViewItem[]> {
         return of(this.basicPropertiesService.getProperties(node));
@@ -63,9 +63,7 @@ export class ContentMetadataService {
                 contentMetadataConfig = this.contentMetadataConfigFactory.createConfig(preset);
             }
 
-            const groupNames = node.aspectNames
-                .concat(node.nodeType)
-                .filter((groupName) => contentMetadataConfig.isGroupAllowed(groupName));
+            const groupNames = node.aspectNames.concat(node.nodeType).filter((groupName) => contentMetadataConfig.isGroupAllowed(groupName));
 
             if (groupNames.length > 0) {
                 groupedProperties = this.propertyDescriptorsService.load(groupNames).pipe(
@@ -74,7 +72,8 @@ export class ContentMetadataService {
                             () => contentMetadataConfig.isIncludeAllEnabled(),
                             of(contentMetadataConfig.appendAllPreset(groups).concat(contentMetadataConfig.reorganiseByConfig(groups))),
                             of(contentMetadataConfig.reorganiseByConfig(groups))
-                        )),
+                        )
+                    ),
                     map((groups) => contentMetadataConfig.filterExcludedPreset(groups)),
                     map((groups) => this.filterEmptyPreset(groups)),
                     map((groups) => this.setTitleToNameIfNotSet(groups)),
@@ -87,13 +86,21 @@ export class ContentMetadataService {
     }
 
     setTitleToNameIfNotSet(propertyGroups: OrganisedPropertyGroup[]): OrganisedPropertyGroup[] {
+        const propertyGroupsTitles = {};
         propertyGroups.map((propertyGroup) => {
-            propertyGroup.title = propertyGroup.title || propertyGroup.name;
+            const title = propertyGroup.title;
+            const name = propertyGroup.name;
+            if (title) {
+                propertyGroup.title = propertyGroupsTitles[title] ? `${title} (${name})` : title;
+                propertyGroupsTitles[title] = title;
+            } else {
+                propertyGroup.title = name;
+            }
         });
         return propertyGroups;
     }
 
-    filterEmptyPreset(propertyGroups: OrganisedPropertyGroup[]): OrganisedPropertyGroup[]  {
+    filterEmptyPreset(propertyGroups: OrganisedPropertyGroup[]): OrganisedPropertyGroup[] {
         return propertyGroups.filter((props) => props.properties.length);
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [x] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

When there are aspects with the same title in a custom model, the UI metadata panels will also have the same title. This situation creates a conflict which prevents the panels from being expanded/collapsed.

**What is the new behaviour?**

When setting the title for each metadata panel, it is now verified if the aspect title is duplicated, if so the aspect name is concatenated to the title, i.e, title (name) - This not only resolves the conflict but also allows to better distinguish aspects with the same title.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

Further information can be found in this [Jira comment](https://hyland.atlassian.net/browse/MNT-24698?focusedCommentId=2205471)