### PR TITLE
Revert "[ACS-10219] add class selector"

### DIFF
--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.html
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.html
@@ -289,7 +289,7 @@
                 <div
                     *ngFor="let col of getVisibleColumns(); let lastColumn = last;"
                     role="gridcell"
-                    class="adf-datatable-cell adf-datatable-cell--{{col.type || 'text'}} {{col.cssClass}} adf-datatable-cell-data adf-datatable-cell--{{getAutomationValue(row)}}"
+                    class="adf-datatable-cell adf-datatable-cell--{{col.type || 'text'}} {{col.cssClass}} adf-datatable-cell-data"
                     [attr.title]="col.title | translate"
                     [attr.data-automation-id]="getAutomationValue(row)"
                     [attr.aria-selected]="row.isSelected"


### PR DESCRIPTION
Reverts Alfresco/alfresco-ng2-components#11387

Reverting as getAutomationValue(row) returns user-controlled value, which could produce invalid CSS classes

https://github.com/Alfresco/alfresco-content-app/pull/5101