### PR TITLE
chore: remove unused moment dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -104,7 +104,6 @@
         "karma-jasmine-html-reporter": "^2.1.0",
         "license-checker": "^25.0.1",
         "lint-staged": "15.5.2",
-        "moment": "^2.29.4",
         "ng-packagr": "19.2.2",
         "nx": "22.6.5",
         "prettier": "3.6.2",
@@ -30293,16 +30292,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/moment": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/mrmime": {

--- a/package.json
+++ b/package.json
@@ -133,7 +133,6 @@
     "karma-jasmine-html-reporter": "^2.1.0",
     "license-checker": "^25.0.1",
     "lint-staged": "15.5.2",
-    "moment": "^2.29.4",
     "ng-packagr": "19.2.2",
     "nx": "22.6.5",
     "prettier": "3.6.2",


### PR DESCRIPTION
## Summary
- Removed `moment` from devDependencies as it is no longer used in the codebase
- Updated package-lock.json accordingly

## Test plan
- Verified no imports of moment exist in the codebase
- npm install completes successfully