### PR TITLE
[MNT-25412] Chip autocomplete set input value when preselected options change

### DIFF
--- a/lib/content-services/src/lib/search/components/search-chip-autocomplete-input/search-chip-autocomplete-input.component.spec.ts
+++ b/lib/content-services/src/lib/search/components/search-chip-autocomplete-input/search-chip-autocomplete-input.component.spec.ts
@@ -21,7 +21,7 @@ import { By } from '@angular/platform-browser';
 import { Subject } from 'rxjs';
 import { ContentTestingModule } from '../../../testing/content.testing.module';
 import { SearchChipAutocompleteInputComponent } from './search-chip-autocomplete-input.component';
-import { DebugElement } from '@angular/core';
+import { DebugElement, SimpleChanges } from '@angular/core';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatChipHarness, MatChipGridHarness } from '@angular/material/chips/testing';
@@ -126,6 +126,16 @@ describe('SearchChipAutocompleteInputComponent', () => {
         component.preselectedOptions = [{ value: 'option1' }];
         component.ngOnInit();
         expect(component.selectedOptions).toEqual([{ value: 'option1' }]);
+    });
+
+    it('should assign preselected values whenever they are changed', async () => {
+        const preselectedOptionsChange: SimpleChanges = {
+            preselectedOptions: { currentValue: [{ value: 'option1' }], previousValue: [], firstChange: false, isFirstChange: () => false }
+        };
+        component.ngOnChanges(preselectedOptionsChange);
+        fixture.detectChanges();
+        expect(component.selectedOptions).toEqual([{ value: 'option1' }]);
+        expect(await getChipValue(0)).toBe('option1');
     });
 
     it('should add new option only if value is predefined when allowOnlyPredefinedValues = true', async () => {

--- a/lib/content-services/src/lib/search/components/search-chip-autocomplete-input/search-chip-autocomplete-input.component.ts
+++ b/lib/content-services/src/lib/search/components/search-chip-autocomplete-input/search-chip-autocomplete-input.component.ts
@@ -122,6 +122,9 @@ export class SearchChipAutocompleteInputComponent implements OnInit, OnChanges {
                     ? this.filter(changes.autocompleteOptions.currentValue, this.formCtrl.value)
                     : [];
         }
+        if (changes.preselectedOptions) {
+            this.selectedOptions = changes.preselectedOptions.currentValue ?? [];
+        }
     }
 
     add(event: MatChipInputEvent) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://hyland.atlassian.net/browse/MNT-25412

**What is the new behaviour?**

Whenever preselected options change input get correct values.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
