### PR TITLE
[ACS-12385] Add language option for en-AU

### DIFF
--- a/lib/core/src/lib/common/models/default-languages.model.ts
+++ b/lib/core/src/lib/common/models/default-languages.model.ts
@@ -20,7 +20,7 @@ import { LanguageItem } from '../services/language-item.interface';
 export const DEFAULT_LANGUAGE_LIST: LanguageItem[] = [
     { key: 'de', label: 'Deutsch' },
     { key: 'en', label: 'English' },
-    { key: 'en-AU', label: 'English - Australia' },
+    { key: 'en-AU', label: 'English (Australia)' },
     { key: 'es', label: 'Español' },
     { key: 'fr', label: 'Français' },
     { key: 'it', label: 'Italiano' },

--- a/lib/core/src/lib/common/models/default-languages.model.ts
+++ b/lib/core/src/lib/common/models/default-languages.model.ts
@@ -20,6 +20,7 @@ import { LanguageItem } from '../services/language-item.interface';
 export const DEFAULT_LANGUAGE_LIST: LanguageItem[] = [
     { key: 'de', label: 'Deutsch' },
     { key: 'en', label: 'English' },
+    { key: 'en-AU', label: 'English - Australia' },
     { key: 'es', label: 'Español' },
     { key: 'fr', label: 'Français' },
     { key: 'it', label: 'Italiano' },

--- a/lib/core/src/lib/mock/language.service.mock.ts
+++ b/lib/core/src/lib/mock/language.service.mock.ts
@@ -25,7 +25,7 @@ export class LanguageServiceMock implements LanguageServiceInterface {
     private readonly languages = new BehaviorSubject<LanguageItem[]>([
         { key: 'de', label: 'Deutsch' },
         { key: 'en', label: 'English' },
-        { key: 'en-AU', label: 'English - Australia' },
+        { key: 'en-AU', label: 'English (Australia)' },
         { key: 'es', label: 'Español' },
         { key: 'fr', label: 'Français' },
         { key: 'it', label: 'Italiano' },

--- a/lib/core/src/lib/mock/language.service.mock.ts
+++ b/lib/core/src/lib/mock/language.service.mock.ts
@@ -25,6 +25,7 @@ export class LanguageServiceMock implements LanguageServiceInterface {
     private readonly languages = new BehaviorSubject<LanguageItem[]>([
         { key: 'de', label: 'Deutsch' },
         { key: 'en', label: 'English' },
+        { key: 'en-AU', label: 'English - Australia' },
         { key: 'es', label: 'Español' },
         { key: 'fr', label: 'Français' },
         { key: 'it', label: 'Italiano' },


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
There was no `English - Australia` in language selection option


**What is the new behaviour?**
User can choose `English (Australian)` as language option


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
https://hyland.atlassian.net/browse/ACS-12385