### PR TITLE
AAE-46434 Fix disabled stying for people widgets

### DIFF
--- a/lib/core/src/lib/form/components/form-renderer.component.scss
+++ b/lib/core/src/lib/form/components/form-renderer.component.scss
@@ -312,6 +312,11 @@ form-field {
             filled-disabled-label-text-color: var(--mat-sys-on-surface)
         )
     );
+    @include mat.chips-overrides(
+        (
+            disabled-label-text-color: var(--mat-sys-on-surface)
+        )
+    );
 
     .mat-datepicker-toggle.mat-mdc-button-disabled {
         color: var(--mat-sys-on-surface-variant);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

**What is the current behaviour?** (You can also link to an open issue here)

Disabled styling for people widgets still lacks contrast.

https://hyland.atlassian.net/browse/AAE-46434

**What is the new behaviour?**

Fixed styling.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
