### PR TITLE
[ACS-9225] serious a11y testing side bar elements must meet minimum color contrast ratio thresholds

### DIFF
--- a/lib/core/src/lib/styles/_components-variables.scss
+++ b/lib/core/src/lib/styles/_components-variables.scss
@@ -91,6 +91,7 @@
         --adf-secondary-modal-text-color: $adf-secondary-modal-text-color,
         --adf-disabled-button-background: $adf-disabled-button-background,
         --adf-chip-border-color: $adf-chip-border-color,
+        --adf-sidenav-active-text-color: $adf-sidenav-active-text-color,
 
         --adf-display-external-property-widget-preview-selection-color: mat.get-color-from-palette($foreground, secondary-text)
     );

--- a/lib/core/src/lib/styles/_reference-variables.scss
+++ b/lib/core/src/lib/styles/_reference-variables.scss
@@ -30,3 +30,4 @@ $adf-secondary-button-background: #2121210d;
 $adf-secondary-modal-text-color: #212121;
 $adf-disabled-button-background: rgba(0, 0, 0, 0.12);
 $adf-chip-border-color: #757575;
+$adf-sidenav-active-text-color: rgba(0, 48, 100, 1);

--- a/lib/process-services/src/lib/process-list/components/process-filters/process-filters.component.scss
+++ b/lib/process-services/src/lib/process-list/components/process-filters/process-filters.component.scss
@@ -23,6 +23,12 @@ adf-process-instance-filters {
                     color: var(--theme-action-button-text-color);
                 }
             }
+
+            &.adf-active {
+                .adf-filter-action-button__label {
+                    color: var(--adf-sidenav-active-text-color);
+                }
+            }
         }
     }
 }

--- a/lib/process-services/src/lib/task-list/components/task-filters/task-filters.component.scss
+++ b/lib/process-services/src/lib/task-list/components/task-filters/task-filters.component.scss
@@ -23,6 +23,12 @@ adf-task-filters {
                     color: var(--theme-action-button-text-color);
                 }
             }
+
+            &.adf-active {
+                .adf-filter-action-button__label {
+                    color: var(--adf-sidenav-active-text-color);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/ACS-9225


**What is the new behaviour?**
Color contrast ratio for sidebar elements is correct. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
ACA PR: https://github.com/Alfresco/alfresco-content-app/pull/4425