### PR TITLE
[MNT-24459] Aspect list get all aspects when not all were fetched by first call

### DIFF
--- a/lib/content-services/src/lib/aspect-list/aspect-list-dialog.component.spec.ts
+++ b/lib/content-services/src/lib/aspect-list/aspect-list-dialog.component.spec.ts
@@ -132,7 +132,7 @@ describe('AspectListDialogComponent', () => {
     describe('Without passing node id', () => {
         beforeEach(() => {
             aspectListService = TestBed.inject(AspectListService);
-            spyOn(aspectListService, 'getAspects').and.returnValue(
+            spyOn(aspectListService, 'getAllAspects').and.returnValue(
                 of({ standardAspectPaging: { list: { entries: aspectListMock } }, customAspectPaging: { list: { entries: customAspectListMock } } })
             );
             fixture.detectChanges();
@@ -249,11 +249,11 @@ describe('AspectListDialogComponent', () => {
             data.nodeId = 'fake-node-id';
             aspectListService = TestBed.inject(AspectListService);
             nodeService = TestBed.inject(NodesApiService);
-            spyOn(aspectListService, 'getAspects').and.returnValue(
+            spyOn(aspectListService, 'getAllAspects').and.returnValue(
                 of({ standardAspectPaging: { list: { entries: aspectListMock } }, customAspectPaging: { list: { entries: customAspectListMock } } })
             );
             spyOn(aspectListService, 'getVisibleAspects').and.returnValue(['frs:AspectOne']);
-            spyOn(aspectListService, 'getCustomAspects').and.returnValue(of({ list: { entries: customAspectListMock } }));
+            spyOn(aspectListService, 'getAspects').and.returnValue(of({ list: { entries: customAspectListMock } }));
             spyOn(nodeService, 'getNode').and.returnValue(
                 of(new Node({ id: 'fake-node-id', aspectNames: ['frs:AspectOne', 'cst:customAspect'] })).pipe(delay(0))
             );

--- a/lib/content-services/src/lib/aspect-list/aspect-list-dialog.component.spec.ts
+++ b/lib/content-services/src/lib/aspect-list/aspect-list-dialog.component.spec.ts
@@ -132,7 +132,9 @@ describe('AspectListDialogComponent', () => {
     describe('Without passing node id', () => {
         beforeEach(() => {
             aspectListService = TestBed.inject(AspectListService);
-            spyOn(aspectListService, 'getAspects').and.returnValue(of(aspectListMock));
+            spyOn(aspectListService, 'getAspects').and.returnValue(
+                of({ standardAspectPaging: { list: { entries: aspectListMock } }, customAspectPaging: { list: { entries: customAspectListMock } } })
+            );
             fixture.detectChanges();
         });
 
@@ -247,9 +249,11 @@ describe('AspectListDialogComponent', () => {
             data.nodeId = 'fake-node-id';
             aspectListService = TestBed.inject(AspectListService);
             nodeService = TestBed.inject(NodesApiService);
-            spyOn(aspectListService, 'getAspects').and.returnValue(of([...aspectListMock, ...customAspectListMock]));
+            spyOn(aspectListService, 'getAspects').and.returnValue(
+                of({ standardAspectPaging: { list: { entries: aspectListMock } }, customAspectPaging: { list: { entries: customAspectListMock } } })
+            );
             spyOn(aspectListService, 'getVisibleAspects').and.returnValue(['frs:AspectOne']);
-            spyOn(aspectListService, 'getCustomAspects').and.returnValue(of(customAspectListMock));
+            spyOn(aspectListService, 'getCustomAspects').and.returnValue(of({ list: { entries: customAspectListMock } }));
             spyOn(nodeService, 'getNode').and.returnValue(
                 of(new Node({ id: 'fake-node-id', aspectNames: ['frs:AspectOne', 'cst:customAspect'] })).pipe(delay(0))
             );

--- a/lib/content-services/src/lib/aspect-list/aspect-list.component.ts
+++ b/lib/content-services/src/lib/aspect-list/aspect-list.component.ts
@@ -162,27 +162,27 @@ export class AspectListComponent implements OnInit {
         const standardAspectOpts: ListAspectsOpts = {
             where: StandardAspectsWhere,
             include: ['properties'],
-            skipCount: standardAspectsPagination?.skipCount || 0,
+            skipCount: standardAspectsPagination?.skipCount ?? 0,
             maxItems: 100
         };
         const customAspectOpts: ListAspectsOpts = {
             where: CustomAspectsWhere,
             include: ['properties'],
-            skipCount: customAspectsPagination?.skipCount || 0,
+            skipCount: customAspectsPagination?.skipCount ?? 0,
             maxItems: 100
         };
         return this.aspectListService.getAllAspects(standardAspectOpts, customAspectOpts).pipe(
             take(1),
             tap((aspectsPaging) => {
-                this.customAspectsLoaded += aspectsPaging.customAspectPaging?.list?.pagination?.count || 0;
-                this.standardAspectsLoaded += aspectsPaging.standardAspectPaging?.list?.pagination?.count || 0;
+                this.customAspectsLoaded += aspectsPaging.customAspectPaging?.list?.pagination?.count ?? 0;
+                this.standardAspectsLoaded += aspectsPaging.standardAspectPaging?.list?.pagination?.count ?? 0;
                 this.hasMoreAspects =
                     aspectsPaging.customAspectPaging?.list?.pagination?.hasMoreItems ||
                     aspectsPaging.standardAspectPaging?.list?.pagination?.hasMoreItems;
             }),
             map((aspectsPaging) => [
-                ...(aspectsPaging.standardAspectPaging?.list?.entries || []),
-                ...(aspectsPaging.customAspectPaging?.list?.entries || [])
+                ...(aspectsPaging.standardAspectPaging?.list?.entries ?? []),
+                ...(aspectsPaging.customAspectPaging?.list?.entries ?? [])
             ])
         );
     }

--- a/lib/content-services/src/lib/aspect-list/aspect-list.component.ts
+++ b/lib/content-services/src/lib/aspect-list/aspect-list.component.ts
@@ -17,11 +17,11 @@
 
 import { Component, DestroyRef, EventEmitter, inject, Input, OnInit, Output, ViewEncapsulation } from '@angular/core';
 import { NodesApiService } from '../common/services/nodes-api.service';
-import { Observable, zip } from 'rxjs';
-import { concatMap, map, tap } from 'rxjs/operators';
+import { EMPTY, Observable, zip } from 'rxjs';
+import { concatMap, expand, map, reduce, take, tap } from 'rxjs/operators';
 import { AspectListService } from './services/aspect-list.service';
 import { MatCheckboxChange, MatCheckboxModule } from '@angular/material/checkbox';
-import { AspectEntry } from '@alfresco/js-api';
+import { AspectEntry, ContentPagingQuery } from '@alfresco/js-api';
 import { CommonModule } from '@angular/common';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatTableModule } from '@angular/material/table';
@@ -63,6 +63,9 @@ export class AspectListComponent implements OnInit {
     isPanelOpen: boolean[] = [];
 
     private readonly destroyRef = inject(DestroyRef);
+    private customAspectsLoaded = 0;
+    private standardAspectsLoaded = 0;
+    private hasMoreAspects = false;
 
     constructor(private aspectListService: AspectListService, private nodeApiService: NodesApiService) {}
 
@@ -72,7 +75,7 @@ export class AspectListComponent implements OnInit {
             const node$ = this.nodeApiService.getNode(this.nodeId);
             const customAspect$ = this.aspectListService
                 .getCustomAspects(this.aspectListService.getVisibleAspects())
-                .pipe(map((customAspects) => customAspects.flatMap((customAspect) => customAspect.entry.id)));
+                .pipe(map((customAspects) => customAspects?.list?.entries.flatMap((customAspect) => customAspect.entry.id)));
             aspects$ = zip(node$, customAspect$).pipe(
                 tap(([node, customAspects]) => {
                     this.nodeAspects = node.aspectNames.filter(
@@ -85,13 +88,19 @@ export class AspectListComponent implements OnInit {
                     this.valueChanged.emit([...this.nodeAspects, ...this.notDisplayedAspects]);
                     this.updateCounter.emit(this.nodeAspects.length);
                 }),
-                concatMap(() => this.aspectListService.getAspects()),
+                concatMap(() => this.loadAspects({ skipCount: this.standardAspectsLoaded }, { skipCount: this.customAspectsLoaded })),
                 takeUntilDestroyed(this.destroyRef)
             );
         } else {
-            aspects$ = this.aspectListService.getAspects().pipe(takeUntilDestroyed(this.destroyRef));
+            aspects$ = this.loadAspects({ skipCount: this.standardAspectsLoaded }, { skipCount: this.customAspectsLoaded });
         }
-        this.aspects$ = aspects$.pipe(map((aspects) => aspects.filter((aspect) => !this.excludedAspects.includes(aspect.entry.id))));
+        this.aspects$ = aspects$.pipe(
+            expand(() =>
+                this.hasMoreAspects ? this.loadAspects({ skipCount: this.standardAspectsLoaded }, { skipCount: this.customAspectsLoaded }) : EMPTY
+            ),
+            map((aspects) => aspects.filter((aspect) => !this.excludedAspects.includes(aspect.entry.id))),
+            reduce((acc, aspects) => [...acc, ...aspects])
+        );
     }
 
     onCheckBoxClick(event: Event) {
@@ -141,5 +150,22 @@ export class AspectListComponent implements OnInit {
         } else {
             this.hasEqualAspect = this.nodeAspects.every((aspect) => this.nodeAspectStatus.includes(aspect));
         }
+    }
+
+    private loadAspects(standardAspectsPagination?: ContentPagingQuery, customAspectsPagination?: ContentPagingQuery): Observable<AspectEntry[]> {
+        return this.aspectListService.getAspects(standardAspectsPagination, customAspectsPagination).pipe(
+            take(1),
+            tap((aspectsPaging) => {
+                this.customAspectsLoaded += aspectsPaging.customAspectPaging?.list?.pagination?.count || 0;
+                this.standardAspectsLoaded += aspectsPaging.standardAspectPaging?.list?.pagination?.count || 0;
+                this.hasMoreAspects =
+                    aspectsPaging.customAspectPaging?.list?.pagination?.hasMoreItems ||
+                    aspectsPaging.standardAspectPaging?.list?.pagination?.hasMoreItems;
+            }),
+            map((aspectsPaging) => [
+                ...(aspectsPaging.standardAspectPaging?.list?.entries || []),
+                ...(aspectsPaging.customAspectPaging?.list?.entries || [])
+            ])
+        );
     }
 }

--- a/lib/content-services/src/lib/aspect-list/interfaces/custom-aspect-paging.interface.ts
+++ b/lib/content-services/src/lib/aspect-list/interfaces/custom-aspect-paging.interface.ts
@@ -1,0 +1,23 @@
+/*!
+ * @license
+ * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AspectPaging } from '@alfresco/js-api';
+
+export interface CustomAspectPaging {
+    standardAspectPaging: AspectPaging;
+    customAspectPaging: AspectPaging;
+}

--- a/lib/content-services/src/lib/aspect-list/public-api.ts
+++ b/lib/content-services/src/lib/aspect-list/public-api.ts
@@ -22,5 +22,6 @@ export * from './services/node-aspect.service';
 export * from './services/dialog-aspect-list.service';
 
 export * from './aspect-list-dialog-data.interface';
+export * from './interfaces/custom-aspect-paging.interface';
 
 export * from './aspect-list.module';

--- a/lib/content-services/src/lib/aspect-list/services/aspect-list.service.spec.ts
+++ b/lib/content-services/src/lib/aspect-list/services/aspect-list.service.spec.ts
@@ -18,18 +18,23 @@
 import { TestBed } from '@angular/core/testing';
 import { AspectListService } from './aspect-list.service';
 import { AspectPaging, AspectsApi, AspectEntry } from '@alfresco/js-api';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { AlfrescoApiService } from '../../services';
+import { provideHttpClient } from '@angular/common/http';
 
 const stdAspect1: AspectEntry = { entry: { id: 'std:standardAspectOne', description: 'Standard Aspect One', title: 'StandardAspectOne' } };
 const stdAspect2: AspectEntry = { entry: { id: 'std:standardAspectTwo', description: 'Standard Aspect Two', title: 'StandardAspectTwo' } };
 const stdAspect3: AspectEntry = { entry: { id: 'std:standardAspectThree', description: 'Standard Aspect Three', title: 'StandardAspectThree' } };
-const standardAspectPagingMock: AspectPaging = { list: { entries: [stdAspect1, stdAspect2, stdAspect3] } };
 
 const cstAspect1: AspectEntry = { entry: { id: 'cst:customAspectOne', description: 'Custom Aspect One', title: 'CustomAspectOne' } };
 const cstAspect2: AspectEntry = { entry: { id: 'cst:customAspectTwo', description: 'Custom Aspect Two', title: 'CustomAspectTwo' } };
 const cstAspect3: AspectEntry = { entry: { id: 'cst:customAspectThree', description: 'Custom Aspect Three', title: 'CustomAspectThree' } };
-const customAspectPagingMock: AspectPaging = { list: { entries: [cstAspect1, cstAspect2, cstAspect3] } };
+
+const standardAspectsWhere = `(modelId in ('cm:contentmodel', 'emailserver:emailserverModel', 'smf:smartFolder', 'app:applicationmodel' ))`;
+const customAspectsWhere = `(not namespaceUri matches('http://www.alfresco.*'))`;
+
+let standardAspectPagingMock: AspectPaging;
+let customAspectPagingMock: AspectPaging;
 
 describe('AspectListService', () => {
     let aspectListService: AspectListService;
@@ -38,74 +43,155 @@ describe('AspectListService', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [HttpClientTestingModule]
+            providers: [provideHttpClient(), provideHttpClientTesting()]
         });
 
         aspectListService = TestBed.inject(AspectListService);
         apiService = TestBed.inject(AlfrescoApiService);
         aspectsApi = new AspectsApi(apiService.getInstance());
         spyOnProperty(aspectListService, 'aspectsApi', 'get').and.returnValue(aspectsApi);
+        standardAspectPagingMock = { list: { entries: [stdAspect1, stdAspect2, stdAspect3] } };
+        customAspectPagingMock = { list: { entries: [cstAspect1, cstAspect2, cstAspect3] } };
     });
 
-    it('should get one standard aspect', (done) => {
-        const visibleAspects = ['std:standardAspectOne'];
-        spyOn(aspectsApi, 'listAspects').and.returnValue(Promise.resolve(standardAspectPagingMock));
-        aspectListService.getStandardAspects(visibleAspects).subscribe((response) => {
-            expect(response).toEqual([stdAspect1]);
-            done();
-        });
-    });
-
-    it('should get two standard aspects', (done) => {
-        const visibleAspects = ['std:standardAspectTwo', 'std:standardAspectThree'];
-        spyOn(aspectsApi, 'listAspects').and.returnValue(Promise.resolve(standardAspectPagingMock));
-        aspectListService.getStandardAspects(visibleAspects).subscribe((response) => {
-            expect(response).toEqual([stdAspect2, stdAspect3]);
-            done();
-        });
-    });
-
-    it('should get one custom aspect', (done) => {
-        const visibleAspects = ['cst:customAspectTwo'];
-        spyOn(aspectsApi, 'listAspects').and.returnValue(Promise.resolve(customAspectPagingMock));
-        aspectListService.getCustomAspects(visibleAspects).subscribe((response) => {
-            expect(response).toEqual([cstAspect2]);
-            done();
-        });
-    });
-
-    it('should get two custom aspects', (done) => {
-        const visibleAspects = ['cst:customAspectOne', 'cst:customAspectThree'];
-        spyOn(aspectsApi, 'listAspects').and.returnValue(Promise.resolve(customAspectPagingMock));
-        aspectListService.getCustomAspects(visibleAspects).subscribe((response) => {
-            expect(response).toEqual([cstAspect1, cstAspect3]);
-            done();
-        });
-    });
-
-    it('should get all custom aspects (visible aspects as undefined)', (done) => {
-        const visibleAspects = undefined;
-        spyOn(aspectsApi, 'listAspects').and.returnValue(Promise.resolve(customAspectPagingMock));
-        aspectListService.getCustomAspects(visibleAspects).subscribe((response) => {
-            expect(response).toEqual([cstAspect1, cstAspect2, cstAspect3]);
-            done();
-        });
-    });
-
-    it('should get all custom aspects (visible aspects as empty array)', (done) => {
+    describe('When API returns error', () => {
         const visibleAspects = [];
-        spyOn(aspectsApi, 'listAspects').and.returnValue(Promise.resolve(customAspectPagingMock));
-        aspectListService.getCustomAspects(visibleAspects).subscribe((response) => {
-            expect(response).toEqual([cstAspect1, cstAspect2, cstAspect3]);
-            done();
+
+        beforeEach(() => {
+            spyOn(aspectsApi, 'listAspects').and.returnValue(Promise.reject(new Error('API error')));
+        });
+
+        it('should return empty paging list for standard aspects when api returns error', (done) => {
+            aspectListService.getStandardAspects(visibleAspects).subscribe((response) => {
+                expect(response.list.entries).toEqual([]);
+                done();
+            });
+        });
+
+        it('should return empty paging list for custom aspects when api returns error', (done) => {
+            aspectListService.getCustomAspects(visibleAspects).subscribe((response) => {
+                expect(response.list.entries).toEqual([]);
+                done();
+            });
         });
     });
 
-    it('should get all custom aspects (visible aspects not supplied)', (done) => {
-        spyOn(aspectsApi, 'listAspects').and.returnValue(Promise.resolve(customAspectPagingMock));
-        aspectListService.getCustomAspects().subscribe((response) => {
-            expect(response).toEqual([cstAspect1, cstAspect2, cstAspect3]);
-            done();
+    describe('Standard aspects', () => {
+        beforeEach(() => {
+            spyOn(aspectsApi, 'listAspects').and.returnValue(Promise.resolve(standardAspectPagingMock));
+        });
+
+        it('should add default pagination for standard aspects list request', (done) => {
+            const visibleAspects = [];
+            aspectListService.getStandardAspects(visibleAspects).subscribe(() => {
+                expect(aspectsApi.listAspects).toHaveBeenCalledWith({
+                    where: standardAspectsWhere,
+                    include: ['properties'],
+                    skipCount: 0,
+                    maxItems: 100
+                });
+                done();
+            });
+        });
+
+        it('should add custom pagination for standard aspects list request when provided', (done) => {
+            const visibleAspects = [];
+            aspectListService.getStandardAspects(visibleAspects, { skipCount: 10, maxItems: 20 }).subscribe(() => {
+                expect(aspectsApi.listAspects).toHaveBeenCalledWith({
+                    where: standardAspectsWhere,
+                    include: ['properties'],
+                    skipCount: 10,
+                    maxItems: 20
+                });
+                done();
+            });
+        });
+
+        it('should get one standard aspect', (done) => {
+            const visibleAspects = ['std:standardAspectOne'];
+            aspectListService.getStandardAspects(visibleAspects).subscribe((response) => {
+                expect(response.list.entries).toEqual([stdAspect1]);
+                done();
+            });
+        });
+
+        it('should get two standard aspects', (done) => {
+            const visibleAspects = ['std:standardAspectTwo', 'std:standardAspectThree'];
+            aspectListService.getStandardAspects(visibleAspects).subscribe((response) => {
+                expect(response.list.entries).toEqual([stdAspect2, stdAspect3]);
+                done();
+            });
+        });
+    });
+
+    describe('Custom aspects', () => {
+        beforeEach(() => {
+            spyOn(aspectsApi, 'listAspects').and.returnValue(Promise.resolve(customAspectPagingMock));
+        });
+
+        it('should add default pagination for custom aspects list request', (done) => {
+            const visibleAspects = [];
+            aspectListService.getCustomAspects(visibleAspects).subscribe(() => {
+                expect(aspectsApi.listAspects).toHaveBeenCalledWith({
+                    where: customAspectsWhere,
+                    include: ['properties'],
+                    skipCount: 0,
+                    maxItems: 100
+                });
+                done();
+            });
+        });
+
+        it('should add custom pagination for custom aspects list request when provided', (done) => {
+            const visibleAspects = [];
+            aspectListService.getCustomAspects(visibleAspects, { skipCount: 15, maxItems: 30 }).subscribe(() => {
+                expect(aspectsApi.listAspects).toHaveBeenCalledWith({
+                    where: customAspectsWhere,
+                    include: ['properties'],
+                    skipCount: 15,
+                    maxItems: 30
+                });
+                done();
+            });
+        });
+
+        it('should get one custom aspect', (done) => {
+            const visibleAspects = ['cst:customAspectTwo'];
+            aspectListService.getCustomAspects(visibleAspects).subscribe((response) => {
+                expect(response.list.entries).toEqual([cstAspect2]);
+                done();
+            });
+        });
+
+        it('should get two custom aspects', (done) => {
+            const visibleAspects = ['cst:customAspectOne', 'cst:customAspectThree'];
+            aspectListService.getCustomAspects(visibleAspects).subscribe((response) => {
+                expect(response.list.entries).toEqual([cstAspect1, cstAspect3]);
+                done();
+            });
+        });
+
+        it('should get all custom aspects (visible aspects as undefined)', (done) => {
+            const visibleAspects = undefined;
+            aspectListService.getCustomAspects(visibleAspects).subscribe((response) => {
+                expect(response.list.entries).toEqual([cstAspect1, cstAspect2, cstAspect3]);
+                done();
+            });
+        });
+
+        it('should get all custom aspects (visible aspects as empty array)', (done) => {
+            const visibleAspects = [];
+            aspectListService.getCustomAspects(visibleAspects).subscribe((response) => {
+                expect(response.list.entries).toEqual([cstAspect1, cstAspect2, cstAspect3]);
+                done();
+            });
+        });
+
+        it('should get all custom aspects (visible aspects not supplied)', (done) => {
+            aspectListService.getCustomAspects().subscribe((response) => {
+                expect(response.list.entries).toEqual([cstAspect1, cstAspect2, cstAspect3]);
+                done();
+            });
         });
     });
 });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://hyland.atlassian.net/browse/MNT-24459

**What is the new behaviour?**

Now when there are still more aspects to be loaded, they will be fetched until all are loaded as user should have the access to all visible aspects.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
