### PR TITLE
AAE-37563 Fix for extra padding on top of fullscreen toolbar

### DIFF
--- a/lib/process-services-cloud/src/lib/form/components/form-cloud.component.html
+++ b/lib/process-services-cloud/src/lib/form/components/form-cloud.component.html
@@ -10,6 +10,7 @@
     <div
         class="adf-cloud-form-content"
         [class.adf-cloud-form-content-standalone-fullscreen]="displayMode === 'standalone' && displayConfiguration?.options?.fullscreen"
+        [class.adf-cloud-form-content-toolbar]="!!displayConfiguration?.options?.displayToolbar"
         [cdkTrapFocus]="displayConfiguration?.options?.trapFocus"
         cdkTrapFocusAutoCapture>
         <adf-toolbar class="adf-cloud-form-toolbar" *ngIf="displayConfiguration?.options?.displayToolbar">

--- a/lib/process-services-cloud/src/lib/form/components/form-cloud.component.scss
+++ b/lib/process-services-cloud/src/lib/form/components/form-cloud.component.scss
@@ -10,9 +10,17 @@
 }
 
 .adf-cloud-form {
+    &-content {
+        padding-top: 40px;
+    }
+
     &-content-standalone-fullscreen {
         background-color: transparent;
         border-radius: 14px;
+    }
+
+    &-content-toolbar {
+        padding-top: 0;
     }
 
     &-container {
@@ -45,11 +53,19 @@
             max-width: 1366px;
             height: auto;
             margin: 40px auto;
+            padding-bottom: 40px;
+            border-radius: 14px;
         }
     }
 
     &-inline-container {
         @extend .adf-full-screen;
+
+        .adf-cloud-form-content {
+            padding-top: 40px;
+            padding-bottom: 40px;
+            border-radius: 14px;
+        }
     }
 
     &-toolbar ::ng-deep {
@@ -87,7 +103,6 @@
     }
 
     &-content-card {
-        padding-bottom: 2em;
         overflow-y: auto;
         position: static;
         height: 70%;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe: CSS fix.


**What is the current behaviour?** (You can also link to an open issue here)

When opening a form in fullscreen with a toolbar on top, there's extra padding on top of the toolbar.


**What is the new behaviour?**

The toolbar no longer has extra padding on top.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
