### PR TITLE
AAE-44435 Fix incorrect Start process button on user task forms

### DIFF
--- a/docs/process-services-cloud/components/form-cloud.component.md
+++ b/docs/process-services-cloud/components/form-cloud.component.md
@@ -89,7 +89,7 @@ The template defined inside `empty-form` will be shown when no form definition i
 | path | `string` |  | Path of the folder where the metadata will be stored. |
 | processInstanceId | `string` |  | ProcessInstanceId id to fetch corresponding form and values. |
 | readOnly | `boolean` | false | Toggle readonly state of the form. Forces all form widgets to render as readonly if enabled. |
-| showCompleteButton | `boolean` | true | Toggle rendering of the `Complete` outcome button. |
+| showCompleteButton | `boolean` | false | Toggle rendering of the `Complete` outcome button. |
 | showRefreshButton | `boolean` | true | Toggle rendering of the `Refresh` button. |
 | showSaveButton | `boolean` | true | Toggle rendering of the `Save` outcome button. |
 | showTitle | `boolean` | true | Toggle rendering of the form title. |

--- a/lib/core/src/lib/form/components/helpers/buttons-visibility.spec.ts
+++ b/lib/core/src/lib/form/components/helpers/buttons-visibility.spec.ts
@@ -1,0 +1,63 @@
+/*!
+ * @license
+ * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FormOutcomeModel } from '../widgets';
+import { isOutcomeButtonVisible } from './buttons-visibility';
+
+describe('isOutcomeButtonVisible', () => {
+    const defaultProps = {
+        isFormReadOnly: false,
+        showCompleteButton: true,
+        showSaveButton: true
+    };
+
+    const outcome = (overrides: Partial<FormOutcomeModel>): FormOutcomeModel => ({ name: '', isSelected: false, ...overrides }) as FormOutcomeModel;
+
+    it('should return false when outcome has no name', () => {
+        expect(isOutcomeButtonVisible(outcome({ name: '' }), defaultProps)).toBe(false);
+    });
+
+    it('should respect showCompleteButton for COMPLETE action', () => {
+        const o = outcome({ name: FormOutcomeModel.COMPLETE_ACTION });
+        expect(isOutcomeButtonVisible(o, { ...defaultProps, showCompleteButton: false })).toBe(false);
+        expect(isOutcomeButtonVisible(o, { ...defaultProps, showCompleteButton: true })).toBe(true);
+    });
+
+    it('should always hide START_PROCESS action regardless of readOnly state', () => {
+        const o = outcome({ name: FormOutcomeModel.START_PROCESS_ACTION });
+        expect(isOutcomeButtonVisible(o, { ...defaultProps, isFormReadOnly: false })).toBe(false);
+        expect(isOutcomeButtonVisible(o, { ...defaultProps, isFormReadOnly: true })).toBe(false);
+    });
+
+    it('should show only selected outcome when form is read-only', () => {
+        const selected = outcome({ name: 'custom-1', isSelected: true });
+        const notSelected = outcome({ name: 'custom-2', isSelected: false });
+        expect(isOutcomeButtonVisible(selected, { ...defaultProps, isFormReadOnly: true })).toBe(true);
+        expect(isOutcomeButtonVisible(notSelected, { ...defaultProps, isFormReadOnly: true })).toBe(false);
+    });
+
+    it('should respect showSaveButton for SAVE action on writable forms', () => {
+        const o = outcome({ name: FormOutcomeModel.SAVE_ACTION });
+        expect(isOutcomeButtonVisible(o, { ...defaultProps, showSaveButton: true })).toBe(true);
+        expect(isOutcomeButtonVisible(o, { ...defaultProps, showSaveButton: false })).toBe(false);
+    });
+
+    it('should show custom outcomes on writable forms', () => {
+        const o = outcome({ name: 'custom-outcome' });
+        expect(isOutcomeButtonVisible(o, defaultProps)).toBe(true);
+    });
+});

--- a/lib/core/src/lib/form/components/helpers/buttons-visibility.ts
+++ b/lib/core/src/lib/form/components/helpers/buttons-visibility.ts
@@ -30,14 +30,14 @@ export const isOutcomeButtonVisible = (outcome: FormOutcomeModel, props: IsOutco
         if (outcome.name === FormOutcomeModel.COMPLETE_ACTION) {
             return showCompleteButton;
         }
+        if (outcome.name === FormOutcomeModel.START_PROCESS_ACTION) {
+            return false;
+        }
         if (isFormReadOnly) {
             return outcome.isSelected;
         }
         if (outcome.name === FormOutcomeModel.SAVE_ACTION) {
             return showSaveButton;
-        }
-        if (outcome.name === FormOutcomeModel.START_PROCESS_ACTION) {
-            return false;
         }
         return true;
     }

--- a/lib/process-services-cloud/src/lib/form/components/form-cloud.component.html
+++ b/lib/process-services-cloud/src/lib/form/components/form-cloud.component.html
@@ -121,20 +121,17 @@
                             }
                             <div class="adf-cloud-form-outcome-buttons">
                                 <ng-content select="adf-cloud-form-custom-outcomes" />
-                                @for (outcome of form.outcomes; track outcome.name) {
-                                    @if (outcome.isVisible) {
-                                        <button
-                                            [id]="'adf-form-' + outcome.name | formatSpace"
-                                            [color]="getColorForOutcome(outcome.name)"
-                                            mat-button
-                                            [disabled]="!isOutcomeButtonEnabled(outcome)"
-                                            [class.adf-form-hide-button]="!isOutcomeButtonVisible(outcome, form.readOnly)"
-                                            class="adf-cloud-form-custom-outcome-button"
-                                            (click)="onOutcomeClicked(outcome)"
-                                        >
-                                            {{ getCustomOutcomeButtonText(outcome) || (outcome.name | translate | uppercase) }}
-                                        </button>
-                                    }
+                                @for (outcome of visibleOutcomes; track outcome.name) {
+                                    <button
+                                        [id]="'adf-form-' + outcome.name | formatSpace"
+                                        [color]="getColorForOutcome(outcome.name)"
+                                        mat-button
+                                        [disabled]="!isOutcomeButtonEnabled(outcome)"
+                                        class="adf-cloud-form-custom-outcome-button"
+                                        (click)="onOutcomeClicked(outcome)"
+                                    >
+                                        {{ getCustomOutcomeButtonText(outcome) || (outcome.name | translate | uppercase) }}
+                                    </button>
                                 }
                             </div>
                         </mat-card-actions>

--- a/lib/process-services-cloud/src/lib/form/components/form-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/form-cloud.component.spec.ts
@@ -1210,6 +1210,32 @@ describe('FormCloudComponent', () => {
         expect(formComponent.isOutcomeButtonEnabled(startProcessOutcome)).toBeTruthy();
     });
 
+    it('should not include START_PROCESS outcome when form is loaded for a task', () => {
+        formComponent.taskId = 'mock-task-id';
+        formComponent.appName = 'mock-app';
+
+        const form = formComponent.parseForm(cloudFormMock);
+
+        const startProcessOutcome = form.outcomes.find((outcome) => outcome.id === FormModel.START_PROCESS_OUTCOME);
+        expect(startProcessOutcome).toBeUndefined();
+    });
+
+    it('should populate visibleOutcomes when the form is set', () => {
+        formComponent.showCompleteButton = true;
+        formComponent.form = new FormModel(cloudFormMock);
+
+        expect(formComponent.visibleOutcomes.length).toBeGreaterThan(0);
+        expect(formComponent.visibleOutcomes.every((outcome) => outcome.name !== FormOutcomeModel.START_PROCESS_ACTION)).toBe(true);
+    });
+
+    it('should clear visibleOutcomes when the form is cleared', () => {
+        formComponent.form = new FormModel(cloudFormMock);
+        expect(formComponent.visibleOutcomes.length).toBeGreaterThan(0);
+
+        formComponent.form = null;
+        expect(formComponent.visibleOutcomes).toEqual([]);
+    });
+
     it('should raise [executeOutcome] event for formService', async () => {
         spyOn(formComponent.executeOutcome, 'emit');
 
@@ -1656,6 +1682,7 @@ describe('FormCloudComponent', () => {
 
     describe('Custom outcome button text for default outcomes', () => {
         beforeEach(() => {
+            formComponent.showCompleteButton = true;
             formComponent.form = formComponent.parseForm(emptyFormRepresentationJSON);
         });
 

--- a/lib/process-services-cloud/src/lib/form/components/form-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/form-cloud.component.spec.ts
@@ -1229,6 +1229,7 @@ describe('FormCloudComponent', () => {
     });
 
     it('should clear visibleOutcomes when the form is cleared', () => {
+        formComponent.showCompleteButton = true;
         formComponent.form = new FormModel(cloudFormMock);
         expect(formComponent.visibleOutcomes.length).toBeGreaterThan(0);
 

--- a/lib/process-services-cloud/src/lib/form/components/form-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/form/components/form-cloud.component.ts
@@ -175,6 +175,15 @@ export class FormCloudComponent extends FormBaseComponent implements OnChanges, 
     formCloudRepresentationJSON: any;
     fieldValidators: FormFieldValidator[] = [];
 
+    /**
+     * Pre-computed list of outcome buttons to render.
+     * Derived from `form.outcomes` filtered by the visibility rules. Updated whenever
+     * the form or any visibility-affecting input (`readOnly`, `showCompleteButton`,
+     * `showSaveButton`) changes. Prevents function calls in the template that would
+     * re-run on every change detection cycle.
+     */
+    visibleOutcomes: FormOutcomeModel[] = [];
+
     readonly id: string;
     displayMode: string;
     displayConfiguration: FormCloudDisplayModeConfiguration = DisplayModeService.DEFAULT_DISPLAY_MODE_CONFIGURATIONS[0];
