### PR TITLE
AAE-37713 Amount locale display v.2

### DIFF
--- a/lib/core/src/lib/app-config/app-config.service.spec.ts
+++ b/lib/core/src/lib/app-config/app-config.service.spec.ts
@@ -204,34 +204,4 @@ describe('AppConfigService', () => {
         expect(appConfigService.get<any>('objectKey').secondUrl).toEqual('http://localhost:8080');
         expect(appConfigService.get<any>('objectKey').thirdUrl).toEqual('http://localhost:8080');
     });
-
-    describe('getLocale', () => {
-        it('returns the first language from navigator.languages when available', () => {
-            const returnedLanguages: string[] = ['fr-FR', 'en-US'];
-            const mockLanguages = spyOnProperty(window, 'navigator').and.returnValue({
-                language: 'en-GB',
-                languages: returnedLanguages
-            } as any);
-
-            expect(appConfigService.getLocale('en-US')).toBe('fr-FR');
-            expect(mockLanguages).toHaveBeenCalled();
-        });
-
-        it('falls back to navigator.language when languages list is absent', () => {
-            const mockLanguages = spyOnProperty(window, 'navigator').and.returnValue({
-                language: 'de-DE',
-                languages: []
-            } as any);
-
-            expect(appConfigService.getLocale('en-US')).toBe('de-DE');
-            expect(mockLanguages).toHaveBeenCalled();
-        });
-
-        it('falls back to the provided default locale when navigator is unavailable', () => {
-            const mockLanguages = spyOnProperty(window, 'navigator').and.returnValue(undefined);
-
-            expect(appConfigService.getLocale('en-US')).toBe('en-US');
-            expect(mockLanguages).toHaveBeenCalled();
-        });
-    });
 });

--- a/lib/core/src/lib/app-config/app-config.service.ts
+++ b/lib/core/src/lib/app-config/app-config.service.ts
@@ -166,22 +166,6 @@ export class AppConfigService {
         return location.port ? prefix + location.port : '';
     }
 
-    /**
-     * Determines the preferred locale for the current user.
-     *
-     * @param defaultLocale Fallback locale to use when browser data is unavailable
-     * @returns Locale identifier resolved from the browser or the default translation locale
-     */
-    getLocale(defaultLocale: string): string {
-        if (typeof window?.navigator === 'undefined') {
-            return defaultLocale;
-        }
-        const wn = window.navigator as Navigator;
-        let lang = wn.languages ? wn.languages[0] : defaultLocale;
-        lang = lang || wn.language;
-        return lang;
-    }
-
     protected onLoaded() {
         this.onLoadSubject.next(this.config);
     }

--- a/lib/core/src/lib/form/components/widgets/amount/amount.widget.spec.ts
+++ b/lib/core/src/lib/form/components/widgets/amount/amount.widget.spec.ts
@@ -27,7 +27,6 @@ import { of } from 'rxjs';
 import { FormService } from '../../../services/form.service';
 import { FormFieldEvent } from '../../../events/form-field.event';
 import { TranslationService } from '../../../../translation/translation.service';
