### PR TITLE
AAE-37287 provideExtensions provider api for Angular standalone

### DIFF
--- a/lib/extensions/src/lib/providers.ts
+++ b/lib/extensions/src/lib/providers.ts
@@ -15,8 +15,10 @@
  * limitations under the License.
  */
 
-import { EnvironmentProviders, inject, provideAppInitializer, Provider } from '@angular/core';
+import { EnvironmentProviders, inject, provideAppInitializer, Provider, Type } from '@angular/core';
 import { AppExtensionService } from './services/app-extension.service';
+import { ExtensionService } from './services/extension.service';
+import { RuleEvaluator } from './config/rule.extensions';
 
 /**
  * Provides all necessary entries for the app extensibility
@@ -27,6 +29,59 @@ export function provideAppExtensions(): (Provider | EnvironmentProviders)[] {
         provideAppInitializer(() => {
             const appExtensionService = inject(AppExtensionService);
             return appExtensionService.load();
+        })
+    ];
+}
+
+/**
+ * Provides a way to register extension entities in a single API
+ *
+ * Example:
+ * ```typescript
+ * providers: [
+ *  provideExtensions({
+ *      authGuards: {
+ *          auth1: guard1,
+ *          auth2: guard2
+ *      },
+ *      evaluators: {
+ *          eval1: evaluator1,
+ *          eval2: evaluator2
+ *      },
+ *      components: {
+ *          component: component1
+ *      }
+ *  });
+ * ]
+ * ```
+ * @param params Parameters for the api
+ * @param params.authGuards Auth guards to register
+ * @param params.evaluators Rule evaluators to register
+ * @param params.components Components to register
+ * @returns list of Angular providers
+ */
+export function provideExtensions(params: {
+    authGuards?: Record<string, unknown>;
+    evaluators?: Record<string, RuleEvaluator>;
+    components: Record<string, Type<any>>;
+}) {
+    return [
+        provideAppInitializer(() => {
+            const service = inject(ExtensionService);
+
+            if (params) {
+                if (params.authGuards) {
+                    service.setAuthGuards(params.authGuards);
+                }
+                if (params.evaluators) {
+                    service.setEvaluators(params.evaluators);
+                }
+                if (params.components) {
+                    service.setComponents(params.components);
+                }
+            }
+
+            return Promise.resolve();
         })
     ];
 }

--- a/lib/extensions/src/lib/providers.ts
+++ b/lib/extensions/src/lib/providers.ts
@@ -63,7 +63,7 @@ export function provideAppExtensions(): (Provider | EnvironmentProviders)[] {
 export function provideExtensions(params: {
     authGuards?: Record<string, unknown>;
     evaluators?: Record<string, RuleEvaluator>;
-    components: Record<string, Type<any>>;
+    components?: Record<string, Type<any>>;
 }) {
     return [
         provideAppInitializer(() => {

--- a/lib/extensions/src/lib/services/component-register.service.ts
+++ b/lib/extensions/src/lib/services/component-register.service.ts
@@ -25,9 +25,9 @@ export interface ExtensionComponent {
 
 @Injectable({ providedIn: 'root' })
 export class ComponentRegisterService {
-    components: { [key: string]: Type<any> } = {};
+    components: Record<string, Type<any>> = {};
 
-    setComponents(values: { [key: string]: Type<any> }) {
+    setComponents(values: Record<string, Type<any>>) {
         if (values) {
             this.components = Object.assign({}, this.components, values);
         }

--- a/lib/extensions/src/lib/services/extension.service.ts
+++ b/lib/extensions/src/lib/services/extension.service.ts
@@ -154,7 +154,7 @@ export class ExtensionService {
      * Adds one or more new rule evaluators to the existing set.
      * @param values The new evaluators to add
      */
-    setEvaluators(values: { [key: string]: RuleEvaluator }) {
+    setEvaluators(values: Record<string, RuleEvaluator>) {
         this.ruleService.setEvaluators(values);
     }
 
@@ -172,7 +172,7 @@ export class ExtensionService {
      * Adds one or more new components to the existing set.
      * @param values The new components to add
      */
-    setComponents(values: { [key: string]: Type<any> }) {
+    setComponents(values: Record<string, Type<any>>) {
         this.componentRegister.setComponents(values);
     }
 

--- a/lib/extensions/src/lib/services/rule.service.ts
+++ b/lib/extensions/src/lib/services/rule.service.ts
@@ -38,7 +38,7 @@ export class RuleService {
      * Adds one or more new rule evaluators to the existing set.
      * @param values The new evaluators to add
      */
-    setEvaluators(values: { [key: string]: RuleEvaluator }) {
+    setEvaluators(values: Record<string, RuleEvaluator>) {
         if (values) {
             this.evaluators = Object.assign({}, this.evaluators, values);
         }


### PR DESCRIPTION
https://hyland.atlassian.net/browse/AAE-37287

Introduce a `provideExtensions` helper API to reduce code related to extension configuration

```typesript 
providers: [
 provideExtensions({
     authGuards: {
         auth1: guard1,
         auth2: guard2
     },
     evaluators: {
         eval1: evaluator1,
         eval2: evaluator2
     },
     components: {
         component: component1
     }
 });
]
```