### PR TITLE
[ACS-9398] Add snackbar notifications for favorite node directive

### DIFF
--- a/lib/content-services/src/lib/directives/library-favorite.directive.ts
+++ b/lib/content-services/src/lib/directives/library-favorite.directive.ts
@@ -19,6 +19,7 @@ import { Directive, HostListener, Input, OnChanges, Output, EventEmitter, Simple
 import { FavoriteBodyCreate, FavoritesApi } from '@alfresco/js-api';
 import { AlfrescoApiService } from '../services/alfresco-api.service';
 import { LibraryEntity } from '../interfaces/library-entity.interface';
+import { NotificationService } from '@alfresco/adf-core';
 
 @Directive({
     standalone: true,
@@ -58,7 +59,7 @@ export class LibraryFavoriteDirective implements OnChanges {
         }
     }
 
-    constructor(private alfrescoApiService: AlfrescoApiService) {}
+    constructor(private readonly alfrescoApiService: AlfrescoApiService, private readonly notificationService: NotificationService) {}
 
     ngOnChanges(changes: SimpleChanges) {
         if (!changes.library.currentValue) {
@@ -92,6 +93,7 @@ export class LibraryFavoriteDirective implements OnChanges {
             .createFavorite('-me-', favoriteBody)
             .then((libraryEntry) => {
                 this.targetLibrary.isFavorite = true;
+                this.notificationService.showInfo('NODE_FAVORITE_DIRECTIVE.MESSAGES.NODE_ADDED', null, { name: this.library.entry.title });
                 this.toggle.emit(libraryEntry);
             })
             .catch((error) => this.error.emit(error));
@@ -102,6 +104,7 @@ export class LibraryFavoriteDirective implements OnChanges {
             .deleteFavorite('-me-', favoriteId)
             .then((libraryBody) => {
                 this.targetLibrary.isFavorite = false;
+                this.notificationService.showInfo('NODE_FAVORITE_DIRECTIVE.MESSAGES.NODE_REMOVED', null, { name: this.library.entry.title });
                 this.toggle.emit(libraryBody);
             })
             .catch((error) => this.error.emit(error));

--- a/lib/content-services/src/lib/directives/node-favorite.directive.ts
+++ b/lib/content-services/src/lib/directives/node-favorite.directive.ts
@@ -53,7 +53,7 @@ export class NodeFavoriteDirective implements OnChanges {
         this.toggleFavorite();
     }
 
-    constructor(private alfrescoApiService: AlfrescoApiService, private notificationService: NotificationService) {}
+    constructor(private readonly alfrescoApiService: AlfrescoApiService, private readonly notificationService: NotificationService) {}
 
     ngOnChanges(changes: SimpleChanges) {
         if (!changes.selection.currentValue.length) {

--- a/lib/content-services/src/lib/i18n/en.json
+++ b/lib/content-services/src/lib/i18n/en.json
@@ -708,5 +708,13 @@
         "FOLDER_SELECTED": "Folders are not compatible with AI Agents."
       }
     }
+  },
+  "NODE_FAVORITE_DIRECTIVE": {
+    "MESSAGES": {
+      "NODE_ADDED": "Added {{ name }} to favorites",
+      "NODES_ADDED": "Added {{ number }} items to favorites",
+      "NODE_REMOVED": "Removed {{ name }} from favorites",
+      "NODES_REMOVED": "Removed {{ number }} items from favorites"
+    }
   }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

There are no notifications for favorite nodes directive.

**What is the new behaviour?**

Snackbar notifications has been added for favorite node directive.
Fixes Alfresco/alfresco-content-app#953
https://hyland.atlassian.net/browse/ACS-9398

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
