### PR TITLE
[ACS-10281] a11y fix - Approve step folder control is focusable twice causing duplicate screen reader

### DIFF
--- a/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.html
+++ b/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.html
@@ -104,12 +104,12 @@
         </mat-form-field>
     </div>
 
-    <div
+    <button
+        type="button"
         *ngSwitchCase="'clickableTemplate'"
         class="adf-textitem-clickable"
         [ngClass]="{ 'adf-property-read-only': !isEditable }"
         [attr.data-automation-id]="'card-textitem-toggle-' + property.key"
-        (keyup.enter)="clicked()"
         (click)="clicked()"
     >
         <mat-form-field class="adf-property-field adf-card-textitem-field" [floatLabel]="'always'">
@@ -117,6 +117,7 @@
                 *ngIf="showProperty || isEditable"
                 [attr.data-automation-id]="'card-textitem-label-' + property.key"
                 class="adf-property-label"
+                (click)="$event.stopPropagation()"
                 [ngClass]="{ 'adf-property-value-editable': editable }"
             >
                 {{ property.label | translate }}
@@ -125,7 +126,6 @@
                 matInput
                 [type]="property.inputType"
                 class="adf-property-value"
-                title="{{ property.label | translate }}"
                 [ngClass]="{
                     'adf-property-value-editable': editable,
                     'adf-textitem-clickable-value': isClickable,
@@ -134,11 +134,11 @@
                     'adf-property-value-has-icon-suffix': showClickableIcon
                 }"
                 [placeholder]="property.default"
-                [attr.aria-label]="property.label | translate"
                 [(ngModel)]="editedValue"
                 (blur)="update()"
                 (keydown.enter)="update()"
                 [readonly]="!isEditable"
+                tabindex="-1"
                 [attr.data-automation-id]="'card-textitem-value-' + property.key"
             />
             <button
@@ -152,7 +152,7 @@
                 <mat-icon class="adf-textitem-icon">{{ property?.icon }}</mat-icon>
             </button>
         </mat-form-field>
-    </div>
+    </button>
 
     <div *ngSwitchCase="'emptyTemplate'">
         <span class="adf-textitem-default-value">{{ property.default | translate }}</span>

--- a/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.scss
+++ b/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.scss
@@ -60,8 +60,12 @@
     }
 
     .adf-textitem-clickable {
+        background: none;
+        border: none;
+        margin: 0;
         cursor: pointer;
-        padding-top: 3px;
+        width: 100%;
+        padding: 3px 0 0;
 
         .adf-textitem-action:hover {
             color: var(--adf-theme-foreground-text-color);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [X] Other... Please describe: a11y


**What is the current behaviour?** (You can also link to an open issue here)

https://hyland.atlassian.net/browse/ACS-10281

**What is the new behaviour?**

Removed focusability from the outer div, so only the input remains focusable.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
