### PR TITLE
AAE-30863 Updated validators to set proper button state

### DIFF
--- a/docs/process-services-cloud/components/form-cloud.component.md
+++ b/docs/process-services-cloud/components/form-cloud.component.md
@@ -252,12 +252,28 @@ There are two other functions that can be very useful when you need to control f
 
 ### Field Validators
 
-You can supply a set of validator objects to the form using the `fieldValidators`
-property. Each validator implements a check for a particular type of data (eg, a
-date validator might check that the date in the field falls between 1980 and 2017).
+You can supply a set of validator objects to the form using the `fieldValidators` property. To do this you must use Token  `FORM_CLOUD_FIELD_VALIDATORS_TOKEN`. This is a A DI token that allows to inject additional form field validators. Each validator implements a check for a particular type of data (eg, a date validator might check that the date in the field falls between 1980 and 2017).
 ADF supplies a standard set of validators that handle most common cases but you can
 also implement your own custom validators to replace or extend the set. See the
 [Form Field Validator](../../core/interfaces/form-field-validator.interface.md) interface for full details and examples.
+
+```ts
+ import { NgModule } from '@angular/core';
+ import { FORM_SERVICE_FIELD_VALIDATORS_TOKEN } from '@alfresco/adf-core';
+
+ @NgModule({
+     imports: [
+         ...Import Required Modules
+     ],
+     providers: [
+         { 
+             provide: FORM_SERVICE_FIELD_VALIDATORS_TOKEN, 
+             useValue: [new AdditionalFormFieldValidator()]
+         }
+     ]
+ })
+ export class ExampleModule {}
+ ```
 
 ### Common scenarios
 

--- a/docs/process-services-cloud/components/user-task-cloud.component.md
+++ b/docs/process-services-cloud/components/user-task-cloud.component.md
@@ -15,7 +15,6 @@ Based on property taskDetails: TaskDetailsCloudModel shows a form or a screen.
 <adf-cloud-user-task
     [appName]="appName"
     [displayModeConfigurations]="displayConfigurations"
-    [fieldValidators]="formFieldValidators"
     [showTitle]="false"
     [showValidationIcon]="false"
     [taskId]="taskId"
@@ -38,7 +37,6 @@ Based on property taskDetails: TaskDetailsCloudModel shows a form or a screen.
 |---------------------------|---------------------------------------|---------------|---------------------------------------------------|
 | appName                   | `string`                              | ""            | App id to fetch corresponding form and values.    |
 | readOnly                  | `boolean`                             | false         | Toggle readonly state of the task.                |
-| fieldValidators           | `FormFieldValidator[]`                |               | Allows to provide additional validators to the form field.                |
 | showCancelButton          | `boolean`                             | true          | Toggle rendering of the `Cancel` button.          |
 | showCompleteButton        | `boolean`                             | true          | Toggle rendering of the `Complete` button.        |
 | showTitle                 | `boolean`                             | true          | Toggle rendering of the form title.               |

--- a/lib/core/src/lib/form/components/widgets/core/form-field-validator.spec.ts
+++ b/lib/core/src/lib/form/components/widgets/core/form-field-validator.spec.ts
@@ -161,6 +161,46 @@ describe('FormFieldValidator', () => {
 
             expect(validator.validate(field)).toBe(false);
         });
