### PR TITLE
[ACS-4749] add button is enabled for comment contains only spaces

### DIFF
--- a/lib/core/src/lib/comments/comments.component.html
+++ b/lib/core/src/lib/comments/comments.component.html
@@ -23,7 +23,7 @@
                     data-automation-id="comments-input-add"
                     color="primary"
                     (click)="addComment()"
-                    [disabled]="emptyComment"
+                    [disabled]="commentControl.invalid"
                 >
                     {{ 'COMMENTS.ADD' | translate }}
                 </button>

--- a/lib/core/src/lib/comments/comments.component.html
+++ b/lib/core/src/lib/comments/comments.component.html
@@ -8,22 +8,22 @@
                     matInput
                     id="comment-input"
                     class="adf-text-text-area"
-                    [placeholder]='"COMMENTS.ADD" | translate'
+                    [placeholder]='("COMMENTS.ADD" | translate) + "*"'
                     [attr.aria-label]="'COMMENTS.ADD' | translate"
-                    [(ngModel)]="message"
+                    [formControl]="commentControl"
                     (keydown.escape)="clearMessage($event)"
                 >
                 </textarea>
+                <mat-error *ngIf="commentControl.invalid && commentControl.touched">{{ 'COMMENTS.EMPTY_ERROR' | translate }}</mat-error>
             </mat-form-field>
 
             <div class="adf-comments-input-actions">
                 <button
                     mat-button
-                    class="adf-comments-input-add"
                     data-automation-id="comments-input-add"
                     color="primary"
                     (click)="addComment()"
-                    [disabled]="!message"
+                    [disabled]="emptyComment"
                 >
                     {{ 'COMMENTS.ADD' | translate }}
                 </button>

--- a/lib/core/src/lib/comments/comments.component.scss
+++ b/lib/core/src/lib/comments/comments.component.scss
@@ -15,10 +15,7 @@ adf-comments {
 
                 &#{$mat-form-field-invalid} {
                     #{$mat-input-element} {
-                        &::placeholder {
-                            color: var(--theme-warn-color);
-                        }
-
+                        &::placeholder,
                         &:focus::placeholder {
                             color: var(--theme-warn-color);
                         }

--- a/lib/core/src/lib/comments/comments.component.scss
+++ b/lib/core/src/lib/comments/comments.component.scss
@@ -12,10 +12,18 @@ adf-comments {
 
             #{$mat-form-field} {
                 width: 100%;
-            }
 
-            #{$mat-form-field-subscript-wrapper} {
-                display: none;
+                &#{$mat-form-field-invalid} {
+                    #{$mat-input-element} {
+                        &::placeholder {
+                            color: var(--theme-warn-color);
+                        }
+
+                        &:focus::placeholder {
+                            color: var(--theme-warn-color);
+                        }
+                    }
+                }
             }
 
             #{$mat-form-field-wrapper} {
@@ -30,6 +38,12 @@ adf-comments {
                     &:focus::placeholder {
                         color: var(--theme-primary-color);
                         -webkit-font-smoothing: subpixel-antialiased;
+                    }
+
+                    &::placeholder {
+                        &::after {
+                            content: '*';
+                        }
                     }
                 }
             }

--- a/lib/core/src/lib/comments/comments.component.scss
+++ b/lib/core/src/lib/comments/comments.component.scss
@@ -39,12 +39,6 @@ adf-comments {
                         color: var(--theme-primary-color);
                         -webkit-font-smoothing: subpixel-antialiased;
                     }
-
-                    &::placeholder {
-                        &::after {
-                            content: '*';
-                        }
-                    }
                 }
             }
 

--- a/lib/core/src/lib/comments/comments.component.spec.ts
+++ b/lib/core/src/lib/comments/comments.component.spec.ts
@@ -25,7 +25,6 @@ import { CommentsService } from './interfaces/comments-service.interface';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { NoopTranslateModule } from '../testing/noop-translate.module';
 import { UnitTestingUtils } from '../testing/unit-testing-utils';
