### PR TITLE
OPSEXP-2987 init-aps-env error reporting on tenant creation failure

### DIFF
--- a/lib/cli/scripts/init-aps-env.ts
+++ b/lib/cli/scripts/init-aps-env.ts
@@ -121,7 +121,7 @@ export default async function main() {
                 logger.info('Something went wrong. Was not able to create the users');
             }
         } catch (error) {
-            logger.info(`Aps something went wrong. Tenant id ${tenantId}`);
+            logger.error(`Aps something went wrong. Tenant id ${tenantId}`, error);
             exit(1);
         }
     } else {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Error in aps tenant creation is being swallowed without emitting any log about it

**What is the new behaviour?**

Make sure to log also the error stacktrace with create tenant failure


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:

[OPSEXP-2987](https://hyland.atlassian.net/browse/OPSEXP-2987)

[OPSEXP-2987]: https://hyland.atlassian.net/browse/OPSEXP-2987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