### PR TITLE
[MNT-25185] Display authority name instead of id if provided

### DIFF
--- a/lib/content-services/src/lib/permission-manager/components/user-name-column/user-name-column.component.spec.ts
+++ b/lib/content-services/src/lib/permission-manager/components/user-name-column/user-name-column.component.spec.ts
@@ -18,11 +18,12 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { UserNameColumnComponent } from './user-name-column.component';
 import { NodeEntry } from '@alfresco/js-api';
+import { UnitTestingUtils } from '@alfresco/adf-core';
 
 describe('UserNameColumnComponent', () => {
     let fixture: ComponentFixture<UserNameColumnComponent>;
     let component: UserNameColumnComponent;
-    let element: HTMLElement;
+    let testingUtils: UnitTestingUtils;
     const person = {
         firstName: 'fake',
         lastName: 'user',
@@ -34,13 +35,15 @@ describe('UserNameColumnComponent', () => {
         displayName: 'fake authority'
     };
 
+    const getUserName = (): string => testingUtils.getInnerTextByCSS('.adf-user-name-column');
+
     beforeEach(() => {
         TestBed.configureTestingModule({
             imports: [UserNameColumnComponent]
         });
         fixture = TestBed.createComponent(UserNameColumnComponent);
         component = fixture.componentInstance;
-        element = fixture.nativeElement;
+        testingUtils = new UnitTestingUtils(fixture.debugElement);
         fixture.detectChanges();
     });
 
@@ -55,8 +58,8 @@ describe('UserNameColumnComponent', () => {
             };
             component.ngOnInit();
             fixture.detectChanges();
-            expect(element.querySelector('[title="fake user"]').textContent).toContain('fake user');
-            expect(element.querySelector('[title="fake@test.com"]').textContent).toContain('fake@test.com');
+            expect(getUserName()).toBe('fake user');
+            expect(testingUtils.getInnerTextByCSS('.adf-user-email-column')).toBe('fake@test.com');
         });
 
         it('should render person value from node', (done) => {
@@ -95,7 +98,7 @@ describe('UserNameColumnComponent', () => {
             };
             component.ngOnInit();
             fixture.detectChanges();
-            expect(element.querySelector('[title="fake authority"]').textContent.trim()).toBe('fake authority');
+            expect(getUserName()).toBe('fake authority');
         });
 
         it('should display group id when display name is not provided', () => {
@@ -110,20 +113,35 @@ describe('UserNameColumnComponent', () => {
             };
             component.ngOnInit();
             fixture.detectChanges();
-            expect(element.querySelector('[title="fake_group_id"]').textContent.trim()).toBe('fake_group_id');
+            expect(getUserName()).toBe('fake_group_id');
         });
 
-        it('should render group for authorityId', () => {
+        it('should render group for authorityId when authorityDisplayName is not provided', () => {
             component.context = {
                 row: {
                     obj: {
-                        authorityId: 'fake-id'
+                        authorityId: 'fake-id',
+                        authorityDisplayName: null
                     }
                 }
             };
             component.ngOnInit();
             fixture.detectChanges();
-            expect(element.querySelector('[title=fake-id]').textContent.trim()).toBe('fake-id');
+            expect(getUserName()).toBe('fake-id');
+        });
+
+        it('should render authority display name when provided', () => {
+            component.context = {
+                row: {
+                    obj: {
+                        authorityId: 'fake-id',
+                        authorityDisplayName: 'Fake authority'
+                    }
+                }
+            };
+            component.ngOnInit();
+            fixture.detectChanges();
+            expect(getUserName()).toBe('Fake authority');
         });
 
         it('should render person value from node', () => {
@@ -137,7 +155,7 @@ describe('UserNameColumnComponent', () => {
             } as NodeEntry;
             component.ngOnInit();
             fixture.detectChanges();
-            expect(element.querySelector('[title="Fake authority"]').textContent.trim()).toBe('Fake authority');
+            expect(getUserName()).toBe('Fake authority');
         });
     });
 });

--- a/lib/content-services/src/lib/permission-manager/components/user-name-column/user-name-column.component.spec.ts
+++ b/lib/content-services/src/lib/permission-manager/components/user-name-column/user-name-column.component.spec.ts
@@ -35,7 +35,7 @@ describe('UserNameColumnComponent', () => {
         displayName: 'fake authority'
     };
 
-    const getUserName = (): string => testingUtils.getInnerTextByCSS('.adf-user-name-column');
+    const getUserName = (): string => testingUtils.getInnerTextByCSS('span.adf-user-name-column');
 
     beforeEach(() => {
         TestBed.configureTestingModule({

--- a/lib/content-services/src/lib/permission-manager/components/user-name-column/user-name-column.component.ts
+++ b/lib/content-services/src/lib/permission-manager/components/user-name-column/user-name-column.component.ts
@@ -53,7 +53,7 @@ export class UserNameColumnComponent implements OnInit {
     ngOnInit() {
         if (this.context != null) {
             const { person, group, authorityId, authorityDisplayName } = this.context.row.obj?.entry ?? this.context.row.obj;
-            const permissionGroup = authorityId ? ({ displayName: authorityDisplayName || authorityId } as Group) : null;
+            const permissionGroup: Group | null = authorityId ? { displayName: authorityDisplayName, id: authorityId } : null;
             this.updatePerson(person);
             this.updateGroup(group || permissionGroup);
         }

--- a/lib/content-services/src/lib/permission-manager/components/user-name-column/user-name-column.component.ts
+++ b/lib/content-services/src/lib/permission-manager/components/user-name-column/user-name-column.component.ts
@@ -52,8 +52,8 @@ export class UserNameColumnComponent implements OnInit {
 
     ngOnInit() {
         if (this.context != null) {
-            const { person, group, authorityId } = this.context.row.obj?.entry ?? this.context.row.obj;
-            const permissionGroup = authorityId ? ({ displayName: authorityId } as Group) : null;
+            const { person, group, authorityId, authorityDisplayName } = this.context.row.obj?.entry ?? this.context.row.obj;
+            const permissionGroup = authorityId ? ({ displayName: authorityDisplayName || authorityId } as Group) : null;
             this.updatePerson(person);
             this.updateGroup(group || permissionGroup);
         }

--- a/lib/content-services/src/lib/permission-manager/models/permission.model.ts
+++ b/lib/content-services/src/lib/permission-manager/models/permission.model.ts
@@ -19,6 +19,7 @@ import { PermissionElement } from '@alfresco/js-api';
 
 export class PermissionDisplayModel implements PermissionElement {
     authorityId?: string;
+    authorityDisplayName?: string;
     name?: string;
     accessStatus?: 'ALLOWED' | 'DENIED' | string;
     isInherited: boolean = false;
@@ -28,6 +29,7 @@ export class PermissionDisplayModel implements PermissionElement {
     constructor(obj?: any) {
         if (obj) {
             this.authorityId = obj.authorityId;
+            this.authorityDisplayName = obj.authorityDisplayName;
             this.name = obj.name;
             this.accessStatus = obj.accessStatus;
             this.isInherited = obj.isInherited !== null && obj.isInherited !== undefined ? obj.isInherited : false;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://hyland.atlassian.net/browse/MNT-25185

**What is the new behaviour?**

Authority display name will be displayed instead of id when provided.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
