### PR TITLE
[ACS-11406] Refactored UnitTestingUtils to use inner scoped utility classes

### DIFF
--- a/lib/content-services/src/lib/dialogs/library/library.dialog.spec.ts
+++ b/lib/content-services/src/lib/dialogs/library/library.dialog.spec.ts
@@ -351,7 +351,7 @@ describe('LibraryDialogComponent', () => {
     it('should not show required error on opening dialog', async () => {
         findSitesSpy.and.returnValue(Promise.resolve(findSitesResponse));
         fixture.detectChanges();
-        const titleFormField = await unitTestingUtils.getMatFormField();
+        const titleFormField = await unitTestingUtils.formField.get();
         const errors = await titleFormField.getTextErrors();
         expect(errors.length).toBe(0);
     });
@@ -371,7 +371,7 @@ describe('LibraryDialogComponent', () => {
         component.form.controls.title.setValue('');
         fixture.detectChanges();
 
-        const titleFormField = await unitTestingUtils.getMatFormField();
+        const titleFormField = await unitTestingUtils.formField.get();
         const errors = await titleFormField.getTextErrors();
 
         expect(component.form.controls.title.errors).toEqual({ required: true });
@@ -385,7 +385,7 @@ describe('LibraryDialogComponent', () => {
         component.form.controls.id.markAsTouched();
         fixture.detectChanges();
 
-        const idFormField = await unitTestingUtils.getMatFormFieldByCSS('.adf-library-dialog-form-field:nth-of-type(2)');
+        const idFormField = await unitTestingUtils.formField.getByCSS('.adf-library-dialog-form-field:nth-of-type(2)');
         const errors = await idFormField.getTextErrors();
 
         expect(component.form.controls.id.errors).toEqual({ required: true });

--- a/lib/content-services/src/lib/search/components/search-filter-container/search-filter-container.component.spec.ts
+++ b/lib/content-services/src/lib/search/components/search-filter-container/search-filter-container.component.spec.ts
@@ -24,7 +24,6 @@ import { SearchFilterContainerComponent } from './search-filter-container.compon
 import { SearchCategory } from '../../models/search-category.interface';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { MatMenuHarness } from '@angular/material/menu/testing';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { MatInputHarness } from '@angular/material/input/testing';
 import { provideRouter } from '@angular/router';
@@ -93,7 +92,7 @@ describe('SearchFilterContainerComponent', () => {
     });
 
     it('should set/update the active filter after the Apply button is clicked', async () => {
-        const menu = await loader.getHarness(MatMenuHarness);
+        const menu = await unitTestingUtils.menu.get();
         await menu.open();
 
         component.widgetContainer.componentRef.instance.value = 'searchText';
@@ -118,7 +117,7 @@ describe('SearchFilterContainerComponent', () => {
     it('should remove active filter after the Clear button is clicked', async () => {
         queryBuilder.setActiveFilter('queryName', 'searchText');
 
-        const menu = await loader.getHarness(MatMenuHarness);
+        const menu = await unitTestingUtils.menu.get();
         await menu.open();
 
         component.widgetContainer.componentRef.instance.value = 'searchText';
@@ -137,7 +136,7 @@ describe('SearchFilterContainerComponent', () => {
             eventRaised = true;
         });
 
-        const menu = await loader.getHarness(MatMenuHarness);
+        const menu = await unitTestingUtils.menu.get();
         await menu.open();
 
         component.widgetContainer.componentRef.instance.value = 'searchText';
@@ -182,7 +181,7 @@ describe('SearchFilterContainerComponent', () => {
         it('should set up a focus trap on the filter when the menu is opened', async () => {
             expect(component.focusTrap).toBeUndefined();
 
-            const menu = await loader.getHarness(MatMenuHarness);
+            const menu = await unitTestingUtils.menu.get();
             await menu.open();
 
             expect(component.focusTrap).toBeDefined();
@@ -193,7 +192,7 @@ describe('SearchFilterContainerComponent', () => {
         // TODO: very flaky test, need to be refactored
         // eslint-disable-next-line ban/ban
         xit('should focus the input element when the menu is opened', async () => {
-            const menu = await loader.getHarness(MatMenuHarness);
+            const menu = await unitTestingUtils.menu.get();
             await menu.open();
 
             const input = await menu.getHarness(MatInputHarness);
@@ -201,7 +200,7 @@ describe('SearchFilterContainerComponent', () => {
         });
 
         it('should focus the menu trigger when the menu is closed', async () => {
-            const menu = await loader.getHarness(MatMenuHarness);
+            const menu = await unitTestingUtils.menu.get();
             await menu.open();
 
             await menu.close();
@@ -209,7 +208,7 @@ describe('SearchFilterContainerComponent', () => {
         });
 
         it('should use a fieldset with aria-labelledby pointing to the legend', async () => {
-            const menu = await loader.getHarness(MatMenuHarness);
+            const menu = await unitTestingUtils.menu.get();
             await menu.open();
             fixture.detectChanges();
 
@@ -225,7 +224,7 @@ describe('SearchFilterContainerComponent', () => {
         });
 
         it('should have the legend text matching the category name', async () => {
-            const menu = await loader.getHarness(MatMenuHarness);
+            const menu = await unitTestingUtils.menu.get();
             await menu.open();
             fixture.detectChanges();
 

--- a/lib/content-services/src/lib/tree/components/tree.component.spec.ts
+++ b/lib/content-services/src/lib/tree/components/tree.component.spec.ts
@@ -29,7 +29,6 @@ import { SelectionChange } from '@angular/cdk/collections';
 import { DebugElement } from '@angular/core';
 import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { MatCheckboxHarness } from '@angular/material/checkbox/testing';
 import { TranslateService } from '@ngx-translate/core';
 
 describe('TreeComponent', () => {
@@ -49,7 +48,7 @@ describe('TreeComponent', () => {
 
     const getNodePadding = (nodeId: string) => parseInt(getComputedStyle(getNode(nodeId).nativeElement).paddingLeft, 10);
 
-    const getNodeSpinner = async (nodeId: string) => testingUtils.getMatProgressSpinnerWithAncestorByDataAutomationId(`node_${nodeId}`);
+    const getNodeSpinner = async (nodeId: string) => testingUtils.progressSpinner.getWithAncestorByDataAutomationId(`node_${nodeId}`);
 
     const clickExpandCollapseBtn = (nodeId: string) => testingUtils.clickByCSS(`${composeNodeSelector(nodeId)} .adf-tree-expand-collapse-button`);
 
@@ -138,7 +137,7 @@ describe('TreeComponent', () => {
         component.loadingRoot$ = of(true);
         fixture.detectChanges();
 
-        const matSpinnerElement = await testingUtils.getMatProgressSpinnerWithAncestorByCSS('.adf-tree-loading-spinner-container');
+        const matSpinnerElement = await testingUtils.progressSpinner.getWithAncestorByCSS('.adf-tree-loading-spinner-container');
         expect(await matSpinnerElement.getMode()).toBe('indeterminate');
     });
 
@@ -148,7 +147,7 @@ describe('TreeComponent', () => {
         component.collapseIcon = 'chevron_left';
         component.treeService.collapseNode(component.treeService.treeNodes[0]);
         fixture.detectChanges();
-        const icon = await testingUtils.getMatIconWithAncestorByCSS('.adf-tree-expand-collapse-button');
+        const icon = await testingUtils.icon.getWithAncestorByCSS('.adf-tree-expand-collapse-button');
         expect(await icon.getName()).toContain('folder');
         spyOn(component.treeService.treeControl, 'isExpanded').and.returnValue(true);
         fixture.detectChanges();
@@ -324,7 +323,7 @@ describe('TreeComponent', () => {
     it('selection should be disabled by default, no checkboxes should be displayed', async () => {
         component.refreshTree();
         fixture.detectChanges();
-        const nodeCheckboxes = await loader.getAllHarnesses(MatCheckboxHarness);
+        const nodeCheckboxes = await testingUtils.checkbox.getAll();
 
         expect(nodeCheckboxes.length).toEqual(0);
         expect(component.selectableNodes).toEqual(false);
@@ -338,7 +337,7 @@ describe('TreeComponent', () => {
         it('should display checkboxes when selection is enabled', async () => {
             component.refreshTree();
             fixture.detectChanges();
-            const nodeCheckboxes = await loader.getAllHarnesses(MatCheckboxHarness);
+            const nodeCheckboxes = await testingUtils.checkbox.getAll();
             const selectableNodes = component.treeService.treeNodes.filter((node: TreeNode) => node.nodeType !== TreeNodeType.LoadMoreNode);
             expect(nodeCheckboxes.length).toEqual(selectableNodes.length);
         });
@@ -577,7 +576,7 @@ describe('TreeComponent', () => {
             component.contextMenuOptions = [contextMenuOption1, contextMenuOption2];
             fixture.detectChanges();
 
-            const menu = await testingUtils.getMatMenuByCSS('#action_menu_right_testId1');
+            const menu = await testingUtils.menu.getByCSS('#action_menu_right_testId1');
             await menu.open();
             expect(await menu.isOpen()).toBeTrue();
             expect(component.contextMenuOptions.length).toEqual(2);

--- a/lib/core/src/lib/about/about-license-list/about-license-list.component.spec.ts
+++ b/lib/core/src/lib/about/about-license-list/about-license-list.component.spec.ts
@@ -48,7 +48,7 @@ describe('AboutLicenseListComponent', () => {
 
         it('should display correct value when contains green check mark icon', async () => {
             fixture.detectChanges();
-            expect(await (await (await unitTestingUtils.getMatCellByColumnName(columnName)).host()).getProperty(innerTextPropertyName)).toEqual(
+            expect(await (await (await unitTestingUtils.cell.getByColumnName(columnName)).host()).getProperty(innerTextPropertyName)).toEqual(
                 '✅ ABOUT.LICENSE.ENABLED Value 1'
             );
         });
@@ -57,7 +57,7 @@ describe('AboutLicenseListComponent', () => {
             component.data[0].value = '&#10060 Value 1';
 
             fixture.detectChanges();
-            expect(await (await (await unitTestingUtils.getMatCellByColumnName(columnName)).host()).getProperty(innerTextPropertyName)).toEqual(
+            expect(await (await (await unitTestingUtils.cell.getByColumnName(columnName)).host()).getProperty(innerTextPropertyName)).toEqual(
                 '❌ ABOUT.LICENSE.DISABLED Value 1'
             );
         });
@@ -66,7 +66,7 @@ describe('AboutLicenseListComponent', () => {
             component.data[0].value = 'Value 1';
 
             fixture.detectChanges();
-            expect(await (await (await unitTestingUtils.getMatCellByColumnName(columnName)).host()).getProperty(innerTextPropertyName)).toEqual(
+            expect(await (await (await unitTestingUtils.cell.getByColumnName(columnName)).host()).getProperty(innerTextPropertyName)).toEqual(
                 'Value 1'
             );
         });
@@ -75,7 +75,7 @@ describe('AboutLicenseListComponent', () => {
             component.data[0].value = 3;
 
             fixture.detectChanges();
-            expect(await (await (await unitTestingUtils.getMatCellByColumnName(columnName)).host()).getProperty(innerTextPropertyName)).toEqual('3');
+            expect(await (await (await unitTestingUtils.cell.getByColumnName(columnName)).host()).getProperty(innerTextPropertyName)).toEqual('3');
         });
     });
 });

--- a/lib/core/src/lib/card-view/components/card-view-arrayitem/card-view-arrayitem.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view-arrayitem/card-view-arrayitem.component.spec.ts
@@ -74,17 +74,17 @@ describe('CardViewArrayItemComponent', () => {
         });
 
         it('should call service on chip click', async () => {
-            await testingUtils.clickMatChip('card-arrayitem-chip-Zlatan');
+            await testingUtils.chip.click('card-arrayitem-chip-Zlatan');
             expect(serviceSpy).toHaveBeenCalled();
         });
 
         it('should call service on edit icon click', async () => {
-            await testingUtils.clickMatButtonByDataAutomationId('card-array-item-clickable-icon-array');
+            await testingUtils.button.clickByDataAutomationId('card-array-item-clickable-icon-array');
             expect(serviceSpy).toHaveBeenCalled();
         });
 
         it('should NOT call service on chip list container click', async () => {
-            await testingUtils.clickMatChipListbox('card-arrayitem-chip-list-container');
+            await testingUtils.chipListbox.click('card-arrayitem-chip-list-container');
             expect(serviceSpy).not.toHaveBeenCalled();
         });
     });
@@ -103,7 +103,7 @@ describe('CardViewArrayItemComponent', () => {
             });
             fixture.detectChanges();
 
-            const chipListBox = await testingUtils.getMatChips();
+            const chipListBox = await testingUtils.chip.getAll();
             expect(chipListBox).not.toBeNull();
             expect(chipListBox.length).toBe(4);
 
@@ -120,12 +120,12 @@ describe('CardViewArrayItemComponent', () => {
             });
             fixture.detectChanges();
 
-            const chipListBox = await testingUtils.getMatChips();
+            const chipListBox = await testingUtils.chip.getAll();
             expect(chipListBox).not.toBeNull();
             expect(chipListBox.length).toBe(4);
 
-            const chip1Icon = await testingUtils.getMatIconWithAncestorByDataAutomationId('card-arrayitem-chip-Zlatan');
-            const chip2Icon = await testingUtils.getMatIconWithAncestorByDataAutomationId('card-arrayitem-chip-Lionel Messi');
+            const chip1Icon = await testingUtils.icon.getWithAncestorByDataAutomationId('card-arrayitem-chip-Zlatan');
+            const chip2Icon = await testingUtils.icon.getWithAncestorByDataAutomationId('card-arrayitem-chip-Lionel Messi');
             const firstChipText = await chipListBox[0].getText();
             const secondChipText = await chipListBox[1].getText();
 
@@ -141,7 +141,7 @@ describe('CardViewArrayItemComponent', () => {
                 clickable: true
             });
             fixture.detectChanges();
-            const editIcon = await testingUtils.getMatIconWithAncestorByDataAutomationId('card-array-item-clickable-icon-array');
+            const editIcon = await testingUtils.icon.getWithAncestorByDataAutomationId('card-array-item-clickable-icon-array');
             expect(await editIcon.getName()).toBe('edit');
         });
 
@@ -152,15 +152,15 @@ describe('CardViewArrayItemComponent', () => {
             });
             fixture.detectChanges();
 
-            expect(await testingUtils.checkIfMatButtonExistsWithDataAutomationId('card-array-item-clickable-icon-array')).toBe(false);
+            expect(await testingUtils.button.existsByDataAutomationId('card-array-item-clickable-icon-array')).toBe(false);
         });
 
         it('should render all values if noOfItemsToDisplay is not defined', async () => {
             fixture.detectChanges();
 
-            const chipList = await testingUtils.getMatChips();
+            const chipList = await testingUtils.chip.getAll();
 
-            expect(await testingUtils.checkIfMatChipExistsWithDataAutomationId('card-arrayitem-more-chip')).toBeFalse();
+            expect(await testingUtils.chip.existsByDataAutomationId('card-arrayitem-more-chip')).toBeFalse();
             expect(chipList.length).toBe(4);
         });
 
@@ -171,7 +171,7 @@ describe('CardViewArrayItemComponent', () => {
             });
             fixture.detectChanges();
 
-            const chipList = await testingUtils.getMatChips();
+            const chipList = await testingUtils.chip.getAll();
 
             expect(chipList.length).toBe(3);
             expect(await chipList[2].getText()).toBe('2 CORE.CARDVIEW.MORE');

--- a/lib/core/src/lib/card-view/components/card-view-boolitem/card-view-boolitem.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view-boolitem/card-view-boolitem.component.spec.ts
@@ -90,7 +90,7 @@ describe('CardViewBoolItemComponent', () => {
             component.property.value = true;
             fixture.detectChanges();
 
-            const checkbox = await testingUtils.getMatCheckboxByDataAutomationId('card-boolean-boolKey');
+            const checkbox = await testingUtils.checkbox.getByDataAutomationId('card-boolean-boolKey');
             expect(checkbox).toBeDefined();
             expect(await checkbox.isChecked()).toBeTrue();
         });
@@ -102,7 +102,7 @@ describe('CardViewBoolItemComponent', () => {
             component.property.default = true;
             fixture.detectChanges();
 
-            const checkbox = await testingUtils.getMatCheckboxByDataAutomationId('card-boolean-boolKey');
+            const checkbox = await testingUtils.checkbox.getByDataAutomationId('card-boolean-boolKey');
             expect(checkbox).toBeDefined();
             expect(await checkbox.isChecked()).toBeTrue();
         });
@@ -111,7 +111,7 @@ describe('CardViewBoolItemComponent', () => {
             component.property.value = false;
             fixture.detectChanges();
 
-            const checkbox = await testingUtils.getMatCheckboxByDataAutomationId('card-boolean-boolKey');
+            const checkbox = await testingUtils.checkbox.getByDataAutomationId('card-boolean-boolKey');
             expect(checkbox).toBeDefined();
             expect(await checkbox.isChecked()).toBeFalse();
         });
@@ -123,7 +123,7 @@ describe('CardViewBoolItemComponent', () => {
             component.property.default = false;
             fixture.detectChanges();
 
-            const checkbox = await testingUtils.getMatCheckboxByDataAutomationId('card-boolean-boolKey');
+            const checkbox = await testingUtils.checkbox.getByDataAutomationId('card-boolean-boolKey');
             expect(checkbox).toBeDefined();
             expect(await checkbox.isChecked()).toBeFalse();
         });
@@ -134,7 +134,7 @@ describe('CardViewBoolItemComponent', () => {
             component.property.value = true;
             fixture.detectChanges();
 
-            const checkbox = await testingUtils.getMatCheckboxByDataAutomationId('card-boolean-boolKey');
+            const checkbox = await testingUtils.checkbox.getByDataAutomationId('card-boolean-boolKey');
             expect(checkbox).toBeDefined();
             expect(await checkbox.isDisabled()).toBeFalse();
         });
@@ -145,7 +145,7 @@ describe('CardViewBoolItemComponent', () => {
             component.property.value = true;
             fixture.detectChanges();
 
-            const checkbox = await testingUtils.getMatCheckboxByDataAutomationId('card-boolean-boolKey');
+            const checkbox = await testingUtils.checkbox.getByDataAutomationId('card-boolean-boolKey');
             expect(checkbox).toBeDefined();
             expect(await checkbox.isDisabled()).toBeTrue();
         });
@@ -156,7 +156,7 @@ describe('CardViewBoolItemComponent', () => {
             component.property.value = true;
             fixture.detectChanges();
 
-            const checkbox = await testingUtils.getMatCheckboxByDataAutomationId('card-boolean-boolKey');
+            const checkbox = await testingUtils.checkbox.getByDataAutomationId('card-boolean-boolKey');
             expect(checkbox).toBeDefined();
             expect(await checkbox.isDisabled()).toBeTrue();
         });

--- a/lib/core/src/lib/card-view/components/card-view-dateitem/card-view-dateitem.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view-dateitem/card-view-dateitem.component.spec.ts
@@ -349,7 +349,7 @@ describe('CardViewDateItemComponent', () => {
         fixture.detectChanges();
         await fixture.whenStable();
 
-        const chips = await testingUtils.getMatChips();
+        const chips = await testingUtils.chip.getAll();
         expect(chips.length).toBe(3);
         expect(await chips[0].getText()).toBe('Jul 10, 2017');
         expect(await chips[1].getText()).toBe('Jul 11, 2017');
@@ -368,7 +368,7 @@ describe('CardViewDateItemComponent', () => {
         fixture.detectChanges();
         await fixture.whenStable();
 
-        const chips = await testingUtils.getMatChips();
+        const chips = await testingUtils.chip.getAll();
         expect(chips.length).toBe(3);
         expect(await chips[0].getText()).toBe('Jul 10, 2017, 0:01');
         expect(await chips[1].getText()).toBe('Jul 11, 2017, 0:01');
@@ -462,7 +462,7 @@ describe('CardViewDateItemComponent', () => {
         it('should render error message when manual input has invalid date format', async () => {
             fixture.detectChanges();
 
-            const manualInput = await testingUtils.getMatInputByDataAutomationId('datepicker-manual-input-dateKey');
+            const manualInput = await testingUtils.input.getByDataAutomationId('datepicker-manual-input-dateKey');
             await manualInput.setValue('not-a-date');
             await manualInput.blur();
             fixture.detectChanges();
@@ -470,7 +470,7 @@ describe('CardViewDateItemComponent', () => {
             fixture.detectChanges();
 
             expect(component.cardViewDateTimeControl.invalid).toBeTrue();
-            const formField = await testingUtils.getMatFormFieldByCSS('.adf-dateitem-editable');
+            const formField = await testingUtils.formField.getByCSS('.adf-dateitem-editable');
             expect(await formField.getTextErrors()).toContain('FORM.FIELD.VALIDATOR.INVALID_DATE_FORMAT');
         });
 

--- a/lib/core/src/lib/card-view/components/card-view-keyvaluepairsitem/card-view-keyvaluepairsitem.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view-keyvaluepairsitem/card-view-keyvaluepairsitem.component.spec.ts
@@ -84,7 +84,7 @@ describe('CardViewKeyValuePairsItemComponent', () => {
             component.ngOnChanges();
             fixture.detectChanges();
 
-            await testingUtils.clickMatButtonByDataAutomationId('card-key-value-pairs-button-key-value-pairs');
+            await testingUtils.button.clickByDataAutomationId('card-key-value-pairs-button-key-value-pairs');
             fixture.detectChanges();
 
             expect(JSON.stringify(component.values)).toBe(JSON.stringify(mockEmptyData));
@@ -103,10 +103,10 @@ describe('CardViewKeyValuePairsItemComponent', () => {
             component.ngOnChanges();
             fixture.detectChanges();
 
-            await testingUtils.clickMatButtonByDataAutomationId('card-key-value-pairs-button-key-value-pairs');
+            await testingUtils.button.clickByDataAutomationId('card-key-value-pairs-button-key-value-pairs');
             fixture.detectChanges();
 
-            await testingUtils.clickMatButtonByCSS('.adf-property-col-delete');
+            await testingUtils.button.clickByCSS('.adf-property-col-delete');
             fixture.detectChanges();
 
             expect(component.values.length).toBe(0);

--- a/lib/core/src/lib/card-view/components/card-view-selectitem/card-view-selectitem.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view-selectitem/card-view-selectitem.component.spec.ts
@@ -99,7 +99,7 @@ describe('CardViewSelectItemComponent', () => {
 
             component.ngOnChanges({});
             fixture.detectChanges();
-            const selectBox = await testingUtils.getMatSelectByDataAutomationId('select-box');
+            const selectBox = await testingUtils.select.getByDataAutomationId('select-box');
 
             expect(await selectBox.isDisabled()).toBe(true);
         });
@@ -117,7 +117,7 @@ describe('CardViewSelectItemComponent', () => {
             expect(component.property.value).toEqual('two');
             expect(component.isEditable).toBe(true);
 
-            const options = await testingUtils.getMatSelectOptions();
+            const options = await testingUtils.select.getOptions();
             expect(options.length).toEqual(4);
             await options[1].click();
 
@@ -137,7 +137,7 @@ describe('CardViewSelectItemComponent', () => {
             expect(component.property.value).toEqual(2);
             expect(component.isEditable).toBe(true);
 
-            const options = await testingUtils.getMatSelectOptions();
+            const options = await testingUtils.select.getOptions();
 
             expect(options.length).toEqual(4);
             await options[1].click();
@@ -157,7 +157,7 @@ describe('CardViewSelectItemComponent', () => {
 
             expect(component.isEditable).toBe(true);
 
-            const options = await testingUtils.getMatSelectOptions();
+            const options = await testingUtils.select.getOptions();
 
             expect(await options[0].getText()).toBe('CORE.CARDVIEW.NONE');
         });
@@ -167,7 +167,7 @@ describe('CardViewSelectItemComponent', () => {
             component.editable = true;
             fixture.detectChanges();
 
-            expect(await testingUtils.checkIfMatSelectExists()).toBe(true);
+            expect(await testingUtils.select.exists()).toBe(true);
         });
 
         it('should not have label twice', async () => {
@@ -175,7 +175,7 @@ describe('CardViewSelectItemComponent', () => {
             component.editable = true;
             fixture.detectChanges();
             const not_editable_label = testingUtils.getByCSS('.adf-property-label-not-editable');
-            const field = await testingUtils.getMatFormFieldByCSS('.adf-property-value');
+            const field = await testingUtils.formField.getByCSS('.adf-property-value');
 
             expect(await field.hasLabel()).toBeTrue();
             expect(not_editable_label).toBeFalsy();
@@ -186,7 +186,7 @@ describe('CardViewSelectItemComponent', () => {
             component.editable = true;
             fixture.detectChanges();
 
-            const selectBox = await testingUtils.getMatSelectByDataAutomationId('select-box');
+            const selectBox = await testingUtils.select.getByDataAutomationId('select-box');
             const host = await selectBox.host();
             expect(await host.getAttribute('aria-label')).toBe('Select box label');
         });
@@ -206,11 +206,11 @@ describe('CardViewSelectItemComponent', () => {
             component.ngOnChanges({});
             fixture.detectChanges();
 
-            let options = await testingUtils.getMatSelectOptions();
+            let options = await testingUtils.select.getOptions();
             expect(options.length).toBe(3);
 
             testingUtils.fillInputByCSS('.adf-select-filter-input input', mockData[0].label);
-            options = await testingUtils.getMatSelectOptions(true);
+            options = await testingUtils.select.getOptions(true);
             expect(options.length).toBe(1);
             expect(await options[0].getText()).toEqual(mockData[0].label);
         });
@@ -228,7 +228,7 @@ describe('CardViewSelectItemComponent', () => {
             component.ngOnChanges({});
             fixture.detectChanges();
 
-            await testingUtils.openMatSelect();
+            await testingUtils.select.open();
             const filterInput = testingUtils.getInputByCSS('.adf-select-filter-input input');
             expect(filterInput).toBeUndefined();
         });
@@ -246,7 +246,7 @@ describe('CardViewSelectItemComponent', () => {
             component.ngOnChanges({});
             fixture.detectChanges();
 
-            await testingUtils.openMatSelect();
+            await testingUtils.select.open();
 
             const filterInput = testingUtils.getInputByCSS('.adf-select-filter-input input');
             expect(filterInput).not.toBe(null);
@@ -341,7 +341,7 @@ describe('CardViewSelectItemComponent', () => {
             component.ngOnChanges({});
             fixture.detectChanges();
 
-            const options = await testingUtils.typeAndGetOptionsForMatAutoComplete(fixture, 'Op');
+            const options = await testingUtils.autocomplete.typeAndGetOptions(fixture, 'Op');
             expect(options.length).toBe(2);
             expect(await options[0].getText()).toContain('Option 1');
             expect(await options[1].getText()).toContain('Option 2');
@@ -378,7 +378,7 @@ describe('CardViewSelectItemComponent', () => {
             component.ngOnChanges({});
             fixture.detectChanges();
 
-            const options = await testingUtils.typeAndGetOptionsForMatAutoComplete(fixture, 'Option');
+            const options = await testingUtils.autocomplete.typeAndGetOptions(fixture, 'Option');
 
             expect(options.length).toBe(2);
             expect(await options[0].getText()).toContain('Option 1');
@@ -490,7 +490,7 @@ describe('CardViewSelectItemComponent', () => {
             component.ngOnChanges({});
             fixture.detectChanges();
 
-            const selectBox = await testingUtils.getMatSelectByDataAutomationId('select-box');
+            const selectBox = await testingUtils.select.getByDataAutomationId('select-box');
             expect(await selectBox.isMultiple()).toBe(true);
         });
 
@@ -500,7 +500,7 @@ describe('CardViewSelectItemComponent', () => {
             component.ngOnChanges({});
             fixture.detectChanges();
 
-            const options = await testingUtils.getMatSelectOptions();
+            const options = await testingUtils.select.getOptions();
             const optionTexts = await Promise.all(options.map((opt) => opt.getText()));
             const hasNoneOption = optionTexts.some((text) => text.includes('CORE.CARDVIEW.NONE'));
 
@@ -515,7 +515,7 @@ describe('CardViewSelectItemComponent', () => {
 
             expect(component.property.value).toEqual(['one']);
 
-            const options = await testingUtils.getMatSelectOptions();
+            const options = await testingUtils.select.getOptions();
             await options[1].click();
 
             expect(component.property.value).toContain('two');
@@ -548,7 +548,7 @@ describe('CardViewSelectItemComponent', () => {
             component.ngOnChanges({ property: new SimpleChange(null, component.property, true) } as SimpleChanges);
             fixture.detectChanges();
 
-            const options = await testingUtils.typeAndGetOptionsForMatAutoComplete(fixture, 'Option');
+            const options = await testingUtils.autocomplete.typeAndGetOptions(fixture, 'Option');
 
             expect(options.length).toBe(3);
 
@@ -584,7 +584,7 @@ describe('CardViewSelectItemComponent', () => {
             expect(component.property.value).toEqual(['option2']);
             expect(updateSpy).toHaveBeenCalledWith(jasmine.objectContaining(component.property), ['option2']);
 
-            const remainingChips = await testingUtils.getMatChips();
+            const remainingChips = await testingUtils.chip.getAll();
             expect(remainingChips.length).toBe(1);
         });
 

--- a/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
@@ -40,7 +40,7 @@ describe('CardViewTextItemComponent', () => {
 
     const expectedErrorMessages = [{ message: 'Something went wrong' } as CardViewItemValidator];
 
-    const getTextField = (key: string): Promise<MatInputHarness> => testingUtils.getMatInputByDataAutomationId(`card-textitem-value-${key}`);
+    const getTextField = (key: string): Promise<MatInputHarness> => testingUtils.input.getByDataAutomationId(`card-textitem-value-${key}`);
 
     const getTextFieldValue = async (key: string): Promise<string> => {
         const textField = await getTextField(key);
@@ -48,7 +48,7 @@ describe('CardViewTextItemComponent', () => {
     };
 
     const updateTextField = async (key: string, value: string) => {
-        await testingUtils.fillMatInputByDataAutomationId(`card-textitem-value-${key}`, value);
+        await testingUtils.input.fillByDataAutomationId(`card-textitem-value-${key}`, value);
         component.update();
         fixture.detectChanges();
     };
@@ -104,7 +104,7 @@ describe('CardViewTextItemComponent', () => {
         fixture.detectChanges();
         await fixture.whenStable();
 
-        const valueChips = await testingUtils.getMatChips();
+        const valueChips = await testingUtils.chip.getAll();
         expect(valueChips.length).toBe(length);
         expect(await valueChips[0].getText()).toBe(param1);
         expect(await valueChips[1].getText()).toBe(param2);
@@ -275,9 +275,7 @@ describe('CardViewTextItemComponent', () => {
 
             fixture.detectChanges();
             await fixture.whenStable();
-            const editIcon = await testingUtils.checkIfMatIconExistsWithAncestorByDataAutomationId(
-                `card-textitem-clickable-icon-${component.property.key}`
-            );
+            const editIcon = await testingUtils.icon.existsWithAncestorByDataAutomationId(`card-textitem-clickable-icon-${component.property.key}`);
             expect(editIcon).toBeFalse();
         });
 
@@ -333,14 +331,14 @@ describe('CardViewTextItemComponent', () => {
             fixture.detectChanges();
 
             expect(getTextFieldError('textkey')).toBe('CORE.CARDVIEW.VALIDATORS.FLOAT_VALIDATION_ERROR');
-            let valueChips = await testingUtils.getMatChips();
+            let valueChips = await testingUtils.chip.getAll();
             expect(valueChips.length).toBe(3);
 
             component.addValueToList({ value: '22.1', chipInput: inputElement } as MatChipInputEvent);
             fixture.detectChanges();
 
             verifyNoErrors('textkey');
-            valueChips = await testingUtils.getMatChips();
+            valueChips = await testingUtils.chip.getAll();
             expect(valueChips.length).toBe(4);
         });
 
@@ -361,7 +359,7 @@ describe('CardViewTextItemComponent', () => {
             await fixture.whenStable();
 
             expect(await getTextFieldValue(component.property.key)).toBe('item1,item2,item3');
-            expect(await testingUtils.checkIfMatChipGridExists()).toBe(false);
+            expect(await testingUtils.chipGrid.exists()).toBe(false);
         });
 
         it('should display the label for multi-valued chips', async () => {
@@ -437,9 +435,7 @@ describe('CardViewTextItemComponent', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            const editIcon = await testingUtils.checkIfMatIconExistsWithAncestorByDataAutomationId(
-                `card-textitem-clickable-icon-${component.property.key}`
-            );
+            const editIcon = await testingUtils.icon.existsWithAncestorByDataAutomationId(`card-textitem-clickable-icon-${component.property.key}`);
             expect(editIcon).toBeFalse();
         });
 
@@ -452,9 +448,7 @@ describe('CardViewTextItemComponent', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            const editIcon = await testingUtils.checkIfMatIconExistsWithAncestorByDataAutomationId(
-                `card-textitem-clickable-icon-${component.property.key}`
-            );
+            const editIcon = await testingUtils.icon.existsWithAncestorByDataAutomationId(`card-textitem-clickable-icon-${component.property.key}`);
             expect(editIcon).toBeFalse();
         });
 
@@ -468,7 +462,7 @@ describe('CardViewTextItemComponent', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            const editIcon = await testingUtils.getMatIconWithAncestorByDataAutomationId(`card-textitem-clickable-icon-${component.property.key}`);
+            const editIcon = await testingUtils.icon.getWithAncestorByDataAutomationId(`card-textitem-clickable-icon-${component.property.key}`);
             expect(editIcon).not.toBeNull();
             expect(await editIcon.getName()).toBe('FAKE_ICON');
         });
@@ -481,9 +475,7 @@ describe('CardViewTextItemComponent', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            const editIcon = await testingUtils.checkIfMatIconExistsWithAncestorByDataAutomationId(
-                `card-textitem-clickable-icon-${component.property.key}`
-            );
+            const editIcon = await testingUtils.icon.existsWithAncestorByDataAutomationId(`card-textitem-clickable-icon-${component.property.key}`);
             expect(editIcon).toBeFalse();
         });
 
@@ -495,9 +487,7 @@ describe('CardViewTextItemComponent', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            const editIcon = await testingUtils.checkIfMatIconExistsWithAncestorByDataAutomationId(
-                `card-textitem-clickable-icon-${component.property.key}`
-            );
+            const editIcon = await testingUtils.icon.existsWithAncestorByDataAutomationId(`card-textitem-clickable-icon-${component.property.key}`);
             expect(editIcon).toBeFalse();
         });
 
@@ -513,9 +503,9 @@ describe('CardViewTextItemComponent', () => {
             await fixture.whenStable();
             fixture.detectChanges();
 
-            const editIcon = await testingUtils.getMatIconWithAncestorByDataAutomationId(`card-textitem-clickable-icon-${component.property.key}`);
+            const editIcon = await testingUtils.icon.getWithAncestorByDataAutomationId(`card-textitem-clickable-icon-${component.property.key}`);
             expect(await editIcon.getName()).toBe('FAKE_ICON');
-            await testingUtils.clickMatIconWithAncestorByDataAutomationId(`card-textitem-clickable-icon-${component.property.key}`);
+            await testingUtils.icon.clickWithAncestorByDataAutomationId(`card-textitem-clickable-icon-${component.property.key}`);
             fixture.detectChanges();
             expect(callBackSpy).toHaveBeenCalled();
         });
@@ -588,9 +578,7 @@ describe('CardViewTextItemComponent', () => {
             component.property.clickable = true;
             component.ngOnChanges({});
 
-            loader = TestbedHarnessEnvironment.loader(fixture);
-            testingUtils.setLoader(loader);
-            const inputHarness = await testingUtils.getMatInputByDataAutomationId(`card-textitem-value-${component.property.key}`);
+            const inputHarness = await testingUtils.input.getByDataAutomationId(`card-textitem-value-${component.property.key}`);
 
             expect(component.isEditable).toBe(false);
             expect(await inputHarness.isDisabled()).toBe(true);

--- a/lib/core/src/lib/card-view/components/card-view/card-view.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view/card-view.component.spec.ts
@@ -158,7 +158,7 @@ describe('CardViewComponent', () => {
         fixture.detectChanges();
         await fixture.whenStable();
 
-        const currentOptions = await testingUtils.getMatSelectOptions();
+        const currentOptions = await testingUtils.select.getOptions();
         expect(currentOptions.length).toBe(3);
         expect(await currentOptions[0].getText()).toContain('CORE.CARDVIEW.NONE');
         expect(await currentOptions[1].getText()).toContain(options[0].label);
@@ -187,7 +187,7 @@ describe('CardViewComponent', () => {
         fixture.detectChanges();
         await fixture.whenStable();
 
-        const currentOptions = await testingUtils.getMatSelectOptions();
+        const currentOptions = await testingUtils.select.getOptions();
         expect(currentOptions.length).toBe(3);
         expect(await currentOptions[0].getText()).toContain('CORE.CARDVIEW.NONE');
         expect(await currentOptions[1].getText()).toContain(options[0].label);
@@ -216,7 +216,7 @@ describe('CardViewComponent', () => {
         fixture.detectChanges();
         await fixture.whenStable();
 
-        const currentOptions = await testingUtils.getMatSelectOptions();
+        const currentOptions = await testingUtils.select.getOptions();
         expect(currentOptions.length).toBe(2);
         expect(await currentOptions[0].getText()).toContain(options[0].label);
         expect(await currentOptions[1].getText()).toContain(options[1].label);

--- a/lib/core/src/lib/clipboard/clipboard.directive.spec.ts
+++ b/lib/core/src/lib/clipboard/clipboard.directive.spec.ts
@@ -60,7 +60,7 @@ describe('ClipboardDirective', () => {
     it('should notify copy target value on button click event', async () => {
         spyOn(clipboardService, 'copyToClipboard');
         testingUtils.fillInputByCSS('input', 'some value');
-        await testingUtils.clickMatButton();
+        await testingUtils.button.click();
 
         expect(clipboardService.copyToClipboard).toHaveBeenCalled();
     });
@@ -68,7 +68,7 @@ describe('ClipboardDirective', () => {
     it('should notify copy target value on keydown event', async () => {
         spyOn(clipboardService, 'copyToClipboard');
         testingUtils.fillInputByCSS('input', 'some value');
-        await testingUtils.sendKeysToMatButton([TestKey.ENTER]);
+        await testingUtils.button.sendKeys([TestKey.ENTER]);
 
         expect(clipboardService.copyToClipboard).toHaveBeenCalled();
     });

--- a/lib/core/src/lib/context-menu/context-menu.directive.spec.ts
+++ b/lib/core/src/lib/context-menu/context-menu.directive.spec.ts
@@ -17,7 +17,6 @@
 
 import { Component } from '@angular/core';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
-import { HarnessLoader } from '@angular/cdk/testing';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { UnitTestingUtils } from '../testing/unit-testing-utils';
 import { ContextMenuDirective } from '@alfresco/adf-core';
@@ -170,7 +169,6 @@ testCases.forEach((testCase) => {
 
         describe('Contextmenu list', () => {
             let contextMenu: HTMLElement | null;
-            let loader: HarnessLoader;
 
             beforeEach(() => {
                 fixture.componentInstance.isEnabled = true;
@@ -179,8 +177,7 @@ testCases.forEach((testCase) => {
                 testingUtils.dispatchCustomEventByCSS('#target', 'contextmenu');
                 fixture.detectChanges();
                 contextMenu = document.querySelector('.adf-context-menu');
-                loader = TestbedHarnessEnvironment.documentRootLoader(fixture);
-                testingUtils.setLoader(loader);
+                testingUtils = new UnitTestingUtils(fixture.debugElement, TestbedHarnessEnvironment.documentRootLoader(fixture));
             });
 
             it('should not render item with visibility property set to false', () => {
@@ -192,7 +189,7 @@ testCases.forEach((testCase) => {
             });
 
             it('should set first not disabled item as active', async () => {
-                const icon = await testingUtils.getMatIconWithAncestorByCSS('adf-context-menu');
+                const icon = await testingUtils.icon.getWithAncestorByCSS('adf-context-menu');
 
                 expect(await icon.getName()).toEqual('action-icon-3');
             });
@@ -212,7 +209,7 @@ testCases.forEach((testCase) => {
             });
 
             it('should not render item icon if not set', async () => {
-                expect(await testingUtils.checkIfMatIconExistsWithAncestorByCSSAndName('adf-context-menu', 'Action 1')).toBeFalse();
+                expect(await testingUtils.icon.existsWithAncestorByCSSAndName('adf-context-menu', 'Action 1')).toBeFalse();
             });
         });
     });

--- a/lib/core/src/lib/datatable/components/columns-selector/columns-selector.component.spec.ts
+++ b/lib/core/src/lib/datatable/components/columns-selector/columns-selector.component.spec.ts
@@ -34,9 +34,8 @@ describe('ColumnsSelectorComponent', () => {
 
     const menuOpenedTrigger = new Subject<void>();
     const menuClosedTrigger = new Subject<void>();
-    const getSelectorInputValue = (): Promise<string> => testingUtils.getMatInputValueByDataAutomationId('adf-columns-selector-search-input');
-    const fillSelectorInput = (value: string): Promise<void> =>
-        testingUtils.fillMatInputByDataAutomationId('adf-columns-selector-search-input', value);
+    const getSelectorInputValue = (): Promise<string> => testingUtils.input.getValueByDataAutomationId('adf-columns-selector-search-input');
+    const fillSelectorInput = (value: string): Promise<void> => testingUtils.input.fillByDataAutomationId('adf-columns-selector-search-input', value);
 
     let mainMenuTrigger: { menuOpened: Observable<void>; menuClosed: Observable<void> };
 
@@ -115,7 +114,7 @@ describe('ColumnsSelectorComponent', () => {
         menuOpenedTrigger.next();
         fixture.detectChanges();
 
-        const options = await testingUtils.getAllMatListOptions();
+        const options = await testingUtils.listOption.getAll();
         const inputColumnsWithTitle = inputColumns.filter((column) => !!column.title);
         expect(options.length).toBe(inputColumnsWithTitle.length);
 
@@ -136,7 +135,7 @@ describe('ColumnsSelectorComponent', () => {
         tick(400);
         fixture.detectChanges();
 
-        const columnOptions = await testingUtils.getAllMatListOptions();
+        const columnOptions = await testingUtils.listOption.getAll();
 
         expect(columnOptions.length).toBe(1);
         expect(await columnOptions[0].getFullText()).toBe(inputColumns[0].title);
@@ -146,7 +145,7 @@ describe('ColumnsSelectorComponent', () => {
         menuOpenedTrigger.next();
         fixture.detectChanges();
 
-        const firstColumnOption = await testingUtils.getMatListOption();
+        const firstColumnOption = await testingUtils.listOption.get();
         const optionName = await firstColumnOption.getFullText();
 
         const toggledColumnItem = component.columnItems.find((item) => item.title === optionName);
@@ -161,7 +160,7 @@ describe('ColumnsSelectorComponent', () => {
             menuOpenedTrigger.next();
             fixture.detectChanges();
 
-            const options = await testingUtils.getAllMatListOptions();
+            const options = await testingUtils.listOption.getAll();
 
             expect(await options[0].isSelected()).toBeTrue();
             expect(await options[1].isSelected()).toBeTrue();
@@ -174,7 +173,7 @@ describe('ColumnsSelectorComponent', () => {
             menuOpenedTrigger.next();
             fixture.detectChanges();
 
-            const options = await testingUtils.getAllMatListOptions();
+            const options = await testingUtils.listOption.getAll();
 
             expect(await options[0].isDisabled()).toBeFalse();
             expect(await options[1].isDisabled()).toBeFalse();
@@ -203,7 +202,7 @@ describe('ColumnsSelectorComponent', () => {
             menuOpenedTrigger.next();
             fixture.detectChanges();
 
-            const options = await testingUtils.getAllMatListOptions();
+            const options = await testingUtils.listOption.getAll();
             expect(await options[0].getFullText()).toBe(shownDataColumn.title);
             expect(await options[1].getFullText()).toBe(hiddenDataColumn.title);
         });
@@ -214,7 +213,7 @@ describe('ColumnsSelectorComponent', () => {
             menuOpenedTrigger.next();
             fixture.detectChanges();
 
-            const options = await testingUtils.getAllMatListOptions();
+            const options = await testingUtils.listOption.getAll();
             expect(await options[0].getFullText()).toBe(hiddenDataColumn.title);
             expect(await options[1].getFullText()).toBe(shownDataColumn.title);
         });
@@ -233,7 +232,7 @@ describe('ColumnsSelectorComponent', () => {
             component.columnsSorting = false;
             menuOpenedTrigger.next();
             fixture.detectChanges();
-            expect(await (await testingUtils.getMatListOption()).getFullText()).toBe(`${column.title}  ${column.subtitle}`);
+            expect(await (await testingUtils.listOption.get()).getFullText()).toBe(`${column.title}  ${column.subtitle}`);
         });
     });
 });

--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.spec.ts
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.spec.ts
@@ -1546,14 +1546,14 @@ describe('DataTable', () => {
             dataTable.displayCheckboxesOnHover = false;
             fixture.detectChanges();
 
-            expect(await testingUtils.checkIfMatCheckboxesHaveClass('adf-datatable-hover-only')).toBeTrue();
+            expect(await testingUtils.checkbox.allHaveClass('adf-datatable-hover-only')).toBeTrue();
         });
 
         it('should display checkboxes on hover when displayCheckboxesOnHover is set to true', async () => {
             dataTable.displayCheckboxesOnHover = true;
             fixture.detectChanges();
 
-            expect(await testingUtils.checkIfMatCheckboxesHaveClass('adf-datatable-hover-only')).toBeTrue();
+            expect(await testingUtils.checkbox.allHaveClass('adf-datatable-hover-only')).toBeTrue();
         });
     });
 

--- a/lib/core/src/lib/datatable/components/icon-cell/icon-cell.component.spec.ts
+++ b/lib/core/src/lib/datatable/components/icon-cell/icon-cell.component.spec.ts
@@ -34,7 +34,7 @@ describe('IconCellComponent', () => {
         component.value$.next(value);
         fixture.detectChanges();
 
-        const icon = await testingUtils.getMatIconOrNull();
+        const icon = await testingUtils.icon.getOrNull();
 
         expectedOccurrence ? expect(icon).not.toBeNull() : expect(icon).toBeNull();
         if (expectedIconName) {

--- a/lib/core/src/lib/datatable/components/json-cell/json-cell.component.spec.ts
+++ b/lib/core/src/lib/datatable/components/json-cell/json-cell.component.spec.ts
@@ -75,7 +75,7 @@ describe('JsonCellComponent', () => {
     it('should render json button inside cell', async () => {
         fixture.detectChanges();
 
-        expect(await testingUtils.checkIfMatButtonExists()).toBe(true);
+        expect(await testingUtils.button.exists()).toBe(true);
     });
 
     it('should not setup cell when has no data', () => {

--- a/lib/core/src/lib/directives/infinite-select-scroll.directive.spec.ts
+++ b/lib/core/src/lib/directives/infinite-select-scroll.directive.spec.ts
@@ -72,7 +72,7 @@ describe('InfiniteSelectScrollDirective', () => {
     }));
 
     it('should call an action on scrollEnd event', async () => {
-        const panel = await testingUtils.getMatSelectHost();
+        const panel = await testingUtils.select.getHost();
         await panel.dispatchEvent('scrollEnd');
 
         expect(component.options.length).toBe(60);

--- a/lib/core/src/lib/form/components/widgets/amount/amount.widget.spec.ts
+++ b/lib/core/src/lib/form/components/widgets/amount/amount.widget.spec.ts
@@ -218,7 +218,7 @@ describe('AmountWidgetComponent', () => {
         });
 
         it('should show tooltip', async () => {
-            const host = await testingUtils.getMatInputHost();
+            const host = await testingUtils.input.getHost();
             await host.hover();
 
             const tooltip = await host.getAttribute('title');
@@ -235,7 +235,7 @@ describe('AmountWidgetComponent', () => {
         });
 
         it('should be marked as invalid after interaction', async () => {
-            const host = await testingUtils.getMatInputHost();
+            const host = await testingUtils.input.getHost();
 
             expect(testingUtils.getByCSS('.adf-invalid')).toBeFalsy();
             await host.blur();
@@ -243,7 +243,7 @@ describe('AmountWidgetComponent', () => {
         });
 
         it('should be able to display label with asterisk and input field is required', async () => {
-            const formField = await testingUtils.getMatFormField();
+            const formField = await testingUtils.formField.get();
             const formControl = await formField.getControl();
 
             expect(formControl.isRequired).toBeTruthy();
@@ -282,7 +282,7 @@ describe('AmountWidgetComponent - rendering', () => {
         });
         fixture.detectChanges();
 
-        const field = await testingUtils.getMatFormField();
+        const field = await testingUtils.formField.get();
         expect(await field.getPrefixText()).toBe('$');
 
         widget.field.currency = '£';
@@ -319,8 +319,8 @@ describe('AmountWidgetComponent - rendering', () => {
         fixture.detectChanges();
         await fixture.whenStable();
 
-        const field = await testingUtils.getMatFormField();
-        const inputField = await testingUtils.getMatInputByPlaceholder('Check Placeholder Text');
+        const field = await testingUtils.formField.get();
+        const inputField = await testingUtils.input.getByPlaceholder('Check Placeholder Text');
         expect(inputField).toBeTruthy();
         expect(await field.getPrefixText()).toBe('$');
 
@@ -328,14 +328,14 @@ describe('AmountWidgetComponent - rendering', () => {
         expect(widgetLabel.textContent.trim()).toBe('Test Amount');
         expect(widget.field.isValid).toBe(false);
 
-        const input = await testingUtils.getMatInput();
+        const input = await testingUtils.input.get();
         await input.setValue('90');
         expect(widget.field.isValid).toBe(true);
 
         await input.setValue('gdfgdf');
         expect(widget.field.isValid).toBe(false);
 
-        const formField = await testingUtils.getMatFormField();
+        const formField = await testingUtils.formField.get();
         const errors = await formField.getTextErrors();
         expect(errors[0]).toContain('FORM.FIELD.VALIDATOR.INVALID_NUMBER');
     });
@@ -364,16 +364,16 @@ describe('AmountWidgetComponent - rendering', () => {
         const widgetLabel = testingUtils.getByCSS('.adf-label').nativeElement;
         expect(widgetLabel.textContent.trim()).toBe('Test Amount');
 
-        const field = await testingUtils.getMatFormField();
+        const field = await testingUtils.formField.get();
         expect(await field.getPrefixText()).toBe('£');
 
         expect(widget.field.isValid).toBe(false);
 
-        const input = await testingUtils.getMatInput();
+        const input = await testingUtils.input.get();
         await input.setValue('8');
         expect(widget.field.isValid).toBe(false);
 
-        const formField = await testingUtils.getMatFormField();
+        const formField = await testingUtils.formField.get();
         let errors = await formField.getTextErrors();
         expect(errors[0].trim()).toContain('FORM.FIELD.VALIDATOR.NOT_LESS_THAN');
 
@@ -505,7 +505,7 @@ describe('AmountWidgetComponent - rendering', () => {
             });
 
             it('should not display prefix with currency when enableDisplayBasedOnLocale = true', async () => {
-                const field = await testingUtils.getMatFormField();
+                const field = await testingUtils.formField.get();
                 expect(await field.getPrefixText()).toBe('');
             });
         });
@@ -666,7 +666,7 @@ describe('AmountWidgetComponent - rendering', () => {
             });
 
             it('should not display prefix with currency when enableDisplayBasedOnLocale = true', async () => {
-                const field = await testingUtils.getMatFormField();
+                const field = await testingUtils.formField.get();
                 expect(await field.getPrefixText()).toBe('');
             });
 
@@ -674,7 +674,7 @@ describe('AmountWidgetComponent - rendering', () => {
                 const focusSpy = spyOn(widget, 'amountWidgetOnFocus').and.callThrough();
                 fixture.detectChanges();
 
-                const field = await testingUtils.getMatInput();
+                const field = await testingUtils.input.get();
                 const fieldValueBeforeFocus = await field.getValue();
                 await field.focus();
                 const fieldValue = await field.getValue();
@@ -691,7 +691,7 @@ describe('AmountWidgetComponent - rendering', () => {
                 const blurSpy = spyOn(widget, 'amountWidgetOnBlur').and.callThrough();
                 fixture.detectChanges();
 
-                const field = await testingUtils.getMatInput();
+                const field = await testingUtils.input.get();
                 const fieldValueBeforeBlur = await field.getValue();
                 await field.setValue(newValue);
                 await field.blur();
@@ -737,7 +737,7 @@ describe('AmountWidgetComponent - rendering', () => {
                 const focusSpy = spyOn(widget, 'amountWidgetOnFocus').and.callThrough();
                 fixture.detectChanges();
 
-                const field = await testingUtils.getMatInput();
+                const field = await testingUtils.input.get();
                 const fieldValueBeforeFocus = await field.getValue();
                 await field.focus();
                 const fieldValue = await field.getValue();
@@ -754,7 +754,7 @@ describe('AmountWidgetComponent - rendering', () => {
                 const blurSpy = spyOn(widget, 'amountWidgetOnBlur').and.callThrough();
                 fixture.detectChanges();
 
-                const field = await testingUtils.getMatInput();
+                const field = await testingUtils.input.get();
                 const fieldValueBeforeBlur = await field.getValue();
                 await field.setValue(newValue);
                 await field.blur();
@@ -795,7 +795,7 @@ describe('AmountWidgetComponent - rendering', () => {
             });
 
             it('should display prefix with currency when enableDisplayBasedOnLocale = true', async () => {
-                const field = await testingUtils.getMatFormField();
+                const field = await testingUtils.formField.get();
                 expect(await field.getPrefixText()).toBe('USD');
             });
 
@@ -803,7 +803,7 @@ describe('AmountWidgetComponent - rendering', () => {
                 const focusSpy = spyOn(widget, 'amountWidgetOnFocus').and.callThrough();
                 fixture.detectChanges();
 
-                const field = await testingUtils.getMatInput();
+                const field = await testingUtils.input.get();
                 const fieldValueBeforeFocus = await field.getValue();
                 await field.focus();
                 const fieldValue = await field.getValue();
@@ -821,7 +821,7 @@ describe('AmountWidgetComponent - rendering', () => {
                 const blurSpy = spyOn(widget, 'amountWidgetOnBlur').and.callThrough();
                 fixture.detectChanges();
 
-                const field = await testingUtils.getMatInput();
+                const field = await testingUtils.input.get();
                 const fieldValueBeforeBlur = await field.getValue();
                 await field.setValue(newValue);
                 await field.blur();

--- a/lib/core/src/lib/form/components/widgets/checkbox/checkbox.widget.spec.ts
+++ b/lib/core/src/lib/form/components/widgets/checkbox/checkbox.widget.spec.ts
@@ -69,7 +69,7 @@ describe('CheckboxWidgetComponent', () => {
         });
 
         it('should be marked as invalid when required after interaction', async () => {
-            const checkbox = await testingUtils.getMatCheckbox();
+            const checkbox = await testingUtils.checkbox.get();
             expect(testingUtils.getByCSS('.adf-invalid')).toBeFalsy();
 
             await checkbox.check();
@@ -92,14 +92,14 @@ describe('CheckboxWidgetComponent', () => {
             widget.field.value = true;
             fixture.detectChanges();
 
-            expect(await testingUtils.checkIfMatCheckboxIsChecked()).toBe(true);
+            expect(await testingUtils.checkbox.isChecked()).toBe(true);
         });
 
         it('should not be checked if false is passed', async () => {
             widget.field.value = false;
             fixture.detectChanges();
 
-            expect(await testingUtils.checkIfMatCheckboxIsChecked()).toBe(false);
+            expect(await testingUtils.checkbox.isChecked()).toBe(false);
         });
 
         describe('when tooltip is set', () => {
@@ -112,8 +112,8 @@ describe('CheckboxWidgetComponent', () => {
             });
 
             it('should show tooltip', async () => {
-                await testingUtils.hoverOverMatCheckbox();
-                const host = await testingUtils.getMatCheckboxHost();
+                await testingUtils.checkbox.hover();
+                const host = await testingUtils.checkbox.getHost();
                 const tooltip = await host.getAttribute('title');
                 expect(tooltip).toBe('my custom tooltip');
             });

--- a/lib/core/src/lib/form/components/widgets/date-time/date-time.widget.spec.ts
+++ b/lib/core/src/lib/form/components/widgets/date-time/date-time.widget.spec.ts
@@ -211,7 +211,7 @@ describe('DateTimeWidgetComponent', () => {
         fixture.detectChanges();
         await fixture.whenStable();
 
-        await testingUtils.fillMatInput('12-09-9999 10:30 AM');
+        await testingUtils.input.fill('12-09-9999 10:30 AM');
 
         expect(field.value).toEqual(jasmine.any(Date));
         expect(field.value.getFullYear()).toBe(9999);
@@ -232,7 +232,7 @@ describe('DateTimeWidgetComponent', () => {
 
         fixture.detectChanges();
 
-        await testingUtils.fillMatInput('123abc');
+        await testingUtils.input.fill('123abc');
 
         expect(widget.datetimeInputControl.invalid).toBeTrue();
         expect(field.value).toBe(null);
@@ -254,7 +254,7 @@ describe('DateTimeWidgetComponent', () => {
         fixture.whenStable();
         await fixture.whenStable();
 
-        await testingUtils.fillMatInput(null);
+        await testingUtils.input.fill(null);
 
         expect(widget.datetimeInputControl.value).toBe(null);
         expect(widget.datetimeInputControl.valid).toBeTrue();
@@ -275,7 +275,7 @@ describe('DateTimeWidgetComponent', () => {
         fixture.detectChanges();
         await fixture.whenStable();
 
-        await testingUtils.fillMatInput('03-25-2025 02:30 PM');
+        await testingUtils.input.fill('03-25-2025 02:30 PM');
 
         expect(field.value).toEqual(jasmine.any(Date));
         expect(field.value.getFullYear()).toBe(2025);
@@ -297,7 +297,7 @@ describe('DateTimeWidgetComponent', () => {
         fixture.detectChanges();
         await fixture.whenStable();
 
-        await testingUtils.fillMatInput('03/25/2025 02:30 PM');
+        await testingUtils.input.fill('03/25/2025 02:30 PM');
 
         expect(widget.datetimeInputControl.invalid).toBeTrue();
         expect(field.isValid).toBeFalse();
@@ -316,12 +316,12 @@ describe('DateTimeWidgetComponent', () => {
         fixture.detectChanges();
         await fixture.whenStable();
 
-        await testingUtils.fillMatInput('invalid-text');
+        await testingUtils.input.fill('invalid-text');
 
         expect(widget.datetimeInputControl.invalid).toBeTrue();
         expect(field.isValid).toBeFalse();
 
-        await testingUtils.fillMatInput('');
+        await testingUtils.input.fill('');
 
         expect(widget.datetimeInputControl.valid).toBeTrue();
         expect(field.isValid).toBeTrue();
@@ -360,7 +360,7 @@ describe('DateTimeWidgetComponent', () => {
         });
 
         it('should show tooltip', async () => {
-            const host = await testingUtils.getMatInputHost();
+            const host = await testingUtils.input.getHost();
             await host.hover();
 
             const tooltip = await host.getAttribute('title');
@@ -405,7 +405,7 @@ describe('DateTimeWidgetComponent', () => {
         });
 
         it('should be able to display label with asterisk and input field is required', async () => {
-            const formField = await testingUtils.getMatFormField();
+            const formField = await testingUtils.formField.get();
             const formControl = await formField.getControl();
 
             expect(formControl.isRequired).toBeTruthy();
@@ -427,7 +427,7 @@ describe('DateTimeWidgetComponent', () => {
             fixture.detectChanges();
             await fixture.whenStable();
 
-            expect(await testingUtils.getMatInputValue()).toBe('30-11-9999 10:30 AM');
+            expect(await testingUtils.input.getValue()).toBe('30-11-9999 10:30 AM');
         });
 
         it('should show the correct format type', async () => {
@@ -442,7 +442,7 @@ describe('DateTimeWidgetComponent', () => {
             fixture.detectChanges();
             await fixture.whenStable();
 
-            expect(await testingUtils.getMatInputValue()).toBe('12-30-9999 10:30 AM');
+            expect(await testingUtils.input.getValue()).toBe('12-30-9999 10:30 AM');
         });
 
         it('should disable date button when is readonly', () => {
@@ -483,7 +483,7 @@ describe('DateTimeWidgetComponent', () => {
         fixture.detectChanges();
         await fixture.whenStable();
 
-        const input = await testingUtils.getMatInput();
+        const input = await testingUtils.input.get();
         expect(await input.getValue()).toBe('12-30-9999 10:30 AM');
 
         widget.field.value = '2020-03-02T00:00:00.000Z';
@@ -508,7 +508,7 @@ describe('DateTimeWidgetComponent', () => {
         fixture.detectChanges();
         await fixture.whenStable();
 
-        const input = await testingUtils.getMatInput();
+        const input = await testingUtils.input.get();
         expect(await input.getValue()).toBe('12/30/9999 10;30 AM');
 
         widget.field.value = '2020-03-02T00:00:00.000Z';
@@ -597,8 +597,8 @@ describe('DateTimeWidgetComponent', () => {
                 required: true
             });
 
-            await testingUtils.focusMatInput();
-            await testingUtils.sendKeysToMatInput([TestKey.ENTER]);
+            await testingUtils.input.focus();
+            await testingUtils.input.sendKeys([TestKey.ENTER]);
 
             expect(testingUtils.getByDataAutomationId('adf-date-time-widget-picker')).toBeTruthy();
         });

--- a/lib/core/src/lib/form/components/widgets/date/date.widget.spec.ts
+++ b/lib/core/src/lib/form/components/widgets/date/date.widget.spec.ts
@@ -391,7 +391,7 @@ describe('DateWidgetComponent', () => {
             fixture.detectChanges();
             await fixture.whenStable();
 
-            await testingUtils.fillMatInput('25-03-2025');
+            await testingUtils.input.fill('25-03-2025');
 
             expect(field.value).toEqual(jasmine.any(Date));
             expect(field.value.getFullYear()).toBe(2025);
@@ -412,7 +412,7 @@ describe('DateWidgetComponent', () => {
             fixture.detectChanges();
             await fixture.whenStable();
 
-            await testingUtils.fillMatInput('03-25-2025');
+            await testingUtils.input.fill('03-25-2025');
 
             expect(field.value).toEqual(jasmine.any(Date));
             expect(field.value.getFullYear()).toBe(2025);
@@ -433,7 +433,7 @@ describe('DateWidgetComponent', () => {
             fixture.detectChanges();
             await fixture.whenStable();
 
-            await testingUtils.fillMatInput('03/25/2025');
+            await testingUtils.input.fill('03/25/2025');
 
             expect(widget.dateInputControl.invalid).toBeTrue();
             expect(field.isValid).toBeFalse();
@@ -452,7 +452,7 @@ describe('DateWidgetComponent', () => {
             fixture.detectChanges();
             await fixture.whenStable();
 
-            await testingUtils.fillMatInput('invalid-text');
+            await testingUtils.input.fill('invalid-text');
 
             expect(widget.dateInputControl.invalid).toBeTrue();
             expect(field.isValid).toBeFalse();
@@ -471,12 +471,12 @@ describe('DateWidgetComponent', () => {
             fixture.detectChanges();
             await fixture.whenStable();
 
-            await testingUtils.fillMatInput('invalid-text');
+            await testingUtils.input.fill('invalid-text');
 
             expect(widget.dateInputControl.invalid).toBeTrue();
             expect(field.isValid).toBeFalse();
 
-            await testingUtils.fillMatInput('');
+            await testingUtils.input.fill('');
 
             expect(widget.dateInputControl.valid).toBeTrue();
             expect(field.isValid).toBeTrue();

--- a/lib/core/src/lib/form/components/widgets/decimal/decimal.component.spec.ts
+++ b/lib/core/src/lib/form/components/widgets/decimal/decimal.component.spec.ts
@@ -69,7 +69,7 @@ describe('DecimalComponent', () => {
         });
 
         it('should show tooltip', async () => {
-            const host = await testingUtils.getMatInputHost();
+            const host = await testingUtils.input.getHost();
             await host.hover();
 
             const tooltip = await host.getAttribute('title');
@@ -90,14 +90,14 @@ describe('DecimalComponent', () => {
         it('should be marked as invalid after interaction', async () => {
             expect(testingUtils.getByCSS('.adf-invalid')).toBeFalsy();
 
-            await testingUtils.blurMatInput();
+            await testingUtils.input.blur();
             fixture.detectChanges();
 
             expect(testingUtils.getByCSS('.adf-invalid')).toBeTruthy();
         });
 
         it('should be able to display label with asterisk and input field is required', async () => {
-            const formField = await testingUtils.getMatFormField();
+            const formField = await testingUtils.formField.get();
             const formControl = await formField.getControl();
 
             expect(formControl.isRequired).toBeTruthy();

--- a/lib/core/src/lib/form/components/widgets/multiline-text/multiline-text.widget.spec.ts
+++ b/lib/core/src/lib/form/components/widgets/multiline-text/multiline-text.widget.spec.ts
@@ -70,7 +70,7 @@ describe('MultilineTextWidgetComponentComponent', () => {
         });
 
         it('should show tooltip', async () => {
-            const host = await testingUtils.getMatInputHost();
+            const host = await testingUtils.input.getHost();
             await host.hover();
 
             const tooltip = await host.getAttribute('title');
@@ -122,12 +122,12 @@ describe('MultilineTextWidgetComponentComponent', () => {
         it('should be marked as invalid after interaction', async () => {
             expect(testingUtils.getByCSS('.adf-invalid')).toBeFalsy();
 
-            await testingUtils.blurMatInput();
+            await testingUtils.input.blur();
             expect(testingUtils.getByCSS('.adf-invalid')).toBeTruthy();
         });
 
         it('should be able to display label with asterisk and input field is required', async () => {
-            const formField = await testingUtils.getMatFormField();
+            const formField = await testingUtils.formField.get();
             const formControl = await formField.getControl();
 
             expect(formControl.isRequired).toBeTruthy();
@@ -179,7 +179,7 @@ describe('MultilineTextWidgetComponentComponent - ADF_CUSTOM_MESSAGE', () => {
                 });
                 fixture.detectChanges();
 
-                await testingUtils.fillMatInput('invalid text');
+                await testingUtils.input.fill('invalid text');
                 expect(widget.field.isValid).toBeFalse();
                 expect(widget.field.validationSummary.message).toBe('Only numbers are allowed');
             });
@@ -219,7 +219,7 @@ describe('MultilineTextWidgetComponentComponent - ADF_CUSTOM_MESSAGE', () => {
                 });
                 fixture.detectChanges();
 
-                await testingUtils.fillMatInput('invalid text');
+                await testingUtils.input.fill('invalid text');
                 expect(widget.field.isValid).toBeFalse();
                 expect(widget.field.validationSummary.message).toBe('FORM.FIELD.VALIDATOR.INVALID_VALUE');
             });
@@ -324,7 +324,7 @@ describe('MultilineTextWidgetComponentComponent - ADF_CUSTOM_MESSAGE', () => {
             });
             fixture.detectChanges();
 
-            await testingUtils.fillMatInput('invalid text');
+            await testingUtils.input.fill('invalid text');
             expect(widget.field.isValid).toBeFalse();
             expect(widget.field.validationSummary.message).toBe('FORM.FIELD.VALIDATOR.INVALID_VALUE');
         });

--- a/lib/core/src/lib/form/components/widgets/number/number.widget.spec.ts
+++ b/lib/core/src/lib/form/components/widgets/number/number.widget.spec.ts
@@ -100,7 +100,7 @@ describe('NumberWidgetComponent', () => {
         });
 
         it('should display the value', async () => {
-            const input = await testingUtils.getMatInput();
+            const input = await testingUtils.input.get();
 
             expect(widget.displayValue).toBe(123);
             expect(await input.getValue()).toBe('123');
@@ -108,21 +108,21 @@ describe('NumberWidgetComponent', () => {
         });
 
         it('should have value null when field is cleared', async () => {
-            const input = await testingUtils.getMatInput();
+            const input = await testingUtils.input.get();
             await input.setValue('');
 
             expect(widget.field.value).toBeNull();
         });
 
         it('should have value null when value is undefined', async () => {
-            const input = await testingUtils.getMatInput();
+            const input = await testingUtils.input.get();
             await input.setValue(undefined);
 
             expect(widget.field.value).toBeNull();
         });
 
         it('should have value null when value is null', async () => {
-            const input = await testingUtils.getMatInput();
+            const input = await testingUtils.input.get();
             await input.setValue(null);
 
             expect(widget.field.value).toBeNull();
@@ -139,7 +139,7 @@ describe('NumberWidgetComponent', () => {
         });
 
         it('should show tooltip', async () => {
-            const host = await testingUtils.getMatInputHost();
+            const host = await testingUtils.input.getHost();
             await host.hover();
 
             const tooltip = await host.getAttribute('title');
@@ -159,13 +159,13 @@ describe('NumberWidgetComponent', () => {
         it('should be marked as invalid after interaction', async () => {
             expect(testingUtils.getByCSS('.adf-invalid')).toBeFalsy();
 
-            await testingUtils.blurMatInput();
+            await testingUtils.input.blur();
 
             expect(testingUtils.getByCSS('.adf-invalid')).toBeTruthy();
         });
 
         it('should be able to display label with asterisk and input field is required', async () => {
-            const formField = await testingUtils.getMatFormField();
+            const formField = await testingUtils.formField.get();
             const formControl = await formField.getControl();
 
             expect(formControl.isRequired).toBeTruthy();

--- a/lib/core/src/lib/form/components/widgets/text/text.widget.spec.ts
+++ b/lib/core/src/lib/form/components/widgets/text/text.widget.spec.ts
@@ -78,7 +78,7 @@ describe('TextWidgetComponent', () => {
                 fixture.detectChanges();
                 expect(widget.field.value).toBe('');
 
-                await testingUtils.fillMatInput('TEXT');
+                await testingUtils.input.fill('TEXT');
 
                 expect(widget.field.value).toBe('TEXT');
             });
@@ -108,7 +108,7 @@ describe('TextWidgetComponent', () => {
                 fixture.detectChanges();
                 await fixture.whenStable();
 
-                expect(await testingUtils.getMatInputByPlaceholder('Your name here')).toBeTruthy();
+                expect(await testingUtils.input.getByPlaceholder('Your name here')).toBeTruthy();
             });
 
             it('should be able to set min/max length properties for Text widget', async () => {
@@ -123,19 +123,19 @@ describe('TextWidgetComponent', () => {
                 });
                 fixture.detectChanges();
 
-                await testingUtils.fillMatInput('TEXT');
+                await testingUtils.input.fill('TEXT');
 
-                const formField = await testingUtils.getMatFormField();
+                const formField = await testingUtils.formField.get();
                 let errors = await formField.getTextErrors();
                 expect(errors[0]).toContain('FORM.FIELD.VALIDATOR.AT_LEAST_LONG');
                 expect(widget.field.isValid).toBe(false);
 
-                await testingUtils.fillMatInput('TEXT VALUE');
+                await testingUtils.input.fill('TEXT VALUE');
 
                 errors = await formField.getTextErrors();
                 expect(widget.field.isValid).toBe(true);
 
-                await testingUtils.fillMatInput('TEXT VALUE TOO LONG');
+                await testingUtils.input.fill('TEXT VALUE TOO LONG');
                 expect(widget.field.isValid).toBe(false);
 
                 errors = await formField.getTextErrors();
@@ -152,7 +152,7 @@ describe('TextWidgetComponent', () => {
                 });
                 fixture.detectChanges();
 
-                await testingUtils.fillMatInput('a'.repeat(1025));
+                await testingUtils.input.fill('a'.repeat(1025));
 
                 expect(widget.field.isValid).toBe(false);
                 expect(widget.field.validationSummary.message).toBe('FORM.FIELD.VALIDATOR.NO_LONGER_THAN');
@@ -333,13 +333,13 @@ describe('TextWidgetComponent', () => {
                 });
                 fixture.detectChanges();
 
-                await testingUtils.fillMatInput('TEXT');
+                await testingUtils.input.fill('TEXT');
                 expect(widget.field.isValid).toBe(false);
 
-                await testingUtils.fillMatInput('8');
+                await testingUtils.input.fill('8');
                 expect(widget.field.isValid).toBe(true);
 
-                await testingUtils.fillMatInput('8XYZ');
+                await testingUtils.input.fill('8XYZ');
                 expect(widget.field.isValid).toBe(false);
             });
         });
@@ -354,7 +354,7 @@ describe('TextWidgetComponent', () => {
             });
 
             it('should show tooltip', async () => {
-                const host = await testingUtils.getMatInputHost();
+                const host = await testingUtils.input.getHost();
                 await host.hover();
 
                 const tooltip = await host.getAttribute('title');
@@ -377,13 +377,13 @@ describe('TextWidgetComponent', () => {
             it('should be marked as invalid after interaction', async () => {
                 expect(testingUtils.getByCSS('.adf-invalid')).toBeFalsy();
 
-                await testingUtils.blurMatInput();
+                await testingUtils.input.blur();
 
                 expect(testingUtils.getByCSS('.adf-invalid')).toBeTruthy();
             });
 
             it('should be able to display label with asterisk and input field is required', async () => {
-                const formField = await testingUtils.getMatFormField();
+                const formField = await testingUtils.formField.get();
                 const formControl = await formField.getControl();
 
                 expect(formControl.isRequired).toBeTruthy();
@@ -407,7 +407,7 @@ describe('TextWidgetComponent', () => {
             });
 
             it('should be disabled on readonly forms', async () => {
-                const input = await testingUtils.getMatInput();
+                const input = await testingUtils.input.get();
                 expect(await input.isDisabled()).toBe(true);
             });
         });
@@ -431,17 +431,17 @@ describe('TextWidgetComponent', () => {
             });
 
             it('should show text widget', async () => {
-                expect(await testingUtils.checkIfMatInputExists()).toBe(true);
+                expect(await testingUtils.input.exists()).toBe(true);
             });
 
             it('should show the field placeholder', async () => {
-                expect(await testingUtils.checkIfMatInputExistsWithPlaceholder('simple placeholder')).toBeTrue();
+                expect(await testingUtils.input.existsByPlaceholder('simple placeholder')).toBeTrue();
             });
 
             it('should show the field placeholder when clicked', async () => {
-                await testingUtils.clickMatInput();
+                await testingUtils.input.click();
 
-                expect(await testingUtils.checkIfMatInputExistsWithPlaceholder('simple placeholder')).toBeTruthy();
+                expect(await testingUtils.input.existsByPlaceholder('simple placeholder')).toBeTruthy();
             });
 
             it('should prevent text to be written if is not allowed by the mask on keyUp event', async () => {
@@ -566,13 +566,13 @@ describe('TextWidgetComponent', () => {
             });
 
             it('should show the input mask placeholder', async () => {
-                expect(await testingUtils.checkIfMatInputExistsWithPlaceholder('Phone : (__) ___-___')).toBeTrue();
+                expect(await testingUtils.input.existsByPlaceholder('Phone : (__) ___-___')).toBeTrue();
             });
 
             it('should show the input mask placeholder when clicked', async () => {
-                await testingUtils.clickMatInput();
+                await testingUtils.input.click();
 
-                expect(await testingUtils.checkIfMatInputExistsWithPlaceholder('Phone : (__) ___-___')).toBeTrue();
+                expect(await testingUtils.input.existsByPlaceholder('Phone : (__) ___-___')).toBeTrue();
             });
         });
 
@@ -782,7 +782,7 @@ describe('TextWidgetComponent - ADF_CUSTOM_MESSAGE', () => {
                 });
                 fixture.detectChanges();
 
-                await testingUtils.fillMatInput('invalid text');
+                await testingUtils.input.fill('invalid text');
                 expect(widget.field.isValid).toBeFalse();
                 expect(widget.field.validationSummary.message).toBe('Only numbers are allowed');
             });
@@ -822,7 +822,7 @@ describe('TextWidgetComponent - ADF_CUSTOM_MESSAGE', () => {
                 });
                 fixture.detectChanges();
 
-                await testingUtils.fillMatInput('invalid text');
+                await testingUtils.input.fill('invalid text');
                 expect(widget.field.isValid).toBeFalse();
                 expect(widget.field.validationSummary.message).toBe('FORM.FIELD.VALIDATOR.INVALID_VALUE');
             });
@@ -927,7 +927,7 @@ describe('TextWidgetComponent - ADF_CUSTOM_MESSAGE', () => {
             });
             fixture.detectChanges();
 
-            await testingUtils.fillMatInput('invalid text');
+            await testingUtils.input.fill('invalid text');
             expect(widget.field.isValid).toBeFalse();
             expect(widget.field.validationSummary.message).toBe('FORM.FIELD.VALIDATOR.INVALID_VALUE');
         });

--- a/lib/core/src/lib/info-drawer/info-drawer.component.spec.ts
+++ b/lib/core/src/lib/info-drawer/info-drawer.component.spec.ts
@@ -127,22 +127,22 @@ describe('Custom InfoDrawer', () => {
     it('should select the tab 1 (index 0) as default', async () => {
         fixture.detectChanges();
 
-        expect(await testingUtils.getSelectedTabLabelFromMatTabGroup()).toEqual('Tab1');
+        expect(await testingUtils.tabGroup.getSelectedTabLabel()).toEqual('Tab1');
     });
 
     it('should select the tab 2 (index 1)', async () => {
         component.tabIndex = 1;
         fixture.detectChanges();
 
-        expect(await testingUtils.getSelectedTabLabelFromMatTabGroup()).toEqual('Tab2');
+        expect(await testingUtils.tabGroup.getSelectedTabLabel()).toEqual('Tab2');
     });
 
     it('should render a tab with icon', async () => {
         component.tabIndex = 2;
         fixture.detectChanges();
 
-        expect(await testingUtils.getSelectedTabLabelFromMatTabGroup()).toContain('Tab3');
-        expect(await testingUtils.getSelectedTabLabelFromMatTabGroup()).toContain('tab-icon');
+        expect(await testingUtils.tabGroup.getSelectedTabLabel()).toContain('Tab3');
+        expect(await testingUtils.tabGroup.getSelectedTabLabel()).toContain('tab-icon');
     });
 
     it('should render a icon with title', () => {

--- a/lib/core/src/lib/layout/components/header/header.component.spec.ts
+++ b/lib/core/src/lib/layout/components/header/header.component.spec.ts
@@ -60,7 +60,7 @@ describe('HeaderLayoutComponent', () => {
             component.backgroundColor = '#42f57e';
             fixture.detectChanges();
 
-            const host = await testingUtils.getMatToolbarHost();
+            const host = await testingUtils.toolbar.getHost();
 
             expect(await host.getCssValue('background-color')).toBe('rgb(66, 245, 126)');
         });
@@ -68,7 +68,7 @@ describe('HeaderLayoutComponent', () => {
         it('should background image be set to none if is not provided', async () => {
             fixture.detectChanges();
 
-            const host = await testingUtils.getMatToolbarHost();
+            const host = await testingUtils.toolbar.getHost();
 
             expect(await host.getCssValue('background-image')).toEqual('none');
         });
@@ -78,7 +78,7 @@ describe('HeaderLayoutComponent', () => {
 
             fixture.detectChanges();
 
-            const host = await testingUtils.getMatToolbarHost();
+            const host = await testingUtils.toolbar.getHost();
 
             expect(await host.getCssValue('background-image')).toEqual('none');
         });
@@ -87,7 +87,7 @@ describe('HeaderLayoutComponent', () => {
             component.backgroundImage = '/assets/someImage.png';
             fixture.detectChanges();
 
-            const host = await testingUtils.getMatToolbarHost();
+            const host = await testingUtils.toolbar.getHost();
 
             expect(await host.getCssValue('background-image')).toContain('/assets/someImage.png');
         });

--- a/lib/core/src/lib/layout/components/layout-container/layout-container.component.spec.ts
+++ b/lib/core/src/lib/layout/components/layout-container/layout-container.component.spec.ts
@@ -172,7 +172,7 @@ describe('LayoutContainerComponent', () => {
         let sidenav: MatSidenavHarness;
 
         beforeEach(async () => {
-            sidenav = await unitTestingUtils.getMatSidenav();
+            sidenav = await unitTestingUtils.sidenav.get();
         });
 
         it('should switch to sidenav to compact state', async () => {
@@ -221,7 +221,7 @@ describe('LayoutContainerComponent', () => {
         };
 
         beforeEach(async () => {
-            sidenav = await unitTestingUtils.getMatSidenav();
+            sidenav = await unitTestingUtils.sidenav.get();
         });
 
         it('should close sidenav on mobile and open on desktop', async () => {

--- a/lib/core/src/lib/notifications/services/notification.service.spec.ts
+++ b/lib/core/src/lib/notifications/services/notification.service.spec.ts
@@ -125,14 +125,14 @@ describe('NotificationService', () => {
         fixture.componentInstance.sendMessage();
         fixture.detectChanges();
 
-        const isLoaded = await testingUtils.checkIfMatSnackbarExists();
+        const isLoaded = await testingUtils.snackbar.exists();
         expect(isLoaded).toBe(true);
     });
 
     it('should open a message notification bar without custom configuration', async () => {
         fixture.componentInstance.sendMessageWithoutConfig();
         fixture.detectChanges();
-        const isLoaded = await testingUtils.checkIfMatSnackbarExists();
+        const isLoaded = await testingUtils.snackbar.exists();
         expect(isLoaded).toBe(true);
     });
 
@@ -140,35 +140,35 @@ describe('NotificationService', () => {
         fixture.componentInstance.sendCustomMessage();
         fixture.detectChanges();
 
-        expect(await testingUtils.checkIfMatSnackbarExists()).toBe(true);
+        expect(await testingUtils.snackbar.exists()).toBe(true);
     });
 
     it('should open a message notification bar with action', async () => {
         fixture.componentInstance.sendMessageAction();
-        expect(await testingUtils.checkIfMatSnackbarExists()).toBe(true);
+        expect(await testingUtils.snackbar.exists()).toBe(true);
     });
 
     it('should open a message notification bar with action and custom configuration', async () => {
         fixture.componentInstance.sendCustomMessageAction();
         fixture.detectChanges();
 
-        expect(await testingUtils.checkIfMatSnackbarExists()).toBe(true);
+        expect(await testingUtils.snackbar.exists()).toBe(true);
     });
 
     it('should open a message notification bar with action and no custom configuration', async () => {
         fixture.componentInstance.sendMessageActionWithoutConfig();
         fixture.detectChanges();
 
-        expect(await testingUtils.checkIfMatSnackbarExists()).toBe(true);
+        expect(await testingUtils.snackbar.exists()).toBe(true);
     });
 
     it('should open a message notification bar with a decorative icon', async () => {
         fixture.componentInstance.sendMessageWithDecorativeIcon();
-        expect(await testingUtils.checkIfMatIconExistsWithAncestorByDataAutomationId('adf-snackbar-message-content')).toBe(true);
+        expect(await testingUtils.icon.existsWithAncestorByDataAutomationId('adf-snackbar-message-content')).toBe(true);
     });
 
     it('should open a message notification bar with action and a decorative icon', async () => {
         fixture.componentInstance.sendMessageWithDecorativeIconAndAction();
-        expect(await testingUtils.checkIfMatIconExistsWithAncestorByDataAutomationId('adf-snackbar-message-content')).toBe(true);
+        expect(await testingUtils.icon.existsWithAncestorByDataAutomationId('adf-snackbar-message-content')).toBe(true);
     });
 });

--- a/lib/core/src/lib/testing/unit-testing-utils.ts
+++ b/lib/core/src/lib/testing/unit-testing-utils.ts
@@ -38,7 +38,7 @@ import { MatProgressSpinnerHarness } from '@angular/material/progress-spinner/te
 import { MatMenuHarness } from '@angular/material/menu/testing';
 import { MatSidenavHarness } from '@angular/material/sidenav/testing';
 
-class HarnessBase {
+abstract class HarnessBase {
     constructor(readonly loader: HarnessLoader) {}
 }
 
@@ -416,10 +416,10 @@ export class UnitTestingUtils {
     readonly menu: MenuUtils;
     readonly sidenav: SidenavUtils;
 
-    private _debugElement?: DebugElement;
-
-    constructor(debugElement?: DebugElement, loader?: HarnessLoader) {
-        this._debugElement = debugElement;
+    constructor(
+        private debugElement?: DebugElement,
+        loader?: HarnessLoader
+    ) {
         this.button = new ButtonUtils(loader);
         this.checkbox = new CheckboxUtils(loader);
         this.icon = new IconUtils(loader);
@@ -443,15 +443,15 @@ export class UnitTestingUtils {
     }
 
     setDebugElement(debugElement: DebugElement): void {
-        this._debugElement = debugElement;
+        this.debugElement = debugElement;
     }
 
     getByCSS(selector: string): DebugElement {
-        return this._debugElement.query(By.css(selector));
+        return this.debugElement.query(By.css(selector));
     }
 
     getAllByCSS(selector: string): DebugElement[] {
-        return this._debugElement.queryAll(By.css(selector));
+        return this.debugElement.queryAll(By.css(selector));
     }
 
     getInnerTextByCSS(selector: string): string {
@@ -467,7 +467,7 @@ export class UnitTestingUtils {
     }
 
     getAllByDataAutomationId(dataAutomationId: string): DebugElement[] {
-        return this._debugElement.queryAll(By.css(`[data-automation-id="${dataAutomationId}"]`));
+        return this.debugElement.queryAll(By.css(`[data-automation-id="${dataAutomationId}"]`));
     }
 
     getInnerTextByDataAutomationId(dataAutomationId: string): string {
@@ -475,11 +475,11 @@ export class UnitTestingUtils {
     }
 
     getByDirective(directive: Type<any>): DebugElement {
-        return this._debugElement.query(By.directive(directive));
+        return this.debugElement.query(By.directive(directive));
     }
 
     getAllByDirective(directive: Type<any>): DebugElement[] {
-        return this._debugElement.queryAll(By.directive(directive));
+        return this.debugElement.queryAll(By.directive(directive));
     }
 
     /** Perform actions */

--- a/lib/core/src/lib/testing/unit-testing-utils.ts
+++ b/lib/core/src/lib/testing/unit-testing-utils.ts
@@ -38,29 +38,420 @@ import { MatProgressSpinnerHarness } from '@angular/material/progress-spinner/te
 import { MatMenuHarness } from '@angular/material/menu/testing';
 import { MatSidenavHarness } from '@angular/material/sidenav/testing';
 
+class HarnessBase {
+    constructor(readonly loader: HarnessLoader) {}
+}
+
+class ButtonUtils extends HarnessBase {
+    async get(): Promise<MatButtonHarness> {
+        return this.loader.getHarness(MatButtonHarness);
+    }
+
+    async getByCSS(selector: string): Promise<MatButtonHarness> {
+        return this.loader.getHarness(MatButtonHarness.with({ selector }));
+    }
+
+    async getByDataAutomationId(dataAutomationId: string): Promise<MatButtonHarness> {
+        return this.loader.getHarness(MatButtonHarness.with({ selector: `[data-automation-id="${dataAutomationId}"]` }));
+    }
+
+    async exists(): Promise<boolean> {
+        return this.loader.hasHarness(MatButtonHarness);
+    }
+
+    async existsByDataAutomationId(dataAutomationId: string): Promise<boolean> {
+        return this.loader.hasHarness(MatButtonHarness.with({ selector: `[data-automation-id="${dataAutomationId}"]` }));
+    }
+
+    async click(): Promise<void> {
+        const button = await this.get();
+        await button.click();
+    }
+
+    async clickByCSS(selector: string): Promise<void> {
+        const button = await this.getByCSS(selector);
+        await button.click();
+    }
+
+    async clickByDataAutomationId(dataAutomationId: string): Promise<void> {
+        const button = await this.getByDataAutomationId(dataAutomationId);
+        await button.click();
+    }
+
+    async sendKeys(keys: (string | TestKey)[]): Promise<void> {
+        const button = await this.get();
+        const host = await button.host();
+        await host.sendKeys(...keys);
+    }
+}
+
+class CheckboxUtils extends HarnessBase {
+    async get(): Promise<MatCheckboxHarness> {
+        return this.loader.getHarness(MatCheckboxHarness);
+    }
+
+    async getByDataAutomationId(dataAutomationId: string): Promise<MatCheckboxHarness> {
+        return this.loader.getHarness(MatCheckboxHarness.with({ selector: `[data-automation-id="${dataAutomationId}"]` }));
+    }
+
+    async getHost(): Promise<TestElement> {
+        const checkbox = await this.get();
+        return checkbox.host();
+    }
+
+    async getAll(): Promise<MatCheckboxHarness[]> {
+        return this.loader.getAllHarnesses(MatCheckboxHarness);
+    }
+
+    async isChecked(): Promise<boolean> {
+        const checkbox = await this.get();
+        return checkbox.isChecked();
+    }
+
+    async allHaveClass(className: string): Promise<boolean> {
+        const checkboxes = await this.getAll();
+        return checkboxes.every(async (checkbox) => (await checkbox.host()).hasClass(className));
+    }
+
+    async hover(): Promise<void> {
+        const host = await this.getHost();
+        await host.hover();
+    }
+}
+
+class IconUtils extends HarnessBase {
+    async getOrNull(): Promise<MatIconHarness> {
+        return this.loader.getHarnessOrNull(MatIconHarness);
+    }
+
+    async getWithAncestorByDataAutomationId(dataAutomationId: string): Promise<MatIconHarness> {
+        return this.loader.getHarness(MatIconHarness.with({ ancestor: `[data-automation-id="${dataAutomationId}"]` }));
+    }
+
+    async getWithAncestorByCSS(selector: string): Promise<MatIconHarness> {
+        return this.loader.getHarness(MatIconHarness.with({ ancestor: selector }));
+    }
+
+    async existsWithAncestorByDataAutomationId(dataAutomationId: string): Promise<boolean> {
+        return this.loader.hasHarness(MatIconHarness.with({ ancestor: `[data-automation-id="${dataAutomationId}"]` }));
+    }
+
+    async existsWithAncestorByCSSAndName(selector: string, name: string): Promise<boolean> {
+        return this.loader.hasHarness(MatIconHarness.with({ ancestor: selector, name }));
+    }
+
+    async clickWithAncestorByDataAutomationId(dataAutomationId: string): Promise<void> {
+        const icon = await this.getWithAncestorByDataAutomationId(dataAutomationId);
+        const host = await icon.host();
+        await host.click();
+    }
+}
+
+class SelectUtils extends HarnessBase {
+    async get(): Promise<MatSelectHarness> {
+        return this.loader.getHarness(MatSelectHarness);
+    }
+
+    async getByDataAutomationId(dataAutomationId: string): Promise<MatSelectHarness> {
+        return this.loader.getHarness(MatSelectHarness.with({ selector: `[data-automation-id="${dataAutomationId}"]` }));
+    }
+
+    async getHost(): Promise<TestElement> {
+        const select = await this.get();
+        return select.host();
+    }
+
+    async getOptions(isOpened = false): Promise<MatOptionHarness[]> {
+        const select = await this.get();
+        if (!isOpened) {
+            await select.open();
+        }
+        return select.getOptions();
+    }
+
+    async exists(): Promise<boolean> {
+        return this.loader.hasHarness(MatSelectHarness);
+    }
+
+    async open(): Promise<void> {
+        const select = await this.get();
+        await select.open();
+    }
+}
+
+class ChipUtils extends HarnessBase {
+    async getByDataAutomationId(dataAutomationId: string): Promise<MatChipHarness> {
+        return this.loader.getHarness(MatChipHarness.with({ selector: `[data-automation-id="${dataAutomationId}"]` }));
+    }
+
+    async existsByDataAutomationId(dataAutomationId: string): Promise<boolean> {
+        return this.loader.hasHarness(MatChipHarness.with({ selector: `[data-automation-id="${dataAutomationId}"]` }));
+    }
+
+    async click(dataAutomationId: string): Promise<void> {
+        const chip = await this.getByDataAutomationId(dataAutomationId);
+        const host = await chip.host();
+        await host.click();
+    }
+
+    async getAll(): Promise<MatChipHarness[]> {
+        return this.loader.getAllHarnesses(MatChipHarness);
+    }
+}
+
+class ChipListboxUtils extends HarnessBase {
+    async getByDataAutomationId(dataAutomationId: string): Promise<MatChipListboxHarness> {
+        return this.loader.getHarness(MatChipListboxHarness.with({ selector: `[data-automation-id="${dataAutomationId}"]` }));
+    }
+
+    async click(dataAutomationId: string): Promise<void> {
+        const chipList = await this.getByDataAutomationId(dataAutomationId);
+        const host = await chipList.host();
+        await host.click();
+    }
+}
+
+class ChipGridUtils extends HarnessBase {
+    async exists(): Promise<boolean> {
+        return this.loader.hasHarness(MatChipGridHarness);
+    }
+}
+
+class ChipInputUtils extends HarnessBase {
+    async get(): Promise<MatChipInputHarness> {
+        return this.loader.getHarness(MatChipInputHarness);
+    }
+
+    async getByDataAutomationId(dataAutomationId: string): Promise<MatChipInputHarness> {
+        return this.loader.getHarness(MatChipInputHarness.with({ selector: `[data-automation-id="${dataAutomationId}"]` }));
+    }
+
+    async getByCSS(selector: string): Promise<MatChipInputHarness> {
+        return this.loader.getHarness(MatChipInputHarness.with({ selector }));
+    }
+}
+
+class FormFieldUtils extends HarnessBase {
+    async get(): Promise<MatFormFieldHarness> {
+        return this.loader.getHarness(MatFormFieldHarness);
+    }
+
+    async getByCSS(selector: string): Promise<MatFormFieldHarness> {
+        return this.loader.getHarness(MatFormFieldHarness.with({ selector }));
+    }
+}
+
+class InputUtils extends HarnessBase {
+    async get(): Promise<MatInputHarness> {
+        return this.loader.getHarness(MatInputHarness);
+    }
+
+    async getByDataAutomationId(dataAutomationId: string): Promise<MatInputHarness> {
+        return this.loader.getHarness(MatInputHarness.with({ selector: `[data-automation-id="${dataAutomationId}"]` }));
+    }
+
+    async getByPlaceholder(placeholder: string): Promise<MatInputHarness> {
+        return this.loader.getHarness(MatInputHarness.with({ placeholder }));
+    }
+
+    async getHost(): Promise<TestElement> {
+        const input = await this.get();
+        return input.host();
+    }
+
+    async exists(): Promise<boolean> {
+        return this.loader.hasHarness(MatInputHarness);
+    }
+
+    async existsByPlaceholder(placeholder: string): Promise<boolean> {
+        return this.loader.hasHarness(MatInputHarness.with({ placeholder }));
+    }
+
+    async click(): Promise<void> {
+        const input = await this.get();
+        const host = await input.host();
+        await host.click();
+    }
+
+    async fill(value: string): Promise<void> {
+        const input = await this.get();
+        await input.setValue(value);
+    }
+
+    async fillByDataAutomationId(dataAutomationId: string, value: string): Promise<void> {
+        const input = await this.getByDataAutomationId(dataAutomationId);
+        await input.setValue(value);
+        await (await input.host()).dispatchEvent('input');
+    }
+
+    async focus(): Promise<void> {
+        const input = await this.get();
+        await input.focus();
+    }
+
+    async blur(): Promise<void> {
+        const input = await this.get();
+        await input.blur();
+    }
+
+    async getValue(): Promise<string> {
+        const input = await this.get();
+        return input.getValue();
+    }
+
+    async getValueByDataAutomationId(dataAutomationId: string): Promise<string> {
+        const input = await this.getByDataAutomationId(dataAutomationId);
+        return input.getValue();
+    }
+
+    async sendKeys(keys: (string | TestKey)[]): Promise<void> {
+        const input = await this.get();
+        const host = await input.host();
+        await host.sendKeys(...keys);
+    }
+}
+
+class AutocompleteUtils extends HarnessBase {
+    async typeAndGetOptions(fixture: ComponentFixture<any>, value: string): Promise<MatOptionHarness[]> {
+        const autocomplete = await this.loader.getHarness(MatAutocompleteHarness);
+        await autocomplete.enterText(value);
+        fixture.detectChanges();
+        return autocomplete.getOptions();
+    }
+}
+
+class TabGroupUtils extends HarnessBase {
+    async getSelectedTab(): Promise<MatTabHarness> {
+        const tabs = await this.loader.getHarness(MatTabGroupHarness);
+        return tabs.getSelectedTab();
+    }
+
+    async getSelectedTabLabel(): Promise<string> {
+        const tab = await this.getSelectedTab();
+        return tab.getLabel();
+    }
+}
+
+class ToolbarUtils extends HarnessBase {
+    async getHost(): Promise<TestElement> {
+        const toolbar = await this.loader.getHarness(MatToolbarHarness);
+        return toolbar.host();
+    }
+}
+
+class SnackbarUtils extends HarnessBase {
+    async exists(): Promise<boolean> {
+        return this.loader.hasHarness(MatSnackBarHarness);
+    }
+}
+
+class ProgressBarUtils extends HarnessBase {
+    async getHost(): Promise<TestElement> {
+        const progress = await this.loader.getHarness(MatProgressBarHarness);
+        return progress.host();
+    }
+}
+
+class ListOptionUtils extends HarnessBase {
+    async get(): Promise<MatListOptionHarness> {
+        return this.loader.getHarness(MatListOptionHarness);
+    }
+
+    async getAll(): Promise<MatListOptionHarness[]> {
+        return this.loader.getAllHarnesses(MatListOptionHarness);
+    }
+}
+
+class CellUtils extends HarnessBase {
+    async getByColumnName(columnName: string): Promise<MatCellHarness> {
+        return this.loader.getHarness(MatCellHarness.with({ columnName }));
+    }
+}
+
+class ProgressSpinnerUtils extends HarnessBase {
+    async getWithAncestorByCSS(selector: string): Promise<MatProgressSpinnerHarness> {
+        return this.loader.getHarness(MatProgressSpinnerHarness.with({ ancestor: selector }));
+    }
+
+    async getWithAncestorByDataAutomationId(dataAutomationId: string): Promise<MatProgressSpinnerHarness> {
+        return this.loader.getHarness(MatProgressSpinnerHarness.with({ ancestor: `[data-automation-id="${dataAutomationId}"]` }));
+    }
+}
+
+class MenuUtils extends HarnessBase {
+    async get(): Promise<MatMenuHarness> {
+        return this.loader.getHarness(MatMenuHarness);
+    }
+
+    async getByCSS(selector: string): Promise<MatMenuHarness> {
+        return this.loader.getHarness(MatMenuHarness.with({ selector }));
+    }
+}
+
+class SidenavUtils extends HarnessBase {
+    async get(): Promise<MatSidenavHarness> {
+        return this.loader.getHarness(MatSidenavHarness);
+    }
+}
+
 export class UnitTestingUtils {
-    constructor(
-        private debugElement?: DebugElement,
-        private loader?: HarnessLoader
-    ) {
-        this.debugElement = debugElement;
-        this.loader = loader;
+    readonly button: ButtonUtils;
+    readonly checkbox: CheckboxUtils;
+    readonly icon: IconUtils;
+    readonly select: SelectUtils;
+    readonly chip: ChipUtils;
+    readonly chipListbox: ChipListboxUtils;
+    readonly chipGrid: ChipGridUtils;
+    readonly chipInput: ChipInputUtils;
+    readonly formField: FormFieldUtils;
+    readonly input: InputUtils;
+    readonly autocomplete: AutocompleteUtils;
+    readonly tabGroup: TabGroupUtils;
+    readonly toolbar: ToolbarUtils;
+    readonly snackbar: SnackbarUtils;
+    readonly progressBar: ProgressBarUtils;
+    readonly listOption: ListOptionUtils;
+    readonly cell: CellUtils;
+    readonly progressSpinner: ProgressSpinnerUtils;
+    readonly menu: MenuUtils;
+    readonly sidenav: SidenavUtils;
+
+    private _debugElement?: DebugElement;
+
+    constructor(debugElement?: DebugElement, loader?: HarnessLoader) {
+        this._debugElement = debugElement;
+        this.button = new ButtonUtils(loader);
+        this.checkbox = new CheckboxUtils(loader);
+        this.icon = new IconUtils(loader);
+        this.select = new SelectUtils(loader);
+        this.chip = new ChipUtils(loader);
+        this.chipListbox = new ChipListboxUtils(loader);
+        this.chipGrid = new ChipGridUtils(loader);
+        this.chipInput = new ChipInputUtils(loader);
+        this.formField = new FormFieldUtils(loader);
+        this.input = new InputUtils(loader);
+        this.autocomplete = new AutocompleteUtils(loader);
+        this.tabGroup = new TabGroupUtils(loader);
+        this.toolbar = new ToolbarUtils(loader);
+        this.snackbar = new SnackbarUtils(loader);
+        this.progressBar = new ProgressBarUtils(loader);
+        this.listOption = new ListOptionUtils(loader);
+        this.cell = new CellUtils(loader);
+        this.progressSpinner = new ProgressSpinnerUtils(loader);
+        this.menu = new MenuUtils(loader);
+        this.sidenav = new SidenavUtils(loader);
     }
 
     setDebugElement(debugElement: DebugElement): void {
-        this.debugElement = debugElement;
-    }
-
-    setLoader(loader: HarnessLoader): void {
-        this.loader = loader;
+        this._debugElement = debugElement;
     }
 
     getByCSS(selector: string): DebugElement {
-        return this.debugElement.query(By.css(selector));
+        return this._debugElement.query(By.css(selector));
     }
 
     getAllByCSS(selector: string): DebugElement[] {
-        return this.debugElement.queryAll(By.css(selector));
+        return this._debugElement.queryAll(By.css(selector));
     }
 
     getInnerTextByCSS(selector: string): string {
@@ -76,7 +467,7 @@ export class UnitTestingUtils {
     }
 
     getAllByDataAutomationId(dataAutomationId: string): DebugElement[] {
-        return this.debugElement.queryAll(By.css(`[data-automation-id="${dataAutomationId}"]`));
+        return this._debugElement.queryAll(By.css(`[data-automation-id="${dataAutomationId}"]`));
     }
 
     getInnerTextByDataAutomationId(dataAutomationId: string): string {
@@ -84,11 +475,11 @@ export class UnitTestingUtils {
     }
 
     getByDirective(directive: Type<any>): DebugElement {
-        return this.debugElement.query(By.directive(directive));
+        return this._debugElement.query(By.directive(directive));
     }
 
     getAllByDirective(directive: Type<any>): DebugElement[] {
-        return this.debugElement.queryAll(By.directive(directive));
+        return this._debugElement.queryAll(By.directive(directive));
     }
 
     /** Perform actions */
@@ -167,354 +558,5 @@ export class UnitTestingUtils {
         const input = this.getInputByDataAutomationId(dataAutomationId);
         input.value = value;
         input.dispatchEvent(new Event('input'));
-    }
-
-    /** MatButton related methods */
-
-    async getMatButton(): Promise<MatButtonHarness> {
-        return this.loader.getHarness(MatButtonHarness);
-    }
-
-    async getMatButtonByCSS(selector: string): Promise<MatButtonHarness> {
-        return this.loader.getHarness(MatButtonHarness.with({ selector }));
-    }
-
-    async getMatButtonByDataAutomationId(dataAutomationId: string): Promise<MatButtonHarness> {
-        return this.loader.getHarness(MatButtonHarness.with({ selector: `[data-automation-id="${dataAutomationId}"]` }));
-    }
-
-    async checkIfMatButtonExists(): Promise<boolean> {
-        return this.loader.hasHarness(MatButtonHarness);
-    }
-
-    async checkIfMatButtonExistsWithDataAutomationId(dataAutomationId: string): Promise<boolean> {
-        return this.loader.hasHarness(MatButtonHarness.with({ selector: `[data-automation-id="${dataAutomationId}"]` }));
-    }
-
-    async clickMatButton(): Promise<void> {
-        const button = await this.getMatButton();
-        await button.click();
-    }
-
-    async clickMatButtonByCSS(selector: string): Promise<void> {
-        const button = await this.getMatButtonByCSS(selector);
-        await button.click();
-    }
-
-    async clickMatButtonByDataAutomationId(dataAutomationId: string): Promise<void> {
-        const button = await this.getMatButtonByDataAutomationId(dataAutomationId);
-        await button.click();
-    }
-
-    async sendKeysToMatButton(keys: (string | TestKey)[]): Promise<void> {
-        const button = await this.getMatButton();
-        const host = await button.host();
-        await host.sendKeys(...keys);
-    }
-
-    /** MatCheckbox related methods */
-
-    async getMatCheckbox(): Promise<MatCheckboxHarness> {
-        return this.loader.getHarness(MatCheckboxHarness);
-    }
-
-    async getMatCheckboxByDataAutomationId(dataAutomationId: string): Promise<MatCheckboxHarness> {
-        return this.loader.getHarness(MatCheckboxHarness.with({ selector: `[data-automation-id="${dataAutomationId}"]` }));
-    }
-
-    async getMatCheckboxHost(): Promise<TestElement> {
-        const checkbox = await this.getMatCheckbox();
-        return checkbox.host();
-    }
-
-    async getAllMatCheckboxes(): Promise<MatCheckboxHarness[]> {
-        return this.loader.getAllHarnesses(MatCheckboxHarness);
-    }
-
-    async checkIfMatCheckboxIsChecked(): Promise<boolean> {
-        const checkbox = await this.getMatCheckbox();
-        return checkbox.isChecked();
-    }
-
-    async checkIfMatCheckboxesHaveClass(className: string): Promise<boolean> {
-        const checkboxes = await this.getAllMatCheckboxes();
-        return checkboxes.every(async (checkbox) => (await checkbox.host()).hasClass(className));
-    }
-
-    async hoverOverMatCheckbox(): Promise<void> {
-        const host = await this.getMatCheckboxHost();
-        await host.hover();
-    }
-
-    /** MatIcon related methods */
-
-    async getMatIconOrNull(): Promise<MatIconHarness> {
-        return this.loader.getHarnessOrNull(MatIconHarness);
-    }
-
-    async getMatIconWithAncestorByDataAutomationId(dataAutomationId: string): Promise<MatIconHarness> {
-        return this.loader.getHarness(MatIconHarness.with({ ancestor: `[data-automation-id="${dataAutomationId}"]` }));
-    }
-
-    async getMatIconWithAncestorByCSS(selector: string): Promise<MatIconHarness> {
-        return this.loader.getHarness(MatIconHarness.with({ ancestor: selector }));
-    }
-
-    async checkIfMatIconExistsWithAncestorByDataAutomationId(dataAutomationId: string): Promise<boolean> {
-        return this.loader.hasHarness(MatIconHarness.with({ ancestor: `[data-automation-id="${dataAutomationId}"]` }));
-    }
-
-    async checkIfMatIconExistsWithAncestorByCSSAndName(selector: string, name: string): Promise<boolean> {
-        return this.loader.hasHarness(MatIconHarness.with({ ancestor: selector, name }));
-    }
-
-    async clickMatIconWithAncestorByDataAutomationId(dataAutomationId: string): Promise<void> {
-        const icon = await this.getMatIconWithAncestorByDataAutomationId(dataAutomationId);
-        const host = await icon.host();
-        await host.click();
-    }
-
-    /** MatSelect related methods */
-
-    async getMatSelectOptions(isOpened = false): Promise<MatOptionHarness[]> {
-        const select = await this.loader.getHarness(MatSelectHarness);
-        if (!isOpened) {
-            await select.open();
-        }
-        return select.getOptions();
-    }
-
-    async getMatSelect(): Promise<MatSelectHarness> {
-        return this.loader.getHarness(MatSelectHarness);
-    }
-
-    async getMatSelectByDataAutomationId(dataAutomationId: string): Promise<MatSelectHarness> {
-        return this.loader.getHarness(MatSelectHarness.with({ selector: `[data-automation-id="${dataAutomationId}"]` }));
-    }
-
-    async getMatSelectHost(): Promise<TestElement> {
-        const select = await this.loader.getHarness(MatSelectHarness);
-        return select.host();
-    }
-
-    async checkIfMatSelectExists(): Promise<boolean> {
-        return this.loader.hasHarness(MatSelectHarness);
-    }
-
-    async openMatSelect(): Promise<void> {
-        const select = await this.loader.getHarness(MatSelectHarness);
-        await select.open();
-    }
-
-    /** MatChips related methods */
-
-    async getMatChipByDataAutomationId(dataAutomationId: string): Promise<MatChipHarness> {
-        return this.loader.getHarness(MatChipHarness.with({ selector: `[data-automation-id="${dataAutomationId}"]` }));
-    }
-
-    async checkIfMatChipExistsWithDataAutomationId(dataAutomationId: string): Promise<boolean> {
-        return this.loader.hasHarness(MatChipHarness.with({ selector: `[data-automation-id="${dataAutomationId}"]` }));
-    }
-
-    async clickMatChip(dataAutomationId: string): Promise<void> {
-        const chip = await this.getMatChipByDataAutomationId(dataAutomationId);
-        const host = await chip.host();
-        await host.click();
-    }
-
-    async getMatChips(): Promise<MatChipHarness[]> {
-        return this.loader.getAllHarnesses(MatChipHarness);
-    }
-
-    /** MatChipListbox related methods */
-
-    async getMatChipListboxByDataAutomationId(dataAutomationId: string): Promise<MatChipListboxHarness> {
-        return this.loader.getHarness(MatChipListboxHarness.with({ selector: `[data-automation-id="${dataAutomationId}"]` }));
-    }
-
-    async clickMatChipListbox(dataAutomationId: string): Promise<void> {
-        const chipList = await this.getMatChipListboxByDataAutomationId(dataAutomationId);
-        const host = await chipList.host();
-        await host.click();
-    }
-
-    /** MatChipGrid related methods */
-
-    async checkIfMatChipGridExists(): Promise<boolean> {
-        return this.loader.hasHarness(MatChipGridHarness);
-    }
-
-    /** MatChipInput related methods */
-
-    async getMatChipInput(): Promise<MatChipInputHarness> {
-        return this.loader.getHarness(MatChipInputHarness);
-    }
-
-    async getMatChipInputByDataAutomationId(dataAutomationId: string): Promise<MatChipInputHarness> {
-        return this.loader.getHarness(MatChipInputHarness.with({ selector: `[data-automation-id="${dataAutomationId}"]` }));
-    }
-
-    async getMatChipInputByCSS(selector: string): Promise<MatChipInputHarness> {
-        return this.loader.getHarness(MatChipInputHarness.with({ selector }));
-    }
-
-    /** MatFromField related methods */
-
-    async getMatFormField(): Promise<MatFormFieldHarness> {
-        return this.loader.getHarness(MatFormFieldHarness);
-    }
-
-    async getMatFormFieldByCSS(selector: string): Promise<MatFormFieldHarness> {
-        return this.loader.getHarness(MatFormFieldHarness.with({ selector }));
-    }
-
-    /** MatInput related methods */
-
-    async getMatInput(): Promise<MatInputHarness> {
-        return this.loader.getHarness(MatInputHarness);
-    }
-
-    async getMatInputByDataAutomationId(dataAutomationId: string): Promise<MatInputHarness> {
-        return this.loader.getHarness(MatInputHarness.with({ selector: `[data-automation-id="${dataAutomationId}"]` }));
-    }
-
-    async getMatInputByPlaceholder(placeholder: string): Promise<MatInputHarness> {
-        return this.loader.getHarness(MatInputHarness.with({ placeholder }));
-    }
-
-    async getMatInputHost(): Promise<TestElement> {
-        const input = await this.getMatInput();
-        return input.host();
-    }
-
-    async checkIfMatInputExists(): Promise<boolean> {
-        return this.loader.hasHarness(MatInputHarness);
-    }
-
-    async checkIfMatInputExistsWithPlaceholder(placeholder: string): Promise<boolean> {
-        return this.loader.hasHarness(MatInputHarness.with({ placeholder }));
-    }
-
-    async clickMatInput(): Promise<void> {
-        const input = await this.getMatInput();
-        const host = await input.host();
-        await host.click();
-    }
-
-    async fillMatInput(value: string): Promise<void> {
-        const input = await this.getMatInput();
-        await input.setValue(value);
-    }
-
-    async fillMatInputByDataAutomationId(dataAutomationId: string, value: string): Promise<void> {
-        const input = await this.getMatInputByDataAutomationId(dataAutomationId);
-        await input.setValue(value);
-        await (await input.host()).dispatchEvent('input');
-    }
-
-    async focusMatInput(): Promise<void> {
-        const input = await this.getMatInput();
-        await input.focus();
-    }
-
-    async blurMatInput(): Promise<void> {
-        const input = await this.getMatInput();
-        await input.blur();
-    }
-
-    async getMatInputValue(): Promise<string> {
-        const input = await this.getMatInput();
-        return input.getValue();
-    }
-
-    async getMatInputValueByDataAutomationId(dataAutomationId: string): Promise<string> {
-        const input = await this.getMatInputByDataAutomationId(dataAutomationId);
-        return input.getValue();
-    }
-
-    async sendKeysToMatInput(keys: (string | TestKey)[]): Promise<void> {
-        const input = await this.getMatInput();
-        const host = await input.host();
-        await host.sendKeys(...keys);
-    }
-
-    /** MatAutoComplete related methods */
-
-    async typeAndGetOptionsForMatAutoComplete(fixture: ComponentFixture<any>, value: string): Promise<MatOptionHarness[]> {
-        const autocomplete = await this.loader.getHarness(MatAutocompleteHarness);
-        await autocomplete.enterText(value);
-        fixture.detectChanges();
-
-        return autocomplete.getOptions();
-    }
-
-    /** MatTabGroup related methods */
-
-    async getSelectedTabFromMatTabGroup(): Promise<MatTabHarness> {
-        const tabs = await this.loader.getHarness(MatTabGroupHarness);
-        return tabs.getSelectedTab();
-    }
-
-    async getSelectedTabLabelFromMatTabGroup(): Promise<string> {
-        const tab = await this.getSelectedTabFromMatTabGroup();
-        return tab.getLabel();
-    }
-
-    /** MatToolbar related methods */
-
-    async getMatToolbarHost(): Promise<TestElement> {
-        const toolbar = await this.loader.getHarness(MatToolbarHarness);
-        return toolbar.host();
-    }
-
-    /** MatSnackbar related methods */
-
-    async checkIfMatSnackbarExists(): Promise<boolean> {
-        return this.loader.hasHarness(MatSnackBarHarness);
-    }
-
-    /** MatProgressBar related methods */
-
-    async getMatProgressBarHost(): Promise<TestElement> {
-        const progress = await this.loader.getHarness(MatProgressBarHarness);
-        return progress.host();
-    }
-
-    /** MatListOption related methods */
-
-    async getMatListOption(): Promise<MatListOptionHarness> {
-        return this.loader.getHarness(MatListOptionHarness);
-    }
-
-    async getAllMatListOptions(): Promise<MatListOptionHarness[]> {
-        return this.loader.getAllHarnesses(MatListOptionHarness);
-    }
-
-    /** MatCell related methods */
-
-    async getMatCellByColumnName(columnName: string): Promise<MatCellHarness> {
-        return this.loader.getHarness(MatCellHarness.with({ columnName }));
-    }
-
-    /** MatProgressSpinner related methods */
-
-    async getMatProgressSpinnerWithAncestorByCSS(selector: string): Promise<MatProgressSpinnerHarness> {
-        return this.loader.getHarness(MatProgressSpinnerHarness.with({ ancestor: selector }));
-    }
-
-    async getMatProgressSpinnerWithAncestorByDataAutomationId(dataAutomationId: string): Promise<MatProgressSpinnerHarness> {
-        return this.loader.getHarness(MatProgressSpinnerHarness.with({ ancestor: `[data-automation-id="${dataAutomationId}"]` }));
-    }
-
-    /** MatMenu related methods */
-
-    async getMatMenuByCSS(selector: string): Promise<MatMenuHarness> {
-        return this.loader.getHarness(MatMenuHarness.with({ selector }));
-    }
-
-    /** MatSidenav related methods */
-
-    async getMatSidenav(): Promise<MatSidenavHarness> {
-        return this.loader.getHarness(MatSidenavHarness);
     }
 }

--- a/lib/process-services-cloud/src/lib/form/components/widgets/date/date-cloud.widget.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/date/date-cloud.widget.spec.ts
@@ -470,7 +470,7 @@ describe('DateCloudWidgetComponent', () => {
 
         it('should be able to display label with asterisk', async () => {
             fixture.detectChanges();
-            const formField = await testingUtils.getMatFormField();
+            const formField = await testingUtils.formField.get();
             const formControl = await formField.getControl();
 
             expect(formControl.isRequired).toBeTruthy();
@@ -557,7 +557,7 @@ describe('DateCloudWidgetComponent', () => {
             fixture.detectChanges();
             await fixture.whenStable();
 
-            await testingUtils.fillMatInput('25-03-2025');
+            await testingUtils.input.fill('25-03-2025');
 
             expect(field.value).toEqual(jasmine.any(Date));
             expect(field.value.getFullYear()).toBe(2025);
@@ -578,7 +578,7 @@ describe('DateCloudWidgetComponent', () => {
             fixture.detectChanges();
             await fixture.whenStable();
 
-            await testingUtils.fillMatInput('03-25-2025');
+            await testingUtils.input.fill('03-25-2025');
 
             expect(field.value).toEqual(jasmine.any(Date));
             expect(field.value.getFullYear()).toBe(2025);
@@ -599,7 +599,7 @@ describe('DateCloudWidgetComponent', () => {
             fixture.detectChanges();
             await fixture.whenStable();
 
-            await testingUtils.fillMatInput('03/25/2025');
+            await testingUtils.input.fill('03/25/2025');
 
             expect(widget.dateInputControl.invalid).toBeTrue();
             expect(field.isValid).toBeFalse();
@@ -620,12 +620,12 @@ describe('DateCloudWidgetComponent', () => {
             fixture.detectChanges();
             await fixture.whenStable();
 
-            await testingUtils.fillMatInput('invalid-text');
+            await testingUtils.input.fill('invalid-text');
 
             expect(widget.dateInputControl.invalid).toBeTrue();
             expect(field.isValid).toBeFalse();
 
-            await testingUtils.fillMatInput('');
+            await testingUtils.input.fill('');
 
             expect(widget.dateInputControl.valid).toBeTrue();
             expect(field.isValid).toBeTrue();

--- a/lib/process-services-cloud/src/lib/form/components/widgets/display-external-property/display-external-property.widget.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/display-external-property/display-external-property.widget.spec.ts
@@ -148,7 +148,7 @@ describe('DisplayExternalPropertyWidgetComponent', () => {
         });
 
         it('should be able to display label with asterisk', async () => {
-            const formField = await testingUtils.getMatFormField();
+            const formField = await testingUtils.formField.get();
             const formControl = await formField.getControl();
 
             expect(formControl.isRequired).toBeTruthy();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [X] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [X] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://hyland.atlassian.net/browse/ACS-11406

**What is the new behaviour?**

Replaces flat method naming (clickMatButton, getMatIcon*, etc.) with a structured API grouped by component type (utils.button.click(), utils.icon.getWithAncestorByCSS(), etc.). Each group is a module-level unexported class extending a shared HarnessBase. All affected spec files in adf-core and content-services packages are updated accordingly.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
