### PR TITLE
[ACS-8999] rename confirmation button label for closing conversation dialog

### DIFF
--- a/lib/core/src/lib/dialogs/unsaved-changes-dialog/unsaved-changes-dialog.component.scss
+++ b/lib/core/src/lib/dialogs/unsaved-changes-dialog/unsaved-changes-dialog.component.scss
@@ -36,6 +36,7 @@
         &-actions {
             margin-top: 11px;
             margin-bottom: 1px;
+            margin-left: 40px;
             padding: 0;
             align-items: flex-end;
 
@@ -51,7 +52,6 @@
 
             &-cancel-button,
             &-discard-changes-button {
-                padding: 4px 12px;
                 height: 32px;
                 display: flex;
                 align-items: center;

--- a/lib/core/src/lib/dialogs/unsaved-changes-dialog/unsaved-changes-dialog.model.ts
+++ b/lib/core/src/lib/dialogs/unsaved-changes-dialog/unsaved-changes-dialog.model.ts
@@ -20,4 +20,5 @@ export interface UnsavedChangesDialogData {
     confirmButtonText?: string;
     descriptionText?: string;
     headerText?: string;
+    maxWidth?: number;
 }

--- a/lib/core/src/lib/dialogs/unsaved-changes-dialog/unsaved-changes-dialog.model.ts
+++ b/lib/core/src/lib/dialogs/unsaved-changes-dialog/unsaved-changes-dialog.model.ts
@@ -20,5 +20,5 @@ export interface UnsavedChangesDialogData {
     confirmButtonText?: string;
     descriptionText?: string;
     headerText?: string;
-    maxWidth?: number;
+    maxWidth?: number | string;
 }

--- a/lib/core/src/lib/dialogs/unsaved-changes-dialog/unsaved-changes.guard.spec.ts
+++ b/lib/core/src/lib/dialogs/unsaved-changes-dialog/unsaved-changes.guard.spec.ts
@@ -123,6 +123,33 @@ describe('UnsavedChangesGuard', () => {
                 expectGuardToBe(true, done, true);
                 afterClosed$.next(false);
             });
+
+            it('should call open on dialog with correct parameters when maxWidth is not set', () => {
+                guard.unsaved = true;
+                guard.data = {
+                    headerText: 'header'
+                };
+
+                guard.canDeactivate();
+                expect(dialog.open).toHaveBeenCalledWith(UnsavedChangesDialogComponent, {
+                    maxWidth: 346,
+                    data: guard.data
+                });
+            });
+
+            it('should call open on dialog with correct parameters when maxWidth is set', () => {
+                guard.unsaved = true;
+                guard.data = {
+                    headerText: 'header',
+                    maxWidth: 'none'
+                };
+
+                guard.canDeactivate();
+                expect(dialog.open).toHaveBeenCalledWith(UnsavedChangesDialogComponent, {
+                    maxWidth: 'none',
+                    data: guard.data
+                });
+            });
         });
 
         describe('Without auth', () => {

--- a/lib/core/src/lib/dialogs/unsaved-changes-dialog/unsaved-changes.guard.ts
+++ b/lib/core/src/lib/dialogs/unsaved-changes-dialog/unsaved-changes.guard.ts
@@ -49,7 +49,7 @@ export class UnsavedChangesGuard implements CanDeactivate<any> {
         return this.unsaved
             ? this.dialog
                   .open<UnsavedChangesDialogComponent>(UnsavedChangesDialogComponent, {
-                      maxWidth: this.data?.maxWidth ?? 'none',
+                      maxWidth: this.data?.maxWidth ?? 346,
                       data: this.data
                   })
                   .afterClosed()

--- a/lib/core/src/lib/dialogs/unsaved-changes-dialog/unsaved-changes.guard.ts
+++ b/lib/core/src/lib/dialogs/unsaved-changes-dialog/unsaved-changes.guard.ts
@@ -49,7 +49,7 @@ export class UnsavedChangesGuard implements CanDeactivate<any> {
         return this.unsaved
             ? this.dialog
                   .open<UnsavedChangesDialogComponent>(UnsavedChangesDialogComponent, {
-                      maxWidth: 346,
+                      maxWidth: this.data?.maxWidth ?? 'none',
                       data: this.data
                   })
                   .afterClosed()


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/ACS-8999


**What is the new behaviour?**
New suggested label is displayed properly. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
ACA PR: https://github.com/Alfresco/alfresco-content-app/pull/4261