### PR TITLE
AAE-46943 Sign Crowdin translation PR commits with GPG

### DIFF
--- a/.github/workflows/pull-from-crowdin.yml
+++ b/.github/workflows/pull-from-crowdin.yml
@@ -28,6 +28,9 @@ jobs:
           localization_branch_name: automated-translations-update
           pull_request_title: "GH auto: Automated Update of Translations from Crowdin"
           pull_request_base_branch_name: develop
+          github_user_name: ${{ vars.SERVICE_ACCOUNT_USERNAME }}
+          github_user_email: ${{ vars.SERVICE_ACCOUNT_EMAIL }}
+          gpg_private_key: ${{ secrets.SERVICE_ACCOUNT_SIGNING_KEY }}
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
           CROWDIN_TOKEN: ${{ secrets.CROWDIN_TRANSLATIONS_TOKEN }}

--- a/.github/workflows/pull-from-crowdin.yml
+++ b/.github/workflows/pull-from-crowdin.yml
@@ -9,6 +9,8 @@ on:
         required: true
       CROWDIN_TRANSLATIONS_TOKEN:
         required: true
+      HXP_GIT_COMMIT_SIGNING_PRIVATE_KEY:
+        required: true
 jobs:
   pull-from-crowdin:
     runs-on: ubuntu-latest
@@ -28,9 +30,9 @@ jobs:
           localization_branch_name: automated-translations-update
           pull_request_title: "GH auto: Automated Update of Translations from Crowdin"
           pull_request_base_branch_name: develop
-          github_user_name: ${{ vars.SERVICE_ACCOUNT_USERNAME }}
-          github_user_email: ${{ vars.SERVICE_ACCOUNT_EMAIL }}
-          gpg_private_key: ${{ secrets.SERVICE_ACCOUNT_SIGNING_KEY }}
+          github_user_name: ${{ vars.HXP_GIT_USERNAME }}
+          github_user_email: ${{ vars.HXP_GIT_EMAIL }}
+          gpg_private_key: ${{ secrets.HXP_GIT_COMMIT_SIGNING_PRIVATE_KEY }}
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
           CROWDIN_TOKEN: ${{ secrets.CROWDIN_TRANSLATIONS_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,6 +173,7 @@ jobs:
     secrets:
       BOT_GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
       CROWDIN_TRANSLATIONS_TOKEN: ${{ secrets.CROWDIN_TRANSLATIONS_TOKEN }}
+      HXP_GIT_COMMIT_SIGNING_PRIVATE_KEY: ${{ secrets.HXP_GIT_COMMIT_SIGNING_PRIVATE_KEY }}
 
   finalize:
     if: always()


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [x] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

**What is the current behaviour?**

Crowdin opens automated PRs (branch `automated-translations-update`) via the `pull-from-crowdin` workflow. With "Require signed commits" enforced, these unsigned commits are rejected. JIRA: https://hyland.atlassian.net/browse/AAE-46943

**What is the new behaviour?**

The Crowdin action now signs commits using the service-account GPG key (`gpg_private_key`) and commits as the service account (`github_user_name`/`github_user_email` from repo/org variables), so commits verify and pass branch protection.

Requires `SERVICE_ACCOUNT_SIGNING_KEY` secret and `SERVICE_ACCOUNT_USERNAME` / `SERVICE_ACCOUNT_EMAIL` variables to be set (being added at org level separately).

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No

**Other information**:
CI/workflow configuration change only. Validation: run `pull-from-crowdin` via workflow_dispatch after secrets land and confirm the resulting commit shows "Verified".