### PR TITLE
[ACS-10280]: Keyboard Navigation: Search: Unnecessary stops in the results table using the Tab key

### DIFF
--- a/lib/content-services/src/lib/document-list/data/share-datatable-adapter.spec.ts
+++ b/lib/content-services/src/lib/document-list/data/share-datatable-adapter.spec.ts
@@ -493,16 +493,4 @@ describe('ShareDataTableAdapter', () => {
             expect(adapter.getRowByNodeId('fake-node-id-2')).toEqual(fakeShareDataRows[1]);
         });
     });
-
-    it('should initialize with allowFocusOnRows as true by default', () => {
-        const adapter = new ShareDataTableAdapter(thumbnailService, contentService, null);
-        expect(adapter.allowFocusOnRows).toBe(true);
-    });
-
-    it('should set allowFocusOnRows value', () => {
-        const adapter = new ShareDataTableAdapter(thumbnailService, contentService, null);
-        expect(adapter.allowFocusOnRows).toBe(true);
-        adapter.setAllowFocusOnTableRows(false);
-        expect(adapter.allowFocusOnRows).toBe(false);
-    });
 });

--- a/lib/content-services/src/lib/document-list/data/share-datatable-adapter.ts
+++ b/lib/content-services/src/lib/document-list/data/share-datatable-adapter.ts
@@ -38,7 +38,6 @@ export class ShareDataTableAdapter implements DataTableAdapter {
     permissionsStyle: PermissionStyleModel[];
     selectedRow: DataRow;
     allowDropFiles: boolean;
-    allowFocusOnRows = true;
 
     set sortingMode(value: string) {
         let newValue = (value || 'client').toLowerCase();
@@ -195,10 +194,6 @@ export class ShareDataTableAdapter implements DataTableAdapter {
 
     setImageResolver(resolver: any) {
         this.imageResolver = resolver;
-    }
-
-    setAllowFocusOnTableRows(allow: boolean) {
-        this.allowFocusOnRows = allow;
     }
 
     private getFolderIcon(node: any) {

--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.html
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.html
@@ -243,9 +243,11 @@
                     {{ row.isSelected ? ('ADF-DATATABLE.ACCESSIBILITY.SELECTED' | translate) : '' }}
                 </span>
 
-                <!-- Drag button -->
-                <div *ngIf="enableDragRows" role="gridcell" class="adf-datatable-cell adf-datatable__actions-cell adf-datatable-hover-only">
-                    <mat-icon adf-icon="drag_indicator" aria-hidden="true" />
+                 <!-- Drag button -->
+                <div *ngIf="enableDragRows"
+                        role="gridcell"
+                        class="adf-datatable-cell adf-datatable__actions-cell adf-datatable-hover-only">
+                        <mat-icon adf-icon="drag_indicator" aria-hidden="true" />
                 </div>
 
                 <!-- Actions (left) -->
@@ -293,7 +295,7 @@
 
                 <div
                     *ngFor="let col of getVisibleColumns(); let lastColumn = last"
-                    role = 'gridcell'
+                    role="gridcell"
                     class="adf-datatable-cell adf-datatable-cell--{{col.type || 'text'}} {{col.cssClass}} adf-datatable-cell-data adf-datatable-cell--{{getAutomationValue(row)}}"
                     [attr.title]="col.title | translate"
                     [attr.data-automation-id]="getAutomationValue(row)"  

--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.html
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.html
@@ -244,7 +244,7 @@
                 </span>
 
                 <!-- Drag button -->
-                <div *ngIf="enableDragRows" class="adf-datatable-cell adf-datatable__actions-cell adf-datatable-hover-only">
+                <div *ngIf="enableDragRows" role="gridcell" class="adf-datatable-cell adf-datatable__actions-cell adf-datatable-hover-only">
                     <mat-icon adf-icon="drag_indicator" aria-hidden="true" />
                 </div>
 
@@ -293,7 +293,7 @@
 
                 <div
                     *ngFor="let col of getVisibleColumns(); let lastColumn = last"
-                    role ='gridcell'
+                    role = 'gridcell'
                     class="adf-datatable-cell adf-datatable-cell--{{col.type || 'text'}} {{col.cssClass}} adf-datatable-cell-data adf-datatable-cell--{{getAutomationValue(row)}}"
                     [attr.title]="col.title | translate"
                     [attr.data-automation-id]="getAutomationValue(row)"  

--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.html
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.html
@@ -231,16 +231,21 @@
                 [class.adf-datatable-row__dragging]="isDraggingRow"
                 [attr.data-automation-id]="'datatable-row-' + idx"
                 (contextmenu)="markRowAsContextMenuSource(row)"
-                [disabled]="!(data?.allowFocusOnRows ?? true)"
-            >
+                [disabled]="!(enableDragRows || multiselect)"
+                [attr.aria-description]="
+                    (multiselect ? ('ADF-DATATABLE.ACCESSIBILITY.ROW_SELECTION' | translate) : '') +
+                    (multiselect && enableDragRows ? '. ' : '') +
+                    (enableDragRows ? ('ADF-DATATABLE.ACCESSIBILITY.DRAGGABLE' | translate) : '')
+                "
+            >   
+                <!-- Live region for selection state  -->
+                <span *ngIf="multiselect" class="adf-sr-only" aria-live="off">
+                    {{ row.isSelected ? ('ADF-DATATABLE.ACCESSIBILITY.SELECTED' | translate) : '' }}
+                </span>
+
                 <!-- Drag button -->
-                <div *ngIf="enableDragRows"
-                        role="gridcell"
-                        class="adf-datatable-cell adf-datatable__actions-cell adf-datatable-hover-only">
-                    <button mat-icon-button
-                            [attr.aria-label]="'ADF-DATATABLE.ACCESSIBILITY.DRAG' | translate">
-                        <mat-icon adf-icon="drag_indicator" />
-                    </button>
+                <div *ngIf="enableDragRows" class="adf-datatable-cell adf-datatable__actions-cell adf-datatable-hover-only">
+                    <mat-icon adf-icon="drag_indicator" aria-hidden="true" />
                 </div>
 
                 <!-- Actions (left) -->
@@ -264,36 +269,33 @@
                 </div>
 
                 <label *ngIf="multiselect"
-                        (keydown.enter)="onEnterKeyPressed(row, $any($event))"
-                        (click)="onCheckboxLabelClick(row, $event)"
-                        [for]="'select-file-' + idx"
-                        class="adf-datatable-cell adf-datatable-checkbox adf-datatable-checkbox-single"
-                        [attr.tabindex]="null">
+                    (keydown.enter)="onEnterKeyPressed(row, $any($event))"
+                    (click)="onCheckboxLabelClick(row, $event)"
+                    [for]="'select-file-' + idx"
+                    class="adf-datatable-cell adf-datatable-checkbox adf-datatable-checkbox-single"
+                    [attr.tabindex]="null"
+                    aria-hidden="true"
+                >
                     <mat-checkbox
                         [id]="'select-file-' + idx"
                         [disabled]="!row?.isSelectable"
                         [class.adf-datatable-checkbox-selected]="row.isSelected"
                         [class.adf-datatable-hover-only]="displayCheckboxesOnHover"
                         [checked]="row.isSelected"
-                        [attr.aria-checked]="row.isSelected"
-                        [aria-label]="'ADF-DATATABLE.ACCESSIBILITY.SELECT_FILE' | translate"
                         data-adf-datatable-row-checkbox
                         (change)="onCheckboxChange(row, $event)"
                         (keydown.enter)="$event.stopPropagation()"
                         class="adf-checkbox-sr-only"
-                    >
-                        {{ 'ADF-DATATABLE.ACCESSIBILITY.SELECT_FILE' | translate }}
-                    </mat-checkbox>
+                        [tabIndex]="-1"
+                        aria-hidden="true"
+                    />
                 </label>
 
                 <div
-                    *ngFor="let col of getVisibleColumns(); let lastColumn = last;"
-                    role="gridcell"
-                    class="adf-datatable-cell adf-datatable-cell--{{col.type || 'text'}} {{col.cssClass}} adf-datatable-cell-data"
-                    [attr.title]="col.title | translate"
-                    [attr.data-automation-id]="getAutomationValue(row)"
-                    [attr.aria-selected]="row.isSelected"
-                    [attr.aria-label]="col.title ? (col.title | translate) : null"
+                    *ngFor="let col of getVisibleColumns(); let lastColumn = last"
+                    [attr.role]="!isRepresentationContent(col) ? 'gridcell' : 'presentation'"
+                    class="adf-datatable-cell adf-datatable-cell--{{col.type || 'text'}} {{col.cssClass}} adf-datatable-cell-data adf-datatable-cell--{{getAutomationValue(row)}}"
+                    [attr.data-automation-id]="getAutomationValue(row)"   
                     (click)="onRowClick(row, $event)"
                     [attr.tabindex]="null"
                     (keydown.enter)="onEnterKeyPressed(row, $any($event))"

--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.html
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.html
@@ -228,62 +228,289 @@
                 [cdkDropListDisabled]="!enableDragRows"
                 role="rowgroup">
                 @if (!noPermission) {
-                    @for (row of data.getRows(); track $index; let idx = $index) {
-                        <adf-datatable-row
-                            cdkDrag
-                            [cdkDragDisabled]="!enableDragRows"
-                            (cdkDragDropped)="onDragDrop($event)"
-                            (cdkDragStarted)="onDragStart()"
-                            (cdkDragEnded)="onDragEnd()"
-                            [cdkDragBoundary]="'.adf-datatable-body'"
-                            [row]="row"
-                            (select)="onEnterKeyPressed(row, $event)"
-                            (keyup)="onRowKeyUp(row, $event)"
-                            (keydown)="onRowEnterKeyDown(row, $event)"
-                            [adf-upload]="rowAllowsDrop(row)"
-                            [adf-upload-data]="row"
-                            [ngStyle]="rowStyle"
-                            [ngClass]="getRowStyle(row)"
-                            [class.adf-datatable-row__dragging]="isDraggingRow"
-                            [attr.data-automation-id]="'datatable-row-' + idx"
-                            (contextmenu)="markRowAsContextMenuSource(row)"
-                            [disabled]="!(enableDragRows || multiselect)"
-                            [attr.aria-description]="
-                                (multiselect ? ('ADF-DATATABLE.ACCESSIBILITY.ROW_SELECTION' | translate) : '') +
-                                (multiselect && enableDragRows ? '. ' : '') +
-                                (enableDragRows ? ('ADF-DATATABLE.ACCESSIBILITY.DRAGGABLE' | translate) : '')
-                            "
-                        >
-                            <!-- Live region for selection state  -->
+                    <adf-datatable-row *ngFor="let row of data.getRows(); let idx = index"
+                        cdkDrag
+                        [cdkDragDisabled]="!enableDragRows"
+                        (cdkDragDropped)="onDragDrop($event)"
+                        (cdkDragStarted)="onDragStart()"
+                        (cdkDragEnded)="onDragEnd()"
+                        [cdkDragBoundary]="'.adf-datatable-body'"
+                        [row]="row"
+                        (select)="onEnterKeyPressed(row, $event)"
+                        (keyup)="onRowKeyUp(row, $event)"
+                        (keydown)="onRowEnterKeyDown(row, $event)"
+                        [adf-upload]="rowAllowsDrop(row)"
+                        [adf-upload-data]="row"
+                        [ngStyle]="rowStyle"
+                        [ngClass]="getRowStyle(row)"
+                        [class.adf-datatable-row__dragging]="isDraggingRow"
+                        [attr.data-automation-id]="'datatable-row-' + idx"
+                        (contextmenu)="markRowAsContextMenuSource(row)"
+                        [disabled]="!(enableDragRows || multiselect)"
+                        [attr.aria-description]="
+                            (multiselect ? ('ADF-DATATABLE.ACCESSIBILITY.ROW_SELECTION' | translate) : '') +
+                            (multiselect && enableDragRows ? '. ' : '') +
+                            (enableDragRows ? ('ADF-DATATABLE.ACCESSIBILITY.DRAGGABLE' | translate) : '')
+                        "
+                    >
+                        <!-- Live region for selection state  -->
+                        @if (multiselect) {
+                            <span class="adf-sr-only" aria-live="off">
+                                {{ row.isSelected ? ('ADF-DATATABLE.ACCESSIBILITY.SELECTED' | translate) : '' }}
+                            </span>
+                        }
+
+                        <!-- Drag button -->
+                        @if (enableDragRows) {
+                            <div
+                                role="gridcell"
+                                class="adf-datatable-cell adf-datatable__actions-cell adf-datatable-hover-only">
+                                <mat-icon adf-icon="drag_indicator" aria-hidden="true" />
+                            </div>
+                        }
+
+                        <!-- Actions (left) -->
+                            @if (actions && actionsPosition === 'left') {
+                            <div role="gridcell" class="adf-datatable-cell">
+                                <button mat-icon-button [matMenuTriggerFor]="menu" #actionsMenuTrigger="matMenuTrigger"
+                                        [ngClass]="getHideActionsWithoutHoverClass(actionsMenuTrigger)"
+                                        [title]="'ADF-DATATABLE.CONTENT-ACTIONS.TOOLTIP' | translate"
+                                        [attr.id]="'action_menu_left_' + idx"
+                                        [attr.data-automation-id]="'action_menu_' + idx">
+                                    <mat-icon adf-icon="more_vert" />
+                                </button>
+                                <mat-menu #menu="matMenu">
+                                    @for (action of getRowActions(row); track action.title) {
+                                        <button mat-menu-item
+                                                [attr.data-automation-id]="action.title"
+                                                [disabled]="action.disabled"
+                                                (click)="onExecuteRowAction(row, action)">
+                                            @if (action.icon) {
+                                                <mat-icon [adf-icon]="action.icon" />
+                                            }
+                                            <span>{{ action.title | translate }}</span>
+                                        </button>
+                                    }
+                                </mat-menu>
+                            </div>
+                            }
+
                             @if (multiselect) {
-                                <span class="adf-sr-only" aria-live="off">
-                                    {{ row.isSelected ? ('ADF-DATATABLE.ACCESSIBILITY.SELECTED' | translate) : '' }}
-                                </span>
+                            <label
+                                (keydown.enter)="onEnterKeyPressed(row, $any($event))"
+                                (click)="onCheckboxLabelClick(row, $event)"
+                                [for]="'select-file-' + idx"
+                                class="adf-datatable-cell adf-datatable-checkbox adf-datatable-checkbox-single"
+                                [attr.tabindex]="null"
+                                aria-hidden="true"
+                            >
+                                <mat-checkbox
+                                    [id]="'select-file-' + idx"
+                                    [disabled]="!row?.isSelectable"
+                                    [class.adf-datatable-checkbox-selected]="row.isSelected"
+                                    [class.adf-datatable-hover-only]="displayCheckboxesOnHover"
+                                    [checked]="row.isSelected"
+                                    data-adf-datatable-row-checkbox
+                                    (change)="onCheckboxChange(row, $event)"
+                                    (keydown.enter)="$event.stopPropagation()"
+                                    class="adf-checkbox-sr-only"
+                                    [tabIndex]="-1"
+                                    aria-hidden="true"
+                                />
+                            </label>
                             }
 
-                            <!-- Drag button -->
-                            @if (enableDragRows) {
-                                <div
-                                    role="gridcell"
-                                    class="adf-datatable-cell adf-datatable__actions-cell adf-datatable-hover-only">
-                                    <mat-icon adf-icon="drag_indicator" aria-hidden="true" />
-                                </div>
-                            }
+                        @for (col of getVisibleColumns(); track col.key; let lastColumn = $last;) {
+                            <div
+                                role="gridcell"
+                                class="adf-datatable-cell adf-datatable-cell--{{col.type || 'text'}} {{col.cssClass}} adf-datatable-cell-data adf-datatable-cell--{{getAutomationValue(row)}}"
+                                [attr.title]="col.title | translate"
+                                [attr.data-automation-id]="getAutomationValue(row)"
+                                [attr.aria-label]="col.title ? (col.title | translate) : null"
+                                [attr.aria-hidden]='isRepresentationContent(col) ? "true" : null'
+                                (click)="onRowClick(row, $event)"
+                                [attr.tabindex]="null"
+                                (keydown.enter)="onEnterKeyPressed(row, $any($event))"
+                                [adf-context-menu]="getContextMenuActions(row, col)"
+                                [adf-context-menu-enabled]="contextMenu"
+                                adf-drop-zone dropTarget="cell" [dropColumn]="col" [dropRow]="row"
+                                [ngStyle]="(col.width) && !lastColumn && {'flex': getFlexValue(col)}"
+                            >
+                                @if (!col.template) {
+                                    <div class="adf-datatable-cell-container">
+                                        @switch (data.getColumnType(row, col)) {
+                                            @case ('image') {
+                                                <div class="adf-cell-value">
+                                                    @if (isIconValue(row, col)) {
+                                                        <mat-icon
+                                                            [attr.aria-label]="col.srTitle? (col.srTitle | translate) : null"
+                                                            [attr.aria-hidden]="!asIconValue(row, col)"
+                                                            [adf-icon]="asIconValue(row, col)"
+                                                        />
+                                                    } @else {
+                                                        @if (row.isSelected && !multiselect) {
+                                                            <mat-icon class="adf-datatable-selected" svgIcon="selected" />
+                                                        } @else {
+                                                            <img class="adf-datatable-center-img-ie"
+                                                                [attr.aria-label]="(data.getValue(row, col) | fileType) === 'disable' ?
+                                                                    ('ADF-DATATABLE.ACCESSIBILITY.ICON_DISABLED' | translate) :
+                                                                    'ADF-DATATABLE.ACCESSIBILITY.ICON_TEXT' | translate:{
+                                                                        type: 'ADF-DATATABLE.FILE_TYPE.' + (data.getValue(row, col) | fileType | uppercase) | translate
+                                                                    }"
+                                                                [attr.alt]="(data.getValue(row, col) | fileType) === 'disable' ?
+                                                                    ('ADF-DATATABLE.ACCESSIBILITY.ICON_DISABLED' | translate) :
+                                                                    'ADF-DATATABLE.ACCESSIBILITY.ICON_TEXT' | translate:{
+                                                                            type: 'ADF-DATATABLE.FILE_TYPE.' + (data.getValue(row, col) | fileType | uppercase) | translate
+                                                                    }"
+                                                                src="{{ data.getValue(row, col) }}"
+                                                                (error)="onImageLoadingError($event, row)">
+                                                        }
+                                                    }
+                                                </div>
+                                            }
+                                            @case ('icon') {
+                                                <div class="adf-cell-value">
+                                                    <adf-icon-cell
+                                                        [data]="data"
+                                                        [column]="col"
+                                                        [row]="row"
+                                                        [resolverFn]="resolverFn"
+                                                        [tooltip]="getCellTooltip(row, col)"
+                                                    />
+                                                </div>
+                                            }
+                                            @case ('date') {
+                                                <div
+                                                    class="adf-cell-value adf-cell-date"
+                                                    [attr.data-automation-id]="'date_' + (data.getValue(row, col, resolverFn) | adfLocalizedDate: 'medium') ">
+                                                    <adf-date-cell class="adf-datatable-center-date-column-ie"
+                                                        [data]="data"
+                                                        [column]="col"
+                                                        [row]="row"
+                                                        [resolverFn]="resolverFn"
+                                                        [tooltip]="getCellTooltip(row, col)"
+                                                        [dateConfig]="col.dateConfig" />
+                                                </div>
+                                            }
+                                            @case ('location') {
+                                                <div class="adf-cell-value"
+                                                    [attr.data-automation-id]="'location' + data.getValue(row, col, resolverFn)">
+                                                    <adf-location-cell
+                                                        [data]="data"
+                                                        [column]="col"
+                                                        [row]="row"
+                                                        [resolverFn]="resolverFn"
+                                                        [tooltip]="getCellTooltip(row, col)" />
+                                                </div>
+                                            }
+                                            @case ('fileSize') {
+                                                <div class="adf-cell-value"
+                                                    [attr.data-automation-id]="'fileSize_' + data.getValue(row, col, resolverFn)">
+                                                    <adf-filesize-cell class="adf-datatable-center-size-column-ie"
+                                                        [data]="data"
+                                                        [column]="col"
+                                                        [row]="row"
+                                                        [resolverFn]="resolverFn"
+                                                        [tooltip]="getCellTooltip(row, col)" />
+                                                </div>
+                                            }
+                                            @case ('text') {
+                                                <div class="adf-cell-value"
+                                                    [attr.data-automation-id]="'text_' + data.getValue(row, col, resolverFn)">
+                                                    <adf-datatable-cell
+                                                        [copyContent]="col.copyContent"
+                                                        [data]="data"
+                                                        [column]="col"
+                                                        [row]="row"
+                                                        [resolverFn]="resolverFn"
+                                                        [tooltip]="getCellTooltip(row, col)" />
+                                                </div>
+                                            }
+                                            @case ('boolean') {
+                                                <div class="adf-cell-value"
+                                                    [attr.data-automation-id]="'boolean_' + data.getValue(row, col, resolverFn)">
+                                                    <adf-boolean-cell
+                                                        [data]="data"
+                                                        [column]="col"
+                                                        [row]="row"
+                                                        [resolverFn]="resolverFn"
+                                                        [tooltip]="getCellTooltip(row, col)" />
+                                                </div>
+                                            }
+                                            @case ('json') {
+                                                <div class="adf-cell-value">
+                                                    <adf-json-cell
+                                                        [editable]="col.editable"
+                                                        [data]="data"
+                                                        [column]="col"
+                                                        [resolverFn]="resolverFn"
+                                                        [row]="row" />
+                                                </div>
+                                            }
+                                            @case ('amount') {
+                                                <div
+                                                    class="adf-cell-value"
+                                                    [attr.data-automation-id]="'amount_' + data.getValue(row, col, resolverFn)">
+                                                    <adf-amount-cell
+                                                        [data]="data"
+                                                        [column]="col"
+                                                        [resolverFn]="resolverFn"
+                                                        [row]="row"
+                                                        [currencyConfig]="col.currencyConfig" />
+                                                </div>
+                                            }
+                                            @case ('number') {
+                                                <div
+                                                    class="adf-cell-value"
+                                                    [attr.data-automation-id]="'number_' + data.getValue(row, col, resolverFn)">
+                                                    <adf-number-cell
+                                                        [data]="data"
+                                                        [column]="col"
+                                                        [resolverFn]="resolverFn"
+                                                        [row]="row"
+                                                        [decimalConfig]="col.decimalConfig" />
+                                                </div>
+                                            }
+                                            @default {
+                                                <span class="adf-cell-value">
+                                                    <!-- empty cell for unknown column type -->
+                                                </span>
+                                            }
+                                        }
+                                    </div>
+                                } @else {
+                                    <div class="adf-datatable-cell-container">
+                                        <div class="adf-cell-value">
+                                            <ng-container
+                                                [ngTemplateOutlet]="col.template"
+                                                [ngTemplateOutletContext]="{ $implicit: { data: data, row: row, col: col }, value: data.getValue(row, col, resolverFn) }" />
+                                        </div>
+                                    </div>
+                                }
+                            </div>
+                        }
 
-                            <!-- Actions (left) -->
-                             @if (actions && actionsPosition === 'left') {
-                                <div role="gridcell" class="adf-datatable-cell">
+                        <!-- Row actions (right) -->
+                            @if (!showProvidedActions && ((actions && actionsPosition === 'right') || (mainActionTemplate && showMainDatatableActions))) {
+                            <div
+                                role="gridcell"
+                                class="adf-datatable-cell adf-datatable__actions-cell adf-datatable-center-actions-column-ie adf-datatable-actions-menu">
+
+                                @if (actions && actionsPosition === 'right') {
                                     <button mat-icon-button [matMenuTriggerFor]="menu" #actionsMenuTrigger="matMenuTrigger"
                                             [ngClass]="getHideActionsWithoutHoverClass(actionsMenuTrigger)"
+                                            [attr.aria-label]="'ADF-DATATABLE.ACCESSIBILITY.ROW_OPTION_BUTTON' | translate"
                                             [title]="'ADF-DATATABLE.CONTENT-ACTIONS.TOOLTIP' | translate"
-                                            [attr.id]="'action_menu_left_' + idx"
-                                            [attr.data-automation-id]="'action_menu_' + idx">
+                                            [attr.id]="'action_menu_right_' + idx"
+                                            [attr.data-automation-id]="'action_menu_' + idx"
+                                            (keydown.enter)="actionsMenuTrigger.openMenu()">
                                         <mat-icon adf-icon="more_vert" />
                                     </button>
                                     <mat-menu #menu="matMenu">
                                         @for (action of getRowActions(row); track action.title) {
                                             <button mat-menu-item
                                                     [attr.data-automation-id]="action.title"
+                                                    [attr.aria-label]="action.title | translate"
                                                     [disabled]="action.disabled"
                                                     (click)="onExecuteRowAction(row, action)">
                                                 @if (action.icon) {
@@ -293,239 +520,10 @@
                                             </button>
                                         }
                                     </mat-menu>
-                                </div>
-                             }
-
-                             @if (multiselect) {
-                                <label
-                                    (keydown.enter)="onEnterKeyPressed(row, $any($event))"
-                                    (click)="onCheckboxLabelClick(row, $event)"
-                                    [for]="'select-file-' + idx"
-                                    class="adf-datatable-cell adf-datatable-checkbox adf-datatable-checkbox-single"
-                                    [attr.tabindex]="null"
-                                    aria-hidden="true"
-                                >
-                                    <mat-checkbox
-                                        [id]="'select-file-' + idx"
-                                        [disabled]="!row?.isSelectable"
-                                        [class.adf-datatable-checkbox-selected]="row.isSelected"
-                                        [class.adf-datatable-hover-only]="displayCheckboxesOnHover"
-                                        [checked]="row.isSelected"
-                                        data-adf-datatable-row-checkbox
-                                        (change)="onCheckboxChange(row, $event)"
-                                        (keydown.enter)="$event.stopPropagation()"
-                                        class="adf-checkbox-sr-only"
-                                        [tabIndex]="-1"
-                                        aria-hidden="true"
-                                    />
-                                </label>
-                             }
-
-                            @for (col of getVisibleColumns(); track col.key; let lastColumn = $last;) {
-                                <div
-                                    role="gridcell"
-                                    class="adf-datatable-cell adf-datatable-cell--{{col.type || 'text'}} {{col.cssClass}} adf-datatable-cell-data adf-datatable-cell--{{getAutomationValue(row)}}"
-                                    [attr.title]="col.title | translate"
-                                    [attr.data-automation-id]="getAutomationValue(row)"
-                                    [attr.aria-label]="col.title ? (col.title | translate) : null"
-                                    [attr.aria-hidden]='isRepresentationContent(col) ? "true" : null'
-                                    (click)="onRowClick(row, $event)"
-                                    [attr.tabindex]="null"
-                                    (keydown.enter)="onEnterKeyPressed(row, $any($event))"
-                                    [adf-context-menu]="getContextMenuActions(row, col)"
-                                    [adf-context-menu-enabled]="contextMenu"
-                                    adf-drop-zone dropTarget="cell" [dropColumn]="col" [dropRow]="row"
-                                    [ngStyle]="(col.width) && !lastColumn && {'flex': getFlexValue(col)}"
-                                >
-                                    @if (!col.template) {
-                                        <div class="adf-datatable-cell-container">
-                                            @switch (data.getColumnType(row, col)) {
-                                                @case ('image') {
-                                                    <div class="adf-cell-value">
-                                                        @if (isIconValue(row, col)) {
-                                                            <mat-icon
-                                                                [attr.aria-label]="col.srTitle? (col.srTitle | translate) : null"
-                                                                [attr.aria-hidden]="!asIconValue(row, col)"
-                                                                [adf-icon]="asIconValue(row, col)"
-                                                            />
-                                                        } @else {
-                                                            @if (row.isSelected && !multiselect) {
-                                                                <mat-icon class="adf-datatable-selected" svgIcon="selected" />
-                                                            } @else {
-                                                                <img class="adf-datatable-center-img-ie"
-                                                                    [attr.aria-label]="(data.getValue(row, col) | fileType) === 'disable' ?
-                                                                        ('ADF-DATATABLE.ACCESSIBILITY.ICON_DISABLED' | translate) :
-                                                                        'ADF-DATATABLE.ACCESSIBILITY.ICON_TEXT' | translate:{
-                                                                            type: 'ADF-DATATABLE.FILE_TYPE.' + (data.getValue(row, col) | fileType | uppercase) | translate
-                                                                        }"
-                                                                    [attr.alt]="(data.getValue(row, col) | fileType) === 'disable' ?
-                                                                        ('ADF-DATATABLE.ACCESSIBILITY.ICON_DISABLED' | translate) :
-                                                                        'ADF-DATATABLE.ACCESSIBILITY.ICON_TEXT' | translate:{
-                                                                                type: 'ADF-DATATABLE.FILE_TYPE.' + (data.getValue(row, col) | fileType | uppercase) | translate
-                                                                        }"
-                                                                    src="{{ data.getValue(row, col) }}"
-                                                                    (error)="onImageLoadingError($event, row)">
-                                                            }
-                                                        }
-                                                    </div>
-                                                }
-                                                @case ('icon') {
-                                                    <div class="adf-cell-value">
-                                                        <adf-icon-cell
-                                                            [data]="data"
-                                                            [column]="col"
-                                                            [row]="row"
-                                                            [resolverFn]="resolverFn"
-                                                            [tooltip]="getCellTooltip(row, col)"
-                                                        />
-                                                    </div>
-                                                }
-                                                @case ('date') {
-                                                    <div
-                                                        class="adf-cell-value adf-cell-date"
-                                                        [attr.data-automation-id]="'date_' + (data.getValue(row, col, resolverFn) | adfLocalizedDate: 'medium') ">
-                                                        <adf-date-cell class="adf-datatable-center-date-column-ie"
-                                                            [data]="data"
-                                                            [column]="col"
-                                                            [row]="row"
-                                                            [resolverFn]="resolverFn"
-                                                            [tooltip]="getCellTooltip(row, col)"
-                                                            [dateConfig]="col.dateConfig" />
-                                                    </div>
-                                                }
-                                                @case ('location') {
-                                                    <div class="adf-cell-value"
-                                                        [attr.data-automation-id]="'location' + data.getValue(row, col, resolverFn)">
-                                                        <adf-location-cell
-                                                            [data]="data"
-                                                            [column]="col"
-                                                            [row]="row"
-                                                            [resolverFn]="resolverFn"
-                                                            [tooltip]="getCellTooltip(row, col)" />
-                                                    </div>
-                                                }
-                                                @case ('fileSize') {
-                                                    <div class="adf-cell-value"
-                                                        [attr.data-automation-id]="'fileSize_' + data.getValue(row, col, resolverFn)">
-                                                        <adf-filesize-cell class="adf-datatable-center-size-column-ie"
-                                                            [data]="data"
-                                                            [column]="col"
-                                                            [row]="row"
-                                                            [resolverFn]="resolverFn"
-                                                            [tooltip]="getCellTooltip(row, col)" />
-                                                    </div>
-                                                }
-                                                @case ('text') {
-                                                    <div class="adf-cell-value"
-                                                        [attr.data-automation-id]="'text_' + data.getValue(row, col, resolverFn)">
-                                                        <adf-datatable-cell
-                                                            [copyContent]="col.copyContent"
-                                                            [data]="data"
-                                                            [column]="col"
-                                                            [row]="row"
-                                                            [resolverFn]="resolverFn"
-                                                            [tooltip]="getCellTooltip(row, col)" />
-                                                    </div>
-                                                }
-                                                @case ('boolean') {
-                                                    <div class="adf-cell-value"
-                                                        [attr.data-automation-id]="'boolean_' + data.getValue(row, col, resolverFn)">
-                                                        <adf-boolean-cell
-                                                            [data]="data"
-                                                            [column]="col"
-                                                            [row]="row"
-                                                            [resolverFn]="resolverFn"
-                                                            [tooltip]="getCellTooltip(row, col)" />
-                                                    </div>
-                                                }
-                                                @case ('json') {
-                                                    <div class="adf-cell-value">
-                                                        <adf-json-cell
-                                                            [editable]="col.editable"
-                                                            [data]="data"
-                                                            [column]="col"
-                                                            [resolverFn]="resolverFn"
-                                                            [row]="row" />
-                                                    </div>
-                                                }
-                                                @case ('amount') {
-                                                    <div
-                                                        class="adf-cell-value"
-                                                        [attr.data-automation-id]="'amount_' + data.getValue(row, col, resolverFn)">
-                                                        <adf-amount-cell
-                                                            [data]="data"
-                                                            [column]="col"
-                                                            [resolverFn]="resolverFn"
-                                                            [row]="row"
-                                                            [currencyConfig]="col.currencyConfig" />
-                                                    </div>
-                                                }
-                                                @case ('number') {
-                                                    <div
-                                                        class="adf-cell-value"
-                                                        [attr.data-automation-id]="'number_' + data.getValue(row, col, resolverFn)">
-                                                        <adf-number-cell
-                                                            [data]="data"
-                                                            [column]="col"
-                                                            [resolverFn]="resolverFn"
-                                                            [row]="row"
-                                                            [decimalConfig]="col.decimalConfig" />
-                                                    </div>
-                                                }
-                                                @default {
-                                                    <span class="adf-cell-value">
-                                                        <!-- empty cell for unknown column type -->
-                                                    </span>
-                                                }
-                                            }
-                                        </div>
-                                    } @else {
-                                        <div class="adf-datatable-cell-container">
-                                            <div class="adf-cell-value">
-                                                <ng-container
-                                                    [ngTemplateOutlet]="col.template"
-                                                    [ngTemplateOutletContext]="{ $implicit: { data: data, row: row, col: col }, value: data.getValue(row, col, resolverFn) }" />
-                                            </div>
-                                        </div>
-                                    }
-                                </div>
+                                }
+                            </div>
                             }
-
-                            <!-- Row actions (right) -->
-                             @if (!showProvidedActions && ((actions && actionsPosition === 'right') || (mainActionTemplate && showMainDatatableActions))) {
-                                <div
-                                    role="gridcell"
-                                    class="adf-datatable-cell adf-datatable__actions-cell adf-datatable-center-actions-column-ie adf-datatable-actions-menu">
-
-                                    @if (actions && actionsPosition === 'right') {
-                                        <button mat-icon-button [matMenuTriggerFor]="menu" #actionsMenuTrigger="matMenuTrigger"
-                                                [ngClass]="getHideActionsWithoutHoverClass(actionsMenuTrigger)"
-                                                [attr.aria-label]="'ADF-DATATABLE.ACCESSIBILITY.ROW_OPTION_BUTTON' | translate"
-                                                [title]="'ADF-DATATABLE.CONTENT-ACTIONS.TOOLTIP' | translate"
-                                                [attr.id]="'action_menu_right_' + idx"
-                                                [attr.data-automation-id]="'action_menu_' + idx"
-                                                (keydown.enter)="actionsMenuTrigger.openMenu()">
-                                            <mat-icon adf-icon="more_vert" />
-                                        </button>
-                                        <mat-menu #menu="matMenu">
-                                            @for (action of getRowActions(row); track action.title) {
-                                                <button mat-menu-item
-                                                        [attr.data-automation-id]="action.title"
-                                                        [attr.aria-label]="action.title | translate"
-                                                        [disabled]="action.disabled"
-                                                        (click)="onExecuteRowAction(row, action)">
-                                                    @if (action.icon) {
-                                                        <mat-icon [adf-icon]="action.icon" />
-                                                    }
-                                                    <span>{{ action.title | translate }}</span>
-                                                </button>
-                                            }
-                                        </mat-menu>
-                                    }
-                                </div>
-                             }
-                        </adf-datatable-row>
-                    }
+                    </adf-datatable-row>
                     @if (isEmpty()) {
                         <div role="row" class="adf-datatable-row">
                             <div class="adf-no-content-container adf-datatable-cell" role="gridcell">

--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.html
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.html
@@ -295,6 +295,7 @@
                     *ngFor="let col of getVisibleColumns(); let lastColumn = last"
                     [attr.role]="!isRepresentationContent(col) ? 'gridcell' : 'presentation'"
                     class="adf-datatable-cell adf-datatable-cell--{{col.type || 'text'}} {{col.cssClass}} adf-datatable-cell-data adf-datatable-cell--{{getAutomationValue(row)}}"
+                    [attr.title]="col.title | translate"
                     [attr.data-automation-id]="getAutomationValue(row)"   
                     (click)="onRowClick(row, $event)"
                     [attr.tabindex]="null"

--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.html
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.html
@@ -293,10 +293,12 @@
 
                 <div
                     *ngFor="let col of getVisibleColumns(); let lastColumn = last"
-                    [attr.role]="!isRepresentationContent(col) ? 'gridcell' : 'presentation'"
+                    role ='gridcell'
                     class="adf-datatable-cell adf-datatable-cell--{{col.type || 'text'}} {{col.cssClass}} adf-datatable-cell-data adf-datatable-cell--{{getAutomationValue(row)}}"
                     [attr.title]="col.title | translate"
-                    [attr.data-automation-id]="getAutomationValue(row)"   
+                    [attr.data-automation-id]="getAutomationValue(row)"  
+                    [attr.aria-label]="col.title ? (col.title | translate) : null" 
+                    [attr.aria-hidden]='isRepresentationContent(col) ? "true" : null'
                     (click)="onRowClick(row, $event)"
                     [attr.tabindex]="null"
                     (keydown.enter)="onEnterKeyPressed(row, $any($event))"

--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.html
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.html
@@ -1,506 +1,567 @@
-<div
-    role="grid"
-    *ngIf="data"
-    class="adf-datatable-list"
-    [class.adf-sticky-header]="isStickyHeaderEnabled()"
-    [class.adf-datatable--empty]="(isEmpty() && !isHeaderVisible()) || loading"
-    [class.adf-datatable--empty--header-visible]="isEmpty() && isHeaderVisible()"
->
-    <div *ngIf="isHeaderVisible()" class="adf-datatable-header" role="rowgroup" [ngClass]="{ 'adf-sr-only': !isHeaderVisible() }">
-        <adf-datatable-row
-            cdkDropList
-            cdkDropListOrientation="horizontal"
-            [cdkDropListSortPredicate]="filterDisabledColumns"
-            data-automation-id="datatable-row-header"
-            class="adf-datatable-row"
-            role="row">
-
-
-            <!-- Drag -->
-            <div *ngIf="enableDragRows" class="adf-datatable-cell-header adf-drag-column">
-                <span class="adf-sr-only">{{ 'ADF-DATATABLE.ACCESSIBILITY.DRAG' | translate }}</span>
-            </div>
-
-            <!-- Actions (left) -->
-            <div *ngIf="actions && actionsPosition === 'left'" class="adf-actions-column adf-datatable-cell-header">
-                <span class="adf-sr-only">{{ 'ADF-DATATABLE.ACCESSIBILITY.ACTIONS' | translate }}</span>
-            </div>
-
-            <!-- Columns -->
-            <div *ngIf="multiselect" class="adf-datatable-cell-header adf-datatable-checkbox">
-                <mat-checkbox
-                    [indeterminate]="isSelectAllIndeterminate"
-                    [checked]="isSelectAllChecked"
-                    (change)="onSelectAllClick($event)"
-                    class="adf-checkbox-sr-only"
-                    [aria-label]="'ADF-DATATABLE.ACCESSIBILITY.SELECT_ALL' | translate"
-                    [matTooltip]="'ADF-DATATABLE.ACCESSIBILITY.SELECT_ALL' | translate"
-                    #tooltip="matTooltip"
-                    (focusin)="tooltip.show()"
-                    (focusout)="tooltip.hide()"
-                >
-                    {{ 'ADF-DATATABLE.ACCESSIBILITY.SELECT_ALL' | translate }}
-                </mat-checkbox>
-            </div>
-
-            <ng-container
-                *ngFor="
-                let col of getVisibleColumns();
-                let columnIndex = index
-                let lastColumn = last"
-            >
-            <div
-                class="adf-datatable-cell--{{col.type || 'text'}} {{col.cssClass}} adf-datatable-cell-header adf-datatable-cell-data"
-                *ngIf="col.title || !showProvidedActions"
-                [attr.data-automation-id]="'auto_id_' + col.key"
-                [ngClass]="{
-                    'adf-sortable': col.sortable,
-                    'adf-datatable__cursor--pointer': !isResizing,
-                    'adf-datatable__header--sorted-asc': isColumnSorted(col, 'asc'),
-                    'adf-datatable__header--sorted-desc': isColumnSorted(col, 'desc')}"
-                [ngStyle]="(col.width) && !lastColumn && {'flex': getFlexValue(col)}"
-                role="columnheader"
-                [attr.aria-label]="col.srTitle ? (col.srTitle | translate) : (col.title | translate) + (col.subtitle ? ' ' + (col.subtitle | translate) : '')"
-                [attr.aria-sort]="col.sortable ? (getAriaSort(col) | translate) : null"
-                cdkDrag
-                cdkDragLockAxis="x"
-                (cdkDragStarted)="isDraggingHeaderColumn = true"
-                (cdkDragDropped)="onDropHeaderColumn($event)"
-                [cdkDragDisabled]="!col.draggable"
-                (mouseenter)="hoveredHeaderColumnIndex = columnIndex"
-                (mouseleave)="hoveredHeaderColumnIndex = -1"
-                adf-drop-zone dropTarget="header"
-                [dropColumn]="col"
-            >
-
-            <div
-                adf-resizable
-                #resizableElement="adf-resizable"
-                [attr.tabindex]="col.sortable ? 0 : null"
-                [attr.role]="col.sortable ? 'button' : null"
-                [attr.aria-description]="
-                    isColumnSortActive(col) ? (getSortLiveAnnouncement(col) | translate: { string: col.title | translate }) : null
-                "
-                 [attr.aria-label]="
-                    col.srTitle
-                        ? (col.srTitle | translate)
-                        : ('ADF-DATATABLE.ACCESSIBILITY.SORT_DEFAULT' | translate) +
-                            ' ' +
-                            (col.title | translate) +
-                            (col.subtitle ? ' ' + (col.subtitle | translate) : '')
-                "
-                (click)="onColumnHeaderClick(col, $event)"
-                (keyup.enter)="onColumnHeaderClick(col, $event)"
-                [coverPadding]="10"
-                (resizing)="onResizing($event, columnIndex)"
-                (keyboardResizing)="onResizing($event, columnIndex)"
-                (resizeStart)="resizingColumnIndex = columnIndex"
-                (resizeEnd)="onResizingEnd()"
-                [attr.data-automation-id]="'auto_header_content_id_' + col.key"
-                class="adf-datatable-cell-header-content"
-                [ngClass]="{ 'adf-datatable-cell-header-content--hovered':
-                    hoveredHeaderColumnIndex === columnIndex &&
-                    !isDraggingHeaderColumn &&
-                    !isResizing && col.sortable}"
-            >
-                <ng-container *ngIf="!col.header">
-                    <span
-                        *ngIf="col.title"
-                        title="{{col.title | translate}}"
-                        class="adf-datatable-cell-value"
-                    >
-                        {{col.title | translate}}
-                    </span>
-
-                    <span
-                        *ngIf="col.subtitle"
-                        title="{{col.subtitle | translate}}"
-                        class="adf-datatable-cell-value adf-datatable-cell-header_subtitle"
-                    >
-                        ({{col.subtitle | translate}})
-                    </span>
-
-                    <span *ngIf="col.title && col.sortable && isDraggingHeaderColumn" class="adf-sr-only" aria-live="polite">
-                        {{ getSortLiveAnnouncement(col) | translate: { string: col.title | translate } }}
-                    </span>
-
-                    <span *ngIf="!col.title && !col.sortable && !headerFilterTemplate" [attr.title]="'ADF-DATATABLE.ACCESSIBILITY.EMPTY_HEADER' | translate"></span>
-                </ng-container>
-
-                <div *ngIf="col.header" class="adf-datatable-cell-value">
-                    <ng-template [ngTemplateOutlet]="col.header" [ngTemplateOutletContext]="{$implicit: col}" />
-                </div>
-
-                <span
-                    [class.adf-datatable__header--sorted-asc]="isColumnSorted(col, 'asc')"
-                    [class.adf-datatable__header--sorted-desc]="isColumnSorted(col, 'desc')">
-                </span>
-
-                <ng-template *ngIf="allowFiltering" [ngTemplateOutlet]="headerFilterTemplate" [ngTemplateOutletContext]="{$implicit: col}" />
-
-                <span
-                    *ngIf="col.draggable"
-                    cdkDragHandle
-                    [ngClass]="{ 'adf-datatable-cell-header-drag-icon': !isResizing }"
-                >
-                    <mat-icon
-                        *ngIf="hoveredHeaderColumnIndex === columnIndex && !isResizing"
-                        svgIcon="adf:drag_indicator"
-                        class="adf-datatable-cell-header-drag-icon-visible"
-                        [attr.data-automation-id]="'adf-datatable-cell-header-drag-icon-'+col.key"
-                        aria-hidden="true"
-                    />
-                </span>
-            </div>
-                <div
-                    *ngIf="isResizingEnabled && col.resizable && !lastColumn"
-                    [ngClass]="hoveredHeaderColumnIndex === columnIndex && !isResizing || resizingColumnIndex === columnIndex ? 'adf-datatable__resize-handle-visible' : 'adf-datatable__resize-handle-hidden'"
-                    adf-resize-handle
-                    tabindex="0"
-                    role="slider"
-                    [attr.aria-valuenow]="col.width ?? 100"
-                    [attr.aria-label]="'ADF-DATATABLE.ACCESSIBILITY.RESIZE_COLUMN' | translate: { column: col.title | translate }"
-                    [attr.aria-valuemin]="100"
-                    [attr.aria-valuemax]="500"
-                    (click)="$event.stopPropagation()"
-                    (keydown)="$event.stopPropagation()"
-                    class="adf-datatable__resize-handle"
-                    [resizableContainer]="resizableElement">
-                    <div class="adf-datatable__resize-handle--divider"></div>
-                </div>
-            <div class="adf-drop-header-cell-placeholder" *cdkDragPlaceholder></div>
-        </div>
-            </ng-container>
-
-            <!-- Header actions (right) -->
-            <div
-                *ngIf="(actions && actionsPosition === 'right') ||
-                       (mainActionTemplate && showMainDatatableActions)"
-                class="adf-actions-column adf-datatable-actions-menu adf-datatable-cell-header adf-datatable__actions-cell"
-                [class.adf-datatable-actions-menu-provided]="showProvidedActions"
-            >
-                <ng-container *ngIf="mainActionTemplate">
-                    <button
-                        data-automation-id="adf-datatable-main-menu-button"
-                        title="{{ 'ADF-DATATABLE.CONTENT-ACTIONS.SELECT_COLUMNS' | translate }}"
-                        mat-icon-button
-                        #mainMenuTrigger="matMenuTrigger"
-                        (click)="onMainMenuOpen()"
-                        [matMenuTriggerFor]="mainMenu">
-                        <mat-icon adf-icon="view_week_outline" />
-                    </button>
-                    <mat-menu #mainMenu (closed)="onMainMenuClosed()">
-                        <div #mainMenuTemplate role="presentation" (keydown.tab)="$event.stopPropagation()">
-                            <ng-container
-                                [ngTemplateOutlet]="mainActionTemplate"
-                                [ngTemplateOutletContext]="{
-                                    $implicit: mainMenuTrigger
-                                }" />
-                        </div>
-                    </mat-menu>
-                    <span class="adf-sr-only">{{ 'ADF-DATATABLE.ACCESSIBILITY.ACTIONS' | translate }}</span>
-                </ng-container>
-            </div>
-
-        </adf-datatable-row>
-    </div>
-
+@if (data) {
     <div
-        *ngIf="!loading; else loadingRowTemplate"
-        class="adf-datatable-body"
-        [ngClass]="{ 'adf-blur-datatable-body': blurOnResize && (isDraggingHeaderColumn || isResizing), 'adf-datatable-body__draggable': enableDragRows && !isDraggingRow, 'adf-datatable-body__dragging': isDraggingRow }"
-        cdkDropList
-        [cdkDropListDisabled]="!enableDragRows"
-        role="rowgroup">
-        <ng-container *ngIf="!noPermission; else noPermissionsRowTemplate">
-            <adf-datatable-row *ngFor="let row of data.getRows(); let idx = index"
-                cdkDrag
-                [cdkDragDisabled]="!enableDragRows"
-                (cdkDragDropped)="onDragDrop($event)"
-                (cdkDragStarted)="onDragStart()"
-                (cdkDragEnded)="onDragEnd()"
-                [cdkDragBoundary]="'.adf-datatable-body'"
-                [row]="row"
-                (select)="onEnterKeyPressed(row, $event)"
-                (keyup)="onRowKeyUp(row, $event)"
-                (keydown)="onRowEnterKeyDown(row, $event)"
-                [adf-upload]="rowAllowsDrop(row)"
-                [adf-upload-data]="row"
-                [ngStyle]="rowStyle"
-                [ngClass]="getRowStyle(row)"
-                [class.adf-datatable-row__dragging]="isDraggingRow"
-                [attr.data-automation-id]="'datatable-row-' + idx"
-                (contextmenu)="markRowAsContextMenuSource(row)"
-                [disabled]="!(enableDragRows || multiselect)"
-                [attr.aria-description]="
-                    (multiselect ? ('ADF-DATATABLE.ACCESSIBILITY.ROW_SELECTION' | translate) : '') +
-                    (multiselect && enableDragRows ? '. ' : '') +
-                    (enableDragRows ? ('ADF-DATATABLE.ACCESSIBILITY.DRAGGABLE' | translate) : '')
-                "
-            >   
-                <!-- Live region for selection state  -->
-                <span *ngIf="multiselect" class="adf-sr-only" aria-live="off">
-                    {{ row.isSelected ? ('ADF-DATATABLE.ACCESSIBILITY.SELECTED' | translate) : '' }}
-                </span>
+        role="grid"
+        class="adf-datatable-list"
+        [class.adf-sticky-header]="isStickyHeaderEnabled()"
+        [class.adf-datatable--empty]="(isEmpty() && !isHeaderVisible()) || loading"
+        [class.adf-datatable--empty--header-visible]="isEmpty() && isHeaderVisible()"
+    >
+        @if (isHeaderVisible()) {
+            <div class="adf-datatable-header" role="rowgroup" [ngClass]="{ 'adf-sr-only': !isHeaderVisible() }">
+                <adf-datatable-row
+                    cdkDropList
+                    cdkDropListOrientation="horizontal"
+                    [cdkDropListSortPredicate]="filterDisabledColumns"
+                    data-automation-id="datatable-row-header"
+                    class="adf-datatable-row"
+                    role="row">
 
-                 <!-- Drag button -->
-                <div *ngIf="enableDragRows"
-                        role="gridcell"
-                        class="adf-datatable-cell adf-datatable__actions-cell adf-datatable-hover-only">
-                        <mat-icon adf-icon="drag_indicator" aria-hidden="true" />
-                </div>
 
-                <!-- Actions (left) -->
-                <div *ngIf="actions && actionsPosition === 'left'" role="gridcell" class="adf-datatable-cell">
-                    <button mat-icon-button [matMenuTriggerFor]="menu" #actionsMenuTrigger="matMenuTrigger"
-                            [ngClass]="getHideActionsWithoutHoverClass(actionsMenuTrigger)"
-                            [title]="'ADF-DATATABLE.CONTENT-ACTIONS.TOOLTIP' | translate"
-                            [attr.id]="'action_menu_left_' + idx"
-                            [attr.data-automation-id]="'action_menu_' + idx">
-                        <mat-icon adf-icon="more_vert" />
-                    </button>
-                    <mat-menu #menu="matMenu">
-                        <button mat-menu-item *ngFor="let action of getRowActions(row)"
-                                [attr.data-automation-id]="action.title"
-                                [disabled]="action.disabled"
-                                (click)="onExecuteRowAction(row, action)">
-                            <mat-icon *ngIf="action.icon" [adf-icon]="action.icon" />
-                            <span>{{ action.title | translate }}</span>
-                        </button>
-                    </mat-menu>
-                </div>
+                    <!-- Drag -->
+                     @if (enableDragRows) {
+                        <div class="adf-datatable-cell-header adf-drag-column">
+                            <span class="adf-sr-only">{{ 'ADF-DATATABLE.ACCESSIBILITY.DRAG' | translate }}</span>
+                        </div>
+                     }
 
-                <label *ngIf="multiselect"
-                    (keydown.enter)="onEnterKeyPressed(row, $any($event))"
-                    (click)="onCheckboxLabelClick(row, $event)"
-                    [for]="'select-file-' + idx"
-                    class="adf-datatable-cell adf-datatable-checkbox adf-datatable-checkbox-single"
-                    [attr.tabindex]="null"
-                    aria-hidden="true"
-                >
-                    <mat-checkbox
-                        [id]="'select-file-' + idx"
-                        [disabled]="!row?.isSelectable"
-                        [class.adf-datatable-checkbox-selected]="row.isSelected"
-                        [class.adf-datatable-hover-only]="displayCheckboxesOnHover"
-                        [checked]="row.isSelected"
-                        data-adf-datatable-row-checkbox
-                        (change)="onCheckboxChange(row, $event)"
-                        (keydown.enter)="$event.stopPropagation()"
-                        class="adf-checkbox-sr-only"
-                        [tabIndex]="-1"
-                        aria-hidden="true"
-                    />
-                </label>
+                    <!-- Actions (left) -->
+                     @if (actions && actionsPosition === 'left') {
+                        <div class="adf-actions-column adf-datatable-cell-header">
+                            <span class="adf-sr-only">{{ 'ADF-DATATABLE.ACCESSIBILITY.ACTIONS' | translate }}</span>
+                        </div>
+                     }
 
-                <div
-                    *ngFor="let col of getVisibleColumns(); let lastColumn = last"
-                    role="gridcell"
-                    class="adf-datatable-cell adf-datatable-cell--{{col.type || 'text'}} {{col.cssClass}} adf-datatable-cell-data adf-datatable-cell--{{getAutomationValue(row)}}"
-                    [attr.title]="col.title | translate"
-                    [attr.data-automation-id]="getAutomationValue(row)"  
-                    [attr.aria-label]="col.title ? (col.title | translate) : null" 
-                    [attr.aria-hidden]='isRepresentationContent(col) ? "true" : null'
-                    (click)="onRowClick(row, $event)"
-                    [attr.tabindex]="null"
-                    (keydown.enter)="onEnterKeyPressed(row, $any($event))"
-                    [adf-context-menu]="getContextMenuActions(row, col)"
-                    [adf-context-menu-enabled]="contextMenu"
-                    adf-drop-zone dropTarget="cell" [dropColumn]="col" [dropRow]="row"
-                    [ngStyle]="(col.width) && !lastColumn && {'flex': getFlexValue(col)}"
-                >
-                    <div *ngIf="!col.template" class="adf-datatable-cell-container">
-                        <ng-container [ngSwitch]="data.getColumnType(row, col)">
-                            <div *ngSwitchCase="'image'" class="adf-cell-value">
-                                <mat-icon
-                                    [attr.aria-label]="col.srTitle? (col.srTitle | translate) : null"
-                                    [attr.aria-hidden]="!asIconValue(row, col)"
-                                    *ngIf="isIconValue(row, col); else no_iconvalue"
-                                    [adf-icon]="asIconValue(row, col)"
-                                />
-                                <ng-template #no_iconvalue>
-                                    <mat-icon class="adf-datatable-selected"
-                                                *ngIf="row.isSelected && !multiselect; else no_selected_row" svgIcon="selected" />
-                                    <ng-template #no_selected_row>
-                                        <img class="adf-datatable-center-img-ie"
-                                            [attr.aria-label]="(data.getValue(row, col) | fileType) === 'disable' ?
-                                                ('ADF-DATATABLE.ACCESSIBILITY.ICON_DISABLED' | translate) :
-                                                'ADF-DATATABLE.ACCESSIBILITY.ICON_TEXT' | translate:{
-                                                    type: 'ADF-DATATABLE.FILE_TYPE.' + (data.getValue(row, col) | fileType | uppercase) | translate
-                                                }"
-                                            [attr.alt]="(data.getValue(row, col) | fileType) === 'disable' ?
-                                                ('ADF-DATATABLE.ACCESSIBILITY.ICON_DISABLED' | translate) :
-                                                'ADF-DATATABLE.ACCESSIBILITY.ICON_TEXT' | translate:{
-                                                        type: 'ADF-DATATABLE.FILE_TYPE.' + (data.getValue(row, col) | fileType | uppercase) | translate
-                                                }"
-                                            src="{{ data.getValue(row, col) }}"
-                                            (error)="onImageLoadingError($event, row)">
-                                    </ng-template>
-                                </ng-template>
-                            </div>
+                    <!-- Columns -->
+                     @if (multiselect) {
+                        <div class="adf-datatable-cell-header adf-datatable-checkbox">
+                            <mat-checkbox
+                                [indeterminate]="isSelectAllIndeterminate"
+                                [checked]="isSelectAllChecked"
+                                (change)="onSelectAllClick($event)"
+                                class="adf-checkbox-sr-only"
+                                [aria-label]="'ADF-DATATABLE.ACCESSIBILITY.SELECT_ALL' | translate"
+                                [matTooltip]="'ADF-DATATABLE.ACCESSIBILITY.SELECT_ALL' | translate"
+                                #tooltip="matTooltip"
+                                (focusin)="tooltip.show()"
+                                (focusout)="tooltip.hide()"
+                            >
+                                {{ 'ADF-DATATABLE.ACCESSIBILITY.SELECT_ALL' | translate }}
+                            </mat-checkbox>
+                        </div>
+                     }
 
-                            <div *ngSwitchCase="'icon'" class="adf-cell-value">
-                                <adf-icon-cell
-                                    [data]="data"
-                                    [column]="col"
-                                    [row]="row"
-                                    [resolverFn]="resolverFn"
-                                    [tooltip]="getCellTooltip(row, col)"
-                                />
-                            </div>
+                     @for (col of getVisibleColumns(); track col.key; let lastColumn = $last; let columnIndex = $index) {
+                        @if (col.title || !showProvidedActions) {
                             <div
-                                *ngSwitchCase="'date'"
-                                class="adf-cell-value adf-cell-date"
-    
-                                [attr.data-automation-id]="'date_' + (data.getValue(row, col, resolverFn) | adfLocalizedDate: 'medium') ">
-                                <adf-date-cell class="adf-datatable-center-date-column-ie"
-                                    [data]="data"
-                                    [column]="col"
-                                    [row]="row"
-                                    [resolverFn]="resolverFn"
-                                    [tooltip]="getCellTooltip(row, col)"
-                                    [dateConfig]="col.dateConfig" />
-                            </div>
+                                class="adf-datatable-cell--{{col.type || 'text'}} {{col.cssClass}} adf-datatable-cell-header adf-datatable-cell-data"
+                                [attr.data-automation-id]="'auto_id_' + col.key"
+                                [ngClass]="{
+                                    'adf-sortable': col.sortable,
+                                    'adf-datatable__cursor--pointer': !isResizing,
+                                    'adf-datatable__header--sorted-asc': isColumnSorted(col, 'asc'),
+                                    'adf-datatable__header--sorted-desc': isColumnSorted(col, 'desc')}"
+                                [ngStyle]="(col.width) && !lastColumn && {'flex': getFlexValue(col)}"
+                                role="columnheader"
+                                [attr.aria-label]="col.srTitle ? (col.srTitle | translate) : (col.title | translate) + (col.subtitle ? ' ' + (col.subtitle | translate) : '')"
+                                [attr.aria-sort]="col.sortable ? (getAriaSort(col) | translate) : null"
+                                cdkDrag
+                                cdkDragLockAxis="x"
+                                (cdkDragStarted)="isDraggingHeaderColumn = true"
+                                (cdkDragDropped)="onDropHeaderColumn($event)"
+                                [cdkDragDisabled]="!col.draggable"
+                                (mouseenter)="hoveredHeaderColumnIndex = columnIndex"
+                                (mouseleave)="hoveredHeaderColumnIndex = -1"
+                                adf-drop-zone dropTarget="header"
+                                [dropColumn]="col">
 
-                            <div *ngSwitchCase="'location'" class="adf-cell-value"
-                                    [attr.data-automation-id]="'location' + data.getValue(row, col, resolverFn)">
-                                <adf-location-cell
-                                    [data]="data"
-                                    [column]="col"
-                                    [row]="row"
-                                    [resolverFn]="resolverFn"
-                                    [tooltip]="getCellTooltip(row, col)" />
+                                <div
+                                    adf-resizable
+                                    #resizableElement="adf-resizable"
+                                    [attr.tabindex]="col.sortable ? 0 : null"
+                                    [attr.role]="col.sortable ? 'button' : null"
+                                    [attr.aria-description]="
+                                        isColumnSortActive(col) ? (getSortLiveAnnouncement(col) | translate: { string: col.title | translate }) : null
+                                    "
+                                    [attr.aria-label]="
+                                        col.srTitle
+                                            ? (col.srTitle | translate)
+                                            : ('ADF-DATATABLE.ACCESSIBILITY.SORT_DEFAULT' | translate) +
+                                                ' ' +
+                                                (col.title | translate) +
+                                                (col.subtitle ? ' ' + (col.subtitle | translate) : '')
+                                    "
+                                    (click)="onColumnHeaderClick(col, $event)"
+                                    (keyup.enter)="onColumnHeaderClick(col, $event)"
+                                    [coverPadding]="10"
+                                    (resizing)="onResizing($event, columnIndex)"
+                                    (keyboardResizing)="onResizing($event, columnIndex)"
+                                    (resizeStart)="resizingColumnIndex = columnIndex"
+                                    (resizeEnd)="onResizingEnd()"
+                                    [attr.data-automation-id]="'auto_header_content_id_' + col.key"
+                                    class="adf-datatable-cell-header-content"
+                                    [ngClass]="{ 'adf-datatable-cell-header-content--hovered':
+                                        hoveredHeaderColumnIndex === columnIndex &&
+                                        !isDraggingHeaderColumn &&
+                                        !isResizing && col.sortable}"
+                                >
+                                    @if (!col.header) {
+                                        @if (col.title) {
+                                            <span
+                                                title="{{col.title | translate}}"
+                                                class="adf-datatable-cell-value"
+                                            >
+                                                {{col.title | translate}}
+                                            </span>
+                                        }
+
+                                        @if (col.subtitle) {
+                                            <span
+                                                title="{{col.subtitle | translate}}"
+                                                class="adf-datatable-cell-value adf-datatable-cell-header_subtitle"
+                                            >
+                                                ({{col.subtitle | translate}})
+                                            </span>
+                                        }
+
+                                        @if (col.title && col.sortable && isDraggingHeaderColumn) {
+                                            <span class="adf-sr-only" aria-live="polite">
+                                                {{ getSortLiveAnnouncement(col) | translate: { string: col.title | translate } }}
+                                            </span>
+                                        }
+
+                                        @if (!col.title && !col.sortable && !headerFilterTemplate) {
+                                            <span [attr.title]="'ADF-DATATABLE.ACCESSIBILITY.EMPTY_HEADER' | translate"></span>
+                                        }
+                                    }
+
+                                    @if (col.header) {
+                                        <div class="adf-datatable-cell-value">
+                                            <ng-template [ngTemplateOutlet]="col.header" [ngTemplateOutletContext]="{$implicit: col}" />
+                                        </div>
+                                    }
+
+                                    <span
+                                        [class.adf-datatable__header--sorted-asc]="isColumnSorted(col, 'asc')"
+                                        [class.adf-datatable__header--sorted-desc]="isColumnSorted(col, 'desc')">
+                                    </span>
+
+                                    @if (allowFiltering) {
+                                        <ng-template [ngTemplateOutlet]="headerFilterTemplate" [ngTemplateOutletContext]="{$implicit: col}" />
+                                    }
+
+                                    @if (col.draggable) {
+                                        <span
+                                            cdkDragHandle
+                                            [ngClass]="{ 'adf-datatable-cell-header-drag-icon': !isResizing }"
+                                        >
+                                            @if (hoveredHeaderColumnIndex === columnIndex && !isResizing) {
+                                                <mat-icon
+                                                    svgIcon="adf:drag_indicator"
+                                                    class="adf-datatable-cell-header-drag-icon-visible"
+                                                    [attr.data-automation-id]="'adf-datatable-cell-header-drag-icon-'+col.key"
+                                                    aria-hidden="true"
+                                                />
+                                            }
+                                        </span>
+                                    }
+                                </div>
+                                @if (isResizingEnabled && col.resizable && !lastColumn) {
+                                    <div
+                                        [ngClass]="hoveredHeaderColumnIndex === columnIndex && !isResizing || resizingColumnIndex === columnIndex ? 'adf-datatable__resize-handle-visible' : 'adf-datatable__resize-handle-hidden'"
+                                        adf-resize-handle
+                                        tabindex="0"
+                                        role="slider"
+                                        [attr.aria-valuenow]="col.width ?? 100"
+                                        [attr.aria-label]="'ADF-DATATABLE.ACCESSIBILITY.RESIZE_COLUMN' | translate: { column: col.title | translate }"
+                                        [attr.aria-valuemin]="100"
+                                        [attr.aria-valuemax]="500"
+                                        (click)="$event.stopPropagation()"
+                                        (keydown)="$event.stopPropagation()"
+                                        class="adf-datatable__resize-handle"
+                                        [resizableContainer]="resizableElement">
+                                        <div class="adf-datatable__resize-handle--divider"></div>
+                                    </div>
+                                }
+                                <div class="adf-drop-header-cell-placeholder" *cdkDragPlaceholder></div>
                             </div>
-                            <div *ngSwitchCase="'fileSize'" class="adf-cell-value"
-                                    [attr.data-automation-id]="'fileSize_' + data.getValue(row, col, resolverFn)">
-                                <adf-filesize-cell class="adf-datatable-center-size-column-ie"
-                                    [data]="data"
-                                    [column]="col"
-                                    [row]="row"
-                                    [resolverFn]="resolverFn"
-                                    [tooltip]="getCellTooltip(row, col)" />
+                        }
+                     }
+
+                    <!-- Header actions (right) -->
+                     @if ((actions && actionsPosition === 'right') || (mainActionTemplate && showMainDatatableActions)) {
+                        <div
+                            class="adf-actions-column adf-datatable-actions-menu adf-datatable-cell-header adf-datatable__actions-cell"
+                            [class.adf-datatable-actions-menu-provided]="showProvidedActions"
+                        >
+                            @if (mainActionTemplate) {
+                                <button
+                                    data-automation-id="adf-datatable-main-menu-button"
+                                    title="{{ 'ADF-DATATABLE.CONTENT-ACTIONS.SELECT_COLUMNS' | translate }}"
+                                    mat-icon-button
+                                    #mainMenuTrigger="matMenuTrigger"
+                                    (click)="onMainMenuOpen()"
+                                    [matMenuTriggerFor]="mainMenu">
+                                    <mat-icon adf-icon="view_week_outline" />
+                                </button>
+                                <mat-menu #mainMenu (closed)="onMainMenuClosed()">
+                                    <div #mainMenuTemplate role="presentation" (keydown.tab)="$event.stopPropagation()">
+                                        <ng-container
+                                            [ngTemplateOutlet]="mainActionTemplate"
+                                            [ngTemplateOutletContext]="{
+                                                $implicit: mainMenuTrigger
+                                            }" />
+                                    </div>
+                                </mat-menu>
+                                <span class="adf-sr-only">{{ 'ADF-DATATABLE.ACCESSIBILITY.ACTIONS' | translate }}</span>
+                            }
+                        </div>
+                     }
+                </adf-datatable-row>
+            </div>
+        }
+
+        @if (!loading) {
+            <div
+                class="adf-datatable-body"
+                [ngClass]="{ 'adf-blur-datatable-body': blurOnResize && (isDraggingHeaderColumn || isResizing), 'adf-datatable-body__draggable': enableDragRows && !isDraggingRow, 'adf-datatable-body__dragging': isDraggingRow }"
+                cdkDropList
+                [cdkDropListDisabled]="!enableDragRows"
+                role="rowgroup">
+                @if (!noPermission) {
+                    @for (row of data.getRows(); track $index; let idx = $index) {
+                        <adf-datatable-row
+                            cdkDrag
+                            [cdkDragDisabled]="!enableDragRows"
+                            (cdkDragDropped)="onDragDrop($event)"
+                            (cdkDragStarted)="onDragStart()"
+                            (cdkDragEnded)="onDragEnd()"
+                            [cdkDragBoundary]="'.adf-datatable-body'"
+                            [row]="row"
+                            (select)="onEnterKeyPressed(row, $event)"
+                            (keyup)="onRowKeyUp(row, $event)"
+                            (keydown)="onRowEnterKeyDown(row, $event)"
+                            [adf-upload]="rowAllowsDrop(row)"
+                            [adf-upload-data]="row"
+                            [ngStyle]="rowStyle"
+                            [ngClass]="getRowStyle(row)"
+                            [class.adf-datatable-row__dragging]="isDraggingRow"
+                            [attr.data-automation-id]="'datatable-row-' + idx"
+                            (contextmenu)="markRowAsContextMenuSource(row)"
+                            [disabled]="!(enableDragRows || multiselect)"
+                            [attr.aria-description]="
+                                (multiselect ? ('ADF-DATATABLE.ACCESSIBILITY.ROW_SELECTION' | translate) : '') +
+                                (multiselect && enableDragRows ? '. ' : '') +
+                                (enableDragRows ? ('ADF-DATATABLE.ACCESSIBILITY.DRAGGABLE' | translate) : '')
+                            "
+                        >
+                            <!-- Live region for selection state  -->
+                            @if (multiselect) {
+                                <span class="adf-sr-only" aria-live="off">
+                                    {{ row.isSelected ? ('ADF-DATATABLE.ACCESSIBILITY.SELECTED' | translate) : '' }}
+                                </span>
+                            }
+
+                            <!-- Drag button -->
+                            @if (enableDragRows) {
+                                <div
+                                    role="gridcell"
+                                    class="adf-datatable-cell adf-datatable__actions-cell adf-datatable-hover-only">
+                                    <mat-icon adf-icon="drag_indicator" aria-hidden="true" />
+                                </div>
+                            }
+
+                            <!-- Actions (left) -->
+                             @if (actions && actionsPosition === 'left') {
+                                <div role="gridcell" class="adf-datatable-cell">
+                                    <button mat-icon-button [matMenuTriggerFor]="menu" #actionsMenuTrigger="matMenuTrigger"
+                                            [ngClass]="getHideActionsWithoutHoverClass(actionsMenuTrigger)"
+                                            [title]="'ADF-DATATABLE.CONTENT-ACTIONS.TOOLTIP' | translate"
+                                            [attr.id]="'action_menu_left_' + idx"
+                                            [attr.data-automation-id]="'action_menu_' + idx">
+                                        <mat-icon adf-icon="more_vert" />
+                                    </button>
+                                    <mat-menu #menu="matMenu">
+                                        @for (action of getRowActions(row); track action.title) {
+                                            <button mat-menu-item
+                                                    [attr.data-automation-id]="action.title"
+                                                    [disabled]="action.disabled"
+                                                    (click)="onExecuteRowAction(row, action)">
+                                                @if (action.icon) {
+                                                    <mat-icon [adf-icon]="action.icon" />
+                                                }
+                                                <span>{{ action.title | translate }}</span>
+                                            </button>
+                                        }
+                                    </mat-menu>
+                                </div>
+                             }
+
+                             @if (multiselect) {
+                                <label
+                                    (keydown.enter)="onEnterKeyPressed(row, $any($event))"
+                                    (click)="onCheckboxLabelClick(row, $event)"
+                                    [for]="'select-file-' + idx"
+                                    class="adf-datatable-cell adf-datatable-checkbox adf-datatable-checkbox-single"
+                                    [attr.tabindex]="null"
+                                    aria-hidden="true"
+                                >
+                                    <mat-checkbox
+                                        [id]="'select-file-' + idx"
+                                        [disabled]="!row?.isSelectable"
+                                        [class.adf-datatable-checkbox-selected]="row.isSelected"
+                                        [class.adf-datatable-hover-only]="displayCheckboxesOnHover"
+                                        [checked]="row.isSelected"
+                                        data-adf-datatable-row-checkbox
+                                        (change)="onCheckboxChange(row, $event)"
+                                        (keydown.enter)="$event.stopPropagation()"
+                                        class="adf-checkbox-sr-only"
+                                        [tabIndex]="-1"
+                                        aria-hidden="true"
+                                    />
+                                </label>
+                             }
+
+                            @for (col of getVisibleColumns(); track col.key; let lastColumn = $last;) {
+                                <div
+                                    role="gridcell"
+                                    class="adf-datatable-cell adf-datatable-cell--{{col.type || 'text'}} {{col.cssClass}} adf-datatable-cell-data adf-datatable-cell--{{getAutomationValue(row)}}"
+                                    [attr.title]="col.title | translate"
+                                    [attr.data-automation-id]="getAutomationValue(row)"
+                                    [attr.aria-label]="col.title ? (col.title | translate) : null"
+                                    [attr.aria-hidden]='isRepresentationContent(col) ? "true" : null'
+                                    (click)="onRowClick(row, $event)"
+                                    [attr.tabindex]="null"
+                                    (keydown.enter)="onEnterKeyPressed(row, $any($event))"
+                                    [adf-context-menu]="getContextMenuActions(row, col)"
+                                    [adf-context-menu-enabled]="contextMenu"
+                                    adf-drop-zone dropTarget="cell" [dropColumn]="col" [dropRow]="row"
+                                    [ngStyle]="(col.width) && !lastColumn && {'flex': getFlexValue(col)}"
+                                >
+                                    @if (!col.template) {
+                                        <div class="adf-datatable-cell-container">
+                                            @switch (data.getColumnType(row, col)) {
+                                                @case ('image') {
+                                                    <div class="adf-cell-value">
+                                                        @if (isIconValue(row, col)) {
+                                                            <mat-icon
+                                                                [attr.aria-label]="col.srTitle? (col.srTitle | translate) : null"
+                                                                [attr.aria-hidden]="!asIconValue(row, col)"
+                                                                [adf-icon]="asIconValue(row, col)"
+                                                            />
+                                                        } @else {
+                                                            @if (row.isSelected && !multiselect) {
+                                                                <mat-icon class="adf-datatable-selected" svgIcon="selected" />
+                                                            } @else {
+                                                                <img class="adf-datatable-center-img-ie"
+                                                                    [attr.aria-label]="(data.getValue(row, col) | fileType) === 'disable' ?
+                                                                        ('ADF-DATATABLE.ACCESSIBILITY.ICON_DISABLED' | translate) :
+                                                                        'ADF-DATATABLE.ACCESSIBILITY.ICON_TEXT' | translate:{
+                                                                            type: 'ADF-DATATABLE.FILE_TYPE.' + (data.getValue(row, col) | fileType | uppercase) | translate
+                                                                        }"
+                                                                    [attr.alt]="(data.getValue(row, col) | fileType) === 'disable' ?
+                                                                        ('ADF-DATATABLE.ACCESSIBILITY.ICON_DISABLED' | translate) :
+                                                                        'ADF-DATATABLE.ACCESSIBILITY.ICON_TEXT' | translate:{
+                                                                                type: 'ADF-DATATABLE.FILE_TYPE.' + (data.getValue(row, col) | fileType | uppercase) | translate
+                                                                        }"
+                                                                    src="{{ data.getValue(row, col) }}"
+                                                                    (error)="onImageLoadingError($event, row)">
+                                                            }
+                                                        }
+                                                    </div>
+                                                }
+                                                @case ('icon') {
+                                                    <div class="adf-cell-value">
+                                                        <adf-icon-cell
+                                                            [data]="data"
+                                                            [column]="col"
+                                                            [row]="row"
+                                                            [resolverFn]="resolverFn"
+                                                            [tooltip]="getCellTooltip(row, col)"
+                                                        />
+                                                    </div>
+                                                }
+                                                @case ('date') {
+                                                    <div
+                                                        class="adf-cell-value adf-cell-date"
+                                                        [attr.data-automation-id]="'date_' + (data.getValue(row, col, resolverFn) | adfLocalizedDate: 'medium') ">
+                                                        <adf-date-cell class="adf-datatable-center-date-column-ie"
+                                                            [data]="data"
+                                                            [column]="col"
+                                                            [row]="row"
+                                                            [resolverFn]="resolverFn"
+                                                            [tooltip]="getCellTooltip(row, col)"
+                                                            [dateConfig]="col.dateConfig" />
+                                                    </div>
+                                                }
+                                                @case ('location') {
+                                                    <div class="adf-cell-value"
+                                                        [attr.data-automation-id]="'location' + data.getValue(row, col, resolverFn)">
+                                                        <adf-location-cell
+                                                            [data]="data"
+                                                            [column]="col"
+                                                            [row]="row"
+                                                            [resolverFn]="resolverFn"
+                                                            [tooltip]="getCellTooltip(row, col)" />
+                                                    </div>
+                                                }
+                                                @case ('fileSize') {
+                                                    <div class="adf-cell-value"
+                                                        [attr.data-automation-id]="'fileSize_' + data.getValue(row, col, resolverFn)">
+                                                        <adf-filesize-cell class="adf-datatable-center-size-column-ie"
+                                                            [data]="data"
+                                                            [column]="col"
+                                                            [row]="row"
+                                                            [resolverFn]="resolverFn"
+                                                            [tooltip]="getCellTooltip(row, col)" />
+                                                    </div>
+                                                }
+                                                @case ('text') {
+                                                    <div class="adf-cell-value"
+                                                        [attr.data-automation-id]="'text_' + data.getValue(row, col, resolverFn)">
+                                                        <adf-datatable-cell
+                                                            [copyContent]="col.copyContent"
+                                                            [data]="data"
+                                                            [column]="col"
+                                                            [row]="row"
+                                                            [resolverFn]="resolverFn"
+                                                            [tooltip]="getCellTooltip(row, col)" />
+                                                    </div>
+                                                }
+                                                @case ('boolean') {
+                                                    <div class="adf-cell-value"
+                                                        [attr.data-automation-id]="'boolean_' + data.getValue(row, col, resolverFn)">
+                                                        <adf-boolean-cell
+                                                            [data]="data"
+                                                            [column]="col"
+                                                            [row]="row"
+                                                            [resolverFn]="resolverFn"
+                                                            [tooltip]="getCellTooltip(row, col)" />
+                                                    </div>
+                                                }
+                                                @case ('json') {
+                                                    <div class="adf-cell-value">
+                                                        <adf-json-cell
+                                                            [editable]="col.editable"
+                                                            [data]="data"
+                                                            [column]="col"
+                                                            [resolverFn]="resolverFn"
+                                                            [row]="row" />
+                                                    </div>
+                                                }
+                                                @case ('amount') {
+                                                    <div
+                                                        class="adf-cell-value"
+                                                        [attr.data-automation-id]="'amount_' + data.getValue(row, col, resolverFn)">
+                                                        <adf-amount-cell
+                                                            [data]="data"
+                                                            [column]="col"
+                                                            [resolverFn]="resolverFn"
+                                                            [row]="row"
+                                                            [currencyConfig]="col.currencyConfig" />
+                                                    </div>
+                                                }
+                                                @case ('number') {
+                                                    <div
+                                                        class="adf-cell-value"
+                                                        [attr.data-automation-id]="'number_' + data.getValue(row, col, resolverFn)">
+                                                        <adf-number-cell
+                                                            [data]="data"
+                                                            [column]="col"
+                                                            [resolverFn]="resolverFn"
+                                                            [row]="row"
+                                                            [decimalConfig]="col.decimalConfig" />
+                                                    </div>
+                                                }
+                                                @default {
+                                                    <span class="adf-cell-value">
+                                                        <!-- empty cell for unknown column type -->
+                                                    </span>
+                                                }
+                                            }
+                                        </div>
+                                    } @else {
+                                        <div class="adf-datatable-cell-container">
+                                            <div class="adf-cell-value">
+                                                <ng-container
+                                                    [ngTemplateOutlet]="col.template"
+                                                    [ngTemplateOutletContext]="{ $implicit: { data: data, row: row, col: col }, value: data.getValue(row, col, resolverFn) }" />
+                                            </div>
+                                        </div>
+                                    }
+                                </div>
+                            }
+
+                            <!-- Row actions (right) -->
+                             @if (!showProvidedActions && ((actions && actionsPosition === 'right') || (mainActionTemplate && showMainDatatableActions))) {
+                                <div
+                                    role="gridcell"
+                                    class="adf-datatable-cell adf-datatable__actions-cell adf-datatable-center-actions-column-ie adf-datatable-actions-menu">
+
+                                    @if (actions && actionsPosition === 'right') {
+                                        <button mat-icon-button [matMenuTriggerFor]="menu" #actionsMenuTrigger="matMenuTrigger"
+                                                [ngClass]="getHideActionsWithoutHoverClass(actionsMenuTrigger)"
+                                                [attr.aria-label]="'ADF-DATATABLE.ACCESSIBILITY.ROW_OPTION_BUTTON' | translate"
+                                                [title]="'ADF-DATATABLE.CONTENT-ACTIONS.TOOLTIP' | translate"
+                                                [attr.id]="'action_menu_right_' + idx"
+                                                [attr.data-automation-id]="'action_menu_' + idx"
+                                                (keydown.enter)="actionsMenuTrigger.openMenu()">
+                                            <mat-icon adf-icon="more_vert" />
+                                        </button>
+                                        <mat-menu #menu="matMenu">
+                                            @for (action of getRowActions(row); track action.title) {
+                                                <button mat-menu-item
+                                                        [attr.data-automation-id]="action.title"
+                                                        [attr.aria-label]="action.title | translate"
+                                                        [disabled]="action.disabled"
+                                                        (click)="onExecuteRowAction(row, action)">
+                                                    @if (action.icon) {
+                                                        <mat-icon [adf-icon]="action.icon" />
+                                                    }
+                                                    <span>{{ action.title | translate }}</span>
+                                                </button>
+                                            }
+                                        </mat-menu>
+                                    }
+                                </div>
+                             }
+                        </adf-datatable-row>
+                    }
+                    @if (isEmpty()) {
+                        <div role="row" class="adf-datatable-row">
+                            <div class="adf-no-content-container adf-datatable-cell" role="gridcell">
+                                @if (noContentTemplate) {
+                                    <ng-template
+                                        ngFor [ngForOf]="[data]"
+                                        [ngForTemplate]="noContentTemplate" />
+                                }
+                                <ng-content select="adf-empty-list" />
                             </div>
-                            <div *ngSwitchCase="'text'" class="adf-cell-value"
-                                    [attr.data-automation-id]="'text_' + data.getValue(row, col, resolverFn)">
-                                <adf-datatable-cell
-                                    [copyContent]="col.copyContent"
-                                    [data]="data"
-                                    [column]="col"
-                                    [row]="row"
-                                    [resolverFn]="resolverFn"
-                                    [tooltip]="getCellTooltip(row, col)" />
-                            </div>
-                            <div *ngSwitchCase="'boolean'" class="adf-cell-value"
-                                    [attr.data-automation-id]="'boolean_' + data.getValue(row, col, resolverFn)">
-                                <adf-boolean-cell
-                                    [data]="data"
-                                    [column]="col"
-                                    [row]="row"
-                                    [resolverFn]="resolverFn"
-                                    [tooltip]="getCellTooltip(row, col)" />
-                            </div>
-                            <div *ngSwitchCase="'json'" class="adf-cell-value">
-                                <adf-json-cell
-                                    [editable]="col.editable"
-                                    [data]="data"
-                                    [column]="col"
-                                    [resolverFn]="resolverFn"
-                                    [row]="row" />
-                            </div>
-                            <div *ngSwitchCase="'amount'"
-                                class="adf-cell-value"
-                                [attr.data-automation-id]="'amount_' + data.getValue(row, col, resolverFn)">
-                                <adf-amount-cell
-                                    [data]="data"
-                                    [column]="col"
-                                    [resolverFn]="resolverFn"
-                                    [row]="row"
-                                    [currencyConfig]="col.currencyConfig" />
-                            </div>
-                            <div *ngSwitchCase="'number'"
-                                class="adf-cell-value"
-                                [attr.data-automation-id]="'number_' + data.getValue(row, col, resolverFn)">
-                                <adf-number-cell
-                                    [data]="data"
-                                    [column]="col"
-                                    [resolverFn]="resolverFn"
-                                    [row]="row"
-                                    [decimalConfig]="col.decimalConfig" />
-                            </div>
-                            <span *ngSwitchDefault class="adf-cell-value">
-                    <!-- empty cell for unknown column type -->
-                    </span>
-                        </ng-container>
-                    </div>
-                    <div *ngIf="col.template" class="adf-datatable-cell-container">
-                        <div class="adf-cell-value">
-                            <ng-container
-                                [ngTemplateOutlet]="col.template"
-                                [ngTemplateOutletContext]="{ $implicit: { data: data, row: row, col: col }, value: data.getValue(row, col, resolverFn) }" />
+                        </div>
+                    }
+                } @else {
+                    <div
+                        role="row"
+                        class="adf-datatable-row adf-no-permission__row">
+                        <div class="adf-no-permission__cell adf-no-content-container adf-datatable-cell">
+                            @if (noPermissionTemplate) {
+                                <ng-template
+                                    ngFor [ngForOf]="[data]"
+                                    [ngForTemplate]="noPermissionTemplate" />
+                            }
                         </div>
                     </div>
-                </div>
-
-                <!-- Row actions (right) -->
-                <div *ngIf="
-                        !showProvidedActions &&
-                        ((actions && actionsPosition === 'right') ||
-                        (mainActionTemplate && showMainDatatableActions))"
-                        role="gridcell"
-                        class="adf-datatable-cell adf-datatable__actions-cell adf-datatable-center-actions-column-ie adf-datatable-actions-menu">
-
-                    <ng-container *ngIf="(actions && actionsPosition === 'right')">
-                        <button mat-icon-button [matMenuTriggerFor]="menu" #actionsMenuTrigger="matMenuTrigger"
-                                [ngClass]="getHideActionsWithoutHoverClass(actionsMenuTrigger)"
-                                [attr.aria-label]="'ADF-DATATABLE.ACCESSIBILITY.ROW_OPTION_BUTTON' | translate"
-                                [title]="'ADF-DATATABLE.CONTENT-ACTIONS.TOOLTIP' | translate"
-                                [attr.id]="'action_menu_right_' + idx"
-                                [attr.data-automation-id]="'action_menu_' + idx"
-                                (keydown.enter)="actionsMenuTrigger.openMenu()">
-                            <mat-icon adf-icon="more_vert" />
-                        </button>
-                        <mat-menu #menu="matMenu">
-                            <button mat-menu-item *ngFor="let action of getRowActions(row)"
-                                    [attr.data-automation-id]="action.title"
-                                    [attr.aria-label]="action.title | translate"
-                                    [disabled]="action.disabled"
-                                    (click)="onExecuteRowAction(row, action)">
-                                <mat-icon *ngIf="action.icon" [adf-icon]="action.icon" />
-                                <span>{{ action.title | translate }}</span>
-                            </button>
-                        </mat-menu>
-                    </ng-container>
-                </div>
-            </adf-datatable-row>
-            <div *ngIf="isEmpty()" role="row" class="adf-datatable-row">
-                <div class="adf-no-content-container adf-datatable-cell" role="gridcell">
-                    <ng-template *ngIf="noContentTemplate"
-                                    ngFor [ngForOf]="[data]"
-                                    [ngForTemplate]="noContentTemplate" />
-                    <ng-content select="adf-empty-list" />
+                }
+            </div>
+        } @else {
+            <div class="adf-datatable-row adf-datatable-data-loading">
+                <div class="adf-no-content-container adf-datatable-cell">
+                    @if (loadingTemplate) {
+                        <ng-template
+                            ngFor [ngForOf]="[data]"
+                            [ngForTemplate]="loadingTemplate" />
+                    }
                 </div>
             </div>
-        </ng-container>
-
-        <ng-template #noPermissionsRowTemplate>
-            <div
-                role="row"
-                class="adf-datatable-row adf-no-permission__row">
-                <div class="adf-no-permission__cell adf-no-content-container adf-datatable-cell">
-                    <ng-template *ngIf="noPermissionTemplate"
-                                ngFor [ngForOf]="[data]"
-                                [ngForTemplate]="noPermissionTemplate" />
-                </div>
-            </div>
-        </ng-template>
+        }
     </div>
-    <ng-template #loadingRowTemplate>
-        <div class="adf-datatable-row adf-datatable-data-loading">
-            <div class="adf-no-content-container adf-datatable-cell">
-                <ng-template *ngIf="loadingTemplate"
-                             ngFor [ngForOf]="[data]"
-                             [ngForTemplate]="loadingTemplate" />
-            </div>
-        </div>
-    </ng-template>
-</div>
+}

--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.spec.ts
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.spec.ts
@@ -1674,40 +1674,40 @@ describe('Accessibility', () => {
             fixture.detectChanges();
         };
 
-        it('should render image column cell with presentation role', () => {
+        it('should render image column cell with aria-hidden', () => {
             setupTable([new ObjectDataColumn({ key: 'photo', type: 'image' })]);
 
             const cell = testingUtils.getByCSS('.adf-datatable-body .adf-datatable-cell--image');
-            expect(cell.attributes['role']).toBe('presentation');
+            expect(cell.attributes['aria-hidden']).toBe('true');
         });
 
-        it('should render icon column cell with presentation role', () => {
+        it('should render icon column cell with aria-hidden', () => {
             setupTable([new ObjectDataColumn({ key: 'status', type: 'icon' })]);
 
             const cell = testingUtils.getByCSS('.adf-datatable-body .adf-datatable-cell--icon');
-            expect(cell.attributes['role']).toBe('presentation');
+            expect(cell.attributes['aria-hidden']).toBe('true');
         });
 
-        it('should render text column cell with gridcell role', () => {
+        it('should render text column cell without aria-hidden', () => {
             setupTable([new ObjectDataColumn({ key: 'name', type: 'text' })]);
 
             const cell = testingUtils.getByCSS('.adf-datatable-body .adf-datatable-cell--text');
-            expect(cell.attributes['role']).toBe('gridcell');
+            expect(cell.attributes['aria-hidden']).toBeUndefined();
         });
 
-        it('should render date column cell with gridcell role', () => {
+        it('should render date column cell without aria-hidden', () => {
             setupTable([new ObjectDataColumn({ key: 'created', type: 'date' })]);
 
             const cell = testingUtils.getByCSS('.adf-datatable-body .adf-datatable-cell--date');
-            expect(cell.attributes['role']).toBe('gridcell');
+            expect(cell.attributes['aria-hidden']).toBeUndefined();
         });
 
-        it('should assign correct roles when mixing representation and non-representation columns', () => {
+        it('should correctly set aria-hidden when mixing representation and non-representation columns', () => {
             setupTable([new ObjectDataColumn({ key: 'photo', type: 'image' }), new ObjectDataColumn({ key: 'name', type: 'text' })]);
 
             const cells = testingUtils.getAllByCSS('.adf-datatable-body .adf-datatable-cell-data');
-            expect(cells[0].attributes['role']).toBe('presentation');
-            expect(cells[1].attributes['role']).toBe('gridcell');
+            expect(cells[0].attributes['aria-hidden']).toBe('true');
+            expect(cells[1].attributes['aria-hidden']).toBeUndefined();
         });
     });
 

--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.spec.ts
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.spec.ts
@@ -36,7 +36,6 @@ import { HarnessLoader } from '@angular/cdk/testing';
 import { ConfigurableFocusTrapFactory } from '@angular/cdk/a11y';
 import { provideRouter } from '@angular/router';
 import { firstValueFrom } from 'rxjs';
-import { DataTableAdapter } from '@alfresco/adf-core';
 import { MatTooltipHarness } from '@angular/material/tooltip/testing';
 
 @Component({
@@ -1668,6 +1667,135 @@ describe('Accessibility', () => {
         expect(datatableBodyCellAttributes['role']).toEqual('gridcell');
     });
 
+    describe('isRepresentationContent', () => {
+        const setupTable = (columns: ObjectDataColumn[]) => {
+            dataTable.data = new ObjectDataTableAdapter([{ photo: '', status: '', name: 'test', created: '' }], columns);
+            dataTable.ngOnChanges({});
+            fixture.detectChanges();
+        };
+
+        it('should render image column cell with presentation role', () => {
+            setupTable([new ObjectDataColumn({ key: 'photo', type: 'image' })]);
+
+            const cell = testingUtils.getByCSS('.adf-datatable-body .adf-datatable-cell--image');
+            expect(cell.attributes['role']).toBe('presentation');
+        });
+
+        it('should render icon column cell with presentation role', () => {
+            setupTable([new ObjectDataColumn({ key: 'status', type: 'icon' })]);
+
+            const cell = testingUtils.getByCSS('.adf-datatable-body .adf-datatable-cell--icon');
+            expect(cell.attributes['role']).toBe('presentation');
+        });
+
+        it('should render text column cell with gridcell role', () => {
+            setupTable([new ObjectDataColumn({ key: 'name', type: 'text' })]);
+
+            const cell = testingUtils.getByCSS('.adf-datatable-body .adf-datatable-cell--text');
+            expect(cell.attributes['role']).toBe('gridcell');
+        });
+
+        it('should render date column cell with gridcell role', () => {
+            setupTable([new ObjectDataColumn({ key: 'created', type: 'date' })]);
+
+            const cell = testingUtils.getByCSS('.adf-datatable-body .adf-datatable-cell--date');
+            expect(cell.attributes['role']).toBe('gridcell');
+        });
+
+        it('should assign correct roles when mixing representation and non-representation columns', () => {
+            setupTable([new ObjectDataColumn({ key: 'photo', type: 'image' }), new ObjectDataColumn({ key: 'name', type: 'text' })]);
+
+            const cells = testingUtils.getAllByCSS('.adf-datatable-body .adf-datatable-cell-data');
+            expect(cells[0].attributes['role']).toBe('presentation');
+            expect(cells[1].attributes['role']).toBe('gridcell');
+        });
+    });
+
+    describe('row aria-description', () => {
+        const rowSelector = '.adf-datatable-body .adf-datatable-row';
+
+        it('should have aria-description on row when multiselect is enabled', () => {
+            const dataRows = [{ name: 'test1' }, { name: 'test2' }];
+            dataTable.multiselect = true;
+            dataTable.data = new ObjectDataTableAdapter([], [new ObjectDataColumn({ key: 'name' })]);
+
+            dataTable.ngOnChanges({
+                rows: new SimpleChange(null, dataRows, false)
+            });
+
+            fixture.detectChanges();
+            const rows = testingUtils.getAllByCSS(rowSelector);
+            expect(rows.length).toBeGreaterThan(0);
+            expect(rows[0].attributes['aria-description']).toBeTruthy();
+        });
+
+        it('should have aria-description on row when enableDragRows is true', () => {
+            const dataRows = [{ name: 'test1' }, { name: 'test2' }];
+            dataTable.enableDragRows = true;
+            dataTable.data = new ObjectDataTableAdapter([], [new ObjectDataColumn({ key: 'name' })]);
+
+            dataTable.ngOnChanges({
+                rows: new SimpleChange(null, dataRows, false)
+            });
+
+            fixture.detectChanges();
+            const rows = testingUtils.getAllByCSS(rowSelector);
+            expect(rows.length).toBeGreaterThan(0);
+            expect(rows[0].attributes['aria-description']).toBeTruthy();
+        });
+
+        it('should not have aria-description on row when neither multiselect nor enableDragRows is enabled', () => {
+            const dataRows = [{ name: 'test1' }, { name: 'test2' }];
+            dataTable.multiselect = false;
+            dataTable.enableDragRows = false;
+            dataTable.data = new ObjectDataTableAdapter([], [new ObjectDataColumn({ key: 'name' })]);
+
+            dataTable.ngOnChanges({
+                rows: new SimpleChange(null, dataRows, false)
+            });
+
+            fixture.detectChanges();
+            const rows = testingUtils.getAllByCSS(rowSelector);
+            expect(rows.length).toBeGreaterThan(0);
+            expect(rows[0].attributes['aria-description']).toBeFalsy();
+        });
+    });
+
+    describe('drag button and multiselect checkbox accessibility', () => {
+        it('should have aria-hidden on drag button', () => {
+            const dataRows = [{ name: 'test1' }];
+            dataTable.enableDragRows = true;
+            dataTable.data = new ObjectDataTableAdapter([], [new ObjectDataColumn({ key: 'name' })]);
+            dataTable.showHeader = ShowHeaderMode.Never;
+
+            dataTable.ngOnChanges({
+                rows: new SimpleChange(null, dataRows, false)
+            });
+
+            fixture.detectChanges();
+            const dragButton = testingUtils.getByCSS('.adf-datatable__actions-cell [aria-hidden="true"]');
+            expect(dragButton).toBeTruthy();
+            expect(dragButton.attributes['aria-hidden']).toBe('true');
+        });
+
+        it('should have aria-hidden and negative tabindex on multiselect checkbox', () => {
+            const dataRows = [{ name: 'test1' }];
+            dataTable.multiselect = true;
+            dataTable.data = new ObjectDataTableAdapter([], [new ObjectDataColumn({ key: 'name' })]);
+            dataTable.showHeader = ShowHeaderMode.Never;
+
+            dataTable.ngOnChanges({
+                rows: new SimpleChange(null, dataRows, false)
+            });
+
+            fixture.detectChanges();
+            const checkboxContainer = testingUtils.getByCSS('.adf-checkbox-sr-only');
+            expect(checkboxContainer).toBeTruthy();
+            expect(checkboxContainer.attributes['aria-hidden']).toBe('true');
+            expect(checkboxContainer.nativeElement.tabIndex).toBe(-1);
+        });
+    });
+
     describe('aria-sort', () => {
         let column: DataColumn;
 
@@ -1700,6 +1828,32 @@ describe('Accessibility', () => {
     describe('Focus row', () => {
         let event: KeyboardEvent;
         let dataRows: { name: string }[];
+        const rowSelector = '.adf-datatable-body .adf-datatable-row';
+
+        const setRows = (): void => {
+            dataTable.ngOnChanges({
+                rows: new SimpleChange(null, dataRows, false)
+            });
+            fixture.detectChanges();
+        };
+
+        const getBodyRows = (): DebugElement[] => testingUtils.getAllByCSS(rowSelector);
+
+        const expectRowsTabindex = (expected: string | null): void => {
+            const rowElements = getBodyRows();
+            expect(rowElements.length).toBeGreaterThan(0);
+            expect(rowElements.every((row) => row.nativeElement.getAttribute('tabindex') === expected)).toBeTrue();
+        };
+
+        const activateRow = (rowIndex: number): void => {
+            const rowElement = getBodyRows()[rowIndex];
+            testingUtils.setDebugElement(rowElement);
+            testingUtils.clickByCSS('.adf-datatable-cell-data');
+        };
+
+        const dispatchKeyUp = (keyboardEvent: KeyboardEvent): void => {
+            fixture.debugElement.nativeElement.dispatchEvent(keyboardEvent);
+        };
 
         beforeEach(() => {
             event = new KeyboardEvent('keyup', {
@@ -1711,6 +1865,26 @@ describe('Accessibility', () => {
             dataTable.data = new ObjectDataTableAdapter([], [new ObjectDataColumn({ key: 'name' })]);
         });
 
+        it('should set tabindex to null (disabled === true) on datatable-body rows when neither multiselect nor enableDragRows is enabled', () => {
+            setRows();
+
+            expectRowsTabindex(null);
+        });
+
+        it('should set tabindex to 0 (disabled === false) on datatable-body rows when multiselect is enabled', () => {
+            dataTable.multiselect = true;
+            setRows();
+
+            expectRowsTabindex('0');
+        });
+
+        it('should set tabindex to 0 (disabled === false) on datatable-body rows when enableDragRows is enabled', () => {
+            dataTable.enableDragRows = true;
+            setRows();
+
+            expectRowsTabindex('0');
+        });
+
         it('should focus next row on ArrowDown event', () => {
             event = new KeyboardEvent('keyup', {
                 code: 'ArrowDown',
@@ -1718,35 +1892,23 @@ describe('Accessibility', () => {
                 keyCode: 40
             } as KeyboardEventInit);
 
-            dataTable.ngOnChanges({
-                rows: new SimpleChange(null, dataRows, false)
-            });
-
-            fixture.detectChanges();
+            dataTable.multiselect = true;
+            setRows();
             dataTable.ngAfterViewInit();
 
-            const rowElement = testingUtils.getAllByCSS('.adf-datatable-body .adf-datatable-row')[0];
-            testingUtils.setDebugElement(rowElement);
-            testingUtils.clickByCSS('.adf-datatable-cell');
-
-            fixture.debugElement.nativeElement.dispatchEvent(event);
+            activateRow(0);
+            dispatchKeyUp(event);
 
             expect(document.activeElement?.getAttribute('data-automation-id')).toBe('datatable-row-1');
         });
 
         it('should focus previous row on ArrowUp event', () => {
-            dataTable.ngOnChanges({
-                rows: new SimpleChange(null, dataRows, false)
-            });
-
-            fixture.detectChanges();
+            dataTable.multiselect = true;
+            setRows();
             dataTable.ngAfterViewInit();
 
-            const rowElement = testingUtils.getAllByCSS('.adf-datatable-body .adf-datatable-row')[1];
-            testingUtils.setDebugElement(rowElement);
-            testingUtils.clickByCSS('.adf-datatable-cell');
-
-            fixture.debugElement.nativeElement.dispatchEvent(event);
+            activateRow(1);
+            dispatchKeyUp(event);
 
             expect(document.activeElement?.getAttribute('data-automation-id')).toBe('datatable-row-0');
         });
@@ -1815,47 +1977,6 @@ describe('Accessibility', () => {
 
         setupAndCheckHeaderColumns(true, headerCellContentSelector, (element) => {
             expect(element?.nativeElement.getAttribute('aria-description')).toBeNull();
-        });
-    });
-
-    describe('ShareDatatable adapter allowFocusOnRows', () => {
-        class ShareAdapterMock extends ObjectDataTableAdapter {
-            public allowFocusOnRows = true;
-
-            constructor(data: any[], schema: DataColumn[]) {
-                super(data, schema);
-            }
-
-            setAllowFocusOnTableRows(allow: boolean) {
-                this.allowFocusOnRows = allow;
-            }
-        }
-        const testAllowFocusOnRows = (expectedTabindex: string | null, adapter: DataTableAdapter) => {
-            const fakeDataRows = [new FakeDataRow(), new FakeDataRow()];
-
-            adapter.setRows(fakeDataRows);
-            dataTable.data = adapter;
-            fixture.detectChanges();
-            const rowElements = testingUtils.getAllByCSS('.adf-datatable-body adf-datatable-row');
-            expect(rowElements.length).toBeGreaterThan(0);
-            expect(rowElements.every((row) => row.nativeElement.getAttribute('tabindex') === expectedTabindex)).toBeTrue();
-        };
-
-        it('should set tabindex to null (disabled === true) on datatable-body rows when allowFocusOnRows is set to false in ShareDatatable adapter', () => {
-            const adapter = new ShareAdapterMock([], []);
-            adapter.setAllowFocusOnTableRows(false);
-            testAllowFocusOnRows(null, adapter);
-        });
-
-        it('should set tabindex to 0 (disabled === false) on datatable-body rows when allowFocusOnRows is not set explicitly in ShareDatatable adapter and falls back to default value ', () => {
-            const adapter = new ShareAdapterMock([], []);
-            adapter.setAllowFocusOnTableRows(true);
-            testAllowFocusOnRows('0', adapter);
-        });
-
-        it('should set tabindex to 0 (disabled === false) by default on datatable-body rows when allowFocusOnRows is not defined in Datatable adapter (fallback case)', () => {
-            const adapter = new ObjectDataTableAdapter([], []);
-            testAllowFocusOnRows('0', adapter);
         });
     });
 

--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.ts
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.ts
@@ -853,6 +853,10 @@ export class DataTableComponent implements OnInit, AfterContentInit, OnChanges, 
         return false;
     }
 
+    isRepresentationContent(col: DataColumn): boolean {
+        return col.type === 'image' || col.type === 'icon';
+    }
+
     asIconValue(row: DataRow, col: DataColumn): string {
         if (this.isIconValue(row, col)) {
             const value = this.data.getValue(row, col) || '';

--- a/lib/core/src/lib/datatable/data/datatable-adapter.ts
+++ b/lib/core/src/lib/datatable/data/datatable-adapter.ts
@@ -22,7 +22,6 @@ import { Subject } from 'rxjs';
 
 export interface DataTableAdapter {
     rowsChanged?: Subject<Array<DataRow>>;
-    allowFocusOnRows?: boolean;
 
     selectedRow: DataRow;
     getRows(): Array<DataRow>;
@@ -34,5 +33,4 @@ export interface DataTableAdapter {
     getSorting(): DataSorting;
     setSorting(sorting: DataSorting): void;
     sort(key?: string, direction?: string): void;
-    setAllowFocusOnTableRows?(allow: boolean): void;
 }

--- a/lib/core/src/lib/i18n/en.json
+++ b/lib/core/src/lib/i18n/en.json
@@ -398,6 +398,8 @@
       "ACTIONS": "Actions",
       "SELECT_ALL": "Select all",
       "SELECT_FILE": "Select file",
+      "SELECTED": "Selected",
+      "ROW_SELECTION": "Press Space to toggle row selection",
       "SORT_ASCENDING": "Ascending",
       "SORT_DESCENDING": "Descending",
       "SORT_NONE": "None",
@@ -408,6 +410,7 @@
       "ICON_DISABLED": "Disabled",
       "ROW_OPTION_BUTTON": "Actions",
       "DRAG": "Drag button",
+      "DRAGGABLE": "Draggable",
       "EMPTY_HEADER": "Empty header",
       "RESIZE_COLUMN": "Resize {{ column }} column. Use arrow keys to adjust width, Shift for larger steps.",
       "COLUMN_WIDTH_CHANGED": "{{ column }} column width: {{ width }} pixels"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/ACS-10280


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No

!!!this PR removes decorative icon/image cells from 
**adf-datatable**'s accessibility tree. That change breaks 

> '[XAT-16631] Should be able to correctly display data table with nested object and special characters in JSON keys for Path to JSON property'

on the hxp project where empty cell is expected and reserved for icon/Image cell. 

suggested fix:
<img width="1211" height="443" alt="image" src="https://github.com/user-attachments/assets/6d3b4b9a-c35a-4bd0-819c-df53ad826e43" />



[XAT-16631]: https://hyland.atlassian.net/browse/XAT-16631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