### PR TITLE
[ACS-9327] Add prohibited symbols validation for Categories dialog

### DIFF
--- a/lib/content-services/src/lib/category/categories-management/categories-management.component.html
+++ b/lib/content-services/src/lib/category/categories-management/categories-management.component.html
@@ -6,7 +6,7 @@
             placeholder="{{'CATEGORIES_MANAGEMENT.CATEGORIES_SEARCH_PLACEHOLDER' | translate }}"
             adf-auto-focus
             />
-        <mat-error *ngIf="categoryNameControl.invalid">{{ categoryNameErrorMessageKey | translate }}</mat-error>
+        <mat-error *ngIf="categoryNameControl.invalid && categoryNameControl.touched">{{ categoryNameErrorMessageKey | translate }}</mat-error>
     </div>
     <div class="adf-categories-list" *ngIf="categories?.length > 0" [class.adf-categories-list-fixed]="!categoryNameControlVisible">
         <span

--- a/lib/content-services/src/lib/category/categories-management/categories-management.component.spec.ts
+++ b/lib/content-services/src/lib/category/categories-management/categories-management.component.spec.ts
@@ -531,7 +531,7 @@ describe('CategoriesManagementComponent', () => {
                 component.categoryNameControl.markAsTouched();
                 fixture.detectChanges();
 
-                expect(getFirstError()).toBe('CATEGORIES_MANAGEMENT.ERRORS.SPECIAL_CHARACTERS');
+                expect(getFirstError()).toBe('CATEGORIES_MANAGEMENT.ERRORS.ENDS_WITH_DOT');
             }));
 
             it('should not display validation error when dot used in positions other than the end', fakeAsync(() => {

--- a/lib/content-services/src/lib/category/categories-management/categories-management.component.spec.ts
+++ b/lib/content-services/src/lib/category/categories-management/categories-management.component.spec.ts
@@ -525,6 +525,22 @@ describe('CategoriesManagementComponent', () => {
 
                 expect(getFirstError()).toBe('CATEGORIES_MANAGEMENT.ERRORS.SPECIAL_CHARACTERS');
             }));
+
+            it('should display validation error when dot placed in the end', fakeAsync(() => {
+                typeCategory('category.');
+                component.categoryNameControl.markAsTouched();
+                fixture.detectChanges();
+
+                expect(getFirstError()).toBe('CATEGORIES_MANAGEMENT.ERRORS.SPECIAL_CHARACTERS');
+            }));
+
+            it('should not display validation error when dot used in positions other than the end', fakeAsync(() => {
+                typeCategory('.category.name');
+                component.categoryNameControl.markAsTouched();
+                fixture.detectChanges();
+
+                expect(component.categoryNameControl.valid).toBeTrue();
+            }));
         });
     });
 });

--- a/lib/content-services/src/lib/category/categories-management/categories-management.component.spec.ts
+++ b/lib/content-services/src/lib/category/categories-management/categories-management.component.spec.ts
@@ -303,12 +303,6 @@ describe('CategoriesManagementComponent', () => {
             expect(component.categoryNameControl.hasValidator(Validators.required)).toBeFalse();
         });
 
-        it('should display validation error when searching for empty category', fakeAsync(() => {
-            typeCategory('   ');
-
-            expect(getFirstError()).toBe('CATEGORIES_MANAGEMENT.ERRORS.EMPTY_CATEGORY');
-        }));
-
         it('should clear categories and hide category control when classifiable aspect is removed', () => {
             const controlVisibilityChangeSpy = spyOn(component.categoryNameControlVisibleChange, 'emit').and.callThrough();
             classifiableChangedSubject.next();
@@ -522,6 +516,14 @@ describe('CategoriesManagementComponent', () => {
                 typeCategory('   ');
 
                 expect(getCreateCategoryLabel().hidden).toBeTrue();
+            }));
+
+            it('should display validation error when prohibited symbol entered', fakeAsync(() => {
+                typeCategory('category:name');
+                component.categoryNameControl.markAsTouched();
+                fixture.detectChanges();
+
+                expect(getFirstError()).toBe('CATEGORIES_MANAGEMENT.ERRORS.SPECIAL_CHARACTERS');
             }));
         });
     });

