### PR TITLE
AAE-49862 Fix Form Rule Does Not Update Hidden Status of Outcomes on First Run

### DIFF
--- a/lib/core/src/lib/form/services/form-validation-service.interface.ts
+++ b/lib/core/src/lib/form/services/form-validation-service.interface.ts
@@ -16,6 +16,7 @@
  */
 
 import { Subject } from 'rxjs';
+import { FormEvent } from '../events/form.event';
 import { FormFieldEvent } from '../events/form-field.event';
 import { FormRulesEvent } from '../events/form-rules.event';
 import { ValidateFormFieldEvent } from '../events/validate-form-field.event';
@@ -26,4 +27,5 @@ export interface FormValidationService {
     validateForm: Subject<ValidateFormEvent>;
     validateFormField: Subject<ValidateFormFieldEvent>;
     formRulesEvent?: Subject<FormRulesEvent>;
+    formVisibilityRefreshed?: Subject<FormEvent>;
 }

--- a/lib/core/src/lib/form/services/form.service.ts
+++ b/lib/core/src/lib/form/services/form.service.ts
@@ -62,6 +62,12 @@ export class FormService implements FormValidationService {
 
     formRulesEvent = new Subject<FormRulesEvent>();
 
+    /**
+     * Emitted after form field/outcome visibility has been re-evaluated via WidgetVisibilityService.refreshVisibility.
+     * Internal ADF form-rendering event — not part of the FormValidationService contract.
+     */
+    formVisibilityRefreshed = new Subject<FormEvent>();
+
     constructor() {
         const injectedFieldValidators = inject(FORM_SERVICE_FIELD_VALIDATORS_TOKEN, { optional: true });
 

--- a/lib/core/src/lib/form/services/widget-visibility.service.spec.ts
+++ b/lib/core/src/lib/form/services/widget-visibility.service.spec.ts
@@ -19,6 +19,7 @@ import { TestBed } from '@angular/core/testing';
 import { ContainerModel, FormFieldModel, FormFieldTypes, FormModel, TabModel } from '../components/widgets/core';
 import { WidgetVisibilityModel } from '../models/widget-visibility.model';
 import { WidgetVisibilityService } from './widget-visibility.service';
+import { FormService } from './form.service';
 import {
     fakeFormJson,
     formTest,
@@ -48,6 +49,30 @@ describe('WidgetVisibilityService', () => {
 
     beforeEach(() => {
         service = TestBed.inject(WidgetVisibilityService);
+    });
+
+    it('should emit formVisibilityRefreshed when visibility is refreshed', () => {
+        const formService = TestBed.inject(FormService);
+        let emittedForm: FormModel | undefined;
+
+        formService.formVisibilityRefreshed.subscribe((event) => {
+            emittedForm = event.form;
+        });
+
+        service.refreshVisibility(stubFormWithFields);
+
+        expect(emittedForm).toBe(stubFormWithFields);
+    });
+
+    it('should not emit formVisibilityRefreshed when form is null', () => {
+        const formService = TestBed.inject(FormService);
+        let emitCount = 0;
+
+        formService.formVisibilityRefreshed.subscribe(() => emitCount++);
+
+        service.refreshVisibility(null);
+
+        expect(emitCount).toBe(0);
     });
 
     describe('should be able to evaluate next condition operations', () => {

--- a/lib/core/src/lib/form/services/widget-visibility.service.ts
+++ b/lib/core/src/lib/form/services/widget-visibility.service.ts
@@ -15,16 +15,20 @@
  * limitations under the License.
  */
 
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { FormFieldModel, FormModel, TabModel, ContainerModel, FormOutcomeModel } from '../components/widgets/core';
+import { FormEvent } from '../events/form.event';
 import { TaskProcessVariableModel } from '../models/task-process-variable.model';
 import { WidgetVisibilityModel, WidgetTypeEnum } from '../models/widget-visibility.model';
 import { format, isValid, parse } from 'date-fns';
+import { FormService } from './form.service';
 
 @Injectable({
     providedIn: 'root'
 })
 export class WidgetVisibilityService {
+    private readonly formService = inject(FormService);
+
     private processVarList: TaskProcessVariableModel[];
     private form: FormModel;
 
@@ -45,6 +49,8 @@ export class WidgetVisibilityService {
             }
 
             form.getFormFields().map((field) => this.refreshEntityVisibility(field));
+
+            this.formService.formVisibilityRefreshed.next(new FormEvent(form));
         }
     }
 

--- a/lib/process-services-cloud/src/lib/form/components/form-cloud.component.spec.ts
+++ b/lib/process-services-cloud/src/lib/form/components/form-cloud.component.spec.ts
@@ -32,6 +32,8 @@ import {
     provideTranslations,
     AuthModule,
     FormFieldEvent,
+    FormEvent,
+    FormRulesEvent,
     NoopTranslateModule,
     NoopAuthModule,
     FORM_FIELD_VALIDATORS
@@ -1296,6 +1298,38 @@ describe('FormCloudComponent', () => {
         expect(formComponent.visibleOutcomes.length).toBeGreaterThan(0);
 
         formComponent.form = null;
+        expect(formComponent.visibleOutcomes).toEqual([]);
+    });
+
+    it('should recompute visibleOutcomes when form visibility is refreshed', () => {
+        formComponent.showCompleteButton = true;
+        const formModel = new FormModel(cloudFormMock);
+        formComponent.form = formModel;
+
+        expect(formComponent.visibleOutcomes.length).toBeGreaterThan(0);
+
+        formModel.outcomes.forEach((outcome) => {
+            outcome.isVisible = false;
+        });
+
+        TestBed.inject(FormService).formVisibilityRefreshed.next(new FormEvent(formModel));
+
+        expect(formComponent.visibleOutcomes).toEqual([]);
+    });
+
+    it('should recompute visibleOutcomes when fieldValueChanged rule event fires', () => {
+        formComponent.showCompleteButton = true;
+        const formModel = new FormModel(cloudFormMock);
+        formComponent.form = formModel;
+
+        expect(formComponent.visibleOutcomes.length).toBeGreaterThan(0);
+
+        formModel.outcomes.forEach((outcome) => {
+            outcome.isVisible = false;
+        });
+
+        TestBed.inject(FormService).formRulesEvent.next(new FormRulesEvent('fieldValueChanged', new FormEvent(formModel)));
+
         expect(formComponent.visibleOutcomes).toEqual([]);
     });
 

--- a/lib/process-services-cloud/src/lib/form/components/form-cloud.component.ts
+++ b/lib/process-services-cloud/src/lib/form/components/form-cloud.component.ts
@@ -30,7 +30,7 @@ import {
     SimpleChanges,
     ViewChild
 } from '@angular/core';
-import { forkJoin, isObservable, Observable, of, Subscription } from 'rxjs';
+import { forkJoin, isObservable, merge, Observable, of, Subscription } from 'rxjs';
 import { filter, map, switchMap } from 'rxjs/operators';
 import {
     ConfirmDialogComponent,
@@ -306,11 +306,11 @@ export class FormCloudComponent extends FormBaseComponent implements OnChanges, 
             }
         });
 
-        this.formService.formRulesEvent
-            .pipe(
-                filter((event) => event?.type === 'fieldValueChanged' && event.form?.id === this.form?.id),
-                takeUntilDestroyed()
-            )
+        merge(
+            this.formService.formVisibilityRefreshed.pipe(filter((event) => event.form?.id === this.form?.id)),
+            this.formService.formRulesEvent.pipe(filter((event) => event?.type === 'fieldValueChanged' && event.form?.id === this.form?.id))
+        )
+            .pipe(takeUntilDestroyed())
             .subscribe(() => this.recomputeVisibleOutcomes());
     }
 
@@ -595,7 +595,6 @@ export class FormCloudComponent extends FormBaseComponent implements OnChanges, 
     checkVisibility(field: FormFieldModel) {
         if (field?.form) {
             this.visibilityService.refreshVisibility(field.form);
-            this.recomputeVisibleOutcomes();
         }
     }
 
@@ -613,7 +612,6 @@ export class FormCloudComponent extends FormBaseComponent implements OnChanges, 
         this.setCheckParentVisibilityForValidationOnFields();
         this.visibilityService.refreshVisibility(this.form);
         this.form.validateForm();
-        this.recomputeVisibleOutcomes();
         this.onFormLoaded(this.form);
         this.formService.formRulesEvent.next(new FormRulesEvent('dataRefreshed', new FormEvent(this.form)));
         this.onFormDataRefreshed(this.form);


### PR DESCRIPTION


**Please check if the PR fulfills these requirements**

> - [ x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/AAE-49862

Problem: Outcome buttons use a pre-computed visibleOutcomes list. After onProcessFinish rules ran, outcome visibility was updated on the model but the buttons did not refresh.

**What is the new behaviour?**

Fix:

Emit formVisibilityRefreshed from WidgetVisibilityService.refreshVisibility() after field/outcome visibility is re-evaluated.
FormCloudComponent recomputes outcomes on both formVisibilityRefreshed (after visibility refresh — covers process finish and the correct ordering) and formRulesEvent / fieldValueChanged (preserves existing behaviour for integrations that rely on the old listener).

Other cleanup:

Removed duplicate recomputeVisibleOutcomes() calls in checkVisibility() and refreshFormData() — both already go through refreshVisibility(), which emits the new event.
Added unit tests for the event emission and FormCloudComponent subscription.


**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
