### PR TITLE
Bugfix/dev shivangi adf 5583 verison visible outside dialog

### DIFF
--- a/docs/core/components/comment-list.component.md
+++ b/docs/core/components/comment-list.component.md
@@ -62,25 +62,33 @@ The component displays user avatars based on the presence of `pictureId` or `ava
 Example user objects:
 
 ```ts
-[
-  {
-    id: 'user1',
-    firstName: 'Alice',
-    lastName: 'Smith',
-    pictureId: 1234
-  },
-  {
-    id: 'user2',
-    firstName: 'Bob',
-    lastName: 'Jones',
-    avatarId: 'avatar-xyz'
-  },
-  {
-    id: 'user3',
-    firstName: 'Charlie',
-    lastName: 'Brown'
+import { CommentModel } from '@alfresco/adf-core';
+
+export class SomeComponent implements OnInit {
+  comments: CommentModel[] = [
+    {
+      id: 'user1',
+      firstName: 'Alice',
+      lastName: 'Smith',
+      pictureId: 1234
+    },
+    {
+      id: 'user2',
+      firstName: 'Bob',
+      lastName: 'Jones',
+      avatarId: 'avatar-xyz'
+    },
+    {
+      id: 'user3',
+      firstName: 'Charlie',
+      lastName: 'Brown'
+    }
+  ];
+
+  onClickCommentRow(comment: CommentModel) {
+    console.log('Clicked row: ', comment);
   }
-]
+}
 ```
 
 In the component template use the [comment list component](comment-list.component.md):

--- a/docs/core/components/comment-list.component.md
+++ b/docs/core/components/comment-list.component.md
@@ -62,35 +62,25 @@ The component displays user avatars based on the presence of `pictureId` or `ava
 Example user objects:
 
 ```ts
-import { CommentModel } from '@alfresco/adf-core';
-
-export class SomeComponent implements OnInit {
-  comments: CommentModel[] = [
-    {
-      id: 'user1',
-      firstName: 'Alice',
-      lastName: 'Smith',
-      pictureId: 1234
-    }
-
-    {
-      id: 'user2',
-      firstName: 'Bob',
-      lastName: 'Jones',
-      avatarId: 'avatar-xyz'
-    }
-
-    {
-      id: 'user3',
-      firstName: 'Charlie',
-      lastName: 'Brown'
-    }
-  ];
-
-  onClickCommentRow(comment: CommentModel) {
-    console.log('Clicked row: ', comment);
+[
+  {
+    id: 'user1',
+    firstName: 'Alice',
+    lastName: 'Smith',
+    pictureId: 1234
+  },
+  {
+    id: 'user2',
+    firstName: 'Bob',
+    lastName: 'Jones',
+    avatarId: 'avatar-xyz'
+  },
+  {
+    id: 'user3',
+    firstName: 'Charlie',
+    lastName: 'Brown'
   }
-}
+]
 ```
 
 In the component template use the [comment list component](comment-list.component.md):

--- a/docs/core/components/comment-list.component.md
+++ b/docs/core/components/comment-list.component.md
@@ -48,6 +48,49 @@ export class SomeComponent implements OnInit {
   onClickCommentRow(comment: CommentModel) {
     console.log('Clicked row: ', comment);
   }
+}
+```
+
+## Avatar Display Logic
+
+The component displays user avatars based on the presence of `pictureId` or `avatarId` properties on the user model:
+
+- If the user has a `pictureId`, the component fetches and displays the avatar image using that ID.
+- If no `pictureId` but an `avatarId` is present, it fetches and displays the avatar image using the `avatarId`.
+- If neither `pictureId` nor `avatarId` is available, the component displays the user's initials as a fallback.
+
+Example user objects:
+
+```ts
+import { CommentModel } from '@alfresco/adf-core';
+
+export class SomeComponent implements OnInit {
+  comments: CommentModel[] = [
+    {
+      id: 'user1',
+      firstName: 'Alice',
+      lastName: 'Smith',
+      pictureId: 1234
+    }
+
+    {
+      id: 'user2',
+      firstName: 'Bob',
+      lastName: 'Jones',
+      avatarId: 'avatar-xyz'
+    }
+
+    {
+      id: 'user3',
+      firstName: 'Charlie',
+      lastName: 'Brown'
+    }
+  ];
+
+  onClickCommentRow(comment: CommentModel) {
+    console.log('Clicked row: ', comment);
+  }
+}
 ```
 
 In the component template use the [comment list component](comment-list.component.md):

--- a/lib/content-services/src/lib/version-manager/version-list.component.scss
+++ b/lib/content-services/src/lib/version-manager/version-list.component.scss
@@ -1,11 +1,15 @@
 .adf-version-list {
     &-viewport {
-        height: 100%;
-        overflow-x: hidden;
         display: flex;
+        flex-direction: column;
+        flex: 1 1 auto;
+        min-height: 200px; // Ensure it's not invisible
+        max-height: 60vh; // Prevent overflow in dialogs/small screens
+        height: 100%; // Take full height if parent provides it
+        overflow: hidden auto; // Scroll vertically if needed // No horizontal scroll
 
         :first-child {
-            max-width: 100%;
+            max-width: 100%; // Prevents content from stretching too far
         }
     }
 
@@ -29,6 +33,10 @@
     }
 
     &.adf-version-list-element {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+
         .adf-version-list-item {
             border-bottom: 1px solid var(--adf-theme-foreground-divider-color);
             width: 100%;

--- a/lib/core/src/lib/comments/comment-list/comment-list.component.html
+++ b/lib/core/src/lib/comments/comment-list/comment-list.component.html
@@ -3,10 +3,12 @@
                   (click)="selectComment(comment)"
                   class="adf-comment-list-item">
         <div class="adf-comment-img-container">
-            <div *ngIf="!comment.hasAvatarPicture" class="adf-comment-user-icon">{{ comment.userInitials }}</div>
-            <img *ngIf="comment.hasAvatarPicture" class="adf-people-img"
-                 [alt]="'COMMENTS.PROFILE_IMAGE' | translate"
-                 [src]="getUserImage(comment.createdBy.id.toString())" />
+            <div *ngIf="!getUserImage(comment.createdBy)" class="adf-comment-user-icon">
+                {{ comment.userInitials }}
+            </div>
+            <img *ngIf="getUserImage(comment.createdBy)" class="adf-people-img"
+                [alt]="'COMMENTS.PROFILE_IMAGE' | translate"
+                [src]="getUserImage(comment.createdBy)" />
         </div>
         <div class="adf-comment-contents">
             <div matLine class="adf-comment-user-name">{{ comment.userDisplayName }}</div>

--- a/lib/core/src/lib/comments/comment-list/comment-list.component.html
+++ b/lib/core/src/lib/comments/comment-list/comment-list.component.html
@@ -3,12 +3,16 @@
                   (click)="selectComment(comment)"
                   class="adf-comment-list-item">
         <div class="adf-comment-img-container">
-            <div *ngIf="!getUserImage(comment.createdBy)" class="adf-comment-user-icon">
-                {{ comment.userInitials }}
-            </div>
-            <img *ngIf="getUserImage(comment.createdBy)" class="adf-people-img"
-                [alt]="'COMMENTS.PROFILE_ALT' | translate:{ name: comment.userDisplayName }"
-                [src]="getUserImage(comment.createdBy)" />
+            <ng-container *ngIf="getUserImage(comment.createdBy) as userImage; else noAvatar">
+                <img class="adf-people-img"
+                    [alt]="'COMMENTS.PROFILE_ALT' | translate:{ name: comment.userDisplayName }"
+                    [src]="userImage" />
+            </ng-container>
+            <ng-template #noAvatar>
+                <div class="adf-people-img adf-people-img-default">
+                    {{ comment.userInitials }}
+                </div>
+            </ng-template>
         </div>
         <div class="adf-comment-contents">
             <div matLine class="adf-comment-user-name">{{ comment.userDisplayName }}</div>

--- a/lib/core/src/lib/comments/comment-list/comment-list.component.html
+++ b/lib/core/src/lib/comments/comment-list/comment-list.component.html
@@ -7,7 +7,7 @@
                 {{ comment.userInitials }}
             </div>
             <img *ngIf="getUserImage(comment.createdBy)" class="adf-people-img"
-                [alt]="'COMMENTS.PROFILE_IMAGE' | translate"
+                [alt]="'COMMENTS.PROFILE_ALT' | translate:{ name: comment.userDisplayName }"
                 [src]="getUserImage(comment.createdBy)" />
         </div>
         <div class="adf-comment-contents">

--- a/lib/core/src/lib/comments/comment-list/comment-list.component.spec.ts
+++ b/lib/core/src/lib/comments/comment-list/comment-list.component.spec.ts
@@ -30,9 +30,9 @@ describe('CommentListComponent', () => {
     let fixture: ComponentFixture<CommentListComponent>;
     let testingUtils: UnitTestingUtils;
 
-    const AVATAR_IMG_SELECTOR = '.adf-people-img';
+    const avatarImgSelector = '.adf-people-img';
 
-    const getAvatarImg = (): DebugElement => testingUtils.getByCSS(AVATAR_IMG_SELECTOR);
+    const getAvatarImg = (): DebugElement => testingUtils.getByCSS(avatarImgSelector);
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -155,7 +155,7 @@ describe('CommentListComponent', () => {
         fixture.detectChanges();
         await fixture.whenStable();
 
-        const elements = testingUtils.getAllByCSS(AVATAR_IMG_SELECTOR);
+        const elements = testingUtils.getAllByCSS(avatarImgSelector);
         expect(elements.length).toBe(1);
     });
 

--- a/lib/core/src/lib/comments/comment-list/comment-list.component.spec.ts
+++ b/lib/core/src/lib/comments/comment-list/comment-list.component.spec.ts
@@ -23,20 +23,16 @@ import { CommentListServiceMock } from './mocks/comment-list.service.mock';
 import { ADF_COMMENTS_SERVICE } from '../interfaces/comments.token';
 import { NoopTranslateModule } from '../../testing/noop-translate.module';
 import { UnitTestingUtils } from '../../testing/unit-testing-utils';
+import { DebugElement } from '@angular/core';
 
 describe('CommentListComponent', () => {
     let commentList: CommentListComponent;
     let fixture: ComponentFixture<CommentListComponent>;
     let testingUtils: UnitTestingUtils;
 
-    /**
-     * Helper to retrieve the avatar image element from the DOM.
-     *
-     * @returns The avatar image element.
-     */
-    function getAvatarImg() {
-        return testingUtils.getByCSS('.adf-people-img');
-    }
+    const AVATAR_IMG_SELECTOR = '.adf-people-img';
+
+    const getAvatarImg = (): DebugElement => testingUtils.getByCSS(AVATAR_IMG_SELECTOR);
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -159,7 +155,7 @@ describe('CommentListComponent', () => {
         fixture.detectChanges();
         await fixture.whenStable();
 
-        const elements = testingUtils.getAllByCSS('.adf-people-img');
+        const elements = testingUtils.getAllByCSS(AVATAR_IMG_SELECTOR);
         expect(elements.length).toBe(1);
     });
 

--- a/lib/core/src/lib/comments/comment-list/comment-list.component.spec.ts
+++ b/lib/core/src/lib/comments/comment-list/comment-list.component.spec.ts
@@ -164,73 +164,85 @@ describe('CommentListComponent', () => {
         expect(elements.length).toBe(1);
     });
 
-    it('should display user images or initials depending on pictureId and avatarId presence', async () => {
-        const comments = [
-            // User with only pictureId
-            new CommentModel({
-                id: 1,
-                message: 'With pictureId only',
-                created: new Date(),
-                createdBy: {
-                    id: 'picUser',
-                    firstName: 'Pic',
-                    lastName: 'User',
-                    pictureId: 1001
-                }
-            }),
-            // User with only avatarId
-            new CommentModel({
-                id: 2,
-                message: 'With avatarId only',
-                created: new Date(),
-                createdBy: {
-                    id: 'avatarUser',
-                    firstName: 'Avatar',
-                    lastName: 'User',
-                    avatarId: 'avatar-xyz'
-                }
-            }),
-            // User with both
-            new CommentModel({
-                id: 3,
-                message: 'With both pictureId and avatarId',
-                created: new Date(),
-                createdBy: {
-                    id: 'bothUser',
-                    firstName: 'Both',
-                    lastName: 'User',
-                    pictureId: 2002,
-                    avatarId: 'avatar-abc'
-                }
-            }),
-            // User with neither
-            new CommentModel({
-                id: 4,
-                message: 'With no avatar or picture',
-                created: new Date(),
-                createdBy: {
-                    id: 'noUser',
-                    firstName: 'No',
-                    lastName: 'Avatar'
-                }
-            })
-        ];
+    it('should display image using pictureId if available', async () => {
+        const comment = new CommentModel({
+            id: 1,
+            message: 'With pictureId only',
+            created: new Date(),
+            createdBy: {
+                firstName: 'Pic',
+                lastName: 'User',
+                pictureId: 1001
+            }
+        });
 
-        commentList.comments = comments;
-
+        commentList.comments = [comment];
         fixture.detectChanges();
         await fixture.whenStable();
 
-        const images = testingUtils.getAllByCSS('.adf-people-img');
-        const initials = testingUtils.getAllByCSS('.adf-comment-user-icon');
+        const img = testingUtils.getByCSS('.adf-people-img');
+        expect(img).not.toBeNull();
+        expect(img.nativeElement.src).toContain('1001');
+    });
 
-        expect(images.length).toBe(3);
-        expect(initials.length).toBe(1);
+    it('should display image using avatarId if pictureId is not available', async () => {
+        const comment = new CommentModel({
+            id: 2,
+            message: 'With avatarId only',
+            created: new Date(),
+            createdBy: {
+                firstName: 'Avatar',
+                lastName: 'User',
+                avatarId: 'avatar-xyz'
+            }
+        });
 
-        expect(images[0].nativeElement.src).toContain('1001'); // pictureId
-        expect(images[1].nativeElement.src).toContain('avatar-xyz'); // avatarId
-        expect(images[2].nativeElement.src).toContain('2002'); // pictureId preferred
+        commentList.comments = [comment];
+        fixture.detectChanges();
+        await fixture.whenStable();
 
-        expect(initials[0].nativeElement.innerText).toBe('NA'); // No Avatar
+        const img = testingUtils.getByCSS('.adf-people-img');
+        expect(img).not.toBeNull();
+        expect(img.nativeElement.src).toContain('avatar-xyz');
+    });
+
+    it('should prefer pictureId over avatarId if both are available', async () => {
+        const comment = new CommentModel({
+            id: 3,
+            message: 'With both',
+            created: new Date(),
+            createdBy: {
+                pictureId: 2002,
+                avatarId: 'avatar-abc'
+            }
+        });
+
+        commentList.comments = [comment];
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const img = testingUtils.getByCSS('.adf-people-img');
+        expect(img).not.toBeNull();
+        expect(img.nativeElement.src).toContain('2002');
+    });
+
+    it('should display user initials if neither pictureId nor avatarId is present', async () => {
+        const comment = new CommentModel({
+            id: 4,
+            message: 'No avatar',
+            created: new Date(),
+            createdBy: {
+                firstName: 'No',
+                lastName: 'Avatar'
+            }
+        });
+
+        commentList.comments = [comment];
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const icon = testingUtils.getByCSS('.adf-comment-user-icon');
+        expect(icon).not.toBeNull();
+        expect(icon.nativeElement.innerText).toBe('NA');
     });
 });

--- a/lib/core/src/lib/comments/comment-list/comment-list.component.spec.ts
+++ b/lib/core/src/lib/comments/comment-list/comment-list.component.spec.ts
@@ -163,4 +163,74 @@ describe('CommentListComponent', () => {
         const elements = testingUtils.getAllByCSS('.adf-comment-user-icon');
         expect(elements.length).toBe(1);
     });
+
+    it('should display user images or initials depending on pictureId and avatarId presence', async () => {
+        const comments = [
+            // User with only pictureId
+            new CommentModel({
+                id: 1,
+                message: 'With pictureId only',
+                created: new Date(),
+                createdBy: {
+                    id: 'picUser',
+                    firstName: 'Pic',
+                    lastName: 'User',
+                    pictureId: 1001
+                }
+            }),
+            // User with only avatarId
+            new CommentModel({
+                id: 2,
+                message: 'With avatarId only',
+                created: new Date(),
+                createdBy: {
+                    id: 'avatarUser',
+                    firstName: 'Avatar',
+                    lastName: 'User',
+                    avatarId: 'avatar-xyz'
+                }
+            }),
+            // User with both
+            new CommentModel({
+                id: 3,
+                message: 'With both pictureId and avatarId',
+                created: new Date(),
+                createdBy: {
+                    id: 'bothUser',
+                    firstName: 'Both',
+                    lastName: 'User',
+                    pictureId: 2002,
+                    avatarId: 'avatar-abc'
+                }
+            }),
+            // User with neither
+            new CommentModel({
+                id: 4,
+                message: 'With no avatar or picture',
+                created: new Date(),
+                createdBy: {
+                    id: 'noUser',
+                    firstName: 'No',
+                    lastName: 'Avatar'
+                }
+            })
+        ];
+
+        commentList.comments = comments;
+
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        const images = testingUtils.getAllByCSS('.adf-people-img');
+        const initials = testingUtils.getAllByCSS('.adf-comment-user-icon');
+
+        expect(images.length).toBe(3);
+        expect(initials.length).toBe(1);
+
+        expect(images[0].nativeElement.src).toContain('1001'); // pictureId
+        expect(images[1].nativeElement.src).toContain('avatar-xyz'); // avatarId
+        expect(images[2].nativeElement.src).toContain('2002'); // pictureId preferred
+
+        expect(initials[0].nativeElement.innerText).toBe('NA'); // No Avatar
+    });
 });

--- a/lib/core/src/lib/comments/comment-list/comment-list.component.spec.ts
+++ b/lib/core/src/lib/comments/comment-list/comment-list.component.spec.ts
@@ -29,6 +29,15 @@ describe('CommentListComponent', () => {
     let fixture: ComponentFixture<CommentListComponent>;
     let testingUtils: UnitTestingUtils;
 
+    /**
+     * Helper to retrieve the avatar image element from the DOM.
+     *
+     * @returns The avatar image element.
+     */
+    function getAvatarImg() {
+        return testingUtils.getByCSS('.adf-people-img');
+    }
+
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [NoopTranslateModule],
@@ -180,7 +189,7 @@ describe('CommentListComponent', () => {
         fixture.detectChanges();
         await fixture.whenStable();
 
-        const img = testingUtils.getByCSS('.adf-people-img');
+        const img = getAvatarImg();
         expect(img).not.toBeNull();
         expect(img.nativeElement.src).toContain('1001');
     });
@@ -201,7 +210,7 @@ describe('CommentListComponent', () => {
         fixture.detectChanges();
         await fixture.whenStable();
 
-        const img = testingUtils.getByCSS('.adf-people-img');
+        const img = getAvatarImg();
         expect(img).not.toBeNull();
         expect(img.nativeElement.src).toContain('avatar-xyz');
     });
@@ -221,7 +230,7 @@ describe('CommentListComponent', () => {
         fixture.detectChanges();
         await fixture.whenStable();
 
-        const img = testingUtils.getByCSS('.adf-people-img');
+        const img = getAvatarImg();
         expect(img).not.toBeNull();
         expect(img.nativeElement.src).toContain('2002');
     });

--- a/lib/core/src/lib/comments/comment-list/comment-list.component.ts
+++ b/lib/core/src/lib/comments/comment-list/comment-list.component.ts
@@ -24,6 +24,7 @@ import { MatListModule } from '@angular/material/list';
 import { MatLineModule } from '@angular/material/core';
 import { TimeAgoPipe } from '../../pipes';
 import { TranslatePipe } from '@ngx-translate/core';
+import { User } from '../../models/general-user.model';
 
 @Component({
     selector: 'adf-comment-list',
@@ -47,7 +48,14 @@ export class CommentListComponent {
         this.clickRow.emit(comment);
     }
 
-    getUserImage(userId: string): string {
-        return this.commentsService.getUserImage(userId);
+    getUserImage(user: User): string | null {
+        if (!user) {
+            return null;
+        }
+
+        const avatarNodeId = user.pictureId?.toString() || user.avatarId;
+
+        if (avatarNodeId) return this.commentsService.getUserImage(avatarNodeId);
+        return null;
     }
 }

--- a/lib/core/src/lib/comments/comment-list/mocks/comment-list.service.mock.ts
+++ b/lib/core/src/lib/comments/comment-list/mocks/comment-list.service.mock.ts
@@ -18,7 +18,7 @@
 import { CommentsService } from '../../interfaces/comments-service.interface';
 
 export class CommentListServiceMock implements Partial<CommentsService> {
-    getUserImage(_userId: string): string {
-        return 'mock-user-image-path';
+    getUserImage(userId: string): string {
+        return `http://localhost/mock-avatars/${userId}`;
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
When the adf-version-list component is used outside of a dialog, the version list is not visible.
The content is rendered but has no scrollable space or fixed height, so versions are not displayed to the user unless a custom height is manually applied.


**What is the new behaviour?**
The adf-version-list component should automatically display and scroll version entries, whether used inside a dialog or as a standalone component, without requiring consumers to manually apply height styles. The component should manage its layout internally using proper flex and scroll properties.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://hyland.atlassian.net/browse/ADF-5583