### PR TITLE
AAE-40391 Stabilize data conversion methods for rows and columns in datatable

### DIFF
--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.spec.ts
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.spec.ts
@@ -2363,4 +2363,102 @@ describe('Column Resizing', () => {
             expect(datatableCells.length).toBe(expectedNumberOfColumns);
         });
     });
+
+    describe('Data conversion methods', () => {
+        describe('convertToRowsData', () => {
+            it('should convert array of objects to ObjectDataRow array', () => {
+                const rowsData = [
+                    { name: 'Row 1', isSelected: true, isSelectable: true },
+                    { name: 'Row 2', isSelected: false, isSelectable: false }
+                ];
+
+                const result = dataTable.convertToRowsData(rowsData);
+
+                expect(result.length).toBe(2);
+                expect(result[0].getValue('name')).toBe('Row 1');
+                expect(result[0].isSelected).toBe(true);
+                expect(result[1].getValue('name')).toBe('Row 2');
+                expect(result[1].isSelected).toBe(false);
+            });
+
+            it('should return empty array when input is null', () => {
+                const result = dataTable.convertToRowsData(null);
+
+                expect(result).toEqual([]);
+            });
+
+            it('should return empty array when input is undefined', () => {
+                const result = dataTable.convertToRowsData(undefined);
+
+                expect(result).toEqual([]);
+            });
+
+            it('should return empty array when input is not an array', () => {
+                const result = dataTable.convertToRowsData({} as any);
+
+                expect(result).toEqual([]);
+            });
+
+            it('should return empty array when input is a string', () => {
+                const result = dataTable.convertToRowsData('not an array' as any);
+
+                expect(result).toEqual([]);
+            });
+
+            it('should return empty array when input is a number', () => {
+                const result = dataTable.convertToRowsData(123 as any);
+
+                expect(result).toEqual([]);
+            });
+        });
+
+        describe('convertToColumnsData', () => {
+            it('should convert array of objects to ObjectDataColumn array', () => {
+                const columnsData = [
+                    { key: 'name', title: 'Name', sortable: true },
+                    { key: 'age', title: 'Age', sortable: false }
+                ];
+
+                const result = dataTable.convertToColumnsData(columnsData);
+
+                expect(result.length).toBe(2);
+                expect(result[0].key).toBe('name');
+                expect(result[0].title).toBe('Name');
+                expect(result[0].sortable).toBe(true);
+                expect(result[1].key).toBe('age');
+                expect(result[1].title).toBe('Age');
+                expect(result[1].sortable).toBe(false);
+            });
+
+            it('should return empty array when input is null', () => {
+                const result = dataTable.convertToColumnsData(null);
+
+                expect(result).toEqual([]);
+            });
+
+            it('should return empty array when input is undefined', () => {
+                const result = dataTable.convertToColumnsData(undefined);
+
+                expect(result).toEqual([]);
+            });
+
+            it('should return empty array when input is not an array', () => {
+                const result = dataTable.convertToColumnsData({} as any);
+
+                expect(result).toEqual([]);
+            });
+
+            it('should return empty array when input is a string', () => {
+                const result = dataTable.convertToColumnsData('not an array' as any);
+
+                expect(result).toEqual([]);
+            });
+
+            it('should return empty array when input is a number', () => {
+                const result = dataTable.convertToColumnsData(456 as any);
+
+                expect(result).toEqual([]);
+            });
+        });
+    });
 });

--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.ts
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.ts
@@ -461,10 +461,16 @@ export class DataTableComponent implements OnInit, AfterContentInit, OnChanges, 
     }
 
     convertToRowsData(rows: any[]): ObjectDataRow[] {
+        if (!Array.isArray(rows)) {
+            return [];
+        }
         return rows.map((row) => new ObjectDataRow(row, row.isSelected, row?.isSelectable));
     }
 
     convertToColumnsData(columns: any[]): ObjectDataColumn[] {
+        if (!Array.isArray(columns)) {
+            return [];
+        }
         return columns.map((column) => new ObjectDataColumn(column));
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

crashes in the browser console when rows not provided or loaded

<img width="543" height="733" alt="Screenshot 2025-11-27 at 14 12 36" src="https://github.com/user-attachments/assets/d2e76658-9e59-46b4-8284-08b3683f83d6" />



**What is the new behaviour?**

add safety checks, unit tests

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://hyland.atlassian.net/browse/AAE-40391