### PR TITLE
[ACS-11325] Add keyboard navigation and a11y support for adf-tree component

### DIFF
--- a/lib/content-services/src/lib/i18n/en.json
+++ b/lib/content-services/src/lib/i18n/en.json
@@ -627,6 +627,10 @@
     "LOAD-MORE-BUTTON": "Load more {{ name }}",
     "ACTIONS": {
       "TOOLTIP": "Open actions menu"
+    },
+    "ARIA": {
+      "SELECTED": "{{ name }} selected",
+      "DESELECTED": "{{ name }} deselected"
     }
   },
   "LIBRARY": {

--- a/lib/content-services/src/lib/tree/components/tree.component.html
+++ b/lib/content-services/src/lib/tree/components/tree.component.html
@@ -42,18 +42,22 @@
             <mat-tree-node
                 class="adf-tree-row"
                 [attr.data-automation-id]="'node_' + node.id"
+                [attr.aria-label]="node.nodeName"
+                [attr.aria-selected]="treeNodesSelection.isSelected(node)"
                 *matTreeNodeDef="let node"
                 matTreeNodePadding
                 [adf-context-menu]="contextMenuOptions"
                 [adf-context-menu-enabled]="!!contextMenuOptions"
                 (contextmenu)="contextMenuSource = node"
+                (keydown.enter)="expandCollapseNode(node); $event.stopPropagation()"
+                (keydown.space)="expandCollapseNode(node); $event.preventDefault(); $event.stopPropagation()"
             >
                 <div class="adf-tree-expand-collapse-container">
                     <button
                         *ngIf="node.hasChildren"
                         class="adf-tree-expand-collapse-button"
-                        (click)="expandCollapseNode(node)"
                         mat-icon-button
+                        matTreeNodeToggle
                     >
                         <mat-progress-spinner
                                 mode="indeterminate"
@@ -70,13 +74,17 @@
                                             [id]="node.id"
                                   [checked]="descendantsAllSelected(node)"
                                   [indeterminate]="descendantsPartiallySelected(node)"
-                                  (change)="onNodeSelected(node)"
+                                  (change)="onNodeSelected(node);"
+                                  (keydown.enter)="$event.stopPropagation()"
+                                  (keydown.space)="$event.stopPropagation()"
                                   data-automation-id="has-children-node-checkbox" />
                     <ng-template #noChildrenNodeCheckbox>
                         <mat-checkbox
                                 [id]="node.id"
                             [checked]="treeNodesSelection.isSelected(node)"
                             (change)="onNodeSelected(node)"
+                            (keydown.enter)="$event.stopPropagation()"
+                            (keydown.space)="$event.stopPropagation()"
                             data-automation-id="no-children-node-checkbox" />
                     </ng-template>
                 </ng-container>
@@ -84,9 +92,6 @@
                     <span
                         class="adf-tree-cell-value"
                         [class.adf-tree-clickable-cell-value]="node.hasChildren"
-                        tabindex="0"
-                        role="button"
-                        (keyup.enter)="expandCollapseNode(node)"
                         (click)="expandCollapseNode(node)">
                         {{ node.nodeName }}
                     </span>
@@ -95,7 +100,9 @@
                     <button mat-icon-button
                             [matMenuTriggerFor]="menu"
                             [attr.aria-label]="'ADF-TREE.ACTIONS.TOOLTIP' | translate"
-                            [attr.id]="'action_menu_right_' + node.id">
+                            [attr.id]="'action_menu_right_' + node.id"
+                            (keydown.enter)="$event.stopPropagation()"
+                            (keydown.space)="$event.stopPropagation()">
                         <mat-icon adf-icon="more_vert" />
                     </button>
                     <mat-menu #menu="matMenu">

--- a/lib/content-services/src/lib/tree/components/tree.component.html
+++ b/lib/content-services/src/lib/tree/components/tree.component.html
@@ -50,7 +50,7 @@
                 [adf-context-menu-enabled]="!!contextMenuOptions"
                 (contextmenu)="contextMenuSource = node"
                 (keydown.enter)="expandCollapseNode(node); $event.stopPropagation()"
-                (keydown.space)="expandCollapseNode(node); $event.preventDefault(); $event.stopPropagation()"
+                (keydown.space)="onNodeSelected(node); $event.preventDefault(); $event.stopPropagation()"
             >
                 <div class="adf-tree-expand-collapse-container">
                     <button

--- a/lib/content-services/src/lib/tree/components/tree.component.html
+++ b/lib/content-services/src/lib/tree/components/tree.component.html
@@ -49,6 +49,7 @@
                 [adf-context-menu]="contextMenuOptions"
                 [adf-context-menu-enabled]="!!contextMenuOptions"
                 (contextmenu)="contextMenuSource = node"
+                (click)="expandCollapseNode(node)"
                 (keydown.enter)="expandCollapseNode(node); $event.stopPropagation()"
                 (keydown.space)="onNodeSelected(node); $event.preventDefault(); $event.stopPropagation()"
             >
@@ -75,6 +76,7 @@
                                   [checked]="descendantsAllSelected(node)"
                                   [indeterminate]="descendantsPartiallySelected(node)"
                                   (change)="onNodeSelected(node);"
+                                  (click)="$event.stopPropagation()"
                                   (keydown.enter)="$event.stopPropagation()"
                                   (keydown.space)="$event.stopPropagation()"
                                   data-automation-id="has-children-node-checkbox" />
@@ -83,6 +85,7 @@
                                 [id]="node.id"
                             [checked]="treeNodesSelection.isSelected(node)"
                             (change)="onNodeSelected(node)"
+                            (click)="$event.stopPropagation()"
                             (keydown.enter)="$event.stopPropagation()"
                             (keydown.space)="$event.stopPropagation()"
                             data-automation-id="no-children-node-checkbox" />
@@ -91,8 +94,7 @@
                 <div class="adf-tree-cell">
                     <span
                         class="adf-tree-cell-value"
-                        [class.adf-tree-clickable-cell-value]="node.hasChildren"
-                        (click)="expandCollapseNode(node)">
+                        [class.adf-tree-clickable-cell-value]="node.hasChildren">
                         {{ node.nodeName }}
                     </span>
                 </div>
@@ -101,6 +103,7 @@
                             [matMenuTriggerFor]="menu"
                             [attr.aria-label]="'ADF-TREE.ACTIONS.TOOLTIP' | translate"
                             [attr.id]="'action_menu_right_' + node.id"
+                            (click)="$event.stopPropagation()"
                             (keydown.enter)="$event.stopPropagation()"
                             (keydown.space)="$event.stopPropagation()">
                         <mat-icon adf-icon="more_vert" />

--- a/lib/content-services/src/lib/tree/components/tree.component.scss
+++ b/lib/content-services/src/lib/tree/components/tree.component.scss
@@ -43,7 +43,8 @@ $tree-header-font-size: 12px !default;
     &:focus {
         background-color: var(--mat-sys-surface-container);
         outline-offset: -1px;
-        outline: 1px solid var(--mat-sys-secondary);
+
+        // outline: 1px solid var(--mat-sys-secondary);
     }
 
     .adf-tree-expand-collapse-button,

--- a/lib/content-services/src/lib/tree/components/tree.component.scss
+++ b/lib/content-services/src/lib/tree/components/tree.component.scss
@@ -43,8 +43,6 @@ $tree-header-font-size: 12px !default;
     &:focus {
         background-color: var(--mat-sys-surface-container);
         outline-offset: -1px;
-
-        // outline: 1px solid var(--mat-sys-secondary);
     }
 
     .adf-tree-expand-collapse-button,

--- a/lib/content-services/src/lib/tree/components/tree.component.spec.ts
+++ b/lib/content-services/src/lib/tree/components/tree.component.spec.ts
@@ -203,8 +203,9 @@ describe('TreeComponent', () => {
         component.treeService.treeNodes[0].isLoading = false;
         fixture.detectChanges();
         component.treeService.treeNodes = Array.from(treeNodesMock);
+        component.treeService.treeNodes[0].isLoading = false;
+        fixture.detectChanges();
         const expandSpy = spyOn(component.treeService, 'expandNode');
-        spyOn(component.treeService.treeControl, 'isExpanded').and.returnValue(false);
         clickExpandCollapseBtn(component.treeService.treeNodes[0].id);
         expect(expandSpy).toHaveBeenCalledWith(component.treeService.treeNodes[0], treeNodesMockExpanded);
     });
@@ -226,7 +227,6 @@ describe('TreeComponent', () => {
         component.treeService.treeNodes[0].isLoading = false;
         fixture.detectChanges();
         spyOn(component.treeService, 'expandNode');
-        spyOn(component.treeService.treeControl, 'isExpanded').and.returnValue(false);
         clickDisplayNameElement(component.treeService.treeNodes[0].id);
         expect(component.treeService.expandNode).toHaveBeenCalledWith(component.treeService.treeNodes[0], treeNodesMockExpanded);
     });

--- a/lib/content-services/src/lib/tree/components/tree.component.spec.ts
+++ b/lib/content-services/src/lib/tree/components/tree.component.spec.ts
@@ -181,6 +181,7 @@ describe('TreeComponent', () => {
         component.refreshTree();
         component.treeService.treeNodes[0].isLoading = false;
         fixture.detectChanges();
+        component.treeService.treeControl.expand(component.treeService.treeNodes[0]);
         const collapseSpy = spyOn(component.treeService, 'collapseNode');
         spyOn(component.treeService.treeControl, 'isExpanded').and.returnValue(true);
         clickExpandCollapseBtn(component.treeService.treeNodes[0].id);
@@ -201,15 +202,17 @@ describe('TreeComponent', () => {
         component.refreshTree();
         component.treeService.treeNodes[0].isLoading = false;
         fixture.detectChanges();
-        const collapseSpy = spyOn(component.treeService, 'expandNode');
+        component.treeService.treeNodes = Array.from(treeNodesMock);
+        const expandSpy = spyOn(component.treeService, 'expandNode');
         spyOn(component.treeService.treeControl, 'isExpanded').and.returnValue(false);
         clickExpandCollapseBtn(component.treeService.treeNodes[0].id);
-        expect(collapseSpy).toHaveBeenCalledWith(component.treeService.treeNodes[0], treeNodesMockExpanded);
+        expect(expandSpy).toHaveBeenCalledWith(component.treeService.treeNodes[0], treeNodesMockExpanded);
     });
 
     it('should call collapseNode on TreeService when collapsing node by clicking at node label and node has children', () => {
         component.refreshTree();
         fixture.detectChanges();
+        component.treeService.treeControl.expand(component.treeService.treeNodes[0]);
         spyOn(component.treeService, 'collapseNode');
         spyOn(component.treeService.treeControl, 'isExpanded').and.returnValue(true);
         clickDisplayNameElement(component.treeService.treeNodes[0].id);
@@ -218,6 +221,9 @@ describe('TreeComponent', () => {
 
     it('should call expandNode on TreeService when expanding node by clicking at node label and node has children', () => {
         component.refreshTree();
+        fixture.detectChanges();
+        component.treeService.treeNodes = Array.from(treeNodesMock);
+        component.treeService.treeNodes[0].isLoading = false;
         fixture.detectChanges();
         spyOn(component.treeService, 'expandNode');
         spyOn(component.treeService.treeControl, 'isExpanded').and.returnValue(false);
@@ -355,6 +361,49 @@ describe('TreeComponent', () => {
             });
             component.loadMoreSubnodes(component.treeService.treeNodes.find((node: TreeNode) => node.nodeType === TreeNodeType.LoadMoreNode));
             fixture.detectChanges();
+        });
+    });
+
+    describe('expansionModel.changed subscription', () => {
+        it('should load and expand node when expansionModel fires added event', () => {
+            fixture.detectChanges();
+            component.treeService.treeNodes = Array.from(treeNodesMock);
+            component.treeService.treeNodes[0].isLoading = false;
+            const expandSpy = spyOn(component.treeService, 'expandNode');
+            component.treeService.treeControl.expand(component.treeService.treeNodes[0]);
+            expect(expandSpy).toHaveBeenCalledWith(component.treeService.treeNodes[0], treeNodesMockExpanded);
+        });
+
+        it('should collapse node when expansionModel fires removed event', () => {
+            fixture.detectChanges();
+            component.treeService.treeControl.expand(component.treeService.treeNodes[0]);
+            const collapseSpy = spyOn(component.treeService, 'collapseNode');
+            component.treeService.treeControl.collapse(component.treeService.treeNodes[0]);
+            expect(collapseSpy).toHaveBeenCalledWith(component.treeService.treeNodes[0]);
+        });
+
+        it('should not expand node when expansionModel fires added event and node is already loading', () => {
+            fixture.detectChanges();
+            component.treeService.treeNodes[0].isLoading = true;
+            const expandSpy = spyOn(component.treeService, 'expandNode');
+            component.treeService.treeControl.expand(component.treeService.treeNodes[0]);
+            expect(expandSpy).not.toHaveBeenCalled();
+        });
+
+        it('should not collapse node when expansionModel fires removed event and node is loading', () => {
+            fixture.detectChanges();
+            component.treeService.treeControl.expand(component.treeService.treeNodes[0]);
+            component.treeService.treeNodes[0].isLoading = true;
+            const collapseSpy = spyOn(component.treeService, 'collapseNode');
+            component.treeService.treeControl.collapse(component.treeService.treeNodes[0]);
+            expect(collapseSpy).not.toHaveBeenCalled();
+        });
+
+        it('should not load children when node is expanded but children are already loaded', () => {
+            fixture.detectChanges();
+            const expandSpy = spyOn(component.treeService, 'expandNode');
+            component.treeService.treeControl.expand(component.treeService.treeNodes[0]);
+            expect(expandSpy).not.toHaveBeenCalled();
         });
     });
 

--- a/lib/content-services/src/lib/tree/components/tree.component.spec.ts
+++ b/lib/content-services/src/lib/tree/components/tree.component.spec.ts
@@ -30,6 +30,7 @@ import { DebugElement } from '@angular/core';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { MatCheckboxHarness } from '@angular/material/checkbox/testing';
+import { TranslateService } from '@ngx-translate/core';
 
 describe('TreeComponent', () => {
     let fixture: ComponentFixture<TreeComponent<TreeNode>>;
@@ -362,6 +363,26 @@ describe('TreeComponent', () => {
             });
             component.loadMoreSubnodes(component.treeService.treeNodes.find((node: TreeNode) => node.nodeType === TreeNodeType.LoadMoreNode));
             fixture.detectChanges();
+        });
+
+        describe('announcement', () => {
+            let translateSpy: jasmine.Spy<TranslateService['instant']>;
+
+            beforeEach(() => {
+                fixture.detectChanges();
+                translateSpy = spyOn(TestBed.inject(TranslateService), 'instant');
+            });
+
+            it('should use selected key when node is selected', () => {
+                component.onNodeSelected(component.treeService.treeNodes[0]);
+                expect(translateSpy).toHaveBeenCalledWith('ADF-TREE.ARIA.SELECTED', { name: 'testName1' });
+            });
+
+            it('should use deselected key when node is deselected', () => {
+                component.treeNodesSelection.select(component.treeService.treeNodes[0]);
+                component.onNodeSelected(component.treeService.treeNodes[0]);
+                expect(translateSpy).toHaveBeenCalledWith('ADF-TREE.ARIA.DESELECTED', { name: 'testName1' });
+            });
         });
     });
 

--- a/lib/content-services/src/lib/tree/components/tree.component.spec.ts
+++ b/lib/content-services/src/lib/tree/components/tree.component.spec.ts
@@ -19,6 +19,7 @@ import { TreeComponent } from './tree.component';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ContextMenuDirective, UnitTestingUtils, UserPreferencesService } from '@alfresco/adf-core';
 import { TreeNode, TreeNodeType } from '../models/tree-node.interface';
+import { TreeResponse } from '../models/tree-response.interface';
 import { singleNode, treeNodesChildrenMockExpanded, treeNodesMock, treeNodesMockExpanded, treeNodesNoChildrenMock } from '../mock/tree-node.mock';
 import { of, Subject } from 'rxjs';
 import { TreeService } from '../services/tree.service';
@@ -404,6 +405,23 @@ describe('TreeComponent', () => {
             const expandSpy = spyOn(component.treeService, 'expandNode');
             component.treeService.treeControl.expand(component.treeService.treeNodes[0]);
             expect(expandSpy).not.toHaveBeenCalled();
+        });
+
+        it('should reset isLoading and collapse node when getSubNodes fails during expansion', () => {
+            fixture.detectChanges();
+            component.treeService.treeNodes = Array.from(treeNodesMock);
+            component.treeService.treeNodes[0].isLoading = false;
+
+            const subject = new Subject<TreeResponse<TreeNode>>();
+            spyOn(component.treeService, 'getSubNodes').and.returnValue(subject.asObservable());
+
+            component.treeService.treeControl.expand(component.treeService.treeNodes[0]);
+            expect(component.treeService.treeNodes[0].isLoading).toBeTrue();
+
+            subject.error(new Error('error'));
+
+            expect(component.treeService.treeNodes[0].isLoading).toBeFalse();
+            expect(component.treeService.treeControl.isExpanded(component.treeService.treeNodes[0])).toBeFalse();
         });
     });
 

