### PR TITLE
AAE-30162 Don't retreive task filter if present

### DIFF
--- a/lib/process-services-cloud/src/lib/task/task-filters/components/edit-task-filters/base-edit-task-filter-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-filters/components/edit-task-filters/base-edit-task-filter-cloud.component.ts
@@ -155,7 +155,13 @@ export abstract class BaseEditTaskFilterCloudComponent<T> implements OnInit, OnC
     ngOnChanges(changes: SimpleChanges) {
         const { id } = changes;
         if (id && id.currentValue !== id.previousValue) {
-            this.retrieveTaskFilterAndBuildForm();
+            if (this.taskFilter) {
+                this.taskFilterProperties = this.createAndFilterProperties();
+                this.taskFilterActions = this.createAndFilterActions();
+                this.buildForm(this.taskFilterProperties);
+            } else {
+                this.retrieveTaskFilterAndBuildForm();
+            }
         }
     }
 

--- a/lib/process-services-cloud/src/lib/task/task-filters/components/edit-task-filters/edit-service-task-filter/edit-service-task-filter-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/task/task-filters/components/edit-task-filters/edit-service-task-filter/edit-service-task-filter-cloud.component.spec.ts
@@ -189,6 +189,7 @@ describe('EditServiceTaskFilterCloudComponent', () => {
 
         describe('Save & Delete buttons', () => {
             it('should disable save and delete button for default task filters', async () => {
+                component.taskFilter = undefined;
                 getTaskFilterSpy.and.returnValue(
                     of({
                         name: 'ADF_CLOUD_SERVICE_TASK_FILTERS.ALL_SERVICE_TASKS',

--- a/lib/process-services-cloud/src/lib/task/task-filters/components/edit-task-filters/edit-task-filter/edit-task-filter-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/task/task-filters/components/edit-task-filters/edit-task-filter/edit-task-filter-cloud.component.spec.ts
@@ -299,6 +299,7 @@ describe('EditTaskFilterCloudComponent', () => {
 
         describe('Save & Delete buttons', () => {
             it('should disable save and delete button for default task filters', async () => {
+                component.taskFilter = undefined;
                 getTaskFilterSpy.and.returnValue(of(mockDefaultTaskFilter));
 
                 component.ngOnChanges({ id: mockTaskFilterIdChange });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/AAE-30162

**What is the new behaviour?**
If the taskFilter input has been provided in user tasks component or service tasks component, it will be used in getting the filter properties and actions, as well as building the form



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
