### PR TITLE
AAE-44761 Remove unused imports in adf-info-drawer and adf-viewer components

### DIFF
--- a/lib/core/src/lib/info-drawer/info-drawer.component.ts
+++ b/lib/core/src/lib/info-drawer/info-drawer.component.ts
@@ -29,12 +29,7 @@ import {
 } from '@angular/core';
 import { MatTabChangeEvent, MatTabsModule } from '@angular/material/tabs';
 import { CommonModule } from '@angular/common';
-import {
-    InfoDrawerButtonsDirective,
-    InfoDrawerContentDirective,
-    InfoDrawerLayoutComponent,
-    InfoDrawerTitleDirective
-} from './info-drawer-layout.component';
+import { InfoDrawerContentDirective, InfoDrawerLayoutComponent, InfoDrawerTitleDirective } from './info-drawer-layout.component';
 import { TranslatePipe } from '@ngx-translate/core';
 import { IconModule } from '../icon/icon.module';
 
@@ -64,10 +59,8 @@ export class InfoDrawerTabComponent {
         TranslatePipe,
         MatTabsModule,
         IconModule,
-        InfoDrawerButtonsDirective,
         InfoDrawerTitleDirective,
-        InfoDrawerContentDirective,
-        InfoDrawerTabComponent
+        InfoDrawerContentDirective
     ],
     templateUrl: './info-drawer.component.html',
     styleUrls: ['./info-drawer.component.scss'],

--- a/lib/core/src/lib/viewer/components/viewer.component.ts
+++ b/lib/core/src/lib/viewer/components/viewer.component.ts
@@ -53,8 +53,6 @@ import { ViewerOpenWithComponent } from './viewer-open-with.component';
 import { ViewerRenderComponent } from './viewer-render/viewer-render.component';
 import { ViewerSidebarComponent } from './viewer-sidebar.component';
 import { ViewerToolbarComponent } from './viewer-toolbar.component';
-import { ViewerToolbarActionsComponent } from './viewer-toolbar-actions.component';
-import { ViewerToolbarCustomActionsComponent } from './viewer-toolbar-custom-actions.component';
 import { ThumbnailService } from '../../common';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { IconModule } from '../../icon/icon.module';
@@ -83,11 +81,7 @@ const DEFAULT_NON_PREVIEW_CONFIG = {
         MatMenuModule,
         ToolbarDividerComponent,
         ViewerRenderComponent,
-        NgTemplateOutlet,
-        ViewerToolbarComponent,
-        ViewerSidebarComponent,
-        ViewerToolbarActionsComponent,
-        ViewerToolbarCustomActionsComponent
+        NgTemplateOutlet
     ],
     providers: [ViewUtilService]
 })


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
When running `npx start studio-hxp -- -c adf` was getting several compiler errors like `error NG8113:XXXX is not used within the template of XXX`

Removed all the unused imports.

`Error: ../alfresco-ng2-components/lib/core/src/lib/info-drawer/info-drawer.component.ts:67:9 - error NG8113: InfoDrawerButtonsDirective is not used within the template of InfoDrawerComponent

Error: ../alfresco-ng2-components/lib/core/src/lib/info-drawer/info-drawer.component.ts:70:9 - error NG8113: InfoDrawerTabComponent is not used within the template of InfoDrawerComponent

Error: ../alfresco-ng2-components/lib/core/src/lib/viewer/components/viewer.component.ts:87:9 - error NG8113: ViewerToolbarComponent is not used within the template of ViewerComponent

Error: ../alfresco-ng2-components/lib/core/src/lib/viewer/components/viewer.component.ts:88:9 - error NG8113: ViewerSidebarComponent is not used within the template of ViewerComponent

Error: ../alfresco-ng2-components/lib/core/src/lib/viewer/components/viewer.component.ts:89:9 - error NG8113: ViewerToolbarActionsComponent is not used within the template of ViewerComponent

Error: ../alfresco-ng2-components/lib/core/src/lib/viewer/components/viewer.component.ts:90:9 - error NG8113: ViewerToolbarCustomActionsComponent is not used within the template of ViewerComponent`


**What is the new behaviour?**
Remove unused imports and able to run `npx start studio-hxp -- -c adf`


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