@@ -267,6 +276,10 @@ export class FormCloudComponent extends FormBaseComponent implements OnChanges, 
             if (this.disableSaveButton) {
                 this.disableSaveButton = false;
             }
+            if (this.form) {
+                this.visibilityService.refreshVisibility(this.form);
+                this.recomputeVisibleOutcomes();
+            }
         });
     }
 
@@ -317,6 +330,10 @@ export class FormCloudComponent extends FormBaseComponent implements OnChanges, 
         if (enableParentVisibilityCheckChange && this.form) {
             this.setCheckParentVisibilityForValidationOnFields();
             this.form.validateForm();
+        }
+
+        if (changes['readOnly'] || changes['showCompleteButton'] || changes['showSaveButton']) {
+            this.recomputeVisibleOutcomes();
         }
     }
 
@@ -511,9 +528,11 @@ export class FormCloudComponent extends FormBaseComponent implements OnChanges, 
             });
 
             const form = new FormModel(formCloudRepresentationJSON, formValues, this.readOnly, this.formService, undefined, this.fieldValidators);
-            if (!form) {
-                form.outcomes = this.getFormDefinitionOutcomes(form);
+
+            if (this.taskId) {
+                form.outcomes = form.outcomes.filter((outcome) => outcome.id !== FormModel.START_PROCESS_OUTCOME);
             }
+
             return form;
         }
 
