### PR TITLE
AAE-30162 Fix duplicated call for user tasks

### DIFF
--- a/lib/process-services-cloud/src/lib/task/task-list/components/base-task-list-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-list/components/base-task-list-cloud.component.ts
@@ -15,19 +15,7 @@
  * limitations under the License.
  */
 
-import {
-    AfterContentInit,
-    ContentChild,
-    DestroyRef,
-    Directive,
-    EventEmitter,
-    inject,
-    Input,
-    OnChanges,
-    OnInit,
-    Output,
-    SimpleChanges
-} from '@angular/core';
+import { ContentChild, DestroyRef, Directive, EventEmitter, inject, Input, OnChanges, OnInit, Output, SimpleChanges } from '@angular/core';
 import {
     AppConfigService,
     CustomEmptyContentTemplateDirective,
@@ -90,10 +78,7 @@ const taskPresetsCloudDefaultModel = {
 
 @Directive()
 // eslint-disable-next-line @angular-eslint/directive-class-suffix
-export abstract class BaseTaskListCloudComponent<T = unknown>
-    extends DataTableSchema<T>
-    implements OnChanges, AfterContentInit, PaginatedComponent, OnInit
-{
+export abstract class BaseTaskListCloudComponent<T = unknown> extends DataTableSchema<T> implements OnChanges, PaginatedComponent, OnInit {
     @ContentChild(CustomEmptyContentTemplateDirective)
     emptyCustomContent: CustomEmptyContentTemplateDirective;
 
@@ -274,10 +259,6 @@ export abstract class BaseTaskListCloudComponent<T = unknown>
                     this.isLoadingPreferences$.next(false);
                 }
             );
-    }
-
-    ngAfterContentInit(): void {
-        this.retrieveTasksPreferences();
     }
 
     isListEmpty(): boolean {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/AAE-30162


**What is the new behaviour?**
Removed the call to retrieveTasksPreferences in ngAfterContentInit, it should be only in ngOnChanges


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
