### PR TITLE
[ACS-11325] remove chevron button from tab order in adf-tree

### DIFF
--- a/lib/content-services/src/lib/tree/components/tree.component.html
+++ b/lib/content-services/src/lib/tree/components/tree.component.html
@@ -58,7 +58,9 @@
                         *ngIf="node.hasChildren"
                         class="adf-tree-expand-collapse-button"
                         mat-icon-button
-                        matTreeNodeToggle
+                        tabindex="-1"
+                        aria-hidden="true"
+                        (click)="expandCollapseNode(node); $event.stopPropagation()"
                     >
                         <mat-progress-spinner
                                 mode="indeterminate"

--- a/lib/content-services/src/lib/tree/components/tree.component.spec.ts
+++ b/lib/content-services/src/lib/tree/components/tree.component.spec.ts
@@ -213,6 +213,26 @@ describe('TreeComponent', () => {
         expect(expandSpy).toHaveBeenCalledWith(component.treeService.treeNodes[0], treeNodesMockExpanded);
     });
 
+    it('should call expandCollapseNode once when chevron is clicked', () => {
+        component.refreshTree();
+        fixture.detectChanges();
+        component.treeService.treeNodes = Array.from(treeNodesMock);
+        component.treeService.treeNodes[0].isLoading = false;
+        fixture.detectChanges();
+        const expandCollapseNodeSpy = spyOn(component, 'expandCollapseNode').and.callThrough();
+        clickExpandCollapseBtn(component.treeService.treeNodes[0].id);
+        expect(expandCollapseNodeSpy).toHaveBeenCalledOnceWith(component.treeService.treeNodes[0]);
+    });
+
+    it('should not trigger node selection when chevron is clicked and selectableNodes is true', () => {
+        component.selectableNodes = true;
+        component.refreshTree();
+        fixture.detectChanges();
+        const onNodeSelectedSpy = spyOn(component, 'onNodeSelected');
+        clickExpandCollapseBtn(component.treeService.treeNodes[0].id);
+        expect(onNodeSelectedSpy).not.toHaveBeenCalled();
+    });
+
     it('should call collapseNode on TreeService when collapsing node by clicking at node label and node has children', () => {
         component.refreshTree();
         fixture.detectChanges();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [X] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

After migration to Angular 20, the chevron expand/collapse `<button>` inside `adf-tree` became an extra focusable element.

**What is the new behaviour?**

Per the [WAI-ARIA Treeview pattern](https://www.w3.org/WAI/ARIA/apg/patterns/treeview/), only the `treeitem` row is in the tab sequence. Expand/collapse is handled via ArrowRight/Left on the focused row. The chevron is a visual affordance only - it requires no separate keyboard interaction.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
