### PR TITLE
[ACS-7266] checkboxes in sorting boxes are put on the right side of the text instead of the left side

### DIFF
--- a/lib/content-services/src/lib/search/components/search-check-list/search-check-list.component.html
+++ b/lib/content-services/src/lib/search/components/search-check-list/search-check-list.component.html
@@ -2,7 +2,6 @@
     <mat-checkbox
         *ngFor="let option of options"
         [checked]="option.checked"
-        labelPosition="before"
         (keydown.enter)="option.checked = !option.checked"
         [attr.data-automation-id]="'checkbox-' + (option.name)"
         [attr.aria-label]="option.name | translate"

--- a/lib/content-services/src/lib/search/components/search-check-list/search-check-list.component.spec.ts
+++ b/lib/content-services/src/lib/search/components/search-check-list/search-check-list.component.spec.ts
@@ -25,11 +25,14 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatCheckboxHarness } from '@angular/material/checkbox/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { ReplaySubject } from 'rxjs';
+import { UnitTestingUtils } from '../../../../../../core';
+import { MatCheckbox } from '@angular/material/checkbox';
 
 describe('SearchCheckListComponent', () => {
     let loader: HarnessLoader;
     let fixture: ComponentFixture<SearchCheckListComponent>;
     let component: SearchCheckListComponent;
+    let unitTestingUtils: UnitTestingUtils;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -38,6 +41,7 @@ describe('SearchCheckListComponent', () => {
         fixture = TestBed.createComponent(SearchCheckListComponent);
         component = fixture.componentInstance;
         loader = TestbedHarnessEnvironment.loader(fixture);
+        unitTestingUtils = new UnitTestingUtils(fixture.debugElement);
 
         component.context = {
             queryFragments: {},
@@ -136,6 +140,18 @@ describe('SearchCheckListComponent', () => {
         expect(component.context.update).toHaveBeenCalled();
         expect(component.context.queryFragments[component.id]).toBe('');
         expect(component.context.filterRawParams[component.id]).toBeUndefined();
+    });
+
+    it('should have set labelPosition to after for checkboxes', () => {
+        component.options = new SearchFilterList<SearchListOption>([
+            { name: 'Folder', value: `TYPE:'cm:folder'`, checked: true },
+            { name: 'Document', value: `TYPE:'cm:content'`, checked: true }
+        ]);
+
+        fixture.detectChanges();
+        const checkboxes = unitTestingUtils.getAllByDirective(MatCheckbox);
+        expect(checkboxes.length).toBe(2);
+        expect(checkboxes.every((checkbox) => checkbox.componentInstance.labelPosition === 'after')).toBeTrue();
     });
 
     describe('Pagination', () => {

--- a/lib/content-services/src/lib/search/components/search-check-list/search-check-list.component.spec.ts
+++ b/lib/content-services/src/lib/search/components/search-check-list/search-check-list.component.spec.ts
@@ -25,7 +25,7 @@ import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatCheckboxHarness } from '@angular/material/checkbox/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { ReplaySubject } from 'rxjs';
-import { UnitTestingUtils } from '../../../../../../core';
+import { UnitTestingUtils } from '@alfresco/adf-core';
 import { MatCheckbox } from '@angular/material/checkbox';
 
 describe('SearchCheckListComponent', () => {

--- a/lib/core/src/lib/testing/unit-testing-utils.ts
+++ b/lib/core/src/lib/testing/unit-testing-utils.ts
@@ -75,6 +75,10 @@ export class UnitTestingUtils {
         return this.debugElement.query(By.directive(directive));
     }
 
+    getAllByDirective(directive: Type<any>): DebugElement[] {
+        return this.debugElement.queryAll(By.directive(directive));
+    }
+
     /** Perform actions */
 
     clickByCSS(selector: string): void {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/ACS-7266


**What is the new behaviour?**
Checkboxes are before labels. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
