### PR TITLE
Adjust release triggers to use cache-writable token

### DIFF
--- a/.github/actions/before-install/action.yml
+++ b/.github/actions/before-install/action.yml
@@ -12,9 +12,14 @@ runs:
     - name: base vars
       shell: bash
       run: |
+        if [ -n "${GITHUB_BASE_REF:-}" ]; then
+          BASE_HASH=$(git merge-base "origin/${GITHUB_BASE_REF}" HEAD 2>/dev/null || git rev-parse HEAD)
+        else
+          BASE_HASH=$(git rev-parse HEAD)
+        fi
         {
           echo "GIT_HASH=$(git rev-parse HEAD)";
-          echo "BASE_HASH=$(git merge-base origin/${GITHUB_BASE_REF} HEAD)";
+          echo "BASE_HASH=${BASE_HASH}";
           echo "HEAD_HASH=HEAD";
           echo "HEAD_COMMIT_HASH=${GH_COMMIT}";
           echo "NX_CALCULATION_FLAGS=--all";
@@ -55,7 +60,7 @@ runs:
         } >> $GITHUB_ENV
 
     - name: RELEASE on master/develop patch branch
-      if: ${{ env.BREAK_ACTION == false && github.event.pull_request.merged }}
+      if: ${{ env.BREAK_ACTION == false && (github.event.pull_request.merged || github.event_name == 'push') }}
       shell: bash
       env:
         REF_NAME: ${{ github.ref_name }}

--- a/.github/actions/enable-dryrun/action.yml
+++ b/.github/actions/enable-dryrun/action.yml
@@ -23,8 +23,8 @@ runs:
       env:
         DRY_RUN_FLAG: ${{ inputs.dry-run-flag }}
       run: |
-          if [[ '$DRY_RUN_FLAG' == 'true' ]]; then
-            echo "dryrun=--dryrun" >> $GITHUB_OUTPUT;
+          if [[ "$DRY_RUN_FLAG" == 'true' ]]; then
+            echo "dryrun=--dry-run" >> $GITHUB_OUTPUT;
             echo "enabling dryrun"
           else
             echo "dryrun=" >> $GITHUB_OUTPUT;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,6 @@
 name: "release"
 
 on:
-  workflow_call:
-    inputs:
-      dry-run-flag:
-        description: 'enable dry-run on artifact push'
-        required: false
-        type: boolean
-        default: true
   workflow_dispatch:
     inputs:
       dry-run-flag:
@@ -15,13 +8,10 @@ on:
         required: false
         type: boolean
         default: true
-  pull_request:
-    types: [closed]
+  push:
     branches:
       - develop
       - develop-patch*
-  push:
-    branches:
       - master
       - master-patch-*
 
@@ -34,8 +24,6 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  BASE_REF: ${{ github.base_ref }}
-  HEAD_REF: ${{ github.head_ref }}
   GH_COMMIT: ${{ github.sha }}
   GH_BUILD_NUMBER: ${{ github.run_id }}
   LOG_LEVEL: "ERROR"
@@ -44,7 +32,7 @@ env:
 jobs:
   setup:
     timeout-minutes: 20
-    if: github.event.pull_request.merged == true || github.ref_name == 'master' || github.ref_name == 'master-patch-*' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     name: "Setup"
     runs-on: ubuntu-latest
     permissions:
@@ -68,7 +56,7 @@ jobs:
     outputs:
       release_version: ${{ steps.set-version.outputs.release_version }}
     timeout-minutes: 30
-    if: github.event.pull_request.merged == true || github.ref_name == 'master' || github.ref_name == 'master-patch-*' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       id-token: write  # Required for OIDC
@@ -108,7 +96,7 @@ jobs:
           node-version-file: '.nvmrc'
           registry-url: 'https://npm.pkg.github.com'
           scope: '@alfresco'
-      - run: pnpm run publish --tag ${{ steps.setup.outputs.npm-tag }} --provenance=false
+      - run: pnpm run publish --tag ${{ steps.setup.outputs.npm-tag }} --provenance=false ${{ steps.set-dryrun.outputs.dryrun }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -117,7 +105,7 @@ jobs:
           node-version-file: '.nvmrc'
           registry-url: 'https://${{ vars.NPM_REGISTRY_ADDRESS }}'
           scope: '@alfresco'
-      - run: pnpm run publish --tag ${{ steps.setup.outputs.npm-tag }}
+      - run: pnpm run publish --tag ${{ steps.setup.outputs.npm-tag }} ${{ steps.set-dryrun.outputs.dryrun }}
 
   create-git-tag:
     runs-on: ubuntu-latest
@@ -138,7 +126,7 @@ jobs:
   npm-check-bundle:
     needs: [release-npm]
     timeout-minutes: 15
-    if: github.event.pull_request.merged == true || github.ref_name == 'master' || github.ref_name == 'master-patch-*' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

`pull_request: [closed]` trigger provides read-only token so cache writes still fails.

**What is the new behaviour?**

According to https://github.blog/changelog/2026-06-26-read-only-actions-cache-for-untrusted-triggers/ new trigger has to be used that actually supports cache-writable token. Additionally PR fixes broken dry-run flag propagation

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