@@ -533,6 +552,7 @@ export class FormCloudComponent extends FormBaseComponent implements OnChanges, 
     checkVisibility(field: FormFieldModel) {
         if (field?.form) {
             this.visibilityService.refreshVisibility(field.form);
+            this.recomputeVisibleOutcomes();
         }
     }
 
@@ -543,6 +563,16 @@ export class FormCloudComponent extends FormBaseComponent implements OnChanges, 
             this.onFormLoaded(this.form);
             this.onFormDataRefreshed(this.form);
         }
+    }
+
+    private recomputeVisibleOutcomes(): void {
+        const outcomes = this.form?.outcomes;
+        if (!outcomes) {
+            this.visibleOutcomes = [];
+            return;
+        }
+
+        this.visibleOutcomes = outcomes.filter((outcome) => outcome.isVisible && this.isOutcomeButtonVisible(outcome, this.form.readOnly));
     }
 
     /**

--- a/lib/process-services-cloud/src/lib/form/components/form-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/form/components/form-cloud.component.ts
@@ -277,7 +277,6 @@ export class FormCloudComponent extends FormBaseComponent implements OnChanges, 
                 this.disableSaveButton = false;
             }
             if (this.form) {
-                this.visibilityService.refreshVisibility(this.form);
                 this.recomputeVisibleOutcomes();
             }
         });
@@ -530,7 +529,7 @@ export class FormCloudComponent extends FormBaseComponent implements OnChanges, 
             const form = new FormModel(formCloudRepresentationJSON, formValues, this.readOnly, this.formService, undefined, this.fieldValidators);
 
             if (this.taskId) {
-                form.outcomes = form.outcomes.filter((outcome) => outcome.id !== FormModel.START_PROCESS_OUTCOME);
+                form.outcomes = (form.outcomes ?? []).filter((outcome) => outcome.id !== FormModel.START_PROCESS_OUTCOME);
             }
 
             return form;
@@ -607,6 +606,7 @@ export class FormCloudComponent extends FormBaseComponent implements OnChanges, 
             this.displayModeOn.emit(this.displayConfiguration);
         }
 
+        this.recomputeVisibleOutcomes();
         this.changeDetector.detectChanges();
         this.formLoaded.emit(form);
     }

--- a/lib/process-services-cloud/src/lib/form/components/form-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/form/components/form-cloud.component.ts
@@ -178,6 +178,16 @@ export class FormCloudComponent extends FormBaseComponent implements OnChanges, 
     /** Pre-computed list of outcome buttons to render, filtered by visibility rules. */
     visibleOutcomes: FormOutcomeModel[] = [];
 
