### PR TITLE
[ACS-9166] Migrate Saved Searches to preferences API from config file

### DIFF
--- a/docs/core/services/saved-searches.service.md
+++ b/docs/core/services/saved-searches.service.md
@@ -1,7 +1,7 @@
 
 # Saved Searches Service
 
-Manages operations related to saving and retrieving user-defined searches in the Alfresco Process Services (APS) environment.
+Manages operations related to saving and retrieving user-defined searches.
 
 ## Class members
 
@@ -14,7 +14,7 @@ Manages operations related to saving and retrieving user-defined searches in the
 
 #### getSavedSearches(): [`Observable`](https://rxjs.dev/api/index/class/Observable)`<SavedSearch[]>`
 
-Fetches the file with list of saved searches either from a locally cached node ID or by querying the APS server. Then it reads the file and maps JSON objects into SavedSearches
+Fetches the file with list of saved searches either from a locally cached node ID or by querying the ACS server. Then it reads the file and maps JSON objects into SavedSearches
 
 - **Returns**:
     - [`Observable`](https://rxjs.dev/api/index/class/Observable)`<SavedSearch[]>` - An observable that emits the list of saved searches.
@@ -51,14 +51,3 @@ this.savedSearchService.saveSearch(newSearch).subscribe((response) => {
     console.log('Saved new search:', response);
 });
 ```
-
-#### Creating Saved Searches Node
-
-When the saved searches file does not exist, it will be created:
-
-```typescript
-this.savedSearchService.createSavedSearchesNode('parent-node-id').subscribe((node) => {
-    console.log('Created config.json node:', node);
-});
-```
-

--- a/lib/content-services/src/lib/common/services/saved-searches.service.spec.ts
+++ b/lib/content-services/src/lib/common/services/saved-searches.service.spec.ts
@@ -17,9 +17,9 @@
 
 import { TestBed } from '@angular/core/testing';
 import { AlfrescoApiService } from '../../services/alfresco-api.service';
+import { AlfrescoApiServiceMock } from '../../mock';
 import { NodeEntry } from '@alfresco/js-api';
 import { SavedSearchesService } from './saved-searches.service';
-import { AlfrescoApiServiceMock } from '@alfresco/adf-content-services';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { AuthenticationService } from '@alfresco/adf-core';
 import { Subject } from 'rxjs';
@@ -28,10 +28,9 @@ describe('SavedSearchesService', () => {
     let service: SavedSearchesService;
     let authService: AuthenticationService;
     let testUserName: string;
-    let getNodeContentSpy: jasmine.Spy;
 
     const testNodeId = 'test-node-id';
-    const SAVED_SEARCHES_NODE_ID = 'saved-searches-node-id__';
+    const LOCAL_STORAGE_KEY = 'saved-searches-test-user-migrated';
     const SAVED_SEARCHES_CONTENT = JSON.stringify([
         { name: 'Search 1', description: 'Description 1', encodedUrl: 'url1', order: 0 },
         { name: 'Search 2', description: 'Description 2', encodedUrl: 'url2', order: 1 }
@@ -59,23 +58,28 @@ describe('SavedSearchesService', () => {
         service = TestBed.inject(SavedSearchesService);
         authService = TestBed.inject(AuthenticationService);
         spyOn(service.nodesApi, 'getNode').and.callFake(() => Promise.resolve({ entry: { id: testNodeId } } as NodeEntry));
-        spyOn(service.nodesApi, 'createNode').and.callFake(() => Promise.resolve({ entry: { id: 'new-node-id' } }));
-        spyOn(service.nodesApi, 'updateNodeContent').and.callFake(() => Promise.resolve({ entry: {} } as NodeEntry));
-        getNodeContentSpy = spyOn(service.nodesApi, 'getNodeContent').and.callFake(() => createBlob());
+        spyOn(service.nodesApi, 'getNodeContent').and.callFake(() => createBlob());
+        spyOn(service.nodesApi, 'deleteNode').and.callFake(() => Promise.resolve());
+        spyOn(service.preferencesApi, 'getPreference').and.callFake(() =>
+            Promise.resolve({ entry: { id: 'saved-searches', value: SAVED_SEARCHES_CONTENT } })
+        );
+        spyOn(service.preferencesApi, 'updatePreference').and.callFake(() =>
+            Promise.resolve({ entry: { id: 'saved-searches', value: SAVED_SEARCHES_CONTENT } })
+        );
     });
 
     afterEach(() => {
-        localStorage.removeItem(SAVED_SEARCHES_NODE_ID + testUserName);
+        localStorage.removeItem(LOCAL_STORAGE_KEY);
     });
 
-    it('should retrieve saved searches from the config.json file', (done) => {
+    it('should retrieve saved searches from the preferences API', (done) => {
         spyOn(authService, 'getUsername').and.callFake(() => testUserName);
-        spyOn(localStorage, 'getItem').and.callFake(() => testNodeId);
-        service.innit();
+        spyOn(localStorage, 'getItem').and.callFake(() => 'true');
+        service.init();
 
         service.getSavedSearches().subscribe((searches) => {
-            expect(localStorage.getItem).toHaveBeenCalledWith(SAVED_SEARCHES_NODE_ID + testUserName);
-            expect(getNodeContentSpy).toHaveBeenCalledWith(testNodeId);
+            expect(localStorage.getItem).toHaveBeenCalledWith(LOCAL_STORAGE_KEY);
+            expect(service.preferencesApi.getPreference).toHaveBeenCalledWith('-me-', 'saved-searches');
             expect(searches.length).toBe(2);
             expect(searches[0].name).toBe('Search 1');
             expect(searches[1].name).toBe('Search 2');
@@ -83,48 +87,44 @@ describe('SavedSearchesService', () => {
         });
     });
 
-    it('should create config.json file if it does not exist', (done) => {
-        const error: Error = { name: 'test', message: '{ "error": { "statusCode": 404 } }' };
+    it('should automatically migrate saved searches if config.json file exists', (done) => {
+        spyOn(localStorage, 'setItem');
         spyOn(authService, 'getUsername').and.callFake(() => testUserName);
-        service.nodesApi.getNode = jasmine.createSpy().and.returnValue(Promise.reject(error));
-        getNodeContentSpy.and.callFake(() => Promise.resolve(new Blob([''])));
-        service.innit();
+        service.init();
 
         service.getSavedSearches().subscribe((searches) => {
             expect(service.nodesApi.getNode).toHaveBeenCalledWith('-my-', { relativePath: 'config.json' });
-            expect(service.nodesApi.createNode).toHaveBeenCalledWith('-my-', jasmine.objectContaining({ name: 'config.json' }));
-            expect(searches.length).toBe(0);
+            expect(service.nodesApi.getNodeContent).toHaveBeenCalledWith(testNodeId);
+            expect(localStorage.setItem).toHaveBeenCalledWith(LOCAL_STORAGE_KEY, 'true');
+            expect(service.preferencesApi.updatePreference).toHaveBeenCalledWith('-me-', 'saved-searches', SAVED_SEARCHES_CONTENT);
+            expect(service.nodesApi.deleteNode).toHaveBeenCalledWith(testNodeId, { permanent: true });
+            expect(searches.length).toBe(2);
             done();
         });
     });
 
     it('should save a new search', (done) => {
         spyOn(authService, 'getUsername').and.callFake(() => testUserName);
-        const nodeId = 'saved-searches-node-id';
-        spyOn(localStorage, 'getItem').and.callFake(() => nodeId);
+        spyOn(localStorage, 'getItem').and.callFake(() => 'true');
         const newSearch = { name: 'Search 3', description: 'Description 3', encodedUrl: 'url3' };
-        service.innit();
+        service.init();
 
         service.saveSearch(newSearch).subscribe(() => {
-            expect(service.nodesApi.updateNodeContent).toHaveBeenCalledWith(nodeId, jasmine.any(String));
+            expect(service.preferencesApi.updatePreference).toHaveBeenCalledWith('-me-', 'saved-searches', jasmine.any(String));
             expect(service.savedSearches$).toBeDefined();
-            service.savedSearches$.subscribe((searches) => {
-                expect(searches.length).toBe(3);
-                expect(searches[2].name).toBe('Search 2');
-                expect(searches[2].order).toBe(2);
-                done();
-            });
+            done();
         });
     });
 
     it('should emit initial saved searches on subscription', (done) => {
-        const nodeId = 'saved-searches-node-id';
-        spyOn(localStorage, 'getItem').and.returnValue(nodeId);
-        service.innit();
+        spyOn(authService, 'getUsername').and.callFake(() => testUserName);
+        spyOn(localStorage, 'getItem').and.returnValue('true');
+        service.init();
 
         service.savedSearches$.pipe().subscribe((searches) => {
             expect(searches.length).toBe(2);
             expect(searches[0].name).toBe('Search 1');
+            expect(service.preferencesApi.getPreference).toHaveBeenCalledWith('-me-', 'saved-searches');
             done();
         });
 
@@ -135,7 +135,7 @@ describe('SavedSearchesService', () => {
         spyOn(authService, 'getUsername').and.callFake(() => testUserName);
         spyOn(localStorage, 'getItem').and.callFake(() => testNodeId);
         const newSearch = { name: 'Search 3', description: 'Description 3', encodedUrl: 'url3' };
-        service.innit();
+        service.init();
 
         let emissionCount = 0;
 
@@ -190,8 +190,7 @@ describe('SavedSearchesService', () => {
      */
     function prepareDefaultMock(): void {
         spyOn(authService, 'getUsername').and.callFake(() => testUserName);
-        const nodeId = 'saved-searches-node-id';
-        spyOn(localStorage, 'getItem').and.callFake(() => nodeId);
-        service.innit();
+        spyOn(localStorage, 'getItem').and.callFake(() => 'true');
+        service.init();
     }
 });

--- a/lib/content-services/src/lib/common/services/saved-searches.service.spec.ts
+++ b/lib/content-services/src/lib/common/services/saved-searches.service.spec.ts
@@ -133,7 +133,6 @@ describe('SavedSearchesService', () => {
     it('should emit updated saved searches after saving a new search', (done) => {
         spyOn(authService, 'getUsername').and.callFake(() => testUserName);
         spyOn(localStorage, 'getItem').and.callFake(() => 'true');
-        // spyOn(service, 'getSavedSearches').and.callFake(() => of([]));
         const newSearch = { name: 'Search 3', description: 'Description 3', encodedUrl: 'url3' };
         service.init();
 

--- a/lib/content-services/src/lib/common/services/saved-searches.service.spec.ts
+++ b/lib/content-services/src/lib/common/services/saved-searches.service.spec.ts
@@ -90,7 +90,6 @@ describe('SavedSearchesService', () => {
     it('should automatically migrate saved searches if config.json file exists', (done) => {
         spyOn(localStorage, 'setItem');
         spyOn(authService, 'getUsername').and.callFake(() => testUserName);
-        service.init();
 
         service.getSavedSearches().subscribe((searches) => {
             expect(service.nodesApi.getNode).toHaveBeenCalledWith('-my-', { relativePath: 'config.json' });
@@ -133,25 +132,19 @@ describe('SavedSearchesService', () => {
 
     it('should emit updated saved searches after saving a new search', (done) => {
         spyOn(authService, 'getUsername').and.callFake(() => testUserName);
-        spyOn(localStorage, 'getItem').and.callFake(() => testNodeId);
+        spyOn(localStorage, 'getItem').and.callFake(() => 'true');
+        // spyOn(service, 'getSavedSearches').and.callFake(() => of([]));
         const newSearch = { name: 'Search 3', description: 'Description 3', encodedUrl: 'url3' };
         service.init();
 
-        let emissionCount = 0;
-
-        service.savedSearches$.subscribe((searches) => {
-            emissionCount++;
-            if (emissionCount === 1) {
-                expect(searches.length).toBe(2);
-            }
-            if (emissionCount === 2) {
+        service.saveSearch(newSearch).subscribe(() => {
+            service.savedSearches$.subscribe((searches) => {
                 expect(searches.length).toBe(3);
                 expect(searches[2].name).toBe('Search 2');
+                expect(service.preferencesApi.updatePreference).toHaveBeenCalledWith('-me-', 'saved-searches', jasmine.any(String));
                 done();
-            }
+            });
         });
-
-        service.saveSearch(newSearch).subscribe();
     });
 
     it('should edit a search', (done) => {

--- a/lib/content-services/src/lib/common/services/saved-searches.service.ts
+++ b/lib/content-services/src/lib/common/services/saved-searches.service.ts
@@ -63,6 +63,7 @@ export class SavedSearchesService {
             );
         } else {
             return this.getSavedSearchesNodeId().pipe(
+                take(1),
                 concatMap(() => {
                     if (this.savedSearchFileNodeId !== '') {
                         return this.migrateSavedSearches();

--- a/lib/content-services/src/lib/common/services/saved-searches.service.ts
+++ b/lib/content-services/src/lib/common/services/saved-searches.service.ts
@@ -232,7 +232,10 @@ export class SavedSearchesService {
     }
 
     private async mapFileContentToSavedSearches(blob: Blob): Promise<Array<SavedSearch>> {
-        return blob.text().then((content) => (content ? JSON.parse(content) : []));
+        return blob
+            .text()
+            .then((content) => (content ? JSON.parse(content) : []))
+            .catch(() => []);
     }
 
     private getLocalStorageKey(): string {

--- a/lib/js-api/src/api/content-rest-api/api/preferences.api.ts
+++ b/lib/js-api/src/api/content-rest-api/api/preferences.api.ts
@@ -84,4 +84,25 @@ export class PreferencesApi extends BaseApi {
             queryParams
         });
     }
+
+    updatePreference(personId: string, preferenceName: string, preferenceValue: string): Promise<PreferenceEntry> {
+        throwIfNotDefined(personId, 'personId');
+        throwIfNotDefined(preferenceName, 'preferenceName');
+        throwIfNotDefined(preferenceValue, 'preferenceValue');
+
+        const pathParams = {
+            personId,
+            preferenceName
+        };
+
+        const bodyParam = {
+            value: preferenceValue
+        };
+
+        return this.put({
+            path: '/people/{personId}/preferences/{preferenceName}',
+            pathParams,
+            bodyParam: bodyParam
+        });
+    }
 }

--- a/lib/js-api/src/api/content-rest-api/docs/PreferencesApi.md
+++ b/lib/js-api/src/api/content-rest-api/docs/PreferencesApi.md
@@ -2,10 +2,11 @@
 
 All URIs are relative to *https://localhost/alfresco/api/-default-/public/alfresco/versions/1*
 
-| Method                              | HTTP request                                            | Description      |
-|-------------------------------------|---------------------------------------------------------|------------------|
-| [getPreference](#getPreference)     | **GET** /people/{personId}/preferences/{preferenceName} | Get a preference |
-| [listPreferences](#listPreferences) | **GET** /people/{personId}/preferences                  | List preferences |
+| Method                                | HTTP request                                             | Description       |
+|---------------------------------------|----------------------------------------------------------|-------------------|
+| [getPreference](#getPreference)       | **GET** /people/{personId}/preferences/{preferenceName}  | Get a preference  |
+| [listPreferences](#listPreferences)   | **GET** /people/{personId}/preferences                   | List preferences  |
+| [updatePreference](#updatePreference) | **POST** /people/{personId}/preferences/{preferenceName} | Update preference |
 
 ## getPreference
 
@@ -67,6 +68,36 @@ const preferencesApi = new PreferencesApi(alfrescoApi);
 const opts = {};
 
 preferencesApi.listPreferences(`<personId>`, opts).then((data) => {
+  console.log('API called successfully. Returned data: ' + data);
+});
+```
+
+## updatePreference
+
+Update preference
+
+You can use the `-me-` string in place of `<personId>` to specify the currently authenticated user.
+
+### Parameters
+
+| Name                | Type   | Description                 |
+|---------------------|--------|-----------------------------|
+| **personId**        | string | The identifier of a person. |
+| **preferenceName**  | string | The name of the preference. |
+| **preferenceValue** | string | New preference value.       |
+
+**Return type**: [PreferenceEntry](#PreferenceEntry)
+
+**Example**
+
+```javascript
+import { AlfrescoApi, PreferencesApi } from '@alfresco/js-api';
+
+const alfrescoApi = new AlfrescoApi(/*..*/);
+const preferencesApi = new PreferencesApi(alfrescoApi);
+const newPreferenceValue = 'test';
+
+preferencesApi.updatePreference(`<personId>`, `<preferenceName>`, newPreferenceValue).then((data) => {
   console.log('API called successfully. Returned data: ' + data);
 });
 ```


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**

Saved Searches will no longer be stored in configuration file in favor of using preferences API. Existing data will be automatically migrated and configuration file will be automatically deleted.
https://hyland.atlassian.net/browse/ACS-9166

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
