### PR TITLE
[ADF-5583] Update style to make version visible outside dialog

### DIFF
--- a/lib/content-services/src/lib/version-manager/version-list.component.scss
+++ b/lib/content-services/src/lib/version-manager/version-list.component.scss
@@ -1,7 +1,6 @@
 .adf-version-list {
     &-viewport {
         display: flex;
-        flex-direction: column;
         min-height: 200px;
         max-height: 60vh;
         height: 100%;

--- a/lib/content-services/src/lib/version-manager/version-list.component.scss
+++ b/lib/content-services/src/lib/version-manager/version-list.component.scss
@@ -2,11 +2,9 @@
     &-viewport {
         display: flex;
         flex-direction: column;
-        flex: 1 1 auto;
         min-height: 200px;
         max-height: 60vh;
         height: 100%;
-        overflow: hidden auto;
 
         :first-child {
             max-width: 100%;

--- a/lib/content-services/src/lib/version-manager/version-list.component.scss
+++ b/lib/content-services/src/lib/version-manager/version-list.component.scss
@@ -1,8 +1,12 @@
 .adf-version-list {
     &-viewport {
-        height: 100%;
-        overflow-x: hidden;
         display: flex;
+        flex-direction: column;
+        flex: 1 1 auto;
+        min-height: 200px;
+        max-height: 60vh;
+        height: 100%;
+        overflow: hidden auto;
 
         :first-child {
             max-width: 100%;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
When the adf-version-list component is used outside of a dialog, the version list is not visible.

**What is the new behaviour?**
The adf-version-list component should automatically display and scroll version entries, whether used inside a dialog or as a standalone component, without requiring consumers to manually apply height styles. The component should manage its layout internally using proper flex and scroll properties.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://hyland.atlassian.net/browse/ADF-5583