### PR TITLE
AAE-39821 Adds quickRunDeployment property

### DIFF
--- a/lib/process-services-cloud/src/lib/app/models/application-instance.model.ts
+++ b/lib/process-services-cloud/src/lib/app/models/application-instance.model.ts
@@ -30,6 +30,7 @@ export interface ApplicationInstanceModel {
     environmentId?: string;
     environment?: string;
     lastModifiedAt?: Date;
+    quickRunDeployment?: boolean;
 }
 
 export interface Descriptor {


### PR DESCRIPTION
Adds the `quickRunDeployment` property to the `ApplicationInstanceModel` interface. https://hyland.atlassian.net/browse/AAE-39821

This allows the admin app to determine if an application instance is a quick run deployment, which is necessary to block upgrades and restores for those instances.

Relates to AAE-39821

**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)



**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
