### PR TITLE
AAE-48859 Allow repeatable section row labels to be configurable

### DIFF
--- a/lib/core/src/lib/form/components/form-renderer.component.html
+++ b/lib/core/src/lib/form/components/form-renderer.component.html
@@ -106,7 +106,10 @@
                             [class.adf-grid-list-container-disabled]="currentRootElement.field.readOnly"
                         >
                             <div class="adf-grid-list-row">
-                                <span  class="adf-grid-list-row-label">{{ 'FORM.FORM_RENDERER.ROW_LABEL' | translate: {number: rowIndex + 1} }}</span>
+                                @if (currentRootElement.field.params.displayRowLabels !== false) {
+                                    @let customRowLabel = currentRootElement.field.params | adfRepeatableRowLabel: rowIndex;
+                                    <span class="adf-grid-list-row-label">{{ customRowLabel ?? ('FORM.FORM_RENDERER.ROW_LABEL' | translate: {number: rowIndex + 1}) }}</span>
+                                }
 
                                 @let shouldDisplayRemoveRowButton = !currentRootElement.field.rows[rowIndex].isInitial || (currentRootElement.field.rows[rowIndex].isInitial && currentRootElement.field.params.allowInitialRowsDelete);
                                 @if (shouldDisplayRemoveRowButton) {

--- a/lib/core/src/lib/form/components/form-renderer.component.scss
+++ b/lib/core/src/lib/form/components/form-renderer.component.scss
@@ -88,6 +88,7 @@
                 padding: 0;
                 width: 30px;
                 height: 30px;
+                margin-left: auto;
                 display: flex;
                 align-items: center;
                 justify-content: center;

--- a/lib/core/src/lib/form/components/form-renderer.component.spec.ts
+++ b/lib/core/src/lib/form/components/form-renderer.component.spec.ts
@@ -1182,5 +1182,46 @@ describe('Form Renderer Component', () => {
                 expect(removeRowButton).toBeFalsy();
             });
         });
+
+        describe('row labels', () => {
+            const labelSelector = '#field-RepeatableSection0tbw2y-container .adf-grid-list-row-label';
+
+            const buildFormWithLabelParams = (labelParams: Record<string, unknown>): FormModel => {
+                const mock = JSON.parse(JSON.stringify(mockRepeatableSectionForm01));
+                Object.assign(mock.formRepresentation.formDefinition.fields[0].params, labelParams);
+                return new FormModel(mock.formRepresentation);
+            };
+
+            const getRenderedLabels = (): string[] =>
+                testingUtils.getAllByCSS(labelSelector).map((element) => element.nativeElement.textContent.trim());
+
+            it('should render the default translated row label when no label params are set', () => {
+                const labels = getRenderedLabels();
+
+                expect(labels.length).toBe(2);
+                labels.forEach((label) => expect(label).toBe('FORM.FORM_RENDERER.ROW_LABEL'));
+            });
+
+            it('should NOT render any row label when displayRowLabels is false', () => {
+                fixture.componentInstance.formDefinition = buildFormWithLabelParams({ displayRowLabels: false });
+                fixture.detectChanges();
+
+                expect(testingUtils.getAllByCSS(labelSelector).length).toBe(0);
+            });
+
+            it('should render the custom label with the row number appended', () => {
+                fixture.componentInstance.formDefinition = buildFormWithLabelParams({ rowLabelText: 'Approver', appendRowNumber: true });
+                fixture.detectChanges();
+
+                expect(getRenderedLabels()).toEqual(['Approver 1', 'Approver 2']);
+            });
+
+            it('should render the custom label without the row number when appendRowNumber is false', () => {
+                fixture.componentInstance.formDefinition = buildFormWithLabelParams({ rowLabelText: 'Approver', appendRowNumber: false });
+                fixture.detectChanges();
+
+                expect(getRenderedLabels()).toEqual(['Approver', 'Approver']);
+            });
+        });
     });
 });

--- a/lib/core/src/lib/form/components/form-renderer.component.ts
+++ b/lib/core/src/lib/form/components/form-renderer.component.ts
@@ -49,6 +49,7 @@ import { ConfirmDialogComponent } from '../../../lib/dialogs/confirm-dialog/conf
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { IconModule } from '../../icon/icon.module';
 import { FormLayoutColumn, getFormLayoutColumnWidth } from './helpers/column-width';
+import { RepeatableRowLabelPipe } from '../pipes/repeatable-row-label.pipe';
 
 @Component({
     selector: 'adf-form-renderer',
@@ -79,7 +80,8 @@ import { FormLayoutColumn, getFormLayoutColumnWidth } from './helpers/column-wid
         HeaderWidgetComponent,
         FormSectionComponent,
         RepeatWidgetComponent,
-        MatTooltipModule
+        MatTooltipModule,
+        RepeatableRowLabelPipe
     ],
     encapsulation: ViewEncapsulation.None
 })

