### PR TITLE
AAE-43391 Disable 'Start process' and 'Complete' when whitespace is entered into required form fields

### DIFF
--- a/lib/core/src/lib/form/components/widgets/core/form-field-validator.spec.ts
+++ b/lib/core/src/lib/form/components/widgets/core/form-field-validator.spec.ts
@@ -120,6 +120,26 @@ describe('FormFieldValidator', () => {
             expect(validator.validate(field)).toBe(false);
         });
 
+        it('should fail (display error) for text with only whitespace', () => {
+            const field = new FormFieldModel(new FormModel(), {
+                type: FormFieldTypes.TEXT,
+                value: '   ',
+                required: true
+            });
+
+            expect(validator.validate(field)).toBe(false);
+        });
+
+        it('should fail (display error) for multiline text with only whitespace', () => {
+            const field = new FormFieldModel(new FormModel(), {
+                type: FormFieldTypes.MULTILINE_TEXT,
+                value: '  \t\n  ',
+                required: true
+            });
+
+            expect(validator.validate(field)).toBe(false);
+        });
+
         it('should succeed for date', () => {
             const field = new FormFieldModel(new FormModel(), {
                 type: FormFieldTypes.DATE,

--- a/lib/core/src/lib/form/components/widgets/core/form-field-validator.ts
+++ b/lib/core/src/lib/form/components/widgets/core/form-field-validator.ts
@@ -72,6 +72,10 @@ export class RequiredFieldValidator implements FormFieldValidator {
             if (field.value === null || field.value === undefined || field.value === '') {
                 return false;
             }
+
+            if (typeof field.value === 'string' && field.value.trim().length === 0) {
+                return false;
+            }
         }
         return true;
     }

--- a/lib/core/src/lib/form/components/widgets/widget.component.spec.ts
+++ b/lib/core/src/lib/form/components/widgets/widget.component.spec.ts
@@ -116,4 +116,40 @@ describe('WidgetComponent', () => {
         widget.field = new FormFieldModel(null, { required: true });
         expect(widget.isRequired()).toBeTruthy();
     });
+
+    describe('isInvalidFieldRequired', () => {
+        it('should return true when required field has no value', () => {
+            widget.field = new FormFieldModel(new FormModel(), {
+                type: 'text',
+                required: true,
+                value: null
+            });
+            widget.field.markAsInvalid();
+            widget.field.validationSummary = null;
+
+            expect(widget.isInvalidFieldRequired()).toBe(true);
+        });
+
+        it('should return true when required field has whitespace-only value', () => {
+            widget.field = new FormFieldModel(new FormModel(), {
+                type: 'text',
+                required: true,
+                value: '   '
+            });
+            widget.field.markAsInvalid();
+
+            expect(widget.isInvalidFieldRequired()).toBe(true);
+        });
+
+        it('should return false when required field has a non-whitespace value', () => {
+            widget.field = new FormFieldModel(new FormModel(), {
+                type: 'text',
+                required: true,
+                value: 'hello'
+            });
+            widget.field.markAsValid();
+
+            expect(widget.isInvalidFieldRequired()).toBe(false);
+        });
+    });
 });

--- a/lib/core/src/lib/form/components/widgets/widget.component.ts
+++ b/lib/core/src/lib/form/components/widgets/widget.component.ts
@@ -88,7 +88,8 @@ export class WidgetComponent implements AfterViewInit {
     }
 
     isInvalidFieldRequired() {
-        return !this.field.isValid && (!this.field.validationSummary || !this.field.value) && this.isRequired();
+        const isValueEmpty = !this.field.value || (typeof this.field.value === 'string' && this.field.value.trim().length === 0);
+        return !this.field.isValid && (!this.field.validationSummary || isValueEmpty) && this.isRequired();
     }
 
     ngAfterViewInit() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://hyland.atlassian.net/browse/AAE-42607
https://hyland.atlassian.net/browse/AAE-43391

**What is the new behaviour?**

Required form fields fail validation with only whitespace

**Does this PR introduce a breaking change?** (check one with "x")

> - [x] Yes
> - [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

See conversation on the MNT ticket: https://hyland.atlassian.net/browse/HXPMNT-1298