### PR TITLE
[ACS-8824] The user cannot edit node properties after failing...

### DIFF
--- a/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.spec.ts
+++ b/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.spec.ts
@@ -380,6 +380,27 @@ describe('ContentMetadataComponent', () => {
             flush();
         }));
 
+        it('should revert changes on unsuccessful save', fakeAsync(() => {
+            component.readOnly = false;
+            const property = { key: 'properties.property-key', value: 'original-value' } as CardViewBaseItemModel;
+            spyOn(nodesApiService, 'updateNode').and.returnValue(throwError(new Error('error message')));
+            spyOn(component, 'revertChanges').and.callThrough();
+            updateService.update(property, 'new-value');
+            tick(600);
+
+            fixture.detectChanges();
+            toggleEditModeForGeneralInfo();
+            tick(100);
+            clickOnGeneralInfoSave();
+            tick(100);
+
+            expect(component.revertChanges).toHaveBeenCalled();
+            expect(component.changedProperties).toEqual({});
+            expect(component.hasMetadataChanged).toBeFalse();
+            discardPeriodicTasks();
+            flush();
+        }));
+
         it('should open the confirm dialog when content type is changed', fakeAsync(() => {
             component.readOnly = false;
             const property = { key: 'nodeType', value: 'ft:sbiruli' } as CardViewBaseItemModel;

--- a/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.ts
+++ b/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.ts
@@ -399,6 +399,7 @@ export class ContentMetadataComponent implements OnChanges, OnInit {
                     this.cardViewContentUpdateService.updateElement(this.targetProperty);
                     this.handleUpdateError(err);
                     this._saving = false;
+                    this.revertChanges();
                     this.loadProperties(this.node);
                     return of(null);
                 })

--- a/lib/content-services/src/lib/content-metadata/services/basic-properties.service.ts
+++ b/lib/content-services/src/lib/content-metadata/services/basic-properties.service.ts
@@ -17,7 +17,13 @@
 
 import { inject, Injectable } from '@angular/core';
 import { Node } from '@alfresco/js-api';
-import { CardViewDateItemModel, CardViewItemMatchValidator, CardViewTextItemModel, FileSizePipe, TranslationService } from '@alfresco/adf-core';
+import {
+    CardViewDateItemModel,
+    CardViewItemMatchValidator,
+    CardViewTextItemModel,
+    FileSizePipe,
+    TranslationService
+} from '@alfresco/adf-core';
 
 @Injectable({
     providedIn: 'root'
@@ -38,7 +44,9 @@ export class BasicPropertiesService {
                 value: node.name,
                 key: 'properties.cm:name',
                 editable: true,
-                validators: [new CardViewItemMatchValidator('[\\/\\*\\\\"\\\\:]')]
+                validators: [
+                    new CardViewItemMatchValidator('[\\/\\*\\\\"\\\\:]')
+                ]
             }),
             new CardViewTextItemModel({
                 label: 'CORE.METADATA.BASIC.TITLE',

--- a/lib/content-services/src/lib/content-metadata/services/basic-properties.service.ts
+++ b/lib/content-services/src/lib/content-metadata/services/basic-properties.service.ts
@@ -17,13 +17,7 @@
 
 import { inject, Injectable } from '@angular/core';
 import { Node } from '@alfresco/js-api';
-import {
-    CardViewDateItemModel,
-    CardViewItemMatchValidator,
-    CardViewTextItemModel,
-    FileSizePipe,
-    TranslationService
-} from '@alfresco/adf-core';
+import { CardViewDateItemModel, CardViewItemMatchValidator, CardViewTextItemModel, FileSizePipe, TranslationService } from '@alfresco/adf-core';
 
 @Injectable({
     providedIn: 'root'
@@ -44,9 +38,7 @@ export class BasicPropertiesService {
                 value: node.name,
                 key: 'properties.cm:name',
                 editable: true,
-                validators: [
-                    new CardViewItemMatchValidator('[\\/\\*\\\\"\\\\]')
-                ]
+                validators: [new CardViewItemMatchValidator('[\\/\\*\\\\"\\\\:]')]
             }),
             new CardViewTextItemModel({
                 label: 'CORE.METADATA.BASIC.TITLE',


### PR DESCRIPTION
[ACA] View Details / The user cannot edit node properties after failing to change node name with special characters

**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://hyland.atlassian.net/browse/ACS-8824

**What is the new behaviour?**

- After an unsuccessful save, changed properties are cleared 
- Added `:` symbol to the validator expression because it is not allowed for the 'name' property

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
