### PR TITLE
[ACS-10165] Move All Libraries page to ACA

### DIFF
--- a/lib/content-services/src/lib/search/components/search-filter-autocomplete-chips/search-filter-autocomplete-chips.component.spec.ts
+++ b/lib/content-services/src/lib/search/components/search-filter-autocomplete-chips/search-filter-autocomplete-chips.component.spec.ts
@@ -169,10 +169,7 @@ describe('SearchFilterAutocompleteChipsComponent', () => {
         const sitesMock: SitePaging = {
             list: {
                 pagination: {},
-                entries: [
-                    { entry: { guid: 'site1', id: 'site1', title: 'Marketing', visibility: 'public' } },
-                    { entry: { guid: 'site2', id: 'site2', title: 'Finance', visibility: 'private' } }
-                ]
+                entries: [{ entry: { guid: 'site1', id: 'site1', title: 'Marketing', visibility: 'public' } }]
             }
         };
         component.settings.field = AutocompleteField.LOCATION;
@@ -182,8 +179,34 @@ describe('SearchFilterAutocompleteChipsComponent', () => {
         component.autocompleteOptions$.subscribe((result) => {
             expect(result).toEqual([
                 { id: 'site1', value: 'Marketing' },
-                { id: 'site2', value: 'Finance' },
                 { value: 'Repository', query: `PATH:'somePath'` }
+            ]);
+            done();
+        });
+    });
+
+    it('should filter LOCATION field options', (done) => {
+        const sitesMock: SitePaging = {
+            list: {
+                pagination: {},
+                entries: [
+                    { entry: { guid: 'site1', id: 'site1', title: 'Marketing', visibility: 'public' } },
+                    { entry: { guid: 'site2', id: 'site2', title: 'Finance', visibility: 'moderated' } },
+                    { entry: { guid: 'site3', id: 'site3', title: 'HR', visibility: 'private' } },
+                    { entry: { guid: 'site4', id: 'site4', title: 'Legal', visibility: 'private', role: 'Consumer' } },
+                    { entry: { guid: 'site5', id: 'site5', title: 'IT', visibility: 'moderated', role: 'SiteManager' } }
+                ]
+            }
+        };
+        component.settings.field = AutocompleteField.LOCATION;
+        component.settings.autocompleteOptions = [];
+        spyOn(sitesService, 'getSites').and.returnValue(of(sitesMock));
+        component.onInputChange('mark');
+        component.autocompleteOptions$.subscribe((result) => {
+            expect(result).toEqual([
+                { id: 'site1', value: 'Marketing' },
+                { id: 'site4', value: 'Legal' },
+                { id: 'site5', value: 'IT' }
             ]);
             done();
         });

--- a/lib/content-services/src/lib/search/components/search-filter-autocomplete-chips/search-filter-autocomplete-chips.component.ts
+++ b/lib/content-services/src/lib/search/components/search-filter-autocomplete-chips/search-filter-autocomplete-chips.component.ts
@@ -198,10 +198,12 @@ export class SearchFilterAutocompleteChipsComponent implements SearchWidget, OnI
             .pipe(
                 map((sites) => {
                     const predefinedOptions = this.settings?.autocompleteOptions || [];
-                    const sitesOptions = sites.list.entries.map<AutocompleteOption>((siteEntry) => ({
-                        id: siteEntry.entry.id,
-                        value: siteEntry.entry.title
-                    }));
+                    const sitesOptions = sites.list.entries
+                        .filter((siteEntry) => siteEntry.entry.visibility === 'public' || siteEntry.entry?.role)
+                        .map<AutocompleteOption>((siteEntry) => ({
+                            id: siteEntry.entry.id,
+                            value: siteEntry.entry.title
+                        }));
                     return [...sitesOptions, ...predefinedOptions];
                 })
             )


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/ACS-10165
It's possible to select libraries that user doesn't have access to in search Location filter. In such case no items appear in search results.


**What is the new behaviour?**
Selectable libraries will always provide search results (unless actually empty)


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
