### PR TITLE
AAE-46248 Format dropdown/radio option labels in display-text expressions

### DIFF
--- a/lib/core/src/lib/form/components/widgets/core/form-field-types.ts
+++ b/lib/core/src/lib/form/components/widgets/core/form-field-types.ts
@@ -57,7 +57,7 @@ export class FormFieldTypes {
 
     static READONLY_TYPES: string[] = [FormFieldTypes.HYPERLINK, FormFieldTypes.DISPLAY_VALUE, FormFieldTypes.READONLY_TEXT, FormFieldTypes.GROUP];
 
-    static DISPLAY_TEXT_TYPES: string[] = [
+    static readonly DISPLAY_TEXT_TYPES: string[] = [
         FormFieldTypes.TEXT,
         FormFieldTypes.MULTILINE_TEXT,
         FormFieldTypes.READONLY_TEXT,

--- a/lib/core/src/lib/form/components/widgets/core/form-field-types.ts
+++ b/lib/core/src/lib/form/components/widgets/core/form-field-types.ts
@@ -57,6 +57,13 @@ export class FormFieldTypes {
 
     static READONLY_TYPES: string[] = [FormFieldTypes.HYPERLINK, FormFieldTypes.DISPLAY_VALUE, FormFieldTypes.READONLY_TEXT, FormFieldTypes.GROUP];
 
+    static DISPLAY_TEXT_TYPES: string[] = [
+        FormFieldTypes.TEXT,
+        FormFieldTypes.MULTILINE_TEXT,
+        FormFieldTypes.READONLY_TEXT,
+        FormFieldTypes.DISPLAY_VALUE
+    ];
+
     static VALIDATABLE_TYPES: string[] = [FormFieldTypes.DISPLAY_EXTERNAL_PROPERTY];
 
     static REACTIVE_TYPES: string[] = [FormFieldTypes.DATE, FormFieldTypes.DATETIME, FormFieldTypes.DROPDOWN];
@@ -65,6 +72,10 @@ export class FormFieldTypes {
 
     static isReadOnlyType(type: string): boolean {
         return FormFieldTypes.READONLY_TYPES.includes(type);
+    }
+
+    static isDisplayTextType(type: string): boolean {
+        return FormFieldTypes.DISPLAY_TEXT_TYPES.includes(type);
     }
 
     static isValidatableType(type: string): boolean {

--- a/lib/core/src/lib/form/components/widgets/core/form-field.model.spec.ts
+++ b/lib/core/src/lib/form/components/widgets/core/form-field.model.spec.ts
@@ -1823,3 +1823,25 @@ describe('FormFieldModel', () => {
         });
     });
 });
+
+describe('FormFieldTypes', () => {
+    describe('isDisplayTextType', () => {
+        it('should return true for text, multi-line text, readonly text and display value types', () => {
+            expect(FormFieldTypes.isDisplayTextType(FormFieldTypes.TEXT)).toBe(true);
+            expect(FormFieldTypes.isDisplayTextType(FormFieldTypes.MULTILINE_TEXT)).toBe(true);
+            expect(FormFieldTypes.isDisplayTextType(FormFieldTypes.READONLY_TEXT)).toBe(true);
+            expect(FormFieldTypes.isDisplayTextType(FormFieldTypes.DISPLAY_VALUE)).toBe(true);
+        });
+
+        it('should return false for typed source field types', () => {
+            expect(FormFieldTypes.isDisplayTextType(FormFieldTypes.PEOPLE)).toBe(false);
+            expect(FormFieldTypes.isDisplayTextType(FormFieldTypes.FUNCTIONAL_GROUP)).toBe(false);
+            expect(FormFieldTypes.isDisplayTextType(FormFieldTypes.DROPDOWN)).toBe(false);
+            expect(FormFieldTypes.isDisplayTextType(FormFieldTypes.RADIO_BUTTONS)).toBe(false);
+        });
+
+        it('should return false for an unknown type', () => {
+            expect(FormFieldTypes.isDisplayTextType('unknown-type')).toBe(false);
+        });
+    });
+});

--- a/lib/core/src/lib/form/services/form-expression.service.spec.ts
+++ b/lib/core/src/lib/form/services/form-expression.service.spec.ts
@@ -330,6 +330,53 @@ describe('FormExpressionService', () => {
                 expect(result).toBe(String(date));
                 expect(result).not.toContain('"');
             });
+
+            it('should format a dropdown id string to its option label', () => {
+                const mockField = {
+                    id: 'dropdownField',
+                    type: FormFieldTypes.DROPDOWN,
+                    value: 'opt1',
+                    options: [
+                        { id: 'opt1', name: 'Apple' },
+                        { id: 'opt2', name: 'Banana' }
+                    ]
+                };
+                spyOn(formModel, 'getFieldById').and.returnValue(mockField as any);
+
+                const result = formattingService.resolveExpressions(formModel, '${field.dropdownField}');
+
+                expect(result).toBe('Apple');
+            });
+
+            it('should format a radio id string to its option label', () => {
+                const mockField = {
+                    id: 'radioField',
+                    type: FormFieldTypes.RADIO_BUTTONS,
+                    value: 'r2',
+                    options: [
+                        { id: 'r1', name: 'Yes' },
+                        { id: 'r2', name: 'No' }
+                    ]
+                };
+                spyOn(formModel, 'getFieldById').and.returnValue(mockField as any);
+
+                const result = formattingService.resolveExpressions(formModel, '${field.radioField}');
+
+                expect(result).toBe('No');
+            });
+
+            it('should leave a plain string value unchanged when the source field has no formatter', () => {
+                const mockField = {
+                    id: 'textField',
+                    type: FormFieldTypes.TEXT,
+                    value: 'plain value'
+                };
+                spyOn(formModel, 'getFieldById').and.returnValue(mockField as any);
+
+                const result = formattingService.resolveExpressions(formModel, '${field.textField}');
+
+                expect(result).toBe('plain value');
+            });
         });
 
         describe('when ADF_TYPED_VALUE_FORMATTING_ENABLED token is not provided', () => {
@@ -347,6 +394,20 @@ describe('FormExpressionService', () => {
 
                 expect(hasFormatterSpy).not.toHaveBeenCalled();
                 expect(result).toBe('{"firstName":"Test","lastName":"User"}');
+            });
+
+            it('should leave a dropdown id string unchanged when formatting is disabled', () => {
+                const mockField = {
+                    id: 'dropdownField',
+                    type: FormFieldTypes.DROPDOWN,
+                    value: 'opt1',
+                    options: [{ id: 'opt1', name: 'Apple' }]
+                };
+                spyOn(formModel, 'getFieldById').and.returnValue(mockField as any);
+
+                const result = service.resolveExpressions(formModel, '${field.dropdownField}');
+
+                expect(result).toBe('opt1');
             });
         });
 

