### PR TITLE
AAE-30168 Form Display Value does not show date variable

### DIFF
--- a/lib/core/src/lib/form/components/widgets/core/form.model.spec.ts
+++ b/lib/core/src/lib/form/components/widgets/core/form.model.spec.ts
@@ -33,9 +33,7 @@ describe('FormModel', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [
-                CoreTestingModule
-            ]
+            imports: [CoreTestingModule]
         });
         formService = new FormService();
     });
@@ -132,10 +130,7 @@ describe('FormModel', () => {
 
     it('should parse tabs', () => {
         const json = {
-            tabs: [
-                { id: 'tab1' },
-                { id: 'tab2' }
-            ]
+            tabs: [{ id: 'tab1' }, { id: 'tab2' }]
         };
 
         const form = new FormModel(json);
@@ -199,10 +194,7 @@ describe('FormModel', () => {
 
     it('should put fields into corresponding tabs', () => {
         const json = {
-            tabs: [
-                { id: 'tab1' },
-                { id: 'tab2' }
-            ],
+            tabs: [{ id: 'tab1' }, { id: 'tab2' }],
             fields: [
                 { id: 'field1', tab: 'tab1', type: FormFieldTypes.CONTAINER },
                 { id: 'field2', tab: 'tab2', type: FormFieldTypes.CONTAINER },
@@ -227,9 +219,7 @@ describe('FormModel', () => {
 
     it('should create standard form outcomes', () => {
         const json = {
-            fields: [
-                { id: 'container1' }
-            ]
+            fields: [{ id: 'container1' }]
         };
 
         const form = new FormModel(json);
@@ -255,12 +245,8 @@ describe('FormModel', () => {
 
     it('should use custom form outcomes', () => {
         const json = {
-            fields: [
-                { id: 'container1' }
-            ],
-            outcomes: [
-                { id: 'custom-1', name: 'custom 1' }
-            ]
+            fields: [{ id: 'container1' }],
+            outcomes: [{ id: 'custom-1', name: 'custom 1' }]
         };
 
         const form = new FormModel(json);
@@ -276,9 +262,7 @@ describe('FormModel', () => {
     it('should raise validation event when validating form', () => {
         const form = new FormModel({}, null, false, formService);
 
-        formService.validateForm.subscribe((validateFormEvent) =>
-            expect(validateFormEvent).toBeTruthy()
-        );
+        formService.validateForm.subscribe((validateFormEvent) => expect(validateFormEvent).toBeTruthy());
         form.validateForm();
     });
 
@@ -286,9 +270,7 @@ describe('FormModel', () => {
         const form = new FormModel({}, null, false, formService);
         const field = jasmine.createSpyObj('FormFieldModel', ['validate']);
 
-        formService.validateFormField.subscribe((validateFormFieldEvent) =>
-            expect(validateFormFieldEvent).toBeTruthy()
-        );
+        formService.validateFormField.subscribe((validateFormFieldEvent) => expect(validateFormFieldEvent).toBeTruthy());
         form.validateField(field);
     });
 
@@ -503,6 +485,12 @@ describe('FormModel', () => {
                     processInstanceId: '1be4785f-c982-11e9-bdd8-96d6903e4e44',
                     taskId: '1beab9f6-c982-11e9-bdd8-96d6903e4e44',
                     taskVariable: true
+                },
+                {
+                    id: 'variables.datetime',
+                    name: 'variables.datetime',
+                    value: '2025-01-23T04:30:00.000+0000',
+                    type: 'date'
                 }
             ];
 
@@ -570,9 +558,14 @@ describe('FormModel', () => {
             expect(value).toBe('29.09.2019T00:00:00.000Z');
         });
 
-        it('should find a process variable by name', () => {
-            const value = form.getProcessVariableValue('booleanVar');
-            expect(value).toEqual(true);
+        [
+            { name: 'booleanVar', result: true },
+            { name: 'datetime', result: '2025-01-23T04:30:00.000+0000' }
+        ].forEach(({ name, result }) => {
+            it('should find a process variable by name and convert it', () => {
+                const value = form.getProcessVariableValue(name);
+                expect(value).toEqual(result);
+            });
         });
 
         it('should not find a process variable', () => {
@@ -614,7 +607,6 @@ describe('FormModel', () => {
             expect(form.values['pfx_property_six']).toEqual('text-value');
             expect(form.values['pfx_property_seven']).toBeNull();
             expect(form.values['pfx_property_eight']).toBeNull();
-
         });
     });
 

--- a/lib/core/src/lib/form/components/widgets/core/form.model.ts
+++ b/lib/core/src/lib/form/components/widgets/core/form.model.ts
@@ -313,7 +313,11 @@ export class FormModel implements ProcessFormModel {
         if (type && value) {
             switch (type) {
                 case 'date':
-                    return value ? `${value}T00:00:00.000Z` : undefined;
+                    if (value) {
+                        return value.toString().includes('T') ? value : `${value}T00:00:00.000Z`;
+                    }
+
+                    return undefined;
                 case 'boolean':
                     return typeof value === 'string' ? JSON.parse(value) : value;
                 default:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Currently when the value of a form field is coming from a process or a form variable the date string is appended with a timestamp, no matter if already one is existing.


**What is the new behaviour?**
The timestamp is only added when there is no timestamp.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://hyland.atlassian.net/browse/AAE-30168