--- a/lib/content-services/src/lib/tree/components/tree.component.spec.ts
+++ b/lib/content-services/src/lib/tree/components/tree.component.spec.ts
@@ -42,7 +42,8 @@ describe('TreeComponent', () => {
     const composeNodeSelector = (nodeId: string) => `[data-automation-id="node_${nodeId}"]`;
     const getNode = (nodeId: string) => testingUtils.getByCSS(composeNodeSelector(nodeId));
 
-    const clickDisplayNameElement = (nodeId: string) => testingUtils.clickByCSS(`${composeNodeSelector(nodeId)} .adf-tree-cell-value`);
+    const clickDisplayNameElement = (nodeId: string) =>
+        testingUtils.getByCSS(`${composeNodeSelector(nodeId)} .adf-tree-cell-value`).nativeElement.click();
 
     const getDisplayNameValue = (nodeId: string) => testingUtils.getInnerTextByCSS(`${composeNodeSelector(nodeId)} .adf-tree-cell-value`);
 

--- a/lib/content-services/src/lib/tree/components/tree.component.ts
+++ b/lib/content-services/src/lib/tree/components/tree.component.ts
@@ -108,7 +108,6 @@ export class TreeComponent<T extends TreeNode> implements OnInit, OnDestroy {
     @ViewChildren(MatCheckbox)
     public nodeCheckboxes: QueryList<MatCheckbox>;
 
-    /** Reference to the underlying MatTree used to reinitialize keyboard focus after data reloads. */
     @ViewChild(MatTree)
     private readonly matTree: MatTree<T>;
 

--- a/lib/content-services/src/lib/tree/components/tree.component.ts
+++ b/lib/content-services/src/lib/tree/components/tree.component.ts
@@ -40,7 +40,8 @@ import { MatCheckbox, MatCheckboxModule } from '@angular/material/checkbox';
 import { TreeContextMenuResult } from '../models/tree-context-menu-result.interface';
 import { takeUntil, catchError } from 'rxjs/operators';
 import { CommonModule } from '@angular/common';
-import { TranslatePipe } from '@ngx-translate/core';
+import { TranslatePipe, TranslateService } from '@ngx-translate/core';
+import { LiveAnnouncer } from '@angular/cdk/a11y';
 import { MatTreeModule, MatTreeNode } from '@angular/material/tree';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatButtonModule } from '@angular/material/button';
@@ -69,6 +70,8 @@ export class TreeComponent<T extends TreeNode> implements OnInit, OnDestroy {
     treeService = inject<TreeService<T>>(TreeService);
     private readonly userPreferenceService = inject(UserPreferencesService);
     private readonly destroyRef = inject(DestroyRef);
+    private readonly translateService = inject(TranslateService);
+    private readonly liveAnnouncer = inject(LiveAnnouncer);
 
     /** TemplateRef to provide empty template when no nodes are loaded */
     @Input()
@@ -262,6 +265,9 @@ export class TreeComponent<T extends TreeNode> implements OnInit, OnDestroy {
      * @param node selected node
      */
     public onNodeSelected(node: T): void {
+        if (!this.selectableNodes) {
+            return;
+        }
         this.treeNodesSelection.toggle(node);
         const descendants: T[] = this.treeService.treeControl.getDescendants(node).filter(this.isRegularNode);
         if (descendants.length > 0) {
@@ -270,6 +276,13 @@ export class TreeComponent<T extends TreeNode> implements OnInit, OnDestroy {
                 : this.treeNodesSelection.deselect(...descendants);
         }
         this.checkParentsSelection(node);
+
+        void this.liveAnnouncer.announce(
+            this.translateService.instant(this.treeNodesSelection.isSelected(node) ? 'ADF-TREE.ARIA.SELECTED' : 'ADF-TREE.ARIA.DESELECTED', {
+                name: node.nodeName
+            }),
+            'assertive'
+        );
     }
 
     /**

--- a/lib/content-services/src/lib/tree/components/tree.component.ts
+++ b/lib/content-services/src/lib/tree/components/tree.component.ts
@@ -25,7 +25,6 @@ import {
     Output,
     QueryList,
     TemplateRef,
-    ViewChild,
     ViewChildren,
     ViewEncapsulation,
     inject
@@ -41,7 +40,7 @@ import { TreeContextMenuResult } from '../models/tree-context-menu-result.interf
 import { takeUntil } from 'rxjs/operators';
 import { CommonModule } from '@angular/common';
 import { TranslatePipe } from '@ngx-translate/core';
-import { MatTree, MatTreeModule } from '@angular/material/tree';
+import { MatTreeModule, MatTreeNode } from '@angular/material/tree';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatButtonModule } from '@angular/material/button';
 import { MatMenuModule } from '@angular/material/menu';
@@ -108,8 +107,8 @@ export class TreeComponent<T extends TreeNode> implements OnInit, OnDestroy {
     @ViewChildren(MatCheckbox)
     public nodeCheckboxes: QueryList<MatCheckbox>;
 
-    @ViewChild(MatTree)
-    private readonly matTree: MatTree<T>;
+    @ViewChildren(MatTreeNode)
+    private readonly matTreeNodes: QueryList<MatTreeNode<T>>;
 
     private readonly loadingRootSource = new BehaviorSubject<boolean>(false);
     private _contextMenuSource: T;
@@ -157,7 +156,7 @@ export class TreeComponent<T extends TreeNode> implements OnInit, OnDestroy {
     ngOnInit(): void {
         this.loadingRoot$ = this.loadingRootSource.asObservable();
         this.refreshTree(0, this.userPreferenceService.paginationSize);
-        this.treeNodesSelection.changed.subscribe((selectionChange: SelectionChange<T>) => {
+        this.treeNodesSelection.changed.pipe(takeUntil(this.destroy$)).subscribe((selectionChange: SelectionChange<T>) => {
             this.onTreeSelectionChange(selectionChange);
         });
         this.treeService.treeControl.expansionModel.changed.pipe(takeUntil(this.destroy$)).subscribe((change: SelectionChange<T>) => {
@@ -218,16 +217,7 @@ export class TreeComponent<T extends TreeNode> implements OnInit, OnDestroy {
             this.treeNodesSelection.deselect(...response.entries);
             this.paginationChanged.emit(response.pagination);
             this.loadingRootSource.next(false);
-            setTimeout(() => {
-                // eslint-disable-next-line no-underscore-dangle
-                const keyManager = (this.matTree as any)?._keyManager;
-                if (keyManager) {
-                    // eslint-disable-next-line no-underscore-dangle
-                    keyManager._hasInitialFocused = false;
-                    // eslint-disable-next-line no-underscore-dangle
-                    keyManager._initializeFocus();
-                }
-            });
+            setTimeout(() => this.matTreeNodes?.first?.makeFocusable());
         });
     }
 
@@ -316,15 +306,22 @@ export class TreeComponent<T extends TreeNode> implements OnInit, OnDestroy {
             return;
         }
         node.isLoading = true;
-        this.treeService.getSubNodes(node.id, 0, this.userPreferenceService.paginationSize).subscribe((response: TreeResponse<T>) => {
-            this.treeService.expandNode(node, response.entries);
-            if (this.treeNodesSelection.isSelected(node)) {
-                // timeout used to update nodeCheckboxes query list after new nodes are added so they can be selected
-                setTimeout(() => {
-                    this.treeNodesSelection.select(...response.entries);
-                });
-            }
-        });
+        this.treeService
+            .getSubNodes(node.id, 0, this.userPreferenceService.paginationSize)
+            .pipe(takeUntil(this.destroy$))
+            .subscribe((response: TreeResponse<T>) => {
+                if (!this.treeService.treeControl.isExpanded(node)) {
+                    node.isLoading = false;
+                    return;
+                }
+                this.treeService.expandNode(node, response.entries);
+                if (this.treeNodesSelection.isSelected(node)) {
+                    // timeout used to update nodeCheckboxes query list after new nodes are added so they can be selected
+                    setTimeout(() => {
+                        this.treeNodesSelection.select(...response.entries);
+                    });
+                }
+            });
     }
 
     private handleNodeCollapsed(node: T): void {

--- a/lib/content-services/src/lib/tree/components/tree.component.ts
+++ b/lib/content-services/src/lib/tree/components/tree.component.ts
@@ -25,6 +25,7 @@ import {
     Output,
     QueryList,
     TemplateRef,
+    ViewChild,
     ViewChildren,
     ViewEncapsulation,
     inject
@@ -40,7 +41,7 @@ import { TreeContextMenuResult } from '../models/tree-context-menu-result.interf
 import { takeUntil } from 'rxjs/operators';
 import { CommonModule } from '@angular/common';
 import { TranslatePipe } from '@ngx-translate/core';
-import { MatTreeModule } from '@angular/material/tree';
+import { MatTree, MatTreeModule } from '@angular/material/tree';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatButtonModule } from '@angular/material/button';
 import { MatMenuModule } from '@angular/material/menu';
@@ -107,10 +108,15 @@ export class TreeComponent<T extends TreeNode> implements OnInit, OnDestroy {
     @ViewChildren(MatCheckbox)
     public nodeCheckboxes: QueryList<MatCheckbox>;
 
+    /** Reference to the underlying MatTree used to reinitialize keyboard focus after data reloads. */
+    @ViewChild(MatTree)
+    private readonly matTree: MatTree<T>;
+
     private readonly loadingRootSource = new BehaviorSubject<boolean>(false);
     private _contextMenuSource: T;
     private _contextMenuOptions: any[];
     private readonly contextMenuOptionsChanged$ = new Subject<void>();
+    private readonly destroy$ = new Subject<void>();
     public loadingRoot$: Observable<boolean>;
     public treeNodesSelection = new SelectionModel<T>(true, [], true, (node1: T, node2: T) => node1.id === node2.id);
 
@@ -155,11 +161,17 @@ export class TreeComponent<T extends TreeNode> implements OnInit, OnDestroy {
         this.treeNodesSelection.changed.subscribe((selectionChange: SelectionChange<T>) => {
             this.onTreeSelectionChange(selectionChange);
         });
+        this.treeService.treeControl.expansionModel.changed.pipe(takeUntil(this.destroy$)).subscribe((change: SelectionChange<T>) => {
+            change.added.forEach((node: T) => this.handleNodeExpanded(node));
+            change.removed.forEach((node: T) => this.handleNodeCollapsed(node));
+        });
     }
 
     ngOnDestroy() {
         this.contextMenuOptionsChanged$.next();
         this.contextMenuOptionsChanged$.complete();
+        this.destroy$.next();
+        this.destroy$.complete();
     }
 
     /**
@@ -207,6 +219,16 @@ export class TreeComponent<T extends TreeNode> implements OnInit, OnDestroy {
             this.treeNodesSelection.deselect(...response.entries);
             this.paginationChanged.emit(response.pagination);
             this.loadingRootSource.next(false);
+            setTimeout(() => {
+                // eslint-disable-next-line no-underscore-dangle
+                const keyManager = (this.matTree as any)?._keyManager;
+                if (keyManager) {
+                    // eslint-disable-next-line no-underscore-dangle
+                    keyManager._hasInitialFocused = false;
+                    // eslint-disable-next-line no-underscore-dangle
+                    keyManager._initializeFocus();
+                }
+            });
         });
     }
 
@@ -217,21 +239,7 @@ export class TreeComponent<T extends TreeNode> implements OnInit, OnDestroy {
      */
     public expandCollapseNode(node: T): void {
         if (node.hasChildren && !node.isLoading) {
-            if (this.treeService.treeControl.isExpanded(node)) {
-                this.treeService.collapseNode(node);
-            } else {
-                node.isLoading = true;
-                this.treeService.getSubNodes(node.id, 0, this.userPreferenceService.paginationSize).subscribe((response: TreeResponse<T>) => {
-                    this.treeService.expandNode(node, response.entries);
-                    node.isLoading = false;
-                    if (this.treeNodesSelection.isSelected(node)) {
-                        //timeout used to update nodeCheckboxes query list after new nodes are added so they can be selected
-                        setTimeout(() => {
-                            this.treeNodesSelection.select(...response.entries);
-                        });
-                    }
-                });
-            }
+            this.treeService.treeControl.toggle(node);
         }
     }
 
@@ -299,6 +307,31 @@ export class TreeComponent<T extends TreeNode> implements OnInit, OnDestroy {
             !this.descendantsAllSelected(node) &&
             descendants.some((descendant: T) => this.treeNodesSelection.isSelected(descendant))
         );
+    }
+
+    private handleNodeExpanded(node: T): void {
+        if (!node.hasChildren || node.isLoading) {
+            return;
+        }
+        if (this.treeService.getChildren(node).length > 0) {
+            return;
+        }
+        node.isLoading = true;
+        this.treeService.getSubNodes(node.id, 0, this.userPreferenceService.paginationSize).subscribe((response: TreeResponse<T>) => {
+            this.treeService.expandNode(node, response.entries);
+            if (this.treeNodesSelection.isSelected(node)) {
+                // timeout used to update nodeCheckboxes query list after new nodes are added so they can be selected
+                setTimeout(() => {
+                    this.treeNodesSelection.select(...response.entries);
+                });
+            }
+        });
+    }
+
+    private handleNodeCollapsed(node: T): void {
+        if (!node.isLoading) {
+            this.treeService.collapseNode(node);
+        }
     }
 
     private checkParentsSelection(node: T): void {

--- a/lib/content-services/src/lib/tree/components/tree.component.ts
+++ b/lib/content-services/src/lib/tree/components/tree.component.ts
@@ -17,6 +17,7 @@
 
 import {
     Component,
+    DestroyRef,
     EventEmitter,
     HostBinding,
     Input,
@@ -29,7 +30,7 @@ import {
     ViewEncapsulation,
     inject
 } from '@angular/core';
-import { BehaviorSubject, merge, Observable, Subject } from 'rxjs';
+import { BehaviorSubject, merge, Observable, Subject, EMPTY } from 'rxjs';
 import { TreeNode, TreeNodeType } from '../models/tree-node.interface';
 import { TreeService } from '../services/tree.service';
 import { ContextMenuDirective, IconModule, PaginationModel, UserPreferencesService } from '@alfresco/adf-core';
@@ -37,13 +38,14 @@ import { SelectionChange, SelectionModel } from '@angular/cdk/collections';
 import { TreeResponse } from '../models/tree-response.interface';
 import { MatCheckbox, MatCheckboxModule } from '@angular/material/checkbox';
 import { TreeContextMenuResult } from '../models/tree-context-menu-result.interface';
-import { takeUntil } from 'rxjs/operators';
+import { takeUntil, catchError } from 'rxjs/operators';
 import { CommonModule } from '@angular/common';
 import { TranslatePipe } from '@ngx-translate/core';
 import { MatTreeModule, MatTreeNode } from '@angular/material/tree';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatButtonModule } from '@angular/material/button';
 import { MatMenuModule } from '@angular/material/menu';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
     selector: 'adf-tree',
@@ -66,6 +68,7 @@ import { MatMenuModule } from '@angular/material/menu';
 export class TreeComponent<T extends TreeNode> implements OnInit, OnDestroy {
     treeService = inject<TreeService<T>>(TreeService);
     private readonly userPreferenceService = inject(UserPreferencesService);
+    private readonly destroyRef = inject(DestroyRef);
 
     /** TemplateRef to provide empty template when no nodes are loaded */
     @Input()
@@ -114,7 +117,6 @@ export class TreeComponent<T extends TreeNode> implements OnInit, OnDestroy {
     private _contextMenuSource: T;
     private _contextMenuOptions: any[];
     private readonly contextMenuOptionsChanged$ = new Subject<void>();
-    private readonly destroy$ = new Subject<void>();
     public loadingRoot$: Observable<boolean>;
     public treeNodesSelection = new SelectionModel<T>(true, [], true, (node1: T, node2: T) => node1.id === node2.id);
 
@@ -156,10 +158,10 @@ export class TreeComponent<T extends TreeNode> implements OnInit, OnDestroy {
     ngOnInit(): void {
         this.loadingRoot$ = this.loadingRootSource.asObservable();
         this.refreshTree(0, this.userPreferenceService.paginationSize);
-        this.treeNodesSelection.changed.pipe(takeUntil(this.destroy$)).subscribe((selectionChange: SelectionChange<T>) => {
+        this.treeNodesSelection.changed.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((selectionChange: SelectionChange<T>) => {
             this.onTreeSelectionChange(selectionChange);
         });
-        this.treeService.treeControl.expansionModel.changed.pipe(takeUntil(this.destroy$)).subscribe((change: SelectionChange<T>) => {
+        this.treeService.treeControl.expansionModel.changed.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((change: SelectionChange<T>) => {
             change.added.forEach((node: T) => this.handleNodeExpanded(node));
             change.removed.forEach((node: T) => this.handleNodeCollapsed(node));
         });
@@ -168,8 +170,6 @@ export class TreeComponent<T extends TreeNode> implements OnInit, OnDestroy {
     ngOnDestroy() {
         this.contextMenuOptionsChanged$.next();
         this.contextMenuOptionsChanged$.complete();
-        this.destroy$.next();
-        this.destroy$.complete();
     }
 
     /**
@@ -299,16 +299,20 @@ export class TreeComponent<T extends TreeNode> implements OnInit, OnDestroy {
     }
 
     private handleNodeExpanded(node: T): void {
-        if (!node.hasChildren || node.isLoading) {
-            return;
-        }
-        if (this.treeService.getChildren(node).length > 0) {
+        if (!node.hasChildren || node.isLoading || this.treeService.getChildren(node).length > 0) {
             return;
         }
         node.isLoading = true;
         this.treeService
             .getSubNodes(node.id, 0, this.userPreferenceService.paginationSize)
-            .pipe(takeUntil(this.destroy$))
+            .pipe(
+                catchError(() => {
+                    node.isLoading = false;
+                    this.treeService.treeControl.collapse(node);
+                    return EMPTY;
+                }),
+                takeUntilDestroyed(this.destroyRef)
+            )
             .subscribe((response: TreeResponse<T>) => {
                 if (!this.treeService.treeControl.isExpanded(node)) {
                     node.isLoading = false;

--- a/lib/content-services/src/lib/tree/components/tree.component.ts
+++ b/lib/content-services/src/lib/tree/components/tree.component.ts
@@ -277,7 +277,7 @@ export class TreeComponent<T extends TreeNode> implements OnInit, OnDestroy {
         }
         this.checkParentsSelection(node);
 
-        void this.liveAnnouncer.announce(
+        this.liveAnnouncer.announce(
             this.translateService.instant(this.treeNodesSelection.isSelected(node) ? 'ADF-TREE.ARIA.SELECTED' : 'ADF-TREE.ARIA.DESELECTED', {
                 name: node.nodeName
             }),

--- a/lib/content-services/src/lib/tree/services/tree.service.spec.ts
+++ b/lib/content-services/src/lib/tree/services/tree.service.spec.ts
@@ -58,11 +58,21 @@ describe('TreeService', () => {
     it('should collapse node containing children', () => {
         const treeNodesMockExpandedCopy = Array.from(treeNodesMockExpanded);
         service.treeNodes = treeNodesMockExpandedCopy;
+        service.treeControl.expand(treeNodesMockExpandedCopy[0]);
         const nodesSourceSpy = spyOn(service.treeNodesSource, 'next');
         const treeControlCollapseSpy = spyOn(service.treeControl, 'collapse');
         service.collapseNode(treeNodesMockExpandedCopy[0]);
         expect(nodesSourceSpy).toHaveBeenCalled();
         expect(treeControlCollapseSpy).toHaveBeenCalledWith(treeNodesMockExpandedCopy[0]);
+        expect(service.treeNodes.length).toEqual(treeNodesMock.length);
+    });
+
+    it('should not call treeControl.collapse when node is not in expansionModel (re-entrant safety)', () => {
+        const treeNodesMockExpandedCopy = Array.from(treeNodesMockExpanded);
+        service.treeNodes = treeNodesMockExpandedCopy;
+        const treeControlCollapseSpy = spyOn(service.treeControl, 'collapse');
+        service.collapseNode(treeNodesMockExpandedCopy[0]);
+        expect(treeControlCollapseSpy).not.toHaveBeenCalled();
         expect(service.treeNodes.length).toEqual(treeNodesMock.length);
     });
 

--- a/lib/content-services/src/lib/tree/services/tree.service.ts
+++ b/lib/content-services/src/lib/tree/services/tree.service.ts
@@ -70,7 +70,9 @@ export abstract class TreeService<T extends TreeNode> extends DataSource<T> {
      */
     public collapseNode(nodeToCollapse: T): void {
         if (nodeToCollapse?.hasChildren) {
-            this.treeControl.collapse(nodeToCollapse);
+            if (this.treeControl.isExpanded(nodeToCollapse)) {
+                this.treeControl.collapse(nodeToCollapse);
+            }
             const children: T[] = this.treeNodes.filter((node: T) => nodeToCollapse.id === node.parentId);
             children.forEach((child: T) => {
                 this.collapseInnerNode(child);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [X] Other... Please describe: a11y


**What is the current behaviour?** (You can also link to an open issue here)

https://hyland.atlassian.net/browse/ACS-11325

**What is the new behaviour?**

Full keyboard navigation support: Tab to focus, ArrowUp/Down to navigate, ArrowRight/Left to expand/collapse, Enter/Space to toggle

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
