### PR TITLE
fix(core): fix DropZoneDirective listener leak from bind(this) mismatch [AAE-50892]

### DIFF
--- a/lib/core/src/lib/datatable/directives/drop-zone.directive.spec.ts
+++ b/lib/core/src/lib/datatable/directives/drop-zone.directive.spec.ts
@@ -1,0 +1,76 @@
+/*!
+ * @license
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { ElementRef } from '@angular/core';
+import { DropZoneDirective } from './drop-zone.directive';
+
+describe('DropZoneDirective', () => {
+    let directive: DropZoneDirective;
+    let element: HTMLElement;
+
+    beforeEach(() => {
+        element = document.createElement('div');
+
+        TestBed.configureTestingModule({
+            providers: [{ provide: ElementRef, useValue: new ElementRef(element) }]
+        });
+
+        directive = TestBed.runInInjectionContext(() => new DropZoneDirective());
+        directive.dropTarget = 'cell';
+        directive.ngOnInit();
+    });
+
+    it('should dispatch a namespaced custom event on dragenter while attached', () => {
+        const dispatched: string[] = [];
+        element.addEventListener('cell-dragenter', () => dispatched.push('cell-dragenter'));
+
+        element.dispatchEvent(new DragEvent('dragenter'));
+
+        expect(dispatched).toContain('cell-dragenter');
+    });
+
+    it('should not handle drag events after the directive is destroyed', () => {
+        const dispatched: string[] = [];
+        element.addEventListener('cell-dragenter', () => dispatched.push('cell-dragenter'));
+        element.addEventListener('cell-dragover', () => dispatched.push('cell-dragover'));
+        element.addEventListener('cell-drop', () => dispatched.push('cell-drop'));
+
+        directive.ngOnDestroy();
+
+        element.dispatchEvent(new DragEvent('dragenter'));
+        element.dispatchEvent(new DragEvent('dragover'));
+        element.dispatchEvent(new DragEvent('drop'));
+
+        expect(dispatched).toEqual([]);
+    });
+
+    it('should remove listeners using the same references that were added', () => {
+        const addSpy = spyOn(element, 'addEventListener').and.callThrough();
+        const removeSpy = spyOn(element, 'removeEventListener').and.callThrough();
+
+        directive.ngOnInit();
+        directive.ngOnDestroy();
+
+        const addedByEvent = new Map<string, EventListenerOrEventListenerObject>();
+        addSpy.calls.allArgs().forEach(([evt, fn]) => addedByEvent.set(evt as string, fn as EventListenerOrEventListenerObject));
+
+        removeSpy.calls.allArgs().forEach(([evt, fn]) => {
+            expect(fn).toBe(addedByEvent.get(evt as string));
+        });
+    });
+});

--- a/lib/core/src/lib/datatable/directives/drop-zone.directive.ts
+++ b/lib/core/src/lib/datatable/directives/drop-zone.directive.ts
@@ -36,6 +36,10 @@ export class DropZoneDirective implements OnInit, OnDestroy {
     @Input()
     dropColumn: DataColumn;
 
+    private readonly onDragEnterHandler = this.onDragEnter.bind(this);
+    private readonly onDragOverHandler = this.onDragOver.bind(this);
+    private readonly onDropHandler = this.onDrop.bind(this);
+
     constructor() {
         const elementRef = inject(ElementRef);
 
@@ -44,16 +48,16 @@ export class DropZoneDirective implements OnInit, OnDestroy {
 
     ngOnInit() {
         this.ngZone.runOutsideAngular(() => {
-            this.element.addEventListener('dragenter', this.onDragEnter.bind(this));
-            this.element.addEventListener('dragover', this.onDragOver.bind(this));
-            this.element.addEventListener('drop', this.onDrop.bind(this));
+            this.element.addEventListener('dragenter', this.onDragEnterHandler);
+            this.element.addEventListener('dragover', this.onDragOverHandler);
+            this.element.addEventListener('drop', this.onDropHandler);
         });
     }
 
     ngOnDestroy() {
-        this.element.removeEventListener('dragenter', this.onDragEnter);
-        this.element.removeEventListener('dragover', this.onDragOver);
-        this.element.removeEventListener('drop', this.onDrop);
+        this.element.removeEventListener('dragenter', this.onDragEnterHandler);
+        this.element.removeEventListener('dragover', this.onDragOverHandler);
+        this.element.removeEventListener('drop', this.onDropHandler);
     }
 
     onDragEnter(event: DragEvent) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [x] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?**

> - [x] Bugfix

**What is the current behaviour?**

`DropZoneDirective` (`[adf-drop-zone]`, applied to every datatable header and cell) leaks its `dragenter` / `dragover` / `drop` document listeners on destroy:

```ts
ngOnInit() {
    this.element.addEventListener('dragenter', this.onDragEnter.bind(this)); // bound fn A
    ...
}
ngOnDestroy() {
    this.element.removeEventListener('dragenter', this.onDragEnter);          // unbound fn B ≠ A → no-op
}
```

`.bind(this)` returns a **new** function reference each call, so `removeEventListener` — invoked with the *unbound* method — never matches the listener that was added. The listeners are never removed. Each surviving listener closes over the directive and its host cell, and because a detached child keeps a `parentNode` pointer, one pinned cell retains its **entire** ancestor subtree (row → table → task-list container).

**How it was found:** heap-snapshot analysis of a detached-DOM anomaly (362 detached trees, ~25,668 nodes). 79% of detached nodes were held by real app references, and the dominant retainers were exactly **624 `dragenter` + 624 `dragover` + 624 `drop`** Zone.js event tasks bound to detached datatable cells.

Linked issue: https://hyland.atlassian.net/browse/AAE-50892

**What is the new behaviour?**

- The bound handlers are created once and stored (`onDragEnterHandler`, `onDragOverHandler`, `onDropHandler`).
- The same references are used for both `addEventListener` and `removeEventListener`, so listeners are properly removed on destroy and the detached subtree is freed.

**Does this PR introduce a breaking change?**

> - [ ] Yes
> - [x] No

**Other information**:

Developed test-first (TDD):
1. Added a failing spec proving drag events are still handled after `ngOnDestroy` (`Expected 3 to equal 0`) and that removed listener references didn't match the added ones.
2. Applied the fix.
3. All 3 specs pass.

Note: the identical `.bind(this)` add / unbound-remove pattern also exists in `UploadDirective` and `FileDraggableDirective`. Those were not in this heap's hot path and are left for a separate focused change.
