### PR TITLE
AAE-28918 Fix for start process button is enabled when required widgets are read only without value

### DIFF
--- a/lib/core/src/lib/form/components/widgets/core/form-field-validator.ts
+++ b/lib/core/src/lib/form/components/widgets/core/form-field-validator.ts
@@ -69,11 +69,7 @@ export class RequiredFieldValidator implements FormFieldValidator {
                 return !!field.value;
             }
 
-            if (field.value === null || field.value === undefined || field.value === '') {
-                return false;
-            }
-
-            if (typeof field.value === 'string' && field.value.trim().length === 0) {
+            if (field.isValueEmpty()) {
                 return false;
             }
         }

--- a/lib/core/src/lib/form/components/widgets/core/form-field-validator.ts
+++ b/lib/core/src/lib/form/components/widgets/core/form-field-validator.ts
@@ -69,7 +69,11 @@ export class RequiredFieldValidator implements FormFieldValidator {
                 return !!field.value;
             }
 
-            if (field.isValueEmpty()) {
+            if (field.value === null || field.value === undefined || field.value === '') {
+                return false;
+            }
+
+            if (typeof field.value === 'string' && field.value.trim().length === 0) {
                 return false;
             }
         }

--- a/lib/core/src/lib/form/components/widgets/core/form-field.model.spec.ts
+++ b/lib/core/src/lib/form/components/widgets/core/form-field.model.spec.ts
@@ -1254,7 +1254,7 @@ describe('FormFieldModel', () => {
         expect(field.validate()).toBe(false);
     });
 
