### PR TITLE
Release cache read/write fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,14 +47,15 @@ jobs:
     if: github.event.pull_request.merged == true || github.ref_name == 'master' || github.ref_name == 'master-patch-*' || github.event_name == 'workflow_dispatch'
     name: "Setup"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup
-        with:
-          enable-node-modules-cache: false
       - name: install
         run: |
           pnpm install --frozen-lockfile
@@ -73,6 +74,7 @@ jobs:
       id-token: write  # Required for OIDC
       contents: read
       packages: write
+      actions: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -80,8 +82,6 @@ jobs:
           fetch-depth: 0
       - id: setup
         uses: ./.github/actions/setup
-        with:
-          enable-node-modules-cache: false
       - id: set-dryrun
         uses: ./.github/actions/enable-dryrun
         with:


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Release process is broken as cache cannot be saved with current permissions. That can be observed in the logs:
`Failed to save: Unable to reserve cache with key dist-28603036178-1.`
 `More details: cache write denied: token has no writable scopes`

**What is the new behaviour?**

Token cache-write permission is granted so setup can actually save.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
