### PR TITLE
[ACS-10296] Upload new version button made accessible with keyboard

### DIFF
--- a/lib/content-services/src/lib/upload/components/upload-button.component.html
+++ b/lib/content-services/src/lib/upload/components/upload-button.component.html
@@ -15,7 +15,7 @@
                 [title]="tooltip"
                 (change)="onFilesAdded($event)"
                 (click)="onClickUploadButton()"/>
-            <label for="upload-single-file" class="adf-upload-button-label">
+            <label tabindex="0" (keydown.enter)="onClickUploadButton()" for="upload-single-file" class="adf-upload-button-label">
                 <mat-icon class="adf-upload-button-icon">file_upload</mat-icon>
                 <span id="upload-single-file-label" *ngIf="!staticTitle">
                     {{ 'FILE_UPLOAD.BUTTON.UPLOAD_FILE' | translate }}</span>

--- a/lib/content-services/src/lib/upload/components/upload-button.component.spec.ts
+++ b/lib/content-services/src/lib/upload/components/upload-button.component.spec.ts
@@ -25,6 +25,7 @@ import { mockUploadErrorPromise } from '../../mock/upload.service.mock';
 import { UploadService } from '../../common/services/upload.service';
 import { NodesApiService } from '../../common/services/nodes-api.service';
 import { FileUploadErrorEvent } from '../../common/events/file.event';
+import { UnitTestingUtils } from '@alfresco/adf-core';
 
 describe('UploadButtonComponent', () => {
     const file = { name: 'fake-name-1', size: 10, webkitRelativePath: 'fake-folder1/fake-name-1.json' };
@@ -43,6 +44,7 @@ describe('UploadButtonComponent', () => {
     let fixture: ComponentFixture<UploadButtonComponent>;
     let uploadService: UploadService;
     let nodesApiService: NodesApiService;
+    let unitTestingUtils: UnitTestingUtils;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -53,6 +55,7 @@ describe('UploadButtonComponent', () => {
         nodesApiService = TestBed.inject(NodesApiService);
 
         component = fixture.componentInstance;
+        unitTestingUtils = new UnitTestingUtils(fixture.debugElement);
         fixture.detectChanges();
     });
 
@@ -198,6 +201,16 @@ describe('UploadButtonComponent', () => {
         component.uploadFolders = true;
         fixture.detectChanges();
         expect(compiled.querySelector('#uploadFolder-label-static').textContent.trim()).toEqual('test-text');
+    });
+
+    it('should call onClickUploadButton when label for single file receives enter key', () => {
+        component.uploadFolders = false;
+        component.multipleFiles = false;
+        spyOn(component, 'onClickUploadButton');
+
+        unitTestingUtils.keyBoardEventByCSS('.adf-upload-button-label', 'keydown', 'Enter', 'Enter');
+
+        expect(component.onClickUploadButton).toHaveBeenCalled();
     });
 
     describe('fileSize', () => {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Upload button is not accessible with keyboard. https://hyland.atlassian.net/browse/ACS-10296

**What is the new behaviour?**

Upload button is accessible with keyboard. 

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
