### PR TITLE
[ACS-9252] Create Button Not Enabled After Resolving Duplicate Folder Name Warning

### DIFF
--- a/lib/content-services/src/lib/dialogs/folder/folder.dialog.spec.ts
+++ b/lib/content-services/src/lib/dialogs/folder/folder.dialog.spec.ts
@@ -325,7 +325,6 @@ describe('FolderDialogComponent', () => {
                 expect(component.disableSubmitButton).toBeTrue();
 
                 component.form.controls['name'].setValue('testName');
-                component.submit();
                 expect(component.disableSubmitButton).toBeFalse();
             });
         });

--- a/lib/content-services/src/lib/dialogs/folder/folder.dialog.spec.ts
+++ b/lib/content-services/src/lib/dialogs/folder/folder.dialog.spec.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogRef } from '@angular/material/dialog';
 import { NodesApiService } from '../../common/services/nodes-api.service';
 
@@ -315,6 +315,15 @@ describe('FolderDialogComponent', () => {
                 component.form.controls['description'].setValue('description');
 
                 component.submit();
+            });
+
+            it('should enable submit button after changing name field when previous value caused error', () => {
+                createFolderNode$.error(throwError('error'));
+                spyOn(component, 'handleError').and.callFake((val) => val);
+                component.form.controls['name'].setValue('');
+                expect(component.disableSubmitButton).toBeTrue();
+                component.form.controls['name'].setValue('testName');
+                expect(component.disableSubmitButton).toBeFalse();
             });
         });
     });

--- a/lib/content-services/src/lib/dialogs/folder/folder.dialog.spec.ts
+++ b/lib/content-services/src/lib/dialogs/folder/folder.dialog.spec.ts
@@ -321,8 +321,8 @@ describe('FolderDialogComponent', () => {
                 createFolderNode$.error(throwError('error'));
                 spyOn(component, 'handleError').and.callFake((val) => val);
                 component.form.controls['name'].setValue('');
-                expect(component.disableSubmitButton).toBeTrue();
                 component.submit();
+                expect(component.disableSubmitButton).toBeTrue();
 
                 component.form.controls['name'].setValue('testName');
                 component.submit();

--- a/lib/content-services/src/lib/dialogs/folder/folder.dialog.spec.ts
+++ b/lib/content-services/src/lib/dialogs/folder/folder.dialog.spec.ts
@@ -322,7 +322,10 @@ describe('FolderDialogComponent', () => {
                 spyOn(component, 'handleError').and.callFake((val) => val);
                 component.form.controls['name'].setValue('');
                 expect(component.disableSubmitButton).toBeTrue();
+                component.submit();
+
                 component.form.controls['name'].setValue('testName');
+                component.submit();
                 expect(component.disableSubmitButton).toBeFalse();
             });
         });

--- a/lib/content-services/src/lib/dialogs/folder/folder.dialog.ts
+++ b/lib/content-services/src/lib/dialogs/folder/folder.dialog.ts
@@ -16,7 +16,7 @@
  */
 
 import { Observable } from 'rxjs';
-import { Component, Inject, OnInit, Optional, EventEmitter, Output, ViewEncapsulation } from '@angular/core';
+import { Component, DestroyRef, EventEmitter, inject, Inject, OnInit, Optional, Output, ViewEncapsulation } from '@angular/core';
 import { ReactiveFormsModule, UntypedFormBuilder, UntypedFormGroup, Validators } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { Node } from '@alfresco/js-api';
@@ -29,6 +29,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { AutoFocusDirective } from '../../directives';
 import { MatButtonModule } from '@angular/material/button';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
     selector: 'adf-folder-dialog',
@@ -93,6 +94,8 @@ export class FolderDialogComponent implements OnInit {
         };
     }
 
+    private readonly destroyRef = inject(DestroyRef);
+
     constructor(
         private formBuilder: UntypedFormBuilder,
         private dialog: MatDialogRef<FolderDialogComponent>,
@@ -132,6 +135,8 @@ export class FolderDialogComponent implements OnInit {
             title: [title],
             description: [description]
         });
+
+        this.form.controls['name'].valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => (this.disableSubmitButton = false));
     }
 
     submit() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/ACS-9252


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
