### PR TITLE
[ACS-11350] keyboard navigation user incorrect focus order after collapsing the left navigation menu

### DIFF
--- a/lib/core/src/lib/layout/components/layout-container/layout-container.component.html
+++ b/lib/core/src/lib/layout/components/layout-container/layout-container.component.html
@@ -4,7 +4,7 @@
         [position]="position"
         [disableClose]="!isMobileScreenSize"
         [@sidenavAnimation]="sidenavAnimationState"
-        [opened]="!isMobileScreenSize || !hideSidenav"
+        [opened]="!isMobileScreenSize && !hideSidenav"
         [mode]="isMobileScreenSize ? 'over' : 'side'">
         <ng-content sidenav select="[app-layout-navigation]" />
     </mat-sidenav>

--- a/lib/core/src/lib/layout/components/layout-container/layout-container.component.spec.ts
+++ b/lib/core/src/lib/layout/components/layout-container/layout-container.component.spec.ts
@@ -21,6 +21,7 @@ import { Direction } from '@angular/cdk/bidi';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { UnitTestingUtils } from '@alfresco/adf-core';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
+import { MatSidenavHarness } from '@angular/material/sidenav/testing';
 
 describe('LayoutContainerComponent', () => {
     let fixture: ComponentFixture<LayoutContainerComponent>;
@@ -55,8 +56,6 @@ describe('LayoutContainerComponent', () => {
         fixture = TestBed.createComponent(LayoutContainerComponent);
         layoutContainerComponent = fixture.componentInstance;
         unitTestingUtils = new UnitTestingUtils(fixture.debugElement, TestbedHarnessEnvironment.loader(fixture));
-        // eslint-disable-next-line
-        console.log(unitTestingUtils);
         layoutContainerComponent.sidenavMin = 70;
         layoutContainerComponent.sidenavMax = 200;
         layoutContainerComponent.mediaQueryList = {
@@ -170,7 +169,13 @@ describe('LayoutContainerComponent', () => {
     });
 
     describe('toggleMenu()', () => {
-        it('should switch to sidenav to compact state', () => {
+        let sidenav: MatSidenavHarness;
+
+        beforeEach(async () => {
+            sidenav = await unitTestingUtils.getMatSidenav();
+        });
+
+        it('should switch to sidenav to compact state', async () => {
             layoutContainerComponent.expandedSidenav = true;
             layoutContainerComponent.ngOnInit();
             layoutContainerComponent.toggleMenu();
@@ -178,9 +183,10 @@ describe('LayoutContainerComponent', () => {
                 value: 'compact',
                 params: { width: layoutContainerComponent.sidenavMin }
             });
+            expect(await sidenav.isOpen()).toBeFalse();
         });
 
-        it('should switch to sidenav to expanded state', () => {
+        it('should switch to sidenav to expanded state', async () => {
             layoutContainerComponent.expandedSidenav = false;
             layoutContainerComponent.ngOnInit();
             layoutContainerComponent.toggleMenu();
@@ -188,10 +194,13 @@ describe('LayoutContainerComponent', () => {
                 value: 'expanded',
                 params: { width: layoutContainerComponent.sidenavMax }
             });
+            expect(await sidenav.isOpen()).toBeTrue();
         });
     });
 
     describe('Media query change', () => {
+        let sidenav: MatSidenavHarness;
+
         const expandedState = {
             value: 'expanded',
             params: { width: 200 }
@@ -209,7 +218,11 @@ describe('LayoutContainerComponent', () => {
             expect(layoutContainerComponent.contentAnimationState).toEqual(expectedContentState);
         };
 
-        it('should close sidenav on mobile and open on desktop', () => {
+        beforeEach(async () => {
+            sidenav = await unitTestingUtils.getMatSidenav();
+        });
+
+        it('should close sidenav on mobile and open on desktop', async () => {
             testMediaQueryChange(true, expandedState, expandedContentState);
             layoutContainerComponent.mediaQueryList.matches = false;
             window.dispatchEvent(new Event('resize'));
@@ -218,10 +231,10 @@ describe('LayoutContainerComponent', () => {
                 value: 'compact',
                 params: { 'margin-left': layoutContainerComponent.sidenavMax }
             });
-            expect(layoutContainerComponent.sidenav.open).toHaveBeenCalled();
+            expect(await sidenav.isOpen()).toBeTrue();
         });
 
-        it('should keep sidenav compact when resized back to desktop and hideSidenav is true', () => {
+        it('should keep sidenav compact when resized back to desktop and hideSidenav is true', async () => {
             layoutContainerComponent.hideSidenav = true;
             testMediaQueryChange(true, expandedState, expandedContentState);
             layoutContainerComponent.mediaQueryList.matches = false;
@@ -231,7 +244,7 @@ describe('LayoutContainerComponent', () => {
                 value: 'expanded',
                 params: { 'margin-left': layoutContainerComponent.sidenavMin }
             });
-            expect(layoutContainerComponent.sidenav.open).not.toHaveBeenCalled();
+            expect(await sidenav.isOpen()).toBeFalse();
         });
     });
 });

--- a/lib/core/src/lib/layout/components/layout-container/layout-container.component.spec.ts
+++ b/lib/core/src/lib/layout/components/layout-container/layout-container.component.spec.ts
@@ -17,11 +17,15 @@
 
 import { LayoutContainerComponent } from './layout-container.component';
 import { SimpleChange } from '@angular/core';
-import { MatSidenav } from '@angular/material/sidenav';
 import { Direction } from '@angular/cdk/bidi';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { UnitTestingUtils } from '@alfresco/adf-core';
+import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 
 describe('LayoutContainerComponent', () => {
+    let fixture: ComponentFixture<LayoutContainerComponent>;
     let layoutContainerComponent: LayoutContainerComponent;
+    let unitTestingUtils: UnitTestingUtils;
 
     const setupComponent = (expandedSidenav: boolean, position: 'start' | 'end', direction: Direction) => {
         layoutContainerComponent.expandedSidenav = expandedSidenav;
@@ -45,7 +49,14 @@ describe('LayoutContainerComponent', () => {
     };
 
     beforeEach(() => {
-        layoutContainerComponent = new LayoutContainerComponent();
+        TestBed.configureTestingModule({
+            imports: [LayoutContainerComponent]
+        });
+        fixture = TestBed.createComponent(LayoutContainerComponent);
+        layoutContainerComponent = fixture.componentInstance;
+        unitTestingUtils = new UnitTestingUtils(fixture.debugElement, TestbedHarnessEnvironment.loader(fixture));
+        // eslint-disable-next-line
+        console.log(unitTestingUtils);
         layoutContainerComponent.sidenavMin = 70;
         layoutContainerComponent.sidenavMax = 200;
         layoutContainerComponent.mediaQueryList = {
@@ -53,11 +64,6 @@ describe('LayoutContainerComponent', () => {
             addListener: jasmine.createSpy('addListener').and.callFake((callback) => window.addEventListener('resize', callback)),
             removeListener: jasmine.createSpy('removeListener').and.callFake((callback) => window.removeEventListener('resize', callback))
         };
-        layoutContainerComponent.sidenav = {
-            open: jasmine.createSpy('open'),
-            close: jasmine.createSpy('close'),
-            toggle: jasmine.createSpy('toggle')
-        } as unknown as MatSidenav;
     });
 
     describe('OnInit', () => {

--- a/lib/core/src/lib/layout/components/layout-container/layout-container.component.spec.ts
+++ b/lib/core/src/lib/layout/components/layout-container/layout-container.component.spec.ts
@@ -179,11 +179,11 @@ describe('LayoutContainerComponent', () => {
             layoutContainerComponent.expandedSidenav = true;
             layoutContainerComponent.ngOnInit();
             layoutContainerComponent.toggleMenu();
+            fixture.detectChanges();
             expect(layoutContainerComponent.sidenavAnimationState).toEqual({
                 value: 'compact',
                 params: { width: layoutContainerComponent.sidenavMin }
             });
-            fixture.detectChanges();
             expect(await sidenav.isOpen()).toBeFalse();
         });
 
@@ -191,6 +191,7 @@ describe('LayoutContainerComponent', () => {
             layoutContainerComponent.expandedSidenav = false;
             layoutContainerComponent.ngOnInit();
             layoutContainerComponent.toggleMenu();
+            fixture.detectChanges();
             expect(layoutContainerComponent.sidenavAnimationState).toEqual({
                 value: 'expanded',
                 params: { width: layoutContainerComponent.sidenavMax }

--- a/lib/core/src/lib/layout/components/layout-container/layout-container.component.spec.ts
+++ b/lib/core/src/lib/layout/components/layout-container/layout-container.component.spec.ts
@@ -19,7 +19,7 @@ import { LayoutContainerComponent } from './layout-container.component';
 import { SimpleChange } from '@angular/core';
 import { Direction } from '@angular/cdk/bidi';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { UnitTestingUtils } from '@alfresco/adf-core';
+import { UnitTestingUtils } from '../../../testing/unit-testing-utils';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatSidenavHarness } from '@angular/material/sidenav/testing';
 

--- a/lib/core/src/lib/layout/components/layout-container/layout-container.component.spec.ts
+++ b/lib/core/src/lib/layout/components/layout-container/layout-container.component.spec.ts
@@ -183,6 +183,7 @@ describe('LayoutContainerComponent', () => {
                 value: 'compact',
                 params: { width: layoutContainerComponent.sidenavMin }
             });
+            fixture.detectChanges();
             expect(await sidenav.isOpen()).toBeFalse();
         });
 
@@ -211,7 +212,7 @@ describe('LayoutContainerComponent', () => {
         };
 
         const testMediaQueryChange = (matches: boolean, expectedSidenavState: any, expectedContentState: any) => {
-            layoutContainerComponent.ngOnInit();
+            fixture.detectChanges();
             layoutContainerComponent.mediaQueryList.matches = matches;
             window.dispatchEvent(new Event('resize'));
             expect(layoutContainerComponent.sidenavAnimationState).toEqual(expectedSidenavState);

--- a/lib/core/src/lib/layout/components/layout-container/layout-container.component.ts
+++ b/lib/core/src/lib/layout/components/layout-container/layout-container.component.ts
@@ -110,6 +110,7 @@ export class LayoutContainerComponent implements OnInit, OnDestroy, OnChanges {
         } else {
             this.sidenavAnimationState = this.toggledSidenavAnimation;
             this.contentAnimationState = this.toggledContentAnimation;
+            this.hideSidenav = this.sidenavAnimationState === this.SIDENAV_STATES.COMPACT;
         }
     }
 

--- a/lib/core/src/lib/testing/unit-testing-utils.ts
+++ b/lib/core/src/lib/testing/unit-testing-utils.ts
@@ -36,6 +36,7 @@ import { MatListOptionHarness } from '@angular/material/list/testing';
 import { MatCellHarness } from '@angular/material/table/testing';
 import { MatProgressSpinnerHarness } from '@angular/material/progress-spinner/testing';
 import { MatMenuHarness } from '@angular/material/menu/testing';
+import { MatSidenavHarness } from '@angular/material/sidenav/testing';
 
 export class UnitTestingUtils {
     constructor(
@@ -495,5 +496,11 @@ export class UnitTestingUtils {
 
     async getMatMenuByCSS(selector: string): Promise<MatMenuHarness> {
         return this.loader.getHarness(MatMenuHarness.with({ selector }));
+    }
+
+    /** MatSidenav related methods */
+
+    async getMatSidenav(): Promise<MatSidenavHarness> {
+        return this.loader.getHarness(MatSidenavHarness);
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/ACS-11350


**What is the new behaviour?**
When sidenav is hidden then focusable elements which are contained by sidenav can't be focused anymore. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
ACA PR: https://github.com/Alfresco/alfresco-content-app/pull/5168
alfresco-applications PR: https://github.com/Alfresco/alfresco-applications/pull/1554