### PR TITLE
AAE-21953 fix broken widget names

### DIFF
--- a/lib/process-services-cloud/src/lib/form/components/form-cloud.component.scss
+++ b/lib/process-services-cloud/src/lib/form/components/form-cloud.component.scss
@@ -97,4 +97,8 @@
             display: flex;
         }
     }
+
+    .adf-label {
+        white-space: normal;
+    }
 }

--- a/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.scss
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/attach-file/attach-file-cloud-widget.component.scss
@@ -15,10 +15,16 @@
         }
     }
 
+    &-label {
+        white-space: normal;
+        height: 100%;
+    }
+
     &-attach-widget__menu-upload {
         display: flex;
         align-items: center;
         margin-right: 8px;
+        word-break: normal;
 
         .adf-attach-widget__menu-upload__button {
             line-height: 28px;
@@ -54,12 +60,14 @@
         margin-bottom: 12px;
 
         .adf-label {
-            width: 32px;
+            width: 100%;
             font-size: var(--theme-caption-font-size);
             line-height: var(--theme-headline-line-height);
             text-align: left;
-            white-space: nowrap;
+            white-space: normal;
             margin-left: 8px;
+            padding-right: 8px;
+            height: 100%;
         }
     }
 


### PR DESCRIPTION
JIRA TICKET: https://hyland.atlassian.net/jira/software/c/projects/AAE/boards/4369?selectedIssue=AAE-21953

Before:
<img width="1410" alt="before" src="https://github.com/user-attachments/assets/28198d0e-fbb5-46e5-b340-8407371fd38d" />

After:
<img width="1410" alt="after" src="https://github.com/user-attachments/assets/7ce33eb0-f7cf-4891-82ef-0b10e8f47563" />


**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Broken long names in cloud form


**What is the new behaviour?**
Labels are displayed correctly


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


