### PR TITLE
[ACS-9237] a11y testing: Error Popups / ARIA hidden element must not be focusable or contain focusable elements

### DIFF
--- a/lib/core/src/lib/snackbar-content/snackbar-content.component.html
+++ b/lib/core/src/lib/snackbar-content/snackbar-content.component.html
@@ -1,5 +1,5 @@
 <p class="adf-snackbar-message-content" data-automation-id="adf-snackbar-message-content" aria-hidden="true"><mat-icon *ngIf="data.decorativeIcon" data-automation-id="adf-snackbar-decorative-icon">{{ data.decorativeIcon }}</mat-icon>{{ data.message }}</p>
-<div *ngIf="data.showAction" class="adf-snackbar-message-content-action" aria-hidden="true">
+<div *ngIf="data.showAction" class="adf-snackbar-message-content-action">
     <button mat-button (click)="snackBarRef.dismissWithAction()" *ngIf="data.actionLabel" class="adf-snackbar-message-content-action-button"
             data-automation-id="adf-snackbar-message-content-action-button">
         {{data.actionLabel}}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/ACS-9237


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
