### PR TITLE
AAE-32255 Start Process button in start event is showing and failing for form with custom outcomes

### DIFF
--- a/lib/core/src/lib/form/components/form-base.component.ts
+++ b/lib/core/src/lib/form/components/form-base.component.ts
@@ -103,6 +103,10 @@ export abstract class FormBaseComponent {
      */
     formStyle: string = '';
 
+    get hasVisibleOutcomes(): boolean {
+        return this.form?.outcomes?.some((outcome) => this.isOutcomeButtonVisible(outcome, this.form.readOnly));
+    }
+
     get form(): FormModel {
         return this._form;
     }

--- a/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.html
+++ b/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.html
@@ -109,7 +109,7 @@
             {{ cancelButtonLabel }}
         </button>
         <button
-            *ngIf="shouldShowStartProcessButton()"
+            *ngIf="showStartProcessButton$ | async"
             color="primary"
             mat-raised-button
             [disabled]="disableStartButton || !isProcessFormValid"

--- a/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.html
+++ b/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.html
@@ -73,6 +73,7 @@
 
             <ng-container *ngIf="hasForm else taskFormCloudButtons">
                 <adf-cloud-form
+                    #startForm
                     [appName]="appName"
                     [appVersion]="processDefinitionCurrent.appVersion"
                     [data]="resolvedValues"
@@ -108,7 +109,7 @@
             {{ cancelButtonLabel }}
         </button>
         <button
-            *ngIf="showStartProcessButton"
+            *ngIf="shouldShowStartProcessButton()"
             color="primary"
             mat-raised-button
             [disabled]="disableStartButton || !isProcessFormValid"

--- a/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.spec.ts
@@ -31,7 +31,8 @@ import {
     fakeNoNameProcessDefinitions,
     fakeSingleProcessDefinition,
     fakeSingleProcessDefinitionWithoutForm,
-    fakeFormModelJson
+    fakeFormModelJson,
+    fakeStartFormWithOutcomes
 } from '../mock/start-process.component.mock';
 import { By } from '@angular/platform-browser';
 import { ProcessPayloadCloud } from '../models/process-payload-cloud.model';
@@ -69,6 +70,8 @@ describe('StartProcessCloudComponent', () => {
 
         const panel = await loader.getHarness(MatAutocompleteHarness);
         await panel.selectOption({ text: name });
+        fixture.detectChanges();
+        await fixture.whenStable();
     };
 
     const typeValueInto = (selector: any, value: string) => {
@@ -185,8 +188,6 @@ describe('StartProcessCloudComponent', () => {
             component.name = 'My new process';
             component.processDefinitionName = 'process';
             await selectOptionByName('processwithoutform2');
-            fixture.detectChanges();
-            await fixture.whenStable();
 
             expect(component.processDefinitionCurrent.name).toBe(JSON.parse(JSON.stringify(fakeProcessDefinitions[1])).name);
             const startBtn = fixture.nativeElement.querySelector('#button-start');
@@ -537,8 +538,6 @@ describe('StartProcessCloudComponent', () => {
             await fixture.whenStable();
 
             await selectOptionByName('processwithform');
-            fixture.detectChanges();
-            await fixture.whenStable();
 
             component.processDefinitionName = fakeProcessDefinitions[2].name;
             component.setProcessDefinitionOnForm(fakeProcessDefinitions[2].name);
@@ -569,9 +568,6 @@ describe('StartProcessCloudComponent', () => {
             component.appName = 'myApp';
             component.ngOnChanges({});
             await selectOptionByName('process');
-
-            fixture.detectChanges();
-            await fixture.whenStable();
 
             expect(component.processDefinitionCurrent.name).toBe(JSON.parse(JSON.stringify(fakeProcessDefinitions[3])).name);
             expect(component.processDefinitionCurrent.key).toBe(JSON.parse(JSON.stringify(fakeProcessDefinitions[3])).key);
@@ -701,14 +697,36 @@ describe('StartProcessCloudComponent', () => {
             fixture.detectChanges();
         });
 
-        it('should see start button', async () => {
+        it('should show start button', () => {
             component.ngOnChanges({ appName: firstChange });
             fixture.detectChanges();
-            await fixture.whenStable();
 
             const startButton = fixture.debugElement.query(By.css('#button-start'));
             expect(startButton).toBeDefined();
             expect(startButton).not.toBeNull();
+        });
+
+        it('should show start button when start process has form without outcomes', async () => {
+            formDefinitionSpy.and.returnValue(of(fakeStartForm));
+            component.ngOnChanges({ appName: firstChange });
+            fixture.detectChanges();
+
+            await selectOptionByName('processwithform');
+
+            const startButton = fixture.debugElement.query(By.css('#button-start'));
+            expect(startButton).toBeDefined();
+            expect(startButton).not.toBeNull();
+        });
+
+        it('should NOT see start button when start process has form with outcomes', async () => {
+            formDefinitionSpy.and.returnValue(of(fakeStartFormWithOutcomes));
+            component.ngOnChanges({ appName: firstChange });
+            fixture.detectChanges();
+
+            await selectOptionByName('processwithform');
+
+            const startButton = fixture.debugElement.query(By.css('#button-start'));
+            expect(startButton).toBeNull();
         });
 
         it('should call service with the correct parameters when button is clicked and variables are defined and formCloud is undefined', async () => {
@@ -820,8 +838,6 @@ describe('StartProcessCloudComponent', () => {
             await fixture.whenStable();
 
             await selectOptionByName('processwithform');
-            fixture.detectChanges();
-            await fixture.whenStable();
 
             component.processDefinitionName = fakeProcessDefinitions[2].name;
             component.setProcessDefinitionOnForm(fakeProcessDefinitions[2].name);
@@ -941,8 +957,6 @@ describe('StartProcessCloudComponent', () => {
             await fixture.whenStable();
             component.processDefinitionName = 'processwithoutform1';
             await selectOptionByName(fakeProcessDefinitions[0].name);
-            fixture.detectChanges();
-            await fixture.whenStable();
             expect(emitSpy).toHaveBeenCalledOnceWith(fakeProcessDefinitions[0]);
         });
 

--- a/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.ts
@@ -261,7 +261,10 @@ export class StartProcessCloudComponent implements OnChanges, OnInit {
     onFormLoaded(form: FormModel) {
         this.isFormCloudLoaded = true;
         this.formCloud = form;
-        this.hasVisibleOutcomesSubject.next(this.startForm.hasVisibleOutcomes);
+
+        if (this.startForm) {
+            this.hasVisibleOutcomesSubject.next(this.startForm.hasVisibleOutcomes);
+        }
     }
 
     private getMaxNameLength(): number {

--- a/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.ts
@@ -86,6 +86,8 @@ export class StartProcessCloudComponent implements OnChanges, OnInit {
     @ViewChild(MatAutocompleteTrigger)
     inputAutocomplete: MatAutocompleteTrigger;
 
+    @ViewChild('startForm') startForm: FormCloudComponent;
+
     /** (required) Name of the app. */
     @Input()
     appName: string = '';
@@ -163,7 +165,7 @@ export class StartProcessCloudComponent implements OnChanges, OnInit {
     isFormCloudLoading = false;
     processDefinitionLoaded = false;
 
-    showStartProcessButton = true;
+    startEnabledConstant: string;
     startProcessButtonLabel: string;
     cancelButtonLabel: string;
 
@@ -294,7 +296,7 @@ export class StartProcessCloudComponent implements OnChanges, OnInit {
             const cancelLabel = constants?.find((constant) => constant.name === 'cancelLabel');
 
             if (displayStart) {
-                this.showStartProcessButton = displayStart?.value === 'true';
+                this.startEnabledConstant = displayStart.value;
             }
             if (startLabel) {
                 this.startProcessButtonLabel = startLabel?.value?.trim()?.length > 0 ? startLabel.value.trim() : this.defaultStartProcessButtonLabel;
@@ -529,5 +531,11 @@ export class StartProcessCloudComponent implements OnChanges, OnInit {
             processName = processName.replace(PROCESS_DEFINITION_IDENTIFIER_REG_EXP, selectedProcessDefinitionName);
         }
         return processName;
+    }
+
+    shouldShowStartProcessButton(): boolean {
+        if (this.startEnabledConstant) return this.startEnabledConstant === 'true';
+
+        return !this.startForm?.hasVisibleOutcomes;
     }
 }

--- a/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/process/start-process/components/start-process-cloud.component.ts
@@ -296,7 +296,7 @@ export class StartProcessCloudComponent implements OnChanges, OnInit {
             const cancelLabel = constants?.find((constant) => constant.name === 'cancelLabel');
 
             if (displayStart) {
-                this.startEnabledConstant = displayStart.value;
+                this.startEnabledConstant = displayStart?.value;
             }
             if (startLabel) {
                 this.startProcessButtonLabel = startLabel?.value?.trim()?.length > 0 ? startLabel.value.trim() : this.defaultStartProcessButtonLabel;

--- a/lib/process-services-cloud/src/lib/process/start-process/mock/start-process.component.mock.ts
+++ b/lib/process-services-cloud/src/lib/process/start-process/mock/start-process.component.mock.ts
@@ -199,6 +199,26 @@ export const fakeStartForm = {
     }
 };
 
+export const fakeStartFormWithOutcomes = {
+    formRepresentation: {
+        ...fakeStartForm.formRepresentation,
+        formDefinition: {
+            ...fakeStartForm.formRepresentation.formDefinition,
+            outcomes: [
+                {
+                    id: 'c5676ca7-8ad4-421c-9538-aaf8560bd5fc',
+                    name: 'Option 1',
+                    visibilityCondition: null
+                },
+                {
+                    id: '48e9c1f8-50b9-4d2f-998c-7836c132986f',
+                    name: 'Option 2',
+                    visibilityCondition: null
+                }
+            ]
+        }
+    }
+};
 export const fakeStartFormNotValid = {
     formRepresentation: {
         id: 'form-a5d50817-5183-4850-802d-17af54b2632f',


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
A Start Process button is shown when the start event is a form, but it has custom required outcomes.


**What is the new behaviour?**
Start process button is hidden in favor of outcomes


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
