### PR TITLE
[ACS-10175] Shows notification after applying A/N BDU label

### DIFF
--- a/.github/workflows/notify-teams-on-bdu-label.yml
+++ b/.github/workflows/notify-teams-on-bdu-label.yml
@@ -1,0 +1,43 @@
+name: "Notify Teams on A/N BDU label"
+
+on:
+  pull_request:
+    types: [opened, reopened, labeled]
+    branches:
+      - develop
+      - master
+      - develop-patch*
+      - master-patch*
+
+concurrency:
+  # De-duplicate: only one notification run per PR at a time.
+  group: notify-bdu-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  notify-bdu:
+    name: Notify Teams when A/N BDU label is present
+    runs-on: ubuntu-latest
+    if: >-
+      (github.event.action == 'labeled' && github.event.label.name == 'A/N BDU') ||
+      ((github.event.action == 'opened' || github.event.action == 'reopened') &&
+        contains(github.event.pull_request.labels.*.name, 'A/N BDU'))
+    steps:
+      - name: Send Teams notification
+        uses: Alfresco/alfresco-build-tools/.github/actions/send-teams-notification@1d671f8f10336861c89c67be57c6648d98876103 # v18.19.0
+        with:
+          webhook-url: ${{ secrets.TEAMS_NOTIFICATION_ADF_BDU_WEBHOOK }}
+          skip_checkout: true
+          title: "A/N BDU PR: ${{ github.event.pull_request.title }}"
+          message: |
+            A pull request labelled **A/N BDU** needs attention.
+
+            - **Repository:** ${{ github.repository }}
+            - **PR:** [#${{ github.event.pull_request.number }} ${{ github.event.pull_request.title }}](${{ github.event.pull_request.html_url }})
+            - **Author:** ${{ github.event.pull_request.user.login }}
+            - **Target branch:** ${{ github.event.pull_request.base.ref }}
+            - **Trigger:** ${{ github.event.action == 'labeled' && 'label added after opening' || github.event.action }}

--- a/.github/workflows/notify-teams-on-bdu-label.yml
+++ b/.github/workflows/notify-teams-on-bdu-label.yml
@@ -3,25 +3,16 @@ name: "Notify Teams on A/N BDU label"
 on:
   pull_request:
     types: [opened, reopened, labeled]
-    branches:
-      - develop
-      - master
-      - develop-patch*
-      - master-patch*
-
-concurrency:
-  # De-duplicate: only one notification run per PR at a time.
-  group: notify-bdu-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
+    branches: [develop]
 
 permissions:
-  contents: read
   pull-requests: read
 
 jobs:
   notify-bdu:
     name: Notify Teams when A/N BDU label is present
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: >-
       (github.event.action == 'labeled' && github.event.label.name == 'A/N BDU') ||
       ((github.event.action == 'opened' || github.event.action == 'reopened') &&
@@ -32,9 +23,12 @@ jobs:
         with:
           webhook-url: ${{ secrets.TEAMS_NOTIFICATION_ADF_BDU_WEBHOOK }}
           skip_checkout: true
+          # Explicit status so the action does not try to auto-compute it from
+          # the workflow run (which would require `actions: read` permission).
+          status: success
           title: "A/N BDU PR: ${{ github.event.pull_request.title }}"
           message: |
-            A pull request labelled **A/N BDU** needs attention.
+            A pull request labelled **A/N BDU** is pushed.
 
             - **Repository:** ${{ github.repository }}
             - **PR:** [#${{ github.event.pull_request.number }} ${{ github.event.pull_request.title }}](${{ github.event.pull_request.html_url }})


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
Notification is not sent when user creates a pr and after that adds a label


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ ] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://hyland.atlassian.net/browse/ACS-10715


This PR is for testing purpose only 