### PR TITLE
[AAE-36397] ADF viewer image is no longer cropped

### DIFF
--- a/lib/core/src/lib/viewer/components/img-viewer/img-viewer.component.scss
+++ b/lib/core/src/lib/viewer/components/img-viewer/img-viewer.component.scss
@@ -64,13 +64,3 @@
         }
     }
 }
-
-.adf-viewer-inline {
-    .adf-image-viewer {
-        height: 100%;
-
-        .adf-image-container {
-            height: 100%;
-        }
-    }
-}

--- a/lib/core/src/lib/viewer/components/unknown-format/unknown-format.component.scss
+++ b/lib/core/src/lib/viewer/components/unknown-format/unknown-format.component.scss
@@ -7,7 +7,3 @@
     justify-content: center;
     color: var(--adf-theme-foreground-text-color);
 }
-
-.adf-viewer-inline .adf-viewer__unknown-format-view {
-    height: 100%;
-}

--- a/lib/core/src/lib/viewer/components/viewer-render/viewer-render.component.scss
+++ b/lib/core/src/lib/viewer/components/viewer-render/viewer-render.component.scss
@@ -86,19 +86,3 @@
         display: contents;
     }
 }
-
-.adf-viewer-inline {
-    .adf-viewer-render {
-        &-main-loader {
-            position: unset;
-        }
-
-        &-layout-content > div {
-            height: 100%;
-        }
-
-        &__loading-screen {
-            height: 100%;
-        }
-    }
-}

--- a/lib/core/src/lib/viewer/components/viewer.component.scss
+++ b/lib/core/src/lib/viewer/components/viewer.component.scss
@@ -53,18 +53,6 @@
         }
     }
 
-    &-inline {
-        display: flex;
-        width: 100%;
-        height: 100%;
-        position: unset;
-
-        .adf-viewer__file-title {
-            position: unset;
-            transform: unset;
-        }
-    }
-
     &__display-name {
         font-size: var(--theme-subheading-2-font-size);
         line-height: 1.5;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://hyland.atlassian.net/browse/AAE-36397

**What is the new behaviour?**

Image is no longer cropped with overlay mode disabled.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
