### PR TITLE
[MNT-24909] Check if property constraint is handled by validators available in ADF

### DIFF
--- a/lib/core/src/lib/card-view/models/card-view-baseitem.model.spec.ts
+++ b/lib/core/src/lib/card-view/models/card-view-baseitem.model.spec.ts
@@ -185,5 +185,23 @@ describe('CardViewBaseItemModel', () => {
             const itemModel = new CarViewCustomItemModel(constrainedProperties);
             expect(itemModel.isValid(itemModel.value)).toBe(true);
         });
+
+        it('should log warning when validator type is not supported by validatorsMap', () => {
+            spyOn(console, 'warn');
+            const constrainedProperties: CardViewItemProperties = {
+                ...properties,
+                value: 'test.',
+                constraints: [
+                    {
+                        id: 'custom-constraint-id',
+                        type: 'org.test.constraint'
+                    }
+                ]
+            };
+
+            const itemModel = new CarViewCustomItemModel(constrainedProperties);
+            expect(itemModel.isValid(itemModel.value)).toBe(true);
+            expect(console.warn).toHaveBeenCalledWith('Validator for type org.test.constraint is not supported');
+        });
     });
 });

--- a/lib/core/src/lib/card-view/models/card-view-baseitem.model.ts
+++ b/lib/core/src/lib/card-view/models/card-view-baseitem.model.ts
@@ -50,7 +50,11 @@ export abstract class CardViewBaseItemModel<T = any> {
             for (const constraint of props.constraints) {
                 if (constraint.type !== 'LIST') {
                     const validatorFactory = validatorsMap[constraint.type.toLowerCase()];
-                    this.validators.push(validatorFactory(constraint.parameters));
+                    if (validatorFactory !== undefined) {
+                        this.validators.push(validatorFactory(constraint.parameters));
+                    } else {
+                        console.warn(`Validator for type ${constraint.type} is not supported`);
+                    }
                 }
             }
         }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://hyland.atlassian.net/browse/MNT-24909

**What is the new behaviour?**

When property has a constraint with custom type that is not supported by default ADF validators the warning should be logged to the console but validation should not fail. It will happen on ACS side while saving new value of the property.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
