### PR TITLE
[ACS-12020] Updated init-aps passwords with secret ones

### DIFF
--- a/lib/cli/scripts/init-aps-env.ts
+++ b/lib/cli/scripts/init-aps-env.ts
@@ -333,14 +333,13 @@ async function createDefaultTenant(tenantName: string) {
  */
 async function createUsers(tenantId: number, user: any) {
     logger.info(`Create user ${user.email} on tenant: ${tenantId}`);
-    const passwordCamelCase = 'Password';
     const userJson = new UserRepresentation({
         email: user.email,
         firstName: user.firstName,
         lastName: user.lastName,
         status: 'active',
         type: 'enterprise',
-        password: passwordCamelCase,
+        password: E2E_USER_PASSWORD,
         tenantId
     });
 

--- a/lib/cli/scripts/init-aps-env.ts
+++ b/lib/cli/scripts/init-aps-env.ts
@@ -30,7 +30,10 @@ import { parseArgs } from 'node:util';
 import { spawnSync } from 'node:child_process';
 import { createReadStream } from 'node:fs';
 import * as path from 'path';
+import { config } from 'dotenv';
 import { logger } from './logger';
+
+config({ path: path.resolve(__dirname, '../../../.env') });
 
 interface InitApsEnvArgs {
     host?: string;
@@ -45,6 +48,7 @@ const TENANT_DEFAULT_ID = 1;
 const TENANT_DEFAULT_NAME = 'default';
 const CONTENT_DEFAULT_NAME = 'adw-content';
 const ACTIVITI_APPS = require('./resources').ACTIVITI_APPS;
+const E2E_USER_PASSWORD = process.env.HR_USER_PASSWORD;
 
 let alfrescoJsApi: AlfrescoApi;
 
@@ -152,7 +156,7 @@ Options:
                 }
                 for (const user of users) {
                     logger.info('Impersonate user: ' + user.username);
-                    await alfrescoJsApi.login(user.username, 'password');
+                    await alfrescoJsApi.login(user.username, E2E_USER_PASSWORD);
                     await authorizeUserToContentRepo(opts, user);
 
                     if (user.username.includes('hruser')) {
@@ -182,7 +186,7 @@ Options:
  */
 async function ensureE2eApplicationDeployed(): Promise<boolean> {
     try {
-        await alfrescoJsApi.login('hruser', 'password');
+        await alfrescoJsApi.login('hruser', E2E_USER_PASSWORD);
         const runtimeAppDefinitionsApi = new RuntimeAppDefinitionsApi(alfrescoJsApi);
         const availableApps = await runtimeAppDefinitionsApi.getAppDefinitions();
         const e2eApp = availableApps.data?.filter((app) => app.name?.includes('e2e-Application'));
@@ -605,7 +609,7 @@ async function authorizeUserToContentRepo(opts: InitApsEnvArgs, user: any) {
 async function authorizeUserToContentWithBasic(opts: InitApsEnvArgs, username: string, contentId: string) {
     logger.info(`Authorize ${username} on contentId: ${contentId} in basic auth`);
     try {
-        const body = { username, password: 'password' };
+        const body = { username, password: E2E_USER_PASSWORD };
         const content = await alfrescoJsApi.oauth2Auth.callCustomApi(
             `${opts.host}/activiti-app/api/enterprise/integration/alfresco/${contentId}/account`,
             'POST',
@@ -673,3 +677,5 @@ function formatError(error: any): string {
 function wait(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
 }
+
+main();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/ACS-12020


**What is the new behaviour?**
Updated init-aps passwords with secret ones instead of using the hardcoded ones


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