+    override get form(): FormModel {
+        return super.form;
+    }
+
+    @Input()
+    override set form(form: FormModel) {
+        super.form = form;
+        this.recomputeVisibleOutcomes();
+    }
+
     readonly id: string;
     displayMode: string;
     displayConfiguration: FormCloudDisplayModeConfiguration = DisplayModeService.DEFAULT_DISPLAY_MODE_CONFIGURATIONS[0];
@@ -270,10 +280,14 @@ export class FormCloudComponent extends FormBaseComponent implements OnChanges, 
             if (this.disableSaveButton) {
                 this.disableSaveButton = false;
             }
-            if (this.form) {
-                this.recomputeVisibleOutcomes();
-            }
         });
+
+        this.formService.formRulesEvent
+            .pipe(
+                filter((event) => event?.type === 'fieldValueChanged' && event.form?.id === this.form?.id),
+                takeUntilDestroyed()
+            )
+            .subscribe(() => this.recomputeVisibleOutcomes());
     }
 
     @HostListener('keydown', ['$event'])
@@ -600,7 +614,6 @@ export class FormCloudComponent extends FormBaseComponent implements OnChanges, 
             this.displayModeOn.emit(this.displayConfiguration);
         }
 
-        this.recomputeVisibleOutcomes();
         this.changeDetector.detectChanges();
         this.formLoaded.emit(form);
     }

--- a/lib/process-services-cloud/src/lib/form/components/form-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/form/components/form-cloud.component.ts
@@ -175,13 +175,7 @@ export class FormCloudComponent extends FormBaseComponent implements OnChanges, 
     formCloudRepresentationJSON: any;
     fieldValidators: FormFieldValidator[] = [];
 
-    /**
-     * Pre-computed list of outcome buttons to render.
-     * Derived from `form.outcomes` filtered by the visibility rules. Updated whenever
-     * the form or any visibility-affecting input (`readOnly`, `showCompleteButton`,
-     * `showSaveButton`) changes. Prevents function calls in the template that would
-     * re-run on every change detection cycle.
-     */
+    /** Pre-computed list of outcome buttons to render, filtered by visibility rules. */
     visibleOutcomes: FormOutcomeModel[] = [];
 
     readonly id: string;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

**What is the current behaviour?** (You can also link to an open issue here)