+
+        it('should succeed for file viewer', () => {
+            const field = new FormFieldModel(new FormModel(), {
+                type: FormFieldTypes.ALFRESCO_FILE_VIEWER,
+                value: [{ sys_id: '123', sys_name: 'screenshot_123' }],
+                required: true
+            });
+
+            expect(validator.validate(field)).toBe(true);
+        });
+
+        it('should fail if file viewer has no value', () => {
+            const field = new FormFieldModel(new FormModel(), {
+                type: FormFieldTypes.ALFRESCO_FILE_VIEWER,
+                value: null,
+                required: true
+            });
+
+            expect(validator.validate(field)).toBe(false);
+        });
+
+        it('should succeed for properties viewer', () => {
+            const field = new FormFieldModel(new FormModel(), {
+                type: FormFieldTypes.PROPERTIES_VIEWER,
+                value: [{ sys_id: '123', sys_name: 'screenshot_123' }],
+                required: true
+            });
+
+            expect(validator.validate(field)).toBe(true);
+        });
+
+        it('should fail for properties viewer with no value', () => {
+            const field = new FormFieldModel(new FormModel(), {
+                type: FormFieldTypes.PROPERTIES_VIEWER,
+                value: null,
+                required: true
+            });
+
+            expect(validator.validate(field)).toBe(false);
+        });
     });
 
     describe('NumberFieldValidator', () => {

--- a/lib/core/src/lib/form/components/widgets/core/form-field-validator.ts
+++ b/lib/core/src/lib/form/components/widgets/core/form-field-validator.ts
@@ -41,7 +41,9 @@ export class RequiredFieldValidator implements FormFieldValidator {
         FormFieldTypes.DYNAMIC_TABLE,
         FormFieldTypes.ATTACH_FOLDER,
         FormFieldTypes.DECIMAL,
-        FormFieldTypes.DISPLAY_EXTERNAL_PROPERTY
+        FormFieldTypes.DISPLAY_EXTERNAL_PROPERTY,
+        FormFieldTypes.ALFRESCO_FILE_VIEWER,
+        FormFieldTypes.PROPERTIES_VIEWER
     ];
 
     isSupported(field: FormFieldModel): boolean {

--- a/lib/process-services-cloud/src/lib/form/components/form-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/form-cloud.component.spec.ts
@@ -59,13 +59,14 @@ import {
 import { FormCloudRepresentation } from '../models/form-cloud-representation.model';
 import { FormCloudService } from '../services/form-cloud.service';
 import { DisplayModeService } from '../services/display-mode.service';
-import { FormCloudComponent } from './form-cloud.component';
+import { FORM_CLOUD_FIELD_VALIDATORS_TOKEN, FormCloudComponent } from './form-cloud.component';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { FormCloudDisplayMode } from '../../services/form-fields.interfaces';
 import { CloudFormRenderingService } from './cloud-form-rendering.service';
 import { ProcessServiceCloudTestingModule } from '../../testing/process-service-cloud.testing.module';
 import { TaskVariableCloud } from '../models/task-variable-cloud.model';
 import { ProcessServicesCloudModule } from '../../process-services-cloud.module';
+import { FormFieldValidator } from '../../../../../core/src/public-api';
 
 const mockOauth2Auth: any = {
     oauth2Auth: {
@@ -74,6 +75,12 @@ const mockOauth2Auth: any = {
     isEcmLoggedIn: jasmine.createSpy('isEcmLoggedIn'),
     reply: jasmine.createSpy('reply')
 };
+
+const fakeValidator = {
+    supportedTypes: ['test'],
+    isSupported: () => true,
+    validate: () => true
+} as FormFieldValidator;
 
 describe('FormCloudComponent', () => {
     let formCloudService: FormCloudService;
@@ -113,7 +120,8 @@ describe('FormCloudComponent', () => {
                     provide: VersionCompatibilityService,
                     useValue: {}
                 },
-                { provide: FormRenderingService, useClass: CloudFormRenderingService }
+                { provide: FormRenderingService, useClass: CloudFormRenderingService },
+                { provide: FORM_CLOUD_FIELD_VALIDATORS_TOKEN, useValue: [fakeValidator] }
             ]
         });
         const apiService = TestBed.inject(AlfrescoApiService);
@@ -1174,6 +1182,13 @@ describe('FormCloudComponent', () => {
         formComponent.onOutcomeClicked(outcome);
 
         expect(formComponent.disableSaveButton).toBeTrue();
+    });
+
+    it('should set field validators with injected validators', () => {
+        formComponent.formCloudRepresentationJSON = new FormCloudRepresentation(JSON.parse(JSON.stringify(cloudFormMock)));
+        const form = formComponent.parseForm(formComponent.formCloudRepresentationJSON);
+        expect(formComponent.fieldValidators.length).toBe(1);
+        expect(form.fieldValidators.length).toBe(10);
     });
 
     describe('form validations', () => {

--- a/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.html
+++ b/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.html
@@ -78,7 +78,6 @@
                     [data]="resolvedValues"
                     [formId]="processDefinitionCurrent.formKey"
                     [displayModeConfigurations]="displayModeConfigurations"
-                    [fieldValidators]="fieldValidators"
                     [showSaveButton]="false"
                     [showCompleteButton]="false"
                     [showRefreshButton]="false"

--- a/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.spec.ts
@@ -17,7 +17,7 @@
 
 import { SimpleChange } from '@angular/core';
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { FORM_FIELD_VALIDATORS, FormModel } from '@alfresco/adf-core';
+import { FormModel } from '@alfresco/adf-core';
 import { of, throwError } from 'rxjs';
 import { StartProcessCloudService } from '../services/start-process-cloud.service';
 import { FormCloudService } from '../../../form/services/form-cloud.service';
@@ -31,8 +31,7 @@ import {
     fakeNoNameProcessDefinitions,
     fakeSingleProcessDefinition,
     fakeSingleProcessDefinitionWithoutForm,
-    fakeFormModelJson,
-    MockFormFieldValidator
+    fakeFormModelJson
 } from '../mock/start-process.component.mock';
 import { By } from '@angular/platform-browser';
 import { ProcessPayloadCloud } from '../models/process-payload-cloud.model';
@@ -690,22 +689,6 @@ describe('StartProcessCloudComponent', () => {
 
             const processDefinitionInput = fixture.nativeElement.querySelector('#processDefinitionName');
             expect(processDefinitionInput.textContent).toEqual('');
-        });
-
-        it('should append additional field validators to the default ones when provided', () => {
-            const mockFirstCustomFieldValidator = new MockFormFieldValidator();
-            const mockSecondCustomFieldValidator = new MockFormFieldValidator();
-
-            component.fieldValidators = [mockFirstCustomFieldValidator, mockSecondCustomFieldValidator];
-            fixture.detectChanges();
-
-            expect(component.fieldValidators).toEqual([...FORM_FIELD_VALIDATORS, mockFirstCustomFieldValidator, mockSecondCustomFieldValidator]);
-        });
-
-        it('should use default field validators when no additional validators are provided', () => {
-            fixture.detectChanges();
-
-            expect(component.fieldValidators).toEqual([...FORM_FIELD_VALIDATORS]);
         });
     });
 

--- a/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.ts
@@ -29,15 +29,7 @@ import {
     ViewChild,
     ViewEncapsulation
 } from '@angular/core';
-import {
-    ContentLinkModel,
-    FORM_FIELD_VALIDATORS,
-    FormFieldValidator,
-    FormModel,
-    InplaceFormInputComponent,
-    LocalizedDatePipe,
-    TranslationService
-} from '@alfresco/adf-core';
+import { ContentLinkModel, FormModel, InplaceFormInputComponent, LocalizedDatePipe, TranslationService } from '@alfresco/adf-core';
 import { AbstractControl, FormControl, FormGroup, ReactiveFormsModule, ValidatorFn, Validators } from '@angular/forms';
 import { MatAutocompleteModule, MatAutocompleteTrigger } from '@angular/material/autocomplete';
 import { catchError, debounceTime } from 'rxjs/operators';
@@ -117,10 +109,6 @@ export class StartProcessCloudComponent implements OnChanges, OnInit {
     /** Parameter to pass form field values in the start form if one is associated. */
     @Input()
     values: TaskVariableCloud[];
-
-    /** FormFieldValidator allow to provide additional validators to the form field. */
-    @Input()
-    fieldValidators: FormFieldValidator[];
 
     /** Show/hide the process dropdown list. */
     @Input()
@@ -235,8 +223,6 @@ export class StartProcessCloudComponent implements OnChanges, OnInit {
     }
 
     ngOnInit() {
-        this.initFieldValidators();
-
         this.processDefinition.setValue(this.processDefinitionName);
         this.processDefinition.valueChanges
             .pipe(debounceTime(PROCESS_DEFINITION_DEBOUNCE))
@@ -268,10 +254,6 @@ export class StartProcessCloudComponent implements OnChanges, OnInit {
     onFormLoaded(form: FormModel) {
         this.isFormCloudLoaded = true;
         this.formCloud = form;
-    }
-
-    private initFieldValidators(): void {
-        this.fieldValidators = this.fieldValidators ? [...FORM_FIELD_VALIDATORS, ...this.fieldValidators] : [...FORM_FIELD_VALIDATORS];
     }
 
     private getMaxNameLength(): number {

--- a/lib/process-services-cloud/src/lib/task/task-form/components/task-form-cloud/task-form-cloud.component.html
+++ b/lib/process-services-cloud/src/lib/task/task-form/components/task-form-cloud/task-form-cloud.component.html
@@ -12,7 +12,6 @@
         [showCompleteButton]="canCompleteTask()"
         [showSaveButton]="canCompleteTask()"
         [displayModeConfigurations]="displayModeConfigurations"
-        [fieldValidators]="fieldValidators"
         (formSaved)="onFormSaved($event)"
         (formCompleted)="onFormCompleted($event)"
         (formError)="onError($event)"

--- a/lib/process-services-cloud/src/lib/task/task-form/components/task-form-cloud/task-form-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/task/task-form/components/task-form-cloud/task-form-cloud.component.spec.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { FORM_FIELD_VALIDATORS, FormFieldModel, FormFieldValidator, FormModel, FormOutcomeEvent, FormOutcomeModel } from '@alfresco/adf-core';
+import { FormModel, FormOutcomeEvent, FormOutcomeModel } from '@alfresco/adf-core';
 import { FormCustomOutcomesComponent } from '@alfresco/adf-process-services-cloud';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
@@ -50,16 +50,6 @@ const taskDetails: TaskDetailsCloudModel = {
     status: TASK_ASSIGNED_STATE,
     permissions: [TASK_VIEW_PERMISSION]
 };
-
-class MockFormFieldValidator implements FormFieldValidator {
-    isSupported(_field: FormFieldModel): boolean {
-        return true;
-    }
-
-    validate(_field: FormFieldModel): boolean {
-        return true;
-    }
-}
 
 describe('TaskFormCloudComponent', () => {
     let taskCloudService: TaskCloudService;
@@ -200,21 +190,6 @@ describe('TaskFormCloudComponent', () => {
 
             const canUnclaimTask = component.canUnclaimTask();
             expect(canUnclaimTask).toBe(false);
-        });
-
-        it('should append additional field validators to the default ones when provided', () => {
-            const mockFirstCustomFieldValidator = new MockFormFieldValidator();
-            const mockSecondCustomFieldValidator = new MockFormFieldValidator();
-            fixture.componentRef.setInput('fieldValidators', [mockFirstCustomFieldValidator, mockSecondCustomFieldValidator]);
-            fixture.detectChanges();
-
-            expect(component.fieldValidators).toEqual([...FORM_FIELD_VALIDATORS, mockFirstCustomFieldValidator, mockSecondCustomFieldValidator]);
-        });
-
-        it('should use default field validators when no additional validators are provided', () => {
-            fixture.detectChanges();
-
-            expect(component.fieldValidators).toEqual([...FORM_FIELD_VALIDATORS]);
         });
     });
 

--- a/lib/process-services-cloud/src/lib/task/task-form/components/task-form-cloud/task-form-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-form/components/task-form-cloud/task-form-cloud.component.ts
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-import { ContentLinkModel, FORM_FIELD_VALIDATORS, FormFieldValidator, FormModel, FormOutcomeEvent, FormRenderingService } from '@alfresco/adf-core';
-import { Component, EventEmitter, Input, OnInit, Output, ViewChild, ViewEncapsulation } from '@angular/core';
+import { ContentLinkModel, FormModel, FormOutcomeEvent, FormRenderingService } from '@alfresco/adf-core';
+import { Component, EventEmitter, Input, Output, ViewChild, ViewEncapsulation } from '@angular/core';
 import { FormCloudComponent } from '../../../../form/components/form-cloud.component';
 import { AttachFileCloudWidgetComponent } from '../../../../form/components/widgets/attach-file/attach-file-cloud-widget.component';
 import { DateCloudWidgetComponent } from '../../../../form/components/widgets/date/date-cloud.widget';
@@ -36,7 +36,7 @@ import { FormCustomOutcomesComponent } from '../../../../form/components/form-cl
     styleUrls: ['./task-form-cloud.component.scss'],
     encapsulation: ViewEncapsulation.None
 })
-export class TaskFormCloudComponent implements OnInit {
+export class TaskFormCloudComponent {
     /** App id to fetch corresponding form and values. */
     @Input()
     appName: string = '';
@@ -82,10 +82,6 @@ export class TaskFormCloudComponent implements OnInit {
      */
     @Input()
     displayModeConfigurations: FormCloudDisplayModeConfiguration[];
-
-    /** FormFieldValidator allow to provide additional validators to the form field. */
-    @Input()
-    fieldValidators: FormFieldValidator[];
 
     /** Task details. */
     @Input()
@@ -147,14 +143,6 @@ export class TaskFormCloudComponent implements OnInit {
         this.formRenderingService.setComponentTypeResolver('upload', () => AttachFileCloudWidgetComponent, true);
         this.formRenderingService.setComponentTypeResolver('dropdown', () => DropdownCloudWidgetComponent, true);
         this.formRenderingService.setComponentTypeResolver('date', () => DateCloudWidgetComponent, true);
-    }
-
-    ngOnInit() {
-        this.initFieldValidators();
-    }
-
-    private initFieldValidators() {
-        this.fieldValidators = this.fieldValidators ? [...FORM_FIELD_VALIDATORS, ...this.fieldValidators] : [...FORM_FIELD_VALIDATORS];
     }
 
     hasForm(): boolean {

--- a/lib/process-services-cloud/src/lib/task/task-form/components/user-task-cloud/user-task-cloud.component.html
+++ b/lib/process-services-cloud/src/lib/task/task-form/components/user-task-cloud/user-task-cloud.component.html
@@ -8,7 +8,6 @@
                     [candidateUsers]="candidateUsers"
                     [candidateGroups]="candidateGroups"
                     [displayModeConfigurations]="displayModeConfigurations"
-                    [fieldValidators]="fieldValidators"
                     [showValidationIcon]="showValidationIcon"
                     [showTitle]="showTitle"
                     [taskId]="taskId"

--- a/lib/process-services-cloud/src/lib/task/task-form/components/user-task-cloud/user-task-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-form/components/user-task-cloud/user-task-cloud.component.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { ContentLinkModel, EmptyContentComponent, FormFieldValidator, FormModel, FormOutcomeEvent } from '@alfresco/adf-core';
+import { ContentLinkModel, EmptyContentComponent, FormModel, FormOutcomeEvent } from '@alfresco/adf-core';
 import { Component, DestroyRef, EventEmitter, inject, Input, OnChanges, OnInit, Output, SimpleChanges, ViewChild } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormCloudDisplayModeConfiguration } from '../../../../services/form-fields.interfaces';
@@ -71,10 +71,6 @@ export class UserTaskCloudComponent implements OnInit, OnChanges {
     /** The available display configurations for the form */
     @Input()
     displayModeConfigurations: FormCloudDisplayModeConfiguration[];
-
-    /** FormFieldValidator allow to provide additional validators to the form field. */
-    @Input()
-    fieldValidators: FormFieldValidator[];
 
     /** Toggle readonly state of the task. */
     @Input()


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/AAE-30863


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [x] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications:

Injecton token for additional field validators has beed added to FormCloudComponent. It replaced set of properties @Input() fieldValidators from components: StartProcessCloudComponent (used by content-ee and workspace-hxp), TaskFormCloudComponent, UserTaskCloudComponent (used by content-ee and workspace-hxp).  The corresponding components from content-ee and workspace-hxp must replace passing fieldValidators through input properties with using injection token.

**Other information**:
