### PR TITLE
AAE-46219 Skip prod deps in cli:installDeps to unblock release

### DIFF
--- a/lib/cli/project.json
+++ b/lib/cli/project.json
@@ -8,7 +8,6 @@
     "build": {
       "executor": "nx:run-commands",
       "outputs": ["{workspaceRoot}/dist/libs/cli"],
-      "dependsOn": ["installDeps"],
       "options": {
         "command": "cd lib/cli && npm run dist"
       },

--- a/lib/cli/project.json
+++ b/lib/cli/project.json
@@ -8,6 +8,7 @@
     "build": {
       "executor": "nx:run-commands",
       "outputs": ["{workspaceRoot}/dist/libs/cli"],
+      "dependsOn": ["installDeps"],
       "options": {
         "command": "cd lib/cli && npm run dist"
       },
@@ -46,7 +47,7 @@
       "options": {
         "commands": [
           {
-            "command": "cd lib/cli && npm i"
+            "command": "cd lib/cli && npm i --omit=prod --no-audit --no-fund"
           }
         ]
       }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?**

ADF releases are failing with:

`npm error notarget No matching version found for @alfresco/js-api@>=9.6.0-<run-id>.`

The release workflow's `scripts/update-version.sh` rewrites `lib/cli/package.json`'s `@alfresco/js-api` dependency to a build-tagged version that is not yet published. Nx then runs `cli:installDeps` (`cd lib/cli && npm i`), which tries to resolve that version against the public registry and fails ETARGET. The cli build never runs and nothing gets published.

`cli:installDeps` is pulled in by `cli:copyToNodeModules.dependsOn: ["installDeps", "build"]`, so it runs regardless of whether `cli:build` lists it.

Issue Link: https://hyland.atlassian.net/browse/AAE-46219

**What is the new behaviour?**

`cli:installDeps` now runs `npm i --omit=prod --no-audit --no-fund`, which skips the runtime `dependencies` block entirely (including `@alfresco/js-api`). Only `devDependencies` are installed - that is everything `tsc` needs in `lib/cli/node_modules` (`typescript`, `@types/ejs`, `@types/node`).

This is safe because:
- `lib/cli/tsconfig.json` resolves `@alfresco/js-api` via a `paths` mapping to `../../dist/libs/js-api`, not from `node_modules`.
- `@types` are also read from the root via `typeRoots: ["node_modules/@types", "../../node_modules/@types"]`.
- `lib/cli/package.json` itself is unchanged, so the published `@alfresco/adf-cli` still declares its runtime deps and consumers' `npm install` pulls them in normally.

The `build -> installDeps` dependency edge is kept, which prevents the `tsc` / `npm install` race on `lib/cli/node_modules` that this PR previously triggered.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


**Other information**:

Related: #11880