### PR TITLE
[ACS-9119] Fixed textOrientation getting reset on arabic after browser refresh

### DIFF
--- a/lib/core/src/lib/common/index.ts
+++ b/lib/core/src/lib/common/index.ts
@@ -30,6 +30,7 @@ export * from './services/url.service';
 
 export * from './models/log-levels.model';
 export * from './models/user-info-mode.enum';
+export * from './models/default-languages.model';
 
 export * from './interface/search-component.interface';
 

--- a/lib/core/src/lib/common/models/default-languages.model.ts
+++ b/lib/core/src/lib/common/models/default-languages.model.ts
@@ -1,0 +1,38 @@
+/*!
+ * @license
+ * Copyright © 2005-2024 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { LanguageItem } from '../services/language-item.interface';
+
+export const DEFAULT_LANGUAGE_LIST: LanguageItem[] = [
+    { key: 'de', label: 'Deutsch' },
+    { key: 'en', label: 'English' },
+    { key: 'es', label: 'Español' },
+    { key: 'fr', label: 'Français' },
+    { key: 'it', label: 'Italiano' },
+    { key: 'ja', label: '日本語' },
+    { key: 'nb', label: 'Bokmål' },
+    { key: 'nl', label: 'Nederlands' },
+    { key: 'pt-BR', label: 'Português (Brasil)' },
+    { key: 'ru', label: 'Русский' },
+    { key: 'zh-CN', label: '中文简体' },
+    { key: 'cs', label: 'Čeština' },
+    { key: 'da', label: 'Dansk' },
+    { key: 'fi', label: 'Suomi' },
+    { key: 'pl', label: 'Polski' },
+    { key: 'sv', label: 'Svenska' },
+    { key: 'ar', label: 'العربية', direction: 'rtl' }
+];

--- a/lib/core/src/lib/common/services/user-preferences.service.spec.ts
+++ b/lib/core/src/lib/common/services/user-preferences.service.spec.ts
@@ -193,6 +193,19 @@ describe('UserPreferencesService', () => {
             expect(storage.getItem(textOrientation)).toBe('rtl');
         });
 
+        it('should set direction from default languages when language config is not present', () => {
+            appConfig.config.languages = [
+                {
+                    key: 'fake-locale-config',
+                    direction: 'ltr'
+                }
+            ];
+            appConfig.config.locale = 'ar';
+            appConfig.load();
+            const textOrientation = preferences.getPropertyKey('textOrientation');
+            expect(storage.getItem(textOrientation)).toBe('rtl');
+        });
+
         it('should not store textOrientation based on language ', () => {
             appConfig.config.languages = [
                 {

--- a/lib/core/src/lib/common/services/user-preferences.service.ts
+++ b/lib/core/src/lib/common/services/user-preferences.service.ts
@@ -247,12 +247,15 @@ export class UserPreferencesService {
 
     private getLanguageByKey(key: string): LanguageItem {
         const defaultLanguage = { key: 'en' } as LanguageItem;
+        let language: LanguageItem;
 
         const customLanguages = this.appConfig.get<Array<LanguageItem>>(AppConfigValues.APP_CONFIG_LANGUAGES_KEY);
         if (customLanguages && Array.isArray(customLanguages)) {
-            return customLanguages.find((language) => key.includes(language.key)) || defaultLanguage;
-        } else {
-            return DEFAULT_LANGUAGE_LIST.find((language) => language.key === key) ?? defaultLanguage;
+            language = customLanguages.find((language) => key.includes(language.key));
         }
+        if (!language) {
+            language = DEFAULT_LANGUAGE_LIST.find((language) => language.key === key) ?? defaultLanguage;
+        }
+        return language;
     }
 }

--- a/lib/core/src/lib/common/services/user-preferences.service.ts
+++ b/lib/core/src/lib/common/services/user-preferences.service.ts
@@ -250,12 +250,10 @@ export class UserPreferencesService {
         let language: LanguageItem;
 
         const customLanguages = this.appConfig.get<Array<LanguageItem>>(AppConfigValues.APP_CONFIG_LANGUAGES_KEY);
-        if (customLanguages && Array.isArray(customLanguages)) {
-            language = customLanguages.find((language) => key.includes(language.key));
+        if (Array.isArray(customLanguages)) {
+            language = customLanguages.find((customLanguage) => key.includes(customLanguage.key));
         }
-        if (!language) {
-            language = DEFAULT_LANGUAGE_LIST.find((language) => language.key === key) ?? defaultLanguage;
-        }
+        language ??= DEFAULT_LANGUAGE_LIST.find((defaultLang) => defaultLang.key === key) ?? defaultLanguage;
         return language;
     }
 }

--- a/lib/core/src/lib/common/services/user-preferences.service.ts
+++ b/lib/core/src/lib/common/services/user-preferences.service.ts
@@ -24,6 +24,7 @@ import { distinctUntilChanged, map } from 'rxjs/operators';
 import { LanguageItem } from './language-item.interface';
 import { DOCUMENT } from '@angular/common';
 import { Directionality, Direction } from '@angular/cdk/bidi';
+import { DEFAULT_LANGUAGE_LIST } from '../models/default-languages.model';
 
 // eslint-disable-next-line no-shadow
 export enum UserPreferenceValues {
@@ -247,10 +248,11 @@ export class UserPreferencesService {
     private getLanguageByKey(key: string): LanguageItem {
         const defaultLanguage = { key: 'en' } as LanguageItem;
 
-        const registeredLanguages = this.appConfig.get<Array<LanguageItem>>(AppConfigValues.APP_CONFIG_LANGUAGES_KEY);
-        if (registeredLanguages && Array.isArray(registeredLanguages)) {
-            return registeredLanguages.find((language) => key.includes(language.key)) || defaultLanguage;
+        const customLanguages = this.appConfig.get<Array<LanguageItem>>(AppConfigValues.APP_CONFIG_LANGUAGES_KEY);
+        if (customLanguages && Array.isArray(customLanguages)) {
+            return customLanguages.find((language) => key.includes(language.key)) || defaultLanguage;
+        } else {
+            return DEFAULT_LANGUAGE_LIST.find((language) => language.key === key) ?? defaultLanguage;
         }
-        return defaultLanguage;
     }
 }

--- a/lib/core/src/lib/language-menu/service/language.service.ts
+++ b/lib/core/src/lib/language-menu/service/language.service.ts
@@ -21,36 +21,15 @@ import { BehaviorSubject } from 'rxjs';
 import { AppConfigService, AppConfigValues } from '../../app-config/app-config.service';
 import { LanguageItem } from '../../common/services/language-item.interface';
 import { UserPreferencesService } from '../../common/services/user-preferences.service';
+import { DEFAULT_LANGUAGE_LIST } from '../../common/models/default-languages.model';
 
-@Injectable({providedIn: 'root'})
+@Injectable({ providedIn: 'root' })
 export class LanguageService implements LanguageServiceInterface {
-
-    private languages = new BehaviorSubject<LanguageItem[]>([
-        {key: 'de', label: 'Deutsch'},
-        {key: 'en', label: 'English'},
-        {key: 'es', label: 'Español'},
-        {key: 'fr', label: 'Français'},
-        {key: 'it', label: 'Italiano'},
-        {key: 'ja', label: '日本語'},
-        {key: 'nb', label: 'Bokmål'},
-        {key: 'nl', label: 'Nederlands'},
-        {key: 'pt-BR', label: 'Português (Brasil)'},
-        {key: 'ru', label: 'Русский'},
-        {key: 'zh-CN', label: '中文简体'},
-        {key: 'cs', label: 'Čeština'},
-        {key: 'da', label: 'Dansk'},
-        {key: 'fi', label: 'Suomi'},
-        {key: 'pl', label: 'Polski'},
-        {key: 'sv', label: 'Svenska'},
-        {key: 'ar', label: 'العربية', direction: 'rtl'}
-    ]);
+    private languages = new BehaviorSubject<LanguageItem[]>(DEFAULT_LANGUAGE_LIST);
 
     languages$ = this.languages.asObservable();
 
-    constructor(
-        appConfigService: AppConfigService,
-        private userPreferencesService: UserPreferencesService) {
-
+    constructor(appConfigService: AppConfigService, private userPreferencesService: UserPreferencesService) {
         const customLanguages = appConfigService.get<Array<LanguageItem>>(AppConfigValues.APP_CONFIG_LANGUAGES_KEY);
         this.setLanguages(customLanguages);
     }

--- a/lib/core/src/lib/language-menu/service/language.service.ts
+++ b/lib/core/src/lib/language-menu/service/language.service.ts
@@ -29,7 +29,7 @@ export class LanguageService implements LanguageServiceInterface {
 
     languages$ = this.languages.asObservable();
 
-    constructor(appConfigService: AppConfigService, private userPreferencesService: UserPreferencesService) {
+    constructor(appConfigService: AppConfigService, private readonly userPreferencesService: UserPreferencesService) {
         const customLanguages = appConfigService.get<Array<LanguageItem>>(AppConfigValues.APP_CONFIG_LANGUAGES_KEY);
         this.setLanguages(customLanguages);
     }

--- a/lib/core/src/lib/layout/components/layout-container/layout-container.component.html
+++ b/lib/core/src/lib/layout/components/layout-container/layout-container.component.html
@@ -1,4 +1,4 @@
-<mat-sidenav-container class="adf-layout-container">
+<mat-sidenav-container class="adf-layout-container" autosize>
     <mat-sidenav
         class="adf-layout-container-sidenav"
         [position]="position"

--- a/lib/core/src/lib/layout/components/layout-container/layout-container.component.scss
+++ b/lib/core/src/lib/layout/components/layout-container/layout-container.component.scss
@@ -37,6 +37,7 @@ adf-layout-container {
 #{$mat-sidenav-content},
 #{$mat-drawer-transition} #{$mat-drawer-content} {
     margin-left: 0 !important;
+    margin-right: 0 !important;
     transform: unset !important;
     transition-property: unset !important;
     transition-duration: unset !important;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
For right-to-left languages (such as arabic), textOrientation would get reset after browser refresh. Additionally, there was additional margin getting added on the right when changing browser window sizes


**What is the new behaviour?**
Fixed textOrientation and margin-right issues


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://hyland.atlassian.net/browse/ACS-9119