### PR TITLE
[ACS-11472] Fix file icon is not updated for version renditions

### DIFF
--- a/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.spec.ts
+++ b/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.spec.ts
@@ -569,6 +569,46 @@ describe('AlfrescoViewerComponent', () => {
             expect(component.mimeType).toEqual('application/pdf');
             expect(component.nodeMimeType).toEqual('application/msWord');
         });
+
+        describe('versioned file with rendition', () => {
+            const docxMimeType = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+            const xlsxMimeType = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+
+            beforeEach(() => {
+                spyOn(component.versionsApi, 'getVersion').and.returnValue(
+                    Promise.resolve(
+                        new VersionEntry({ entry: new Node({ name: 'file.docx', content: new ContentInfo({ mimeType: docxMimeType }) }) })
+                    )
+                );
+                spyOn(renditionService, 'getNodeRendition').and.returnValue(Promise.resolve({ url: 'rendition-url', mimeType: 'application/pdf' }));
+
+                component.nodeId = 'node-id';
+                component.versionId = '2.0';
+                component.showViewer = true;
+            });
+
+            it('should set nodeMimeType from versionData.content.mimeType, not nodeData.content.mimeType', fakeAsync(() => {
+                spyOn(component.nodesApi, 'getNode').and.returnValue(
+                    Promise.resolve(new NodeEntry({ entry: new Node({ name: 'file.xlsx', content: new ContentInfo({ mimeType: xlsxMimeType }) }) }))
+                );
+
+                component.ngOnChanges(getSimpleChangesWithVersion('node-id', '1.0'));
+                tick();
+
+                expect(component.mimeType).toBe('application/pdf');
+                expect(component.nodeMimeType).toBe(docxMimeType);
+            }));
+
+            it('should preserve nodeMimeType from versionData when nodeData has no content', fakeAsync(() => {
+                spyOn(component.nodesApi, 'getNode').and.returnValue(Promise.resolve(new NodeEntry({ entry: new Node({ name: 'file.docx' }) })));
+
+                component.ngOnChanges(getSimpleChangesWithVersion('node-id', '1.0'));
+                tick();
+
+                expect(component.mimeType).toBe('application/pdf');
+                expect(component.nodeMimeType).toBe(docxMimeType);
+            }));
+        });
     });
 
     describe('Toolbar', () => {

--- a/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.spec.ts
+++ b/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.spec.ts
@@ -573,38 +573,51 @@ describe('AlfrescoViewerComponent', () => {
         describe('versioned file with rendition', () => {
             const docxMimeType = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
             const xlsxMimeType = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+            const nodeId = 'node-id';
+            const previousVersionId = '1.0';
+            const newVersionId = '2.0';
 
             beforeEach(() => {
                 spyOn(component.versionsApi, 'getVersion').and.returnValue(
                     Promise.resolve(
-                        new VersionEntry({ entry: new Node({ name: 'file.docx', content: new ContentInfo({ mimeType: docxMimeType }) }) })
+                        new VersionEntry({
+                            entry: new Node({ id: newVersionId, name: 'file.docx', content: new ContentInfo({ mimeType: docxMimeType }) })
+                        })
                     )
                 );
                 spyOn(renditionService, 'getNodeRendition').and.returnValue(Promise.resolve({ url: 'rendition-url', mimeType: 'application/pdf' }));
 
-                component.nodeId = 'node-id';
-                component.versionId = '2.0';
+                component.nodeId = nodeId;
+                component.versionId = previousVersionId;
                 component.showViewer = true;
             });
 
             it('should set nodeMimeType from versionData.content.mimeType, not nodeData.content.mimeType', fakeAsync(() => {
                 spyOn(component.nodesApi, 'getNode').and.returnValue(
-                    Promise.resolve(new NodeEntry({ entry: new Node({ name: 'file.xlsx', content: new ContentInfo({ mimeType: xlsxMimeType }) }) }))
+                    Promise.resolve(
+                        new NodeEntry({ entry: new Node({ id: nodeId, name: 'file.xlsx', content: new ContentInfo({ mimeType: xlsxMimeType }) }) })
+                    )
                 );
 
-                component.ngOnChanges(getSimpleChangesWithVersion('node-id', '1.0'));
+                component.versionId = newVersionId;
+                component.ngOnChanges(getSimpleChangesWithVersion(nodeId, newVersionId, nodeId, previousVersionId));
                 tick();
 
+                expect(renditionService.getNodeRendition).toHaveBeenCalledWith(nodeId, newVersionId);
                 expect(component.mimeType).toBe('application/pdf');
                 expect(component.nodeMimeType).toBe(docxMimeType);
             }));
 
             it('should preserve nodeMimeType from versionData when nodeData has no content', fakeAsync(() => {
-                spyOn(component.nodesApi, 'getNode').and.returnValue(Promise.resolve(new NodeEntry({ entry: new Node({ name: 'file.docx' }) })));
+                spyOn(component.nodesApi, 'getNode').and.returnValue(
+                    Promise.resolve(new NodeEntry({ entry: new Node({ id: nodeId, name: 'file.docx' }) }))
+                );
 
-                component.ngOnChanges(getSimpleChangesWithVersion('node-id', '1.0'));
+                component.versionId = newVersionId;
+                component.ngOnChanges(getSimpleChangesWithVersion(nodeId, newVersionId, nodeId, previousVersionId));
                 tick();
 
+                expect(renditionService.getNodeRendition).toHaveBeenCalledWith(nodeId, newVersionId);
                 expect(component.mimeType).toBe('application/pdf');
                 expect(component.nodeMimeType).toBe(docxMimeType);
             }));

--- a/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.ts
+++ b/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.ts
@@ -315,7 +315,6 @@ export class AlfrescoViewerComponent implements OnChanges, OnInit {
     private async setUpNodeFile(nodeData: Node, versionData?: Version): Promise<void> {
         this.canEditNode = this.contentService.hasAllowableOperations(nodeData, 'update');
         let mimeType: string;
-        let nodeMimeType: string;
         let urlFileContent: string;
 
         if (versionData?.content) {
@@ -323,7 +322,7 @@ export class AlfrescoViewerComponent implements OnChanges, OnInit {
         } else if (nodeData.content) {
             mimeType = nodeData.content.mimeType;
         }
-        nodeMimeType = mimeType;
+        const nodeMimeType = mimeType;
 
         const currentFileVersion = this.nodeEntry?.entry?.properties?.['cm:versionLabel']
             ? encodeURI(this.nodeEntry?.entry?.properties['cm:versionLabel'])

--- a/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.ts
+++ b/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.ts
@@ -345,7 +345,6 @@ export class AlfrescoViewerComponent implements OnChanges, OnInit {
             if (nodeRendition) {
                 urlFileContent = nodeRendition.url;
 
-                nodeMimeType = nodeData?.content?.mimeType;
                 const renditionMimeType = nodeRendition.mimeType;
                 mimeType = renditionMimeType || nodeMimeType;
             }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://hyland.atlassian.net/browse/ACS-11472

**What is the new behaviour?**

Removed the `nodeMimeType = nodeData?.content?.mimeType` overwrite from the rendition block. `nodeMimeType` is already correctly set before the block runs and should not be touched there.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
