### PR TITLE
[ACS-11974] [ACA] Upload new version button is no longer disabled when clicked once

### DIFF
--- a/lib/content-services/src/lib/upload/components/upload-button.component.scss
+++ b/lib/content-services/src/lib/upload/components/upload-button.component.scss
@@ -17,4 +17,11 @@
         box-shadow: var(--mat-sys-level2);
         border-radius: 4px;
     }
+
+    &-upload-button-file-container input:disabled + .adf-upload-button-label {
+        cursor: not-allowed;
+        color: var(--mat-sys-outline);
+        box-shadow: none;
+        background-color: var(--mat-sys-surface);
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://hyland.atlassian.net/browse/ACS-11974

**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
