### PR TITLE
[ACS-10238] sr personal files close button lacks appropriate label

### DIFF
--- a/lib/content-services/src/lib/i18n/en.json
+++ b/lib/content-services/src/lib/i18n/en.json
@@ -2,7 +2,8 @@
   "COMMON": {
     "APPLY": "Apply",
     "CANCEL": "Cancel",
-    "NAME": "Name"
+    "NAME": "Name",
+    "CLEAR": "Clear"
   },
   "ADF_VERSION_LIST": {
     "ACTIONS": {

--- a/lib/content-services/src/lib/i18n/en.json
+++ b/lib/content-services/src/lib/i18n/en.json
@@ -557,7 +557,8 @@
       "CLOSE-ACTION": "CANCEL",
       "BASE-DIALOG-TITLE": "Search a group or people to add...",
       "EVERYONE": "EVERYONE",
-      "USER-GROUP-LIST": "User or Group List"
+      "USER-GROUP-LIST": "User or Group List",
+      "REMOVE_USER_GROUP": "Remove"
     },
     "COLUMN": {
       "NAME": "Users and Groups ({{ count }})",

--- a/lib/content-services/src/lib/permission-manager/components/add-permission/add-permission-dialog.component.html
+++ b/lib/content-services/src/lib/permission-manager/components/add-permission/add-permission-dialog.component.html
@@ -60,6 +60,8 @@
                                     class="adf-add-member-action"
                                     [style.display]="entry.row.obj.readonly ? 'none': 'block'"
                                     (click)="onMemberDelete(entry.row.obj)"
+                                    [attr.aria-label]="'PERMISSION_MANAGER.ADD-PERMISSION.REMOVE_USER_GROUP' | translate"
+                                    [attr.title]="'PERMISSION_MANAGER.ADD-PERMISSION.REMOVE_USER_GROUP' | translate"
                                     data-automation-id="adf-delete-permission-button">
                                 <mat-icon>highlight_off</mat-icon>
                             </button>

--- a/lib/content-services/src/lib/permission-manager/components/add-permission/add-permission-panel.component.html
+++ b/lib/content-services/src/lib/permission-manager/components/add-permission/add-permission-panel.component.html
@@ -10,16 +10,18 @@
         [attr.aria-label]="'PERMISSION_MANAGER.ADD-PERMISSION.SEARCH' | translate"
         [value]="searchedWord"
     />
-
-    <mat-icon
+    <button
+        matSuffix
+        mat-icon-button
         *ngIf="searchedWord?.length > 0"
-        class="adf-permission-search-icon"
         data-automation-id="adf-permission-clear-input"
         id="adf-permission-clear-input"
-        matSuffix
+        class="adf-permission-search-input-clear-button"
         (click)="clearSearch()"
-        >clear
-    </mat-icon>
+        [attr.aria-label]="'COMMON.CLEAR' | translate"
+        [attr.title]="'COMMON.CLEAR' | translate">
+        <mat-icon class="adf-permission-search-icon">clear</mat-icon>
+    </button>
 
     <mat-icon *ngIf="searchedWord?.length === 0" class="adf-permission-search-icon" data-automation-id="adf-permission-search-icon" matSuffix
         >search

--- a/lib/content-services/src/lib/permission-manager/components/add-permission/add-permission-panel.component.scss
+++ b/lib/content-services/src/lib/permission-manager/components/add-permission/add-permission-panel.component.scss
@@ -86,6 +86,13 @@ $search-result-height: calc(100% - 60px);
                     color: var(--adf-theme-foreground-base-color);
                 }
             }
+
+            .adf-permission-search-input-clear-button {
+                padding: 0;
+                width: 20px;
+                height: 32px;
+                margin-right: 1.5px;
+            }
         }
     }
 

--- a/lib/content-services/src/lib/permission-manager/components/add-permission/add-permission-panel.component.ts
+++ b/lib/content-services/src/lib/permission-manager/components/add-permission/add-permission-panel.component.ts
@@ -30,6 +30,7 @@ import { MatInputModule } from '@angular/material/input';
 import { TranslatePipe } from '@ngx-translate/core';
 import { MatIconModule } from '@angular/material/icon';
 import { UserIconColumnComponent } from '../user-icon-column/user-icon-column.component';
+import { MatIconButton } from '@angular/material/button';
 
 @Component({
     selector: 'adf-add-permission-panel',
@@ -42,7 +43,8 @@ import { UserIconColumnComponent } from '../user-icon-column/user-icon-column.co
         MatIconModule,
         MatListModule,
         UserIconColumnComponent,
-        SearchComponent
+        SearchComponent,
+        MatIconButton
     ],
     templateUrl: './add-permission-panel.component.html',
     styleUrls: ['./add-permission-panel.component.scss'],

--- a/lib/content-services/src/lib/search/components/search-text/search-text.component.html
+++ b/lib/content-services/src/lib/search/components/search-text/search-text.component.html
@@ -11,7 +11,9 @@
         *ngIf="value"
         matSuffix
         (click)="clear()"
-        class="adf-search-text-form-field-clear-button">
+        class="adf-search-text-form-field-clear-button"
+        [attr.aria-label]="'SEARCH.FILTER.ACTIONS.CLEAR' | translate"
+        [attr.title]="'SEARCH.FILTER.ACTIONS.CLEAR' | translate">
         <mat-icon>close</mat-icon>
     </button>
 </mat-form-field>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/ACS-10238


**What is the new behaviour?**
Screen readers read remove user/group icon from add permission dialog, clear input in add permission dialog and clear input for column filter. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
