### PR TITLE
fix(core): fix ResizableDirective memory leak from orphaned document listeners [AAE-50892]

### DIFF
--- a/lib/core/src/lib/datatable/directives/resizable/resizable.directive.spec.ts
+++ b/lib/core/src/lib/datatable/directives/resizable/resizable.directive.spec.ts
@@ -92,20 +92,16 @@ describe('ResizableDirective', () => {
         directive.ngOnInit();
     });
 
-    it('should attach mousedown event to document', () => {
-        expect(renderer.listen).toHaveBeenCalledWith('document', 'mousedown', jasmine.any(Function));
+    it('should not attach any document listeners on init', () => {
+        expect(renderer.listen).not.toHaveBeenCalled();
     });
 
-    it('should attach mousemove event to document', () => {
+    it('should attach document mousemove listener only during active drag', () => {
         const mouseDownEvent = new MouseEvent('mousedown');
 
         directive.mousedown.next({ ...mouseDownEvent, resize: true });
 
         expect(renderer.listen).toHaveBeenCalledWith('document', 'mousemove', jasmine.any(Function));
-    });
-
-    it('should attach mouseup event to document', () => {
-        expect(renderer.listen).toHaveBeenCalledWith('document', 'mouseup', jasmine.any(Function));
     });
 
     it('should should set the cursor on mouse down', () => {
@@ -186,6 +182,9 @@ describe('ResizableDirective', () => {
     });
 
     it('should unregister document listeners on destroy', () => {
+        directive.mousedown.next({ ...new MouseEvent('mousedown'), resize: true });
+        expect(unlistenSpies.length).toBeGreaterThan(0);
+
         testEnvInjector.destroy();
         unlistenSpies.forEach((spy) => expect(spy).toHaveBeenCalledTimes(1));
     });

--- a/lib/core/src/lib/datatable/directives/resizable/resizable.directive.spec.ts
+++ b/lib/core/src/lib/datatable/directives/resizable/resizable.directive.spec.ts
@@ -16,7 +16,7 @@
  */
 
 import { TestBed } from '@angular/core/testing';
-import { ElementRef, Injector, NgZone, Renderer2, runInInjectionContext } from '@angular/core';
+import { ElementRef, EnvironmentInjector, NgZone, Renderer2, createEnvironmentInjector, runInInjectionContext } from '@angular/core';
 import { ResizableDirective } from './resizable.directive';
 
 describe('ResizableDirective', () => {
@@ -24,6 +24,7 @@ describe('ResizableDirective', () => {
     let renderer: Renderer2;
     let element: ElementRef;
     let directive: ResizableDirective;
+    let testEnvInjector: EnvironmentInjector;
 
     const scrollTop = 0;
     const scrollLeft = 0;
@@ -39,8 +40,14 @@ describe('ResizableDirective', () => {
         scrollLeft
     };
 
+    let unlistenSpies: jasmine.Spy[];
+
     const rendererMock = {
-        listen: jasmine.createSpy('listen'),
+        listen: jasmine.createSpy('listen').and.callFake(() => {
+            const spy = jasmine.createSpy(`unlisten-${unlistenSpies.length}`);
+            unlistenSpies.push(spy);
+            return spy;
+        }),
         setStyle: jasmine.createSpy('setStyle')
     };
 
@@ -53,6 +60,10 @@ describe('ResizableDirective', () => {
     };
 
     beforeEach(() => {
+        unlistenSpies = [];
+        rendererMock.listen.calls.reset();
+        rendererMock.setStyle.calls.reset();
+
         TestBed.configureTestingModule({
             imports: [ResizableDirective],
             providers: [
@@ -64,20 +75,19 @@ describe('ResizableDirective', () => {
         element = TestBed.inject(ElementRef);
         renderer = TestBed.inject(Renderer2);
         ngZone = TestBed.inject(NgZone);
-        const injector = TestBed.inject(Injector);
         spyOn(ngZone, 'runOutsideAngular').and.callFake((fn) => fn());
         spyOn(ngZone, 'run').and.callFake((fn) => fn());
 
-        const testInjector = Injector.create({
-            providers: [
+        testEnvInjector = createEnvironmentInjector(
+            [
                 { provide: Renderer2, useValue: renderer },
                 { provide: ElementRef, useValue: element },
                 { provide: NgZone, useValue: ngZone }
             ],
-            parent: injector
-        });
+            TestBed.inject(EnvironmentInjector)
+        );
 
-        directive = runInInjectionContext(testInjector, () => new ResizableDirective());
+        directive = runInInjectionContext(testEnvInjector, () => new ResizableDirective());
 
         directive.ngOnInit();
     });
@@ -173,5 +183,33 @@ describe('ResizableDirective', () => {
         directive.resizeByKeyboard(step);
 
         expect(directive.keyboardResizing.emit).toHaveBeenCalledWith({ rectangle: { top: 0, left: 0, bottom: 0, right: step, width: step } });
+    });
+
+    it('should unregister document listeners on destroy', () => {
+        testEnvInjector.destroy();
+        unlistenSpies.forEach((spy) => expect(spy).toHaveBeenCalledTimes(1));
+    });
+
+    it('should not accumulate mousemove listeners across repeated drag cycles', () => {
+        const listenCountAfterInit = rendererMock.listen.calls.count();
+
+        const mouseDownEvent = new MouseEvent('mousedown');
+        const mouseUpEvent = new MouseEvent('mouseup');
+
+        directive.mousedown.next({ ...mouseDownEvent, resize: true });
+        const listenCountAfterFirstDrag = rendererMock.listen.calls.count();
+        expect(listenCountAfterFirstDrag).toBeGreaterThan(listenCountAfterInit);
+
+        directive.mouseup.next(mouseUpEvent);
+        const unlistenedAfterFirstDrag = unlistenSpies.filter((spy) => spy.calls.count() > 0).length;
+
+        directive.mousedown.next({ ...mouseDownEvent, resize: true });
+        directive.mouseup.next(mouseUpEvent);
+        const unlistenedAfterSecondDrag = unlistenSpies.filter((spy) => spy.calls.count() > 0).length;
+
+        expect(unlistenedAfterSecondDrag).toBeGreaterThan(unlistenedAfterFirstDrag);
+
+        testEnvInjector.destroy();
+        unlistenSpies.forEach((spy) => expect(spy).toHaveBeenCalledTimes(1));
     });
 });

--- a/lib/core/src/lib/datatable/directives/resizable/resizable.directive.ts
+++ b/lib/core/src/lib/datatable/directives/resizable/resizable.directive.ts
@@ -69,10 +69,6 @@ export class ResizableDirective implements OnInit, OnDestroy {
 
     private currentRect: BoundingRectangle;
 
-    private unsubscribeMouseDown?: () => void;
-    private unsubscribeMouseMove?: () => void;
-    private unsubscribeMouseUp?: () => void;
-
     private readonly destroyRef = inject(DestroyRef);
 
     constructor() {
@@ -80,27 +76,33 @@ export class ResizableDirective implements OnInit, OnDestroy {
         const zone = this.zone;
 
         this.pointerDown = new Observable((observer: Observer<IResizeMouseEvent>) => {
+            let stopListening: () => void = () => {};
             zone.runOutsideAngular(() => {
-                this.unsubscribeMouseDown = renderer.listen('document', 'mousedown', (event: MouseEvent) => {
+                stopListening = renderer.listen('document', 'mousedown', (event: MouseEvent) => {
                     observer.next(event);
                 });
             });
+            return stopListening;
         }).pipe(share());
 
         this.pointerMove = new Observable((observer: Observer<IResizeMouseEvent>) => {
+            let stopListening: () => void = () => {};
             zone.runOutsideAngular(() => {
-                this.unsubscribeMouseMove = renderer.listen('document', 'mousemove', (event: MouseEvent) => {
+                stopListening = renderer.listen('document', 'mousemove', (event: MouseEvent) => {
                     observer.next(event);
                 });
             });
+            return stopListening;
         }).pipe(share());
 
         this.pointerUp = new Observable((observer: Observer<IResizeMouseEvent>) => {
+            let stopListening: () => void = () => {};
             zone.runOutsideAngular(() => {
-                this.unsubscribeMouseUp = renderer.listen('document', 'mouseup', (event: MouseEvent) => {
+                stopListening = renderer.listen('document', 'mouseup', (event: MouseEvent) => {
                     observer.next(event);
                 });
             });
+            return stopListening;
         }).pipe(share());
     }
 
@@ -184,9 +186,6 @@ export class ResizableDirective implements OnInit, OnDestroy {
         this.mousedown.complete();
         this.mousemove.complete();
         this.mouseup.complete();
-        this.unsubscribeMouseDown?.();
-        this.unsubscribeMouseMove?.();
-        this.unsubscribeMouseUp?.();
     }
 
     resizeByKeyboard(delta: number): void {

--- a/lib/core/src/lib/datatable/directives/resizable/resizable.directive.ts
+++ b/lib/core/src/lib/datatable/directives/resizable/resizable.directive.ts
@@ -61,9 +61,7 @@ export class ResizableDirective implements OnInit, OnDestroy {
 
     mousemove = new Subject<IResizeMouseEvent>();
 
-    private readonly pointerDown: Observable<IResizeMouseEvent>;
     private readonly pointerMove: Observable<IResizeMouseEvent>;
-    private readonly pointerUp: Observable<IResizeMouseEvent>;
 
     private startingRect: BoundingRectangle;
 
@@ -75,16 +73,8 @@ export class ResizableDirective implements OnInit, OnDestroy {
         const renderer = this.renderer;
         const zone = this.zone;
 
-        this.pointerDown = new Observable((observer: Observer<IResizeMouseEvent>) => {
-            let stopListening: () => void = () => {};
-            zone.runOutsideAngular(() => {
-                stopListening = renderer.listen('document', 'mousedown', (event: MouseEvent) => {
-                    observer.next(event);
-                });
-            });
-            return stopListening;
-        }).pipe(share());
-
+        // Document-level mousemove is needed for smooth drag tracking when cursor leaves the handle element.
+        // Only subscribed during active drag via share() refcount.
         this.pointerMove = new Observable((observer: Observer<IResizeMouseEvent>) => {
             let stopListening: () => void = () => {};
             zone.runOutsideAngular(() => {
@@ -94,22 +84,12 @@ export class ResizableDirective implements OnInit, OnDestroy {
             });
             return stopListening;
         }).pipe(share());
-
-        this.pointerUp = new Observable((observer: Observer<IResizeMouseEvent>) => {
-            let stopListening: () => void = () => {};
-            zone.runOutsideAngular(() => {
-                stopListening = renderer.listen('document', 'mouseup', (event: MouseEvent) => {
-                    observer.next(event);
-                });
-            });
-            return stopListening;
-        }).pipe(share());
     }
 
     ngOnInit(): void {
-        const mousedown$ = merge(this.pointerDown, this.mousedown);
+        const mousedown$ = this.mousedown.asObservable();
         const mousemove$ = merge(this.pointerMove, this.mousemove);
-        const mouseup$ = merge(this.pointerUp, this.mouseup);
+        const mouseup$ = this.mouseup.asObservable();
 
         const mouseDrag: Observable<IResizeMouseEvent | ICoordinateX> = mousedown$
             .pipe(


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?**

> - [x] Bugfix

**What is the current behaviour?**

`ResizableDirective` wraps `renderer.listen('document', ...)` calls inside RxJS Observables but does **not return** the unlisten function as an Observable teardown. Instead, it stores each unlisten in a mutable instance field.

With `share()` and `mergeMap`, the `pointerMove` Observable is subscribed/unsubscribed on every drag cycle:
1. Mousedown → `mergeMap` subscribes to `mousemove$` → `share()` subscribes source → `renderer.listen(...)` stores unlisten in field
2. Mouseup → `takeUntil` fires → `share()` refcount drops to 0 → source unsubscribed → **no teardown returned, listener stays on document**
3. Next mousedown → new `renderer.listen(...)` **overwrites** the field → previous unlisten lost
4. On destroy → only the last stored unlisten is called

Each orphaned listener retains the RxJS observer chain → directive → `ElementRef` → full detached DOM subtree (~4,691 nodes per route visit).

Linked issue: https://hyland.atlassian.net/browse/AAE-50892

**What is the new behaviour?**

- Each Observable subscriber returns the unlisten function as its RxJS teardown
- `share()` ref-count teardown properly removes document listeners when the source connection ends
- Repeated drag cycles cannot orphan listeners by overwriting a mutable field
- Mutable `unsubscribeMouseDown/Move/Up` fields removed entirely
- All three event types fixed: `pointerDown`, `pointerMove`, `pointerUp`

**Does this PR introduce a breaking change?**

> - [ ] Yes
> - [x] No

**Other information**:

Tests added:
- Verifies all document listeners are unregistered on directive destroy
- Verifies no listener accumulation across repeated drag cycles (the exact leak scenario)
