### PR TITLE
[MNT-25647] Handle facets label wrapped in quotes

### DIFF
--- a/lib/content-services/src/lib/search/components/search-chip-list/search-chip-list.component.spec.ts
+++ b/lib/content-services/src/lib/search/components/search-chip-list/search-chip-list.component.spec.ts
@@ -109,7 +109,10 @@ describe('SearchChipListComponent', () => {
                     label: 'test',
                     filterQuery: 'query'
                 },
-                field: null
+                field: {
+                    field: 'test',
+                    label: 'test'
+                }
             }
         ];
 

--- a/lib/content-services/src/lib/search/services/search-facet-filters.service.spec.ts
+++ b/lib/content-services/src/lib/search/services/search-facet-filters.service.spec.ts
@@ -198,6 +198,53 @@ describe('SearchFacetFiltersService', () => {
         expect(searchFacetFiltersService.responseFacets[1].buckets.length).toEqual(2);
     });
 
+    it('should parse facets when response labels are wrapped in quotes', () => {
+        searchFacetFiltersService.responseFacets = null;
+
+        queryBuilder.config = {
+            id: 'test-config',
+            categories: [],
+            facetFields: {
+                fields: [
+                    { label: 'test1', field: 'test1', mincount: 0 },
+                    { label: 'test2 test3', field: 'test2 test3', mincount: 0 },
+                    { label: 'test4 "" test5', field: 'test4 "" test5', mincount: 0 }
+                ]
+            }
+        };
+
+        const data = {
+            list: {
+                context: {
+                    facets: [
+                        {
+                            type: 'field',
+                            label: 'test1',
+                            buckets: [{ label: 'test1', metrics: [{ value: { count: 1 } }] }]
+                        },
+                        {
+                            type: 'field',
+                            label: '"test2 test3"',
+                            buckets: [{ label: 'test2 test3', metrics: [{ value: { count: 1 } }] }]
+                        },
+                        {
+                            type: 'field',
+                            label: '"test4 "" test5"',
+                            buckets: [{ label: 'test4 "" test5', metrics: [{ value: { count: 1 } }] }]
+                        }
+                    ]
+                }
+            }
+        };
+
+        searchFacetFiltersService.onDataLoaded(data);
+
+        expect(searchFacetFiltersService.responseFacets.length).toBe(3);
+        expect(searchFacetFiltersService.responseFacets[0].label).toBe('test1');
+        expect(searchFacetFiltersService.responseFacets[1].label).toBe('test2 test3');
+        expect(searchFacetFiltersService.responseFacets[2].label).toBe('test4 "" test5');
+    });
+
     it('should filter response facet fields based on search filter config method', () => {
         queryBuilder.config = {
             id: 'test-config',

--- a/lib/content-services/src/lib/search/services/search-facet-filters.service.ts
+++ b/lib/content-services/src/lib/search/services/search-facet-filters.service.ts
@@ -89,7 +89,7 @@ export class SearchFacetFiltersService {
     }
 
     private parseFacets(context: ResultSetContext) {
-        context.facets?.forEach((facet) => (facet.label = facet.label.replace(/^"|"$/g, '')));
+        context.facets?.forEach((facet) => (facet.label = facet.label ? facet.label.replace(/^"|"$/g, '') : ''));
         this.parseFacetFields(context);
         this.parseFacetIntervals(context);
         this.parseFacetQueries(context);

--- a/lib/content-services/src/lib/search/services/search-facet-filters.service.ts
+++ b/lib/content-services/src/lib/search/services/search-facet-filters.service.ts
@@ -89,6 +89,7 @@ export class SearchFacetFiltersService {
     }
 
     private parseFacets(context: ResultSetContext) {
+        context.facets?.forEach((facet) => (facet.label = facet.label.replace(/^"|"$/g, '')));
         this.parseFacetFields(context);
         this.parseFacetIntervals(context);
         this.parseFacetQueries(context);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://hyland.atlassian.net/browse/MNT-25647

**What is the new behaviour?**

When facet label contain whitespaces SE wraps it with quotes, now when facets are parsed those quotes are handled properly.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
