### PR TITLE
AAE-46392 TypeError: editedValue.toLowerCase is not a function after clicking on user task

### DIFF
--- a/lib/core/src/lib/card-view/components/card-view-selectitem/card-view-selectitem.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view-selectitem/card-view-selectitem.component.spec.ts
@@ -276,7 +276,8 @@ describe('CardViewSelectItemComponent', () => {
         });
 
         it('should set initial value to autocompleteControl', () => {
-            component.ngOnChanges({});
+            fixture.componentRef.setInput('property', component.property);
+            fixture.componentRef.setInput('editable', true);
             fixture.detectChanges();
 
             expect(component.autocompleteControl.value).toBe('initial value');
@@ -390,6 +391,70 @@ describe('CardViewSelectItemComponent', () => {
             const input = testingUtils.getInputByCSS('.adf-property-value');
             expect(input).toBeTruthy();
             expect(input.getAttribute('aria-label')).toBe('Test Label');
+        });
+    });
+
+    describe('Numeric initial value', () => {
+        const priorityOptions = [
+            { key: 0, label: 'PROCESS_EDITOR.PRIORITIES.NONE' },
+            { key: 1, label: 'PROCESS_EDITOR.PRIORITIES.LOW' },
+            { key: 2, label: 'PROCESS_EDITOR.PRIORITIES.MEDIUM' },
+            { key: 3, label: 'PROCESS_EDITOR.PRIORITIES.HIGH' }
+        ];
+
+        const createNumericProperty = (config: {
+            autocompleteBased: boolean;
+            value: number;
+            label?: string;
+            displayNoneOption?: boolean;
+            options?: { key: number; label: string }[];
+        }) =>
+            new CardViewSelectItemModel({
+                label: config.label ?? 'Priority',
+                value: config.value,
+                key: 'priority',
+                editable: true,
+                autocompleteBased: config.autocompleteBased,
+                displayNoneOption: config.displayNoneOption,
+                options$: of(config.options ?? priorityOptions)
+            });
+
+        const applyInputs = (property: CardViewSelectItemModel<number>) => {
+            fixture.componentRef.setInput('property', property);
+            fixture.componentRef.setInput('editable', true);
+            fixture.detectChanges();
+        };
+
+        it('should not throw when autocompleteBased and initial value is numeric', fakeAsync(() => {
+            const property = createNumericProperty({
+                autocompleteBased: true,
+                value: 1,
+                options: [
+                    { key: 1, label: 'Option 1' },
+                    { key: 2, label: 'Option 2' }
+                ]
+            });
+            const filterOptionsSpy = spyOn<any>(component, 'filterOptions').and.callThrough();
+
+            applyInputs(property);
+            tick(50);
+
+            expect(filterOptionsSpy).toHaveBeenCalled();
+        }));
+
+        it('should not call filterOptions when autocompleteBased is false and initial value is numeric', () => {
+            const property = createNumericProperty({
+                autocompleteBased: false,
+                value: 0,
+                label: 'PROCESS_EDITOR.ELEMENT_PROPERTIES.PRIORITY',
+                displayNoneOption: false
+            });
+            const filterOptionsSpy = spyOn<any>(component, 'filterOptions');
+
+            applyInputs(property);
+
+            expect(component.property.value).toBe(0);
+            expect(filterOptionsSpy).not.toHaveBeenCalled();
         });
     });
 

--- a/lib/core/src/lib/card-view/components/card-view-selectitem/card-view-selectitem.component.ts
+++ b/lib/core/src/lib/card-view/components/card-view-selectitem/card-view-selectitem.component.ts
@@ -91,7 +91,7 @@ export class CardViewSelectItemComponent extends BaseCardView<CardViewSelectItem
             this.property.value = [];
         }
 
-        if (changes.property?.firstChange) {
+        if (changes.property?.firstChange && this.property.autocompleteBased) {
             this.autocompleteControl.valueChanges
                 .pipe(
                     filter((textInputValue) => textInputValue !== this.editedValue && textInputValue !== null && !Array.isArray(textInputValue)),
@@ -126,7 +126,10 @@ export class CardViewSelectItemComponent extends BaseCardView<CardViewSelectItem
             });
 
         this.list$ = this.getList();
-        this.autocompleteControl.setValue(this.property.value);
+
+        if (this.property.autocompleteBased) {
+            this.autocompleteControl.setValue(this.property.value);
+        }
     }
 
     onFilterInputChange(value: string) {
@@ -199,16 +202,21 @@ export class CardViewSelectItemComponent extends BaseCardView<CardViewSelectItem
     }
 
     private filterOptions() {
+        if (!this.property.autocompleteBased) {
+            return;
+        }
+
         this.getOptions()
             .pipe(
-                map((options) =>
-                    options.filter((option) => {
+                map((options) => {
+                    const filterValue = String(this.editedValue ?? '').toLowerCase();
+                    return options.filter((option) => {
                         const isSelected = this.property.multivalued
                             ? this.property.value.some((val) => val === option.key)
                             : this.property.value === option.key;
-                        return !isSelected && option.label.toLowerCase().includes(this.editedValue.toLowerCase());
-                    })
-                )
+                        return !isSelected && option.label.toLowerCase().includes(filterValue);
+                    });
+                })
             )
             .pipe(take(1))
             .subscribe((options: CardViewSelectItemOption<string | number>[]) => {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

**What is the current behaviour?** (You can also link to an open issue here)

Clicking a User Task with a numeric priority value in the properties panel throws `TypeError: editedValue.toLowerCase is not a function` because autocomplete filtering runs for mat-select properties.

Issue: https://hyland.atlassian.net/browse/AAE-46392

**What is the new behaviour?**

Autocomplete wiring and `filterOptions` run only when `autocompleteBased` is true. 
Additional change to avoid the problem in future, but not the actual fix: Filter text is coerced with `String()` so numeric values do not throw.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No

**Other information**: