### PR TITLE
AAE-34656 Hide all counters in Workspace which do not provide value

### DIFF
--- a/lib/process-services-cloud/src/lib/process/process-filters/components/process-filters/process-filters-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/process/process-filters/components/process-filters/process-filters-cloud.component.spec.ts
@@ -531,6 +531,19 @@ describe('ProcessFiltersCloudComponent', () => {
             expect(component.updatedFiltersSet.has(filterKeyTest)).toBeFalsy();
         });
 
+        it('should call fetchProcessFilterCounter only if filter.showCounter is true', () => {
+            const filterWithCounter = { ...mockProcessFilters[0], showCounter: true };
+            const filterWithoutCounter = { ...mockProcessFilters[1], showCounter: false };
+            const fetchSpy = spyOn<any>(component, 'fetchProcessFilterCounter').and.returnValue(of(42));
+
+            component.filters = [filterWithCounter, filterWithoutCounter];
+            component.updateFilterCounters();
+
+            expect(fetchSpy).toHaveBeenCalledTimes(1);
+            expect(fetchSpy).toHaveBeenCalledWith(filterWithCounter);
+            expect(fetchSpy).not.toHaveBeenCalledWith(filterWithoutCounter);
+        });
+
         describe('Highlight Selected Filter', () => {
             const allProcessesFilterKey = mockProcessFilters[0].key;
             const runningProcessesFilterKey = mockProcessFilters[1].key;

--- a/lib/process-services-cloud/src/lib/process/process-filters/components/process-filters/process-filters-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/process/process-filters/components/process-filters/process-filters-cloud.component.ts
@@ -278,6 +278,10 @@ export class ProcessFiltersCloudComponent implements OnInit, OnChanges {
      * @param filter filter
      */
     updateFilterCounter(filter: ProcessFilterCloudModel): void {
+        if (!filter?.showCounter) {
+            return;
+        }
+
         this.fetchProcessFilterCounter(filter)
             .pipe(
                 tap((filterCounter) => {

--- a/lib/process-services-cloud/src/lib/process/process-filters/models/process-filter-cloud.model.ts
+++ b/lib/process-services-cloud/src/lib/process/process-filters/models/process-filter-cloud.model.ts
@@ -49,6 +49,7 @@ export class ProcessFilterCloudModel {
     suspendedDateType: DateCloudFilterType;
     completedDate: Date;
     environmentId?: string;
+    showCounter: boolean;
 
     processDefinitionNames: string[] | null;
     processNames: string[] | null;
@@ -74,6 +75,7 @@ export class ProcessFilterCloudModel {
             this.name = obj.name || null;
             this.key = obj.key || null;
             this.environmentId = obj.environmentId;
+            this.showCounter = obj.showCounter || false;
             this.icon = obj.icon || null;
             this.index = obj.index || null;
             this.appName = obj.appName || obj.appName === '' ? obj.appName : null;

--- a/lib/process-services-cloud/src/lib/process/process-filters/services/process-filter-cloud.service.ts
+++ b/lib/process-services-cloud/src/lib/process/process-filters/services/process-filter-cloud.service.ts
@@ -378,7 +378,8 @@ export class ProcessFilterCloudService {
                 appName,
                 sort: 'startDate',
                 status: 'RUNNING',
-                order: 'DESC'
+                order: 'DESC',
+                showCounter: true
             }),
             new ProcessFilterCloudModel({
                 name: 'ADF_CLOUD_PROCESS_FILTERS.COMPLETED_PROCESSES',
@@ -387,7 +388,8 @@ export class ProcessFilterCloudService {
                 appName,
                 sort: 'startDate',
                 status: 'COMPLETED',
-                order: 'DESC'
+                order: 'DESC',
+                showCounter: false
             }),
             new ProcessFilterCloudModel({
                 name: 'ADF_CLOUD_PROCESS_FILTERS.ALL_PROCESSES',
@@ -396,7 +398,8 @@ export class ProcessFilterCloudService {
                 appName,
                 sort: 'startDate',
                 status: '',
-                order: 'DESC'
+                order: 'DESC',
+                showCounter: false
             })
         ];
     }

--- a/lib/process-services-cloud/src/lib/task/task-filters/components/task-filters/task-filters-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/task/task-filters/components/task-filters/task-filters-cloud.component.spec.ts
@@ -32,6 +32,7 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { TaskFilterCloudAdapter } from '../../../../models/filter-cloud-model';
 import { ApolloTestingModule } from 'apollo-angular/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { TaskFilterCloudModel } from '../../models/filter-cloud.model';
 
 describe('TaskFiltersCloudComponent', () => {
     let loader: HarnessLoader;
@@ -563,8 +564,8 @@ describe('TaskFiltersCloudComponent', () => {
         });
 
         it('should call fetchTaskFilterCounter only if filter.showCounter is true', () => {
-            const filterWithCounter = { ...mockProcessFilters[0], showCounter: true };
-            const filterWithoutCounter = { ...mockProcessFilters[1], showCounter: false };
+            const filterWithCounter = new TaskFilterCloudModel({ ...defaultTaskFiltersMock[0], showCounter: true });
+            const filterWithoutCounter = new TaskFilterCloudModel({ ...defaultTaskFiltersMock[1], showCounter: false });
             const fetchSpy = spyOn<any>(component, 'fetchTaskFilterCounter').and.returnValue(of(42));
 
             component.filters = [filterWithCounter, filterWithoutCounter];

--- a/lib/process-services-cloud/src/lib/task/task-filters/components/task-filters/task-filters-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/task/task-filters/components/task-filters/task-filters-cloud.component.spec.ts
@@ -562,6 +562,19 @@ describe('TaskFiltersCloudComponent', () => {
             expect(component.updatedCountersSet.has(fakeFilterKey)).toBe(true);
         });
 
+        it('should call fetchTaskFilterCounter only if filter.showCounter is true', () => {
+            const filterWithCounter = { ...mockProcessFilters[0], showCounter: true };
+            const filterWithoutCounter = { ...mockProcessFilters[1], showCounter: false };
+            const fetchSpy = spyOn<any>(component, 'fetchTaskFilterCounter').and.returnValue(of(42));
+
+            component.filters = [filterWithCounter, filterWithoutCounter];
+            component.updateFilterCounters();
+
+            expect(fetchSpy).toHaveBeenCalledTimes(1);
+            expect(fetchSpy).toHaveBeenCalledWith(filterWithCounter);
+            expect(fetchSpy).not.toHaveBeenCalledWith(filterWithoutCounter);
+        });
+
         describe('Highlight Selected Filter', () => {
             const assignedTasksFilterKey = defaultTaskFiltersMock[1].key;
             const queuedTasksFilterKey = defaultTaskFiltersMock[0].key;


### PR DESCRIPTION
https://hyland.atlassian.net/browse/AAE-34365

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
In workspace we are showing different counters. Currently we are displaying counters for e.g. "Completed Processes" but not for "Completed Tasks".


**What is the new behaviour?**
All counters which do not provide any value are removed. As such:
* Completed Processes
* All Processes



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
