### PR TITLE
[ACS-9986] [ADW][ACA][ACC] – Dragging a column header hides the headers to its right.

### DIFF
--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.scss
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.scss
@@ -61,8 +61,6 @@ $data-table-cell-min-width-file-size: $data-table-cell-min-width-1 !default;
     border: 1px solid var(--adf-theme-foreground-text-color-007);
     box-sizing: border-box;
     overflow-x: auto;
-    min-width: 100%;
-    width: fit-content;
 
     @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none) {
         .adf-datatable-center-size-column-ie {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
[[ADW][ACA][ACC] – Dragging a column header hides the headers to its right.](https://hyland.atlassian.net/browse/ACS-9986)


**What is the new behaviour?**
column overflow fixed


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
