### PR TITLE
[ACS-11928] convert ReadStream to Blob before appending to FormData

### DIFF
--- a/lib/js-api/src/fetchHttpClient.ts
+++ b/lib/js-api/src/fetchHttpClient.ts
@@ -367,11 +367,11 @@ export class FetchHttpClient implements HttpClient {
             const normalizedParams = FetchHttpClient.normalizeParams(formParams);
             const formData = new FormData();
             for (const [key, value] of Object.entries(normalizedParams)) {
-                const { blob, filename } = FetchHttpClient.toFormDataValue(value);
+                const { data, filename } = FetchHttpClient.toFormDataValue(value);
                 if (filename) {
-                    formData.append(key, blob, filename);
+                    formData.append(key, data, filename);
                 } else {
-                    formData.append(key, blob);
+                    formData.append(key, data);
                 }
             }
             return formData;
@@ -530,23 +530,23 @@ export class FetchHttpClient implements HttpClient {
         return false;
     }
 
-    private static toFormDataValue(value: any): { blob: any; filename?: string } {
+    private static toFormDataValue(value: any): { data: any; filename?: string } {
         if (value && typeof value === 'object' && value.path && typeof value.path === 'string' && !(value instanceof Blob)) {
             try {
                 const nodeFs = Function('return require("fs")')();
                 const nodePath = Function('return require("path")')();
                 const buffer = nodeFs.readFileSync(value.path);
                 const filename: string = nodePath.basename(value.path);
-                return { blob: new Blob([buffer]), filename };
+                return { data: new Blob([buffer]), filename };
             } catch {
-                return { blob: value };
+                return { data: value };
             }
         }
 
         if (typeof Buffer === 'function' && value instanceof Buffer) {
-            return { blob: new Blob([value]) };
+            return { data: new Blob([value]) };
         }
 
-        return { blob: value };
+        return { data: value };
     }
 }

--- a/lib/js-api/src/fetchHttpClient.ts
+++ b/lib/js-api/src/fetchHttpClient.ts
@@ -367,7 +367,12 @@ export class FetchHttpClient implements HttpClient {
             const normalizedParams = FetchHttpClient.normalizeParams(formParams);
             const formData = new FormData();
             for (const [key, value] of Object.entries(normalizedParams)) {
-                formData.append(key, value as any);
+                const { blob, filename } = FetchHttpClient.toFormDataValue(value);
+                if (filename) {
+                    formData.append(key, blob, filename);
+                } else {
+                    formData.append(key, blob);
+                }
             }
             return formData;
         }
@@ -523,5 +528,29 @@ export class FetchHttpClient implements HttpClient {
             return true;
         }
         return false;
+    }
+
+    private static toFormDataValue(value: any): { blob: any; filename?: string } {
+        // ReadStream (has .path) — read into a Blob so native FormData can serialize it
+        if (value && typeof value === 'object' && value.path && typeof value.path === 'string' && !(value instanceof Blob)) {
+            try {
+                /* eslint-disable @typescript-eslint/no-require-imports */
+                const nodeFs = Function('return require("fs")')();
+                const nodePath = Function('return require("path")')();
+                /* eslint-enable @typescript-eslint/no-require-imports */
+                const buffer = nodeFs.readFileSync(value.path);
+                const filename: string = nodePath.basename(value.path);
+                return { blob: new Blob([buffer]), filename };
+            } catch {
+                return { blob: value };
+            }
+        }
+
+        // Buffer — wrap in a Blob
+        if (typeof Buffer === 'function' && value instanceof Buffer) {
+            return { blob: new Blob([value]) };
+        }
+
+        return { blob: value };
     }
 }

