### PR TITLE
[ACA-4556] Copy/Move button is now disabled on the My Libraries Page in Copy/Move dialog

### DIFF
--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel/content-node-selector-panel.component.spec.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel/content-node-selector-panel.component.spec.ts
@@ -441,7 +441,7 @@ describe('ContentNodeSelectorPanelComponent', () => {
                 const fakeNode = new Node({
                     id: 'fake-node',
                     path: { elements: [{ nodeType: 'st:site', name: 'fake-site' }] }
-                }) as Node;
+                });
                 component.chosenNode = [fakeNode];
                 component.documentList.currentFolderId = '-mysites-';
                 component.documentList.folderNode = fakeFolderNode;

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel/content-node-selector-panel.component.spec.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel/content-node-selector-panel.component.spec.ts
@@ -437,6 +437,19 @@ describe('ContentNodeSelectorPanelComponent', () => {
                 expect(fakeNodePage.list.pagination.hasMoreItems).toBe(false);
             });
 
+            it('should not update chosen node if currently selected location is within the DISABLE_ACTION_FOLDER_LIST property', () => {
+                const fakeNode = new Node({
+                    id: 'fake-node',
+                    path: { elements: [{ nodeType: 'st:site', name: 'fake-site' }] }
+                }) as Node;
+                component.chosenNode = [fakeNode];
+                component.documentList.currentFolderId = '-mysites-';
+                component.documentList.folderNode = fakeFolderNode;
+                component.onFolderLoaded(nodePage);
+                expect(component.chosenNode).not.toEqual([fakeFolderNode]);
+                expect(component.chosenNode).toEqual([fakeNode]);
+            });
+
             describe('in the case when isSelectionValid is a custom function for checking permissions,', () => {
                 beforeEach(() => {
                     component.isSelectionValid = returnHasPermission;

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel/content-node-selector-panel.component.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel/content-node-selector-panel.component.ts
@@ -124,6 +124,8 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
         skipCount: 0
     });
 
+    readonly DISABLE_ACTION_FOLDER_LIST = ['-mysites-'];
+
     private showSiteList = true;
     private showSearchField = true;
     private showCounter = false;
@@ -461,7 +463,7 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
 
     private isExcludedSiteContent(row: ShareDataRow): boolean {
         const entry = row.node.entry;
-        if (this._excludeSiteContent?.length && entry && entry.properties?.['st:componentId']) {
+        if (this._excludeSiteContent?.length && entry?.properties?.['st:componentId']) {
             const excludedItem = this._excludeSiteContent.find((id: string) => entry.properties['st:componentId'] === id);
             return !!excludedItem;
         }
@@ -470,7 +472,6 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
 
     /**
      * Updates the site attribute and starts a new search
-     *
      * @param chosenSite SiteEntry to search within
      */
     siteChanged(chosenSite: SiteEntry): void {
@@ -482,7 +483,6 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
 
     /**
      * Get current breadcrumb folder node
-     *
      * @returns the actually selected|entered folder node or null in case of searching for the breadcrumb
      */
     get breadcrumbFolderNode(): Node | null {
@@ -499,7 +499,6 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
 
     /**
      * Prepares the dialog for a new search
-     *
      * @param searchRequest request options
      */
     prepareDialogForNewSearch(searchRequest: SearchRequest): void {
@@ -572,7 +571,6 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
 
     /**
      * Show the results of the search
-     *
      * @param results Search results
      */
     private showSearchResults(results: NodePaging): void {
@@ -585,7 +583,6 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
 
     /**
      * Sets showingSearchResults state to be able to differentiate between search results or folder results
-     *
      * @param $event node event
      */
     onFolderChange($event: NodeEntryEvent): void {
@@ -600,7 +597,6 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
 
     /**
      * Attempts to set the currently loaded node
-     *
      * @param nodePaging pagination model
      */
     onFolderLoaded(nodePaging: NodePaging): void {
@@ -616,7 +612,6 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
 
     /**
      * Updates pagination.hasMoreItems to false after filtering only folders during 'COPY' and 'MOVE' action
-     *
      * @param nodePaging pagination model
      */
     updatePaginationAfterRowFilter(nodePaging: NodePaging): void {
@@ -627,7 +622,6 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
 
     /**
      * Returns whether breadcrumb has to be shown or not
-     *
      * @returns `true` if needs to show the breadcrumb, otherwise `false`
      */
     showBreadcrumbs() {
@@ -636,7 +630,6 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
 
     /**
      * Loads the next batch of search results
-     *
      * @param pagination Pagination object
      */
     getNextPageOfSearch(pagination: Pagination): void {
@@ -651,13 +644,16 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
 
     /**
      * Selects node as chosen if it has the right permission, clears the selection otherwise
-     *
      * @param entry node entry
      */
     private attemptNodeSelection(entry: Node): void {
-        if (entry && this.isSelectionValid(entry)) {
+        if (entry && this.isSelectionValid(entry) && !this.isActionDisabledForFolder(this.documentList.currentFolderId)) {
             this.chosenNode = [entry];
         }
+    }
+
+    private isActionDisabledForFolder(folderId: string): boolean {
+        return this.DISABLE_ACTION_FOLDER_LIST.includes(folderId);
     }
 
     /**
@@ -669,7 +665,6 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
 
     /**
      * It filters and emit the selection coming from the document list
-     *
      * @param nodesEntries selected nodes
      */
     onCurrentSelection(nodesEntries: NodeEntry[]): void {

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel/content-node-selector-panel.component.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel/content-node-selector-panel.component.ts
@@ -15,17 +15,7 @@
  * limitations under the License.
  */
 
-import {
-    Component,
-    DestroyRef,
-    EventEmitter,
-    inject,
-    Input,
-    OnInit,
-    Output,
-    ViewChild,
-    ViewEncapsulation
-} from '@angular/core';
+import { Component, DestroyRef, EventEmitter, inject, Input, OnInit, Output, ViewChild, ViewEncapsulation } from '@angular/core';
 import {
     CustomEmptyContentTemplateDirective,
     DataColumnComponent,
@@ -40,24 +30,9 @@ import {
     UserPreferencesService,
     UserPreferenceValues
 } from '@alfresco/adf-core';
-import {
-    FileUploadCompleteEvent,
-    FileUploadDeleteEvent,
-    NodesApiService,
-    SitesService,
-    UploadService
-} from '../../common';
+import { FileUploadCompleteEvent, FileUploadDeleteEvent, NodesApiService, SitesService, UploadService } from '../../common';
 import { ReactiveFormsModule, UntypedFormControl } from '@angular/forms';
-import {
-    Node,
-    NodeEntry,
-    NodePaging,
-    Pagination,
-    RequestScope,
-    SearchRequest,
-    SiteEntry,
-    SitePaging
-} from '@alfresco/js-api';
+import { Node, NodeEntry, NodePaging, Pagination, RequestScope, SearchRequest, SiteEntry, SitePaging } from '@alfresco/js-api';
 import { DocumentListComponent } from '../../document-list/components/document-list.component';
 import { RowFilter } from '../../document-list/data/row-filter.model';
 import { ImageResolver } from '../../document-list/data/image-resolver.model';
@@ -124,7 +99,7 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
         skipCount: 0
     });
 
-    readonly DISABLE_ACTION_FOLDER_LIST = ['-mysites-'];
+    readonly disableActionFolderList = ['-mysites-'];
 
     private showSiteList = true;
     private showSearchField = true;
@@ -360,11 +335,13 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
     }
 
     ngOnInit() {
-        this.searchInput.valueChanges.pipe(debounceTime(this.debounceSearch), takeUntilDestroyed(this.destroyRef)).subscribe((searchValue: string) => {
-            this.searchTerm = searchValue;
-            this.queryBuilderService.userQuery = searchValue.length > 0 ? `${searchValue}*` : searchValue;
-            this.queryBuilderService.update();
-        });
+        this.searchInput.valueChanges
+            .pipe(debounceTime(this.debounceSearch), takeUntilDestroyed(this.destroyRef))
+            .subscribe((searchValue: string) => {
+                this.searchTerm = searchValue;
+                this.queryBuilderService.userQuery = searchValue.length > 0 ? `${searchValue}*` : searchValue;
+                this.queryBuilderService.update();
+            });
 
         this.queryBuilderService.updated.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((searchRequest) => {
             if (searchRequest) {
@@ -663,7 +640,7 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
     }
 
     private isActionDisabledForFolder(folderId: string): boolean {
-        return this.DISABLE_ACTION_FOLDER_LIST.includes(folderId);
+        return this.disableActionFolderList.includes(folderId);
     }
 
     /**

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel/content-node-selector-panel.component.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel/content-node-selector-panel.component.ts
@@ -472,6 +472,7 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
 
     /**
      * Updates the site attribute and starts a new search
+     *
      * @param chosenSite SiteEntry to search within
      */
     siteChanged(chosenSite: SiteEntry): void {
@@ -483,6 +484,7 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
 
     /**
      * Get current breadcrumb folder node
+     *
      * @returns the actually selected|entered folder node or null in case of searching for the breadcrumb
      */
     get breadcrumbFolderNode(): Node | null {
@@ -499,6 +501,7 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
 
     /**
      * Prepares the dialog for a new search
+     *
      * @param searchRequest request options
      */
     prepareDialogForNewSearch(searchRequest: SearchRequest): void {
@@ -571,6 +574,7 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
 
     /**
      * Show the results of the search
+     *
      * @param results Search results
      */
     private showSearchResults(results: NodePaging): void {
@@ -583,6 +587,7 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
 
     /**
      * Sets showingSearchResults state to be able to differentiate between search results or folder results
+     *
      * @param $event node event
      */
     onFolderChange($event: NodeEntryEvent): void {
@@ -597,6 +602,7 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
 
     /**
      * Attempts to set the currently loaded node
+     *
      * @param nodePaging pagination model
      */
     onFolderLoaded(nodePaging: NodePaging): void {
@@ -612,6 +618,7 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
 
     /**
      * Updates pagination.hasMoreItems to false after filtering only folders during 'COPY' and 'MOVE' action
+     *
      * @param nodePaging pagination model
      */
     updatePaginationAfterRowFilter(nodePaging: NodePaging): void {
@@ -622,6 +629,7 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
 
     /**
      * Returns whether breadcrumb has to be shown or not
+     *
      * @returns `true` if needs to show the breadcrumb, otherwise `false`
      */
     showBreadcrumbs() {
@@ -630,6 +638,7 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
 
     /**
      * Loads the next batch of search results
+     *
      * @param pagination Pagination object
      */
     getNextPageOfSearch(pagination: Pagination): void {
@@ -644,6 +653,7 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
 
     /**
      * Selects node as chosen if it has the right permission, clears the selection otherwise
+     *
      * @param entry node entry
      */
     private attemptNodeSelection(entry: Node): void {
@@ -665,6 +675,7 @@ export class ContentNodeSelectorPanelComponent implements OnInit {
 
     /**
      * It filters and emit the selection coming from the document list
+     *
      * @param nodesEntries selected nodes
      */
     onCurrentSelection(nodesEntries: NodeEntry[]): void {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Copy/Move button is enabled if user switches from Personal Files to My Libraries via the dropdown in Copy/Move dialog


**What is the new behaviour?**
Copy/Move button is now disabled


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://hyland.atlassian.net/browse/ACA-4556