### PR TITLE
[ACS-8955] [ACA] Data Table / Column Pills Drag button is not centered horizontally

### DIFF
--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.html
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.html
@@ -102,6 +102,7 @@
                         <adf-icon
                             *ngIf="hoveredHeaderColumnIndex === columnIndex && !isResizing"
                             value="adf:drag_indicator"
+                            class="adf-datatable-cell-header-drag-icon-visible"
                             [attr.data-automation-id]="'adf-datatable-cell-header-drag-icon-'+col.key" />
                     </span>
                 </div>

--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.scss
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.scss
@@ -567,6 +567,10 @@ $data-table-cell-min-width-file-size: $data-table-cell-min-width-1 !default;
         cursor: move;
         margin-right: -0.5rem;
         padding-left: -0.5rem;
+
+        &-visible {
+            display: flex;
+        }
     }
 
     .adf-datatable-cell-value {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/ACS-8955


**What is the new behaviour?**
Icons are centered correctly


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