--- a/lib/js-api/src/fetchHttpClient.ts
+++ b/lib/js-api/src/fetchHttpClient.ts
@@ -531,13 +531,10 @@ export class FetchHttpClient implements HttpClient {
     }
 
     private static toFormDataValue(value: any): { blob: any; filename?: string } {
-        // ReadStream (has .path) — read into a Blob so native FormData can serialize it
         if (value && typeof value === 'object' && value.path && typeof value.path === 'string' && !(value instanceof Blob)) {
             try {
-                /* eslint-disable @typescript-eslint/no-require-imports */
                 const nodeFs = Function('return require("fs")')();
                 const nodePath = Function('return require("path")')();
-                /* eslint-enable @typescript-eslint/no-require-imports */
                 const buffer = nodeFs.readFileSync(value.path);
                 const filename: string = nodePath.basename(value.path);
                 return { blob: new Blob([buffer]), filename };
@@ -546,7 +543,6 @@ export class FetchHttpClient implements HttpClient {
             }
         }
 
-        // Buffer — wrap in a Blob
         if (typeof Buffer === 'function' && value instanceof Buffer) {
             return { blob: new Blob([value]) };
         }

--- a/lib/js-api/test/fetchHttpClient.spec.ts
+++ b/lib/js-api/test/fetchHttpClient.spec.ts
@@ -19,6 +19,8 @@
 import { FetchHttpClient } from '../src/fetchHttpClient';
 import { EventEmitter } from 'eventemitter3';
 import { getGlobalMockAgent, mockHost } from './mockObjects/base.mock';
+import * as fs from 'fs';
+import * as path from 'path';
 
 describe('FetchHttpClient', () => {
     const host = 'https://127.0.0.1:8080';
@@ -1095,6 +1097,69 @@ describe('FetchHttpClient', () => {
                 { total: 100, loaded: 30, percent: 30 },
                 { total: 100, loaded: 100, percent: 100 }
             ]);
+        });
+    });
+
+    describe('#toFormDataValue', () => {
+        const toFormDataValue = (FetchHttpClient as any).toFormDataValue;
+        let originalFunction: typeof global.Function;
+
+        beforeEach(() => {
+            originalFunction = global.Function;
+            global.Function = ((code: string) => {
+                if (code.includes('require')) {
+                    return () => require(code.match(/"([^"]+)"/)?.[1] || '');
+                }
+                return originalFunction(code);
+            }) as any;
+        });
+
+        afterEach(() => {
+            global.Function = originalFunction;
+        });
+
+        it('should pass through Blob values unchanged', () => {
+            const blob = new Blob(['content'], { type: 'text/plain' });
+            const result = toFormDataValue(blob);
+            expect(result).toEqual({ data: blob });
+        });
+
+        it('should pass through string values unchanged', () => {
+            const result = toFormDataValue('text-value');
+            expect(result).toEqual({ data: 'text-value' });
+        });
+
+        it('should convert Buffer to Blob', () => {
+            const buffer = Buffer.from('file content');
+            const result = toFormDataValue(buffer);
+            expect(result.data).toBeInstanceOf(Blob);
+            expect(result.filename).toBeUndefined();
+        });
+
+        it('should read file from path for objects with .path property', () => {
+            const tmpFile = path.join(__dirname, '__test_toFormDataValue__.txt');
+            fs.writeFileSync(tmpFile, 'test content');
+
+            try {
+                const result = toFormDataValue({ path: tmpFile });
+                expect(result.data).toBeInstanceOf(Blob);
+                expect(result.filename).toBe('__test_toFormDataValue__.txt');
+            } finally {
+                fs.unlinkSync(tmpFile);
+            }
+        });
+
+        it('should fall back to raw value if file read fails', () => {
+            const value = { path: '/non/existent/file.txt' };
+            const result = toFormDataValue(value);
+            expect(result).toEqual({ data: value });
+        });
+
+        it('should not treat Blob with path property as file object', () => {
+            const blob = new Blob(['content']);
+            (blob as any).path = '/some/path.txt';
+            const result = toFormDataValue(blob);
+            expect(result).toEqual({ data: blob });
         });
     });
 });

--- a/lib/js-api/test/fetchHttpClient.spec.ts
+++ b/lib/js-api/test/fetchHttpClient.spec.ts
@@ -1107,7 +1107,7 @@ describe('FetchHttpClient', () => {
             originalFunction = global.Function;
             global.Function = ((code: string) => {
                 if (code.includes('require')) {
-                    return () => require(code.match(/"([^"]+)"/)?.[1] || '');
+                    return () => require(/"([^"]+)"/.exec(code)?.[1] || '');
                 }
                 return originalFunction(code);
             }) as FunctionConstructor;

--- a/lib/js-api/test/fetchHttpClient.spec.ts
+++ b/lib/js-api/test/fetchHttpClient.spec.ts
@@ -1100,8 +1100,7 @@ describe('FetchHttpClient', () => {
         });
     });
 
