### PR TITLE
AAE-47042 Add auto grow support to multiline text widget

### DIFF
--- a/lib/core/src/lib/form/components/widgets/multiline-text/multiline-text.widget.html
+++ b/lib/core/src/lib/form/components/widgets/multiline-text/multiline-text.widget.html
@@ -2,6 +2,7 @@
     class="adf-multiline-text-widget {{ field.className }}"
     [class.adf-invalid]="!field.isValid && isTouched()"
     [class.adf-readonly]="field.readOnly"
+    [class.adf-multiline-text-widget--capped]="field.params?.autoGrow === false"
 >
     <mat-form-field
         floatPlaceholder="never"

--- a/lib/core/src/lib/form/components/widgets/multiline-text/multiline-text.widget.scss
+++ b/lib/core/src/lib/form/components/widgets/multiline-text/multiline-text.widget.scss
@@ -8,6 +8,12 @@
         .adf-label {
             top: 20px;
         }
+
+        &--capped textarea.adf-input {
+            max-height: 72px;
+            overflow-y: auto;
+            resize: vertical;
+        }
     }
 
     &-multiline-word-counter:has(.adf-multiline-word-counter-value) {

--- a/lib/core/src/lib/form/components/widgets/multiline-text/multiline-text.widget.spec.ts
+++ b/lib/core/src/lib/form/components/widgets/multiline-text/multiline-text.widget.spec.ts
@@ -79,6 +79,37 @@ describe('MultilineTextWidgetComponentComponent', () => {
         });
     });
 
+    describe('auto grow', () => {
+        it('should not apply the capped modifier when autoGrow is not set (default unbounded)', () => {
+            widget.field = new FormFieldModel(new FormModel({ taskId: '<id>' }), {
+                type: FormFieldTypes.MULTILINE_TEXT
+            });
+            fixture.detectChanges();
+
+            expect(testingUtils.getByCSS('.adf-multiline-text-widget--capped')).toBeFalsy();
+        });
+
+        it('should not apply the capped modifier when autoGrow is true', () => {
+            widget.field = new FormFieldModel(new FormModel({ taskId: '<id>' }), {
+                type: FormFieldTypes.MULTILINE_TEXT,
+                params: { autoGrow: true }
+            });
+            fixture.detectChanges();
+
+            expect(testingUtils.getByCSS('.adf-multiline-text-widget--capped')).toBeFalsy();
+        });
+
+        it('should apply the capped modifier when autoGrow is false', () => {
+            widget.field = new FormFieldModel(new FormModel({ taskId: '<id>' }), {
+                type: FormFieldTypes.MULTILINE_TEXT,
+                params: { autoGrow: false }
+            });
+            fixture.detectChanges();
+
+            expect(testingUtils.getByCSS('.adf-multiline-text-widget--capped')).toBeTruthy();
+        });
+    });
+
     describe('when is required', () => {
         beforeEach(() => {
             widget.field = new FormFieldModel(new FormModel({ taskId: '<id>' }), {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our guidelines
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

**What is the current behaviour?**

The multiline text widget always renders unbounded height. The 72px height cap was applied downstream via a global stylesheet override in the consuming app, so the behaviour was inconsistent across the Studio modeler preview and the Workspace form runtime.

**What is the new behaviour?**

The widget now caps its height (max-height 72px, scroll, vertical resize) when its field is explicitly configured with `params.autoGrow === false`. When `autoGrow` is `true` or unset, the textarea grows unbounded (existing default). The capping logic lives in the widget itself, so all consumers behave consistently.

- New modifier class `adf-multiline-text-widget--capped` bound to `field.params?.autoGrow === false`.
- Cap styles moved into the widget SCSS.
- Unit tests cover unset (unbounded), `true` (unbounded), and `false` (capped).

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No