### PR TITLE
AAE-27160 Fix the structure of data returned from service-tasks API

### DIFF
--- a/lib/process-services-cloud/src/lib/task/task-list/components/service-task-list/service-task-list-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/task/task-list/components/service-task-list/service-task-list-cloud.component.spec.ts
@@ -230,7 +230,7 @@ describe('ServiceTaskListCloudComponent', () => {
 
     describe('component changes', () => {
         beforeEach(() => {
-            component.rows = fakeServiceTask.list.entries;
+            component.rows = fakeServiceTask.list.entries.map((task) => task.entry);
             fixture.detectChanges();
         });
 

--- a/lib/process-services-cloud/src/lib/task/task-list/components/service-task-list/service-task-list-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/task/task-list/components/service-task-list/service-task-list-cloud.component.ts
@@ -87,7 +87,7 @@ export class ServiceTaskListCloudComponent extends BaseTaskListCloudComponent {
                 .pipe(takeUntilDestroyed(this.destroyRef))
                 .subscribe(
                     ([tasks]) => {
-                        this.rows = tasks.list.entries;
+                        this.rows = tasks.list.entries.map((task) => task.entry);
                         this.success.emit(tasks);
                         this.pagination.next(tasks.list.pagination);
                         this.isReloadingSubject$.next(false);

--- a/lib/process-services-cloud/src/lib/task/task-list/mock/fake-task-response.mock.ts
+++ b/lib/process-services-cloud/src/lib/task/task-list/mock/fake-task-response.mock.ts
@@ -51,22 +51,24 @@ export const fakeServiceTask = {
     list: {
         entries: [
             {
-                activityType: 'serviceTask',
-                activityName: 'serviceTaskName',
-                appName: 'simpleapp',
-                completedDate: '2020-09-22T16:03:37.482+0000',
-                elementId: 'ServiceTask_0lszm0x',
-                executionId: '2023b099-fced-11ea-b116-62141048995a',
-                id: '04fdf69f-4ddd-48ab-9563-da776c9b163c',
-                processDefinitionId: 'Process_24rkVVSR:1:0db78dcd-fc14-11ea-bce0-62141048995a',
-                processDefinitionKey: 'Process_24rkVVSR',
-                processDefinitionVersion: 1,
-                processInstanceId: '2023b097-fced-11ea-b116-62141048995a',
-                serviceFullName: 'simpleapp-rb',
-                serviceName: 'simpleapp-rb',
-                serviceVersion: '',
-                startedDate: '2020-09-22T16:03:37.444+0000',
-                status: 'COMPLETED'
+                entry: {
+                    activityType: 'serviceTask',
+                    activityName: 'serviceTaskName',
+                    appName: 'simpleapp',
+                    completedDate: '2020-09-22T16:03:37.482+0000',
+                    elementId: 'ServiceTask_0lszm0x',
+                    executionId: '2023b099-fced-11ea-b116-62141048995a',
+                    id: '04fdf69f-4ddd-48ab-9563-da776c9b163c',
+                    processDefinitionId: 'Process_24rkVVSR:1:0db78dcd-fc14-11ea-bce0-62141048995a',
+                    processDefinitionKey: 'Process_24rkVVSR',
+                    processDefinitionVersion: 1,
+                    processInstanceId: '2023b097-fced-11ea-b116-62141048995a',
+                    serviceFullName: 'simpleapp-rb',
+                    serviceName: 'simpleapp-rb',
+                    serviceVersion: '',
+                    startedDate: '2020-09-22T16:03:37.444+0000',
+                    status: 'COMPLETED'
+                }
             }
         ],
         pagination: {
@@ -79,18 +81,17 @@ export const fakeServiceTask = {
     }
 };
 
-export const fakeCustomSchema =
-    [
-        new ObjectDataColumn<ProcessListDataColumnCustomData>({
-            key: 'fakeName',
-            type: 'text',
-            title: 'ADF_CLOUD_TASK_LIST.PROPERTIES.FAKE',
-            sortable: true
-        }),
-        new ObjectDataColumn<ProcessListDataColumnCustomData>({
-            key: 'fakeTaskName',
-            type: 'text',
-            title: 'ADF_CLOUD_TASK_LIST.PROPERTIES.TASK_FAKE',
-            sortable: true
-        })
-    ];
+export const fakeCustomSchema = [
+    new ObjectDataColumn<ProcessListDataColumnCustomData>({
+        key: 'fakeName',
+        type: 'text',
+        title: 'ADF_CLOUD_TASK_LIST.PROPERTIES.FAKE',
+        sortable: true
+    }),
+    new ObjectDataColumn<ProcessListDataColumnCustomData>({
+        key: 'fakeTaskName',
+        type: 'text',
+        title: 'ADF_CLOUD_TASK_LIST.PROPERTIES.TASK_FAKE',
+        sortable: true
+    })
+];


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

[AAE-27160](https://hyland.atlassian.net/browse/AAE-27160)

Columns in the service task list cannot be sorted.  This is because the sortKey doesn't match column key since there is an additional layer in the data (`entry`).  Attempting to update the sortKey to match, for example `entry.startDate`, allows the columns to sort correctly, but API calls include `entry.startDate` as the column name in query parameters.

During review, I noticed some mock data was actually correct and contained the `entry` node in data.  This change is breaking, but provides consistency with similar components.


**What is the new behaviour?**
Server data is filtered and mapped to exclude the extra `entry` layer.


**Does this PR introduce a breaking change?** (check one with "x")

> - [x] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

Applications that use this component will need to update the `key` value in their column definitions as well as update the success callback and ng-template that use the data.  For Hyland Experience, this specifically means the app.config.json templates need to be updated for both admin-apa and admin-hxp.


[AAE-27160]: https://hyland.atlassian.net/browse/AAE-27160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