### PR TITLE
[ACS-10275] a11y - Notification & Filter indicators not announced by screen readers

### DIFF
--- a/lib/content-services/src/lib/i18n/en.json
+++ b/lib/content-services/src/lib/i18n/en.json
@@ -380,6 +380,7 @@
       "TITLE": "Filter",
       "TYPE": "Type",
       "FILTER_BY": "Filter by {{ category }}",
+      "ACTIVE_FILTER": "Active filter",
       "CLEAR": "Clear",
       "APPLY": "Apply",
       "FILTERS": {

--- a/lib/content-services/src/lib/search/components/search-filter-container/search-filter-container.component.html
+++ b/lib/content-services/src/lib/search/components/search-filter-container/search-filter-container.component.html
@@ -8,7 +8,7 @@
         (menuOpened)="onMenuOpen()"
         (keyup.enter)="$event.stopPropagation()"
         class="adf-filter-button"
-        [attr.aria-label]="getTooltipTranslation(col?.title)"
+        [attr.aria-label]="isActive() ? getTooltipTranslation(col?.title) + ' (' + ('SEARCH.SEARCH_HEADER.ACTIVE_FILTER' | translate) + ')' : getTooltipTranslation(col?.title)"
         [title]="getTooltipTranslation(col?.title)"
     >
         <adf-icon

--- a/lib/core/src/lib/i18n/en.json
+++ b/lib/core/src/lib/i18n/en.json
@@ -24,6 +24,7 @@
   "CLOSE": "CLOSE",
   "NOTIFICATIONS": {
     "NO_MESSAGE": "You have no notifications at this time.",
+    "UNREAD_MESSAGES": "You have unread notifications.",
     "TITLE": "Notifications",
     "MARK_AS_READ": "Mark all as read",
     "SYSTEM": "System",

--- a/lib/core/src/lib/notifications/components/notification-history.component.html
+++ b/lib/core/src/lib/notifications/components/notification-history.component.html
@@ -1,7 +1,7 @@
 <button mat-button
         [matMenuTriggerFor]="menu"
         aria-hidden="false"
-        [attr.aria-label]="'NOTIFICATIONS.OPEN_HISTORY' | translate"
+        [attr.aria-label]="('NOTIFICATIONS.' + (notifications.length ? 'UNREAD_MESSAGES' : 'NO_MESSAGE') | translate) + ' ' + ('NOTIFICATIONS.OPEN_HISTORY' | translate)"
         title="{{ 'NOTIFICATIONS.OPEN_HISTORY' | translate }}"
         class="adf-notification-history-menu_button"
         id="adf-notification-history-open-button"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [X] Other... Please describe: a11y


**What is the current behaviour?** (You can also link to an open issue here)

https://hyland.atlassian.net/browse/ACS-10275

**What is the new behaviour?**

Notification & Filter indicators are now announced with appropriate status by screen readers

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
