### PR TITLE
AAE-34959 Fix withCredentials can not be set by app.config.json

### DIFF
--- a/lib/content-services/src/lib/api-factories/alfresco-api-v2-loader.service.ts
+++ b/lib/content-services/src/lib/api-factories/alfresco-api-v2-loader.service.ts
@@ -19,6 +19,7 @@ import { AlfrescoApiConfig } from '@alfresco/js-api';
 import { Injectable } from '@angular/core';
 import { AppConfigService, AppConfigValues, StorageService } from '@alfresco/adf-core';
 import { AlfrescoApiService } from '../services/alfresco-api.service';
+import { SecurityOptionsLoaderService } from '../security-options-loader/security-options-loader.service';
 
 /**
  * Create a factory to resolve an api service instance
@@ -37,11 +38,12 @@ export class AlfrescoApiLoaderService {
     constructor(
         private readonly appConfig: AppConfigService,
         private readonly apiService: AlfrescoApiService,
+        private readonly securityOptionsLoaderService: SecurityOptionsLoaderService,
         private storageService: StorageService
     ) {}
 
     async init(): Promise<any> {
-        await this.appConfig.load();
+        await this.appConfig.load(this.securityOptionsLoaderService.load);
         return this.initAngularAlfrescoApi();
     }
 

--- a/lib/content-services/src/lib/content.module.ts
+++ b/lib/content-services/src/lib/content.module.ts
@@ -49,6 +49,7 @@ import { AlfrescoIconComponent } from './alfresco-icon/alfresco-icon.component';
 import { AlfrescoApiService } from './services/alfresco-api.service';
 import { AlfrescoApiNoAuthService } from './api-factories/alfresco-api-no-auth.service';
 import { AlfrescoApiLoaderService, createAlfrescoApiInstance } from './api-factories/alfresco-api-v2-loader.service';
+import { SecurityOptionsLoaderService } from './security-options-loader/security-options-loader.service';
 
 @NgModule({
     imports: [
@@ -132,7 +133,8 @@ export class ContentModule {
                     useFactory: createAlfrescoApiInstance,
                     deps: [AlfrescoApiLoaderService],
                     multi: true
-                }
+                },
+                SecurityOptionsLoaderService
             ]
         };
     }

--- a/lib/content-services/src/lib/security-options-loader/security-options-loader.service.spec.ts
+++ b/lib/content-services/src/lib/security-options-loader/security-options-loader.service.spec.ts
@@ -1,0 +1,73 @@
+/*!
+ * @license
+ * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { SecurityOptionsLoaderService } from './security-options-loader.service';
+import { AppConfigService, AppConfigValues } from '@alfresco/adf-core';
+import { AdfHttpClient } from '@alfresco/adf-core/api';
+
+describe('SecurityOptionsLoaderService', () => {
+    let service: SecurityOptionsLoaderService;
+    let appConfigServiceSpy: jasmine.SpyObj<AppConfigService>;
+    let adfHttpClientSpy: jasmine.SpyObj<AdfHttpClient>;
+
+    beforeEach(() => {
+        appConfigServiceSpy = jasmine.createSpyObj('AppConfigService', ['get']);
+        adfHttpClientSpy = jasmine.createSpyObj('AdfHttpClient', ['setDefaultSecurityOption']);
+
+        service = new SecurityOptionsLoaderService(appConfigServiceSpy, adfHttpClientSpy);
+    });
+
+    it('should set withCredentials when value is true', () => {
+        appConfigServiceSpy.get.and.callFake((key: string): any => {
+            if (key === AppConfigValues.AUTH_WITH_CREDENTIALS) {
+                return true;
+            }
+        });
+
+        service.load();
+
+        expect(adfHttpClientSpy.setDefaultSecurityOption).toHaveBeenCalledWith({ withCredentials: true });
+    });
+
+    it('should set withCredentials when value is false', () => {
+        appConfigServiceSpy.get.and.callFake((key: string): any => {
+            if (key === AppConfigValues.AUTH_WITH_CREDENTIALS) {
+                return false;
+            }
+        });
+
+        service.load();
+
+        expect(adfHttpClientSpy.setDefaultSecurityOption).toHaveBeenCalledWith({ withCredentials: false });
+    });
+
+    it('should not call setDefaultSecurityOption when value is undefined', () => {
+        appConfigServiceSpy.get.and.returnValue(undefined);
+
+        service.load();
+
+        expect(adfHttpClientSpy.setDefaultSecurityOption).not.toHaveBeenCalled();
+    });
+
+    it('should not call setDefaultSecurityOption when value is null', () => {
+        appConfigServiceSpy.get.and.returnValue(null);
+
+        service.load();
+
+        expect(adfHttpClientSpy.setDefaultSecurityOption).not.toHaveBeenCalled();
+    });
+});

--- a/lib/content-services/src/lib/security-options-loader/security-options-loader.service.ts
+++ b/lib/content-services/src/lib/security-options-loader/security-options-loader.service.ts
@@ -1,0 +1,32 @@
+/*!
+ * @license
+ * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AppConfigService, AppConfigValues } from '@alfresco/adf-core';
+import { AdfHttpClient } from '@alfresco/adf-core/api';
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class SecurityOptionsLoaderService {
+    constructor(private appConfigService: AppConfigService, private adfHttpClient: AdfHttpClient) {}
+
+    load = () => {
+        const withCredentials = this.appConfigService.get<boolean>(AppConfigValues.AUTH_WITH_CREDENTIALS);
+        if (withCredentials !== undefined && withCredentials !== null) {
+            this.adfHttpClient.setDefaultSecurityOption({ withCredentials });
+        }
+    };
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**
https://hyland.atlassian.net/browse/AAE-34959


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
