### PR TITLE
AAE-47577 Form Spinner persists outside of Automate Form

### DIFF
--- a/lib/process-services-cloud/src/lib/form/services/spinner/form-cloud-spinner.service.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/services/spinner/form-cloud-spinner.service.spec.ts
@@ -96,4 +96,18 @@ describe('FormCloudSpinnerService', () => {
         const spinners = await rootLoader.getAllHarnesses(MatProgressSpinnerHarness);
         expect(spinners.length).toBe(1);
     });
+
+    it('should dispose the spinner overlay when the host destroyRef fires without a hide event', async () => {
+        spinnerService.initSpinnerHandling(destroyRef);
+        formService.toggleFormSpinner.next(showSpinnerEvent);
+        fixture.detectChanges();
+
+        expect(await rootLoader.hasHarness(MatProgressSpinnerHarness)).toBeTrue();
+
+        fixture.destroy();
+
+        const overlayContainer = document.querySelector('.cdk-overlay-container');
+        expect(overlayContainer?.querySelector('.cdk-overlay-pane')).toBeNull();
+        expect(overlayContainer?.querySelector('.cdk-overlay-backdrop')).toBeNull();
+    });
 });

--- a/lib/process-services-cloud/src/lib/form/services/spinner/form-cloud-spinner.service.ts
+++ b/lib/process-services-cloud/src/lib/form/services/spinner/form-cloud-spinner.service.ts
@@ -40,9 +40,15 @@ export class FormCloudSpinnerService {
                 const componentRef = this.overlayRef.attach(userProfilePortal);
                 componentRef.instance.message = event.payload.message;
             } else if (event?.payload.showSpinner === false) {
-                this.overlayRef?.detach();
-                this.overlayRef = null;
+                this.disposeOverlay();
             }
         });
+
+        destroyRef.onDestroy(() => this.disposeOverlay());
+    }
+
+    private disposeOverlay(): void {
+        this.overlayRef?.dispose();
+        this.overlayRef = null;
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

A form uses a form rule to display a spinner while a process call is running, and the spinner should hide when the process call completes. When the process call does not complete and the user clicks the browser back button to return to the main Workspace page, the spinner remains displayed over Workspace instead of being cleared.

https://hyland.atlassian.net/browse/AAE-47577

**What is the new behaviour?**

The overlay is torn down when the form-cloud component is destroyed

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
