### PR TITLE
[ACS-12286] Pass includeFields through to getRecentFiles for -recent-

### DIFF
--- a/docs/content-services/services/custom-resources.service.md
+++ b/docs/content-services/services/custom-resources.service.md
@@ -23,11 +23,12 @@ Manages Document List information that is specific to a user.
     -   _node:_ `any`  - Node object
     -   _nodeId:_ `string`  - ID of the node object
     -   **Returns** `string` - ID value
--   **getRecentFiles**(personId: `string`, pagination: [`PaginationModel`](../../../lib/core/src/lib/models/pagination.model.ts), filters?: `string[]`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`NodePaging`](https://github.com/Alfresco/alfresco-js-api/blob/develop/src/api/content-rest-api/docs/NodePaging.md)`>`<br/>
+-   **getRecentFiles**(personId: `string`, pagination: [`PaginationModel`](../../../lib/core/src/lib/models/pagination.model.ts), filters?: `string[]`, includeFields: `string[]` = `[]`): [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`NodePaging`](https://github.com/Alfresco/alfresco-js-api/blob/develop/src/api/content-rest-api/docs/NodePaging.md)`>`<br/>
     Gets files recently accessed by a user.
     -   _personId:_ `string`  - ID of the user
     -   _pagination:_ [`PaginationModel`](../../../lib/core/src/lib/models/pagination.model.ts)  - Specifies how to paginate the results
     -   _filters:_ `string[]`  - (Optional) Specifies additional filters to apply (joined with **AND**)
+    -   _includeFields:_ `string[]`  - List of data field names to include in the results
     -   **Returns** [`Observable`](http://reactivex.io/documentation/observable.html)`<`[`NodePaging`](https://github.com/Alfresco/alfresco-js-api/blob/develop/src/api/content-rest-api/docs/NodePaging.md)`>` - List of nodes for the recently used files
 -   **hasCorrespondingNodeIds**(nodeId: `string`): `boolean`<br/>
     Does the well-known alias have a corresponding node ID?

--- a/lib/content-services/src/lib/document-list/services/custom-resources.service.spec.ts
+++ b/lib/content-services/src/lib/document-list/services/custom-resources.service.spec.ts
@@ -24,6 +24,8 @@ import {
     FavoritePagingList,
     NodeEntry,
     NodePaging,
+    Person,
+    PersonEntry,
     ResultSetPaging,
     Site,
     SiteEntry,
@@ -203,7 +205,9 @@ describe('CustomResourcesService', () => {
         const pagination: PaginationModel = { maxItems: 100, skipCount: 0 };
 
         beforeEach(() => {
-            spyOn(customResourcesService.peopleApi, 'getPerson').and.returnValue(Promise.resolve({ entry: { id: 'user' } } as any));
+            spyOn(customResourcesService.peopleApi, 'getPerson').and.returnValue(
+                Promise.resolve(new PersonEntry({ entry: new Person({ id: 'user' }) }))
+            );
         });
 
         it('should pass includeFields through to the search request, keeping the defaults', (done) => {

--- a/lib/content-services/src/lib/document-list/services/custom-resources.service.spec.ts
+++ b/lib/content-services/src/lib/document-list/services/custom-resources.service.spec.ts
@@ -24,6 +24,7 @@ import {
     FavoritePagingList,
     NodeEntry,
     NodePaging,
+    ResultSetPaging,
     Site,
     SiteEntry,
     SiteMember,
@@ -194,7 +195,55 @@ describe('CustomResourcesService', () => {
             spyOn(customResourcesService, 'getRecentFiles').and.stub();
 
             customResourcesService.loadFolderByNodeId('-recent-', pagination, ['include'], 'where', ['filters']);
-            expect(customResourcesService.getRecentFiles).toHaveBeenCalledWith('-me-', pagination, ['filters']);
+            expect(customResourcesService.getRecentFiles).toHaveBeenCalledWith('-me-', pagination, ['filters'], ['include']);
+        });
+    });
+
+    describe('getRecentFiles', () => {
+        const pagination: PaginationModel = { maxItems: 100, skipCount: 0 };
+
+        beforeEach(() => {
+            spyOn(customResourcesService.peopleApi, 'getPerson').and.returnValue(Promise.resolve({ entry: { id: 'user' } } as any));
+        });
+
+        it('should pass includeFields through to the search request, keeping the defaults', (done) => {
+            const searchSpy = spyOn(customResourcesService.searchApi, 'search').and.returnValue(Promise.resolve(new ResultSetPaging()));
+
+            customResourcesService.getRecentFiles('-me-', pagination, undefined, ['isFavorite']).subscribe(() => {
+                expect(searchSpy).toHaveBeenCalledTimes(1);
+                expect(searchSpy.calls.mostRecent().args[0].include).toEqual([
+                    'path',
+                    'properties',
+                    'allowableOperations',
+                    'aspectNames',
+                    'isFavorite'
+                ]);
+                done();
+            });
+        });
+
+        it('should keep the default include fields when no includeFields are provided', (done) => {
+            const searchSpy = spyOn(customResourcesService.searchApi, 'search').and.returnValue(Promise.resolve(new ResultSetPaging()));
+
+            customResourcesService.getRecentFiles('-me-', pagination).subscribe(() => {
+                expect(searchSpy.calls.mostRecent().args[0].include).toEqual(['path', 'properties', 'allowableOperations', 'aspectNames']);
+                done();
+            });
+        });
+
+        it('should not duplicate an includeField that is already a default', (done) => {
+            const searchSpy = spyOn(customResourcesService.searchApi, 'search').and.returnValue(Promise.resolve(new ResultSetPaging()));
+
+            customResourcesService.getRecentFiles('-me-', pagination, undefined, ['properties', 'isFavorite']).subscribe(() => {
+                expect(searchSpy.calls.mostRecent().args[0].include).toEqual([
+                    'path',
+                    'properties',
+                    'allowableOperations',
+                    'aspectNames',
+                    'isFavorite'
+                ]);
+                done();
+            });
         });
     });
 

--- a/lib/content-services/src/lib/document-list/services/custom-resources.service.ts
+++ b/lib/content-services/src/lib/document-list/services/custom-resources.service.ts
@@ -73,9 +73,10 @@ export class CustomResourcesService {
      * @param personId ID of the user
      * @param pagination Specifies how to paginate the results
      * @param filters Specifies additional filters to apply (joined with **AND**)
+     * @param includeFields List of data field names to include in the results
      * @returns List of nodes for the recently used files
      */
-    getRecentFiles(personId: string, pagination: PaginationModel, filters?: string[]): Observable<ResultSetPaging> {
+    getRecentFiles(personId: string, pagination: PaginationModel, filters?: string[], includeFields: string[] = []): Observable<ResultSetPaging> {
         const defaultFilter = [
             'TYPE:"content"',
             '-PATH:"//cm:wiki/*"',
@@ -121,7 +122,7 @@ export class CustomResourcesService {
                             language: SEARCH_LANGUAGE.AFTS
                         },
                         filterQueries,
-                        include: ['path', 'properties', 'allowableOperations', 'aspectNames'],
+                        include: [...new Set(['path', 'properties', 'allowableOperations', 'aspectNames', ...includeFields])],
                         sort: [
                             {
                                 type: 'FIELD',
@@ -380,7 +381,7 @@ export class CustomResourcesService {
         } else if (nodeId === '-favorites-') {
             return this.loadFavorites(pagination, includeFields, where);
         } else if (nodeId === '-recent-') {
-            return this.getRecentFiles('-me-', pagination, filters);
+            return this.getRecentFiles('-me-', pagination, filters, includeFields);
         } else {
             return of(null);
         }


### PR DESCRIPTION
JIRA: https://hyland.atlassian.net/browse/ACS-12286

**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [x] Docs have been added / updated (for bug fixes / features)

<!-- JSDoc for `getRecentFiles` updated, and the service reference doc (docs/content-services/services/custom-resources.service.md) updated to document the new `includeFields` parameter. -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

Fixes https://github.com/Alfresco/alfresco-ng2-components/issues/11472.

`CustomResourcesService.loadFolderByNodeId()` forwards `includeFields` to every custom source **except** `-recent-`: it calls `getRecentFiles('-me-', pagination, filters)` and drops the `includeFields` argument. `getRecentFiles()` has no `includeFields` parameter and hardcodes `include: ['path', 'properties', 'allowableOperations', 'aspectNames']`. As a result, requesting extra fields (e.g. `isFavorite`) for recently used files is impossible.


**What is the new behaviour?**

`getRecentFiles()` accepts an optional `includeFields: string[] = []` (appended as the last argument to remain backward-compatible) and merges it — de-duplicated — into the search request's `include` array. `loadFolderByNodeId('-recent-', …)` now forwards `includeFields`. Callers can request additional fields such as `isFavorite` for `-recent-`, while the default include set is preserved.

The shared `getIncludesFields()` helper was intentionally **not** reused, because it also injects `permissions`, which recent-files does not currently request — using it would change the baseline payload for all existing consumers (out of scope for this fix).

Verified with `nx test content-services` (custom-resources spec) → **34/34 pass**, including new tests asserting `includeFields` is threaded into the search `include`, defaults are preserved when none are passed, and duplicates are de-duplicated. eslint clean; husky pre-commit passed.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**: `includeFields` is optional with a default of `[]`, so existing callers of `getRecentFiles()` are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
