### PR TITLE
[ACS-10325] a11y SR: Metadata edit button announced twice

### DIFF
--- a/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.html
+++ b/lib/content-services/src/lib/content-metadata/components/content-metadata/content-metadata.component.html
@@ -9,7 +9,7 @@
         hideToggle>
         <mat-expansion-panel-header
             class="adf-metadata-properties-header"
-            [attr.aria-label]="('CORE.METADATA.BASIC.HEADER' | translate) + ' ' + ('CORE.METADATA.ACCESSIBILITY.SECTION' | translate)"
+            [attr.aria-label]="'CORE.METADATA.ACCESSIBILITY.SECTION' | translate: { sectionName: ('CORE.METADATA.BASIC.HEADER' | translate) }"
             [class.adf-metadata-properties-header-expanded]="currentPanel.panelTitle === DefaultPanels.PROPERTIES && currentPanel.expanded">
             <adf-content-metadata-header
                 [title]="'CORE.METADATA.BASIC.HEADER'"
@@ -19,7 +19,7 @@
                     mat-icon-button
                     (click)="toggleGroupEditing(DefaultPanels.PROPERTIES, $event)"
                     [attr.title]="'CORE.METADATA.ACTIONS.EDIT' | translate"
-                    [attr.aria-label]="('CORE.METADATA.BASIC.HEADER' | translate) + ' ' + ('CORE.METADATA.ACTIONS.EDIT' | translate)"
+                    [attr.aria-label]="'CORE.METADATA.ACCESSIBILITY.EDIT' | translate: { sectionName: ('CORE.METADATA.BASIC.HEADER' | translate) }"
                     data-automation-id="meta-data-general-info-edit"
                     class="adf-edit-icon-buttons">
                     <mat-icon>mode_edit</mat-icon>
@@ -66,7 +66,7 @@
             data-automation-id="adf-content-metadata-tags-panel">
             <mat-expansion-panel-header
                 class="adf-metadata-properties-header"
-                [attr.aria-label]="('METADATA.BASIC.TAGS' | translate) + ' ' + ('CORE.METADATA.ACCESSIBILITY.SECTION' | translate)"
+                [attr.aria-label]="'CORE.METADATA.ACCESSIBILITY.SECTION' | translate: { sectionName: ('METADATA.BASIC.TAGS' | translate) }"
                 [class.adf-metadata-properties-header-expanded]="currentPanel.panelTitle === DefaultPanels.TAGS && currentPanel.expanded">
                 <adf-content-metadata-header [title]="'METADATA.BASIC.TAGS'" [expanded]="currentPanel.panelTitle === DefaultPanels.TAGS && currentPanel.expanded">
                     <button
@@ -74,7 +74,7 @@
                         mat-icon-button
                         (click)="toggleGroupEditing(DefaultPanels.TAGS, $event)"
                         [attr.title]="'CORE.METADATA.ACTIONS.EDIT' | translate"
-                        [attr.aria-label]="('METADATA.BASIC.TAGS' | translate) + ' ' + ('CORE.METADATA.ACTIONS.EDIT' | translate)"
+                        [attr.aria-label]="'CORE.METADATA.ACCESSIBILITY.EDIT' | translate: { sectionName: ('METADATA.BASIC.TAGS' | translate) }"
                         data-automation-id="showing-tag-input-button"
                         class="adf-edit-icon-buttons">
                         <mat-icon>mode_edit</mat-icon>
@@ -128,7 +128,7 @@
             data-automation-id="adf-content-metadata-categories-panel">
             <mat-expansion-panel-header
                 class="adf-metadata-properties-header"
-                [attr.aria-label]="('CATEGORIES_MANAGEMENT.CATEGORIES_TITLE' | translate) + ' ' + ('CORE.METADATA.ACCESSIBILITY.SECTION' | translate)"
+                [attr.aria-label]="'CORE.METADATA.ACCESSIBILITY.SECTION' | translate: { sectionName: ('CATEGORIES_MANAGEMENT.CATEGORIES_TITLE' | translate) }"
                 [class.adf-metadata-properties-header-expanded]="currentPanel.panelTitle === DefaultPanels.CATEGORIES && currentPanel.expanded">
                 <adf-content-metadata-header
                     [title]="'CATEGORIES_MANAGEMENT.CATEGORIES_TITLE'"
