### PR TITLE
[MNT-25447] Fix: Viewing preview renditions for versions fails

### DIFF
--- a/lib/content-services/src/lib/common/services/rendition.service.ts
+++ b/lib/content-services/src/lib/common/services/rendition.service.ts
@@ -184,7 +184,7 @@ export class RenditionService {
 
                                 if (status === 'CREATED') {
                                     clearInterval(intervalId);
-                                    return resolve(this.handleNodeRendition(nodeId, rendition.entry.content.mimeType, versionId));
+                                    return resolve(this.handleNodeRendition(nodeId, renditionId, versionId));
                                 }
                             },
                             () => reject(new Error('Error geting version rendition'))

--- a/lib/content-services/src/lib/common/services/rendition.services.spec.ts
+++ b/lib/content-services/src/lib/common/services/rendition.services.spec.ts
@@ -17,7 +17,7 @@
 
 import { TestBed } from '@angular/core/testing';
 import { TranslationService, ViewUtilService } from '@alfresco/adf-core';
-import { Rendition, RenditionEntry, RenditionPaging, RenditionsApi } from '@alfresco/js-api';
+import { ContentApi, Rendition, RenditionEntry, RenditionPaging, RenditionsApi, VersionsApi } from '@alfresco/js-api';
 import { AlfrescoApiService } from '../../services/alfresco-api.service';
 import { RenditionService } from './rendition.service';
 
@@ -37,7 +37,9 @@ const getRenditionPaging = (status: Rendition.StatusEnum): RenditionPaging => ({
 
 describe('RenditionService', () => {
     let renditionService: RenditionService;
-    let renditionsApi: any;
+    let renditionsApi: jasmine.SpyObj<RenditionsApi>;
+    let versionsApiSpy: jasmine.SpyObj<VersionsApi>;
+    let contentApiSpy: jasmine.SpyObj<ContentApi>;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -53,12 +55,30 @@ describe('RenditionService', () => {
                         getRendition: jasmine.createSpy('getRendition'),
                         createRendition: jasmine.createSpy('createRendition')
                     }
+                },
+                {
+                    provide: VersionsApi,
+                    useValue: {
+                        listVersionRenditions: jasmine.createSpy('listVersionRenditions'),
+                        createVersionRendition: jasmine.createSpy('createVersionRendition').and.returnValue(Promise.resolve()),
+                        getVersionRendition: jasmine.createSpy('getVersionRendition')
+                    }
+                },
+                {
+                    provide: ContentApi,
+                    useValue: {
+                        getVersionRenditionUrl: jasmine.createSpy('getVersionRenditionUrl').and.returnValue('version-rendition-url')
+                    }
                 }
             ]
         });
         renditionService = TestBed.inject(RenditionService);
-        renditionsApi = TestBed.inject(RenditionsApi);
+        renditionsApi = TestBed.inject(RenditionsApi) as jasmine.SpyObj<RenditionsApi>;
+        versionsApiSpy = TestBed.inject(VersionsApi) as jasmine.SpyObj<VersionsApi>;
+        contentApiSpy = TestBed.inject(ContentApi) as jasmine.SpyObj<ContentApi>;
         spyOnProperty(renditionService, 'renditionsApi').and.returnValue(renditionsApi);
+        spyOnProperty(renditionService, 'versionsApi').and.returnValue(versionsApiSpy);
+        spyOnProperty(renditionService, 'contentApi').and.returnValue(contentApiSpy);
     });
 
     describe('getRendition', () => {
@@ -101,4 +121,20 @@ describe('RenditionService', () => {
         expect(result).toEqual(mockRenditionPaging.list.entries[0]);
         expect(renditionsApi.getRendition).not.toHaveBeenCalled();
     });
+
+    it('should pass renditionId (not mimeType) to getVersionRenditionUrl when version rendition transitions to CREATED', async () => {
+        const nodeId = 'nodeId';
+        const versionId = 'versionId';
+        const renditionId = 'pdf';
+        const mimeType = 'application/pdf';
+
+        versionsApiSpy.listVersionRenditions.and.returnValue(Promise.resolve(getRenditionPaging(Rendition.StatusEnum.NOTCREATED)));
+        versionsApiSpy.getVersionRendition.and.returnValue(Promise.resolve(getRenditionEntry(Rendition.StatusEnum.CREATED)));
+
+        const result = await renditionService.getNodeRendition(nodeId, versionId);
+
+        expect(contentApiSpy.getVersionRenditionUrl).toHaveBeenCalledWith(nodeId, versionId, renditionId);
+        expect(contentApiSpy.getVersionRenditionUrl).not.toHaveBeenCalledWith(nodeId, versionId, mimeType);
+        expect(result.url).toBe('version-rendition-url');
+    }, 10100);
 });

