### PR TITLE
AAE-29501 Filter columns clears previously selected columns

### DIFF
--- a/lib/core/src/lib/datatable/components/columns-selector/columns-search-filter.pipe.spec.ts
+++ b/lib/core/src/lib/datatable/components/columns-selector/columns-search-filter.pipe.spec.ts
@@ -1,0 +1,65 @@
+/*!
+ * @license
+ * Copyright © 2005-2024 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ColumnsSearchFilterPipe } from './columns-search-filter.pipe';
+import { DataColumn } from '../../data/data-column.model';
+import { NoopTranslateModule } from '@alfresco/adf-core';
+import { TestBed } from '@angular/core/testing';
+
+describe('ColumnsSeearchFilterPipe', () => {
+    let pipe: ColumnsSearchFilterPipe;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [NoopTranslateModule, ColumnsSearchFilterPipe],
+            providers: [ColumnsSearchFilterPipe]
+        });
+
+        pipe = TestBed.inject(ColumnsSearchFilterPipe);
+    });
+
+    it('should filter columns', () => {
+        const columns: DataColumn[] = [
+            {
+                title: 'Column 1',
+                key: '',
+                type: 'text'
+            },
+            {
+                title: 'Column 2',
+                key: '',
+                type: 'number'
+            },
+            {
+                title: 'Column 3',
+                key: '',
+                type: 'number'
+            }
+        ];
+
+        const filteredColumns = pipe.transform(columns, '1');
+
+        expect(filteredColumns.length).toBe(1);
+        expect(filteredColumns).toEqual([
+            {
+                title: 'Column 1',
+                key: '',
+                type: 'text'
+            }
+        ]);
+    });
+});

--- a/lib/core/src/lib/datatable/components/columns-selector/columns-search-filter.pipe.ts
+++ b/lib/core/src/lib/datatable/components/columns-selector/columns-search-filter.pipe.ts
@@ -1,0 +1,56 @@
+/*!
+ * @license
+ * Copyright © 2005-2024 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { inject, Pipe, PipeTransform } from '@angular/core';
+import { DataColumn } from '../../data/data-column.model';
+import { TranslationService } from '../../../translation';
+
+@Pipe({
+    name: 'columnsSearchFilter',
+    standalone: true
+})
+export class ColumnsSearchFilterPipe implements PipeTransform {
+    private translationService = inject(TranslationService);
+
+    transform(columns: DataColumn[], searchByName: string): DataColumn[] {
+        const result = [];
+
+        for (const column of columns) {
+            if (!column.title) {
+                continue;
+            }
+
+            if (!searchByName) {
+                result.push(column);
+                continue;
+            }
+
+            const title = this.translationService.instant(column.title);
+
+            if (this.filterString(title, searchByName)) {
+                result.push(column);
+            }
+        }
+
+        return result;
+    }
+
+    private filterString(value: string = '', filterBy: string = ''): string {
+        const testResult = filterBy ? value.toLowerCase().indexOf(filterBy.toLowerCase()) > -1 : true;
+        return testResult ? value : '';
+    }
+}

--- a/lib/core/src/lib/datatable/components/columns-selector/columns-selector.component.html
+++ b/lib/core/src/lib/datatable/components/columns-selector/columns-selector.component.html
@@ -37,7 +37,7 @@
     </div>
 
     <div class="adf-columns-selector-list-container">
-        <div *ngFor="let column of columnItems" class="adf-columns-selector-list-item">
+        <div *ngFor="let column of (columnItems | columnsSearchFilter: searchQuery)" class="adf-columns-selector-list-item">
             <mat-checkbox
                 color="primary"
                 class="adf-columns-selector-column-checkbox"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Test Case:

1. Select column in Column selector
2. Click Apply
3. Click again Column selector
4. Search for some column (so the results wont has column selected in pt1)
5. Click Apply

Column selected in pt1. disappears in table.

**What is the new behaviour?**
Selectors works fine


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