-    it('should NOT validate readOnly field if it is NOT validatable', () => {
+    it('should validate readOnly required field even if type is not in validatable list', () => {
         const form = new FormModel();
         const field = new FormFieldModel(form, {
             id: 'mockTextFieldId',
@@ -1268,7 +1268,59 @@ describe('FormFieldModel', () => {
         form.fieldValidators = [validator];
 
         expect(FormFieldTypes.isValidatableType(FormFieldTypes.TEXT)).toBeFalse();
+        expect(field.validate()).toBe(false);
+    });
+
+    it('should pass validation for readOnly required field that has a value', () => {
+        const form = new FormModel();
+        const field = new FormFieldModel(form, {
+            id: 'mockTextFieldId',
+            type: FormFieldTypes.TEXT,
+            readOnly: true,
+            required: true,
+            value: 'some value'
+        });
+
+        const validator = new RequiredFieldValidator();
+        form.fieldValidators = [validator];
+
         expect(field.validate()).toBe(true);
+    });
+
+    it('should skip validation for readOnly non-required field', () => {
+        const form = new FormModel();
+        const field = new FormFieldModel(form, {
+            id: 'mockTextFieldId',
+            type: FormFieldTypes.TEXT,
+            readOnly: true,
+            required: false,
+            value: null
+        });
+
+        const validator = new RequiredFieldValidator();
+        form.fieldValidators = [validator];
+
+        expect(field.validate()).toBe(true);
+    });
+
+    it('should pass validation for readOnly required field with empty value when field or parent is hidden', () => {
+        const form = new FormModel();
+        const field = new FormFieldModel(form, {
+            id: 'mockTextFieldId',
+            type: FormFieldTypes.TEXT,
+            readOnly: true,
+            required: true,
+            value: null
+        });
+
+        const validator = new RequiredFieldValidator();
+        form.fieldValidators = [validator];
+
+        spyOn(form, 'isFieldOrParentHidden').and.returnValue(true);
+
+        expect(FormFieldTypes.isValidatableType(FormFieldTypes.TEXT)).toBeFalse();
+        expect(field.validate()).toBe(true);
+        expect(form.isFieldOrParentHidden).toHaveBeenCalledWith(field);
     });
 
     it('should set the tooltip correctly', () => {

--- a/lib/core/src/lib/form/components/widgets/core/form-field.model.spec.ts
+++ b/lib/core/src/lib/form/components/widgets/core/form-field.model.spec.ts
@@ -1220,7 +1220,7 @@ describe('FormFieldModel', () => {
         });
     });
 
-    it('should validate readOnly field if it is validatable', () => {
+    it('should fail validation for readOnly required display-external-property field with null value', () => {
         const form = new FormModel();
         const field = new FormFieldModel(form, {
             id: 'mockDisplayExternalPropertyFieldId',
@@ -1233,11 +1233,10 @@ describe('FormFieldModel', () => {
         const validator = new RequiredFieldValidator();
         form.fieldValidators = [validator];
 
-        expect(FormFieldTypes.isValidatableType(FormFieldTypes.DISPLAY_EXTERNAL_PROPERTY)).toBeTrue();
         expect(field.validate()).toBe(false);
     });
 
-    it('should validate NOT readOnly field if it is validatable', () => {
+    it('should fail validation for required display-external-property field with null value', () => {
         const form = new FormModel();
         const field = new FormFieldModel(form, {
             id: 'mockDisplayExternalPropertyFieldId',
@@ -1250,11 +1249,10 @@ describe('FormFieldModel', () => {
         const validator = new RequiredFieldValidator();
         form.fieldValidators = [validator];
 
-        expect(FormFieldTypes.isValidatableType(FormFieldTypes.DISPLAY_EXTERNAL_PROPERTY)).toBeTrue();
         expect(field.validate()).toBe(false);
     });
 
-    it('should validate readOnly required field even if type is not in validatable list', () => {
+    it('should fail validation for readOnly required text field with null value', () => {
         const form = new FormModel();
         const field = new FormFieldModel(form, {
             id: 'mockTextFieldId',
@@ -1267,7 +1265,6 @@ describe('FormFieldModel', () => {
         const validator = new RequiredFieldValidator();
         form.fieldValidators = [validator];
 
-        expect(FormFieldTypes.isValidatableType(FormFieldTypes.TEXT)).toBeFalse();
         expect(field.validate()).toBe(false);
     });
 
@@ -1287,7 +1284,7 @@ describe('FormFieldModel', () => {
         expect(field.validate()).toBe(true);
     });
 
-    it('should skip validation for readOnly non-required field', () => {
+    it('should pass validation for readOnly non-required field with null value', () => {
         const form = new FormModel();
         const field = new FormFieldModel(form, {
             id: 'mockTextFieldId',
@@ -1318,7 +1315,6 @@ describe('FormFieldModel', () => {
 
         spyOn(form, 'isFieldOrParentHidden').and.returnValue(true);
 
-        expect(FormFieldTypes.isValidatableType(FormFieldTypes.TEXT)).toBeFalse();
         expect(field.validate()).toBe(true);
         expect(form.isFieldOrParentHidden).toHaveBeenCalledWith(field);
     });

--- a/lib/core/src/lib/form/components/widgets/core/form-field.model.ts
+++ b/lib/core/src/lib/form/components/widgets/core/form-field.model.ts
@@ -170,24 +170,16 @@ export class FormFieldModel extends FormWidgetModel {
     validate(): boolean {
         this.validationSummary = new ErrorMessageModel();
 
-        if (this.isFieldValidatable()) {
-            const validators = this.form.fieldValidators || [];
-            for (const validator of validators) {
-                if (!validator.validate(this)) {
-                    this._isValid = false;
-                    return this._isValid;
-                }
+        const validators = this.form?.fieldValidators || [];
+        for (const validator of validators) {
+            if (!validator.validate(this)) {
+                this._isValid = false;
+                return this._isValid;
             }
-        } else if (this.readOnly && this.required && !this.form?.isFieldOrParentHidden(this) && this.isValueEmpty()) {
-            this._isValid = false;
-            return this._isValid;
         }
+
         this._isValid = true;
         return this._isValid;
-    }
-
-    private isFieldValidatable(): boolean {
-        return !this.readOnly || FormFieldTypes.isValidatableType(this.type);
     }
 
     isValueEmpty(): boolean {

--- a/lib/core/src/lib/form/components/widgets/core/form-field.model.ts
+++ b/lib/core/src/lib/form/components/widgets/core/form-field.model.ts
@@ -178,7 +178,7 @@ export class FormFieldModel extends FormWidgetModel {
                     return this._isValid;
                 }
             }
-        } else if (this.readOnly && this._required && !this.form?.isFieldOrParentHidden(this) && this.isValueEmpty()) {
+        } else if (this.readOnly && this.required && !this.form?.isFieldOrParentHidden(this) && this.isValueEmpty()) {
             this._isValid = false;
             return this._isValid;
         }
@@ -190,7 +190,7 @@ export class FormFieldModel extends FormWidgetModel {
         return !this.readOnly || FormFieldTypes.isValidatableType(this.type);
     }
 
-    private isValueEmpty(): boolean {
+    isValueEmpty(): boolean {
         if (this.value === null || this.value === undefined || this.value === '') {
             return true;
         }

--- a/lib/core/src/lib/form/components/widgets/core/form-field.model.ts
+++ b/lib/core/src/lib/form/components/widgets/core/form-field.model.ts
@@ -182,22 +182,6 @@ export class FormFieldModel extends FormWidgetModel {
         return this._isValid;
     }
 
-    isValueEmpty(): boolean {
-        if (this.value === null || this.value === undefined || this.value === '') {
-            return true;
-        }
-        if (typeof this.value === 'string' && this.value.trim().length === 0) {
-            return true;
-        }
-        if (this.type === FormFieldTypes.BOOLEAN) {
-            return !this.value;
-        }
-        if (Array.isArray(this.value)) {
-            return this.value.length === 0;
-        }
-        return false;
-    }
-
     constructor(form: any, json?: any, parent?: RepeatableSectionModel) {
         super(form, json);
         if (json) {

--- a/lib/core/src/lib/form/components/widgets/core/form-field.model.ts
+++ b/lib/core/src/lib/form/components/widgets/core/form-field.model.ts
@@ -178,6 +178,9 @@ export class FormFieldModel extends FormWidgetModel {
                     return this._isValid;
                 }
             }
+        } else if (this.readOnly && this._required && !this.form?.isFieldOrParentHidden(this) && this.isValueEmpty()) {
+            this._isValid = false;
+            return this._isValid;
         }
         this._isValid = true;
         return this._isValid;
@@ -185,6 +188,22 @@ export class FormFieldModel extends FormWidgetModel {
 
     private isFieldValidatable(): boolean {
         return !this.readOnly || FormFieldTypes.isValidatableType(this.type);
+    }
+
+    private isValueEmpty(): boolean {
+        if (this.value === null || this.value === undefined || this.value === '') {
+            return true;
+        }
+        if (typeof this.value === 'string' && this.value.trim().length === 0) {
+            return true;
+        }
+        if (this.type === FormFieldTypes.BOOLEAN) {
+            return !this.value;
+        }
+        if (Array.isArray(this.value)) {
+            return this.value.length === 0;
+        }
+        return false;
     }
 
     constructor(form: any, json?: any, parent?: RepeatableSectionModel) {


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**

> - [ x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/AAE-28918
Start button is enable if all fields are read-only and required. Clicking Start button will return validation error from BE.

**What is the new behaviour?**
Start button is disable if all fields are read only and required


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