-import { By } from '@angular/platform-browser';
 import { MatError } from '@angular/material/form-field';
 
 describe('CommentsComponent', () => {
@@ -158,10 +157,9 @@ describe('CommentsComponent', () => {
     });
 
     describe('Add comment', () => {
-        const getError = (): string => fixture.debugElement.query(By.directive(MatError))?.nativeElement?.textContent;
+        const getError = (): string => testingUtils.getByDirective(MatError)?.nativeElement?.textContent;
 
-        const getAddCommentButton = (): HTMLButtonElement =>
-            fixture.debugElement.query(By.css('[data-automation-id=comments-input-add]')).nativeElement;
+        const getAddCommentButton = (): HTMLButtonElement => testingUtils.getByDataAutomationId('comments-input-add').nativeElement;
 
         beforeEach(() => {
             component.id = '123';
@@ -170,8 +168,8 @@ describe('CommentsComponent', () => {
         });
 
         it('should normalize comment when user input contains spaces sequence', async () => {
-            component.message = 'test comment';
-            testingUtils.clickByCSS('.adf-comments-input-add');
+            component.commentControl.setValue('test comment');
+            getAddCommentButton().dispatchEvent(new Event('click'));
 
             fixture.detectChanges();
             await fixture.whenStable();
@@ -191,8 +189,8 @@ describe('CommentsComponent', () => {
             getCommentSpy.and.returnValue(of([]));
             addCommentSpy.and.returnValue(commentsResponseMock.addComment(commentText));
 
-            component.message = commentText;
-            testingUtils.clickByCSS('.adf-comments-input-add');
+            component.commentControl.setValue(commentText);
+            getAddCommentButton().dispatchEvent(new Event('click'));
 
             fixture.detectChanges();
             await fixture.whenStable();
@@ -202,9 +200,10 @@ describe('CommentsComponent', () => {
         });
 
         it('should call service to add a comment when add button is pressed', async () => {
-            component.message = 'Test Comment';
-            addCommentSpy.and.returnValue(commentsResponseMock.addComment(component.message));
-            testingUtils.clickByCSS('.adf-comments-input-add');
+            const comment = 'Test Comment';
+            component.commentControl.setValue(comment);
+            addCommentSpy.and.returnValue(commentsResponseMock.addComment(comment));
+            getAddCommentButton().dispatchEvent(new Event('click'));
 
             fixture.detectChanges();
             await fixture.whenStable();
@@ -216,8 +215,8 @@ describe('CommentsComponent', () => {
         });
 
         it('should not call service to add a comment when comment is empty', async () => {
-            component.message = '';
-            testingUtils.clickByCSS('.adf-comments-input-add');
+            component.commentControl.setValue('');
+            getAddCommentButton().dispatchEvent(new Event('click'));
 
             fixture.detectChanges();
             await fixture.whenStable();
@@ -238,7 +237,7 @@ describe('CommentsComponent', () => {
         it('should emit an error when an error occurs adding the comment', () => {
             const emitSpy = spyOn(component.error, 'emit');
             addCommentSpy.and.returnValue(throwError(() => new Error('error')));
-            component.message = 'Test comment';
+            component.commentControl.setValue('Test comment');
             component.addComment();
             expect(emitSpy).toHaveBeenCalled();
         });

--- a/lib/core/src/lib/comments/comments.component.spec.ts
+++ b/lib/core/src/lib/comments/comments.component.spec.ts
@@ -25,6 +25,8 @@ import { CommentsService } from './interfaces/comments-service.interface';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { NoopTranslateModule } from '../testing/noop-translate.module';
 import { UnitTestingUtils } from '../testing/unit-testing-utils';
+import { By } from '@angular/platform-browser';
+import { MatError } from '@angular/material/form-field';
 
 describe('CommentsComponent', () => {
     let component: CommentsComponent;
@@ -156,6 +158,11 @@ describe('CommentsComponent', () => {
     });
 
     describe('Add comment', () => {
+        const getError = (): string => fixture.debugElement.query(By.directive(MatError))?.nativeElement?.textContent;
+
+        const getAddCommentButton = (): HTMLButtonElement =>
+            fixture.debugElement.query(By.css('[data-automation-id=comments-input-add]')).nativeElement;
+
         beforeEach(() => {
             component.id = '123';
             fixture.detectChanges();
@@ -255,9 +262,85 @@ describe('CommentsComponent', () => {
         });
 
         it('should not add comment if message is empty', () => {
-            component.message = '';
+            component.commentControl.setValue('');
             component.addComment();
             expect(addCommentSpy).not.toHaveBeenCalled();
+        });
+
+        it('should not display error message initially', () => {
+            expect(getError()).toBeUndefined();
+        });
+
+        it('should display error message when comment is empty and was touched', () => {
+            component.commentControl.setValue('');
+            component.commentControl.markAsTouched();
+
+            fixture.detectChanges();
+            expect(getError()).toBe('COMMENTS.EMPTY_ERROR');
+        });
+
+        it('should display error message when comment has only spaces and was touched', () => {
+            component.commentControl.setValue('    ');
+            component.commentControl.markAsTouched();
+
+            fixture.detectChanges();
+            expect(getError()).toBe('COMMENTS.EMPTY_ERROR');
+        });
+
+        it('should not display error message when comment is empty but was not touched', () => {
+            component.commentControl.setValue('');
+
+            fixture.detectChanges();
+            expect(getError()).toBeUndefined();
+        });
+
+        it('should not display error message when comment has only spaces but was not touched', () => {
+            component.commentControl.setValue('    ');
+
+            fixture.detectChanges();
+            expect(getError()).toBeUndefined();
+        });
+
+        it('should not display error message when comment is not empty and was touched', () => {
+            component.commentControl.setValue('Some comment');
+            component.commentControl.markAsTouched();
+
+            fixture.detectChanges();
+            expect(getError()).toBeUndefined();
+        });
+
+        it('should not display error message when comment is not empty and was not touched', () => {
+            component.commentControl.setValue('Some comment');
+
+            fixture.detectChanges();
+            expect(getError()).toBeUndefined();
+        });
+
+        it('should disable add button initially', () => {
+            expect(getAddCommentButton().disabled).toBeTrue();
+        });
+
+        it('should disable add button when comment is empty', () => {
+            component.commentControl.setValue('Some comment');
+            component.commentControl.setValue('');
+
+            fixture.detectChanges();
+            expect(getAddCommentButton().disabled).toBeTrue();
+        });
+
+        it('should disable add button when comment has only spaces', () => {
+            component.commentControl.setValue('Some comment');
+            component.commentControl.setValue('    ');
+
+            fixture.detectChanges();
+            expect(getAddCommentButton().disabled).toBeTrue();
+        });
+
+        it('should enable add button when comment is not empty', () => {
+            component.commentControl.setValue('Some comment');
+
+            fixture.detectChanges();
+            expect(getAddCommentButton().disabled).toBeFalse();
         });
     });
 });

--- a/lib/core/src/lib/comments/comments.component.ts
+++ b/lib/core/src/lib/comments/comments.component.ts
@@ -16,7 +16,7 @@
  */
 
 import { CommentModel } from '../models/comment.model';
-import { Component, DestroyRef, EventEmitter, inject, Input, OnChanges, OnInit, Output, SimpleChanges, ViewEncapsulation } from '@angular/core';
+import { Component, EventEmitter, inject, Input, OnChanges, Output, SimpleChanges, ViewEncapsulation } from '@angular/core';
 import { ADF_COMMENTS_SERVICE } from './interfaces/comments.token';
 import { CommentsService } from './interfaces/comments-service.interface';
 import { CommonModule } from '@angular/common';
@@ -26,7 +26,6 @@ import { MatInputModule } from '@angular/material/input';
 import { FormControl, FormsModule, ReactiveFormsModule, ValidationErrors } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { CommentListComponent } from './comment-list';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
     selector: 'adf-comments',
@@ -45,7 +44,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
     styleUrls: ['./comments.component.scss'],
     encapsulation: ViewEncapsulation.None
 })
-export class CommentsComponent implements OnChanges, OnInit {
+export class CommentsComponent implements OnChanges {
     /** The numeric ID of the task. */
     @Input()
     id: string;
@@ -62,13 +61,7 @@ export class CommentsComponent implements OnChanges, OnInit {
     beingAdded: boolean = false;
 
     private commentsService = inject<CommentsService>(ADF_COMMENTS_SERVICE);
-    private destroyRef = inject(DestroyRef);
-    private _emptyComment = true;
-    private _commentControl: FormControl<string> = new FormControl('', [this.validateEmptyComment]);
-
-    get emptyComment(): boolean {
-        return this._emptyComment;
-    }
+    private _commentControl = new FormControl('', [this.validateEmptyComment]);
 
     get commentControl(): FormControl<string> {
         return this._commentControl;
@@ -84,10 +77,6 @@ export class CommentsComponent implements OnChanges, OnInit {
         } else {
             this.resetComments();
         }
-    }
-
-    ngOnInit(): void {
-        this._commentControl.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((comment) => (this._emptyComment = !comment?.trim()));
     }
 
     loadComments() {

--- a/lib/core/src/lib/comments/comments.component.ts
+++ b/lib/core/src/lib/comments/comments.component.ts
@@ -61,7 +61,8 @@ export class CommentsComponent implements OnChanges {
     beingAdded: boolean = false;
 
     private commentsService = inject<CommentsService>(ADF_COMMENTS_SERVICE);
-    private _commentControl = new FormControl('', [this.validateEmptyComment]);
+
+    private readonly _commentControl = new FormControl('', [this.validateEmptyComment]);
 
     get commentControl(): FormControl<string> {
         return this._commentControl;

--- a/lib/core/src/lib/i18n/en.json
+++ b/lib/core/src/lib/i18n/en.json
@@ -306,6 +306,7 @@
     "HEADER": "Comments ({{ count }})",
     "CREATED_BY_HEADER": "Created by",
     "MESSAGE_HEADER": "Message",
+    "EMPTY_ERROR": "Comment can't be empty",
     "DIALOG": {
       "TITLE": "New comment",
       "LABELS": {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/ACS-4749


**What is the new behaviour?**
Add button for comment is disabled when comment contains only spaces. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
