### PR TITLE
[MNT-25043] Skip adding json as content type for FormData body requests

### DIFF
--- a/lib/core/auth/src/authentication-interceptor/authentication.interceptor.ts
+++ b/lib/core/auth/src/authentication-interceptor/authentication.interceptor.ts
@@ -45,7 +45,7 @@ export class AuthenticationInterceptor implements HttpInterceptor {
         if (req.context.get(SHOULD_ADD_AUTH_TOKEN)) {
             return this.authService.addTokenToHeader(req.url, req.headers).pipe(
                 mergeMap((headersWithBearer) => {
-                    const headerWithContentType = this.appendJsonContentType(headersWithBearer);
+                    const headerWithContentType = this.appendJsonContentType(headersWithBearer, req.body);
                     const kcReq = req.clone({ headers: headerWithContentType });
                     return next.handle(kcReq).pipe(catchError((error) => observableThrowError(error)));
                 })
@@ -55,7 +55,7 @@ export class AuthenticationInterceptor implements HttpInterceptor {
         return next.handle(req).pipe(catchError((error) => observableThrowError(error)));
     }
 
-    private appendJsonContentType(headers: HttpHeaders): HttpHeaders {
+    private appendJsonContentType(headers: HttpHeaders, reqBody: any): HttpHeaders {
         // prevent adding any content type, to properly handle formData with boundary browser generated value,
         // as adding any Content-Type its going to break the upload functionality
 
@@ -63,7 +63,7 @@ export class AuthenticationInterceptor implements HttpInterceptor {
             return headers.delete('Content-Type');
         }
 
-        if (!headers.get('Content-Type')) {
+        if (!headers.get('Content-Type') && !(reqBody instanceof FormData)) {
             return headers.set('Content-Type', 'application/json;charset=UTF-8');
         }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://hyland.atlassian.net/browse/MNT-25043

**What is the new behaviour?**

When request with FormData as body is intercepted we should not set json as content type.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
