### PR TITLE
[ACS-10145] Corrected font size and alignment for date field in metadata properties panel

### DIFF
--- a/lib/core/src/lib/card-view/components/card-view-dateitem/card-view-dateitem.component.html
+++ b/lib/core/src/lib/card-view/components/card-view-dateitem/card-view-dateitem.component.html
@@ -19,7 +19,7 @@
             >{{ property.displayValue }}</span
         >
     </span>
-    <mat-form-field *ngIf="isEditable && !property.multivalued" class="adf-dateitem-editable hxp-input" [floatLabel]="property.default ? 'always' : null">
+    <mat-form-field *ngIf="isEditable && !property.multivalued" class="adf-property-field adf-dateitem-editable hxp-input" [floatLabel]="property.default ? 'always' : null">
         <mat-label
             class="adf-property-label"
             [attr.data-automation-id]="'card-dateitem-label-' + property.key"

--- a/lib/core/src/lib/card-view/components/card-view-dateitem/card-view-dateitem.component.scss
+++ b/lib/core/src/lib/card-view/components/card-view-dateitem/card-view-dateitem.component.scss
@@ -1,6 +1,8 @@
 @use '../../../styles/mat-selectors' as ms;
 
 .adf-card-view-dateitem {
+    display: flow-root;
+
     .adf-dateitem-editable {
         cursor: pointer;
         width: 100%;
@@ -9,6 +11,10 @@
             display: flex;
             align-items: center;
             justify-content: space-between;
+            top: 6px;
+            position: relative;
+            left: 12px;
+            height: 20px;
 
             #{ms.$mat-icon} {
                 opacity: 0.5;
@@ -29,6 +35,11 @@
                 position: relative;
             }
         }
+
+        #{ms.$mat-line-ripple},
+        #{ms.$mat-form-field-subscript-wrapper} {
+            display: none;
+        }
     }
 
     .adf-property-value {
@@ -43,20 +54,18 @@
             align-items: center;
             border-radius: 6px;
             border-bottom: inherit;
-            margin-bottom: 18px;
+            padding-left: 0;
 
             &:not(.adf-property-readonly-value) {
                 margin-top: 35px;
             }
 
             .adf-date-reset-icon {
-                top: 10px;
                 position: relative;
                 padding: 0;
             }
 
             .adf-dateitem-picker-toggle {
-                top: 10px;
                 position: relative;
             }
         }
@@ -75,6 +84,10 @@
         margin: 0;
         padding: 0;
         float: right;
+
+        &#{ms.$mat-input-element}#{ms.$mat-form-field-input-control} {
+            margin-top: 35px;
+        }
     }
 
     .adf-dateitem-chip-list-container.adf-property-field {

--- a/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.scss
+++ b/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.scss
@@ -49,6 +49,14 @@
         #{ms.$mat-form-field-label} {
             margin-top: 6px;
         }
+
+        #{ms.$mat-form-field-infix} {
+            padding-top: 0;
+
+            .adf-property-value {
+                margin-left: 0;
+            }
+        }
     }
 
     .adf-textitem-clickable {

--- a/lib/core/src/lib/styles/_mat-selectors.scss
+++ b/lib/core/src/lib/styles/_mat-selectors.scss
@@ -17,6 +17,7 @@ $mat-checkbox: '.mat-mdc-checkbox';
 $mat-checkbox-label: '.mdc-label';
 $mat-button: '.mat-mdc-button';
 $mat-button-label: '.mdc-button__label';
+$mat-form-field-input-control: '.mat-mdc-form-field-input-control';
 $mat-form-field: '.mat-mdc-form-field';
 $mat-form-field-flex: '.mat-mdc-form-field-flex';
 $mat-form-field-wrapper: '.mat-mdc-text-field-wrapper';


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/ACS-10145


**What is the new behaviour?**
Size of font and alignment for date fields in metadata properties sidebar are correct now. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
