### PR TITLE
AAE-38881 Adds lastModifiedAt to application instance

### DIFF
--- a/lib/process-services-cloud/src/lib/app/models/application-instance.model.ts
+++ b/lib/process-services-cloud/src/lib/app/models/application-instance.model.ts
@@ -32,6 +32,7 @@ export interface ApplicationInstanceModel {
     descriptor?: Descriptor;
     environmentId?: string;
     environment?: string;
+    lastModifiedAt?: Date;
 }
 
 export interface Descriptor {


### PR DESCRIPTION
Adds the `lastModifiedAt` property to the `ApplicationInstanceModel`.

This allows the UI to display the last modification time of a workspace deployment, addressing the requirement to show when a deployment was last modified.

Fixes AAE-38881

**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe: Missing property added


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://hyland.atlassian.net/browse/AAE-38881