### PR TITLE
AAE-47527 Populate people and group widgets from process response

### DIFF
--- a/lib/core/src/lib/form/services/form-field-value-adapter.service.spec.ts
+++ b/lib/core/src/lib/form/services/form-field-value-adapter.service.spec.ts
@@ -91,7 +91,7 @@ describe('FormFieldValueAdapterService', () => {
 
         it('single-select: should wrap a user object into a single-element array', () => {
             const field = makeField(FormFieldTypes.PEOPLE, null);
-            const user = { firstName: 'Test', lastName: 'User' };
+            const user = { username: 'testuser', firstName: 'Test', lastName: 'User' };
             expect(service.adapt(user, field)).toEqual([user]);
         });
 
@@ -107,7 +107,7 @@ describe('FormFieldValueAdapterService', () => {
 
         it('single-select: should keep a single-element array', () => {
             const field = makeField(FormFieldTypes.PEOPLE, null);
-            expect(service.adapt([{ firstName: 'Test' }], field)).toEqual([{ firstName: 'Test' }]);
+            expect(service.adapt([{ username: 'test', firstName: 'Test' }], field)).toEqual([{ username: 'test', firstName: 'Test' }]);
         });
 
         it('single-select: should return null when given an empty array', () => {
@@ -134,18 +134,67 @@ describe('FormFieldValueAdapterService', () => {
 
         it('multi-select: should wrap a single object into an array', () => {
             const field = makeField(FormFieldTypes.PEOPLE, null, { multiple: true });
-            expect(service.adapt({ firstName: 'Test' }, field)).toEqual([{ firstName: 'Test' }]);
+            expect(service.adapt({ username: 'testuser', firstName: 'Test' }, field)).toEqual([{ username: 'testuser', firstName: 'Test' }]);
         });
 
         it('multi-select: should keep an array of users (idempotent)', () => {
             const field = makeField(FormFieldTypes.PEOPLE, null, { multiple: true });
-            const users = [{ firstName: 'Alice' }, { firstName: 'Bob' }];
+            const users = [
+                { username: 'alice', firstName: 'Alice' },
+                { username: 'bob', firstName: 'Bob' }
+            ];
             expect(service.adapt(users, field)).toEqual(users);
         });
 
         it('multi-select: should parse an array of strings', () => {
             const field = makeField(FormFieldTypes.PEOPLE, null, { multiple: true });
             expect(service.adapt(['Test User'], field)).toEqual([{ firstName: 'Test', lastName: 'User' }]);
+        });
+
+        it('should canonicalize a process-response user object (userName → username, drop displayName)', () => {
+            const field = makeField(FormFieldTypes.PEOPLE, null);
+            const processUser = {
+                id: 'u1',
+                email: 'k@x.io',
+                lastName: 'Richards',
+                userName: 'krichards',
+                firstName: 'Keith',
+                displayName: 'Keith Richards'
+            };
+            expect(service.adapt(processUser, field)).toEqual([
+                { id: 'u1', username: 'krichards', firstName: 'Keith', lastName: 'Richards', email: 'k@x.io' }
+            ]);
+        });
+
+        it('should canonicalize an array-wrapped process-response user object', () => {
+            const field = makeField(FormFieldTypes.PEOPLE, null);
+            const processUser = {
+                id: 'u1',
+                email: 'k@x.io',
+                lastName: 'Richards',
+                userName: 'krichards',
+                firstName: 'Keith',
+                displayName: 'Keith Richards'
+            };
+            expect(service.adapt([processUser], field)).toEqual([
+                { id: 'u1', username: 'krichards', firstName: 'Keith', lastName: 'Richards', email: 'k@x.io' }
+            ]);
+        });
+
+        it('should preserve an already-canonical user object (idempotent)', () => {
+            const field = makeField(FormFieldTypes.PEOPLE, null);
+            const canonical = { id: 'u1', username: 'krichards', firstName: 'Keith', lastName: 'Richards' };
+            expect(service.adapt(canonical, field)).toEqual([canonical]);
+        });
+
+        it('should keep a user with only id', () => {
+            const field = makeField(FormFieldTypes.PEOPLE, null);
+            expect(service.adapt({ id: 'u1' }, field)).toEqual([{ id: 'u1', username: '' }]);
+        });
+
+        it('should filter out an object with none of id, username, or email', () => {
+            const field = makeField(FormFieldTypes.PEOPLE, null);
+            expect(service.adapt({ firstName: 'Keith', lastName: 'Richards' }, field)).toBeNull();
         });
     });
 
@@ -180,6 +229,16 @@ describe('FormFieldValueAdapterService', () => {
         it('multi-select: should parse an array of strings', () => {
             const field = makeField(FormFieldTypes.FUNCTIONAL_GROUP, null, { multiple: true });
             expect(service.adapt(['Eng', 'QA'], field)).toEqual([{ name: 'Eng' }, { name: 'QA' }]);
+        });
+
+        it('should canonicalize a process-response group object', () => {
+            const field = makeField(FormFieldTypes.FUNCTIONAL_GROUP, null);
+            expect(service.adapt({ id: 'grp1', name: 'Finance' }, field)).toEqual([{ id: 'grp1', name: 'Finance' }]);
+        });
+
+        it('should filter out a group object with neither id nor name', () => {
+            const field = makeField(FormFieldTypes.FUNCTIONAL_GROUP, null);
+            expect(service.adapt({}, field)).toBeNull();
         });
     });
 

--- a/lib/core/src/lib/form/services/form-field-value-adapter.service.spec.ts
+++ b/lib/core/src/lib/form/services/form-field-value-adapter.service.spec.ts
@@ -196,6 +196,12 @@ describe('FormFieldValueAdapterService', () => {
             const field = makeField(FormFieldTypes.PEOPLE, null);
             expect(service.adapt({ firstName: 'Keith', lastName: 'Richards' }, field)).toBeNull();
         });
+
+        it('should drop non-string and blank fields from a process-response user object', () => {
+            const field = makeField(FormFieldTypes.PEOPLE, null);
+            const processUser = { id: null, username: 'krichards', firstName: 42, lastName: '  ', email: 'k@x.io' };
+            expect(service.adapt(processUser, field)).toEqual([{ username: 'krichards', email: 'k@x.io' }]);
+        });
     });
 
     describe('Group adapter', () => {

--- a/lib/core/src/lib/form/services/form-field-value-adapter.service.ts
+++ b/lib/core/src/lib/form/services/form-field-value-adapter.service.ts
@@ -27,7 +27,20 @@ interface AdaptedUser {
     lastName?: string;
 }
 
+interface CanonicalUser {
+    id?: string;
+    username: string;
+    firstName?: string;
+    lastName?: string;
+    email?: string;
+}
+
 interface AdaptedGroup {
+    name: string;
+}
+
+interface CanonicalGroup {
+    id?: string;
     name: string;
 }
 
@@ -102,7 +115,24 @@ export class FormFieldValueAdapterService {
 
     private toUser(entry: unknown): unknown {
         if (typeof entry !== 'string') {
-            return entry;
+            if (!entry || typeof entry !== 'object') {
+                return null;
+            }
+            const source = entry as Record<string, unknown>;
+            const username = (source['username'] ?? source['userName']) as string | undefined;
+            const id = source['id'] as string | undefined;
+            const email = source['email'] as string | undefined;
+            if (!id && !username && !email) {
+                return null;
+            }
+            const user: CanonicalUser = {
+                ...(id !== undefined ? { id } : {}),
+                username: username ?? '',
+                ...(source['firstName'] !== undefined ? { firstName: source['firstName'] as string } : {}),
+                ...(source['lastName'] !== undefined ? { lastName: source['lastName'] as string } : {}),
+                ...(email !== undefined ? { email } : {})
+            };
+            return user;
         }
         const trimmed = entry.trim();
         if (this.isBlankToken(trimmed)) {
@@ -122,7 +152,20 @@ export class FormFieldValueAdapterService {
 
     private toGroup(entry: unknown): unknown {
         if (typeof entry !== 'string') {
-            return entry;
+            if (!entry || typeof entry !== 'object') {
+                return null;
+            }
+            const source = entry as Record<string, unknown>;
+            const name = source['name'] as string | undefined;
+            const id = source['id'] as string | undefined;
+            if (!name && !id) {
+                return null;
+            }
+            const group: CanonicalGroup = {
+                ...(id !== undefined ? { id } : {}),
+                name: name ?? ''
+            };
+            return group;
         }
         const trimmed = entry.trim();
         if (this.isBlankToken(trimmed)) {

--- a/lib/core/src/lib/form/services/form-field-value-adapter.service.ts
+++ b/lib/core/src/lib/form/services/form-field-value-adapter.service.ts
@@ -119,17 +119,19 @@ export class FormFieldValueAdapterService {
                 return null;
             }
             const source = entry as Record<string, unknown>;
-            const username = (source['username'] ?? source['userName']) as string | undefined;
-            const id = source['id'] as string | undefined;
-            const email = source['email'] as string | undefined;
+            const username = this.toStringField(source['username'] ?? source['userName']);
+            const id = this.toStringField(source['id']);
+            const email = this.toStringField(source['email']);
+            const firstName = this.toStringField(source['firstName']);
+            const lastName = this.toStringField(source['lastName']);
             if (!id && !username && !email) {
                 return null;
             }
             const user: CanonicalUser = {
                 ...(id !== undefined ? { id } : {}),
                 username: username ?? '',
-                ...(source['firstName'] !== undefined ? { firstName: source['firstName'] as string } : {}),
-                ...(source['lastName'] !== undefined ? { lastName: source['lastName'] as string } : {}),
+                ...(firstName !== undefined ? { firstName } : {}),
+                ...(lastName !== undefined ? { lastName } : {}),
                 ...(email !== undefined ? { email } : {})
             };
             return user;
@@ -156,8 +158,8 @@ export class FormFieldValueAdapterService {
                 return null;
             }
             const source = entry as Record<string, unknown>;
-            const name = source['name'] as string | undefined;
-            const id = source['id'] as string | undefined;
+            const name = this.toStringField(source['name']);
+            const id = this.toStringField(source['id']);
             if (!name && !id) {
                 return null;
             }
@@ -177,6 +179,10 @@ export class FormFieldValueAdapterService {
 
     private isBlankToken(value: string): boolean {
         return value === '' || value === '[]' || value === '{}';
+    }
+
+    private toStringField(value: unknown): string | undefined {
+        return typeof value === 'string' && value.trim() !== '' ? value : undefined;
     }
 
     private toOptionId(entry: unknown): unknown {

--- a/lib/process-services-cloud/src/lib/form/components/widgets/group/group-cloud.widget.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/group/group-cloud.widget.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Component, DestroyRef, inject, OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, DestroyRef, inject, OnInit, ViewChild, ViewEncapsulation } from '@angular/core';
 import { ErrorWidgetComponent, WidgetComponent } from '@alfresco/adf-core';
 import { UntypedFormControl } from '@angular/forms';
 import { filter } from 'rxjs/operators';
@@ -50,6 +50,9 @@ import { GroupCloudComponent } from '../../../../group/components/group-cloud.co
 export class GroupCloudWidgetComponent extends WidgetComponent implements OnInit {
     private readonly reactivePreselection: ReactivePreselectionService<IdentityGroupModel> = inject(ReactivePreselectionService);
 
+    @ViewChild(GroupCloudComponent)
+    private readonly groupCloud: GroupCloudComponent;
+
     typeId = 'GroupCloudWidgetComponent';
     roles: string[];
     mode: ComponentSelectionMode;
@@ -65,7 +68,7 @@ export class GroupCloudWidgetComponent extends WidgetComponent implements OnInit
             getFieldId: () => this.field?.id,
             getFormId: () => this.field?.form?.id,
             getFieldValue: () => this.field?.value,
-            getPreselection: () => this.preSelectGroup,
+            getSelection: () => this.groupCloud?.selectedGroups ?? [],
             setPreselection: (value) => (this.preSelectGroup = value),
             identityOf: (group) => group?.id ?? group?.name
         });

--- a/lib/process-services-cloud/src/lib/form/components/widgets/people/people-cloud.widget.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/people/people-cloud.widget.spec.ts
@@ -25,7 +25,9 @@ import {
     NoopAuthModule
 } from '@alfresco/adf-core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { PeopleCloudWidgetComponent } from './people-cloud.widget';
+import { PeopleCloudComponent } from '../../../../people/components/people-cloud.component';
 import { IdentityUserService } from '../../../../people/services/identity-user.service';
 import { mockShepherdsPie, mockYorkshirePudding } from '../../../../people/mock/people-cloud.mock';
 import { HarnessLoader } from '@angular/cdk/testing';
@@ -356,6 +358,38 @@ describe('PeopleCloudWidgetComponent', () => {
                 formService.formRulesEvent.next({ type: 'fieldValueChanged' } as any);
 
                 expect(widget.preSelectUsers).toBe(initial);
+            });
+        });
+
+        describe('single-event population (two-click repro)', () => {
+            let formService: FormService;
+
+            beforeEach(() => {
+                TestBed.resetTestingModule();
+                TestBed.configureTestingModule({
+                    imports: [NoopAuthModule, PeopleCloudWidgetComponent],
+                    providers: [{ provide: ADF_TYPED_VALUE_FORMATTING_ENABLED, useValue: true }]
+                });
+                formService = TestBed.inject(FormService);
+                fixture = TestBed.createComponent(PeopleCloudWidgetComponent);
+                widget = fixture.componentInstance;
+                element = fixture.nativeElement;
+            });
+
+            it('should populate the rendered people component after a SINGLE rule event', async () => {
+                const users = [{ id: 'a', username: 'alpha' }];
+                widget.field = new FormFieldModel(new FormModel(), { id: 'target', type: FormFieldTypes.PEOPLE, value: null });
+                fixture.detectChanges();
+                await fixture.whenStable();
+
+                widget.field.value = users;
+                formService.formRulesEvent.next({ type: 'fieldValueChanged', field: { id: 'target' } } as any);
+
+                fixture.detectChanges();
+                await fixture.whenStable();
+
+                const peopleComponent = fixture.debugElement.query(By.directive(PeopleCloudComponent)).componentInstance as PeopleCloudComponent;
+                expect(peopleComponent.getSelectedUsers()).toEqual(users);
             });
         });
     });

--- a/lib/process-services-cloud/src/lib/form/components/widgets/people/people-cloud.widget.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/people/people-cloud.widget.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { Component, DestroyRef, inject, OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, DestroyRef, inject, OnInit, ViewChild, ViewEncapsulation } from '@angular/core';
 import { ErrorWidgetComponent, WidgetComponent } from '@alfresco/adf-core';
 import { UntypedFormControl } from '@angular/forms';
 import { filter } from 'rxjs/operators';
@@ -53,6 +53,9 @@ export class PeopleCloudWidgetComponent extends WidgetComponent implements OnIni
     private readonly identityUserService = inject(IdentityUserService);
     private readonly reactivePreselection: ReactivePreselectionService<IdentityUserModel> = inject(ReactivePreselectionService);
 
+    @ViewChild(PeopleCloudComponent)
+    private readonly peopleCloud: PeopleCloudComponent;
+
     typeId = 'PeopleCloudWidgetComponent';
     appName: string;
     roles: string[];
@@ -70,7 +73,7 @@ export class PeopleCloudWidgetComponent extends WidgetComponent implements OnIni
             getFieldId: () => this.field?.id,
             getFormId: () => this.field?.form?.id,
             getFieldValue: () => this.field?.value,
-            getPreselection: () => this.preSelectUsers,
+            getSelection: () => this.peopleCloud?.getSelectedUsers() ?? [],
             setPreselection: (value) => (this.preSelectUsers = value),
             identityOf: (user) => user?.id ?? user?.username ?? user?.email
         });

--- a/lib/process-services-cloud/src/lib/form/components/widgets/reactive-preselection.service.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/reactive-preselection.service.spec.ts
@@ -56,7 +56,7 @@ describe('ReactivePreselectionService', () => {
             getFieldId: () => HOST_FIELD_ID,
             getFormId: () => HOST_FORM_ID,
             getFieldValue: () => fieldValue,
-            getPreselection: () => preselection,
+            getSelection: () => preselection,
             setPreselection: (value) => (preselection = value),
             identityOf: (item) => item?.id ?? item?.name
         };
@@ -111,11 +111,20 @@ describe('ReactivePreselectionService', () => {
             expect(preselection).toBe(initial);
         });
 
-        it('should ignore changes originating from the host field itself', () => {
+        it('should react to changes originating from the host field itself', () => {
+            fieldValue = [{ id: 'a' }];
+
+            formRulesEvent.next({ type: 'fieldValueChanged', field: { id: HOST_FIELD_ID }, form: { id: HOST_FORM_ID } });
+
+            expect(preselection).toEqual([{ id: 'a' }]);
+        });
+
+        it('should not reassign when the value already matches the current selection', () => {
+            preselection = [{ id: 'a' }];
             const initial = preselection;
             fieldValue = [{ id: 'a' }];
 
-            formRulesEvent.next({ type: 'fieldValueChanged', field: { id: HOST_FIELD_ID } });
+            formRulesEvent.next({ type: 'fieldValueChanged', field: { id: HOST_FIELD_ID }, form: { id: HOST_FORM_ID } });
 
             expect(preselection).toBe(initial);
         });

--- a/lib/process-services-cloud/src/lib/form/components/widgets/reactive-preselection.service.ts
+++ b/lib/process-services-cloud/src/lib/form/components/widgets/reactive-preselection.service.ts
@@ -25,7 +25,7 @@ export interface ReactivePreselectionHost<T> {
     getFieldId(): string;
     getFormId(): string;
     getFieldValue(): unknown;
-    getPreselection(): T[];
+    getSelection(): T[];
     setPreselection(value: T[]): void;
     identityOf(item: T): string;
 }
@@ -63,17 +63,13 @@ export class ReactivePreselectionService<T = unknown> {
         this.subscribed = true;
         this.formService.formRulesEvent
             .pipe(
-                filter((event) => event?.type === 'fieldValueChanged' && this.isExternalChange(event)),
+                filter((event) => event?.type === 'fieldValueChanged' && this.isSameForm(event)),
                 takeUntilDestroyed(this.destroyRef)
             )
             .subscribe(() => this.sync());
     }
 
-    private isExternalChange(event: FormRulesEvent): boolean {
-        const eventFieldId = event?.field?.id;
-        if (eventFieldId && eventFieldId === this.host.getFieldId()) {
-            return false;
-        }
+    private isSameForm(event: FormRulesEvent): boolean {
         const eventFormId = event?.form?.id;
         return !eventFormId || eventFormId === this.host.getFormId();
     }
@@ -83,7 +79,7 @@ export class ReactivePreselectionService<T = unknown> {
             return;
         }
         const next = this.toPreselection(this.host.getFieldValue());
-        if (this.isSamePreselection(this.host.getPreselection(), next)) {
+        if (this.isSamePreselection(this.host.getSelection(), next)) {
             return;
         }
         this.host.setPreselection(next);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

**What is the current behaviour?**

The People and Group cloud widgets do not reliably populate from a process-response value on a single form-rule event. The reactive preselection ignores the widget's own field-value change, so it lags one event behind, and non-canonical user/group objects are not normalized before assignment.

**What is the new behaviour?**

The widgets react to their own field-value changes and sync against the live selection, so they populate on the first event. Process-response user and group objects are canonicalized before being assigned to the field.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
