### PR TITLE
[MNT-25612] ADW Metadata Drawer ignores read‑only presets (readOnlyAspects / readOnlyProperties)

### DIFF
--- a/lib/content-services/src/lib/content-metadata/interfaces/layout-oriented-config.interface.ts
+++ b/lib/content-services/src/lib/content-metadata/interfaces/layout-oriented-config.interface.ts
@@ -29,6 +29,8 @@ export interface LayoutOrientedConfigItem {
 export interface LayoutOrientedConfigLayoutBlock {
     title: string;
     items: LayoutOrientedConfigItem[];
+    readOnlyProperties?: string | string[];
+    readOnlyAspects?: string | string[];
 }
 
 export type LayoutOrientedConfig = Array<LayoutOrientedConfigLayoutBlock>;

--- a/lib/content-services/src/lib/content-metadata/services/config/layout-oriented-config.service.ts
+++ b/lib/content-services/src/lib/content-metadata/services/config/layout-oriented-config.service.ts
@@ -63,9 +63,16 @@ export class LayoutOrientedConfigService implements ContentMetadataConfig {
         return Object.keys(propertyGroups).map((groupName) => {
             const propertyGroup = propertyGroups[groupName];
             const properties = propertyGroup.properties;
+            const isGroupReadOnly = this.isAspectReadOnly(groupName);
 
             return Object.assign({}, propertyGroup, {
-                properties: Object.keys(properties).map((propertyName) => properties[propertyName])
+                properties: Object.keys(properties).map((propertyName) => {
+                    const property = properties[propertyName];
+                    if (isGroupReadOnly || this.isPropertyReadOnly(propertyName)) {
+                        property.editable = false;
+                    }
+                    return property;
+                })
             });
         });
     }
@@ -93,12 +100,35 @@ export class LayoutOrientedConfigService implements ContentMetadataConfig {
 
     private setEditableProperty(propertyGroup: Property | Property[], itemConfig): Property | Property[] {
         if (Array.isArray(propertyGroup)) {
-            propertyGroup.forEach((property) => (property.editable = itemConfig.editable !== undefined ? itemConfig.editable : true));
+            propertyGroup.forEach((property) => (property.editable = this.resolveEditable(property, itemConfig)));
         } else {
-            propertyGroup.editable = itemConfig.editable !== undefined ? itemConfig.editable : true;
+            propertyGroup.editable = this.resolveEditable(propertyGroup, itemConfig);
         }
 
         return propertyGroup;
+    }
+
+    private resolveEditable(property: Property, itemConfig): boolean {
+        if (this.isAspectReadOnly(itemConfig.groupName) || this.isPropertyReadOnly(property?.name)) {
+            return false;
+        }
+
+        return itemConfig.editable !== undefined ? itemConfig.editable : true;
+    }
+
+    private isPropertyReadOnly(propertyName: string): boolean {
+        return this.getReadOnlyNames('readOnlyProperties').includes(propertyName);
+    }
+
+    private isAspectReadOnly(groupName: string): boolean {
+        return this.getReadOnlyNames('readOnlyAspects').includes(groupName);
+    }
+
+    private getReadOnlyNames(key: 'readOnlyProperties' | 'readOnlyAspects'): string[] {
+        return this.config
+            .map((block) => block?.[key])
+            .filter((names) => names !== undefined)
+            .flat();
     }
 
     private setPropertyTitle(item: Property | Property[], property: Property): Property | Property[] {

--- a/lib/content-services/src/lib/content-metadata/services/content-metadata.service.spec.ts
+++ b/lib/content-services/src/lib/content-metadata/services/content-metadata.service.spec.ts
@@ -102,6 +102,27 @@ describe('ContentMetaDataService', () => {
         }
     };
 
+    const titledResponse: PropertyGroup = {
+        name: 'cm:titled',
+        title: 'Titled',
+        properties: {
+            'cm:title': {
+                title: 'Title',
+                name: 'cm:title',
+                dataType: 'd:text',
+                mandatory: false,
+                multiValued: false
+            },
+            'cm:description': {
+                title: 'Description',
+                name: 'cm:description',
+                dataType: 'd:text',
+                mandatory: false,
+                multiValued: false
+            }
+        }
+    };
+
     const verResponse: PropertyGroup = {
         name: 'cm:versionable',
         title: 'Versionable',
@@ -247,6 +268,69 @@ describe('ContentMetaDataService', () => {
         expect(titleProperty.editable).toBeFalse();
         expect(descriptionProperty.editable).toBeFalse();
         expect(authorProperty.editable).toBeTrue();
+    });
+
+    it('should mark basic properties as read-only when their aspect is listed in readOnlyAspects', async () => {
+        setConfig('custom', [{ includeAll: true, readOnlyAspects: ['cm:titled'] }]);
+        spyOn(classesApi, 'getClass').and.returnValue(Promise.resolve(titledResponse));
+
+        const res = await firstValueFrom(service.getBasicProperties(fakeContentNode, 'custom'));
+        const titleProperty = res.find((property) => property.key === 'properties.cm:title');
+        const descriptionProperty = res.find((property) => property.key === 'properties.cm:description');
+        const nameProperty = res.find((property) => property.key === 'properties.cm:name');
+
+        expect(classesApi.getClass).toHaveBeenCalledWith('cm_titled');
+        expect(titleProperty.editable).toBeFalse();
+        expect(descriptionProperty.editable).toBeFalse();
+        expect(nameProperty.editable).toBeTrue();
+    });
+
+    it('should mark custom aspect properties as read-only when that aspect is listed in readOnlyAspects', async () => {
+        const customAspectNode = { ...fakeContentNode, aspectNames: ['fn:custom'] } as Node;
+        setConfig('custom', [{ includeAll: true, readOnlyAspects: ['fn:custom'] }]);
+        spyOn(classesApi, 'getClass').and.returnValue(
+            Promise.resolve({
+                name: 'fn:custom',
+                title: 'Custom',
+                properties: {
+                    'cm:title': { title: 'Title', name: 'cm:title', dataType: 'd:text', mandatory: false, multiValued: false }
+                }
+            } as PropertyGroup)
+        );
+
+        const res = await firstValueFrom(service.getBasicProperties(customAspectNode, 'custom'));
+
+        expect(classesApi.getClass).toHaveBeenCalledWith('fn_custom');
+        expect(res.find((property) => property.key === 'properties.cm:title').editable).toBeFalse();
+    });
+
+    it('should keep basic properties editable when the readOnlyAspects lookup fails', async () => {
+        setConfig('custom', [{ includeAll: true, readOnlyAspects: ['cm:titled'] }]);
+        spyOn(classesApi, 'getClass').and.returnValue(Promise.reject(new Error('boom')));
+
+        const res = await firstValueFrom(service.getBasicProperties(fakeContentNode, 'custom'));
+
+        expect(res.find((property) => property.key === 'properties.cm:title').editable).toBeTrue();
+    });
+
+    it('should not call the classes api when the node does not have the read-only aspect', async () => {
+        setConfig('custom', [{ includeAll: true, readOnlyAspects: ['cm:titled'] }]);
+        spyOn(classesApi, 'getClass');
+
+        const res = await firstValueFrom(service.getBasicProperties(fakeNode, 'custom'));
+
+        expect(classesApi.getClass).not.toHaveBeenCalled();
+        expect(res.find((property) => property.key === 'properties.cm:title').editable).toBeTrue();
+    });
+
+    it('should not call the classes api when no readOnlyAspects are configured', async () => {
+        setConfig('custom', [{ includeAll: true, readOnlyProperties: ['cm:title'] }]);
+        spyOn(classesApi, 'getClass');
+
+        const res = await firstValueFrom(service.getBasicProperties(fakeNode, 'custom'));
+
+        expect(classesApi.getClass).not.toHaveBeenCalled();
+        expect(res.find((property) => property.key === 'properties.cm:title').editable).toBeFalse();
     });
 
     it('should hide basic properties from general info when they are excluded', async () => {
@@ -493,6 +577,62 @@ describe('ContentMetaDataService', () => {
     });
 
     describe('LayoutOriented preset', () => {
+        it('should mark grouped properties as read-only when listed in readOnlyProperties', async () => {
+            setConfig('custom', [{ includeAll: true, readOnlyProperties: ['cm:title'] }]);
+            spyOn(classesApi, 'getClass').and.returnValue(Promise.resolve(titledResponse));
+
+            const groups = await firstValueFrom(service.getGroupedProperties(fakeContentNode, 'custom'));
+            const properties = groups.flatMap((group) => group.properties);
+
+            expect(properties.find((property) => property.key === 'properties.cm:title').editable).toBeFalse();
+            expect(properties.find((property) => property.key === 'properties.cm:description').editable).toBeTrue();
+        });
+
+        it('should mark grouped properties as read-only when their aspect is listed in readOnlyAspects', async () => {
+            setConfig('custom', [{ includeAll: true, readOnlyAspects: ['cm:titled'] }]);
+            spyOn(classesApi, 'getClass').and.returnValue(Promise.resolve(titledResponse));
+
+            const groups = await firstValueFrom(service.getGroupedProperties(fakeContentNode, 'custom'));
+            const properties = groups.flatMap((group) => group.properties);
+
+            expect(properties.find((property) => property.key === 'properties.cm:title').editable).toBeFalse();
+            expect(properties.find((property) => property.key === 'properties.cm:description').editable).toBeFalse();
+        });
+
+        it('should mark explicitly configured items as read-only when listed in readOnlyProperties', async () => {
+            setConfig('custom', [
+                {
+                    readOnlyProperties: ['cm:title'],
+                    title: 'Titled',
+                    items: [{ aspect: 'cm:titled', properties: '*' }]
+                }
+            ]);
+            spyOn(classesApi, 'getClass').and.returnValue(Promise.resolve(titledResponse));
+
+            const groups = await firstValueFrom(service.getGroupedProperties(fakeContentNode, 'custom'));
+            const properties = groups.flatMap((group) => group.properties);
+
+            expect(properties.find((property) => property.key === 'properties.cm:title').editable).toBeFalse();
+            expect(properties.find((property) => property.key === 'properties.cm:description').editable).toBeTrue();
+        });
+
+        it('should mark explicitly configured items as read-only when their aspect is listed in readOnlyAspects', async () => {
+            setConfig('custom', [
+                {
+                    readOnlyAspects: ['cm:titled'],
+                    title: 'Titled',
+                    items: [{ aspect: 'cm:titled', properties: '*' }]
+                }
+            ]);
+            spyOn(classesApi, 'getClass').and.returnValue(Promise.resolve(titledResponse));
+
+            const groups = await firstValueFrom(service.getGroupedProperties(fakeContentNode, 'custom'));
+            const properties = groups.flatMap((group) => group.properties);
+
+            expect(properties.find((property) => property.key === 'properties.cm:title').editable).toBeFalse();
+            expect(properties.find((property) => property.key === 'properties.cm:description').editable).toBeFalse();
+        });
+
         it('should return the node property', (done) => {
             const customLayoutOrientedScheme = [
                 {

--- a/lib/content-services/src/lib/content-metadata/services/content-metadata.service.ts
+++ b/lib/content-services/src/lib/content-metadata/services/content-metadata.service.ts
@@ -24,13 +24,12 @@ import { AppConfigService, CardViewItem } from '@alfresco/adf-core';
 import { CardViewGroup, OrganisedPropertyGroup, PresetConfig } from '../interfaces/content-metadata.interfaces';
 import { ContentMetadataConfigFactory } from './config/content-metadata-config.factory';
 import { PropertyDescriptorsService } from './property-descriptors.service';
-import { map, switchMap } from 'rxjs/operators';
+import { catchError, map, switchMap } from 'rxjs/operators';
 import { ContentTypePropertiesService } from './content-type-property.service';
 import { LayoutOrientedConfig, LayoutOrientedConfigLayoutBlock } from '../interfaces/layout-oriented-config.interface';
 import { Property } from '../interfaces/property.interface';
 
 interface LayoutBlockWithReadOnly extends LayoutOrientedConfigLayoutBlock {
-    readOnlyProperties?: string | string[];
     exclude?: string | string[];
 }
 
@@ -52,6 +51,7 @@ export class ContentMetadataService {
 
     getBasicProperties(node: Node, preset: string | PresetConfig = 'default'): Observable<CardViewItem[]> {
         const readOnlyProperties = this.getReadOnlyPropertyNames(preset);
+        const readOnlyAspects = this.getReadOnlyAspectNames(preset);
         const excludedNames = this.getExcludedNames(preset);
 
         const properties = this.basicPropertiesService.getProperties(node).filter((property) => {
@@ -59,16 +59,32 @@ export class ContentMetadataService {
             return !propertyName || !excludedNames.includes(propertyName);
         });
 
-        if (readOnlyProperties.length) {
+        const setReadOnly = (names: string[]) =>
             properties.forEach((property) => {
                 const propertyName = this.getBasicPropertyName(property.key);
-                if (propertyName && readOnlyProperties.includes(propertyName)) {
+                if (propertyName && names.includes(propertyName)) {
                     property.editable = false;
                 }
             });
+
+        if (readOnlyProperties.length) {
+            setReadOnly(readOnlyProperties);
         }
 
-        return of(properties);
+        const nodeGroupNames = (node.aspectNames || []).concat(node.nodeType);
+        const groupNamesToLoad = readOnlyAspects.filter((aspectName) => nodeGroupNames.includes(aspectName));
+
+        if (!groupNamesToLoad.length) {
+            return of(properties);
+        }
+
+        return this.propertyDescriptorsService.load(groupNamesToLoad).pipe(
+            map((groups) => {
+                setReadOnly(Object.values(groups).flatMap((group) => Object.keys(group?.properties || {})));
+                return properties;
+            }),
+            catchError(() => of(properties))
+        );
     }
 
     private getBasicPropertyName(key: string): string | undefined {
@@ -84,6 +100,23 @@ export class ContentMetadataService {
 
         if (presetConfig != null && typeof presetConfig === 'object') {
             return this.normaliseToArray(presetConfig.readOnlyProperties);
+        }
+
+        return [];
+    }
+
+    private getReadOnlyAspectNames(preset: string | PresetConfig): string[] {
+        const presetConfig = this.getPresetConfig(preset);
+
+        if (this.isLayoutConfig(presetConfig)) {
+            return presetConfig.reduce(
+                (readOnly, block) => readOnly.concat(this.normaliseToArray((block as LayoutBlockWithReadOnly)?.readOnlyAspects)),
+                [] as string[]
+            );
+        }
+
+        if (presetConfig != null && typeof presetConfig === 'object') {
+            return this.normaliseToArray(presetConfig.readOnlyAspects);
         }
 
         return [];


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:


**What is the current behaviour?** (You can also link to an open issue here)
https://hyland.atlassian.net/browse/MNT-25612


**What is the new behaviour?**



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
