### PR TITLE
AAE-34478 Hide "open next task" checkbox on claim screen

### DIFF
--- a/lib/process-services-cloud/src/lib/task/task-form/components/user-task-cloud/user-task-cloud.component.html
+++ b/lib/process-services-cloud/src/lib/task/task-form/components/user-task-cloud/user-task-cloud.component.html
@@ -1,4 +1,4 @@
- <div class="adf-user-task-cloud-container">
+<div class="adf-user-task-cloud-container">
     <div *ngIf="!loading; else loadingTemplate">
         <ng-container [ngSwitch]="taskType">
             <ng-container *ngSwitchCase="taskTypeEnum.Form">
@@ -12,7 +12,7 @@
                     [showTitle]="showTitle"
                     [taskId]="taskId"
                     [taskDetails]="taskDetails"
-                    [showNextTaskCheckbox]="showNextTaskCheckbox"
+                    [showNextTaskCheckbox]="showNextTaskCheckbox && canCompleteTask()"
                     [isNextTaskCheckboxChecked]="isNextTaskCheckboxChecked"
                     (cancelClick)="onCancelForm()"
                     (executeOutcome)="onExecuteOutcome($event)"
@@ -38,7 +38,6 @@
                     [showCancelButton]="showCancelButton"
                     [taskName]="taskDetails.name"
                     [taskId]="taskId"
-
                     (cancelTask)="onCancelClick()"
                     (claimTask)="onClaimTask()"
                     (error)="onError($event)"
@@ -63,10 +62,17 @@
                         <adf-empty-content
                             [icon]="'description'"
                             [title]="'ADF_CLOUD_TASK_FORM.EMPTY_FORM.TITLE'"
-                            [subtitle]="'ADF_CLOUD_TASK_FORM.EMPTY_FORM.SUBTITLE'" />
+                            [subtitle]="'ADF_CLOUD_TASK_FORM.EMPTY_FORM.SUBTITLE'"
+                        />
                     </mat-card-content>
                     <mat-card-actions class="adf-task-form-actions" align="end">
-                        <mat-checkbox id="adf-form-open-next-task" *ngIf="showNextTaskCheckbox" [checked]="isNextTaskCheckboxChecked" (change)="onNextTaskCheckboxCheckedChanged($event)">{{'ADF_CLOUD_TASK_FORM.OPEN_NEXT_TASK.LABEL' | translate}}</mat-checkbox>
+                        <mat-checkbox
+                            id="adf-form-open-next-task"
+                            *ngIf="showNextTaskCheckbox && canCompleteTask()"
+                            [checked]="isNextTaskCheckboxChecked"
+                            (change)="onNextTaskCheckboxCheckedChanged($event)"
+                            >{{ 'ADF_CLOUD_TASK_FORM.OPEN_NEXT_TASK.LABEL' | translate }}
+                        </mat-checkbox>
                         <span class="adf-card-actions-spacer"></span>
                         <ng-template [ngTemplateOutlet]="taskFormCloudButtons" />
                         <button
@@ -80,12 +86,11 @@
                             color="primary"
                             id="adf-form-complete"
                         >
-                            {{'ADF_CLOUD_TASK_FORM.EMPTY_FORM.BUTTONS.COMPLETE' | translate}}
+                            {{ 'ADF_CLOUD_TASK_FORM.EMPTY_FORM.BUTTONS.COMPLETE' | translate }}
                         </button>
                     </mat-card-actions>
                 </mat-card>
             </ng-container>
-
         </ng-container>
     </div>
 </div>