--- a/lib/core/src/lib/form/pipes/repeatable-row-label.pipe.spec.ts
+++ b/lib/core/src/lib/form/pipes/repeatable-row-label.pipe.spec.ts
@@ -1,0 +1,59 @@
+/*!
+ * @license
+ * Copyright © 2005-2025 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RepeatableRowLabelPipe } from './repeatable-row-label.pipe';
+
+describe('RepeatableRowLabelPipe', () => {
+    let pipe: RepeatableRowLabelPipe;
+
+    beforeEach(() => {
+        pipe = new RepeatableRowLabelPipe();
+    });
+
+    it('should return null when the label text is empty', () => {
+        expect(pipe.transform({ rowLabelText: '', appendRowNumber: true }, 0)).toBeNull();
+    });
+
+    it('should return null when the label text is undefined', () => {
+        expect(pipe.transform({ appendRowNumber: true }, 0)).toBeNull();
+    });
+
+    it('should return null when the label text is only whitespace', () => {
+        expect(pipe.transform({ rowLabelText: '   ', appendRowNumber: true }, 0)).toBeNull();
+    });
+
+    it('should return null when the params are undefined', () => {
+        expect(pipe.transform(undefined as any, 0)).toBeNull();
+    });
+
+    it('should append the 1-based row number when appendRowNumber is true', () => {
+        expect(pipe.transform({ rowLabelText: 'Approver', appendRowNumber: true }, 0)).toBe('Approver 1');
+        expect(pipe.transform({ rowLabelText: 'Approver', appendRowNumber: true }, 4)).toBe('Approver 5');
+    });
+
+    it('should append the row number by default when appendRowNumber is undefined', () => {
+        expect(pipe.transform({ rowLabelText: 'Approver' }, 1)).toBe('Approver 2');
+    });
+
+    it('should NOT append the row number when appendRowNumber is false', () => {
+        expect(pipe.transform({ rowLabelText: 'Approver', appendRowNumber: false }, 3)).toBe('Approver');
+    });
+
+    it('should trim the label text', () => {
+        expect(pipe.transform({ rowLabelText: '  Approver  ', appendRowNumber: true }, 0)).toBe('Approver 1');
+    });
+});

--- a/lib/core/src/lib/form/pipes/repeatable-row-label.pipe.spec.ts
+++ b/lib/core/src/lib/form/pipes/repeatable-row-label.pipe.spec.ts
@@ -37,7 +37,11 @@ describe('RepeatableRowLabelPipe', () => {
     });
 
     it('should return null when the params are undefined', () => {
-        expect(pipe.transform(undefined as any, 0)).toBeNull();
+        expect(pipe.transform(undefined, 0)).toBeNull();
+    });
+
+    it('should return null when the label text is not a string', () => {
+        expect(pipe.transform({ rowLabelText: 5 as unknown as string, appendRowNumber: true }, 0)).toBeNull();
     });
 
     it('should append the 1-based row number when appendRowNumber is true', () => {

--- a/lib/core/src/lib/form/pipes/repeatable-row-label.pipe.ts
+++ b/lib/core/src/lib/form/pipes/repeatable-row-label.pipe.ts
@@ -15,5 +15,24 @@
  * limitations under the License.
  */
 
-export * from './field-style.pipe';
-export * from './repeatable-row-label.pipe';
+import { Pipe, PipeTransform } from '@angular/core';
+
+export interface RepeatableRowLabelParams {
+    rowLabelText?: string;
+    appendRowNumber?: boolean;
+}
+
+@Pipe({
+    name: 'adfRepeatableRowLabel'
+})
+export class RepeatableRowLabelPipe implements PipeTransform {
+    transform(params: RepeatableRowLabelParams, rowIndex: number): string | null {
+        const rowLabelText = params?.rowLabelText?.trim();
+
+        if (!rowLabelText) {
+            return null;
+        }
+
+        return params?.appendRowNumber === false ? rowLabelText : `${rowLabelText} ${rowIndex + 1}`;
+    }
+}

--- a/lib/core/src/lib/form/pipes/repeatable-row-label.pipe.ts
+++ b/lib/core/src/lib/form/pipes/repeatable-row-label.pipe.ts
@@ -26,8 +26,8 @@ export interface RepeatableRowLabelParams {
     name: 'adfRepeatableRowLabel'
 })
 export class RepeatableRowLabelPipe implements PipeTransform {
-    transform(params: RepeatableRowLabelParams, rowIndex: number): string | null {
-        const rowLabelText = params?.rowLabelText?.trim();
+    transform(params: RepeatableRowLabelParams | undefined, rowIndex: number): string | null {
+        const rowLabelText = typeof params?.rowLabelText === 'string' ? params.rowLabelText.trim() : '';
 
         if (!rowLabelText) {
             return null;


### PR DESCRIPTION
> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

https://hyland.atlassian.net/browse/AAE-48859

**What is the new behaviour?**

https://hyland.atlassian.net/browse/AAE-48859

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
