### PR TITLE
[ACS-9435] Resolve a11y issues for 'Add use/group' dialog

### DIFF
--- a/lib/content-services/src/lib/permission-manager/components/add-permission/add-permission-panel.component.html
+++ b/lib/content-services/src/lib/permission-manager/components/add-permission/add-permission-panel.component.html
@@ -7,6 +7,7 @@
         type="text"
         title="{{ 'PERMISSION_MANAGER.ADD-PERMISSION.SEARCH' | translate }}"
         placeholder="{{ 'PERMISSION_MANAGER.ADD-PERMISSION.SEARCH' | translate }}"
+        [attr.aria-label]="'PERMISSION_MANAGER.ADD-PERMISSION.SEARCH' | translate"
         [value]="searchedWord"
     />
 
@@ -40,6 +41,8 @@
         <mat-selection-list
             class="adf-permission-result-list-elements"
             title="{{ 'PERMISSION_MANAGER.ADD-PERMISSION.USER-GROUP-LIST' | translate }}"
+            tabindex="0"
+            [attr.aria-label]="'PERMISSION_MANAGER.ADD-PERMISSION.USER-GROUP-LIST' | translate"
             (selectionChange)="onSelectionChange()"
         >
             <mat-list-option id="adf-add-permission-group-everyone" #eveyone [disableRipple]="true" [value]="EVERYONE">

--- a/lib/content-services/src/lib/search/components/search.component.html
+++ b/lib/content-services/src/lib/search/components/search.component.html
@@ -1,4 +1,4 @@
-<div role="listbox" id="adf-search-results-content" title="{{'PERMISSION_MANAGER.ADD-PERMISSION.USER-GROUP-LIST' | translate}}"
+<div id="adf-search-results-content" title="{{'PERMISSION_MANAGER.ADD-PERMISSION.USER-GROUP-LIST' | translate}}"
     [ngClass]="_classList" #panel>
     <ng-template
         [ngTemplateOutlet]="template"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [X] Other... Please describe: a11y


**What is the current behaviour?** (You can also link to an open issue here)

https://hyland.atlassian.net/browse/ACS-9435
![image](https://github.com/user-attachments/assets/1c973a00-7f0b-4329-b5bf-4d6e4f642062)


**What is the new behaviour?**

![Screenshot 2025-04-07 at 09 14 45](https://github.com/user-attachments/assets/e6378077-bcb5-4ed7-8b25-f4420f4b4981)


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
