### PR TITLE
AAE-45774 Show error for date fields if invalid format

### DIFF
--- a/lib/core/src/lib/card-view/components/card-view-dateitem/card-view-dateitem.component.html
+++ b/lib/core/src/lib/card-view/components/card-view-dateitem/card-view-dateitem.component.html
@@ -82,9 +82,11 @@
                 [startAt]="valueDate"
                 [ngClass]="{ 'cdk-visually-hidden': !editable || isReadonlyProperty}"
             />
-            <mat-error>
-                {{ 'FORM.FIELD.VALIDATOR.INVALID_DATE_FORMAT' | translate: { format: property.format } }}
-            </mat-error>
+            @if (cardViewDateTimeControl.hasError('matDatepickerParse')) {
+                <mat-error>
+                    {{ 'FORM.FIELD.VALIDATOR.INVALID_DATE_FORMAT' | translate: { format: property.format ?? '' } }}
+                </mat-error>
+            }
         </mat-form-field>
     } @else {
         <mat-form-field class="adf-property-field adf-dateitem-editable" [floatLabel]="property.default ? 'always' : null">

--- a/lib/core/src/lib/card-view/components/card-view-dateitem/card-view-dateitem.component.html
+++ b/lib/core/src/lib/card-view/components/card-view-dateitem/card-view-dateitem.component.html
@@ -82,6 +82,9 @@
                 [startAt]="valueDate"
                 [ngClass]="{ 'cdk-visually-hidden': !editable || isReadonlyProperty}"
             />
+            <mat-error>
+                {{ 'FORM.FIELD.VALIDATOR.INVALID_DATE_FORMAT' | translate: { format: property.format } }}
+            </mat-error>
         </mat-form-field>
     } @else {
         <mat-form-field class="adf-property-field adf-dateitem-editable" [floatLabel]="property.default ? 'always' : null">

--- a/lib/core/src/lib/card-view/components/card-view-dateitem/card-view-dateitem.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view-dateitem/card-view-dateitem.component.spec.ts
@@ -459,6 +459,21 @@ describe('CardViewDateItemComponent', () => {
             expect(component.cardViewDateTimeControl.value).not.toBeNull();
         });
 
+        it('should render error message when manual input has invalid date format', async () => {
+            fixture.detectChanges();
+
+            const manualInput = await testingUtils.getMatInputByDataAutomationId('datepicker-manual-input-dateKey');
+            await manualInput.setValue('not-a-date');
+            await manualInput.blur();
+            fixture.detectChanges();
+            await fixture.whenStable();
+            fixture.detectChanges();
+
+            expect(component.cardViewDateTimeControl.invalid).toBeTrue();
+            const formField = await testingUtils.getMatFormFieldByCSS('.adf-dateitem-editable');
+            expect(await formField.getTextErrors()).toContain('FORM.FIELD.VALIDATOR.INVALID_DATE_FORMAT');
+        });
+
         it('should clear the form control value when onDateClear is called', () => {
             fixture.detectChanges();
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/AAE-45774

When invalid date format was entered in, no error message was shown. Just highlighted the field red.


**What is the new behaviour?**
Show errors


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
