### PR TITLE
AAE-46057 Absorb 3px display-text overflow to prevent form tab scrollbar

### DIFF
--- a/lib/core/src/lib/form/components/form-renderer.component.scss
+++ b/lib/core/src/lib/form/components/form-renderer.component.scss
@@ -33,6 +33,7 @@
 
     .adf-form-tab-content {
         margin-top: 1em;
+        padding-bottom: 3px;
     }
 
     .adf-form-tab-group {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [x] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (check one with "x")

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

**What is the current behaviour?**

A pre-existing `position: relative; top: 3px;` rule on the Display Text widget causes its content to extend 3px past its parent's bottom boundary. This overflow was previously absorbed by the larger form field margins, but reducing those margins as part of the Satori form-field spacing work exposed it, producing a spurious vertical scrollbar on `.adf-form-tab-content`.

**What is the new behaviour?**

`.adf-form-tab-content` reserves 3px of bottom padding to absorb the Display Text widget's overflow, removing the scrollbar without touching the widget's existing offset.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...