--- a/lib/core/src/lib/form/services/form-expression.service.ts
+++ b/lib/core/src/lib/form/services/form-expression.service.ts
@@ -71,22 +71,11 @@ export class FormExpressionService {
             return '';
         }
 
-        if (typeof expressionResult === 'string' && !this.hasTypedFormatter(form, match)) {
+        if (typeof expressionResult === 'string' && !this.formattingEnabled) {
             return expressionResult;
         }
 
         return this.formatTypedExpressionResult(form, match, expressionResult);
-    }
-
-    private hasTypedFormatter(form: FormModel, match: string): boolean {
-        if (!this.formattingEnabled) {
-            return false;
-        }
-
-        const fieldId = this.extractFieldIdFromMatch(match);
-        const sourceField = fieldId ? form.getFieldById(fieldId) : undefined;
-
-        return !!sourceField && this.formFieldValueFormatter.hasFormatter(sourceField.type);
     }
 
     private formatTypedExpressionResult(form: FormModel, match: string, expressionResult: any): string {
@@ -99,6 +88,10 @@ export class FormExpressionService {
 
         if (sourceField && this.formFieldValueFormatter.hasFormatter(sourceField.type)) {
             return this.formFieldValueFormatter.formatValue(expressionResult, sourceField);
+        }
+
+        if (typeof expressionResult === 'string') {
+            return expressionResult;
         }
 
         return this.formFieldValueFormatter.stringifyValue(expressionResult);

--- a/lib/core/src/lib/form/services/form-expression.service.ts
+++ b/lib/core/src/lib/form/services/form-expression.service.ts
@@ -71,11 +71,22 @@ export class FormExpressionService {
             return '';
         }
 
-        if (typeof expressionResult === 'string') {
+        if (typeof expressionResult === 'string' && !this.hasTypedFormatter(form, match)) {
             return expressionResult;
         }
 
         return this.formatTypedExpressionResult(form, match, expressionResult);
+    }
+
+    private hasTypedFormatter(form: FormModel, match: string): boolean {
+        if (!this.formattingEnabled) {
+            return false;
+        }
+
+        const fieldId = this.extractFieldIdFromMatch(match);
+        const sourceField = fieldId ? form.getFieldById(fieldId) : undefined;
+
+        return !!sourceField && this.formFieldValueFormatter.hasFormatter(sourceField.type);
     }
 
     private formatTypedExpressionResult(form: FormModel, match: string, expressionResult: any): string {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

**What is the current behaviour?** (You can also link to an open issue here)

Dropdown/Radio field IDs referenced in a display-text expression (e.g. `${field.myDropdown}`
inside a text/readonly-text/display-value widget) render the raw option **id**, not the
selected option's label.

**What is the new behaviour?**

Added `FormFieldTypes.isDisplayTextType()` to identify text, multi-line text, readonly text,
and display-value field types. `FormExpressionService.normalizeExpressionResult` now checks
whether the source field referenced in the expression has a registered typed formatter
(`FormFieldValueFormatterService.hasFormatter`) before short-circuiting on plain strings —
so a Dropdown/Radio id resolves to its option **label** instead of the raw id.

Gated behind the existing `ADF_TYPED_VALUE_FORMATTING_ENABLED` token (wired to the
`studio-typed-form-rules` feature flag downstream in HXP). When the token/flag is off,
behavior is unchanged from before this PR — plain string values still pass through as-is.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No

**Other information**:

Companion HXP-side change (`field-actions.service.ts`, Path B) applies the same
`FormFieldValueFormatterService` formatting when a form rule copies a People/Group/
Dropdown/Radio value into a text/display-text target field.