### PR TITLE
AAE-48705 Fix for datatable column name wrapping when hovering over it

### DIFF
--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.html
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.html
@@ -145,6 +145,7 @@
                                     }
 
                                     <span
+                                        class="adf-datatable-cell-header-sort-indicator"
                                         [class.adf-datatable__header--sorted-asc]="isColumnSorted(col, 'asc')"
                                         [class.adf-datatable__header--sorted-desc]="isColumnSorted(col, 'desc')"
                                     >

--- a/lib/core/src/lib/datatable/components/datatable/datatable.component.scss
+++ b/lib/core/src/lib/datatable/components/datatable/datatable.component.scss
@@ -562,17 +562,21 @@ $data-table-cell-min-width-file-size: $data-table-cell-min-width-1 !default;
         align-items: center;
     }
 
+    &.adf-sortable .adf-datatable-cell-header-sort-indicator {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        box-sizing: border-box;
+        flex: 0 0 24px;
+        min-width: 0;
+    }
+
     .adf-datatable__header--sorted-asc,
     .adf-datatable__header--sorted-desc {
-        padding-right: 0.25rem;
-
         &::after {
             @include mixins.typo-icon;
 
             content: '\e5d8';
-            left: 5px;
-            right: 5px;
-            position: relative;
             vertical-align: middle;
         }
     }
@@ -605,6 +609,11 @@ $data-table-cell-min-width-file-size: $data-table-cell-min-width-1 !default;
     }
 
     .adf-datatable-cell-header-drag-icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        flex: 0 0 24px;
+        min-width: 0;
         margin-left: auto;
         cursor: move;
         margin-right: -0.5rem;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
-->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)

On `adf-datatable`, when a sortable column header has a two-word label, the sort-direction indicator eats into the header content's available width. Because `.adf-datatable-cell-header-content` and `.adf-datatable-cell-value` have no `white-space`/`overflow` guard, the second word wraps onto a new line, growing the header cell and the whole header row height shifts.

AAE-48705: https://hyland.atlassian.net/browse/AAE-48705

**What is the new behaviour?**

`.adf-datatable-cell-header-content` now has `white-space: nowrap; overflow: hidden;` and `.adf-datatable-cell-value` has `text-overflow: ellipsis;`. Two-word (or longer) header labels stay on a single line truncating with an ellipsis if the column is too narrow instead of wrapping, so the header row height no longer shifts.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...