### PR TITLE
chore: remove unused @nx/node dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,6 @@
         "@nx/eslint-plugin": "22.7.2",
         "@nx/jest": "22.7.2",
         "@nx/js": "22.7.2",
-        "@nx/node": "22.7.2",
         "@nx/storybook": "22.7.2",
         "@nx/workspace": "22.7.2",
         "@schematics/angular": "19.2.22",
@@ -9045,18 +9044,6 @@
         "node": ">=0.12.18"
       }
     },
-    "node_modules/@nx/docker": {
-      "version": "22.7.2",
-      "resolved": "https://registry.npmjs.org/@nx/docker/-/docker-22.7.2.tgz",
-      "integrity": "sha512-VSORTGE28czjDePM5XvNnbwneowlT/6N0t0Jhh6cJtSGCCWwaT4WQb8uVYOgchDr77HwOGhgezI79mmoKHWnsw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nx/devkit": "22.7.2",
-        "enquirer": "~2.3.6",
-        "tslib": "^2.3.0"
-      }
-    },
     "node_modules/@nx/eslint": {
       "version": "22.7.2",
       "resolved": "https://registry.npmjs.org/@nx/eslint/-/eslint-22.7.2.tgz",
@@ -9549,23 +9536,6 @@
         "@swc/helpers": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@nx/node": {
-      "version": "22.7.2",
-      "resolved": "https://registry.npmjs.org/@nx/node/-/node-22.7.2.tgz",
-      "integrity": "sha512-6nj6siMZy45r4hITYfHcqrOFpadYEkbfqwQP3xgTXZvTt6foX0HHoeOcv1rvaEvgdG6/DuZWQj4z8ursCnMWPw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nx/devkit": "22.7.2",
-        "@nx/docker": "22.7.2",
-        "@nx/eslint": "22.7.2",
-        "@nx/jest": "22.7.2",
-        "@nx/js": "22.7.2",
-        "kill-port": "^1.6.1",
-        "tcp-port-used": "^1.0.2",
-        "tslib": "^2.3.0"
       }
     },
     "node_modules/@nx/nx-darwin-arm64": {
@@ -20961,13 +20931,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/get-them-args": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/get-them-args/-/get-them-args-1.3.2.tgz",
-      "integrity": "sha512-LRn8Jlk+DwZE4GTlDbT3Hikd1wSHgLMme/+7ddlqKd7ldwR6LjJgTVWzBnR01wnYGe4KgrXjg287RaI22UHmAw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -22095,16 +22058,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/ip-regex": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
-      "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/ipaddr.js": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.3.0.tgz",
@@ -22653,13 +22606,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-url": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
-      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -22737,21 +22683,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is2": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/is2/-/is2-2.0.9.tgz",
-      "integrity": "sha512-rZkHeBn9Zzq52sd9IUIV3a5mfwBY+o2HePMh0wkGBM4z4qjvy2GwVxQ6nNXSfw6MmVP6gf1QIlWjiOavhM3x5g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "deep-is": "^0.1.3",
-        "ip-regex": "^4.1.0",
-        "is-url": "^1.2.4"
-      },
-      "engines": {
-        "node": ">=v0.10.0"
       }
     },
     "node_modules/isarray": {
@@ -28211,20 +28142,6 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
-      }
-    },
-    "node_modules/kill-port": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/kill-port/-/kill-port-1.6.1.tgz",
-      "integrity": "sha512-un0Y55cOM7JKGaLnGja28T38tDDop0AQ8N0KlAdyh+B1nmMoX8AnNmqPNZbS3mUMgiST51DCVqmbFT1gNJpVNw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-them-args": "1.3.2",
-        "shell-exec": "1.0.2"
-      },
-      "bin": {
-        "kill-port": "cli.js"
       }
     },
     "node_modules/kind-of": {
@@ -34005,13 +33922,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/shell-exec": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/shell-exec/-/shell-exec-1.0.2.tgz",
-      "integrity": "sha512-jyVd+kU2X+mWKMmGhx4fpWbPsjvD53k9ivqetutVW/BQ+WIZoDoP4d8vUMGezV6saZsiNoW2f9GIhg9Dondohg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/shell-quote": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
@@ -35728,42 +35638,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/tcp-port-used": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tcp-port-used/-/tcp-port-used-1.0.2.tgz",
-      "integrity": "sha512-l7ar8lLUD3XS1V2lfoJlCBaeoaWo/2xfYt81hM7VlvR4RrMVFqfmzfhLVk40hAb368uitje5gPtBRL1m/DGvLA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4.3.1",
-        "is2": "^2.0.6"
-      }
-    },
-    "node_modules/tcp-port-used/node_modules/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/tcp-port-used/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/telejson": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "@nx/eslint-plugin": "22.7.2",
     "@nx/jest": "22.7.2",
     "@nx/js": "22.7.2",
-    "@nx/node": "22.7.2",
     "@nx/storybook": "22.7.2",
     "@nx/workspace": "22.7.2",
     "@schematics/angular": "19.2.22",


### PR DESCRIPTION
## Summary
- Removed `@nx/node` from devDependencies as it is not used anywhere in the codebase
- No project.json files reference `@nx/node` executors
- The package was likely leftover from initial setup

## Test plan
- [x] Verified no `@nx/node` executors in use
- [x] npm install completed successfully
- [ ] CI passes