### PR TITLE
 AAE-50901 Allow provideMockFeatureFlags to receive observables

### DIFF
--- a/lib/core/feature-flags/src/lib/interfaces/features.interface.ts
+++ b/lib/core/feature-flags/src/lib/interfaces/features.interface.ts
@@ -32,11 +32,13 @@ export interface QaFeaturesHelperConfig {
     helperExposeKeyOnDocument?: string;
 }
 
+export interface FlagChangesetValues {
+    current: any;
+    previous: any;
+}
+
 export interface FlagChangeset {
-    [key: string]: {
-        current: any;
-        previous: any;
-    };
+    [key: string]: FlagChangesetValues;
 }
 
 export interface WritableFlagChangeset {

--- a/lib/core/feature-flags/src/lib/mocks/features-service-mock.factory.spec.ts
+++ b/lib/core/feature-flags/src/lib/mocks/features-service-mock.factory.spec.ts
@@ -21,7 +21,7 @@ import { FeaturesServiceToken, IFeaturesService } from '../interfaces/features.i
 import { MockFeatureFlags, provideMockFeatureFlags } from './features-service-mock.factory';
 
 describe('provideMockFeatureFlags', () => {
-    let featureValue$: Subject<boolean>;
+    let featureValue$: BehaviorSubject<boolean>;
     const feature1 = 'feature1';
 
     const setupFeatureService = (featureFlags: MockFeatureFlags | string | string[]): IFeaturesService => {
@@ -33,24 +33,24 @@ describe('provideMockFeatureFlags', () => {
     };
 
     beforeEach(() => {
-        featureValue$ = new Subject();
+        featureValue$ = new BehaviorSubject(false);
     });
 
     it('should emit the updated value when an observable feature flag changes', async () => {
         const featuresService = setupFeatureService({ [feature1]: featureValue$ });
-        const isOnResult = firstValueFrom(featuresService.isOn$(feature1));
-        const isOffResult = firstValueFrom(featuresService.isOff$(feature1));
+
+        expect(await firstValueFrom(featuresService.isOn$(feature1))).toBe(false);
+        expect(await firstValueFrom(featuresService.isOff$(feature1))).toBe(true);
 
         featureValue$.next(true);
-        expect(await isOnResult).toBe(true);
-        expect(await isOffResult).toBe(false);
 
-        const updatedIsOnResult = firstValueFrom(featuresService.isOn$(feature1));
-        const updatedIsOffResult = firstValueFrom(featuresService.isOff$(feature1));
+        expect(await firstValueFrom(featuresService.isOn$(feature1))).toBe(true);
+        expect(await firstValueFrom(featuresService.isOff$(feature1))).toBe(false);
 
         featureValue$.next(false);
-        expect(await updatedIsOnResult).toBe(false);
-        expect(await updatedIsOffResult).toBe(true);
+
+        expect(await firstValueFrom(featuresService.isOn$(feature1))).toBe(false);
+        expect(await firstValueFrom(featuresService.isOff$(feature1))).toBe(true);
     });
 
     it('should not let a consumer change the feature flag value through the observable returned by isOn$', async () => {

--- a/lib/core/feature-flags/src/lib/mocks/features-service-mock.factory.spec.ts
+++ b/lib/core/feature-flags/src/lib/mocks/features-service-mock.factory.spec.ts
@@ -1,0 +1,128 @@
+/*!
+ * @license
+ * Copyright © 2005-2026 Hyland Software, Inc. and its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TestBed } from '@angular/core/testing';
+import { BehaviorSubject, firstValueFrom, of, Subject } from 'rxjs';
+import { FeaturesServiceToken, IFeaturesService } from '../interfaces/features.interface';
+import { MockFeatureFlags, provideMockFeatureFlags } from './features-service-mock.factory';
+
+describe('provideMockFeatureFlags', () => {
+    let featureValue$: Subject<boolean>;
+    const feature1 = 'feature1';
+
+    const setupFeatureService = (featureFlags: MockFeatureFlags | string | string[]): IFeaturesService => {
+        TestBed.configureTestingModule({
+            providers: [provideMockFeatureFlags(featureFlags)]
+        });
+
+        return TestBed.inject(FeaturesServiceToken);
+    };
+
+    beforeEach(() => {
+        featureValue$ = new Subject();
+    });
+
+    it('should emit the updated value when an observable feature flag changes', async () => {
+        const featuresService = setupFeatureService({ [feature1]: featureValue$ });
+        const isOnResult = firstValueFrom(featuresService.isOn$(feature1));
+        const isOffResult = firstValueFrom(featuresService.isOff$(feature1));
+
+        featureValue$.next(true);
+        expect(await isOnResult).toBe(true);
+        expect(await isOffResult).toBe(false);
+
+        const updatedIsOnResult = firstValueFrom(featuresService.isOn$(feature1));
+        const updatedIsOffResult = firstValueFrom(featuresService.isOff$(feature1));
+
+        featureValue$.next(false);
+        expect(await updatedIsOnResult).toBe(false);
+        expect(await updatedIsOffResult).toBe(true);
+    });
+
+    it('should not let a consumer change the feature flag value through the observable returned by isOn$', async () => {
+        const originalValue$ = new BehaviorSubject(true);
+        const service = setupFeatureService({ [feature1]: originalValue$ });
+
+        const isOn$ = service.isOn$(feature1) as Subject<boolean>;
+
+        expect(isOn$).not.toBe(originalValue$);
+        expect(() => isOn$.next(false)).toThrow();
+        expect(await firstValueFrom(service.isOn$(feature1))).toBe(true);
+        expect(await firstValueFrom(originalValue$)).toBe(true);
+    });
+
+    it('should mock a string feature flag as enabled', async () => {
+        const service = setupFeatureService(feature1);
+
+        expect(await firstValueFrom(service.isOn$(feature1))).toBe(true);
+        expect(await firstValueFrom(service.isOff$(feature1))).toBe(false);
+    });
+
+    it('should mock every feature flag in an array as enabled', async () => {
+        const feature2 = 'feature2';
+        const service = setupFeatureService([feature1, feature2]);
+
+        expect(await firstValueFrom(service.getFlags$())).toEqual({
+            [feature1]: { current: true, previous: null },
+            [feature2]: { current: true, previous: null }
+        });
+    });
+
+    it('should emit an empty changeset when no feature flags are provided', async () => {
+        const service = setupFeatureService({});
+
+        expect(await firstValueFrom(service.getFlags$())).toEqual({});
+        expect(await firstValueFrom(service.init())).toEqual({});
+    });
+
+    it('should emit an empty changeset when an empty feature flag array is provided', async () => {
+        const service = setupFeatureService([]);
+
+        expect(await firstValueFrom(service.getFlags$())).toEqual({});
+        expect(await firstValueFrom(service.init())).toEqual({});
+    });
+
+    [
+        { initialState: true, expectedIsOn: true, expectedIsOff: false },
+        { initialState: false, expectedIsOn: false, expectedIsOff: true }
+    ].forEach(({ initialState, expectedIsOn, expectedIsOff }) => {
+        it(`should return the expected state when the feature flag is ${initialState}`, async () => {
+            const service = setupFeatureService({ [feature1]: initialState });
+
+            expect(await firstValueFrom(service.init())).toEqual({
+                [feature1]: { current: initialState, previous: null }
+            });
+            expect(await firstValueFrom(service.isOn$(feature1))).toBe(expectedIsOn);
+            expect(await firstValueFrom(service.isOff$(feature1))).toBe(expectedIsOff);
+        });
+    });
+
+    it('should resolve observable values in the complete feature flags result', async () => {
+        const service = setupFeatureService({ [feature1]: of(true) });
+
+        expect(await firstValueFrom(service.getFlags$())).toEqual({
+            [feature1]: { current: true, previous: null }
+        });
+    });
+
+    it('should throw when a feature flag has not been mocked', () => {
+        const featuresService = setupFeatureService({ [feature1]: true });
+
+        expect(() => featuresService.isOn$('missing-feature')).toThrowError(/missing-feature.*not mocked/);
+        expect(() => featuresService.isOff$('missing-feature')).toThrowError(/missing-feature.*not mocked/);
+    });
+});

--- a/lib/core/feature-flags/src/lib/mocks/features-service-mock.factory.spec.ts
+++ b/lib/core/feature-flags/src/lib/mocks/features-service-mock.factory.spec.ts
@@ -96,19 +96,24 @@ describe('provideMockFeatureFlags', () => {
         expect(await firstValueFrom(service.init())).toEqual({});
     });
 
-    [
-        { initialState: true, expectedIsOn: true, expectedIsOff: false },
-        { initialState: false, expectedIsOn: false, expectedIsOff: true }
-    ].forEach(({ initialState, expectedIsOn, expectedIsOff }) => {
-        it(`should return the expected state when the feature flag is ${initialState}`, async () => {
-            const service = setupFeatureService({ [feature1]: initialState });
+    it('should return the expected state when the feature flag is true', async () => {
+        const service = setupFeatureService({ [feature1]: true });
 
-            expect(await firstValueFrom(service.init())).toEqual({
-                [feature1]: { current: initialState, previous: null }
-            });
-            expect(await firstValueFrom(service.isOn$(feature1))).toBe(expectedIsOn);
-            expect(await firstValueFrom(service.isOff$(feature1))).toBe(expectedIsOff);
+        expect(await firstValueFrom(service.init())).toEqual({
+            [feature1]: { current: true, previous: null }
         });
+        expect(await firstValueFrom(service.isOn$(feature1))).toBe(true);
+        expect(await firstValueFrom(service.isOff$(feature1))).toBe(false);
+    });
+
+    it('should return the expected state when the feature flag is false', async () => {
+        const service = setupFeatureService({ [feature1]: false });
+
+        expect(await firstValueFrom(service.init())).toEqual({
+            [feature1]: { current: false, previous: null }
+        });
+        expect(await firstValueFrom(service.isOn$(feature1))).toBe(false);
+        expect(await firstValueFrom(service.isOff$(feature1))).toBe(true);
     });
 
     it('should resolve observable values in the complete feature flags result', async () => {

--- a/lib/core/feature-flags/src/lib/mocks/features-service-mock.factory.ts
+++ b/lib/core/feature-flags/src/lib/mocks/features-service-mock.factory.ts
@@ -133,28 +133,20 @@ const mockFeatureFlagsToFlagChangeset = (mockFeatureFlags: MockFeatureFlags) => 
 
 /**
  * Mock the FeaturesService with the provided feature flags.
- * When we provide string or string[], all these features will be set to true.
- * For MockFeatureFlags, we can set value depending on our needs
+ * A string or string[] sets every listed feature to true, a MockFeatureFlags object sets each value explicitly.
+ * Every flag the code under test asks for has to be mocked, otherwise 'isOn$'/'isOff$' throw.
  *
- * Every flag the component under test asks for has to be mocked, 'isOn$'/'isOff$' throw for an unknown flag.
+ * Use a 'BehaviorSubject' for a flag that changes during the test. A bare 'Subject' has no current value,
+ * so the flag stays silent and 'getFlags$()'/'init()' withhold the whole changeset, until it emits.
  *
  * @example
  *
- * Enable a single feature, or a few of them
+ * const featureA$ = new BehaviorSubject(false);
  *
  * providers: [provideMockFeatureFlags('featureA')]
  * providers: [provideMockFeatureFlags(['featureA', 'featureB'])]
- *
- * Set each value explicitly
- *
  * providers: [provideMockFeatureFlags({ featureA: true, featureB: false })]
- *
- * Change a value during the test, 'BehaviorSubject' (or 'of(...)') is required so the flag has a current
- * value from the start, a bare 'Subject' withholds the whole changeset until it emits
- *
- * const featureA$ = new BehaviorSubject(false);
  * providers: [provideMockFeatureFlags({ featureA: featureA$ })]
- * featureA$.next(true);
  *
  * @param featureFlag The feature flag(s) to mock. Can be a single feature flag string, an array of feature flag strings, or a MockFeatureFlags object.
  * @returns A provider object for the FeaturesServiceToken with the mocked feature flags.

--- a/lib/core/feature-flags/src/lib/mocks/features-service-mock.factory.ts
+++ b/lib/core/feature-flags/src/lib/mocks/features-service-mock.factory.ts
@@ -15,11 +15,27 @@
  * limitations under the License.
  */
 
-import { of } from 'rxjs';
-import { FeaturesServiceToken, FlagChangeset, IFeaturesService } from '../interfaces/features.interface';
+import { of, Observable, map, combineLatest, take, defer } from 'rxjs';
+import { FeaturesServiceToken, FlagChangeset, FlagChangesetValues, IFeaturesService } from '../interfaces/features.interface';
 
+/**
+ * Feature flags to mock. A boolean sets a fixed value, an observable lets the test change the value over time.
+ *
+ * Observable flags must have a current value, use 'BehaviorSubject' or 'of(...)'.
+ * A bare 'Subject' has no value until it emits, and 'getFlags$()'/'init()' withhold the whole changeset
+ * until every observable flag has emitted at least once.
+ */
 export interface MockFeatureFlags {
-    [key: string]: boolean;
+    [key: string]: boolean | Observable<boolean>;
+}
+
+interface MockFlagChangesetValues extends FlagChangesetValues {
+    current: boolean | Observable<boolean>;
+    previous: boolean | Observable<boolean>;
+}
+
+interface MockFlagChangeset extends FlagChangeset {
+    [key: string]: MockFlagChangesetValues;
 }
 
 const assertFeatureFlag = (flagChangeset: FlagChangeset, key: string): void => {
@@ -32,18 +48,71 @@ const assertFeatureFlag = (flagChangeset: FlagChangeset, key: string): void => {
     }
 };
 
-const mockFeaturesService = (flagChangeset: FlagChangeset): IFeaturesService => ({
-    init: () => of(flagChangeset),
+/**
+ * Calling 'pipe' on a 'Subject' returns an 'AnonymousSubject' that still writes through to the original 'Subject',
+ * so piping alone does not stop a consumer from pushing values into the mocked flag.
+ * 'defer' breaks that chain and gives back a plain, read only observable.
+ *
+ * @param value$ Observable feature flag value provided by the test
+ * @returns Observable that cannot be used to change the mocked value
+ */
+const toReadOnly = (value$: Observable<boolean>): Observable<boolean> => defer(() => value$);
+
+const mockFeaturesService = (flagChangeset: MockFlagChangeset): IFeaturesService => ({
+    init: () => resolveFeatureFlagValues(flagChangeset).pipe(take(1)),
     isOn$: (key) => {
         assertFeatureFlag(flagChangeset, key);
-        return of(flagChangeset[key].current);
+        const featureFlagValue = flagChangeset[key].current;
+
+        // In case of an observable, we do not want to return the original observable, so a consumer cannot 'next', 'error' or 'complete' it
+        return typeof featureFlagValue === 'boolean' ? of(featureFlagValue) : toReadOnly(featureFlagValue).pipe(map(Boolean));
     },
     isOff$: (key) => {
         assertFeatureFlag(flagChangeset, key);
-        return of(!flagChangeset[key].current);
+        const featureFlagValue = flagChangeset[key].current;
+
+        return typeof featureFlagValue === 'boolean' ? of(!featureFlagValue) : toReadOnly(featureFlagValue).pipe(map((value) => !value));
     },
-    getFlags$: () => of(flagChangeset)
+    getFlags$: () => resolveFeatureFlagValues(flagChangeset)
 });
+
+/**
+ * 'provideMockFeatureFlags' can receive observables, therefore we need to resolve these values
+ *
+ * @param mockFlagChangeset Mocked flag changeset
+ * @returns FlagChangeset
+ */
+const resolveFeatureFlagValues = (mockFlagChangeset: MockFlagChangeset): Observable<FlagChangeset> => {
+    // No FF provided, just return empty object
+    if (Object.keys(mockFlagChangeset).length === 0) {
+        return of({});
+    }
+
+    const resolveFeatureFlagValues$ = Object.entries(mockFlagChangeset).map(([featureKey, values]) => {
+        if (typeof values.current === 'boolean') {
+            return of([featureKey, { ...values }] as const);
+        }
+
+        // Value is observable, we need to resolve it
+        const observableValue$ = values.current;
+
+        const resolveFlagValue$ = observableValue$.pipe(map((resolvedValue) => [featureKey, { current: resolvedValue, previous: null }] as const));
+
+        return resolveFlagValue$;
+    });
+
+    return combineLatest(resolveFeatureFlagValues$).pipe(
+        map((resolvedFlags) => {
+            const resolvedFeatureFlag: FlagChangeset = {};
+
+            resolvedFlags.forEach(([key, values]) => {
+                resolvedFeatureFlag[key] = values;
+            });
+
+            return resolvedFeatureFlag;
+        })
+    );
+};
 
 const arrayToFlagChangeset = (featureFlags: string[]): FlagChangeset => {
     const flagChangeset: FlagChangeset = {};
@@ -62,6 +131,34 @@ const mockFeatureFlagsToFlagChangeset = (mockFeatureFlags: MockFeatureFlags) => 
     return flagChangeset;
 };
 
+/**
+ * Mock the FeaturesService with the provided feature flags.
+ * When we provide string or string[], all these features will be set to true.
+ * For MockFeatureFlags, we can set value depending on our needs
+ *
+ * Every flag the component under test asks for has to be mocked, 'isOn$'/'isOff$' throw for an unknown flag.
+ *
+ * @example
+ *
+ * Enable a single feature, or a few of them
+ *
+ * providers: [provideMockFeatureFlags('featureA')]
+ * providers: [provideMockFeatureFlags(['featureA', 'featureB'])]
+ *
+ * Set each value explicitly
+ *
+ * providers: [provideMockFeatureFlags({ featureA: true, featureB: false })]
+ *
+ * Change a value during the test, 'BehaviorSubject' (or 'of(...)') is required so the flag has a current
+ * value from the start, a bare 'Subject' withholds the whole changeset until it emits
+ *
+ * const featureA$ = new BehaviorSubject(false);
+ * providers: [provideMockFeatureFlags({ featureA: featureA$ })]
+ * featureA$.next(true);
+ *
+ * @param featureFlag The feature flag(s) to mock. Can be a single feature flag string, an array of feature flag strings, or a MockFeatureFlags object.
+ * @returns A provider object for the FeaturesServiceToken with the mocked feature flags.
+ */
 export const provideMockFeatureFlags = (featureFlag: MockFeatureFlags | string | string[]) => {
     if (typeof featureFlag === 'string') {
         featureFlag = [featureFlag];

--- a/lib/core/feature-flags/src/lib/mocks/features-service-mock.factory.ts
+++ b/lib/core/feature-flags/src/lib/mocks/features-service-mock.factory.ts
@@ -31,7 +31,7 @@ export interface MockFeatureFlags {
 
 interface MockFlagChangesetValues extends FlagChangesetValues {
     current: boolean | Observable<boolean>;
-    previous: boolean | Observable<boolean>;
+    previous: null;
 }
 
 interface MockFlagChangeset extends FlagChangeset {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

> - [ ] The commit message follows our [guidelines](https://github.com/Alfresco/alfresco-ng2-components/wiki/Commit-format)
> - [ ] Tests for the changes have been added (for bug fixes / features)
> - [ ] Docs have been added / updated (for bug fixes / features)

<!--
 Before submitting your PR, please check that your code follows our contribution guidelines:
 https://github.com/Alfresco/alfresco-ng2-components/wiki/Code-contribution-acceptance-criteria
 -->

**What kind of change does this PR introduce?** (check one with "x")

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe:

Added posibility to use observables in `provideMockFeatureFlags`



**What is the current behaviour?** (You can also link to an open issue here)

Currently, every time when we need to test diferent feature flag state, we have to create new `TestBed.configureTestingModule` (feature flag is provided only once as fixed value)

**What is the new behaviour?**

Goal of this task is to update provideMockFeatureFlags so it can accept observables as well

So we can do something like:

```
const myFlag$ = new BehaviorSubject()

provideMockFeatureFlags({
 [MY_FLAG]: myFlag$
}),
```
and for testing different flags we can just:
```
describe('with FF on', () => {
  beforeEach(() => {
    myFlag$.next(true);
    fixture.detectChanges();
  })
  ...  
})

```

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