-import { AppConfigService } from '../../../../app-config/app-config.service';
 
 describe('AmountWidgetComponent', () => {
     let loader: HarnessLoader;
@@ -38,10 +37,7 @@ describe('AmountWidgetComponent', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [AmountWidgetComponent],
-            providers: [
-                { provide: TranslationService, useValue: { userLang: 'de' } },
-                { provide: AppConfigService, useValue: { getLocale: () => 'en-US' } }
-            ]
+            providers: [{ provide: TranslationService, useValue: { getLocale: () => 'en-US' } }]
         });
 
         fixture = TestBed.createComponent(AmountWidgetComponent);
@@ -126,10 +122,6 @@ describe('AmountWidgetComponent', () => {
     });
 
     it('should set initial values with correct currency', () => {
-        const returnedLanguages: string[] = ['en-GB'];
-        spyOnProperty(window, 'navigator').and.returnValue({
-            languages: returnedLanguages
-        } as any);
         widget.field = new FormFieldModel(null, { id: 2, name: 'test', value: 25, currency: 'GBP' });
         widget.enableDisplayBasedOnLocale = true;
         widget.currency = 'GBP';
@@ -140,10 +132,6 @@ describe('AmountWidgetComponent', () => {
     });
 
     it('should set initial values with correct currency icon', () => {
-        const returnedLanguages: string[] = ['en-GB'];
-        spyOnProperty(window, 'navigator').and.returnValue({
-            languages: returnedLanguages
-        } as any);
         widget.field = new FormFieldModel(null, { id: 2, name: 'test', value: 25, currency: '¥' });
         widget.enableDisplayBasedOnLocale = true;
         widget.currency = '¥';
@@ -154,10 +142,6 @@ describe('AmountWidgetComponent', () => {
     });
 
     it('should set initial values without currency', () => {
-        const returnedLanguages: string[] = ['en-GB'];
-        spyOnProperty(window, 'navigator').and.returnValue({
-            languages: returnedLanguages
-        } as any);
         widget.field = new FormFieldModel(null, { id: 3, name: 'test', value: 25, currency: '' });
         widget.enableDisplayBasedOnLocale = true;
         widget.currency = '';
@@ -490,14 +474,13 @@ describe('AmountWidgetComponent - rendering', () => {
             beforeEach(async () => {
                 TestBed.configureTestingModule({
                     imports: [AmountWidgetComponent],
-                    providers: [{ provide: ADF_AMOUNT_SETTINGS, useValue: of({ enableDisplayBasedOnLocale: true }) }]
+                    providers: [
+                        { provide: ADF_AMOUNT_SETTINGS, useValue: of({ enableDisplayBasedOnLocale: true }) },
+                        { provide: TranslationService, useValue: { getLocale: () => 'en-US' } }
+                    ]
                 });
                 fixture = TestBed.createComponent(AmountWidgetComponent);
                 widget = fixture.componentInstance;
-                const returnedLanguages: string[] = ['en-GB', 'en-US', 'en', 'de-DE', 'pl'];
-                spyOnProperty(window, 'navigator').and.returnValue({
-                    languages: returnedLanguages
-                } as any);
                 fixture.componentRef.setInput('field', mockField);
                 loader = TestbedHarnessEnvironment.loader(fixture);
                 testingUtils = new UnitTestingUtils(fixture.debugElement, loader);
@@ -507,7 +490,7 @@ describe('AmountWidgetComponent - rendering', () => {
             it('should set enableDisplayBasedOnLocale to true', () => {
                 expect(widget.enableDisplayBasedOnLocale).toBeTrue();
                 expect(widget.decimalProperty).toBe('1.2-2');
-                expect(widget.locale).toBe('en-GB');
+                expect(widget.locale).toBe('en-US');
                 expect(widget.valueAsNumber).toBe('1234.55');
                 expect(widget.amountWidgetValue).toBe('$1,234.55');
             });

--- a/lib/core/src/lib/form/components/widgets/amount/amount.widget.ts
+++ b/lib/core/src/lib/form/components/widgets/amount/amount.widget.ts
@@ -29,7 +29,6 @@ import { WidgetComponent } from '../widget.component';
 import { filter, isObservable, Observable } from 'rxjs';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormFieldEvent } from '../../../events/form-field.event';
-import { AppConfigService } from '../../../../app-config/app-config.service';
 import { TranslationService } from '../../../../translation/translation.service';
 
 export interface AmountWidgetSettings {
@@ -83,7 +82,6 @@ export class AmountWidgetComponent extends WidgetComponent implements OnInit {
         public formService: FormService,
         @Optional() @Inject(ADF_AMOUNT_SETTINGS) settings: Observable<AmountWidgetSettings> | AmountWidgetSettings,
         private currencyPipe: CurrencyPipe,
-        private appConfigService: AppConfigService,
         private translationService: TranslationService
     ) {
         super(formService);
@@ -150,8 +148,7 @@ export class AmountWidgetComponent extends WidgetComponent implements OnInit {
     setInitialValues(): void {
         if (this.enableDisplayBasedOnLocale) {
             this.decimalProperty = this.field.enableFractions ? this.showDecimalDigits : this.notShowDecimalDigits;
-            const defaultLocale = this.translationService.userLang;
-            this.locale = this.appConfigService.getLocale(defaultLocale);
+            this.locale = this.translationService.getLocale();
             this.updateValue(this.field.value);
         } else {
             this.amountWidgetValue = this.field.value;

--- a/lib/core/src/lib/mock/translation.service.mock.ts
+++ b/lib/core/src/lib/mock/translation.service.mock.ts
@@ -47,6 +47,8 @@ export class TranslationMock implements TranslationService {
         return of(key);
     }
 
+    getLocale(): any {}
+
     instant(key: string | Array<string>): string | any {
         return key;
     }

--- a/lib/core/src/lib/testing/noop-translate.module.ts
+++ b/lib/core/src/lib/testing/noop-translate.module.ts
@@ -41,6 +41,8 @@ export class NoopTranslationService implements TranslationService {
         return of(key);
     }
 
+    getLocale(): any {}
+
     instant(key: string | Array<string>): string | any {
         return key;
     }

--- a/lib/core/src/lib/translation/translation.service.spec.ts
+++ b/lib/core/src/lib/translation/translation.service.spec.ts
@@ -83,4 +83,37 @@ describe('TranslationService', () => {
         expect(translationService.instant('')).toEqual('');
         expect(translationService.instant(undefined)).toEqual('');
     });
+
+    describe('getLocale', () => {
+        it('returns the first language from navigator.languages when available', () => {
+            translationService.userLang = 'it';
+            const returnedLanguages: string[] = ['fr-FR', 'en-US'];
+            const mockLanguages = spyOnProperty(window, 'navigator').and.returnValue({
+                language: 'en-GB',
+                languages: returnedLanguages
+            } as any);
+
+            expect(translationService.getLocale()).toBe('fr-FR');
+            expect(mockLanguages).toHaveBeenCalled();
+        });
+
+        it('falls back to navigator.language when languages list is absent', () => {
+            translationService.userLang = 'fr';
+            const mockLanguages = spyOnProperty(window, 'navigator').and.returnValue({
+                language: 'de-DE',
+                languages: []
+            } as any);
+
+            expect(translationService.getLocale()).toBe('de-DE');
+            expect(mockLanguages).toHaveBeenCalled();
+        });
+
+        it('falls back to the provided default locale when navigator is unavailable', () => {
+            translationService.userLang = 'en';
+            const mockLanguages = spyOnProperty(window, 'navigator').and.returnValue(undefined);
+
+            expect(translationService.getLocale()).toBe('en');
+            expect(mockLanguages).toHaveBeenCalled();
+        });
+    });
 });

--- a/lib/core/src/lib/translation/translation.service.ts
+++ b/lib/core/src/lib/translation/translation.service.ts
@@ -152,6 +152,22 @@ export class TranslationService {
     }
 
     /**
+     * Determines the preferred locale for the current user.
+     *
+     * @returns Locale identifier resolved from the browser or the default translation locale
+     */
+    getLocale(): string {
+        const defaultLocale = this.userLang || this.defaultLang;
+        if (typeof window?.navigator === 'undefined') {
+            return defaultLocale;
+        }
+        const wn = window.navigator as Navigator;
+        let lang = wn.languages ? wn.languages[0] : defaultLocale;
+        lang = lang || wn.language;
+        return lang;
+    }
+
+    /**
      * Directly returns the translation for the supplied key.
      *
      * @param key Key to translate


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**
https://hyland.atlassian.net/browse/AAE-37713

The idea behind this change is to allow the user to see the amount formatted according to local settings. For example, instead of seeing the number 12345.67, the user will see something like $12,345.67 (this may vary depending on the locale). The current solution for the amount widget is based on using the field.value property to display the field's value. With this PR, this will be changed. The amountWidgetValue property will be used to display the value in the input field. 

The exact value of this property will be based on the state of the input field. If the field is focused, it will show a numeric value, e.g., 12345.67. If the field is blurred, it will be converted into a currency string, e.g., $12,345.67. The widget also subscribes to form changes to respond accordingly to changes in the field.value. Changes can come both from form rules and from other external sources.

**Does this PR introduce a breaking change?** (check one with "x")

> - [x] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
Parameters of method parseForm from class FormCloudService has been updated and parameter for formService has been added. Currently this method creates FormModel with passing undefined instead of instance of FormService. But instance of FormService is needed to track the changes of field of forms like changes from form rules. 
**Other information**:
Call of FormService method parseForm in FormEditorComponent needs to be updated.
