### PR TITLE
AAE-34959 Fix Application CORS issue if withCredentials equal to true

### DIFF
--- a/lib/core/src/lib/app-config/app-config.loader.spec.ts
+++ b/lib/core/src/lib/app-config/app-config.loader.spec.ts
@@ -1,0 +1,123 @@
+/*!
+ * @license
+ * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AdfHttpClient } from '@alfresco/adf-core/api';
+import { StorageService } from '../common';
+import { StoragePrefixFactory } from './app-config-storage-prefix.factory';
+import { loadAppConfig } from './app-config.loader';
+import { AppConfigService, AppConfigValues } from './app-config.service';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { HttpClientModule } from '@angular/common/http';
+import { of } from 'rxjs';
+
+describe('loadAppConfig', () => {
+    let appConfigServiceSpy: jasmine.SpyObj<AppConfigService>;
+    let storageServiceSpy: jasmine.SpyObj<StorageService>;
+    let adfHttpClientSpy: jasmine.SpyObj<AdfHttpClient>;
+    let storagePrefixFactorySpy: jasmine.SpyObj<StoragePrefixFactory>;
+
+    let appConfigGetSpy: jasmine.Spy;
+    let appConfigLoadSpy: jasmine.Spy;
+
+    let factoryFunction: () => void;
+
+    beforeEach(() => {
+        adfHttpClientSpy = jasmine.createSpyObj('AdfHttpClient', ['setDefaultSecurityOption']);
+        storagePrefixFactorySpy = jasmine.createSpyObj('StoragePrefixFactory', ['getPrefix']);
+
+        TestBed.configureTestingModule({
+            imports: [HttpClientModule],
+            providers: [
+                { provide: AppConfigService },
+                { provide: StorageService },
+                {
+                    provide: AdfHttpClient,
+                    useValue: adfHttpClientSpy
+                },
+                { provide: StoragePrefixFactory, useValue: storagePrefixFactorySpy }
+            ]
+        });
+
+        appConfigServiceSpy = TestBed.inject(AppConfigService) as jasmine.SpyObj<AppConfigService>;
+        appConfigGetSpy = spyOn(appConfigServiceSpy, 'get');
+        appConfigLoadSpy = spyOn(appConfigServiceSpy, 'load');
+        appConfigLoadSpy.and.callFake((callback: () => void) => {
+            callback();
+        });
+
+        storageServiceSpy = TestBed.inject(StorageService) as jasmine.SpyObj<StorageService>;
+        spyOnProperty(storageServiceSpy, 'prefix', 'get').and.callThrough();
+
+        storagePrefixFactorySpy.getPrefix.and.returnValue({ subscribe: () => {} } as any);
+
+        factoryFunction = loadAppConfig(appConfigServiceSpy, storageServiceSpy, adfHttpClientSpy, storagePrefixFactorySpy);
+    });
+
+    it('should disable CSRF based on app config', () => {
+        appConfigGetSpy.and.callFake((key: string): any => {
+            if (key === AppConfigValues.DISABLECSRF) {
+                return true;
+            }
+        });
+
+        factoryFunction();
+
+        expect(appConfigServiceSpy.get).toHaveBeenCalledWith('disableCSRF', true);
+        expect(adfHttpClientSpy.disableCsrf).toBeTrue();
+    });
+
+    it('should set default security option when auth.withCredentials is defined', () => {
+        appConfigServiceSpy.get.and.callFake((key: string): any => {
+            if (key === AppConfigValues.AUTH_WITH_CREDENTIALS) {
+                return true;
+            }
+        });
+
+        factoryFunction();
+
+        expect(adfHttpClientSpy.setDefaultSecurityOption).toHaveBeenCalledWith({ withCredentials: true });
+    });
+
+    it('should set storage prefix from app config', () => {
+        appConfigServiceSpy.get.and.callFake((key: string, _default): any => {
+            if (key === AppConfigValues.STORAGE_PREFIX) {
+                return 'test-prefix';
+            }
+        });
+
+        factoryFunction();
+
+        expect(appConfigServiceSpy.get).toHaveBeenCalledWith(AppConfigValues.STORAGE_PREFIX, '');
+        expect(storageServiceSpy.prefix).toEqual('test-prefix_');
+    });
+
+    it('should update storage prefix from storagePrefixFactory', fakeAsync(() => {
+        storagePrefixFactorySpy.getPrefix.and.returnValue(of('new-amazing-prefix'));
+
+        factoryFunction();
+        tick();
+
+        expect(storagePrefixFactorySpy.getPrefix).toHaveBeenCalled();
+        expect(storageServiceSpy.prefix).toEqual('new-amazing-prefix_');
+    }));
+
+    it('should call appConfigService.load with the init function', () => {
+        factoryFunction();
+
+        expect(appConfigLoadSpy).toHaveBeenCalledWith(jasmine.any(Function));
+    });
+});

--- a/lib/core/src/lib/app-config/app-config.loader.ts
+++ b/lib/core/src/lib/app-config/app-config.loader.ts
@@ -37,6 +37,11 @@ export function loadAppConfig(
 ) {
     const init = () => {
         adfHttpClient.disableCsrf = appConfigService.get<boolean>(AppConfigValues.DISABLECSRF, true);
+        const withCredentials = appConfigService.get<boolean>(AppConfigValues.AUTH_WITH_CREDENTIALS);
+        if (withCredentials !== undefined && withCredentials !== null) {
+            adfHttpClient.setDefaultSecurityOption({ withCredentials });
+        }
+
         storageService.prefix = appConfigService.get<string>(AppConfigValues.STORAGE_PREFIX, '');
 
         storagePrefixFactory.getPrefix().subscribe((property) => {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/AAE-34959


**What is the new behaviour?**
If the identity provider does't support credentialed requests, it's is possible to set `withCredentials: false` within the `app.config.json`

```javascript
  "auth": {
    "withCredentials": false
  },
``` 

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
