### PR TITLE
[ACS-9564] Corrected models after change of Knowledge Retrieval answer structure

### DIFF
--- a/lib/content-services/src/lib/search-ai/services/search-ai.service.spec.ts
+++ b/lib/content-services/src/lib/search-ai/services/search-ai.service.spec.ts
@@ -60,11 +60,38 @@ describe('SearchAiService', () => {
             const answer: AiAnswerEntry = {
                 entry: {
                     answer: 'Some answer 1',
-                    questionId,
-                    references: [
+                    complete: true,
+                    question: 'Some question',
+                    objectReferences: [
                         {
-                            referenceId: 'some reference id 1',
-                            referenceText: 'some reference text 1'
+                            objectId: 'some id 1',
+                            references: [
+                                {
+                                    referenceId: 'some reference id 1',
+                                    rank: 1,
+                                    rankScore: 0.005
+                                },
+                                {
+                                    referenceId: 'some reference id 2',
+                                    rank: 2,
+                                    rankScore: 0.004
+                                }
+                            ]
+                        },
+                        {
+                            objectId: 'some id 2',
+                            references: [
+                                {
+                                    referenceId: 'some reference id 3',
+                                    rank: 1,
+                                    rankScore: 0.005
+                                },
+                                {
+                                    referenceId: 'some reference id 4',
+                                    rank: 2,
+                                    rankScore: 0.004
+                                }
+                            ]
                         }
                     ]
                 }

--- a/lib/js-api/src/api/content-rest-api/docs/SearchAiApi.md
+++ b/lib/js-api/src/api/content-rest-api/docs/SearchAiApi.md
@@ -58,20 +58,20 @@ A paginated list is returned in the response body. For example:
         "complete": true,
         "objectReferences": [
             {
-                "objectId": "b40356d4-a0b5-485d-8356-d4a0b5585dbd",
+                "objectId": "some-object-id",
                 "references": [
                     {
-                        "referenceId": "c85add01-4333-43c8-9680-7e6847c33807",
+                        "referenceId": "some-reference-id1",
                         "rankScore": 0.031,
                         "rank": 2
                     },
                     {
-                        "referenceId": "1f4f83ba-c1bd-4c48-8202-8c4dd6439294",
+                        "referenceId": "some-reference-id2",
                         "rankScore": 0.031,
                         "rank": 1
                     },
                     {
-                        "referenceId": "62926342-6894-4b79-bd45-c6aee9f482e1",
+                        "referenceId": "some-reference-id3",
                         "rankScore": 0.028,
                         "rank": 3
                     }

--- a/lib/js-api/src/api/content-rest-api/docs/SearchAiApi.md
+++ b/lib/js-api/src/api/content-rest-api/docs/SearchAiApi.md
@@ -52,26 +52,30 @@ A paginated list is returned in the response body. For example:
 
 ```json
 {
-    "list": {
-        "pagination": {
-            "count": 2,
-            "hasMoreItems": false,
-            "totalItems": 2,
-            "skipCount": 0,
-            "maxItems": 100
-        },
-        "entries": [
+    "entry": {
+        "answer": "Some answer",
+        "question": "Some question",
+        "complete": true,
+        "objectReferences": [
             {
-                "entry": {
-                    "answer": "Some answer",
-                    "questionId": "Some question id",
-                    "references": [
-                        {
-                            "referenceId": "Some reference id",
-                            "referenceText": "Some reference text"
-                        }
-                    ]
-                }
+                "objectId": "b40356d4-a0b5-485d-8356-d4a0b5585dbd",
+                "references": [
+                    {
+                        "referenceId": "c85add01-4333-43c8-9680-7e6847c33807",
+                        "rankScore": 0.031,
+                        "rank": 2
+                    },
+                    {
+                        "referenceId": "1f4f83ba-c1bd-4c48-8202-8c4dd6439294",
+                        "rankScore": 0.031,
+                        "rank": 1
+                    },
+                    {
+                        "referenceId": "62926342-6894-4b79-bd45-c6aee9f482e1",
+                        "rankScore": 0.028,
+                        "rank": 3
+                    }
+                ]
             }
         ]
     }
@@ -139,20 +143,31 @@ searchAiApi.getConfig().then((answer) => {
 
 **Properties**
 
+| Name                 | Type                                                  |
+|----------------------|-------------------------------------------------------|
+| **answer**           | string                                                |
+| **question**         | string                                                |
+| **complete**         | boolean                                               |
+| **objectReferences** | [AiAnswerObjectReference](#AiAnswerObjectReference)[] |
+
+## AiAnswerObjectReference
+
+**Properties**
+
 | Name           | Type                                      |
 |----------------|-------------------------------------------|
-| **answer**     | string                                    |
-| **questionId** | string                                    |
+| **objectId**   | string                                    |
 | **references** | [AiAnswerReference](#AiAnswerReference)[] |
 
 ## AiAnswerReference
 
 **Properties**
 
-| Name              | Type   |
-|-------------------|--------|
-| **referenceId**   | string |
-| **referenceText** | string |
+| Name            | Type   |
+|-----------------|--------|
+| **referenceId** | string |
+| **rankScore**   | number |
+| **rank**        | number |
 
 ## QuestionModel
 

--- a/lib/js-api/src/api/content-rest-api/model/aiAnswerObjectReference.ts
+++ b/lib/js-api/src/api/content-rest-api/model/aiAnswerObjectReference.ts
@@ -15,11 +15,9 @@
  * limitations under the License.
  */
 
-import { AiAnswerObjectReference } from './aiAnswerObjectReference';
+import { AiAnswerReference } from './aiAnswerReference';
 
-export interface AiAnswer {
-    answer?: string;
-    question: string;
-    complete: boolean;
-    objectReferences: AiAnswerObjectReference[];
+export interface AiAnswerObjectReference {
+    objectId: string;
+    references: AiAnswerReference[];
 }

--- a/lib/js-api/src/api/content-rest-api/model/aiAnswerReference.ts
+++ b/lib/js-api/src/api/content-rest-api/model/aiAnswerReference.ts
@@ -17,5 +17,6 @@
 
 export interface AiAnswerReference {
     referenceId: string;
-    referenceText: string;
+    rankScore: number;
+    rank: number;
 }

--- a/lib/js-api/src/api/content-rest-api/model/index.ts
+++ b/lib/js-api/src/api/content-rest-api/model/index.ts
@@ -34,6 +34,7 @@ export * from './agentPagingList';
 export * from './aiAnswer';
 export * from './aiAnswerEntry';
 export * from './aiAnswerReference';
+export * from './aiAnswerObjectReference';
 export * from './association';
 export * from './associationBody';
 export * from './associationEntry';

--- a/lib/js-api/test/content-services/searchAiApi.spec.ts
+++ b/lib/js-api/test/content-services/searchAiApi.spec.ts
@@ -68,11 +68,38 @@ describe('SearchAiApi', () => {
                 assert.deepStrictEqual(answer, {
                     entry: {
                         answer: 'Some answer 1',
-                        questionId: 'some id 1',
-                        references: [
+                        complete: true,
+                        question: 'Some question',
+                        objectReferences: [
                             {
-                                referenceId: 'some reference id 1',
-                                referenceText: 'some reference text 1'
+                                objectId: 'some id 1',
+                                references: [
+                                    {
+                                        referenceId: 'some reference id 1',
+                                        rank: 1,
+                                        rankScore: 0.005
+                                    },
+                                    {
+                                        referenceId: 'some reference id 2',
+                                        rank: 2,
+                                        rankScore: 0.004
+                                    }
+                                ]
+                            },
+                            {
+                                objectId: 'some id 2',
+                                references: [
+                                    {
+                                        referenceId: 'some reference id 3',
+                                        rank: 1,
+                                        rankScore: 0.005
+                                    },
+                                    {
+                                        referenceId: 'some reference id 4',
+                                        rank: 2,
+                                        rankScore: 0.004
+                                    }
+                                ]
                             }
                         ]
                     }

--- a/lib/js-api/test/mockObjects/content-services/search-ai.mock.ts
+++ b/lib/js-api/test/mockObjects/content-services/search-ai.mock.ts
@@ -46,11 +46,38 @@ export class SearchAiMock extends BaseMock {
             .reply(200, {
                 entry: {
                     answer: 'Some answer 1',
-                    questionId: 'some id 1',
-                    references: [
+                    complete: true,
+                    question: 'Some question',
+                    objectReferences: [
                         {
-                            referenceId: 'some reference id 1',
-                            referenceText: 'some reference text 1'
+                            objectId: 'some id 1',
+                            references: [
+                                {
+                                    referenceId: 'some reference id 1',
+                                    rank: 1,
+                                    rankScore: 0.005
+                                },
+                                {
+                                    referenceId: 'some reference id 2',
+                                    rank: 2,
+                                    rankScore: 0.004
+                                }
+                            ]
+                        },
+                        {
+                            objectId: 'some id 2',
+                            references: [
+                                {
+                                    referenceId: 'some reference id 3',
+                                    rank: 1,
+                                    rankScore: 0.005
+                                },
+                                {
+                                    referenceId: 'some reference id 4',
+                                    rank: 2,
+                                    rankScore: 0.004
+                                }
+                            ]
                         }
                     ]
                 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/ACS-9564


**What is the new behaviour?**
Models are changed to render Knowledge Retrieval's answer properly after change of AI response from backend side. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [x] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: 
Changes for AiAnswer model: 
- question has been changed to questionId 
- references has been changed to objectReferences 

Changes for AiAnswerReference: 
- earlier referenceId was id of file based which answer was retrieved, now that value is in AiAnswerObjectReference in objectId and referenceId indicates id of fragment based which answer was retrieved.  

**Other information**:
ACA PR: https://github.com/Alfresco/alfresco-content-app/pull/4534