--- a/lib/process-services-cloud/src/lib/task/task-form/components/user-task-cloud/user-task-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/task/task-form/components/user-task-cloud/user-task-cloud.component.spec.ts
@@ -482,28 +482,89 @@ describe('UserTaskCloudComponent', () => {
     it('should allow controlling [open next task] checkbox visibility', () => {
         taskDetails.formKey = 'form';
         component.getTaskType();
+        component.taskId = 'taskId';
+        component.appName = 'app';
+
+        const spy = spyOn(taskCloudService, 'canCompleteTask');
 
         const isCheckboxShown = () => {
             const checkbox = fixture.debugElement.query(By.css('#adf-form-open-next-task'));
             return !!checkbox;
         };
 
-        fixture.detectChanges();
+        const prepareTestCase = (testCase: {
+            showNextTaskCheckbox: boolean;
+            showCompleteButton: boolean;
+            readOnly: boolean;
+            canCompleteTask: boolean;
+        }): void => {
+            component.showNextTaskCheckbox = testCase.showNextTaskCheckbox;
+            component.showCompleteButton = testCase.showCompleteButton;
+            component.readOnly = testCase.readOnly;
+            spy.calls.reset();
+            spy.and.returnValue(testCase.canCompleteTask);
+            fixture.detectChanges();
+        };
+
+        prepareTestCase({ showNextTaskCheckbox: false, showCompleteButton: false, readOnly: false, canCompleteTask: false });
         expect(isCheckboxShown()).toBeFalse();
 
-        component.showNextTaskCheckbox = true;
-        fixture.detectChanges();
+        prepareTestCase({ showNextTaskCheckbox: false, showCompleteButton: false, readOnly: false, canCompleteTask: true });
+        expect(isCheckboxShown()).toBeFalse();
+
+        prepareTestCase({ showNextTaskCheckbox: false, showCompleteButton: false, readOnly: true, canCompleteTask: false });
+        expect(isCheckboxShown()).toBeFalse();
+
+        prepareTestCase({ showNextTaskCheckbox: false, showCompleteButton: false, readOnly: true, canCompleteTask: true });
+        expect(isCheckboxShown()).toBeFalse();
+
+        prepareTestCase({ showNextTaskCheckbox: false, showCompleteButton: true, readOnly: false, canCompleteTask: false });
+        expect(isCheckboxShown()).toBeFalse();
+
+        prepareTestCase({ showNextTaskCheckbox: false, showCompleteButton: true, readOnly: false, canCompleteTask: true });
+        expect(isCheckboxShown()).toBeFalse();
+
+        prepareTestCase({ showNextTaskCheckbox: false, showCompleteButton: true, readOnly: true, canCompleteTask: false });
+        expect(isCheckboxShown()).toBeFalse();
+
+        prepareTestCase({ showNextTaskCheckbox: false, showCompleteButton: true, readOnly: true, canCompleteTask: true });
+        expect(isCheckboxShown()).toBeFalse();
+
+        prepareTestCase({ showNextTaskCheckbox: true, showCompleteButton: false, readOnly: false, canCompleteTask: false });
+        expect(isCheckboxShown()).toBeFalse();
+
+        prepareTestCase({ showNextTaskCheckbox: true, showCompleteButton: false, readOnly: false, canCompleteTask: true });
+        expect(isCheckboxShown()).toBeFalse();
+
+        prepareTestCase({ showNextTaskCheckbox: true, showCompleteButton: false, readOnly: true, canCompleteTask: false });
+        expect(isCheckboxShown()).toBeFalse();
+
+        prepareTestCase({ showNextTaskCheckbox: true, showCompleteButton: false, readOnly: true, canCompleteTask: true });
+        expect(isCheckboxShown()).toBeFalse();
+
+        prepareTestCase({ showNextTaskCheckbox: true, showCompleteButton: true, readOnly: true, canCompleteTask: false });
+        expect(isCheckboxShown()).toBeFalse();
+
+        prepareTestCase({ showNextTaskCheckbox: true, showCompleteButton: true, readOnly: true, canCompleteTask: true });
+        expect(isCheckboxShown()).toBeFalse();
+
+        prepareTestCase({ showNextTaskCheckbox: true, showCompleteButton: true, readOnly: false, canCompleteTask: false });
+        expect(isCheckboxShown()).toBeFalse();
+
+        prepareTestCase({ showNextTaskCheckbox: true, showCompleteButton: true, readOnly: false, canCompleteTask: true });
         expect(isCheckboxShown()).toBeTrue();
-
-        component.showNextTaskCheckbox = false;
-        fixture.detectChanges();
-        expect(isCheckboxShown()).toBeFalse();
     });
 
     it('should allow controlling [open next task] checkbox value', async () => {
         taskDetails.formKey = 'form';
         component.getTaskType();
+
+        component.taskId = 'taskId';
+        component.appName = 'app';
         component.showNextTaskCheckbox = true;
+        component.showCompleteButton = true;
+        component.readOnly = false;
+        spyOn(taskCloudService, 'canCompleteTask').and.returnValue(true);
 
         const isCheckboxChecked = async () => {
             const checkbox = await loader.getHarness(MatCheckboxHarness.with({ selector: '#adf-form-open-next-task' }));
@@ -526,7 +587,13 @@ describe('UserTaskCloudComponent', () => {
         taskDetails.formKey = 'form';
         component.getTaskType();
 
+        component.taskId = 'taskId';
+        component.appName = 'app';
         component.showNextTaskCheckbox = true;
+        component.showCompleteButton = true;
+        component.readOnly = false;
+        spyOn(taskCloudService, 'canCompleteTask').and.returnValue(true);
+
         fixture.detectChanges();
         const checkbox = await loader.getHarnessOrNull(MatCheckboxHarness);
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Checkbox is shown on claim task screen.
https://hyland.atlassian.net/browse/AAE-34478


**What is the new behaviour?**
Checkbox is hidden on claim task screen. Will be hidden always if the task cannot be completed.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
