### PR TITLE
[MNT-25274] Fixed issue while uploading files with multi-valued properties

### DIFF
--- a/lib/core/api/src/lib/alfresco-api/alfresco-api.utils.spec.ts
+++ b/lib/core/api/src/lib/alfresco-api/alfresco-api.utils.spec.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { isConstructor, getQueryParamsWithCustomEncoder, removeNilValues } from './alfresco-api.utils';
+import { isConstructor, getQueryParamsWithCustomEncoder, removeNilValues, convertObjectToFormData } from './alfresco-api.utils';
 
 describe('AlfrescoApiUtils', () => {
     describe('isConstructor', () => {
@@ -91,6 +91,32 @@ describe('AlfrescoApiUtils', () => {
 
             expect(actual?.get('key2')).toEqual('value2');
             expect(actual?.getAll('key2')).toEqual(['value2', 'value3']);
+        });
+    });
+
+    describe('convertObjectToFormData', () => {
+        it('should create correct FormData entries for string values', () => {
+            const testParams: Record<string, string> = { name: 'file name', description: 'file description' };
+            const result = convertObjectToFormData(testParams);
+
+            expect(result.get('name')).toBe('file name');
+            expect(result.get('description')).toBe('file description');
+        });
+
+        it('should handle Blob files correctly', () => {
+            const testFile = new File(['content'], 'test.txt', { type: 'text/plain' });
+            const testParams: Record<string, Blob> = { file: testFile };
+
+            const result = convertObjectToFormData(testParams);
+            expect(result.get('file')).toEqual(testFile);
+        });
+
+        it('should create multiple entries with same key for arrays', () => {
+            const testParams: Record<string, Array<string>> = { categories: ['category1', 'category2', 'category3'] };
+            const result = convertObjectToFormData(testParams);
+
+            const values = result.getAll('categories');
+            expect(values).toEqual(['category1', 'category2', 'category3']);
         });
     });
 });

--- a/lib/core/api/src/lib/alfresco-api/alfresco-api.utils.ts
+++ b/lib/core/api/src/lib/alfresco-api/alfresco-api.utils.ts
@@ -85,7 +85,7 @@ export const removeNilValues = (obj: Record<string | number, unknown>) => {
     }, {});
 };
 
-export const convertObjectToFormData = (formParams: Record<string | number, string | Blob>): FormData => {
+export const convertObjectToFormData = (formParams: Record<string | number, string | Blob | Array<any>>): FormData => {
     const formData = new FormData();
 
     for (const key in formParams) {
@@ -93,6 +93,8 @@ export const convertObjectToFormData = (formParams: Record<string | number, stri
             const value = formParams[key];
             if (value instanceof File) {
                 formData.append(key, value, value.name);
+            } else if (Array.isArray(value)) {
+                value.forEach((item) => formData.append(key, item));
             } else {
                 formData.append(key, value);
             }

--- a/lib/core/api/src/lib/alfresco-api/alfresco-api.utils.ts
+++ b/lib/core/api/src/lib/alfresco-api/alfresco-api.utils.ts
@@ -85,7 +85,7 @@ export const removeNilValues = (obj: Record<string | number, unknown>) => {
     }, {});
 };
 
-export const convertObjectToFormData = (formParams: Record<string | number, string | Blob | Array<any>>): FormData => {
+export const convertObjectToFormData = (formParams: Record<string | number, string | Blob | Array<string | Blob>>): FormData => {
     const formData = new FormData();
 
     for (const key in formParams) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://hyland.atlassian.net/browse/MNT-25274

Multi-valued properties uploaded as a single string value
<img width="364" height="236" alt="Screenshot 2025-09-08 at 11 32 26" src="https://github.com/user-attachments/assets/eee1eaa4-689f-46c2-88b5-7a1afc020420" />


**What is the new behaviour?**

Multi-valued properties uploaded as a collection with multiple values
<img width="363" height="208" alt="Screenshot 2025-09-08 at 11 32 04" src="https://github.com/user-attachments/assets/1fc6bfb8-08f4-4e43-b5a3-3e42e1f2d4c9" />


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