On an active user task form in Automate Workspace, an extra **Start process** button intermittently appears alongside `Cancel`, `Save`, and `Submit` after a browser refresh. Clicking it wrongly completes the task. The same ghost button is also visible on completed (read-only) task forms (only `Cancel` is enabled, but the extra buttons are still rendered).

Root cause (three layered issues):

1. `FormModel.parseOutcomes()` always appends a system `START_PROCESS` outcome when no custom outcomes are defined, and `FormOutcomeModel.isVisible` defaults to `true`.
2. The cloud form template rendered every outcome in the DOM and relied solely on an `adf-form-hide-button` CSS class (`display: none`) to visually suppress `START PROCESS`. That class is declared only inside `form-renderer.component.scss` (leaks globally via `ViewEncapsulation.None`), so it races with initial paint on refresh — sometimes the button is visible before the style is applied.
3. `isOutcomeButtonVisible` short-circuited on `isFormReadOnly` **before** the `START_PROCESS_ACTION` check, so on completed task forms the button was never marked hidden at all.

Issue: https://hyland.atlassian.net/browse/AAE-44435

**What is the new behaviour?**

- **Task forms no longer carry a `START_PROCESS` outcome.** `FormCloudComponent.parseForm()` now strips `START_PROCESS_OUTCOME` from `form.outcomes` whenever the form is bound to a task (`this.taskId` is set). Start forms (process start) are unaffected.
- **Outcome rendering uses a pre-computed, filtered list.** The template iterates over `visibleOutcomes` (buttons that pass both `outcome.isVisible` and `isOutcomeButtonVisible(...)`) instead of rendering every outcome and hiding some via CSS. This removes the refresh-time race — the Start Process button is no longer in the DOM when it should not be shown.
- **`isOutcomeButtonVisible` returns `false` for `START_PROCESS_ACTION` before the read-only short-circuit.** Completed task forms no longer show the extra buttons.
- `visibleOutcomes` is recomputed when the form is set, when `readOnly` / `showCompleteButton` / `showSaveButton` change, when field values change, and on visibility refresh — no function calls in the template.

Tests added:
- `buttons-visibility.spec.ts` (new) — unit tests for the helper, including the read-only + START_PROCESS case.
- `form-cloud.component.spec.ts` — asserts `START_PROCESS_OUTCOME` is removed from task forms and that `visibleOutcomes` is populated/cleared correctly and never contains `START PROCESS`.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No

Behaviour change is scoped to task forms only. Start-process forms are unaffected. The public API of `FormCloudComponent`, `FormModel`, and `FormOutcomeModel` is unchanged. Consumers iterating `form.outcomes` on task forms will no longer see a `START_PROCESS` entry — this matches the documented behaviour (task forms never show a Start Process button), but it is a shape change worth noting in review.

**Other information**:

Issue: https://hyland.atlassian.net/browse/AAE-44435

Files changed:
- `lib/core/src/lib/form/components/helpers/buttons-visibility.ts` — reorder check so `START_PROCESS_ACTION` is hidden before the read-only short-circuit.
- `lib/core/src/lib/form/components/helpers/buttons-visibility.spec.ts` — new unit tests.
- `lib/process-services-cloud/src/lib/form/components/form-cloud.component.ts` — strip `START_PROCESS_OUTCOME` from task forms in `parseForm`; add `visibleOutcomes` + `recomputeVisibleOutcomes`; wire recompute into the `form` accessor, `ngOnChanges`, `formFieldValueChanged`, and `checkVisibility`.
- `lib/process-services-cloud/src/lib/form/components/form-cloud.component.html` — iterate `visibleOutcomes` instead of every outcome; drop the `adf-form-hide-button` CSS-based hiding.
- `lib/process-services-cloud/src/lib/form/components/form-cloud.component.spec.ts` — coverage for the new behaviour.

Follow-up candidates (not in this PR):
- Consider removing the `override get form`/`set form` accessor in `FormCloudComponent` in favour of explicit `recomputeVisibleOutcomes()` calls at the 3 internal assignment sites — the setter side-effect is a hidden coupling point.
- Update `docs/features/maps/outcome-buttons-functionality.map.md` (Visibility Determination + Component Tree sections, Change Log entry) once this lands.