### PR TITLE
[ACS-10333] Personal files: New File Title Not Announced by Screen Readers After Upload

### DIFF
--- a/lib/content-services/src/lib/upload/components/file-uploading-dialog.component.html
+++ b/lib/content-services/src/lib/upload/components/file-uploading-dialog.component.html
@@ -53,7 +53,6 @@
     <section class="adf-upload-dialog__content"
         [class.adf-upload-dialog--padding]="isConfirmation" aria-live="polite">
         <adf-file-uploading-list
-            role="list"
             class="adf-file-uploading-list"
             [class.adf-upload-dialog--hide]="isConfirmation"
             #uploadList

--- a/lib/content-services/src/lib/upload/components/file-uploading-list-row.component.html
+++ b/lib/content-services/src/lib/upload/components/file-uploading-list-row.component.html
@@ -1,4 +1,4 @@
-<div class="adf-file-uploading-row" role="listitem" [attr.aria-label]="file.name + ' ' + file.status">
+<div class="adf-file-uploading-row" [attr.aria-label]="file.name + ' ' + file.status">
     <mat-icon *ngIf="mimeType === 'default'" matListItemIcon class="adf-file-uploading-row__type">
         insert_drive_file
     </mat-icon>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://hyland.atlassian.net/browse/ACS-10333

**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
