### PR TITLE
AAE-27984 Fix fieldValueChanged called on init and blur for date widgets

### DIFF
--- a/lib/core/src/lib/form/components/widgets/date-time/date-time.widget.html
+++ b/lib/core/src/lib/form/components/widgets/date-time/date-time.widget.html
@@ -21,7 +21,6 @@
                    (keydown.enter)="datetimePicker.open()"
                    [placeholder]="field.placeholder"
                    [title]="field.tooltip"
-                   (blur)="updateField()"
                    [min]="minDate"
                    [max]="maxDate">
             <mat-datetimepicker-toggle matSuffix [for]="datetimePicker"

--- a/lib/core/src/lib/form/components/widgets/date-time/date-time.widget.spec.ts
+++ b/lib/core/src/lib/form/components/widgets/date-time/date-time.widget.spec.ts
@@ -61,6 +61,28 @@ describe('DateTimeWidgetComponent', () => {
         TestBed.resetTestingModule();
     });
 
+    it('should not call onFieldChanged on init', () => {
+        spyOn(widget, 'onFieldChanged').and.callThrough();
+        expect(widget.onFieldChanged).not.toHaveBeenCalled();
+    });
+
+    it('should call onFieldChanged when datetime changes', () => {
+        const spy = spyOn(widget, 'onFieldChanged').and.callThrough();
+        const field = new FormFieldModel(form, {
+            id: 'date-id',
+            name: 'date-name',
+            type: FormFieldTypes.DATETIME
+        });
+        const newDate = new Date('1982-03-13T10:00:00.000Z');
+
+        widget.field = field;
+        fixture.detectChanges();
+        widget.datetimeInputControl.setValue(newDate);
+
+        expect(spy).toHaveBeenCalled();
+        expect(spy.calls.mostRecent().args[0].value).toBe(newDate);
+    });
+
     it('should setup min value for date picker', () => {
         const minValue = '1982-03-13T10:00:00Z';
         widget.field = new FormFieldModel(form, {

--- a/lib/core/src/lib/form/components/widgets/date-time/date-time.widget.ts
+++ b/lib/core/src/lib/form/components/widgets/date-time/date-time.widget.ts
@@ -63,12 +63,7 @@ export class DateTimeWidgetComponent extends WidgetComponent implements OnInit, 
         this.initDateAdapter();
         this.initDateRange();
         this.subscribeToDateChanges();
-        this.updateField();
-    }
-
-    updateField(): void {
         this.validateField();
-        this.onFieldChanged(this.field);
     }
 
     updateReactiveFormControl(): void {
@@ -94,6 +89,11 @@ export class DateTimeWidgetComponent extends WidgetComponent implements OnInit, 
             this.field.value = newDate;
             this.updateField();
         });
+    }
+
+    private updateField(): void {
+        this.validateField();
+        this.onFieldChanged(this.field);
     }
 
     private validateField(): void {

--- a/lib/core/src/lib/form/components/widgets/date/date.widget.html
+++ b/lib/core/src/lib/form/components/widgets/date/date.widget.html
@@ -12,7 +12,7 @@
                [placeholder]="field.placeholder"
                [min]="minDate"
                [max]="maxDate"
-               (blur)="updateField()">
+        />
         <mat-datepicker-toggle matSuffix [for]="datePicker" [disabled]="field.readOnly" />
         <mat-datepicker #datePicker
                         [startAt]="startAt"

--- a/lib/core/src/lib/form/components/widgets/date/date.widget.spec.ts
+++ b/lib/core/src/lib/form/components/widgets/date/date.widget.spec.ts
@@ -42,6 +42,29 @@ describe('DateWidgetComponent', () => {
         testingUtils = new UnitTestingUtils(fixture.debugElement);
     });
 
+    it('should not call onFieldChanged on init', () => {
+        spyOn(widget, 'onFieldChanged').and.callThrough();
+        expect(widget.onFieldChanged).not.toHaveBeenCalled();
+    });
+
+    it('should call onFieldChanged when date changes', () => {
+        const spy = spyOn(widget, 'onFieldChanged').and.callThrough();
+        const field = new FormFieldModel(form, {
+            id: 'date-field-id',
+            name: 'date-name',
+            value: '9-9-9999',
+            type: 'date'
+        });
+        const newDate = new Date('12/12/2012');
+
+        widget.field = field;
+        fixture.detectChanges();
+        widget.dateInputControl.setValue(newDate);
+
+        expect(spy).toHaveBeenCalled();
+        expect(spy.calls.mostRecent().args[0].value).toBe(newDate);
+    });
+
     it('[C310333] - should be able to set a placeholder', () => {
         widget.field = new FormFieldModel(form, {
             id: 'date-id',

--- a/lib/core/src/lib/form/components/widgets/date/date.widget.ts
+++ b/lib/core/src/lib/form/components/widgets/date/date.widget.ts
@@ -75,12 +75,7 @@ export class DateWidgetComponent extends WidgetComponent implements OnInit, Reac
         this.initDateRange();
         this.initStartAt();
         this.subscribeToDateChanges();
-        this.updateField();
-    }
-
-    updateField(): void {
         this.validateField();
-        this.onFieldChanged(this.field);
     }
 
     updateReactiveFormControl(): void {
@@ -106,6 +101,11 @@ export class DateWidgetComponent extends WidgetComponent implements OnInit, Reac
             this.field.value = newDate;
             this.updateField();
         });
+    }
+
+    private updateField(): void {
+        this.validateField();
+        this.onFieldChanged(this.field);
     }
 
     private validateField(): void {

--- a/lib/process-services-cloud/src/lib/form/components/widgets/date/date-cloud.widget.html
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/date/date-cloud.widget.html
@@ -15,7 +15,7 @@
                 [min]="minDate"
                 [max]="maxDate"
                 [title]="field.tooltip"
-                (blur)="updateField()">
+            />
             <mat-datepicker-toggle matSuffix [for]="datePicker" [disabled]="field.readOnly" />
             <mat-datepicker #datePicker
                 [startAt]="startAt"

--- a/lib/process-services-cloud/src/lib/form/components/widgets/date/date-cloud.widget.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/date/date-cloud.widget.spec.ts
@@ -43,6 +43,29 @@ describe('DateCloudWidgetComponent', () => {
         element = fixture.nativeElement;
     });
 
+    it('should not call onFieldChanged on init', () => {
+        spyOn(widget, 'onFieldChanged').and.callThrough();
+        expect(widget.onFieldChanged).not.toHaveBeenCalled();
+    });
+
+    it('should call onFieldChanged when date changes', () => {
+        const spy = spyOn(widget, 'onFieldChanged').and.callThrough();
+        const field = new FormFieldModel(form, {
+            id: 'date-field-id',
+            name: 'date-name',
+            value: '9-9-9999',
+            type: 'date'
+        });
+        const newDate = new Date('12/12/2012');
+
+        widget.field = field;
+        fixture.detectChanges();
+        widget.dateInputControl.setValue(newDate);
+
+        expect(spy).toHaveBeenCalled();
+        expect(spy.calls.mostRecent().args[0].value).toBe(newDate);
+    });
+
     it('should setup min value for date picker', () => {
         const minValue = '1982-03-13';
         widget.field = new FormFieldModel(null, {

--- a/lib/process-services-cloud/src/lib/form/components/widgets/date/date-cloud.widget.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/date/date-cloud.widget.ts
@@ -83,12 +83,7 @@ export class DateCloudWidgetComponent extends WidgetComponent implements OnInit,
         this.initRangeSelection();
         this.initStartAt();
         this.subscribeToDateChanges();
-        this.updateField();
-    }
-
-    updateField(): void {
         this.validateField();
-        this.onFieldChanged(this.field);
     }
 
     updateReactiveFormControl(): void {
@@ -114,6 +109,11 @@ export class DateCloudWidgetComponent extends WidgetComponent implements OnInit,
             this.field.value = newDate;
             this.updateField();
         });
+    }
+
+    private updateField(): void {
+        this.validateField();
+        this.onFieldChanged(this.field);
     }
 
     private validateField(): void {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/AAE-27984
fieldValueChanged is called on widget init as well as unfocus (blur). This happens only for date and datetime widgets.

**What is the new behaviour?**

Fixed the unnecessary calls

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
