### PR TITLE
[ACS-7706] create tags return promise tag paging instead of tag entry

### DIFF
--- a/docs/content-services/services/tag.service.md
+++ b/docs/content-services/services/tag.service.md
@@ -23,10 +23,10 @@ Manages tags in Content Services.
     -   _nodeId:_ `string`  - Id of node to which tags should be assigned.
     -   _tags:_ `TagBody[]`  - List of tags to create and assign or just assign if they already exist.
     -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`TagPaging`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/TagPaging.md)`|`[`TagEntry`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/TagEntry.md)`>` - Just linked tags to node or single tag if linked only one tag.
--   **createTags**(tags: `TagBody[]`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`TagEntry`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/TagEntry.md)`[]>`<br/>
+-   **createTags**(tags: `TagBody[]`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`TagEntry`](../../../lib/js-api/src/api/content-rest-api/docs/TagsApi.md#TagEntry) `|` [`TagPaging`](../../../lib/js-api/src/api/content-rest-api/docs/TagsApi.md#TagPaging)`>`<br/>
     Creates tags.
     -   _tags:_ `TagBody[]`  - list of tags to create.
-    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`TagEntry`](https://github.com/Alfresco/alfresco-js-api/blob/master/src/alfresco-core-rest-api/docs/TagEntry.md)`[]>` - Created tags.
+    -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`TagEntry`](../../../lib/js-api/src/api/content-rest-api/docs/TagsApi.md#TagEntry) `|` [`TagPaging`](../../../lib/js-api/src/api/content-rest-api/docs/TagsApi.md#TagPaging)`>` - Created tags.
 -   **deleteTag**(tagId: `string`): [`Observable`](http://reactivex.io/documentation/observable.html)`<void>`<br/>
     Deletes a tag with tagId. This will cause the tag to be removed from all nodes. You must have admin rights to delete a tag.
     -   _tagId:_ `string`  - of the tag to be deleted

--- a/lib/content-services/src/lib/tag/services/tag.service.spec.ts
+++ b/lib/content-services/src/lib/tag/services/tag.service.spec.ts
@@ -89,7 +89,7 @@ describe('TagService', () => {
 
         describe('createTags', () => {
             it('should call createTags on tagsApi', () => {
-                spyOn(service.tagsApi, 'createTags').and.returnValue(Promise.resolve([]));
+                spyOn(service.tagsApi, 'createTags').and.returnValue(Promise.resolve({}));
                 const tag1 = new TagBody();
                 tag1.tag = 'Some tag 1';
                 const tag2 = new TagBody();
@@ -101,19 +101,17 @@ describe('TagService', () => {
             });
 
             it('should emit refresh when tags creation is success', async () => {
-                const tags: TagEntry[] = [
-                    {
-                        entry: {
-                            id: 'Some id 1',
-                            tag: 'Some tag 1'
-                        }
+                const tag: TagEntry = {
+                    entry: {
+                        id: 'Some id 1',
+                        tag: 'Some tag 1'
                     }
-                ];
+                };
                 spyOn(service.refresh, 'emit');
-                spyOn(service.tagsApi, 'createTags').and.returnValue(Promise.resolve(tags));
+                spyOn(service.tagsApi, 'createTags').and.returnValue(Promise.resolve(tag));
 
                 await service.createTags([]).toPromise();
-                expect(service.refresh.emit).toHaveBeenCalledWith(tags);
+                expect(service.refresh.emit).toHaveBeenCalledWith(tag);
             });
         });
 

--- a/lib/content-services/src/lib/tag/services/tag.service.ts
+++ b/lib/content-services/src/lib/tag/services/tag.service.ts
@@ -99,7 +99,7 @@ export class TagService {
      * @param tags list of tags to create.
      * @returns Created tags.
      */
-    createTags(tags: TagBody[]): Observable<TagEntry[]> {
+    createTags(tags: TagBody[]): Observable<TagEntry | TagPaging> {
         return from(this.tagsApi.createTags(tags)).pipe(tap((tagEntries) => this.refresh.emit(tagEntries)));
     }
 

--- a/lib/js-api/src/api/content-rest-api/api/tags.api.ts
+++ b/lib/js-api/src/api/content-rest-api/api/tags.api.ts
@@ -209,9 +209,9 @@ export class TagsApi extends BaseApi {
     /**
      * Create specified by **tags** list of tags.
      * @param tags List of tags to create.
-     * @returns Promise<TagEntry[]>
+     * @returns Promise<TagEntry | TagPaging>
      */
-    createTags(tags: TagBody[]): Promise<TagEntry[]> {
+    createTags(tags: TagBody[]): Promise<TagEntry | TagPaging> {
         throwIfNotDefined(tags, 'tags');
 
         return this.post({

--- a/lib/js-api/src/api/content-rest-api/docs/TagsApi.md
+++ b/lib/js-api/src/api/content-rest-api/docs/TagsApi.md
@@ -240,7 +240,7 @@ Create specified by **tags** list of tags.
 |----------|-----------------------|-------------------------|
 | **tags** | [TagBody[]](#TagBody) | List of tags to create. |
 
-**Return type**: [TagEntry[]](#TagEntry)
+**Return type**: [TagEntry](#TagEntry) | [TagPaging](#TagPaging)
 
 **Example**
 

--- a/lib/js-api/test/content-services/tagApi.spec.ts
+++ b/lib/js-api/test/content-services/tagApi.spec.ts
@@ -16,7 +16,7 @@
  */
 
 import assert from 'assert';
-import { AlfrescoApi, TagBody, TagEntry, TagsApi } from '../../src';
+import { AlfrescoApi, TagBody, TagEntry, TagPaging, TagsApi } from '../../src';
 import { EcmAuthMock, TagMock } from '../mockObjects';
 
 describe('Tags', () => {
@@ -105,10 +105,10 @@ describe('Tags', () => {
     describe('createTags', () => {
         it('should return created tags', (done) => {
             tagMock.createTags201Response();
-            tagsApi.createTags([new TagBody(), new TagBody()]).then((tags) => {
-                assert.equal(tags.length, 2);
-                assert.equal(tags[0].entry.tag, 'tag-test-1');
-                assert.equal(tags[1].entry.tag, 'tag-test-2');
+            tagsApi.createTags([new TagBody(), new TagBody()]).then((tags: TagPaging) => {
+                assert.equal(tags.list.entries.length, 2);
+                assert.equal(tags.list.entries[0].entry.tag, 'tag-test-1');
+                assert.equal(tags.list.entries[1].entry.tag, 'tag-test-2');
                 done();
             });
         });

--- a/lib/js-api/test/mockObjects/content-services/tag.mock.ts
+++ b/lib/js-api/test/mockObjects/content-services/tag.mock.ts
@@ -65,7 +65,7 @@ export class TagMock extends BaseMock {
     createTags201Response(): void {
         nock(this.host, { encodedQueryParams: true })
             .post('/alfresco/api/-default-/public/alfresco/versions/1/tags')
-            .reply(201, [this.mockTagEntry(), this.mockTagEntry('tag-test-2', 'd79bdbd0-9f55-45bb-9521-811e15bf48f6')]);
+            .reply(201, this.getPaginatedListOfTags());
     }
 
     get201ResponseForAssigningTagsToNode(body: TagBody[]): void {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/ACS-7706


**What is the new behaviour?**
Returned type for createTags function is correct now. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
