### PR TITLE
AAE-30901 Allow to use different saveSearch API service

### DIFF
--- a/lib/content-services/src/lib/common/services/saved-searches.service.ts
+++ b/lib/content-services/src/lib/common/services/saved-searches.service.ts
@@ -15,13 +15,20 @@
  * limitations under the License.
  */
 
-import { NodesApi, NodeEntry, PreferencesApi } from '@alfresco/js-api';
-import { Injectable } from '@angular/core';
+import { NodesApi, NodeEntry, PreferencesApi, ContentFieldsQuery, PreferenceEntry } from '@alfresco/js-api';
+import { inject, Injectable, InjectionToken } from '@angular/core';
 import { Observable, of, from, ReplaySubject, throwError } from 'rxjs';
 import { catchError, concatMap, first, map, switchMap, take, tap } from 'rxjs/operators';
 import { AlfrescoApiService } from '../../services/alfresco-api.service';
 import { SavedSearch } from '../interfaces/saved-search.interface';
 import { AuthenticationService } from '@alfresco/adf-core';
+
+export interface SavedSearchesPreferencesApiService {
+    getPreference: (personId: string, preferenceName: string, opts?: ContentFieldsQuery) => Promise<PreferenceEntry> | Observable<PreferenceEntry>;
+    updatePreference: (personId: string, preferenceName: string, preferenceValue: string) => Promise<PreferenceEntry> | Observable<PreferenceEntry>;
+}
+
+export const SAVED_SEARCHES_SERVICE_PREFERENCES = new InjectionToken<SavedSearchesPreferencesApiService>('SAVED_SEARCHES_SERVICE_PREFERENCES');
 
 @Injectable({
     providedIn: 'root'
@@ -29,14 +36,20 @@ import { AuthenticationService } from '@alfresco/adf-core';
 export class SavedSearchesService {
     private savedSearchFileNodeId: string;
     private _nodesApi: NodesApi;
-    private _preferencesApi: PreferencesApi;
+    private _preferencesApi: SavedSearchesPreferencesApiService;
+    private preferencesService = inject(SAVED_SEARCHES_SERVICE_PREFERENCES, { optional: true });
 
     get nodesApi(): NodesApi {
         this._nodesApi = this._nodesApi ?? new NodesApi(this.apiService.getInstance());
         return this._nodesApi;
     }
 
-    get preferencesApi(): PreferencesApi {
+    get preferencesApi(): SavedSearchesPreferencesApiService {
+        if (this.preferencesService) {
+            this._preferencesApi = this.preferencesService;
+            return this._preferencesApi;
+        }
+
         this._preferencesApi = this._preferencesApi ?? new PreferencesApi(this.apiService.getInstance());
         return this._preferencesApi;
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
[AAE-30901](https://hyland.atlassian.net/browse/AAE-30901)


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:


[AAE-30901]: https://hyland.atlassian.net/browse/AAE-30901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