@@ -138,7 +138,7 @@
                         mat-icon-button
                         (click)="toggleGroupEditing(DefaultPanels.CATEGORIES, $event)"
                         [attr.title]="'CORE.METADATA.ACTIONS.EDIT' | translate"
-                        [attr.aria-label]="('CATEGORIES_MANAGEMENT.CATEGORIES_TITLE' | translate) + ' ' + ('CORE.METADATA.ACTIONS.EDIT' | translate)"
+                        [attr.aria-label]="'CORE.METADATA.ACCESSIBILITY.EDIT' | translate: { sectionName: ('CATEGORIES_MANAGEMENT.CATEGORIES_TITLE' | translate) }"
                         data-automation-id="meta-data-categories-edit"
                         class="adf-categories-button adf-edit-icon-buttons">
                         <mat-icon>mode_edit</mat-icon>
@@ -191,7 +191,7 @@
         hideToggle>
         <mat-expansion-panel-header
             class="adf-metadata-properties-header"
-            [attr.aria-label]="(customPanel.panelTitle | translate) + ' ' + ('CORE.METADATA.ACCESSIBILITY.SECTION' | translate)"
+            [attr.aria-label]="'CORE.METADATA.ACCESSIBILITY.SECTION' | translate: { sectionName: (customPanel.panelTitle | translate) }"
             [class.adf-metadata-properties-header-expanded]="currentPanel.panelTitle === customPanel.panelTitle && currentPanel.expanded">
             <adf-content-metadata-header
                 class="adf-metadata-custom-panel-title"
@@ -212,14 +212,14 @@
                 hideToggle>
                 <mat-expansion-panel-header
                     class="adf-metadata-properties-header"
-                    [attr.aria-label]="(group.title | translate) + ' ' + ('CORE.METADATA.ACCESSIBILITY.SECTION' | translate)"
+                    [attr.aria-label]="'CORE.METADATA.ACCESSIBILITY.SECTION' | translate: { sectionName: (group.title | translate) }"
                     [class.adf-metadata-properties-header-expanded]="currentPanel.panelTitle === group.title && currentPanel.expanded">
                     <adf-content-metadata-header [title]="group.title" [expanded]="currentPanel.panelTitle === group.title && currentPanel.expanded">
                         <button
                             *ngIf="group.editable && !this.readOnly && !isPanelEditing(group.title)"
                             mat-icon-button
                             [attr.title]="'CORE.METADATA.ACTIONS.EDIT' | translate"
-                            [attr.aria-label]="(group.title | translate) + ' ' + ('CORE.METADATA.ACTIONS.EDIT' | translate)"
+                            [attr.aria-label]="'CORE.METADATA.ACCESSIBILITY.EDIT' | translate: { sectionName: (group.title | translate) }"
                             data-automation-id="meta-data-card-toggle-edit"
                             class="adf-edit-icon-buttons"
                             (click)="toggleGroupEditing(group.title, $event)">

--- a/lib/core/src/lib/i18n/en.json
+++ b/lib/core/src/lib/i18n/en.json
@@ -285,10 +285,11 @@
         "EDIT_ASPECTS": "Edit Aspect"
       },
       "ACCESSIBILITY": {
+        "EDIT": "Edit {{ sectionName }}",
         "DATEPICKER": "Use the arrow keys to navigate between dates. Up and down move to the next or previous week but on the same day. Left and right move to the next or previous day. Press Enter or Return to select a date.",
         "COPY_TO_CLIPBOARD_MESSAGE": "Value copied to clipboard",
         "EDIT_ASPECTS": "Edit Aspect",
-        "SECTION": "section"
+        "SECTION": "{{ sectionName }} section"
       }
     },
     "SEARCH": {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [X] Other... Please describe: a11y


**What is the current behaviour?** (You can also link to an open issue here)

https://hyland.atlassian.net/browse/ACS-10325

**What is the new behaviour?**

Panel header & Edit button announced correctly by screen reader 

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
