### PR TITLE
[ACS-8467] Removed duplicated dialog after clicking label in folder rules creation dialog

### DIFF
--- a/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.html
+++ b/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.html
@@ -107,7 +107,7 @@
             class="adf-textitem-clickable"
             [ngClass]="{ 'adf-property-read-only': isReadonlyProperty }"
             [attr.data-automation-id]="'card-textitem-toggle-' + property.key"
-            (click)="clicked()"
+            (click)="clicked($event)"
         >
             <mat-form-field class="adf-property-field adf-card-textitem-field">
                 <mat-label

--- a/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
+++ b/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.spec.ts
@@ -510,6 +510,30 @@ describe('CardViewTextItemComponent', () => {
             expect(callBackSpy).toHaveBeenCalled();
         });
 
+        it('should call preventDefault on event when label of clickable input is clicked', () => {
+            component.property.clickable = true;
+            component.ngOnChanges({});
+            fixture.detectChanges();
+
+            const clickEvent = new MouseEvent('click', { bubbles: true });
+            spyOn(clickEvent, 'preventDefault');
+            testingUtils.getByDataAutomationId(`card-textitem-label-${component.property.key}`).nativeElement.dispatchEvent(clickEvent);
+            fixture.detectChanges();
+            expect(clickEvent.preventDefault).toHaveBeenCalled();
+        });
+
+        it('should call preventDefault on event when button wrapper of clickable input is clicked', () => {
+            component.property.clickable = true;
+            component.ngOnChanges({});
+            fixture.detectChanges();
+
+            const clickEvent = new MouseEvent('click');
+            spyOn(clickEvent, 'preventDefault');
+            testingUtils.getByDataAutomationId(`card-textitem-toggle-${component.property.key}`).nativeElement.dispatchEvent(clickEvent);
+            fixture.detectChanges();
+            expect(clickEvent.preventDefault).toHaveBeenCalled();
+        });
+
         it('should click event to the event stream when clickable property enabled', async () => {
             const cardViewUpdateService = TestBed.inject(CardViewUpdateService);
             spyOn(cardViewUpdateService, 'clicked').and.stub();

--- a/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.ts
+++ b/lib/core/src/lib/card-view/components/card-view-textitem/card-view-textitem.component.ts
@@ -203,12 +203,13 @@ export class CardViewTextItemComponent extends BaseCardView<CardViewTextItemMode
         }
     }
 
-    clicked(): void {
+    clicked(event: MouseEvent): void {
         if (typeof this.property.clickCallBack === 'function') {
             this.property.clickCallBack();
         } else {
             this.cardViewUpdateService.clicked(this.property);
         }
+        event.preventDefault();
     }
 
     clearValue() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/ACS-8467


**What is the new behaviour?**
After clicking label, duplicated dialog is not opened 


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