--- a/lib/content-services/src/lib/common/services/rendition.services.spec.ts
+++ b/lib/content-services/src/lib/common/services/rendition.services.spec.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { TestBed } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { TranslationService, ViewUtilService } from '@alfresco/adf-core';
 import { ContentApi, Rendition, RenditionEntry, RenditionPaging, RenditionsApi, VersionsApi } from '@alfresco/js-api';
 import { AlfrescoApiService } from '../../services/alfresco-api.service';
@@ -82,16 +82,18 @@ describe('RenditionService', () => {
     });
 
     describe('getRendition', () => {
-        it('should retry getting the rendition until maxRetries if status is NOT_CREATED', async () => {
+        it('should retry getting the rendition until maxRetries if status is NOT_CREATED', fakeAsync(() => {
             const mockRenditionPaging: RenditionPaging = getRenditionPaging(Rendition.StatusEnum.NOTCREATED);
             const mockRenditionEntry: RenditionEntry = getRenditionEntry(Rendition.StatusEnum.NOTCREATED);
 
             renditionsApi.listRenditions.and.returnValue(Promise.resolve(mockRenditionPaging));
             renditionsApi.getRendition.and.returnValue(Promise.resolve(mockRenditionEntry));
 
-            await renditionService.getRendition('nodeId', 'pdf');
+            renditionService.getRendition('nodeId', 'pdf');
+            tick(5000);
+
             expect(renditionsApi.getRendition).toHaveBeenCalledTimes(renditionService.maxRetries);
-        }, 10000);
+        }));
     });
 
     it('should return the rendition when status transitions from PENDING to CREATED', async () => {
@@ -122,7 +124,7 @@ describe('RenditionService', () => {
         expect(renditionsApi.getRendition).not.toHaveBeenCalled();
     });
 
-    it('should pass renditionId (not mimeType) to getVersionRenditionUrl when version rendition transitions to CREATED', async () => {
+    it('should pass renditionId (not mimeType) to getVersionRenditionUrl when version rendition transitions to CREATED', fakeAsync(() => {
         const nodeId = 'nodeId';
         const versionId = 'versionId';
         const renditionId = 'pdf';
@@ -131,10 +133,13 @@ describe('RenditionService', () => {
         versionsApiSpy.listVersionRenditions.and.returnValue(Promise.resolve(getRenditionPaging(Rendition.StatusEnum.NOTCREATED)));
         versionsApiSpy.getVersionRendition.and.returnValue(Promise.resolve(getRenditionEntry(Rendition.StatusEnum.CREATED)));
 
-        const result = await renditionService.getNodeRendition(nodeId, versionId);
+        let result: { url: string; mimeType: string };
+        renditionService.getNodeRendition(nodeId, versionId).then((r) => (result = r));
+
+        tick(10000);
 
         expect(contentApiSpy.getVersionRenditionUrl).toHaveBeenCalledWith(nodeId, versionId, renditionId);
         expect(contentApiSpy.getVersionRenditionUrl).not.toHaveBeenCalledWith(nodeId, versionId, mimeType);
         expect(result.url).toBe('version-rendition-url');
-    }, 10100);
+    }));
 });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://hyland.atlassian.net/browse/MNT-25447

Once a rendition reached CREATED status, mimeType was incorrectly passed as the renditionId argument to `handleNodeRendition`. This caused `getVersionRenditionUrl` to be called with an invalid identifier, producing a broken preview URL.

**What is the new behaviour?**

Pass renditionId instead of mimeType to `handleNodeRendition` to match the expected behaviour.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