--- a/lib/content-services/src/lib/category/categories-management/categories-management.component.ts
+++ b/lib/content-services/src/lib/category/categories-management/categories-management.component.ts
@@ -82,7 +82,13 @@ export class CategoriesManagementComponent implements OnInit, OnDestroy {
     private cancelExistingCategoriesLoading$ = new Subject<void>();
     private _categoryNameControl = new FormControl<string>(
         '',
-        [this.validateIfNotAlreadyAdded.bind(this), this.validateEmptyCategory, this.validateSpecialCharacters, Validators.required],
+        [
+            this.validateIfNotAlreadyAdded.bind(this),
+            this.validateEmptyCategory,
+            this.validateSpecialCharacters,
+            this.validateEndsWithDot,
+            Validators.required
+        ],
         this.validateIfNotAlreadyCreated.bind(this)
     );
     private _existingCategories: Category[];
@@ -363,6 +369,11 @@ export class CategoriesManagementComponent implements OnInit, OnDestroy {
     private validateSpecialCharacters(categoryNameControl: FormControl<string>): CategoryNameControlErrors | null {
         const specialSymbolsRegex = /[:"\\|<>/?*]/;
         return categoryNameControl.value.length && specialSymbolsRegex.test(categoryNameControl.value) ? { specialCharacters: true } : null;
+    }
+
+    private validateEndsWithDot(categoryNameControl: FormControl<string>): CategoryNameControlErrors | null {
+        const endsWithDotRegex = /\.$/;
+        return categoryNameControl.value.length && endsWithDotRegex.test(categoryNameControl.value.trim()) ? { specialCharacters: true } : null;
     }
 
     private setCategoryNameControlErrorMessageKey() {

--- a/lib/content-services/src/lib/category/categories-management/categories-management.component.ts
+++ b/lib/content-services/src/lib/category/categories-management/categories-management.component.ts
@@ -372,7 +372,7 @@ export class CategoriesManagementComponent implements OnInit, OnDestroy {
     }
 
     private validateEndsWithDot(categoryNameControl: FormControl<string>): CategoryNameControlErrors | null {
-        return categoryNameControl.value.length && categoryNameControl.value.trim().endsWith('.') ? { specialCharacters: true } : null;
+        return categoryNameControl.value.trim().endsWith('.') ? { specialCharacters: true } : null;
     }
 
     private setCategoryNameControlErrorMessageKey() {

--- a/lib/content-services/src/lib/category/categories-management/categories-management.component.ts
+++ b/lib/content-services/src/lib/category/categories-management/categories-management.component.ts
@@ -49,6 +49,7 @@ interface CategoryNameControlErrors {
     duplicatedCategory?: boolean;
     emptyCategory?: boolean;
     required?: boolean;
+    specialCharacters?: boolean;
 }
 
 @Component({
@@ -73,14 +74,15 @@ export class CategoriesManagementComponent implements OnInit, OnDestroy {
         ['duplicatedExistingCategory', 'ALREADY_EXISTS'],
         ['duplicatedCategory', 'DUPLICATED_CATEGORY'],
         ['emptyCategory', 'EMPTY_CATEGORY'],
-        ['required', 'REQUIRED']
+        ['required', 'REQUIRED'],
+        ['specialCharacters', 'SPECIAL_CHARACTERS']
     ]);
 
     private existingCategoryLoaded$ = new Subject<void>();
     private cancelExistingCategoriesLoading$ = new Subject<void>();
     private _categoryNameControl = new FormControl<string>(
         '',
-        [this.validateIfNotAlreadyAdded.bind(this), this.validateEmptyCategory, Validators.required],
+        [this.validateIfNotAlreadyAdded.bind(this), this.validateEmptyCategory, this.validateSpecialCharacters, Validators.required],
         this.validateIfNotAlreadyCreated.bind(this)
     );
     private _existingCategories: Category[];
@@ -356,6 +358,11 @@ export class CategoriesManagementComponent implements OnInit, OnDestroy {
 
     private validateEmptyCategory(categoryNameControl: FormControl<string>): CategoryNameControlErrors | null {
         return categoryNameControl.value.length && !categoryNameControl.value.trim() ? { emptyCategory: true } : null;
+    }
+
+    private validateSpecialCharacters(categoryNameControl: FormControl<string>): CategoryNameControlErrors | null {
+        const specialSymbolsRegex = /[:"\\|<>/?*]/;
+        return categoryNameControl.value.length && specialSymbolsRegex.test(categoryNameControl.value) ? { specialCharacters: true } : null;
     }
 
     private setCategoryNameControlErrorMessageKey() {

--- a/lib/content-services/src/lib/category/categories-management/categories-management.component.ts
+++ b/lib/content-services/src/lib/category/categories-management/categories-management.component.ts
@@ -372,8 +372,7 @@ export class CategoriesManagementComponent implements OnInit, OnDestroy {
     }
 
     private validateEndsWithDot(categoryNameControl: FormControl<string>): CategoryNameControlErrors | null {
-        const endsWithDotRegex = /\.$/;
-        return categoryNameControl.value.length && endsWithDotRegex.test(categoryNameControl.value.trim()) ? { specialCharacters: true } : null;
+        return categoryNameControl.value.length && categoryNameControl.value.trim().endsWith('.') ? { specialCharacters: true } : null;
     }
 
     private setCategoryNameControlErrorMessageKey() {

--- a/lib/content-services/src/lib/category/categories-management/categories-management.component.ts
+++ b/lib/content-services/src/lib/category/categories-management/categories-management.component.ts
@@ -50,6 +50,7 @@ interface CategoryNameControlErrors {
     emptyCategory?: boolean;
     required?: boolean;
     specialCharacters?: boolean;
+    endsWithDot?: boolean;
 }
 
 @Component({
@@ -75,7 +76,8 @@ export class CategoriesManagementComponent implements OnInit, OnDestroy {
         ['duplicatedCategory', 'DUPLICATED_CATEGORY'],
         ['emptyCategory', 'EMPTY_CATEGORY'],
         ['required', 'REQUIRED'],
-        ['specialCharacters', 'SPECIAL_CHARACTERS']
+        ['specialCharacters', 'SPECIAL_CHARACTERS'],
+        ['endsWithDot', 'ENDS_WITH_DOT']
     ]);
 
     private existingCategoryLoaded$ = new Subject<void>();
@@ -372,7 +374,7 @@ export class CategoriesManagementComponent implements OnInit, OnDestroy {
     }
 
     private validateEndsWithDot(categoryNameControl: FormControl<string>): CategoryNameControlErrors | null {
-        return categoryNameControl.value.trim().endsWith('.') ? { specialCharacters: true } : null;
+        return categoryNameControl.value.trim().endsWith('.') ? { endsWithDot: true } : null;
     }
 
     private setCategoryNameControlErrorMessageKey() {

--- a/lib/content-services/src/lib/i18n/en.json
+++ b/lib/content-services/src/lib/i18n/en.json
@@ -183,7 +183,8 @@
       "ALREADY_EXISTS": "Category already exists",
       "DUPLICATED_CATEGORY": "Category is already added",
       "CREATE_CATEGORIES": "Error while creating categories",
-      "EXISTING_CATEGORIES": "Some categories already exist"
+      "EXISTING_CATEGORIES": "Some categories already exist",
+      "SPECIAL_CHARACTERS": "Category name cannot contain prohibited characters"
     },
     "CATEGORIES_SEARCH_PLACEHOLDER": "Search Categories"
   },

--- a/lib/content-services/src/lib/i18n/en.json
+++ b/lib/content-services/src/lib/i18n/en.json
@@ -184,7 +184,8 @@
       "DUPLICATED_CATEGORY": "Category is already added",
       "CREATE_CATEGORIES": "Error while creating categories",
       "EXISTING_CATEGORIES": "Some categories already exist",
-      "SPECIAL_CHARACTERS": "Category name cannot contain prohibited characters"
+      "SPECIAL_CHARACTERS": "Category name cannot contain prohibited characters",
+      "ENDS_WITH_DOT": "Category name cannot end with a dot"
     },
     "CATEGORIES_SEARCH_PLACEHOLDER": "Search Categories"
   },


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://hyland.atlassian.net/browse/ACS-9327

**What is the new behaviour?**

Added prohibited symbols validation for Categories dialog

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