-    describe('#toFormDataValue', () => {
-        const toFormDataValue = (FetchHttpClient as any).toFormDataValue;
+    describe('multipart form data upload', () => {
         let originalFunction: typeof global.Function;
 
         beforeEach(() => {
@@ -1118,48 +1117,105 @@ describe('FetchHttpClient', () => {
             global.Function = originalFunction;
         });
 
-        it('should pass through Blob values unchanged', () => {
+        it('should send Blob when form param is a Blob', async () => {
+            mockHost(host).post('/api/upload').reply(200, { success: true });
+
             const blob = new Blob(['content'], { type: 'text/plain' });
-            const result = toFormDataValue(blob);
-            expect(result).toEqual({ data: blob });
+            const result = await client.post(
+                host + '/api/upload',
+                {
+                    httpMethod: 'POST',
+                    queryParams: {},
+                    headerParams: {},
+                    formParams: { file: blob },
+                    bodyParam: null,
+                    contentType: 'multipart/form-data',
+                    accept: 'application/json',
+                    responseType: null,
+                    returnType: null
+                },
+                defaultSecurityOptions,
+                emitters
+            );
+
+            expect(result).toEqual({ success: true });
         });
 
-        it('should pass through string values unchanged', () => {
-            const result = toFormDataValue('text-value');
-            expect(result).toEqual({ data: 'text-value' });
-        });
+        it('should convert Buffer to Blob when form param is a Buffer', async () => {
+            mockHost(host).post('/api/upload').reply(200, { success: true });
 
-        it('should convert Buffer to Blob', () => {
             const buffer = Buffer.from('file content');
-            const result = toFormDataValue(buffer);
-            expect(result.data).toBeInstanceOf(Blob);
-            expect(result.filename).toBeUndefined();
+            const result = await client.post(
+                host + '/api/upload',
+                {
+                    httpMethod: 'POST',
+                    queryParams: {},
+                    headerParams: {},
+                    formParams: { file: buffer },
+                    bodyParam: null,
+                    contentType: 'multipart/form-data',
+                    accept: 'application/json',
+                    responseType: null,
+                    returnType: null
+                },
+                defaultSecurityOptions,
+                emitters
+            );
+
+            expect(result).toEqual({ success: true });
         });
 
-        it('should read file from path for objects with .path property', () => {
-            const tmpFile = path.join(__dirname, '__test_toFormDataValue__.txt');
+        it('should read file and send as Blob when form param has .path property', async () => {
+            mockHost(host).post('/api/upload').reply(200, { success: true });
+
+            const tmpFile = path.join(__dirname, '__test_upload__.txt');
             fs.writeFileSync(tmpFile, 'test content');
 
             try {
-                const result = toFormDataValue({ path: tmpFile });
-                expect(result.data).toBeInstanceOf(Blob);
-                expect(result.filename).toBe('__test_toFormDataValue__.txt');
+                const result = await client.post(
+                    host + '/api/upload',
+                    {
+                        httpMethod: 'POST',
+                        queryParams: {},
+                        headerParams: {},
+                        formParams: { file: { path: tmpFile } },
+                        bodyParam: null,
+                        contentType: 'multipart/form-data',
+                        accept: 'application/json',
+                        responseType: null,
+                        returnType: null
+                    },
+                    defaultSecurityOptions,
+                    emitters
+                );
+
+                expect(result).toEqual({ success: true });
             } finally {
                 fs.unlinkSync(tmpFile);
             }
         });
 
-        it('should fall back to raw value if file read fails', () => {
-            const value = { path: '/non/existent/file.txt' };
-            const result = toFormDataValue(value);
-            expect(result).toEqual({ data: value });
-        });
+        it('should pass through string values when form params are strings', async () => {
+            mockHost(host).post('/api/upload').reply(200, { success: true });
 
-        it('should not treat Blob with path property as file object', () => {
-            const blob = new Blob(['content']);
-            (blob as any).path = '/some/path.txt';
-            const result = toFormDataValue(blob);
-            expect(result).toEqual({ data: blob });
+            const result = await client.post(
+                host + '/api/upload',
+                {
+                    httpMethod: 'POST',
+                    queryParams: {},
+                    headerParams: {},
+                    formParams: { name: 'test-file', description: 'a test' },
+                    bodyParam: null,
+                    contentType: 'multipart/form-data',
+                    accept: 'application/json',
+                    responseType: null,
+                    returnType: null
+                },
+                defaultSecurityOptions,
+                emitters
+            );
+
+            expect(result).toEqual({ success: true });
         });
     });
 });

--- a/lib/js-api/test/fetchHttpClient.spec.ts
+++ b/lib/js-api/test/fetchHttpClient.spec.ts
@@ -1110,7 +1110,7 @@ describe('FetchHttpClient', () => {
                     return () => require(code.match(/"([^"]+)"/)?.[1] || '');
                 }
                 return originalFunction(code);
-            }) as any;
+            }) as FunctionConstructor;
         });
 
         afterEach(() => {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/ACS-11928


**What is the new behaviour?**
Before, the raw ReadStream was appended directly to FormData (which Node 24 can't serialize); now the file is read into a Blob first.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
