### PR TITLE
AAE-32763 Custom column visibility is not persistent after refresh

### DIFF
--- a/lib/core/src/lib/common/services/storage.service.ts
+++ b/lib/core/src/lib/common/services/storage.service.ts
@@ -61,7 +61,7 @@ export class StorageService {
         if (this.useLocalStorage) {
             for (let i = 0; i < localStorage.length; i++) {
                 const key = localStorage.key(i);
-                if (key && key.startsWith(this.prefix)) {
+                if (key?.startsWith(this.prefix)) {
                     const keyWithoutPrefix = key.slice(this.prefix.length);
                     items[keyWithoutPrefix] = localStorage.getItem(key);
                 }

--- a/lib/core/src/lib/common/services/storage.service.ts
+++ b/lib/core/src/lib/common/services/storage.service.ts
@@ -52,6 +52,33 @@ export class StorageService {
     }
 
     /**
+     * Gets all items from the storage.
+     *
+     * @returns All items stored
+     */
+    getItems(): { [key: string]: any } {
+        const items: { [key: string]: any } = {};
+        if (this.useLocalStorage) {
+            for (let i = 0; i < localStorage.length; i++) {
+                const key = localStorage.key(i);
+                if (key && key.startsWith(this.prefix)) {
+                    const keyWithoutPrefix = key.slice(this.prefix.length);
+                    items[keyWithoutPrefix] = localStorage.getItem(key);
+                }
+            }
+        } else {
+            Object.keys(this.memoryStore).forEach((key) => {
+                if (key.startsWith(this.prefix)) {
+                    const unprefixedKey = key.slice(this.prefix.length);
+                    items[unprefixedKey] = this.memoryStore[key];
+                }
+            });
+        }
+
+        return items;
+    }
+
+    /**
      * Stores an item
      *
      * @param key Key to identify the item

--- a/lib/process-services-cloud/src/lib/process/process-list/components/process-list-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/process/process-list/components/process-list-cloud.component.spec.ts
@@ -272,6 +272,41 @@ describe('ProcessListCloudComponent', () => {
             configureTestingModule('GET');
         });
 
+        it('should load preferences and create datatable schema', () => {
+            const columnsOrder = ['startDate', 'id'];
+            const columnsVisibility = { startDate: true, id: false };
+            const columnsWidths = { startDate: 100, id: 200 };
+
+            spyOn(preferencesService, 'getPreferenceByKey').and.callFake((_, key) => {
+                switch (key) {
+                    case ProcessListCloudPreferences.columnOrder:
+                        return of(columnsOrder);
+                    case ProcessListCloudPreferences.columnsVisibility:
+                        return of(columnsVisibility);
+                    case ProcessListCloudPreferences.columnsWidths:
+                        return of(columnsWidths);
+                    default:
+                        return of(null);
+                }
+            });
+
+            fixture.detectChanges();
+
+            expect(preferencesService.getPreferenceByKey).toHaveBeenCalledWith(component.appName, ProcessListCloudPreferences.columnOrder);
+            expect(preferencesService.getPreferenceByKey).toHaveBeenCalledWith(component.appName, ProcessListCloudPreferences.columnsVisibility);
+            expect(preferencesService.getPreferenceByKey).toHaveBeenCalledWith(component.appName, ProcessListCloudPreferences.columnsWidths);
+
+            const firstColumn = component.columns[0];
+            expect(firstColumn.id).toBe('startDate');
+            expect(firstColumn.isHidden).toBe(false);
+            expect(firstColumn.width).toBe(100);
+
+            const secondColumn = component.columns[1];
+            expect(secondColumn.id).toBe('id');
+            expect(secondColumn.isHidden).toBe(true);
+            expect(secondColumn.width).toBe(200);
+        });
+
         it('should load spinner and show the content', async () => {
             spyOn(processListCloudService, 'getProcessByRequest').and.returnValue(of(fakeProcessCloudList));
             const appName = new SimpleChange(null, 'FAKE-APP-NAME', true);

--- a/lib/process-services-cloud/src/lib/process/process-list/components/process-list-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/process/process-list/components/process-list-cloud.component.spec.ts
@@ -272,7 +272,7 @@ describe('ProcessListCloudComponent', () => {
             configureTestingModule('GET');
         });
 
-        it('should load preferences and create datatable schema', () => {
+        it('should load preferences', () => {
             const columnsOrder = ['startDate', 'id'];
             const columnsVisibility = { startDate: true, id: false };
             const columnsWidths = { startDate: 100, id: 200 };

--- a/lib/process-services-cloud/src/lib/process/process-list/components/process-list-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/process/process-list/components/process-list-cloud.component.ts
@@ -49,11 +49,11 @@ import {
     UserPreferenceValues
 } from '@alfresco/adf-core';
 import { ProcessListCloudService } from '../services/process-list-cloud.service';
-import { BehaviorSubject, combineLatest, Subject } from 'rxjs';
+import { BehaviorSubject, combineLatest, of, Subject, throwError } from 'rxjs';
 import { processCloudPresetsDefaultModel } from '../models/process-cloud-preset.model';
 import { ProcessListRequestModel, ProcessQueryCloudRequestModel } from '../models/process-cloud-query-request.model';
 import { ProcessListCloudSortingModel, ProcessListRequestSortingModel } from '../models/process-list-sorting.model';
-import { filter, map, switchMap, take, tap } from 'rxjs/operators';
+import { catchError, filter, map, switchMap, take, tap } from 'rxjs/operators';
 import { PreferenceCloudServiceInterface } from '../../../services/preference-cloud.interface';
 import { PROCESS_LISTS_PREFERENCES_SERVICE_TOKEN } from '../../../services/cloud-token.service';
 import { ProcessListCloudPreferences } from '../models/process-cloud-preferences';
@@ -407,6 +407,17 @@ export class ProcessListCloudComponent
                         columnsVisibility: columnsVisibility ? JSON.parse(columnsVisibility.entry.value) : this.columnsVisibility,
                         columnsWidths: columnsWidths ? JSON.parse(columnsWidths.entry.value) : undefined
                     };
+                }),
+                catchError((error) => {
+                    if (error.status === 404) {
+                        return of({
+                            columnsOrder: undefined,
+                            columnsVisibility: this.columnsVisibility,
+                            columnsWidths: undefined
+                        });
+                    } else {
+                        return throwError(error);
+                    }
                 })
             )
             .subscribe(({ columnsOrder, columnsVisibility, columnsWidths }) => {

--- a/lib/process-services-cloud/src/lib/process/process-list/components/process-list-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/process/process-list/components/process-list-cloud.component.ts
@@ -49,11 +49,11 @@ import {
     UserPreferenceValues
 } from '@alfresco/adf-core';
 import { ProcessListCloudService } from '../services/process-list-cloud.service';
-import { BehaviorSubject, combineLatest, forkJoin, Subject } from 'rxjs';
+import { BehaviorSubject, combineLatest, Subject } from 'rxjs';
 import { processCloudPresetsDefaultModel } from '../models/process-cloud-preset.model';
 import { ProcessListRequestModel, ProcessQueryCloudRequestModel } from '../models/process-cloud-query-request.model';
 import { ProcessListCloudSortingModel, ProcessListRequestSortingModel } from '../models/process-list-sorting.model';
-import { filter, switchMap, take, tap } from 'rxjs/operators';
+import { filter, map, switchMap, take, tap } from 'rxjs/operators';
 import { PreferenceCloudServiceInterface } from '../../../services/preference-cloud.interface';
 import { PROCESS_LISTS_PREFERENCES_SERVICE_TOKEN } from '../../../services/cloud-token.service';
 import { ProcessListCloudPreferences } from '../models/process-cloud-preferences';
@@ -390,25 +390,40 @@ export class ProcessListCloudComponent
     }
 
     ngAfterContentInit() {
-        forkJoin([
-            this.cloudPreferenceService.getPreferenceByKey(this.appName, ProcessListCloudPreferences.columnOrder),
-            this.cloudPreferenceService.getPreferenceByKey(this.appName, ProcessListCloudPreferences.columnsVisibility),
-            this.cloudPreferenceService.getPreferenceByKey(this.appName, ProcessListCloudPreferences.columnsWidths)
-        ]).subscribe(([columnsOrder, columnsVisibility, columnsWidths]) => {
-            if (columnsOrder) {
-                this.columnsOrder = columnsOrder;
-            }
+        this.cloudPreferenceService
+            .getPreferences(this.appName)
+            .pipe(
+                take(1),
+                map((preferences) => {
+                    const preferencesList = preferences?.list?.entries || [];
+                    const columnsOrder = preferencesList.find((preference) => preference.entry.key === ProcessListCloudPreferences.columnOrder);
+                    const columnsVisibility = preferencesList.find(
+                        (preference) => preference.entry.key === ProcessListCloudPreferences.columnsVisibility
+                    );
+                    const columnsWidths = preferencesList.find((preference) => preference.entry.key === ProcessListCloudPreferences.columnsWidths);
 
-            if (columnsVisibility) {
-                this.columnsVisibility = columnsVisibility;
-            }
+                    return {
+                        columnsOrder: columnsOrder ? JSON.parse(columnsOrder.entry.value) : undefined,
+                        columnsVisibility: columnsVisibility ? JSON.parse(columnsVisibility.entry.value) : this.columnsVisibility,
+                        columnsWidths: columnsWidths ? JSON.parse(columnsWidths.entry.value) : undefined
+                    };
+                })
+            )
+            .subscribe(({ columnsOrder, columnsVisibility, columnsWidths }) => {
+                if (columnsVisibility) {
+                    this.columnsVisibility = columnsVisibility;
+                }
 
-            if (columnsWidths) {
-                this.columnsWidths = columnsWidths;
-            }
+                if (columnsOrder) {
+                    this.columnsOrder = columnsOrder;
+                }
 
-            this.createDatatableSchema();
-        });
+                if (columnsWidths) {
+                    this.columnsWidths = columnsWidths;
+                }
+
+                this.createDatatableSchema();
+            });
     }
     ngOnChanges(changes: SimpleChanges) {
         if (this.isPropertyChanged(changes, 'sorting')) {

--- a/lib/process-services-cloud/src/lib/services/local-preference-cloud.service.spec.ts
+++ b/lib/process-services-cloud/src/lib/services/local-preference-cloud.service.spec.ts
@@ -1,0 +1,65 @@
+/*!
+ * @license
+ * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { LocalPreferenceCloudService } from './local-preference-cloud.service';
+import { StorageService } from '@alfresco/adf-core';
+
+describe('LocalPreferenceCloudService', () => {
+    let service: LocalPreferenceCloudService;
+    let storageServiceSpy: jasmine.SpyObj<StorageService>;
+
+    beforeEach(() => {
+        const spy = jasmine.createSpyObj('StorageService', ['getItem', 'getItems', 'setItem']);
+
+        TestBed.configureTestingModule({
+            providers: [LocalPreferenceCloudService, { provide: StorageService, useValue: spy }]
+        });
+
+        service = TestBed.inject(LocalPreferenceCloudService);
+        storageServiceSpy = TestBed.inject(StorageService) as jasmine.SpyObj<StorageService>;
+    });
+
+    it('should return preferences for a given key', (done) => {
+        const key = 'testKey';
+        const value = '[{"name": "test"}]';
+        storageServiceSpy.getItem.and.returnValue(value);
+
+        service.getPreferences('', key).subscribe((result) => {
+            expect(result.list.entries[0].entry.key).toBe(key);
+            expect(result.list.entries[0].entry.value).toBe(value);
+            done();
+        });
+    });
+
+    it('should return all preferences if no key is provided', (done) => {
+        const items = {
+            key1: '[{"name": "test1"}]',
+            key2: '[{"name": "test2"}]'
+        };
+        storageServiceSpy.getItems.and.returnValue(items);
+
+        service.getPreferences('', undefined).subscribe((result) => {
+            expect(result.list.entries.length).toBe(2);
+            expect(result.list.entries[0].entry.key).toBe('key1');
+            expect(result.list.entries[0].entry.value).toBe(items['key1']);
+            expect(result.list.entries[1].entry.key).toBe('key2');
+            expect(result.list.entries[1].entry.value).toBe(items['key2']);
+            done();
+        });
+    });
+});

--- a/lib/process-services-cloud/src/lib/services/local-preference-cloud.service.ts
+++ b/lib/process-services-cloud/src/lib/services/local-preference-cloud.service.ts
@@ -37,10 +37,10 @@ export class LocalPreferenceCloudService implements PreferenceCloudServiceInterf
         }
 
         const items = this.storage.getItems();
-        const entries = Object.keys(items).map((key) => ({
+        const entries = Object.keys(items).map((k) => ({
             entry: {
-                key,
-                value: items[key] || '[]'
+                key: k,
+                value: items[k] || '[]'
             }
         }));
 

--- a/lib/process-services-cloud/src/lib/services/local-preference-cloud.service.ts
+++ b/lib/process-services-cloud/src/lib/services/local-preference-cloud.service.ts
@@ -35,9 +35,18 @@ export class LocalPreferenceCloudService implements PreferenceCloudServiceInterf
         if (key || key === '') {
             return of(this.prepareLocalPreferenceResponse(key));
         }
+
+        const items = this.storage.getItems();
+        const entries = Object.keys(items).map((key) => ({
+            entry: {
+                key,
+                value: items[key] || '[]'
+            }
+        }));
+
         return of({
             list: {
-                entries: []
+                entries
             }
         });
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
The local storage is provided, the used method only works for the user cloud storage. I adjusted getPreferences so it works for both (UserPreferenceCloudService and LocalPreferenceCloudService), now it can easily be replaced. Not sure if the actual bug is that we use local storage instead of user storage here.

`this.cloudPreferenceService.getPreferences(this.appName)` always returned an empty list for local storage.

**What is the new behaviour?**
`this.cloudPreferenceService.getPreferences(this.appName)` now returns all items from the storage with the respective prefix. So the same code can be used to find a value from UserPreferenceCloudService or LocalPreferenceCloudService


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
