### PR TITLE
[ACS-8961] Emit onLogout when redirected to login page

### DIFF
--- a/lib/core/src/lib/auth/guard/auth-guard.service.spec.ts
+++ b/lib/core/src/lib/auth/guard/auth-guard.service.spec.ts
@@ -171,6 +171,17 @@ describe('AuthGuardService', () => {
         expect(router.navigateByUrl).toHaveBeenCalledWith(router.parseUrl('/login?redirectUrl=some-url'));
     });
 
+    it('should emit onLogout if the user is NOT logged in and basic authentication is used', async () => {
+        spyOn(authService, 'isLoggedIn').and.returnValue(false);
+        spyOn(authService, 'isOauth').and.returnValue(false);
+        appConfigService.config.loginRoute = 'login';
+        spyOn(basicAlfrescoAuthService.onLogout, 'next');
+
+        await TestBed.runInInjectionContext(() => AuthGuard(route, state));
+
+        expect(basicAlfrescoAuthService.onLogout.next).toHaveBeenCalledWith(true);
+    });
+
     it('should set redirect url with query params', async () => {
         state.url = 'some-url;q=query';
         appConfigService.config.loginRoute = 'login';

--- a/lib/core/src/lib/auth/guard/auth-guard.service.ts
+++ b/lib/core/src/lib/auth/guard/auth-guard.service.ts
@@ -67,12 +67,12 @@ export class AuthGuardService {
                 provider: this.getProvider(),
                 url
             });
-
+            this.basicAlfrescoAuthService.onLogout.next(true);
             urlToRedirect = `${urlToRedirect}?redirectUrl=${url}`;
             return this.navigate(urlToRedirect);
         } else if (this.getOauthConfig().silentLogin && !this.oidcAuthenticationService.isPublicUrl()) {
             const shouldPerformSsoLogin = await new Promise((resolve) => {
-                this.oidcAuthenticationService.shouldPerformSsoLogin$.subscribe(value => resolve(value));
+                this.oidcAuthenticationService.shouldPerformSsoLogin$.subscribe((value) => resolve(value));
             });
             if (shouldPerformSsoLogin) {
                 this.oidcAuthenticationService.ssoLogin(url);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://hyland.atlassian.net/browse/ACS-8961

**What is the new behaviour?**

onLogout is emitted when the user is redirected to the login page 

**Does this PR introduce a breaking change?** (check one with "x")

> - [] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
