### PR TITLE
[ACS-12098] firefox headless race condition viewer fix

### DIFF
--- a/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.spec.ts
+++ b/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.spec.ts
@@ -32,7 +32,8 @@ import {
     ViewerMoreActionsComponent,
     ViewerToolbarActionsComponent,
     NoopAuthModule,
-    NoopTranslateModule
+    NoopTranslateModule,
+    UnitTestingUtils
 } from '@alfresco/adf-core';
 import { NodesApiService } from '../../common/services/nodes-api.service';
 import { UploadService } from '../../common/services/upload.service';
@@ -177,6 +178,7 @@ describe('AlfrescoViewerComponent', () => {
     let renditionService: RenditionService;
     let viewUtilService: ViewUtilService;
     let nodeActionsService: NodeActionsService;
+    let testingUtils: UnitTestingUtils;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -197,6 +199,7 @@ describe('AlfrescoViewerComponent', () => {
         fixture = TestBed.createComponent(AlfrescoViewerComponent);
         element = fixture.nativeElement;
         component = fixture.componentInstance;
+        testingUtils = new UnitTestingUtils(fixture.debugElement);
         uploadService = TestBed.inject(UploadService);
         nodesApiService = TestBed.inject(NodesApiService);
         dialog = TestBed.inject(MatDialog);
@@ -398,12 +401,16 @@ describe('AlfrescoViewerComponent', () => {
         component.nodeId = 'id1';
         component.showViewer = true;
         component.versionId = null;
-        component.ngOnChanges(getSimpleChanges('id1'));
 
-        await fixture.whenStable();
+        await fixture.ngZone.run(async () => {
+            component.ngOnChanges(getSimpleChanges('id1'));
+            await fixture.whenStable();
+        });
+        fixture.detectChanges();
 
-        expect(component.fileName).toBe('file1.pdf');
-        expect(component.blobFileContent).toBe(mockBlob);
+        const viewer = testingUtils.getByDirective(ViewerComponent).componentInstance as ViewerComponent<unknown>;
+        expect(viewer.fileName).toBe('file1.pdf');
+        expect(viewer.blobFile).toBe(mockBlob);
     });
 
     it('should change display name every time node`s version changes', fakeAsync(() => {
@@ -1080,13 +1087,17 @@ describe('AlfrescoViewerComponent', () => {
 
             component.nodeId = 'node-1';
             component.showViewer = true;
-            component.ngOnChanges(getSimpleChanges('node-1'));
 
-            await fixture.whenStable();
+            await fixture.ngZone.run(async () => {
+                component.ngOnChanges(getSimpleChanges('node-1'));
+                await fixture.whenStable();
+            });
+            fixture.detectChanges();
 
-            expect(component.blobFileContent).toBe(mockBlob);
-            expect(component.urlFileContent).toBeNull();
-            expect(component.mimeType).toBe('application/pdf');
+            const viewer = testingUtils.getByDirective(ViewerComponent).componentInstance as ViewerComponent<unknown>;
+            expect(viewer.blobFile).toBe(mockBlob);
+            expect(viewer.urlFile).toBeFalsy();
+            expect(viewer.mimeType).toBe('application/pdf');
         });
 
         it('should fall back to URL-based viewing when PDF blob fetch fails', async () => {
@@ -1108,13 +1119,17 @@ describe('AlfrescoViewerComponent', () => {
 
             component.nodeId = 'node-1';
             component.showViewer = true;
-            component.ngOnChanges(getSimpleChanges('node-1'));
 
-            await fixture.whenStable();
+            await fixture.ngZone.run(async () => {
+                component.ngOnChanges(getSimpleChanges('node-1'));
+                await fixture.whenStable();
+            });
+            fixture.detectChanges();
 
-            expect(component.blobFileContent).toBeNull();
-            expect(component.urlFileContent).not.toBeNull();
-            expect(component.mimeType).toBe('application/pdf');
+            const viewer = testingUtils.getByDirective(ViewerComponent).componentInstance as ViewerComponent<unknown>;
+            expect(viewer.blobFile).toBeFalsy();
+            expect(viewer.urlFile).toBeTruthy();
+            expect(viewer.mimeType).toBe('application/pdf');
         });
 
         it('should fall back to URL-based viewing when PDF fetch returns non-ok response', async () => {
@@ -1137,13 +1152,17 @@ describe('AlfrescoViewerComponent', () => {
 
             component.nodeId = 'node-1';
             component.showViewer = true;
-            component.ngOnChanges(getSimpleChanges('node-1'));
 
-            await fixture.whenStable();
+            await fixture.ngZone.run(async () => {
+                component.ngOnChanges(getSimpleChanges('node-1'));
+                await fixture.whenStable();
+            });
+            fixture.detectChanges();
 
-            expect(component.blobFileContent).toBeNull();
-            expect(component.urlFileContent).not.toBeNull();
-            expect(component.mimeType).toBe('application/pdf');
+            const viewer = testingUtils.getByDirective(ViewerComponent).componentInstance as ViewerComponent<unknown>;
+            expect(viewer.blobFile).toBeFalsy();
+            expect(viewer.urlFile).toBeTruthy();
+            expect(viewer.mimeType).toBe('application/pdf');
         });
 
         it('should not expose intermediate null state during node setup', async () => {
@@ -1161,13 +1180,17 @@ describe('AlfrescoViewerComponent', () => {
 
             component.nodeId = 'node-1';
             component.showViewer = true;
-            component.ngOnChanges(getSimpleChanges('node-1'));
 
-            await fixture.whenStable();
+            await fixture.ngZone.run(async () => {
+                component.ngOnChanges(getSimpleChanges('node-1'));
+                await fixture.whenStable();
+            });
+            fixture.detectChanges();
 
-            expect(component.blobFileContent).toBe(mockBlob);
-            expect(component.urlFileContent).toBeNull();
-            expect(component.fileName).toBe('test.pdf');
+            const viewer = testingUtils.getByDirective(ViewerComponent).componentInstance as ViewerComponent<unknown>;
+            expect(viewer.blobFile).toBe(mockBlob);
+            expect(viewer.urlFile).toBeFalsy();
+            expect(viewer.fileName).toBe('test.pdf');
         });
     });
 });

--- a/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.spec.ts
+++ b/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.spec.ts
@@ -1063,4 +1063,111 @@ describe('AlfrescoViewerComponent', () => {
             });
         });
     });
+
+    describe('PDF blob fetch and atomic state assignment', () => {
+        it('should assign blobFileContent and null urlFileContent when PDF blob fetch succeeds', async () => {
+            const mockBlob = new Blob(['pdf content'], { type: 'application/pdf' });
+            const mockResponse = { ok: true, blob: () => Promise.resolve(mockBlob) } as Response;
+            spyOn(window, 'fetch').and.returnValue(Promise.resolve(mockResponse));
+
+            spyOn(component.nodesApi, 'getNode').and.returnValue(
+                Promise.resolve(
+                    new NodeEntry({
+                        entry: new Node({ name: 'test.pdf', id: 'node-1', content: new ContentInfo({ mimeType: 'application/pdf' }) })
+                    })
+                )
+            );
+
+            component.nodeId = 'node-1';
+            component.showViewer = true;
+            component.ngOnChanges(getSimpleChanges('node-1'));
+
+            await fixture.whenStable();
+
+            expect(component.blobFileContent).toBe(mockBlob);
+            expect(component.urlFileContent).toBeNull();
+            expect(component.mimeType).toBe('application/pdf');
+        });
+
+        it('should fall back to URL-based viewing when PDF blob fetch fails', async () => {
+            spyOn(window, 'fetch').and.returnValue(Promise.reject(new Error('Network error')));
+            spyOn(component.contentApi, 'getContentUrl').and.returnValue('/content/url');
+
+            spyOn(component.nodesApi, 'getNode').and.returnValue(
+                Promise.resolve(
+                    new NodeEntry({
+                        entry: new Node({
+                            name: 'test.pdf',
+                            id: 'node-1',
+                            content: new ContentInfo({ mimeType: 'application/pdf' }),
+                            properties: { 'cm:versionLabel': '1.0' }
+                        })
+                    })
+                )
+            );
+
+            component.nodeId = 'node-1';
+            component.showViewer = true;
+            component.ngOnChanges(getSimpleChanges('node-1'));
+
+            await fixture.whenStable();
+
+            expect(component.blobFileContent).toBeNull();
+            expect(component.urlFileContent).not.toBeNull();
+            expect(component.mimeType).toBe('application/pdf');
+        });
+
+        it('should fall back to URL-based viewing when PDF fetch returns non-ok response', async () => {
+            const mockResponse = { ok: false, status: 403 } as Response;
+            spyOn(window, 'fetch').and.returnValue(Promise.resolve(mockResponse));
+            spyOn(component.contentApi, 'getContentUrl').and.returnValue('/content/url');
+
+            spyOn(component.nodesApi, 'getNode').and.returnValue(
+                Promise.resolve(
+                    new NodeEntry({
+                        entry: new Node({
+                            name: 'test.pdf',
+                            id: 'node-1',
+                            content: new ContentInfo({ mimeType: 'application/pdf' }),
+                            properties: { 'cm:versionLabel': '1.0' }
+                        })
+                    })
+                )
+            );
+
+            component.nodeId = 'node-1';
+            component.showViewer = true;
+            component.ngOnChanges(getSimpleChanges('node-1'));
+
+            await fixture.whenStable();
+
+            expect(component.blobFileContent).toBeNull();
+            expect(component.urlFileContent).not.toBeNull();
+            expect(component.mimeType).toBe('application/pdf');
+        });
+
+        it('should not expose intermediate null state during node setup', async () => {
+            const mockBlob = new Blob(['pdf content'], { type: 'application/pdf' });
+            const mockResponse = { ok: true, blob: () => Promise.resolve(mockBlob) } as Response;
+            spyOn(window, 'fetch').and.returnValue(Promise.resolve(mockResponse));
+
+            spyOn(component.nodesApi, 'getNode').and.returnValue(
+                Promise.resolve(
+                    new NodeEntry({
+                        entry: new Node({ name: 'test.pdf', id: 'node-1', content: new ContentInfo({ mimeType: 'application/pdf' }) })
+                    })
+                )
+            );
+
+            component.nodeId = 'node-1';
+            component.showViewer = true;
+            component.ngOnChanges(getSimpleChanges('node-1'));
+
+            await fixture.whenStable();
+
+            expect(component.blobFileContent).toBe(mockBlob);
+            expect(component.urlFileContent).toBeNull();
+            expect(component.fileName).toBe('test.pdf');
+        });
+    });
 });

--- a/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.ts
+++ b/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.ts
@@ -366,7 +366,6 @@ export class AlfrescoViewerComponent implements OnChanges, OnInit {
             }
         }
 
-        // from propagating to child components during Zone.js-triggered change detection
         this.mimeType = mimeType;
         this.nodeMimeType = nodeMimeType;
         this.fileName = versionData ? versionData.name : nodeData.name;

--- a/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.ts
+++ b/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.ts
@@ -275,9 +275,9 @@ export class AlfrescoViewerComponent implements OnChanges, OnInit {
     private async onNodeUpdated(node: Node) {
         if (node && node.id === this.nodeId) {
             this.generateCacheBusterNumber();
-            this.blobFileContent = null;
 
             await this.setUpNodeFile(node);
+            this.cdr.detectChanges();
         }
     }
 
@@ -300,7 +300,6 @@ export class AlfrescoViewerComponent implements OnChanges, OnInit {
 
     private async setupNode() {
         try {
-            this.blobFileContent = null;
             this.nodeEntry = await this.nodesApi.getNode(this.nodeId, { include: ['allowableOperations'] });
             if (this.versionId) {
                 this.versionEntry = await this.versionsApi.getVersion(this.nodeId, this.versionId);
@@ -318,6 +317,7 @@ export class AlfrescoViewerComponent implements OnChanges, OnInit {
         this.canEditNode = this.contentService.hasAllowableOperations(nodeData, 'update');
         let mimeType: string;
         let urlFileContent: string;
+        let blobContent: Blob = null;
 
         if (versionData?.content) {
             mimeType = versionData.content.mimeType;
@@ -368,16 +368,19 @@ export class AlfrescoViewerComponent implements OnChanges, OnInit {
                     throw new Error(`HTTP error! status: ${response.status}`);
                 }
 
-                this.blobFileContent = await response.blob();
+                blobContent = await response.blob();
                 urlFileContent = null;
             } catch (error) {
                 console.error('[ADF DEBUG] Failed to fetch PDF as blob, falling back to URL', error);
             }
         }
 
+        // Assign all bound properties atomically to prevent intermediate states
+        // from propagating to child components during Zone.js-triggered change detection
         this.mimeType = mimeType;
         this.nodeMimeType = nodeMimeType;
         this.fileName = versionData ? versionData.name : nodeData.name;
+        this.blobFileContent = blobContent;
         this.urlFileContent = urlFileContent ? urlFileContent + (this.cacheBusterNumber ? '&' + this.cacheBusterNumber : '') : null;
         this.sidebarRightTemplateContext.node = nodeData;
         this.sidebarLeftTemplateContext.node = nodeData;

--- a/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.ts
+++ b/lib/content-services/src/lib/viewer/components/alfresco-viewer.component.ts
@@ -352,30 +352,20 @@ export class AlfrescoViewerComponent implements OnChanges, OnInit {
         } else if (viewerType === 'media') {
             this.tracks = await this.renditionService.generateMediaTracksRendition(this.nodeId);
         } else if (viewerType === 'pdf') {
-            try {
-                const contentUrl = versionData
-                    ? this.contentApi.getVersionContentUrl(this.nodeId, versionData.id)
-                    : this.contentApi.getContentUrl(this.nodeId);
+            const contentUrl = versionData
+                ? this.contentApi.getVersionContentUrl(this.nodeId, versionData.id)
+                : this.contentApi.getContentUrl(this.nodeId);
 
-                // Fetch the content as Blob using fetch API with credentials
-                const response = await fetch(contentUrl, {
-                    credentials: 'include',
-                    headers: {
-                        'Cache-Control': 'no-cache'
-                    }
-                });
-                if (!response.ok) {
-                    throw new Error(`HTTP error! status: ${response.status}`);
-                }
+            const blob = await fetch(contentUrl, { credentials: 'include', headers: { 'Cache-Control': 'no-cache' } })
+                .then((response) => (response.ok ? response.blob() : null))
+                .catch(() => null);
 
-                blobContent = await response.blob();
+            if (blob) {
+                blobContent = blob;
                 urlFileContent = null;
-            } catch (error) {
-                console.error('[ADF DEBUG] Failed to fetch PDF as blob, falling back to URL', error);
             }
         }
 
-        // Assign all bound properties atomically to prevent intermediate states
         // from propagating to child components during Zone.js-triggered change detection
         this.mimeType = mimeType;
         this.nodeMimeType = nodeMimeType;

--- a/lib/core/src/lib/viewer/components/viewer-render/viewer-render.component.spec.ts
+++ b/lib/core/src/lib/viewer/components/viewer-render/viewer-render.component.spec.ts
@@ -539,7 +539,7 @@ describe('ViewerComponent', () => {
             fixture.detectChanges();
 
             expect(getMainLoader()).toBeNull();
-            expect(component.viewerType).toBe('media');
+            expect(testingUtils.getByDirective(MediaPlayerComponent)).not.toBeNull();
         });
 
         it('should display spinner when viewerType is pdf', () => {
@@ -553,7 +553,7 @@ describe('ViewerComponent', () => {
             imgViewer.triggerEventHandler('pagesLoaded', null);
             fixture.detectChanges();
 
-            expect(component.viewerType).toBe('pdf');
+            expect(testingUtils.getByDirective(MockPdfViewerComponent)).not.toBeNull();
         });
 
         it('should show spinner until renderer calls markAsLoaded', () => {
@@ -570,7 +570,7 @@ describe('ViewerComponent', () => {
             fixture.detectChanges();
 
             expect(getMainLoader()).toBeNull();
-            expect(component.viewerType).toBe('image');
+            expect(testingUtils.getByDirective(ImgViewerComponent)).not.toBeNull();
             expect(component.markAsLoaded).toHaveBeenCalled();
         });
 
@@ -582,7 +582,7 @@ describe('ViewerComponent', () => {
             component.onUnsupportedFile();
             fixture.detectChanges();
             expect(getMainLoader()).toBeNull();
-            expect(component.viewerType).toBe('unknown');
+            expect(testingUtils.getByCSS('adf-viewer-unknown-format')).not.toBeNull();
         });
     });
 
@@ -590,46 +590,52 @@ describe('ViewerComponent', () => {
         it('should resolve viewerType from blob type when blob has valid MIME type', () => {
             component.blobFile = new Blob(['content'], { type: 'application/pdf' });
             component.ngOnChanges();
+            fixture.detectChanges();
 
-            expect(component.viewerType).toBe('pdf');
+            expect(testingUtils.getByDirective(MockPdfViewerComponent)).not.toBeNull();
         });
 
         it('should fall back to mimeType input when blob type resolves to unknown', () => {
             component.blobFile = new Blob(['content'], { type: '' });
             component.mimeType = 'application/pdf';
             component.ngOnChanges();
+            fixture.detectChanges();
 
-            expect(component.viewerType).toBe('pdf');
+            expect(testingUtils.getByDirective(MockPdfViewerComponent)).not.toBeNull();
         });
 
         it('should remain unknown when both blob type and mimeType input are empty', () => {
             component.blobFile = new Blob(['content'], { type: '' });
             component.mimeType = '';
             component.ngOnChanges();
+            fixture.detectChanges();
 
-            expect(component.viewerType).toBe('unknown');
+            expect(testingUtils.getByCSS('adf-viewer-unknown-format')).not.toBeNull();
         });
 
         it('should strip MIME type parameters (e.g. charset) from blob type before resolving viewer type', () => {
             component.blobFile = new Blob(['content'], { type: 'application/pdf;charset=utf-8' });
             component.ngOnChanges();
+            fixture.detectChanges();
 
-            expect(component.viewerType).toBe('pdf');
+            expect(testingUtils.getByDirective(MockPdfViewerComponent)).not.toBeNull();
         });
 
         it('should strip MIME type parameters from mimeType input during fallback', () => {
             component.blobFile = new Blob(['content'], { type: '' });
             component.mimeType = 'application/pdf;charset=utf-8';
             component.ngOnChanges();
+            fixture.detectChanges();
 
-            expect(component.viewerType).toBe('pdf');
+            expect(testingUtils.getByDirective(MockPdfViewerComponent)).not.toBeNull();
         });
 
         it('should resolve image viewer from blob type with parameters', () => {
             component.blobFile = new Blob(['content'], { type: 'image/png; charset=binary' });
             component.ngOnChanges();
+            fixture.detectChanges();
 
-            expect(component.viewerType).toBe('image');
+            expect(testingUtils.getByDirective(ImgViewerComponent)).not.toBeNull();
         });
 
         it('should emit extensionChange with blob MIME type when available', () => {

--- a/lib/core/src/lib/viewer/components/viewer-render/viewer-render.component.spec.ts
+++ b/lib/core/src/lib/viewer/components/viewer-render/viewer-render.component.spec.ts
@@ -585,4 +585,68 @@ describe('ViewerComponent', () => {
             expect(component.viewerType).toBe('unknown');
         });
     });
+
+    describe('Blob MIME type handling', () => {
+        it('should resolve viewerType from blob type when blob has valid MIME type', () => {
+            component.blobFile = new Blob(['content'], { type: 'application/pdf' });
+            component.ngOnChanges();
+
+            expect(component.viewerType).toBe('pdf');
+        });
+
+        it('should fall back to mimeType input when blob type resolves to unknown', () => {
+            component.blobFile = new Blob(['content'], { type: '' });
+            component.mimeType = 'application/pdf';
+            component.ngOnChanges();
+
+            expect(component.viewerType).toBe('pdf');
+        });
+
+        it('should remain unknown when both blob type and mimeType input are empty', () => {
+            component.blobFile = new Blob(['content'], { type: '' });
+            component.mimeType = '';
+            component.ngOnChanges();
+
+            expect(component.viewerType).toBe('unknown');
+        });
+
+        it('should strip MIME type parameters (e.g. charset) from blob type before resolving viewer type', () => {
+            component.blobFile = new Blob(['content'], { type: 'application/pdf;charset=utf-8' });
+            component.ngOnChanges();
+
+            expect(component.viewerType).toBe('pdf');
+        });
+
+        it('should strip MIME type parameters from mimeType input during fallback', () => {
+            component.blobFile = new Blob(['content'], { type: '' });
+            component.mimeType = 'application/pdf;charset=utf-8';
+            component.ngOnChanges();
+
+            expect(component.viewerType).toBe('pdf');
+        });
+
+        it('should resolve image viewer from blob type with parameters', () => {
+            component.blobFile = new Blob(['content'], { type: 'image/png; charset=binary' });
+            component.ngOnChanges();
+
+            expect(component.viewerType).toBe('image');
+        });
+
+        it('should emit extensionChange with blob MIME type when available', () => {
+            spyOn(component.extensionChange, 'emit');
+            component.blobFile = new Blob(['content'], { type: 'application/pdf' });
+            component.ngOnChanges();
+
+            expect(component.extensionChange.emit).toHaveBeenCalledWith('application/pdf');
+        });
+
+        it('should emit extensionChange with mimeType input when blob type is empty', () => {
+            spyOn(component.extensionChange, 'emit');
+            component.blobFile = new Blob(['content'], { type: '' });
+            component.mimeType = 'application/pdf';
+            component.ngOnChanges();
+
+            expect(component.extensionChange.emit).toHaveBeenCalledWith('application/pdf');
+        });
+    });
 });

--- a/lib/core/src/lib/viewer/components/viewer-render/viewer-render.component.ts
+++ b/lib/core/src/lib/viewer/components/viewer-render/viewer-render.component.ts
@@ -241,13 +241,32 @@ export class ViewerRenderComponent implements OnChanges, OnInit {
 
     private setUpBlobData() {
         this.internalFileName = this.fileName;
-        this.viewerType = this.viewUtilService.getViewerTypeByMimeType(this.blobFile.type);
+        const blobMimeType = this.extractMimeTypeEssence(this.blobFile.type);
+        this.viewerType = this.viewUtilService.getViewerTypeByMimeType(blobMimeType);
+        if (this.viewerType === 'unknown' && this.mimeType) {
+            this.viewerType = this.viewUtilService.getViewerTypeByMimeType(this.extractMimeTypeEssence(this.mimeType));
+        }
         if (this.viewerType === 'unknown') {
             this.isLoading = false;
         }
 
-        this.extensionChange.emit(this.blobFile.type);
+        this.extensionChange.emit(blobMimeType || this.mimeType);
         this.scrollTop();
+    }
+
+    /**
+     * Extracts the MIME type essence (type/subtype) stripping any parameters like charset.
+     * Firefox includes parameters in blob.type (e.g. "application/pdf;charset=utf-8"),
+     * while Chrome strips them. This normalizes the behavior.
+     *
+     * @param mimeType - raw MIME type string potentially containing parameters
+     * @returns the type/subtype portion without parameters
+     */
+    private extractMimeTypeEssence(mimeType: string): string {
+        if (!mimeType) {
+            return mimeType;
+        }
+        return mimeType.split(';')[0].trim();
     }
 
     private setUpUrlFile() {

--- a/lib/core/src/lib/viewer/components/viewer-render/viewer-render.component.ts
+++ b/lib/core/src/lib/viewer/components/viewer-render/viewer-render.component.ts
@@ -254,14 +254,6 @@ export class ViewerRenderComponent implements OnChanges, OnInit {
         this.scrollTop();
     }
 
-    /**
-     * Extracts the MIME type essence (type/subtype) stripping any parameters like charset.
-     * Firefox includes parameters in blob.type (e.g. "application/pdf;charset=utf-8"),
-     * while Chrome strips them. This normalizes the behavior.
-     *
-     * @param mimeType - raw MIME type string potentially containing parameters
-     * @returns the type/subtype portion without parameters
-     */
     private extractMimeTypeEssence(mimeType: string): string {
         if (!mimeType) {
             return mimeType;

--- a/lib/core/src/lib/viewer/components/viewer-render/viewer-render.component.ts
+++ b/lib/core/src/lib/viewer/components/viewer-render/viewer-render.component.ts
@@ -250,15 +250,12 @@ export class ViewerRenderComponent implements OnChanges, OnInit {
             this.isLoading = false;
         }
 
-        this.extensionChange.emit(blobMimeType || this.mimeType);
+        this.extensionChange.emit(blobMimeType || this.extractMimeTypeEssence(this.mimeType));
         this.scrollTop();
     }
 
     private extractMimeTypeEssence(mimeType: string): string {
-        if (!mimeType) {
-            return mimeType;
-        }
-        return mimeType.split(';')[0].trim();
+        return (mimeType || '').split(';')[0].trim();
     }
 
     private setUpUrlFile() {

--- a/lib/core/src/lib/viewer/components/viewer.component.spec.ts
+++ b/lib/core/src/lib/viewer/components/viewer.component.spec.ts
@@ -34,6 +34,7 @@ import { ViewerWithCustomToolbarComponent } from './mock/adf-viewer-container-to
 import { ViewerComponent } from './viewer.component';
 import { ThumbnailService } from '../../common/services/thumbnail.service';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { ViewerRenderComponent } from './viewer-render/viewer-render.component';
 
 @Component({
     selector: 'adf-dialog-dummy',
@@ -113,8 +114,10 @@ describe('ViewerComponent', () => {
             };
 
             component.ngOnChanges(mockSimpleChanges);
+            fixture.detectChanges();
 
-            expect(component.mimeType).toBe('image/png');
+            const viewerRender = testingUtils.getByDirective(ViewerRenderComponent).componentInstance as ViewerRenderComponent;
+            expect(viewerRender.mimeType).toBe('image/png');
         });
 
         it('should strip MIME type parameters from blob type', () => {
@@ -123,8 +126,10 @@ describe('ViewerComponent', () => {
             };
 
             component.ngOnChanges(mockSimpleChanges);
+            fixture.detectChanges();
 
-            expect(component.mimeType).toBe('application/pdf');
+            const viewerRender = testingUtils.getByDirective(ViewerRenderComponent).componentInstance as ViewerRenderComponent;
+            expect(viewerRender.mimeType).toBe('application/pdf');
         });
 
         it('should strip MIME type parameters with spaces from blob type', () => {
@@ -133,8 +138,10 @@ describe('ViewerComponent', () => {
             };
 
             component.ngOnChanges(mockSimpleChanges);
+            fixture.detectChanges();
 
-            expect(component.mimeType).toBe('image/png');
+            const viewerRender = testingUtils.getByDirective(ViewerRenderComponent).componentInstance as ViewerRenderComponent;
+            expect(viewerRender.mimeType).toBe('image/png');
         });
 
         it('should handle empty blob type gracefully', () => {
@@ -143,8 +150,10 @@ describe('ViewerComponent', () => {
             };
 
             component.ngOnChanges(mockSimpleChanges);
+            fixture.detectChanges();
 
-            expect(component.mimeType).toBe('');
+            const viewerRender = testingUtils.getByDirective(ViewerRenderComponent).componentInstance as ViewerRenderComponent;
+            expect(viewerRender.mimeType).toBe('');
         });
 
         it('should set mimeTypeIconUrl with stripped MIME type from blob', () => {

--- a/lib/core/src/lib/viewer/components/viewer.component.spec.ts
+++ b/lib/core/src/lib/viewer/components/viewer.component.spec.ts
@@ -117,6 +117,47 @@ describe('ViewerComponent', () => {
             expect(component.mimeType).toBe('image/png');
         });
 
+        it('should strip MIME type parameters from blob type', () => {
+            const mockSimpleChanges: SimpleChanges = {
+                blobFile: new SimpleChange(null, { type: 'application/pdf;charset=utf-8' }, true)
+            };
+
+            component.ngOnChanges(mockSimpleChanges);
+
+            expect(component.mimeType).toBe('application/pdf');
+        });
+
+        it('should strip MIME type parameters with spaces from blob type', () => {
+            const mockSimpleChanges: SimpleChanges = {
+                blobFile: new SimpleChange(null, { type: 'image/png; charset=binary' }, true)
+            };
+
+            component.ngOnChanges(mockSimpleChanges);
+
+            expect(component.mimeType).toBe('image/png');
+        });
+
+        it('should handle empty blob type gracefully', () => {
+            const mockSimpleChanges: SimpleChanges = {
+                blobFile: new SimpleChange(null, { type: '' }, true)
+            };
+
+            component.ngOnChanges(mockSimpleChanges);
+
+            expect(component.mimeType).toBe('');
+        });
+
+        it('should set mimeTypeIconUrl with stripped MIME type from blob', () => {
+            spyOn(thumbnailService, 'getMimeTypeIcon').and.returnValue('icon-url');
+            const mockSimpleChanges: SimpleChanges = {
+                blobFile: new SimpleChange(null, { type: 'application/pdf;charset=utf-8' }, true)
+            };
+
+            component.ngOnChanges(mockSimpleChanges);
+
+            expect(thumbnailService.getMimeTypeIcon).toHaveBeenCalledWith('application/pdf');
+        });
+
         it('should set mimeTypeIconUrl when mimeType changes and no nodeMimeType is provided', () => {
             spyOn(thumbnailService, 'getMimeTypeIcon').and.returnValue('image/png');
             const mockSimpleChanges: SimpleChanges = {

--- a/lib/core/src/lib/viewer/components/viewer.component.ts
+++ b/lib/core/src/lib/viewer/components/viewer.component.ts
@@ -347,8 +347,9 @@ export class ViewerComponent<T> implements OnDestroy, OnInit, OnChanges {
         const { blobFile, urlFile, mimeType, nodeMimeType } = changes;
 
         if (blobFile?.currentValue) {
-            this.mimeType = blobFile.currentValue.type;
-            this.mimeTypeIconUrl = this.thumbnailService.getMimeTypeIcon(blobFile.currentValue.type);
+            const blobMimeType = (blobFile.currentValue.type || '').split(';')[0].trim();
+            this.mimeType = blobMimeType;
+            this.mimeTypeIconUrl = this.thumbnailService.getMimeTypeIcon(blobMimeType);
         }
 
         if (urlFile?.currentValue) {

--- a/lib/core/src/lib/viewer/components/viewer.component.ts
+++ b/lib/core/src/lib/viewer/components/viewer.component.ts
@@ -347,7 +347,7 @@ export class ViewerComponent<T> implements OnDestroy, OnInit, OnChanges {
         const { blobFile, urlFile, mimeType, nodeMimeType } = changes;
 
         if (blobFile?.currentValue) {
-            const blobMimeType = (blobFile.currentValue.type || '').split(';')[0].trim();
+            const blobMimeType = this.extractMimeTypeEssence(blobFile.currentValue.type);
             this.mimeType = blobMimeType;
             this.mimeTypeIconUrl = this.thumbnailService.getMimeTypeIcon(blobMimeType);
         }
@@ -357,12 +357,16 @@ export class ViewerComponent<T> implements OnDestroy, OnInit, OnChanges {
         }
 
         if (mimeType?.currentValue && !nodeMimeType?.currentValue) {
-            this.mimeTypeIconUrl = this.thumbnailService.getMimeTypeIcon(mimeType.currentValue);
+            this.mimeTypeIconUrl = this.thumbnailService.getMimeTypeIcon(this.extractMimeTypeEssence(mimeType.currentValue));
         }
 
         if (nodeMimeType?.currentValue) {
-            this.mimeTypeIconUrl = this.thumbnailService.getMimeTypeIcon(nodeMimeType.currentValue);
+            this.mimeTypeIconUrl = this.thumbnailService.getMimeTypeIcon(this.extractMimeTypeEssence(nodeMimeType.currentValue));
         }
+    }
+
+    private extractMimeTypeEssence(mimeType: string): string {
+        return (mimeType || '').split(';')[0].trim();
     }
 
     ngOnInit(): void {

--- a/lib/core/viewer/pdf/src/lib/components/pdf-viewer/pdf-viewer.component.spec.ts
+++ b/lib/core/viewer/pdf/src/lib/components/pdf-viewer/pdf-viewer.component.spec.ts
@@ -365,7 +365,7 @@ describe('Test PdfViewer - executePdf error handling', () => {
             onPassword: null,
             onProgress: null,
             destroy: () => Promise.resolve()
-        } as unknown as PDFDocumentLoadingTask;
+        } as PDFDocumentLoadingTask;
 
         const pdfjsLibMock = {
             GlobalWorkerOptions: {},

--- a/lib/core/viewer/pdf/src/lib/components/pdf-viewer/pdf-viewer.component.spec.ts
+++ b/lib/core/viewer/pdf/src/lib/components/pdf-viewer/pdf-viewer.component.spec.ts
@@ -160,6 +160,44 @@ describe('Test PdfViewer component', () => {
         });
     });
 
+    describe('executePdf error handling', () => {
+        it('should emit error event when PDF loading fails', fakeAsync(() => {
+            spyOn(component.error, 'emit');
+            spyOn(console, 'error');
+
+            const failingLoadingTask = {
+                promise: Promise.reject(new Error('PDF load failed')),
+                onPassword: null,
+                onProgress: null
+            };
+            spyOn(component as any, 'setupPdfJsWorker').and.returnValue(Promise.resolve());
+            (component as any).pdfjsLib = { getDocument: () => failingLoadingTask, GlobalWorkerOptions: {} };
+
+            component.executePdf({ data: new ArrayBuffer(0) });
+            flush();
+
+            expect(component.error.emit).toHaveBeenCalled();
+        }));
+
+        it('should log error to console when PDF loading fails', fakeAsync(() => {
+            spyOn(component.error, 'emit');
+            spyOn(console, 'error');
+
+            const failingLoadingTask = {
+                promise: Promise.reject(new Error('PDF load failed')),
+                onPassword: null,
+                onProgress: null
+            };
+            spyOn(component as any, 'setupPdfJsWorker').and.returnValue(Promise.resolve());
+            (component as any).pdfjsLib = { getDocument: () => failingLoadingTask, GlobalWorkerOptions: {} };
+
+            component.executePdf({ data: new ArrayBuffer(0) });
+            flush();
+
+            expect(console.error).toHaveBeenCalledWith('[ADF-PDF-VIEWER] executePdf failed:', jasmine.any(Error));
+        }));
+    });
+
     describe('View with url file', () => {
         let fixtureUrlTestComponent: ComponentFixture<UrlTestComponent>;
         let elementUrlTestComponent: HTMLElement;

--- a/lib/core/viewer/pdf/src/lib/components/pdf-viewer/pdf-viewer.component.spec.ts
+++ b/lib/core/viewer/pdf/src/lib/components/pdf-viewer/pdf-viewer.component.spec.ts
@@ -27,6 +27,7 @@ import { PdfThumbListComponent } from '../pdf-viewer-thumbnails/pdf-viewer-thumb
 import { PDFJS_MODULE, PDFJS_VIEWER_MODULE, PdfViewerComponent } from './pdf-viewer.component';
 import pdfjsLibraryMock, { annotations } from '../mock/pdfjs-lib.mock';
 import { TranslateService } from '@ngx-translate/core';
+import { PDFDocumentLoadingTask } from 'pdfjs-dist/types/src/display/api';
 
 declare const pdfjsLib: {
     PasswordResponses: {
@@ -158,44 +159,6 @@ describe('Test PdfViewer component', () => {
                 component.ngOnChanges({ blobFile: change });
             }).toThrow(new Error('Attribute urlFile or blobFile is required'));
         });
-    });
-
-    describe('executePdf error handling', () => {
-        it('should emit error event when PDF loading fails', fakeAsync(() => {
-            spyOn(component.error, 'emit');
-            spyOn(console, 'error');
-
-            const failingLoadingTask = {
-                promise: Promise.reject(new Error('PDF load failed')),
-                onPassword: null,
-                onProgress: null
-            };
-            spyOn(component as any, 'setupPdfJsWorker').and.returnValue(Promise.resolve());
-            (component as any).pdfjsLib = { getDocument: () => failingLoadingTask, GlobalWorkerOptions: {} };
-
-            component.executePdf({ data: new ArrayBuffer(0) });
-            flush();
-
-            expect(component.error.emit).toHaveBeenCalled();
-        }));
-
-        it('should log error to console when PDF loading fails', fakeAsync(() => {
-            spyOn(component.error, 'emit');
-            spyOn(console, 'error');
-
-            const failingLoadingTask = {
-                promise: Promise.reject(new Error('PDF load failed')),
-                onPassword: null,
-                onProgress: null
-            };
-            spyOn(component as any, 'setupPdfJsWorker').and.returnValue(Promise.resolve());
-            (component as any).pdfjsLib = { getDocument: () => failingLoadingTask, GlobalWorkerOptions: {} };
-
-            component.executePdf({ data: new ArrayBuffer(0) });
-            flush();
-
-            expect(console.error).toHaveBeenCalledWith('[ADF-PDF-VIEWER] executePdf failed:', jasmine.any(Error));
-        }));
     });
 
     describe('View with url file', () => {
@@ -390,6 +353,54 @@ describe('Test PdfViewer component', () => {
             });
         });
     });
+});
+
+describe('Test PdfViewer - executePdf error handling', () => {
+    let fixture: ComponentFixture<PdfViewerComponent>;
+    let component: PdfViewerComponent;
+
+    beforeEach(() => {
+        const failingLoadingTask = {
+            promise: Promise.reject(new Error('PDF load failed')),
+            onPassword: null,
+            onProgress: null,
+            destroy: () => Promise.resolve()
+        } as unknown as PDFDocumentLoadingTask;
+
+        const pdfjsLibMock = {
+            GlobalWorkerOptions: {},
+            getDocument: () => failingLoadingTask
+        };
+
+        TestBed.configureTestingModule({
+            imports: [PdfViewerComponent],
+            providers: [
+                provideCoreAuthTesting(),
+                {
+                    provide: MatDialog,
+                    useValue: {
+                        open: () => {}
+                    }
+                },
+                RenderingQueueServices,
+                { provide: PDFJS_MODULE, useValue: pdfjsLibMock }
+            ]
+        });
+
+        fixture = TestBed.createComponent(PdfViewerComponent);
+        component = fixture.componentInstance;
+    });
+
+    it('should emit error event when PDF loading fails', fakeAsync(() => {
+        spyOn(component.error, 'emit');
+        // Pre-set the worker URL so the real setupPdfJsWorker logic runs without performing a network fetch
+        component.pdfJsWorkerUrl = URL.createObjectURL(new Blob([''], { type: 'application/javascript' }));
+
+        component.executePdf({ data: new ArrayBuffer(0) });
+        flush();
+
+        expect(component.error.emit).toHaveBeenCalled();
+    }));
 });
 
 describe('Test PdfViewer - Zoom customization', () => {

--- a/lib/core/viewer/pdf/src/lib/components/pdf-viewer/pdf-viewer.component.ts
+++ b/lib/core/viewer/pdf/src/lib/components/pdf-viewer/pdf-viewer.component.ts
@@ -292,7 +292,10 @@ export class PdfViewerComponent implements OnChanges, OnDestroy {
                 .then(() => {
                     setTimeout(() => this.scalePage('init'));
                 })
-                .catch(() => this.error.emit());
+                .catch((err) => {
+                    console.error('[ADF-PDF-VIEWER] executePdf failed:', err);
+                    this.error.emit();
+                });
         });
     }
 

--- a/lib/core/viewer/pdf/src/lib/components/pdf-viewer/pdf-viewer.component.ts
+++ b/lib/core/viewer/pdf/src/lib/components/pdf-viewer/pdf-viewer.component.ts
@@ -292,8 +292,7 @@ export class PdfViewerComponent implements OnChanges, OnDestroy {
                 .then(() => {
                     setTimeout(() => this.scalePage('init'));
                 })
-                .catch((err) => {
-                    console.error('[ADF-PDF-VIEWER] executePdf failed:', err);
+                .catch(() => {
                     this.error.emit();
                 });
         });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/ACS-12098


**What is the new behaviour?**
no race condition for firefox headless CI e2e runs in viewer


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
