### PR TITLE
fix create dialog name field hint

### DIFF
--- a/lib/content-services/src/lib/dialogs/folder/folder.dialog.html
+++ b/lib/content-services/src/lib/dialogs/folder/folder.dialog.html
@@ -14,16 +14,22 @@
                 [formControlName]="'name'"
                 adf-auto-focus
             />
+            @if (form.controls['name'].dirty && form.controls['name'].invalid) {
+                <mat-error>
+                    @if (form.controls['name'].hasError('required')) {
+                        <span>
+                            {{ 'CORE.FOLDER_DIALOG.FOLDER_NAME.ERRORS.REQUIRED' | translate }}
+                        </span>
+                    }
 
-            <mat-hint *ngIf="form.controls['name'].dirty">
-                <span *ngIf="form.controls['name'].errors?.required">
-                    {{ 'CORE.FOLDER_DIALOG.FOLDER_NAME.ERRORS.REQUIRED' | translate }}
-                </span>
+                    @else if (form.controls['name'].hasError('message')) {
+                        <span>
+                            {{ form.controls['name'].errors?.message | translate }}
+                        </span>
+                    }
+                </mat-error>
+            }
 
-                <span *ngIf="!form.controls['name'].errors?.required && form.controls['name'].errors?.message">
-                    {{ form.controls['name'].errors?.message | translate }}
-                </span>
-            </mat-hint>
         </mat-form-field>
 
         <mat-form-field class="adf-full-width adf-folder-dialog-form-field">


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Mat Hint is rendered when field is dirty, even when there is no text inside the hint.


**What is the new behaviour?**
Mat Hint is replaced with Mat Error and displayed only when the field is actually invalid


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
