### PR TITLE
[ACS-9015] Context menu cell is not accessible via keyboard when it's displayed on hover

### DIFF
--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.html
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.html
@@ -370,6 +370,7 @@
                         (actions && actionsPosition === 'right') ||
                         (mainActionTemplate && showMainDatatableActions)"
                      role="gridcell"
+                     tabindex="0"
                      class="adf-datatable-cell adf-datatable__actions-cell adf-datatable-center-actions-column-ie adf-datatable-actions-menu">
 
                     <ng-container *ngIf="(actions && actionsPosition === 'right')">

--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.scss
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.scss
@@ -350,7 +350,14 @@ $data-table-cell-min-width-file-size: $data-table-cell-min-width-1 !default;
     }
 
     .adf-datatable-row:not(:hover) .adf-datatable-hide-actions-without-hover {
-        display: none;
+        visibility: hidden;
+    }
+
+    .adf-datatable-actions-menu:focus-visible,
+    .adf-datatable-actions-menu:focus-within {
+        .adf-datatable-hide-actions-without-hover {
+            visibility: visible;
+        }
     }
 
     .adf-datatable-cell--image {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

When context menu cell is displayed on hover only there is no way to access it via keyboard.

**What is the new behaviour?**

When context menu cell is focused the menu trigger element is displayed and can be accessed via keyboard.
https://hyland.atlassian.net/browse/ACS-9015

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
