### PR TITLE
[ACS-8824] Disable node properties save button if values are invalid

### DIFF
--- a/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.html
+++ b/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.html
@@ -38,7 +38,7 @@
                         (click)="saveChanges($event)"
                         color="primary"
                         data-automation-id="save-general-info-metadata"
-                        [disabled]="!hasMetadataChanged">
+                        [disabled]="!hasMetadataChanged || invalidProperties.length > 0">
                         <mat-icon>check</mat-icon>
                     </button>
                 </div>
@@ -235,7 +235,7 @@
                                 (click)="saveChanges($event)"
                                 color="primary"
                                 data-automation-id="save-metadata"
-                                [disabled]="!hasMetadataChanged">
+                                [disabled]="!hasMetadataChanged || invalidProperties.length > 0">
                                 <mat-icon>check</mat-icon>
                             </button>
                         </div>

--- a/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.html
+++ b/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.html
@@ -38,7 +38,7 @@
                         (click)="saveChanges($event)"
                         color="primary"
                         data-automation-id="save-general-info-metadata"
-                        [disabled]="!hasMetadataChanged || invalidProperties.length > 0">
+                        [disabled]="!hasMetadataChanged || invalidProperties.size > 0">
                         <mat-icon>check</mat-icon>
                     </button>
                 </div>
@@ -235,7 +235,7 @@
                                 (click)="saveChanges($event)"
                                 color="primary"
                                 data-automation-id="save-metadata"
-                                [disabled]="!hasMetadataChanged || invalidProperties.length > 0">
+                                [disabled]="!hasMetadataChanged || invalidProperties.size > 0">
                                 <mat-icon>check</mat-icon>
                             </button>
                         </div>

--- a/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.spec.ts
+++ b/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.spec.ts
@@ -306,27 +306,38 @@ describe('ContentMetadataComponent', () => {
             });
 
             it('should disable the save button if metadata has not changed', () => {
-                component.hasMetadataChanged = false;
                 fixture.detectChanges();
                 toggleEditModeForGroup();
                 expect(getGroupSaveButton().disabled).toBeTrue();
             });
 
-            it('should disable the save button if there are invalid properties', () => {
-                component.hasMetadataChanged = true;
-                component.invalidProperties = ['invalidPropertyKey'];
+            it('should disable the save button if there are invalid properties', fakeAsync(() => {
+                updateService.update(
+                    {
+                        key: 'properties.property-key',
+                        isValidValue: false
+                    } as CardViewBaseItemModel,
+                    'updated-value'
+                );
+                tick(500);
                 fixture.detectChanges();
                 toggleEditModeForGroup();
                 expect(getGroupSaveButton().disabled).toBeTrue();
-            });
+            }));
 
