### PR TITLE
[ACS-11973] Fix: context menu disappears during bulk upload

### DIFF
--- a/docs/content-services/services/document-list.service.md
+++ b/docs/content-services/services/document-list.service.md
@@ -2,7 +2,7 @@
 Title: Document List service
 Added: v2.0.0
 Status: Active
-Last reviewed: 2019-01-16
+Last reviewed: 2026-06-16
 ---
 
 # Document List Service
@@ -21,10 +21,11 @@ import { DocumentListService } from '@alfresco/adf-core';
 
 ### Events
 
-| Name              | Description                                     |
-|-------------------|-------------------------------------------------|
-| `reload$`         | Emits when the document list should be reloaded |
-| `resetSelection$` | Emits when the selection should be reset        |
+| Name              | Description                                                                                  |
+|-------------------|----------------------------------------------------------------------------------------------|
+| `reload$`         | Emits when the document list should be reloaded.                                             |
+| `resetSelection$` | Emits when the selection should be reset.                                                    |
+| `reloadSilently$` | Emits when the document list should be reloaded **without** resetting the current selection. |
 
 ### Methods
 
@@ -32,6 +33,8 @@ import { DocumentListService } from '@alfresco/adf-core';
     Reloads the document list.
 - **resetSelection**(): `void`<br/>
     Resets the selection.
+- **reloadSilently**(): `void`<br/>
+    Reloads the document list **without** resetting the current selection.
 -   **copyNode**(nodeId: `string`, targetParentId: `string`): `Observable<NodeEntry>`<br/>
     Copy a node to destination node
     -   _nodeId:_ `string`  - The id of the node to be copied

--- a/lib/content-services/src/lib/document-list/components/document-list.component.spec.ts
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.spec.ts
@@ -175,6 +175,16 @@ describe('DocumentList', () => {
         expect(documentList.resetSelection).not.toHaveBeenCalled();
     });
 
+    it('should call reloadWithoutResettingSelection and NOT resetSelection when reloadSilently$ is emitted', () => {
+        spyOn(documentList, 'reloadWithoutResettingSelection').and.callThrough();
+        spyOn(documentList, 'resetSelection').and.callThrough();
+
+        documentListService.reloadSilently();
+
+        expect(documentList.reloadWithoutResettingSelection).toHaveBeenCalled();
+        expect(documentList.resetSelection).not.toHaveBeenCalled();
+    });
+
     describe('presets', () => {
         const validatePreset = (keys: string[]) => {
             const columns = documentList.data.getColumns();

--- a/lib/content-services/src/lib/document-list/components/document-list.component.ts
+++ b/lib/content-services/src/lib/document-list/components/document-list.component.ts
@@ -561,6 +561,10 @@ export class DocumentListComponent extends DataTableSchema implements OnInit, On
             this.reload();
         });
 
+        this.documentListService.reloadSilently$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+            this.reloadWithoutResettingSelection();
+        });
+
         this.documentListService.resetSelection$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
             this.resetSelection();
         });

--- a/lib/content-services/src/lib/document-list/services/document-list.service.spec.ts
+++ b/lib/content-services/src/lib/document-list/services/document-list.service.spec.ts
@@ -93,6 +93,13 @@ describe('DocumentListService', () => {
         service.reload();
     });
 
+    it('should emit reloadSilently$ when reloadSilently is called', (done) => {
+        service.reloadSilently$.subscribe(() => {
+            done();
+        });
+        service.reloadSilently();
+    });
+
     it('should return the folder info', fakeAsync(() => {
         spyOn(service.nodes, 'listNodeChildren').and.returnValue(Promise.resolve(fakeFolder as any));
 

--- a/lib/content-services/src/lib/document-list/services/document-list.service.ts
+++ b/lib/content-services/src/lib/document-list/services/document-list.service.ts
@@ -41,9 +41,13 @@ export class DocumentListService implements DocumentListLoader {
 
     private readonly _reload = new Subject<void>();
     private readonly _resetSelection = new Subject<void>();
+    private readonly _reloadSilently = new Subject<void>();
 
     /** Gets an observable that emits when the document list should be reloaded. */
     reload$ = this._reload.asObservable();
+
+    /** Gets an observable that emits when the document list should be reloaded without resetting the current selection. */
+    reloadSilently$ = this._reloadSilently.asObservable();
 
     /** Gets an observable that emits when the selection should be reset. */
     resetSelection$ = this._resetSelection.asObservable();
@@ -51,6 +55,11 @@ export class DocumentListService implements DocumentListLoader {
     /** Reloads the document list. */
     reload() {
         this._reload.next();
+    }
+
+    /** Reloads the document list without resetting the current selection. */
+    reloadSilently() {
+        this._reloadSilently.next();
     }
 
     /** Resets the selection. */


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [X] Tests for the changes have been added (for bug fixes / features)
> - [X] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [X] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://hyland.atlassian.net/browse/ACS-11973

**What is the new behaviour?**

Added reloadSilently() method and reloadSilently$ observable. Triggers a data refresh without emitting on reload$, so consumers can reload the document list without side effects on selection state

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
