### PR TITLE
[AAE-34481] Field error message has preserved space

### DIFF
--- a/lib/core/src/lib/form/components/form-renderer.component.scss
+++ b/lib/core/src/lib/form/components/form-renderer.component.scss
@@ -243,3 +243,7 @@ form-field {
         line-height: normal;
     }
 }
+
+.adf-error-messages-container {
+    min-height: 35px;
+}

--- a/lib/core/src/lib/form/components/widgets/amount/amount.widget.scss
+++ b/lib/core/src/lib/form/components/widgets/amount/amount.widget.scss
@@ -31,7 +31,3 @@
         }
     }
 }
-
-.adf-error-messages-container {
-    min-height: 35px;
-}

--- a/lib/core/src/lib/form/components/widgets/base-viewer/base-viewer.widget.scss
+++ b/lib/core/src/lib/form/components/widgets/base-viewer/base-viewer.widget.scss
@@ -17,7 +17,3 @@ base-viewer-widget {
         }
     }
 }
-
-.adf-error-messages-container {
-    min-height: 35px;
-}

--- a/lib/core/src/lib/form/components/widgets/checkbox/checkbox.widget.ts
+++ b/lib/core/src/lib/form/components/widgets/checkbox/checkbox.widget.ts
@@ -35,9 +35,6 @@ import { WidgetComponent } from '../widget.component';
             .adf-checkbox {
                 word-break: break-word;
             }
-            .adf-error-messages-container {
-                min-height: 35px;
-            }
         `
     ],
     host: {

--- a/lib/core/src/lib/form/components/widgets/date-time/date-time.widget.scss
+++ b/lib/core/src/lib/form/components/widgets/date-time/date-time.widget.scss
@@ -25,7 +25,3 @@
 .mat-datetimepicker-toggle {
     color: var(--adf-theme-foreground-icon-color);
 }
-
-.adf-error-messages-container {
-    min-height: 35px;
-}

--- a/lib/core/src/lib/form/components/widgets/date/date.widget.ts
+++ b/lib/core/src/lib/form/components/widgets/date/date.widget.ts
@@ -41,13 +41,6 @@ import { ReactiveFormWidget } from '../reactive-widget.interface';
         { provide: MAT_DATE_FORMATS, useValue: ADF_DATE_FORMATS },
         { provide: DateAdapter, useClass: AdfDateFnsAdapter }
     ],
-    styles: [
-        `
-            .adf-error-messages-container {
-                min-height: 35px;
-            }
-        `
-    ],
     templateUrl: './date.widget.html',
     host: {
         '(click)': 'event($event)',

--- a/lib/core/src/lib/form/components/widgets/decimal/decimal.component.scss
+++ b/lib/core/src/lib/form/components/widgets/decimal/decimal.component.scss
@@ -7,7 +7,3 @@
         }
     }
 }
-
-.adf-error-messages-container {
-    min-height: 35px;
-}

--- a/lib/core/src/lib/form/components/widgets/multiline-text/multiline-text.widget.scss
+++ b/lib/core/src/lib/form/components/widgets/multiline-text/multiline-text.widget.scss
@@ -27,7 +27,3 @@
         display: flex;
     }
 }
-
-.adf-error-messages-container {
-    min-height: 35px;
-}

--- a/lib/core/src/lib/form/components/widgets/number/number.widget.scss
+++ b/lib/core/src/lib/form/components/widgets/number/number.widget.scss
@@ -7,7 +7,3 @@
         }
     }
 }
-
-.adf-error-messages-container {
-    min-height: 35px;
-}

--- a/lib/core/src/lib/form/components/widgets/text/text.widget.scss
+++ b/lib/core/src/lib/form/components/widgets/text/text.widget.scss
@@ -10,7 +10,3 @@
         }
     }
 }
-
-.adf-error-messages-container {
-    min-height: 35px;
-}

--- a/lib/process-services-cloud/src/lib/form/components/widgets/date/date-cloud.widget.scss
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/date/date-cloud.widget.scss
@@ -23,7 +23,3 @@
         }
     }
 }
-
-.adf-error-messages-container {
-    min-height: 35px;
-}

--- a/lib/process-services-cloud/src/lib/group/components/group-cloud.component.scss
+++ b/lib/process-services-cloud/src/lib/group/components/group-cloud.component.scss
@@ -53,7 +53,3 @@
         }
     }
 }
-
-.adf-error-messages-container {
-    min-height: 35px;
-}

--- a/lib/process-services-cloud/src/lib/people/components/people-cloud.component.scss
+++ b/lib/process-services-cloud/src/lib/people/components/people-cloud.component.scss
@@ -65,7 +65,3 @@
         color: var(--theme-warn-color);
     }
 }
-
-.adf-error-messages-container {
-    min-height: 35px;
-}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/AAE-34481
Error message for form field does not have preserved space. When error message appears it takes up space, and as a result, the field is not aligned with the other fields.


**What is the new behaviour?**
Each widget used in form field has preserved space for possible error message. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
