### PR TITLE
[ACS-9227] Fixed interactive controls must not be nested issue in datatable.component.html

### DIFF
--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.html
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.html
@@ -254,7 +254,6 @@
                         [checked]="row.isSelected"
                         [attr.aria-checked]="row.isSelected"
                         [aria-label]="'ADF-DATATABLE.ACCESSIBILITY.SELECT_FILE' | translate"
-                        role="checkbox"
                         data-adf-datatable-row-checkbox
                         (change)="onCheckboxChange(row, $event)"
                         class="adf-checkbox-sr-only">


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe:
Accessibility issue

**What is the current behaviour?** (You can also link to an open issue here)
Checkboxes for selecting files in datatable.component were giving an accessibility issue of 'Interactive controls must not be nested'


**What is the new behaviour?**
Resolved the accessibility issue


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://hyland.atlassian.net/browse/ACS-9227