### PR TITLE
AAE-35728 Add aria-label to viewer loading bars

### DIFF
--- a/lib/core/src/lib/i18n/en.json
+++ b/lib/core/src/lib/i18n/en.json
@@ -452,7 +452,8 @@
       "CANCEL": "Cancel",
       "RESET": "Reset",
       "THUMBNAILS": "Document thumbnails",
-      "THUMBNAILS_PANLEL_CLOSE": "Close thumbnails panel"
+      "THUMBNAILS_PANLEL_CLOSE": "Close thumbnails panel",
+      "LOADING": "Document is loading"
     },
     "PAGE_LABEL": {
       "SHOWING": "Showing",

--- a/lib/core/src/lib/viewer/components/pdf-viewer/pdf-viewer.component.html
+++ b/lib/core/src/lib/viewer/components/pdf-viewer/pdf-viewer.component.html
@@ -33,7 +33,8 @@
                  aria-expanded="true">
                 <div id="loader-container" class="adf-loader-container">
                     <div class="adf-loader-item">
-                        <mat-progress-bar class="adf-loader-item-progress-bar" mode="indeterminate" />
+                        <mat-progress-bar [attr.aria-label]="'ADF_VIEWER.ARIA.LOADING' | translate"
+                                          class="adf-loader-item-progress-bar" mode="indeterminate" />
                     </div>
                 </div>
             </div>

--- a/lib/core/src/lib/viewer/components/viewer-render/viewer-render.component.html
+++ b/lib/core/src/lib/viewer/components/viewer-render/viewer-render.component.html
@@ -2,9 +2,10 @@
     <div class="adf-viewer-render-layout-content adf-viewer__fullscreen-container">
         <div class="adf-viewer-render-content-container">
             <div class="adf-viewer-render__loading-screen">
-                <h2>{{ 'ADF_VIEWER.LOADING' | translate }}</h2>
+                <h2 id="loading-spinner-label">{{ 'ADF_VIEWER.LOADING' | translate }}</h2>
                 <div>
-                    <mat-spinner class="adf-viewer-render__loading-screen__spinner" />
+                    <mat-spinner attr.aria-labelledby="loading-spinner-label"
+                                 class="adf-viewer-render__loading-screen__spinner" />
                 </div>
             </div>
         </div>
@@ -103,5 +104,7 @@
     </div>
 }
 <ng-container *ngIf="viewerTemplateExtensions">
-    <ng-template [ngTemplateOutlet]="viewerTemplateExtensions" [ngTemplateOutletContext]="{ urlFile: urlFile, extension: extension, markAsLoaded: markAsLoaded.bind(this) }" [ngTemplateOutletInjector]="injector" />
+    <ng-template [ngTemplateOutlet]="viewerTemplateExtensions"
+                 [ngTemplateOutletContext]="{ urlFile: urlFile, extension: extension, markAsLoaded: markAsLoaded.bind(this) }"
+                 [ngTemplateOutletInjector]="injector" />
 </ng-container>


### PR DESCRIPTION
Improves accessibility by adding screen reader support to loading indicators.

This ensures that users with disabilities are informed when the document is loading, improving the overall user experience.

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/AAE-35728


**What is the new behaviour?**
Aria-label attribute is added to progress bar and spinner


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