-            it('should enable the save button if metadata has changed and there are no invalid properties', () => {
-                component.hasMetadataChanged = true;
-                component.invalidProperties = [];
+            it('should enable the save button if metadata has changed and there are no invalid properties', fakeAsync(() => {
+                updateService.update(
+                    {
+                        key: 'properties.property-key',
+                        isValidValue: true
+                    } as CardViewBaseItemModel,
+                    'updated-value'
+                );
+                tick(500);
                 fixture.detectChanges();
                 toggleEditModeForGroup();
                 expect(getGroupSaveButton().disabled).toBeFalse();
-            });
+            }));
         });
 
         describe('Save button - Basic Properties', () => {
@@ -337,23 +348,34 @@ describe('ContentMetadataComponent', () => {
             }));
 
             it('should disable the save button if metadata has not changed', fakeAsync(() => {
-                component.hasMetadataChanged = false;
                 fixture.detectChanges();
                 toggleEditModeForGeneralInfo();
                 expect(findSaveGeneralInfoButton().disabled).toBeTrue();
             }));
 
             it('should enable the save button if metadata has changed and there are no invalid properties', fakeAsync(() => {
-                component.hasMetadataChanged = true;
-                component.invalidProperties = [];
+                updateService.update(
+                    {
+                        key: 'properties.property-key',
+                        isValidValue: true
+                    } as CardViewBaseItemModel,
+                    'updated-value'
+                );
+                tick(500);
                 fixture.detectChanges();
                 toggleEditModeForGeneralInfo();
                 expect(findSaveGeneralInfoButton().disabled).toBeFalse();
             }));
 
             it('should disable the save button if there are invalid properties', fakeAsync(() => {
-                component.hasMetadataChanged = true;
-                component.invalidProperties = ['invalidPropertyKey'];
+                updateService.update(
+                    {
+                        key: 'properties.property-key',
+                        isValidValue: false
+                    } as CardViewBaseItemModel,
+                    'updated-value'
+                );
+                tick(500);
                 fixture.detectChanges();
                 toggleEditModeForGeneralInfo();
                 expect(findSaveGeneralInfoButton().disabled).toBeTrue();
@@ -362,39 +384,37 @@ describe('ContentMetadataComponent', () => {
 
         describe('updateInvalidProperties', () => {
             it('should add the property key to invalidProperties if isValidValue is false and key is not present', fakeAsync(() => {
-                const property = { key: 'properties.property-key', value: 'original-value', isValidValue: false } as CardViewBaseItemModel;
-                component.invalidProperties = [];
+                const property = { key: 'properties.property-key', isValidValue: false } as CardViewBaseItemModel;
+                expect(component.invalidProperties.size).toBe(0);
                 updateService.update(property, 'updated-value');
                 tick(500);
-                fixture.detectChanges();
-                expect(component.invalidProperties).toContain(property.key);
+                expect(component.invalidProperties.has(property.key)).toBeTrue();
             }));
 
             it('should not add the property key to invalidProperties if isValidValue is false and key is already present', fakeAsync(() => {
-                const property = { key: 'properties.property-key', value: 'original-value', isValidValue: false } as CardViewBaseItemModel;
-                component.invalidProperties = [property.key];
-                updateService.update(property, 'updated-value');
+                const property = { key: 'properties.property-key', isValidValue: false } as CardViewBaseItemModel;
+                updateService.update(property, 'updated-value-1');
                 tick(500);
-                fixture.detectChanges();
-                expect(component.invalidProperties).toEqual([property.key]);
+                updateService.update(property, 'updated-value-2');
+                tick(500);
+                expect(component.invalidProperties.size).toBe(1);
+                expect(component.invalidProperties.has(property.key)).toBeTrue();
             }));
 
             it('should remove the property key from invalidProperties if isValidValue is true and key is present', fakeAsync(() => {
-                const property = { key: 'properties.property-key', value: 'original-value', isValidValue: true } as CardViewBaseItemModel;
-                component.invalidProperties = [property.key];
-                updateService.update(property, 'updated-value');
+                updateService.update({ key: 'properties.property-key', isValidValue: false } as CardViewBaseItemModel, 'updated-value');
                 tick(500);
-                fixture.detectChanges();
-                expect(component.invalidProperties).not.toContain(property.key);
+                expect(component.invalidProperties).toContain('properties.property-key');
+                updateService.update({ key: 'properties.property-key', isValidValue: true } as CardViewBaseItemModel, 'updated-value');
+                tick(500);
+                expect(component.invalidProperties.has('properties.property-key')).toBeFalse();
             }));
 
             it('should not change invalidProperties if isValidValue is true and key is not present', fakeAsync(() => {
-                const property = { key: 'properties.property-key', value: 'original-value', isValidValue: true } as CardViewBaseItemModel;
-                component.invalidProperties = [];
-                updateService.update(property, property.key);
+                expect(component.invalidProperties.size).toBe(0);
+                updateService.update({ key: 'properties.property-key', isValidValue: true } as CardViewBaseItemModel, 'updated-value');
                 tick(500);
-                fixture.detectChanges();
-                expect(component.invalidProperties).toEqual([]);
+                expect(component.invalidProperties.size).toBe(0);
             }));
         });
 

--- a/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.spec.ts
+++ b/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.spec.ts
@@ -309,7 +309,6 @@ describe('ContentMetadataComponent', () => {
                 component.hasMetadataChanged = false;
                 fixture.detectChanges();
                 toggleEditModeForGroup();
-                fixture.detectChanges();
                 expect(getGroupSaveButton().disabled).toBeTrue();
             });
 
@@ -318,7 +317,6 @@ describe('ContentMetadataComponent', () => {
                 component.invalidProperties = ['invalidPropertyKey'];
                 fixture.detectChanges();
                 toggleEditModeForGroup();
-                fixture.detectChanges();
                 expect(getGroupSaveButton().disabled).toBeTrue();
             });
 
@@ -333,7 +331,7 @@ describe('ContentMetadataComponent', () => {
 
         describe('Save button - Basic Properties', () => {
             beforeEach(fakeAsync(() => {
-                spyOn(contentMetadataService, 'getBasicProperties').and.returnValue(of([]) as any);
+                spyOn(contentMetadataService, 'getBasicProperties').and.returnValue(of([]));
                 component.ngOnInit();
                 component.readOnly = false;
             }));
@@ -353,10 +351,9 @@ describe('ContentMetadataComponent', () => {
                 expect(findSaveGeneralInfoButton().disabled).toBeFalse();
             }));
 
-            it('should enable the save button if metadata has changed and there are invalid properties', fakeAsync(() => {
+            it('should disable the save button if there are invalid properties', fakeAsync(() => {
                 component.hasMetadataChanged = true;
                 component.invalidProperties = ['invalidPropertyKey'];
-                component.readOnly = false;
                 fixture.detectChanges();
                 toggleEditModeForGeneralInfo();
                 expect(findSaveGeneralInfoButton().disabled).toBeTrue();

--- a/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.ts
+++ b/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.ts
@@ -164,6 +164,7 @@ export class ContentMetadataComponent implements OnChanges, OnInit {
     categoriesManagementMode = CategoriesManagementMode.ASSIGN;
     classifiableChanged = this.classifiableChangedSubject.asObservable();
     editing = false;
+    invalidProperties: string[] = [];
     editedPanelTitle = '';
     currentPanel: ContentMetadataPanel = {
         expanded: false,
@@ -194,6 +195,7 @@ export class ContentMetadataComponent implements OnChanges, OnInit {
             .subscribe((updatedNode: UpdateNotification) => {
                 this.hasMetadataChanged = true;
                 this.targetProperty = updatedNode.target;
+                this.updateInvalidProperties();
                 this.updateChanges(updatedNode.changed);
             });
 
@@ -548,5 +550,18 @@ export class ContentMetadataComponent implements OnChanges, OnInit {
             }
         }
         return observables;
+    }
+
+    private updateInvalidProperties() {
+        if (this.targetProperty?.isValidValue === false) {
+            if (!this.invalidProperties.includes(this.targetProperty.key)) {
+                this.invalidProperties.push(this.targetProperty.key);
+            }
+        } else if (this.targetProperty?.isValidValue === true) {
+            const index = this.invalidProperties.indexOf(this.targetProperty.key);
+            if (index > -1) {
+                this.invalidProperties.splice(index, 1);
+            }
+        }
     }
 }

--- a/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.ts
+++ b/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.ts
@@ -164,7 +164,7 @@ export class ContentMetadataComponent implements OnChanges, OnInit {
     categoriesManagementMode = CategoriesManagementMode.ASSIGN;
     classifiableChanged = this.classifiableChangedSubject.asObservable();
     editing = false;
-    invalidProperties: string[] = [];
+    invalidProperties = new Set<string>();
     editedPanelTitle = '';
     currentPanel: ContentMetadataPanel = {
         expanded: false,
@@ -554,14 +554,9 @@ export class ContentMetadataComponent implements OnChanges, OnInit {
 
     private updateInvalidProperties() {
         if (this.targetProperty?.isValidValue === false) {
-            if (!this.invalidProperties.includes(this.targetProperty.key)) {
-                this.invalidProperties.push(this.targetProperty.key);
-            }
+            this.invalidProperties.add(this.targetProperty.key);
         } else if (this.targetProperty?.isValidValue === true) {
-            const index = this.invalidProperties.indexOf(this.targetProperty.key);
-            if (index > -1) {
-                this.invalidProperties.splice(index, 1);
-            }
+            this.invalidProperties.delete(this.targetProperty.key);
         }
     }
 }

--- a/lib/content-services/src/lib/content-metadata/services/basic-properties.service.ts
+++ b/lib/content-services/src/lib/content-metadata/services/basic-properties.service.ts
@@ -17,13 +17,7 @@
 
 import { inject, Injectable } from '@angular/core';
 import { Node } from '@alfresco/js-api';
-import {
-    CardViewDateItemModel,
-    CardViewItemMatchValidator,
-    CardViewTextItemModel,
-    FileSizePipe,
-    TranslationService
-} from '@alfresco/adf-core';
+import { CardViewDateItemModel, CardViewItemMatchValidator, CardViewTextItemModel, FileSizePipe, TranslationService } from '@alfresco/adf-core';
 
 @Injectable({
     providedIn: 'root'
@@ -44,9 +38,7 @@ export class BasicPropertiesService {
                 value: node.name,
                 key: 'properties.cm:name',
                 editable: true,
-                validators: [
-                    new CardViewItemMatchValidator('[\\/\\*\\\\"\\\\:]')
-                ]
+                validators: [new CardViewItemMatchValidator('[\\/\\*\\\\"\\\\:|?<>]')]
             }),
             new CardViewTextItemModel({
                 label: 'CORE.METADATA.BASIC.TITLE',

--- a/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
@@ -501,7 +501,7 @@ describe('CardViewTextItemComponent', () => {
             await fixture.whenStable();
 
             expect(itemUpdatedSpy).toHaveBeenCalledWith({
-                target: { ...component.property },
+                target: { ...component.property, isValidValue: true },
                 changed: {
                     textkey: expectedText
                 }
@@ -577,11 +577,11 @@ describe('CardViewTextItemComponent', () => {
             updateTextField(component.property.key, 'updated-value');
             await fixture.whenStable();
 
-            const property = { ...component.property };
+            const property = { ...component.property, isValidValue: true };
             expect(cardViewUpdateService.update).toHaveBeenCalledWith(property, 'updated-value');
         });
 
-        it('should NOT trigger the update event if the editedValue is invalid', async () => {
+        it('should trigger the update event if the editedValue is NOT valid', async () => {
             const cardViewUpdateService = TestBed.inject(CardViewUpdateService);
             spyOn(cardViewUpdateService, 'update');
             component.property.isValid = () => false;
@@ -589,7 +589,8 @@ describe('CardViewTextItemComponent', () => {
             updateTextField(component.property.key, '@invalid-value');
             await fixture.whenStable();
 
-            expect(cardViewUpdateService.update).not.toHaveBeenCalled();
+            const property = { ...component.property, isValidValue: false };
+            expect(cardViewUpdateService.update).toHaveBeenCalledWith(property, '@invalid-value');
         });
 
         it('should trigger the update event if the editedValue is valid', async () => {
@@ -663,7 +664,7 @@ describe('CardViewTextItemComponent', () => {
             await fixture.whenStable();
 
             expect(itemUpdatedSpy).toHaveBeenCalledWith({
-                target: { ...component.property },
+                target: { ...component.property, isValidValue: true },
                 changed: {
                     textkey: expectedText
                 }
@@ -711,7 +712,7 @@ describe('CardViewTextItemComponent', () => {
             await fixture.whenStable();
 
             expect(itemUpdatedSpy).toHaveBeenCalledWith({
-                target: { ...component.property },
+                target: { ...component.property, isValidValue: true },
                 changed: {
                     textkey: expectedText
                 }
@@ -827,7 +828,7 @@ describe('CardViewTextItemComponent', () => {
             await fixture.whenStable();
 
             expect(itemUpdatedSpy).toHaveBeenCalledWith({
-                target: { ...component.property },
+                target: { ...component.property, isValidValue: true },
                 changed: {
                     textkey: expectedNumber.toString()
                 }
@@ -887,7 +888,7 @@ describe('CardViewTextItemComponent', () => {
             await fixture.whenStable();
 
             expect(itemUpdatedSpy).toHaveBeenCalledWith({
-                target: { ...component.property },
+                target: { ...component.property, isValidValue: true },
                 changed: {
                     textkey: expectedNumber.toString()
                 }

--- a/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.ts
+++ b/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.ts
@@ -15,16 +15,7 @@
  * limitations under the License.
  */
 
-import {
-    ChangeDetectorRef,
-    Component,
-    DestroyRef,
-    inject,
-    Input,
-    OnChanges,
-    SimpleChanges,
-    ViewEncapsulation
-} from '@angular/core';
+import { ChangeDetectorRef, Component, DestroyRef, inject, Input, OnChanges, SimpleChanges, ViewEncapsulation } from '@angular/core';
 import { CardViewTextItemModel } from '../../models/card-view-textitem.model';
 import { BaseCardView } from '../base-card-view';
 import { MatChipInputEvent, MatChipsModule } from '@angular/material/chips';
@@ -91,7 +82,7 @@ export class CardViewTextItemComponent extends BaseCardView<CardViewTextItemMode
     errors: CardViewItemValidator[];
     templateType: string;
     textInput = new UntypedFormControl();
-    
+
     private readonly destroyRef = inject(DestroyRef);
 
     constructor(private clipboardService: ClipboardService, private translateService: TranslationService, private cd: ChangeDetectorRef) {
@@ -158,9 +149,10 @@ export class CardViewTextItemComponent extends BaseCardView<CardViewTextItemMode
             this.resetErrorMessages();
             if (this.property.isValid(this.editedValue)) {
                 this.property.value = this.prepareValueForUpload(this.property, this.editedValue);
-                this.cardViewUpdateService.update({ ...this.property } as CardViewTextItemModel, this.property.value);
+                this.cardViewUpdateService.update({ ...this.property, isValidValue: true } as CardViewTextItemModel, this.property.value);
             } else {
                 this.errors = this.property.getValidationErrors(this.editedValue);
+                this.cardViewUpdateService.update({ ...this.property, isValidValue: false } as CardViewTextItemModel, this.editedValue);
             }
         }
     }

--- a/lib/core/src/lib/card-view/models/card-view-baseitem.model.ts
+++ b/lib/core/src/lib/card-view/models/card-view-baseitem.model.ts
@@ -31,6 +31,7 @@ export abstract class CardViewBaseItemModel<T = any> {
     data?: any;
     type?: string;
     multivalued?: boolean;
+    isValidValue?: boolean;
 
     constructor(props: CardViewItemProperties) {
         this.label = props.label || '';
@@ -44,6 +45,7 @@ export abstract class CardViewBaseItemModel<T = any> {
         this.validators = props.validators || [];
         this.data = props.data || null;
         this.multivalued = !!props.multivalued;
+        // this.isVal = undefined;
 
         if (props?.constraints?.length ?? 0) {
             for (const constraint of props.constraints) {

--- a/lib/core/src/lib/card-view/models/card-view-baseitem.model.ts
+++ b/lib/core/src/lib/card-view/models/card-view-baseitem.model.ts
@@ -45,7 +45,6 @@ export abstract class CardViewBaseItemModel<T = any> {
         this.validators = props.validators || [];
         this.data = props.data || null;
         this.multivalued = !!props.multivalued;
-        // this.isVal = undefined;
 
         if (props?.constraints?.length ?? 0) {
             for (const constraint of props.constraints) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

  > - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://hyland.atlassian.net/browse/ACS-8824
- Some forbidden symbols ignored by validator 
- Save button is active when form has errors 

**What is the new behaviour?**

- Disable save button if property validation fails 
- Add missing forbidden symbols to validator

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
