### PR TITLE
[MNT-25230] Displayed modified time for node version

### DIFF
--- a/lib/content-services/src/lib/version-manager/version-list.component.html
+++ b/lib/content-services/src/lib/version-manager/version-list.component.html
@@ -12,7 +12,7 @@
                         <span class="adf-version-list-item-line adf-version-list-item-version"
                           [id]="'adf-version-list-item-version-' + version.entry.id">{{ version.entry.id }}</span> -
                         <span class="adf-version-list-item-line adf-version-list-item-date"
-                              [id]="'adf-version-list-item-date-' + version.entry.id">{{ version.entry.modifiedAt | date }}</span>
+                              [id]="'adf-version-list-item-date-' + version.entry.id">{{ version.entry.modifiedAt | date: 'medium' }}</span>
                     </p>
                     @if (version.entry.modifiedByUser?.displayName) {
                         <p

--- a/lib/content-services/src/lib/version-manager/version-list.component.spec.ts
+++ b/lib/content-services/src/lib/version-manager/version-list.component.spec.ts
@@ -178,7 +178,10 @@ describe('VersionListComponent', () => {
                 expect(versionIdText).toBe('1.0');
                 expect(versionComment.trim()).toBe('test-version-comment');
                 expect(testingUtils.getInnerTextByDataAutomationId('adf-version-list-item-modified-by-1.0')).toBe('TestUser1');
-                expect(testingUtils.getInnerTextByCSS('.adf-version-list-item-date')).toBe('Jan 15, 2026, 9:56:42 AM');
+                const expectedModifiedAt = new Intl.DateTimeFormat('en-US', { dateStyle: 'medium', timeStyle: 'medium' }).format(
+                    versionTest[0].entry.modifiedAt
+                );
+                expect(testingUtils.getInnerTextByCSS('#adf-version-list-item-date-1\\.0')).toBe(expectedModifiedAt);
                 done();
             });
         });

--- a/lib/content-services/src/lib/version-manager/version-list.component.spec.ts
+++ b/lib/content-services/src/lib/version-manager/version-list.component.spec.ts
@@ -45,7 +45,8 @@ describe('VersionListComponent', () => {
                 versionComment: 'test-version-comment',
                 modifiedByUser: new UserInfo({
                     displayName: 'TestUser1'
-                })
+                }),
+                modifiedAt: new Date(2026, 0, 15, 9, 56, 42, 581)
             })
         }),
         new VersionEntry({
@@ -177,6 +178,7 @@ describe('VersionListComponent', () => {
                 expect(versionIdText).toBe('1.0');
                 expect(versionComment.trim()).toBe('test-version-comment');
                 expect(testingUtils.getInnerTextByDataAutomationId('adf-version-list-item-modified-by-1.0')).toBe('TestUser1');
+                expect(testingUtils.getInnerTextByCSS('.adf-version-list-item-date')).toBe('Jan 15, 2026, 9:56:42 AM');
                 done();
             });
         });


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/MNT-25230


**What is the new behaviour?**
Modification time is displayed too for version. 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
