### PR TITLE
AAE-19688 Persist feature flag overrides in session storage

### DIFF
--- a/lib/core/feature-flags/src/lib/services/debug-features.service.spec.ts
+++ b/lib/core/feature-flags/src/lib/services/debug-features.service.spec.ts
@@ -17,37 +17,37 @@
 
 import { TestBed } from '@angular/core/testing';
 import { DebugFeaturesService } from './debug-features.service';
-import { StorageService } from '../../../../src/lib/common/services/storage.service';
-import { OverridableFeaturesServiceToken, WritableFeaturesServiceToken } from '../interfaces/features.interface';
+import { OverridableFeaturesServiceToken, WritableFeaturesServiceConfigToken, WritableFeaturesServiceToken } from '../interfaces/features.interface';
 import { DummyFeaturesService } from './dummy-features.service';
 import { StorageFeaturesService } from './storage-features.service';
 import { take } from 'rxjs/operators';
 
 describe('DebugFeaturesService', () => {
     let service: DebugFeaturesService;
-    const mockStorage = {
-        getItem: () =>
-            JSON.stringify({
-                feature1: {
-                    current: true
-                },
-                feature2: {
-                    current: false,
-                    fictive: true
-                }
-            }),
-        setItem: () => {}
-    };
+    let mockStorageKey: string;
+    let mockStorage;
 
     beforeEach(() => {
+        mockStorageKey = 'storage-key-test';
+        mockStorage = { [mockStorageKey]: true };
+
         TestBed.configureTestingModule({
             providers: [
                 DebugFeaturesService,
-                { provide: StorageService, useValue: mockStorage },
+                {
+                    provide: WritableFeaturesServiceConfigToken,
+                    useValue: { storageKey: mockStorageKey }
+                },
                 { provide: WritableFeaturesServiceToken, useClass: StorageFeaturesService },
                 { provide: OverridableFeaturesServiceToken, useClass: DummyFeaturesService }
             ]
         });
+
+        spyOn(sessionStorage, 'getItem').and.callFake((key) => JSON.stringify(mockStorage[key]));
+        spyOn(sessionStorage, 'setItem').and.callFake((key, value) => {
+            mockStorage[key] = value;
+        });
+
         service = TestBed.inject(DebugFeaturesService);
     });
 

--- a/lib/core/feature-flags/src/lib/services/storage-features.service.spec.ts
+++ b/lib/core/feature-flags/src/lib/services/storage-features.service.spec.ts
@@ -17,17 +17,20 @@
 
 import { TestBed } from '@angular/core/testing';
 import { StorageFeaturesService } from './storage-features.service';
-import { StorageService } from '../../../../src/public-api';
 import { FlagSet, WritableFeaturesServiceConfigToken } from '../interfaces/features.interface';
 import { skip, take } from 'rxjs/operators';
 
 describe('StorageFeaturesService', () => {
     let storageFeaturesService: StorageFeaturesService;
 
-    describe('if flags are present in LocalStorage', () => {
-        const mockStorage = {
-            getItem: () =>
-                JSON.stringify({
+    describe('if flags are present in sessionStorage', () => {
+        let mockStorageKey: string;
+        let mockStorage;
+
+        beforeEach(() => {
+            mockStorageKey = 'storage-key-test';
+            mockStorage = {
+                [mockStorageKey]: {
                     feature1: {
                         current: true
                     },
@@ -35,21 +38,21 @@ describe('StorageFeaturesService', () => {
                         current: false,
                         fictive: true
                     }
-                }),
-            setItem: () => {}
-        };
+                }
+            };
 
-        beforeEach(() => {
             TestBed.configureTestingModule({
                 providers: [
-                    { provide: StorageService, useValue: mockStorage },
                     {
                         provide: WritableFeaturesServiceConfigToken,
-                        useValue: {
-                            storageKey: 'storage-key-test'
-                        }
+                        useValue: { storageKey: mockStorageKey }
                     }
                 ]
+            });
+
+            spyOn(sessionStorage, 'getItem').and.callFake((key) => JSON.stringify(mockStorage[key]));
+            spyOn(sessionStorage, 'setItem').and.callFake((key, value) => {
+                mockStorage[key] = value;
             });
 
             storageFeaturesService = TestBed.inject(StorageFeaturesService);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/AAE-19688


**What is the new behaviour?**

StorageFeaturesService and DebugFeaturesService will use sessionStorage to store it's respective data

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
