### PR TITLE
Remove unused jasmine-spec-reporter dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -96,7 +96,6 @@
         "husky": "^9.1.7",
         "jasmine-core": "5.13.0",
         "jasmine-reporters": "^2.5.2",
-        "jasmine-spec-reporter": "7.0.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "jest-preset-angular": "14.4.2",
@@ -16684,16 +16683,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
     "node_modules/columnify": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.6.0.tgz",
@@ -23404,16 +23393,6 @@
       "dependencies": {
         "@xmldom/xmldom": "^0.8.5",
         "mkdirp": "^1.0.4"
-      }
-    },
-    "node_modules/jasmine-spec-reporter": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/jasmine-spec-reporter/-/jasmine-spec-reporter-7.0.0.tgz",
-      "integrity": "sha512-OtC7JRasiTcjsaCBPtMO0Tl8glCejM4J4/dNuOJdA8lBjz4PmWjYQ6pzb0uzpBNAWJMDudYuj9OdXJWqM2QTJg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "colors": "1.4.0"
       }
     },
     "node_modules/jest": {

--- a/package.json
+++ b/package.json
@@ -125,7 +125,6 @@
     "husky": "^9.1.7",
     "jasmine-core": "5.13.0",
     "jasmine-reporters": "^2.5.2",
-    "jasmine-spec-reporter": "7.0.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "jest-preset-angular": "14.4.2",


### PR DESCRIPTION
## Summary
- Remove `jasmine-spec-reporter` from devDependencies as it's no longer used in the codebase

## Details
The `jasmine-spec-reporter` package is not referenced in any Karma configuration files. The project currently uses `karma-jasmine-html-reporter` for HTML reporting and the standard `progress` reporter for console output.

## Test plan
- Verify tests still run successfully
- Confirm no references to `jasmine-spec-reporter` in the codebase
- Check that test reporting still works as expected