### PR TITLE
[ACS-8994] the upload new version button is not disabled when clicked and the uploading starts

### DIFF
--- a/lib/content-services/src/lib/upload/components/upload-button.component.html
+++ b/lib/content-services/src/lib/upload/components/upload-button.component.html
@@ -5,6 +5,7 @@
         <!--Single Files Upload-->
         <ng-container *ngIf="!multipleFiles">
             <input
+                class="adf-upload-button-file-container-upload-single-file"
                 id="upload-single-file"
                 data-automation-id="upload-single-file"
                 [type]="file ? 'button' : 'file'"

--- a/lib/content-services/src/lib/upload/components/upload-button.component.scss
+++ b/lib/content-services/src/lib/upload/components/upload-button.component.scss
@@ -1,4 +1,17 @@
 .adf {
+    &-upload-button-file-container {
+        .adf-upload-button-icon {
+            margin: 0;
+            font-size: 24px;
+            width: 24px;
+            height: 24px;
+        }
+
+        input {
+            display: none;
+        }
+    }
+
     &-upload-button-label {
         display: flex;
         align-items: center;
@@ -12,23 +25,10 @@
         }
     }
 
-    &-upload-button-file-container {
-        .adf-upload-button-icon {
-            margin: 0;
-            font-size: 24px;
-            width: 24px;
-            height: 24px;
-        }
-
-        input {
-            display: none;
-        }
-
-        &-upload-single-file[disabled] + .adf-upload-button-label {
-            background-color: var(--adf-disabled-button-background);
-            color: var(--adf-theme-foreground-disabled-text-color);
-            box-shadow: none;
-            cursor: default;
-        }
+    &-upload-button-file-container-upload-single-file[disabled] + &-upload-button-label {
+        background-color: var(--adf-disabled-button-background);
+        color: var(--adf-theme-foreground-disabled-text-color);
+        box-shadow: none;
+        cursor: default;
     }
 }

--- a/lib/content-services/src/lib/upload/components/upload-button.component.scss
+++ b/lib/content-services/src/lib/upload/components/upload-button.component.scss
@@ -1,4 +1,17 @@
 .adf {
+    &-upload-button-label {
+        display: flex;
+        align-items: center;
+        cursor: pointer;
+        padding: 8px 16px;
+        box-shadow: 0 3px 1px -2px #0003, 0 2px 2px rgba(0, 0, 0, 0.14), 0 1px 5px rgba(0, 0, 0, 0.12);
+        border-radius: 4px;
+
+        &:active {
+            box-shadow: 0 5px 5px -3px #0003, 0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12);
+        }
+    }
+
     &-upload-button-file-container {
         .adf-upload-button-icon {
             margin: 0;
@@ -10,18 +23,12 @@
         input {
             display: none;
         }
-    }
 
-    &-upload-button-label {
-        display: flex;
-        align-items: center;
-        cursor: pointer;
-        padding: 8px 16px;
-        box-shadow: 0 3px 1px -2px #0003, 0 2px 2px rgba(0, 0, 0, 0.14), 0 1px 5px rgba(0, 0, 0, 0.12);
-        border-radius: 4px;
-
-        &:active {
-            box-shadow: 0 5px 5px -3px #0003, 0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12);
+        &-upload-single-file[disabled] + .adf-upload-button-label {
+            background-color: var(--adf-disabled-button-background);
+            color: var(--adf-theme-foreground-disabled-text-color);
+            box-shadow: none;
+            cursor: default;
         }
     }
 }

--- a/lib/content-services/src/lib/version-manager/version-upload.component.ts
+++ b/lib/content-services/src/lib/version-manager/version-upload.component.ts
@@ -138,7 +138,6 @@ export class VersionUploadComponent implements OnInit, OnDestroy {
     }
 
     onSuccess(event: any) {
-        this.disabled = false;
         this.success.emit(event);
     }
 

--- a/lib/core/src/lib/styles/_components-variables.scss
+++ b/lib/core/src/lib/styles/_components-variables.scss
@@ -89,6 +89,7 @@
         --adf-error-color: $adf-error-color,
         --adf-secondary-button-background: $adf-secondary-button-background,
         --adf-secondary-modal-text-color: $adf-secondary-modal-text-color,
+        --adf-disabled-button-background: $adf-disabled-button-background,
 
         --adf-display-external-property-widget-preview-selection-color: mat.get-color-from-palette($foreground, secondary-text)
     );

--- a/lib/core/src/lib/styles/_reference-variables.scss
+++ b/lib/core/src/lib/styles/_reference-variables.scss
@@ -28,3 +28,4 @@ $adf-ref-header-icon-border-radius: 50%;
 $adf-error-color: #ba1b1b;
 $adf-secondary-button-background: #2121210d;
 $adf-secondary-modal-text-color: #212121;
+$adf-disabled-button-background: rgba(0, 0, 0, 0.12);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/ACS-8994


**What is the new behaviour?**
Upload new version button is disabled so user can't click it again when version is uploading


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
