### PR TITLE
AAE-25571 Add title to file name in adf viewer

### DIFF
--- a/lib/core/src/lib/viewer/components/viewer.component.spec.ts
+++ b/lib/core/src/lib/viewer/components/viewer.component.spec.ts
@@ -171,6 +171,28 @@ describe('ViewerComponent', () => {
                 expect(component.getDisplayFileName()).toBe('');
                 expect(getFileName()).toBe('');
             });
+
+            it('should include title if it is available and put fileName into brackets', () => {
+                const fileShortName = 'shortname.txt';
+                const title = 'Alfresco title';
+                component.fileName = fileShortName;
+                component.title = title;
+                fixture.detectChanges();
+
+                expect(component.getDisplayFileName()).toBe(`${title} (${fileShortName})`);
+                expect(getFileName()).toBe(fileShortName);
+            });
+
+            it('should not include title if it is empty and do not put fileName into brackets', () => {
+                const fileShortName = 'shortname.txt';
+                const title = '';
+                component.fileName = fileShortName;
+                component.title = title;
+                fixture.detectChanges();
+
+                expect(component.getDisplayFileName()).toBe(fileShortName);
+                expect(getFileName()).toBe(fileShortName);
+            });
         });
 
         describe('fileName setter integration', () => {

--- a/lib/core/src/lib/viewer/components/viewer.component.ts
+++ b/lib/core/src/lib/viewer/components/viewer.component.ts
@@ -253,6 +253,10 @@ export class ViewerComponent<T> implements OnDestroy, OnInit, OnChanges {
     @Input()
     customError: string = undefined;
 
+    /** File title to be displayed in the viewer. */
+    @Input()
+    title: string = undefined;
+
     /** Toggles dividers visibility */
     @Input()
     showToolbarDividers = true;
@@ -474,7 +478,10 @@ export class ViewerComponent<T> implements OnDestroy, OnInit, OnChanges {
     }
 
     getDisplayFileName(): string {
-        const fullName = (this.fileNameWithoutExtension || '') + (this.fileExtension || '');
+        const title = this.title;
+        const fileName = (this.fileNameWithoutExtension || '') + (this.fileExtension || '');
+
+        const fullName = title ? `${title} (${fileName})` : fileName;
         const maxLength = 50;
 
         if (fullName.length <= maxLength) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->
JIRA TICKET:
https://hyland.atlassian.net/browse/AAE-25571

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Only fileName is displayed in adf-viewer.


**What is the new behaviour?**
Title is display next to the fileName in adf-viewer.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
