### PR TITLE
AAE-48307 Rebase silentRefreshRedirectUri onto the current window origin to prevent cross-domain logout

### DIFF
--- a/lib/core/src/lib/auth/oidc/auth-config.service.spec.ts
+++ b/lib/core/src/lib/auth/oidc/auth-config.service.spec.ts
@@ -167,6 +167,38 @@ describe('AuthConfigService', () => {
             spyOnProperty(appConfigService, 'oauth2').and.returnValue(mockAuthConfigSubfolder2RedirectUri);
             expect(service.loadAppConfig().silentRefreshRedirectUri).toBe(expectedUri);
         });
+
+        it('should rebase the silentRefreshRedirectUri onto the current window origin when the configured domain differs', () => {
+            spyOnProperty(appConfigService, 'oauth2').and.returnValue({
+                ...mockAuthConfigImplicitFlow,
+                redirectSilentIframeUri: 'https://different-domain.com/assets/silent-refresh.html'
+            });
+            expect(service.loadAppConfig().silentRefreshRedirectUri).toBe('http://localhost:3000/assets/silent-refresh.html');
+        });
+
+        it('should preserve the subfolder path while rebasing onto the current window origin', () => {
+            spyOnProperty(appConfigService, 'oauth2').and.returnValue({
+                ...mockAuthConfigImplicitFlow,
+                redirectSilentIframeUri: 'https://different-domain.com/subfolder/assets/silent-refresh.html'
+            });
+            expect(service.loadAppConfig().silentRefreshRedirectUri).toBe('http://localhost:3000/subfolder/assets/silent-refresh.html');
+        });
+
+        it('should resolve a relative silentRefreshRedirectUri against the current window origin', () => {
+            spyOnProperty(appConfigService, 'oauth2').and.returnValue({
+                ...mockAuthConfigImplicitFlow,
+                redirectSilentIframeUri: '/assets/silent-refresh.html'
+            });
+            expect(service.loadAppConfig().silentRefreshRedirectUri).toBe('http://localhost:3000/assets/silent-refresh.html');
+        });
+
+        it('should return the configured value unchanged when redirectSilentIframeUri is not set', () => {
+            spyOnProperty(appConfigService, 'oauth2').and.returnValue({
+                ...mockAuthConfigImplicitFlow,
+                redirectSilentIframeUri: undefined
+            });
+            expect(service.loadAppConfig().silentRefreshRedirectUri).toBeUndefined();
+        });
     });
 
     describe('postLogoutRedirectUri', () => {

--- a/lib/core/src/lib/auth/oidc/auth-config.service.ts
+++ b/lib/core/src/lib/auth/oidc/auth-config.service.ts
@@ -63,7 +63,7 @@ export class AuthConfigService {
             issuer: oauth2.host,
             nonceStateSeparator: '~',
             redirectUri,
-            silentRefreshRedirectUri: oauth2.redirectSilentIframeUri,
+            silentRefreshRedirectUri: this.getSilentRefreshRedirectUri(),
             postLogoutRedirectUri: this.generatePostLogoutUri(origin, oauth2.redirectUriLogout),
             clientId: oauth2.clientId,
             scope: oauth2.scope,
@@ -104,6 +104,17 @@ export class AuthConfigService {
         // handle issue from the OIDC library with hashStrategy and implicitFlow, with would append &state to the url with would lead to error
         // `cannot match any routes`, and displaying the wildcard ** error page
         return (oauth2.codeFlow || oauth2.implicitFlow) && useHash ? `${redirectUri}/?` : redirectUri;
+    }
+
+    private getSilentRefreshRedirectUri(): string | undefined {
+        const uri = this.appConfigService.oauth2.redirectSilentIframeUri;
+        const origin = this.getLocationOrigin();
+        try {
+            const { pathname, search, hash } = new URL(uri || origin, origin);
+            return uri ? `${origin}${pathname}${search}${hash}` : uri;
+        } catch {
+            return uri;
+        }
     }
 
     private getLocationOrigin() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/AAE-48307


**What is the new behaviour?**
If **Implicit Flow** is enabled, [silentRefreshRedirectUri](https://github.com/Alfresco/alfresco-ng2-components/pull/12053/changes#diff-235ea76319105206f3c793b1751e2e225fffb0f9a2e145161782283519414c7aR66) is now built from the current window origin plus the path of the configured [redirectSilentIframeUri](https://github.com/Alfresco/alfresco-ng2-components/pull/12053/changes#diff-235ea76319105206f3c793b1751e2e225fffb0f9a2e145161782283519414c7aR109-R119), so the silent-refresh iframe is always same origin with the running app regardless of the domain in the config


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
