### PR TITLE
chore: remove unused eslint-plugin-prefer-arrow

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -102,7 +102,6 @@ module.exports = {
                 ],
                 '@typescript-eslint/member-ordering': 'off',
                 '@typescript-eslint/no-empty-function': 'off',
-                'prefer-arrow/prefer-arrow-functions': 'off',
                 '@typescript-eslint/no-explicit-any': 'off',
                 'prefer-promise-reject-errors': 'error',
                 'brace-style': 'off',

--- a/lib/cli/.eslintrc.json
+++ b/lib/cli/.eslintrc.json
@@ -10,7 +10,6 @@
         "createDefaultProgram": true
       },
       "rules": {
-        "prefer-arrow/prefer-arrow-functions": "off",
         "@typescript-eslint/no-var-requires": "off",
         "@typescript-eslint/naming-convention": "warn",
         "quote-props": "off",

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,6 @@
         "eslint-plugin-import": "2.32.0",
         "eslint-plugin-jsdoc": "50.3.1",
         "eslint-plugin-license-header": "0.8.0",
-        "eslint-plugin-prefer-arrow": "1.2.3",
         "eslint-plugin-prettier": "^5.5.4",
         "eslint-plugin-rxjs": "^5.0.3",
         "eslint-plugin-storybook": "^10.2.0",
@@ -20168,16 +20167,6 @@
       "license": "MIT",
       "dependencies": {
         "requireindex": "^1.2.0"
-      }
-    },
-    "node_modules/eslint-plugin-prefer-arrow": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prefer-arrow/-/eslint-plugin-prefer-arrow-1.2.3.tgz",
-      "integrity": "sha512-J9I5PKCOJretVuiZRGvPQxCbllxGAV/viI20JO3LYblAodofBxyMnZAJ+WGeClHgANnSJberTNoFWWjrWKBuXQ==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "eslint": ">=2.0.0"
       }
     },
     "node_modules/eslint-plugin-prettier": {

--- a/package.json
+++ b/package.json
@@ -113,7 +113,6 @@
     "eslint-plugin-import": "2.32.0",
     "eslint-plugin-jsdoc": "50.3.1",
     "eslint-plugin-license-header": "0.8.0",
-    "eslint-plugin-prefer-arrow": "1.2.3",
     "eslint-plugin-prettier": "^5.5.4",
     "eslint-plugin-rxjs": "^5.0.3",
     "eslint-plugin-storybook": "^10.2.0",


### PR DESCRIPTION
## Summary
- Removed `eslint-plugin-prefer-arrow` dependency from package.json
- Removed `prefer-arrow/prefer-arrow-functions` rule from .eslintrc.js
- Removed `prefer-arrow/prefer-arrow-functions` rule from lib/cli/.eslintrc.json

## Rationale
The `prefer-arrow/prefer-arrow-functions` rule was disabled ('off') in all ESLint configurations, making the plugin unnecessary. Removing unused dependencies reduces bundle size and simplifies maintenance.

## Test plan
- [x] Verify ESLint still runs without errors
- [x] Confirm no references to prefer-arrow remain in the codebase