### PR TITLE
AAE-34137 Fix for disabling `complete` button on the form after declining form confirmation dialog

### DIFF
--- a/lib/process-services-cloud/src/lib/form/components/form-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/form-cloud.component.spec.ts
@@ -1026,7 +1026,7 @@ describe('FormCloudComponent', () => {
         expect(formComponent.form.selectedOutcomeId).toBe(outcomeId);
     });
 
-    it('should not confirm form if user rejects', () => {
+    it('should not confirm form and reenable save and complete buttons if user rejects', () => {
         const outcome = 'complete';
         spyOn(matDialog, 'open').and.returnValue({ afterClosed: () => of(false) } as any);
 
@@ -1040,10 +1040,15 @@ describe('FormCloudComponent', () => {
         formComponent.form = formModel;
         spyOn(formComponent['formCloudService'], 'completeTaskForm');
 
+        formComponent.disableSaveButton = true;
+        formComponent.disableCompleteButton = true;
+
         formComponent.completeTaskForm(outcome);
 
         expect(matDialog.open).toHaveBeenCalled();
         expect(formComponent['formCloudService'].completeTaskForm).not.toHaveBeenCalled();
+        expect(formComponent.disableSaveButton).toBe(false);
+        expect(formComponent.disableCompleteButton).toBe(false);
     });
 
     it('should require json to parse form', () => {

--- a/lib/process-services-cloud/src/lib/form/components/form-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/form/components/form-cloud.component.ts
@@ -419,14 +419,17 @@ export class FormCloudComponent extends FormBaseComponent implements OnChanges, 
                 minWidth: '450px'
             });
 
-            dialogRef.afterClosed().subscribe((result) => {
-                if (result === true) {
-                    this.completeForm(outcome, outcomeId);
-                } else {
-                    this.disableSaveButton = false;
-                    this.disableCompleteButton = false;
-                }
-            });
+            dialogRef
+                .afterClosed()
+                .pipe(takeUntilDestroyed(this.destroyRef))
+                .subscribe((result) => {
+                    if (result === true) {
+                        this.completeForm(outcome, outcomeId);
+                    } else {
+                        this.disableSaveButton = false;
+                        this.disableCompleteButton = false;
+                    }
+                });
         } else {
             this.completeForm(outcome, outcomeId);
         }

--- a/lib/process-services-cloud/src/lib/form/components/form-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/form/components/form-cloud.component.ts
@@ -422,6 +422,9 @@ export class FormCloudComponent extends FormBaseComponent implements OnChanges, 
             dialogRef.afterClosed().subscribe((result) => {
                 if (result === true) {
                     this.completeForm(outcome, outcomeId);
+                } else {
+                    this.disableSaveButton = false;
+                    this.disableCompleteButton = false;
                 }
             });
         } else {


### PR DESCRIPTION


**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/AAE-34137


**What is the new behaviour?**
Save and Complete buttons reenabled if user clicks No on Confirmation Dialog


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
