### PR TITLE
AAE 31996 refresh button on filters not working as expected

### DIFF
--- a/lib/process-services-cloud/src/lib/form/components/widgets/display-rich-text/display-rich-text.widget.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/display-rich-text/display-rich-text.widget.ts
@@ -68,7 +68,7 @@ export class DisplayRichTextWidgetComponent extends WidgetComponent implements O
     }
 
     ngOnInit(): void {
-        this.parsedHTML = edjsHTML(DisplayRichTextWidgetComponent.CUSTOM_PARSER, { strict: true }).parse(this.field.value);
+        this.parsedHTML = edjsHTML(DisplayRichTextWidgetComponent.CUSTOM_PARSER).parse(this.field.value);
 
         if (!(this.parsedHTML instanceof Error)) {
             this.sanitizeHtmlContent();

--- a/lib/process-services-cloud/src/lib/form/components/widgets/display-rich-text/display-rich-text.widget.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/display-rich-text/display-rich-text.widget.ts
@@ -68,7 +68,7 @@ export class DisplayRichTextWidgetComponent extends WidgetComponent implements O
     }
 
     ngOnInit(): void {
-        this.parsedHTML = edjsHTML(DisplayRichTextWidgetComponent.CUSTOM_PARSER).parse(this.field.value);
+         this.parsedHTML = edjsHTML(DisplayRichTextWidgetComponent.CUSTOM_PARSER, { strict: true }).parse(this.field.value);
 
         if (!(this.parsedHTML instanceof Error)) {
             this.sanitizeHtmlContent();

--- a/lib/process-services-cloud/src/lib/process/process-filters/components/process-filters/process-filters-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/process/process-filters/components/process-filters/process-filters-cloud.component.spec.ts
@@ -578,7 +578,7 @@ describe('ProcessFiltersCloudComponent', () => {
                 expect(getProcessNotificationSubscriptionSpy).toHaveBeenCalled();
             });
 
-            it('should not emit filter key when filter counter is set for first time', () => {
+            it('should emit filter key when filter counter is set for first time', () => {
                 component.currentFiltersValues = {};
                 const fakeFilterKey = 'testKey';
                 const fakeFilterValue = 10;
@@ -588,7 +588,7 @@ describe('ProcessFiltersCloudComponent', () => {
 
                 expect(component.currentFiltersValues).not.toEqual({});
                 expect(component.currentFiltersValues[fakeFilterKey]).toBe(fakeFilterValue);
-                expect(updatedFilterSpy).not.toHaveBeenCalled();
+                expect(updatedFilterSpy).toHaveBeenCalled();
             });
 
             it('should not emit filter key when filter counter has not changd', () => {
@@ -604,24 +604,26 @@ describe('ProcessFiltersCloudComponent', () => {
 
                 component.checkIfFilterValuesHasBeenUpdated(fakeFilterKey, fakeFilterValue);
                 expect(component.currentFiltersValues[fakeFilterKey]).toBe(fakeFilterValue);
-                expect(updatedFilterSpy).not.toHaveBeenCalled();
+                expect(updatedFilterSpy).toHaveBeenCalledTimes(1);
             });
 
             it('should emit filter key when filter counter is increased', () => {
                 component.currentFiltersValues = {};
                 const fakeFilterKey = 'testKey';
+                const fakeFilterValueInitial = 10;
+                const fakeFilterValueSecondary = 20;
                 const updatedFilterSpy = spyOn(component.updatedFilter, 'emit');
-                component.checkIfFilterValuesHasBeenUpdated(fakeFilterKey, 10);
-                fixture.detectChanges();
-
-                expect(updatedFilterSpy).not.toHaveBeenCalledWith(fakeFilterKey);
-                expect(component.currentFiltersValues[fakeFilterKey]).toBe(10);
-
-                component.checkIfFilterValuesHasBeenUpdated(fakeFilterKey, 20);
+                component.checkIfFilterValuesHasBeenUpdated(fakeFilterKey, fakeFilterValueInitial);
                 fixture.detectChanges();
 
                 expect(updatedFilterSpy).toHaveBeenCalledWith(fakeFilterKey);
-                expect(component.currentFiltersValues[fakeFilterKey]).toBe(20);
+                expect(component.currentFiltersValues[fakeFilterKey]).toBe(fakeFilterValueInitial);
+
+                component.checkIfFilterValuesHasBeenUpdated(fakeFilterKey, fakeFilterValueSecondary);
+                fixture.detectChanges();
+
+                expect(updatedFilterSpy).toHaveBeenCalledWith(fakeFilterKey);
+                expect(component.currentFiltersValues[fakeFilterKey]).toBe(fakeFilterValueSecondary);
             });
 
             it('should emit filter key when filter counter is decreased', () => {
@@ -631,7 +633,7 @@ describe('ProcessFiltersCloudComponent', () => {
                 component.checkIfFilterValuesHasBeenUpdated(fakeFilterKey, 10);
                 fixture.detectChanges();
 
-                expect(updatedFilterSpy).not.toHaveBeenCalledWith(fakeFilterKey);
+                expect(updatedFilterSpy).toHaveBeenCalledWith(fakeFilterKey);
                 expect(component.currentFiltersValues[fakeFilterKey]).toBe(10);
 
                 component.checkIfFilterValuesHasBeenUpdated(fakeFilterKey, 5);

--- a/lib/process-services-cloud/src/lib/process/process-filters/components/process-filters/process-filters-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/process/process-filters/components/process-filters/process-filters-cloud.component.ts
@@ -293,11 +293,7 @@ export class ProcessFiltersCloudComponent implements OnInit, OnChanges {
     }
 
     checkIfFilterValuesHasBeenUpdated(filterKey: string, filterValue: number): void {
-        if (!this.currentFiltersValues[filterKey]) {
-            this.currentFiltersValues[filterKey] = filterValue;
-            return;
-        }
-        if (this.currentFiltersValues[filterKey] !== filterValue) {
+        if (this.currentFiltersValues[filterKey] === undefined || this.currentFiltersValues[filterKey] !== filterValue) {
             this.currentFiltersValues[filterKey] = filterValue;
             this.updatedFilter.emit(filterKey);
             this.updatedFiltersSet.add(filterKey);

--- a/lib/process-services-cloud/src/lib/task/task-filters/components/task-filters/task-filters-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/task/task-filters/components/task-filters/task-filters-cloud.component.spec.ts
@@ -468,39 +468,34 @@ describe('TaskFiltersCloudComponent', () => {
             expect(component.getFilters).toHaveBeenCalledWith(appName);
         });
 
-        it('should emit filter key when filter counter is set for first time', (done) => {
-            component.currentFiltersValues = {};
-            const fakeFilterKey = 'testKey';
-            const fakeFilterValue = 10;
-
-            component.updatedFilter.pipe(first()).subscribe((updateFilter: string) => {
-                expect(updateFilter).toBe(fakeFilterKey);
-                expect(component.currentFiltersValues).not.toEqual({});
-                expect(component.currentFiltersValues[fakeFilterKey]).toBe(fakeFilterValue);
-                done();
-            });
-
-            component.checkIfFilterValuesHasBeenUpdated(fakeFilterKey, fakeFilterValue);
-            fixture.detectChanges();
-        });
-
-        it('should not emit filter key when filter counter has not changd', fakeAsync(() => {
+        it('should emit filter key when filter counter is set for first time', () => {
             component.currentFiltersValues = {};
             const fakeFilterKey = 'testKey';
             const fakeFilterValue = 10;
             const updatedFilterSpy = spyOn(component.updatedFilter, 'emit');
             component.checkIfFilterValuesHasBeenUpdated(fakeFilterKey, fakeFilterValue);
             fixture.detectChanges();
-
             expect(component.currentFiltersValues).not.toEqual({});
             expect(component.currentFiltersValues[fakeFilterKey]).toBe(fakeFilterValue);
             expect(updatedFilterSpy).toHaveBeenCalled();
+        });
+        it('should not emit filter key when filter counter has not changed', fakeAsync(() => {
+            component.currentFiltersValues = {};
+            const fakeFilterKey = 'testKey';
+            const fakeFilterValue = 10;
+
+            component.checkIfFilterValuesHasBeenUpdated(fakeFilterKey, fakeFilterValue);
+            fixture.detectChanges();
+            expect(component.currentFiltersValues).not.toEqual({});
+            expect(component.currentFiltersValues[fakeFilterKey]).toBe(fakeFilterValue);
 
             component.updatedFilter.pipe(first()).subscribe(() => {
-                fail('Should not have emitted filter key if there is no change in the filter value');
+                fail('Should not have been called if the filterKey value is already there');
             });
 
             component.checkIfFilterValuesHasBeenUpdated(fakeFilterKey, fakeFilterValue);
+            fixture.detectChanges();
+
             expect(component.currentFiltersValues[fakeFilterKey]).toBe(fakeFilterValue);
             flush();
         }));
@@ -509,7 +504,6 @@ describe('TaskFiltersCloudComponent', () => {
             component.currentFiltersValues = {};
             const fakeFilterKey = 'testKey';
             component.checkIfFilterValuesHasBeenUpdated(fakeFilterKey, 10);
-
             component.updatedFilter.pipe(first()).subscribe((updatedFilter: string) => {
                 expect(updatedFilter).toBe(fakeFilterKey);
                 expect(component.currentFiltersValues[fakeFilterKey]).toBe(20);
@@ -518,17 +512,14 @@ describe('TaskFiltersCloudComponent', () => {
             component.checkIfFilterValuesHasBeenUpdated(fakeFilterKey, 20);
             fixture.detectChanges();
         });
-
         it('should emit filter key when filter counter is decreased', (done) => {
             component.currentFiltersValues = {};
             const fakeFilterKey = 'testKey';
             component.checkIfFilterValuesHasBeenUpdated(fakeFilterKey, 10);
-
             component.updatedFilter.pipe(first()).subscribe((updatedFilter: string) => {
                 expect(updatedFilter).toBe(fakeFilterKey);
                 done();
             });
-
             component.checkIfFilterValuesHasBeenUpdated(fakeFilterKey, 5);
             fixture.detectChanges();
         });

--- a/lib/process-services-cloud/src/lib/task/task-filters/components/task-filters/task-filters-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-filters/components/task-filters/task-filters-cloud.component.ts
@@ -261,11 +261,7 @@ export class TaskFiltersCloudComponent extends BaseTaskFiltersCloudComponent imp
     }
 
     checkIfFilterValuesHasBeenUpdated(filterKey: string, filterValue: number) {
-        if (!this.currentFiltersValues[filterKey]) {
-            this.currentFiltersValues[filterKey] = filterValue;
-            return;
-        }
-        if (this.currentFiltersValues[filterKey] !== filterValue) {
+        if (this.currentFiltersValues || this.currentFiltersValues[filterKey] !== filterValue) {
             this.currentFiltersValues[filterKey] = filterValue;
             this.updatedFilter.emit(filterKey);
             this.updatedCountersSet.add(filterKey);

--- a/lib/process-services-cloud/src/lib/task/task-filters/components/task-filters/task-filters-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-filters/components/task-filters/task-filters-cloud.component.ts
@@ -261,7 +261,7 @@ export class TaskFiltersCloudComponent extends BaseTaskFiltersCloudComponent imp
     }
 
     checkIfFilterValuesHasBeenUpdated(filterKey: string, filterValue: number) {
-        if (this.currentFiltersValues || this.currentFiltersValues[filterKey] !== filterValue) {
+        if (this.currentFiltersValues[filterKey] == undefined || this.currentFiltersValues[filterKey] !== filterValue) {
             this.currentFiltersValues[filterKey] = filterValue;
             this.updatedFilter.emit(filterKey);
             this.updatedCountersSet.add(filterKey);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/AAE-31996


**What is the new behaviour?**
First time when the notification count becomes ``zero`` to ``one`` It behaves abnormally and not recognizes there is a notification sometime in the workspace application.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
