### PR TITLE
Viewer renderer stop loading when subsequent renderer throws error

### DIFF
--- a/lib/core/src/lib/viewer/components/viewer-render/viewer-render.component.spec.ts
+++ b/lib/core/src/lib/viewer/components/viewer-render/viewer-render.component.spec.ts
@@ -537,5 +537,17 @@ describe('ViewerComponent', () => {
             expect(component.viewerType).toBe('image');
             expect(component.markAsLoaded).toHaveBeenCalled();
         });
+
+        it('should not show spinner and set viewerType to unknow if subsequent renderer throws an error', () => {
+            component.urlFile = 'some-url.png';
+            component.ngOnChanges();
+            fixture.detectChanges();
+            expect(getMainLoader()).not.toBeNull();
+
+            component.onUnsupportedFile();
+            fixture.detectChanges();
+            expect(getMainLoader()).toBeNull();
+            expect(component.viewerType).toBe('unknown');
+        });
     });
 });

--- a/lib/core/src/lib/viewer/components/viewer-render/viewer-render.component.ts
+++ b/lib/core/src/lib/viewer/components/viewer-render/viewer-render.component.ts
@@ -235,6 +235,7 @@ export class ViewerRenderComponent implements OnChanges, OnInit {
 
     onUnsupportedFile() {
         this.viewerType = 'unknown';
+        this.isLoading = false;
     }
 
     onClose() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

When subsequent renderer throws an error loading continues.

**What is the new behaviour?**

Error stops loading.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
